### PR TITLE
Implement Redis time series support

### DIFF
--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -285,7 +285,9 @@ As mentioned above, the API is divided into groups:
 - graph - `.graph()` (requires the https://redis.com/modules/redis-graph/[RedisGraph] module on the server side).
 These commands are marked as experimental, as we would need feedback before making them stable.
 - search - `.search()` (requires the https://redis.com/modules/redis-search/[RedisSearch] module on the server side).
-- auto-suggest - `.autosuggest()` (requires the https://redis.com/modules/redis-search/[RedisSearch] module on the server side).O
+- auto-suggest - `.autosuggest()` (requires the https://redis.com/modules/redis-search/[RedisSearch] module on the server side).
+- time-series - `.timeseries()` (requires the https://redis.com/modules/redis-timeseries/[Redis Time Series] module on the server side).
+
 These commands are marked as experimental, as we would need feedback before making them stable.
 
 Each of these methods returns an object that lets you execute the commands related to the group.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
@@ -20,6 +20,7 @@ import io.quarkus.redis.datasource.search.ReactiveSearchCommands;
 import io.quarkus.redis.datasource.set.ReactiveSetCommands;
 import io.quarkus.redis.datasource.sortedset.ReactiveSortedSetCommands;
 import io.quarkus.redis.datasource.string.ReactiveStringCommands;
+import io.quarkus.redis.datasource.timeseries.ReactiveTimeSeriesCommands;
 import io.quarkus.redis.datasource.topk.ReactiveTopKCommands;
 import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
@@ -559,6 +560,27 @@ public interface ReactiveRedisDataSource {
     @Experimental("The Redis auto-suggest support is experimental")
     default ReactiveAutoSuggestCommands<String> autosuggest() {
         return autosuggest(String.class);
+    }
+
+    /**
+     * Gets the object to emit commands from the {@code time series} group.
+     * This group requires the <a href="https://redis.io/docs/stack/timeseries/">Redis Time Series module</a>.
+     *
+     * @param <K> the type of keys
+     * @return the object to manipulate time series
+     */
+    @Experimental("The Redis time series support is experimental")
+    <K> ReactiveTimeSeriesCommands<K> timeseries(Class<K> redisKeyType);
+
+    /**
+     * Gets the object to emit commands from the {@code time series} group.
+     * This group requires the <a href="https://redis.io/docs/stack/timeseries/">Redis Time Series module</a>.
+     *
+     * @return the object to manipulate time series
+     */
+    @Experimental("The Redis time series support is experimental")
+    default ReactiveTimeSeriesCommands<String> timeseries() {
+        return timeseries(String.class);
     }
 
     /**

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
@@ -21,6 +21,7 @@ import io.quarkus.redis.datasource.search.SearchCommands;
 import io.quarkus.redis.datasource.set.SetCommands;
 import io.quarkus.redis.datasource.sortedset.SortedSetCommands;
 import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.timeseries.TimeSeriesCommands;
 import io.quarkus.redis.datasource.topk.TopKCommands;
 import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionResult;
@@ -548,6 +549,27 @@ public interface RedisDataSource {
     @Experimental("The Redis auto-suggest support is experimental")
     default AutoSuggestCommands<String> autosuggest() {
         return autosuggest(String.class);
+    }
+
+    /**
+     * Gets the object to emit commands from the {@code time series} group.
+     * This group requires the <a href="https://redis.io/docs/stack/timeseries/">Redis Time Series module</a>.
+     *
+     * @param <K> the type of keys
+     * @return the object to manipulate time series
+     */
+    @Experimental("The Redis time series support is experimental")
+    <K> TimeSeriesCommands<K> timeseries(Class<K> redisKeyType);
+
+    /**
+     * Gets the object to emit commands from the {@code time series} group.
+     * This group requires the <a href="https://redis.io/docs/stack/timeseries/">Redis Time Series module</a>.
+     *
+     * @return the object to manipulate time series
+     */
+    @Experimental("The Redis time series support is experimental")
+    default TimeSeriesCommands<String> timeseries() {
+        return timeseries(String.class);
     }
 
     /**

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/AddArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/AddArgs.java
@@ -1,0 +1,136 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.RedisCommandExtraArguments;
+
+/**
+ * Represents the extra arguments of the {@code ts.add} command.
+ */
+public class AddArgs implements RedisCommandExtraArguments {
+
+    private Duration retention;
+    private String enc;
+    private int chunkSize;
+    private DuplicatePolicy onDuplicate;
+    private final Map<String, Object> labels = new HashMap<>();
+
+    /**
+     * Set the maximum retention period, compared to the maximum existing timestamp, in milliseconds.
+     * <p>
+     * Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time
+     * series.
+     *
+     * @param retention the retention, must not be {@code null}
+     * @return the current {@code AddArgs}
+     */
+    public AddArgs setRetention(Duration retention) {
+        this.retention = nonNull(retention, "retention");
+        return this;
+    }
+
+    /**
+     * Set the series sample's encoding format to {@code COMPRESSED}
+     * Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing
+     * time series.
+     *
+     * @return the current {@code AddArgs}
+     */
+    public AddArgs compressed() {
+        this.enc = "COMPRESSED";
+        return this;
+    }
+
+    /**
+     * Set the series sample's encoding format to {@code UNCOMPRESSED}
+     * Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing
+     * time series.
+     *
+     * @return the current {@code AddArgs}
+     */
+    public AddArgs uncompressed() {
+        this.enc = "UNCOMPRESSED";
+        return this;
+    }
+
+    /**
+     * Sets the memory size, in bytes, allocated for each data chunk.
+     * Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing
+     * time series.
+     *
+     * @param size the chunk size, between 48 and 1048576
+     * @return the current {@code AddArgs}
+     */
+    public AddArgs chunkSize(int size) {
+        this.chunkSize = size;
+        return this;
+    }
+
+    /**
+     * Overwrite key and database configuration for DUPLICATE_POLICY, the policy for handling samples with identical
+     * timestamps.
+     *
+     * @param policy the policy, must not be {@code null}
+     * @return the current {@code AddArgs}
+     */
+    public AddArgs onDuplicate(DuplicatePolicy policy) {
+        this.onDuplicate = policy;
+        return this;
+    }
+
+    /**
+     * Set a label-value pairs that represent metadata labels of the time series.
+     *
+     * @param label the label, must not be {@code null}
+     * @param value the value, must not be {@code  null}
+     * @return the current {@code AddArgs}
+     */
+    public AddArgs label(String label, Object value) {
+        labels.put(label, value);
+        return this;
+    }
+
+    @Override
+    public List<String> toArgs() {
+        List<String> list = new ArrayList<>();
+        if (retention != null) {
+            list.add("RETENTION");
+            if (retention == Duration.ZERO) {
+                list.add("0");
+            } else {
+                list.add(Long.toString(retention.toMillis()));
+            }
+        }
+
+        if (enc != null) {
+            list.add("ENCODING");
+            list.add(enc);
+        }
+
+        if (chunkSize > 0) {
+            list.add("CHUNK_SIZE");
+            list.add(Integer.toString(chunkSize));
+        }
+
+        if (onDuplicate != null) {
+            list.add("ON_DUPLICATE");
+            list.add(onDuplicate.name().toUpperCase());
+        }
+
+        if (!labels.isEmpty()) {
+            list.add("LABELS");
+            for (Map.Entry<String, Object> entry : labels.entrySet()) {
+                list.add(entry.getKey());
+                list.add(entry.getValue().toString());
+            }
+        }
+
+        return list;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/Aggregation.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/Aggregation.java
@@ -1,0 +1,67 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import java.util.Locale;
+
+/**
+ * Time Series Aggregation functions
+ */
+public enum Aggregation {
+
+    /**
+     * Arithmetic mean of all values
+     */
+    AVG,
+    /**
+     * Sum of all values
+     */
+    SUM,
+    /**
+     * Minimum value
+     */
+    MIN,
+    /**
+     * Maximum value
+     */
+    MAX,
+    /**
+     * Difference between the highest and the lowest value
+     */
+    RANGE,
+    /**
+     * Number of values.
+     */
+    COUNT,
+    /**
+     * Value with lowest timestamp in the bucket
+     */
+    FIRST,
+    /**
+     * Value with highest timestamp in the bucket
+     */
+    LAST,
+    /**
+     * Population standard deviation of the values
+     */
+    STD_P,
+    /**
+     * Sample standard deviation of the values
+     */
+    STD_S,
+    /**
+     * Population variance of the values
+     */
+    VAR_P,
+    /**
+     * Sample variance of the values
+     */
+    VAR_S,
+    /**
+     * Time-weighted average over the bucket's timeframe (since RedisTimeSeries v1.8)
+     */
+    TWA;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/AlterArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/AlterArgs.java
@@ -1,0 +1,131 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.RedisCommandExtraArguments;
+
+/**
+ * Represents the extra arguments of the {@code ts.alter} command.
+ */
+public class AlterArgs implements RedisCommandExtraArguments {
+
+    private Duration retention;
+    private String enc;
+    private int chunkSize;
+    private DuplicatePolicy policy;
+    private final Map<String, Object> labels = new HashMap<>();
+
+    /**
+     * Set the maximum age for samples compared to the highest reported timestamp, in milliseconds.
+     * Samples are expired based solely on the difference between their timestamp and the timestamps passed to
+     * subsequent TS.ADD, TS.MADD, TS.INCRBY, and TS.DECRBY calls.
+     * <p>
+     * When set to 0, samples never expire. When not specified, the option is set to the global RETENTION_POLICY
+     * configuration of the database, which by default is 0.
+     *
+     * @param retention the retention, must not be {@code null}
+     * @return the current {@code AlterArgs}
+     */
+    public AlterArgs setRetention(Duration retention) {
+        this.retention = nonNull(retention, "retention");
+        return this;
+    }
+
+    /**
+     * Set the retention duration so the samples never expire.
+     *
+     * @return the current {@code AlterArgs}
+     * @see #setRetention(Duration)
+     */
+    public AlterArgs forever() {
+        this.retention = Duration.ZERO;
+        return this;
+    }
+
+    /**
+     * Sets the initial allocation size, in bytes, for the data part of each new chunk.
+     * Actual chunks may consume more memory. Changing chunkSize (using TS.ALTER) does not affect existing chunks.
+     * <p>
+     * Must be a multiple of 8 in the range [48 .. 1048576].
+     * When not specified, it is set to 4096 bytes (a single memory page).
+     *
+     * @param size the chunk size, between 48 and 1048576
+     * @return the current {@code AlterArgs}
+     */
+    public AlterArgs chunkSize(int size) {
+        this.chunkSize = size;
+        return this;
+    }
+
+    /**
+     * Set the policy for handling insertion (TS.ADD and TS.MADD) of multiple samples with identical timestamps.
+     * <p>
+     * When not specified: set to the global DUPLICATE_POLICY configuration of the database (which, by default, is BLOCK).
+     *
+     * @param policy the policy, must not be {@code null}
+     * @return the current {@code AlterArgs}
+     */
+    public AlterArgs duplicatePolicy(DuplicatePolicy policy) {
+        this.policy = policy;
+        return this;
+    }
+
+    /**
+     * Set a label-value pairs that represent metadata labels of the key and serve as a secondary index.
+     * <p>
+     * The TS.MGET, TS.MRANGE, and TS.MREVRANGE commands operate on multiple time series based on their labels.
+     * The TS.QUERYINDEX command returns all time series keys matching a given filter based on their labels.
+     *
+     * @param label the label, must not be {@code null}
+     * @param value the value, must not be {@code  null}
+     * @return the current {@code AlterArgs}
+     */
+    public AlterArgs label(String label, Object value) {
+        labels.put(label, value);
+        return this;
+    }
+
+    @Override
+    public List<String> toArgs() {
+        List<String> list = new ArrayList<>();
+        if (retention != null) {
+            list.add("RETENTION");
+            if (retention == Duration.ZERO) {
+                list.add("0");
+            } else {
+                list.add(Long.toString(retention.toMillis()));
+            }
+        }
+
+        if (enc != null) {
+            list.add("ENCODING");
+            list.add(enc);
+        }
+
+        if (chunkSize > 0) {
+            list.add("CHUNK_SIZE");
+            list.add(Integer.toString(chunkSize));
+        }
+
+        if (policy != null) {
+            list.add("DUPLICATE_POLICY");
+            list.add(policy.name().toUpperCase());
+        }
+
+        if (!labels.isEmpty()) {
+            list.add("LABELS");
+            for (Map.Entry<String, Object> entry : labels.entrySet()) {
+                list.add(entry.getKey());
+                list.add(entry.getValue().toString());
+            }
+        }
+
+        return list;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/BucketTimestamp.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/BucketTimestamp.java
@@ -1,0 +1,28 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import java.util.Locale;
+
+/**
+ * Configure the bucket timestamp of an aggregation in the {@code TS.MRANGE} command.
+ * It controls how bucket timestamps are reported.
+ */
+public enum BucketTimestamp {
+
+    /**
+     * the bucket's start time (default).
+     */
+    LOW,
+    /**
+     * the bucket's end time.
+     */
+    HIGH,
+    /**
+     * the bucket's mid time (rounded down if not an integer)
+     */
+    MID;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/CreateArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/CreateArgs.java
@@ -1,0 +1,162 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.RedisCommandExtraArguments;
+
+/**
+ * Represents the extra arguments of the {@code ts.create} command.
+ */
+public class CreateArgs implements RedisCommandExtraArguments {
+
+    private Duration retention;
+    private String enc;
+    private int chunkSize;
+    private DuplicatePolicy policy;
+    private final Map<String, Object> labels = new HashMap<>();
+
+    /**
+     * Set the maximum age for samples compared to the highest reported timestamp, in milliseconds.
+     * Samples are expired based solely on the difference between their timestamp and the timestamps passed to
+     * subsequent TS.ADD, TS.MADD, TS.INCRBY, and TS.DECRBY calls.
+     * <p>
+     * When set to 0, samples never expire. When not specified, the option is set to the global RETENTION_POLICY
+     * configuration of the database, which by default is 0.
+     *
+     * @param retention the retention, must not be {@code null}
+     * @return the current {@code CreateArgs}
+     */
+    public CreateArgs setRetention(Duration retention) {
+        this.retention = nonNull(retention, "retention");
+        return this;
+    }
+
+    /**
+     * Set the retention duration so the samples never expire.
+     *
+     * @return the current {@code CreateArgs}
+     * @see #setRetention(Duration)
+     */
+    public CreateArgs forever() {
+        this.retention = Duration.ZERO;
+        return this;
+    }
+
+    /**
+     * Set the series samples encoding format to {@code COMPRESSED}, applies compression to the series samples.
+     * {@code COMPRESSED} is almost always the right choice. Compression not only saves memory but usually improves
+     * performance due to a lower number of memory accesses. It can result in about 90% memory reduction.
+     * The exception are highly irregular timestamps or values, which occur rarely.
+     * <p>
+     * When not specified, the option is set to COMPRESSED.
+     *
+     * @return the current {@code CreateArgs}
+     */
+    public CreateArgs compressed() {
+        this.enc = "COMPRESSED";
+        return this;
+    }
+
+    /**
+     * Set the series samples encoding format to {@code UNCOMPRESSED}, applies compression to the series samples.
+     * <p>
+     * {@code COMPRESSED} is almost always the right choice. Compression not only saves memory but usually improves
+     * performance due to a lower number of memory accesses. It can result in about 90% memory reduction.
+     * The exception are highly irregular timestamps or values, which occur rarely.
+     * <p>
+     * When not specified, the option is set to COMPRESSED.
+     *
+     * @return the current {@code CreateArgs}
+     */
+    public CreateArgs uncompressed() {
+        this.enc = "UNCOMPRESSED";
+        return this;
+    }
+
+    /**
+     * Sets the initial allocation size, in bytes, for the data part of each new chunk.
+     * Actual chunks may consume more memory. Changing chunkSize (using TS.ALTER) does not affect existing chunks.
+     * <p>
+     * Must be a multiple of 8 in the range [48 .. 1048576].
+     * When not specified, it is set to 4096 bytes (a single memory page).
+     *
+     * @param size the chunk size, between 48 and 1048576
+     * @return the current {@code CreateArgs}
+     */
+    public CreateArgs chunkSize(int size) {
+        this.chunkSize = size;
+        return this;
+    }
+
+    /**
+     * Set the policy for handling insertion (TS.ADD and TS.MADD) of multiple samples with identical timestamps.
+     * <p>
+     * When not specified: set to the global DUPLICATE_POLICY configuration of the database (which, by default, is BLOCK).
+     *
+     * @param policy the policy, must not be {@code null}
+     * @return the current {@code CreateArgs}
+     */
+    public CreateArgs duplicatePolicy(DuplicatePolicy policy) {
+        this.policy = policy;
+        return this;
+    }
+
+    /**
+     * Set a label-value pairs that represent metadata labels of the key and serve as a secondary index.
+     * <p>
+     * The TS.MGET, TS.MRANGE, and TS.MREVRANGE commands operate on multiple time series based on their labels.
+     * The TS.QUERYINDEX command returns all time series keys matching a given filter based on their labels.
+     *
+     * @param label the label, must not be {@code null}
+     * @param value the value, must not be {@code  null}
+     * @return the current {@code CreateArgs}
+     */
+    public CreateArgs label(String label, Object value) {
+        labels.put(label, value);
+        return this;
+    }
+
+    @Override
+    public List<String> toArgs() {
+        List<String> list = new ArrayList<>();
+        if (retention != null) {
+            list.add("RETENTION");
+            if (retention == Duration.ZERO) {
+                list.add("0");
+            } else {
+                list.add(Long.toString(retention.toMillis()));
+            }
+        }
+
+        if (enc != null) {
+            list.add("ENCODING");
+            list.add(enc);
+        }
+
+        if (chunkSize > 0) {
+            list.add("CHUNK_SIZE");
+            list.add(Integer.toString(chunkSize));
+        }
+
+        if (policy != null) {
+            list.add("DUPLICATE_POLICY");
+            list.add(policy.name().toUpperCase());
+        }
+
+        if (!labels.isEmpty()) {
+            list.add("LABELS");
+            for (Map.Entry<String, Object> entry : labels.entrySet()) {
+                list.add(entry.getKey());
+                list.add(entry.getValue().toString());
+            }
+        }
+
+        return list;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/DuplicatePolicy.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/DuplicatePolicy.java
@@ -1,0 +1,29 @@
+package io.quarkus.redis.datasource.timeseries;
+
+public enum DuplicatePolicy {
+    /**
+     * BLOCK: ignore any newly reported value and reply with an error
+     */
+    BLOCK,
+    /**
+     * FIRST: ignore any newly reported value
+     */
+    FIRST,
+    /**
+     * LAST: override with the newly reported value
+     */
+    LAST,
+    /**
+     * MIN: only override if the value is lower than the existing value
+     */
+    MIN,
+    /**
+     * MAX: only override if the value is higher than the existing value
+     */
+    MAX,
+    /**
+     * SUM: If a previous sample exists, add the new sample to it so that the updated value is equal
+     * to (previous + new). If no previous sample exists, set the updated value equal to the new value.
+     */
+    SUM
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/Filter.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/Filter.java
@@ -1,0 +1,119 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+/**
+ * Represents a filter used in the {@code MGET} command.
+ */
+public interface Filter {
+
+    String toString();
+
+    /**
+     * Creates a {@code label=value}, selecting samples where the label equals value.
+     *
+     * @param label the label, must not be {@code null}
+     * @param value the value, must not be {@code null}
+     * @return the filter
+     */
+    static Filter withLabel(String label, Object value) {
+        nonNull(label, "label");
+        nonNull(value, "value");
+        return new Filter() {
+            @Override
+            public String toString() {
+                return label + "=" + value;
+            }
+        };
+    }
+
+    /**
+     * Creates a {@code label!=value}, selecting samples where the label is not equal to value.
+     *
+     * @param label the label, must not be {@code null}
+     * @param value the value, must not be {@code null}
+     * @return the filter
+     */
+    static Filter withoutLabel(String label, String value) {
+        nonNull(label, "label");
+        nonNull(value, "value");
+        return new Filter() {
+            @Override
+            public String toString() {
+                return label + "!=" + value;
+            }
+        };
+    }
+
+    /**
+     * Creates a {@code label=}, selecting samples containing the given label.
+     *
+     * @param label the label, must not be {@code null}
+     * @return the filter
+     */
+    static Filter withLabel(String label) {
+        nonNull(label, "label");
+        return new Filter() {
+            @Override
+            public String toString() {
+                return label + "=";
+            }
+        };
+    }
+
+    /**
+     * Creates a {@code label!=}, selecting samples that do not have the given label.
+     *
+     * @param label the label, must not be {@code null}
+     * @return the filter
+     */
+    static Filter withoutLabel(String label) {
+        nonNull(label, "label");
+        return new Filter() {
+            @Override
+            public String toString() {
+                return label + "!=";
+            }
+        };
+
+    }
+
+    /**
+     * Creates a {@code label=(value1,value2,...)}, selecting samples with the given label equals one of the values
+     * in the list
+     *
+     * @param label the label, must not be {@code null}
+     * @return the filter
+     */
+    static Filter withLabelHavingValueFrom(String label, String... values) {
+        nonNull(label, "label");
+        doesNotContainNull(values, "values");
+        return new Filter() {
+            @Override
+            public String toString() {
+                return label + "=(" + String.join(",", values) + ")";
+            }
+        };
+    }
+
+    /**
+     * Creates a {@code label!=(value1,value2,...)}, selecting samples with the given label with a value not equal to
+     * any of the values in the list.
+     *
+     * @param label the label, must not be {@code null}
+     * @param values the values
+     * @return the filter
+     */
+    static Filter withLabelNotHavingValueFrom(String label, String... values) {
+        nonNull(label, "label");
+        doesNotContainNull(values, "values");
+        return new Filter() {
+            @Override
+            public String toString() {
+                return label + "!=(" + String.join(",", values) + ")";
+            }
+        };
+    }
+
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/IncrementArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/IncrementArgs.java
@@ -1,0 +1,132 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.RedisCommandExtraArguments;
+
+/**
+ * Represents the extra arguments of the {@code ts.decrby} and {@code tx.incrby} commands.
+ */
+public class IncrementArgs implements RedisCommandExtraArguments {
+
+    private long timestamp = -1;
+
+    private Duration retention;
+
+    private boolean uncompressed;
+
+    private int chunkSize;
+    private final Map<String, Object> labels = new HashMap<>();
+
+    /**
+     * Set (integer) UNIX sample timestamp in milliseconds.
+     * <p>
+     * timestamp must be equal to or higher than the maximum existing timestamp. When equal, the value of the sample
+     * with the maximum existing timestamp is decreased. If it is higher, a new sample with a timestamp set to timestamp
+     * is created, and its value is set to the value of the sample with the maximum existing timestamp minus value.
+     * <p>
+     * If the time series is empty, the value is set to {@code value}.
+     * <p>
+     * When not specified, the timestamp is set according to the server clock.
+     *
+     * @param value the value
+     * @return the current {@code IncrementArgs}
+     */
+    public IncrementArgs setTimestamp(long value) {
+        this.timestamp = value;
+        return this;
+    }
+
+    /**
+     * Set the maximum retention period, compared to the maximum existing timestamp, in milliseconds.
+     * <p>
+     * Use it only if you are creating a new time series.
+     * It is ignored if you are adding samples to an existing time series.
+     *
+     * @param retention the retention, must not be {@code null}
+     * @return the current {@code IncrementArgs}
+     */
+    public IncrementArgs setRetention(Duration retention) {
+        this.retention = nonNull(retention, "retention");
+        return this;
+    }
+
+    /**
+     * Changes data storage from compressed (default) to uncompressed.
+     * <p>
+     * Use it only if you are creating a new time series.
+     * It is ignored if you are adding samples to an existing time series
+     *
+     * @return the current {@code IncrementArgs}
+     */
+    public IncrementArgs uncompressed() {
+        this.uncompressed = true;
+        return this;
+    }
+
+    /**
+     * Sets memory size, in bytes, allocated for each data chunk. Use it only if you are creating a new time series.
+     * It is ignored if you are adding samples to an existing time series.
+     *
+     * @param size the chunk size, between 48 and 1048576
+     * @return the current {@code IncrementArgs}
+     */
+    public IncrementArgs chunkSize(int size) {
+        this.chunkSize = size;
+        return this;
+    }
+
+    /**
+     * Set a label-value pairs that represent metadata labels of the time series.
+     *
+     * @param label the label, must not be {@code null}
+     * @param value the value, must not be {@code  null}
+     * @return the current {@code IncrementArgs}
+     */
+    public IncrementArgs label(String label, Object value) {
+        labels.put(label, value);
+        return this;
+    }
+
+    @Override
+    public List<String> toArgs() {
+        List<String> list = new ArrayList<>();
+        if (timestamp >= 0) {
+            list.add("TIMESTAMP");
+            list.add(Long.toString(timestamp));
+        }
+        if (retention != null) {
+            list.add("RETENTION");
+            if (retention == Duration.ZERO) {
+                list.add("0");
+            } else {
+                list.add(Long.toString(retention.toMillis()));
+            }
+        }
+
+        if (uncompressed) {
+            list.add("UNCOMPRESSED");
+        }
+
+        if (chunkSize > 0) {
+            list.add("CHUNK_SIZE");
+            list.add(Integer.toString(chunkSize));
+        }
+
+        if (!labels.isEmpty()) {
+            list.add("LABELS");
+            for (Map.Entry<String, Object> entry : labels.entrySet()) {
+                list.add(entry.getKey());
+                list.add(entry.getValue().toString());
+            }
+        }
+
+        return list;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/MGetArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/MGetArgs.java
@@ -1,0 +1,77 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.redis.datasource.RedisCommandExtraArguments;
+
+/**
+ * Represents the extra arguments of the {@code ts.mget} command.
+ */
+public class MGetArgs implements RedisCommandExtraArguments {
+
+    private boolean latest;
+
+    private boolean withLabels;
+
+    private final List<String> selectedLabels = new ArrayList<>();
+
+    /**
+     * With LATEST, TS.MGET also reports the compacted value of the latest possibly partial bucket, given that this
+     * bucket's start time falls within [fromTimestamp, toTimestamp]. Without LATEST, TS.MGET does not report the
+     * latest possibly partial bucket. When a time series is not a compaction, LATEST is ignored.
+     *
+     * @return the current {@code MGetArgs}
+     */
+    public MGetArgs latest() {
+        this.latest = true;
+        return this;
+    }
+
+    /**
+     * includes in the reply all label-value pairs representing metadata labels of the time series.
+     * If WITHLABELS or SELECTED_LABELS are not specified, by default, an empty list is reported as label-value pairs.
+     *
+     * @return the current {@code MGetArgs}
+     */
+    public MGetArgs withLabels() {
+        this.withLabels = true;
+        return this;
+    }
+
+    /**
+     * Add a label to the list of selected label.
+     * Returns a subset of the label-value pairs that represent metadata labels of the time series.
+     * Use when a large number of labels exists per series, but only the values of some of the labels are required.
+     * If WITHLABELS or SELECTED_LABELS are not specified, by default, an empty list is reported as label-value pairs.
+     *
+     * @param label the label to select
+     * @return the current {@code MGetArgs}
+     */
+    public MGetArgs selectedLabel(String label) {
+        selectedLabels.add(nonNull(label, "label"));
+        return this;
+    }
+
+    @Override
+    public List<String> toArgs() {
+        List<String> list = new ArrayList<>();
+        if (latest) {
+            list.add("LATEST");
+        }
+        if (withLabels) {
+            list.add("WITHLABELS");
+        }
+        if (!selectedLabels.isEmpty()) {
+            list.add("SELECTED_LABELS");
+            list.addAll(selectedLabels);
+        }
+        if (withLabels && !selectedLabels.isEmpty()) {
+            throw new IllegalArgumentException("Cannot use `WITHLABELS` and `SELECTED_LABELS together");
+        }
+
+        return list;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/MRangeArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/MRangeArgs.java
@@ -1,0 +1,273 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.quarkus.redis.datasource.RedisCommandExtraArguments;
+
+/**
+ * Represent the {@code TS.MRANGE} and {@code TS.MREVRANGE} commands optional parameters.
+ */
+public class MRangeArgs implements RedisCommandExtraArguments {
+
+    private boolean latest;
+    private List<Long> filterByTimestamps;
+    private boolean filterByValue;
+    private double min;
+    private double max;
+    private boolean withLabels;
+    private String[] selectedLabels;
+    private int count = -1;
+    private String align;
+    private Aggregation aggregation;
+    private long bucketDuration;
+    private BucketTimestamp bucketTimestamp;
+    private boolean empty;
+    private String groupByLabel;
+    private Reducer reducer;
+
+    /**
+     * Used when a time series is a compaction. With LATEST, TS.MRANGE also reports the compacted value of the latest
+     * possibly partial bucket, given that this bucket's start time falls within [fromTimestamp, toTimestamp].
+     * Without LATEST, TS.MRANGE does not report the latest possibly partial bucket. When a time series is not a
+     * compaction, LATEST is ignored.
+     *
+     * @return the current {@code MRangeArgs}
+     */
+    public MRangeArgs latest() {
+        this.latest = true;
+        return this;
+    }
+
+    /**
+     * Filters samples by a list of specific timestamps.
+     * A sample passes the filter if its exact timestamp is specified and falls within [fromTimestamp, toTimestamp].
+     *
+     * @param timestamps the timestamps
+     * @return the current {@code MRangeArgs}
+     */
+    public MRangeArgs filterByTimestamp(long... timestamps) {
+        if (filterByTimestamps == null) {
+            filterByTimestamps = new ArrayList<>(timestamps.length);
+        }
+        for (long timestamp : timestamps) {
+            if (timestamp < 0) {
+                throw new IllegalArgumentException("The timestamp must be positive");
+            }
+            filterByTimestamps.add(timestamp);
+        }
+        return this;
+    }
+
+    /**
+     * Filters samples by minimum and maximum values.
+     *
+     * @param min the min value of the sample
+     * @param max the max value of the sample
+     * @return the current {@code MRangeArgs}
+     */
+    public MRangeArgs filterByValue(double min, double max) {
+        this.filterByValue = true;
+        this.min = min;
+        this.max = max;
+
+        return this;
+    }
+
+    /**
+     * Includes in the reply all label-value pairs representing metadata labels of the time series.
+     * If WITHLABELS or SELECTED_LABELS are not specified, by default, an empty list is reported as label-value pairs.
+     *
+     * @return the current {@code MRangeArgs}
+     */
+    public MRangeArgs withLabels() {
+        this.withLabels = true;
+        return this;
+    }
+
+    /**
+     * Returns a subset of the label-value pairs that represent metadata labels of the time series.
+     * Use when a large number of labels exists per series, but only the values of some of the labels are required.
+     * <p>
+     * If WITHLABELS or SELECTED_LABELS are not specified, by default, an empty list is reported as label-value pairs.
+     *
+     * @param labels the set of labels to select
+     * @return the current {@code MRangeArgs}
+     */
+    public MRangeArgs selectedLabels(String... labels) {
+        doesNotContainNull(labels, "labels");
+        this.selectedLabels = labels;
+        return this;
+    }
+
+    /**
+     * Limits the number of returned samples.
+     *
+     * @param count the max number of samples to return
+     * @return the current {@code MRangeArgs}
+     */
+    public MRangeArgs count(int count) {
+        this.count = count;
+        return this;
+    }
+
+    /**
+     * Set the time bucket alignment control for AGGREGATION.
+     * It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
+     *
+     * @param timestamp the timestamp
+     * @return the current {@code MRangeArgs}
+     */
+    public MRangeArgs align(long timestamp) {
+        this.align = Long.toString(timestamp);
+        return this;
+    }
+
+    /**
+     * Set the time bucket alignment control for AGGREGATION to the query start interval time (fromTimestamp).
+     * It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
+     *
+     * @return the current {@code MRangeArgs}
+     */
+    public MRangeArgs alignUsingRangeStart() {
+        this.align = "-";
+        return this;
+    }
+
+    /**
+     * Set the time bucket alignment control for AGGREGATION to the query end interval time (toTimestamp).
+     * It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
+     *
+     * @return the current {@code MRangeArgs}
+     */
+    public MRangeArgs alignUsingRangeEnd() {
+        this.align = "+";
+        return this;
+    }
+
+    /**
+     * Aggregates results into time buckets.
+     *
+     * @param aggregation the aggregation function, must not be {@code null}
+     * @param bucketDuration the duration of each bucket, must not be {@code null}
+     * @return the current {@code MRangeArgs}
+     */
+    public MRangeArgs aggregation(Aggregation aggregation, Duration bucketDuration) {
+        this.aggregation = nonNull(aggregation, "aggregation");
+        this.bucketDuration = positive(nonNull(bucketDuration, "bucketDuration").toMillis(), "bucketDuration");
+        return this;
+    }
+
+    /**
+     * Controls how bucket timestamps are reported.
+     *
+     * @param ts the bucket timestamp configuration, must not be {@code null}
+     * @return the current {@code MRangeArgs}
+     */
+    public MRangeArgs bucketTimestamp(BucketTimestamp ts) {
+        this.bucketTimestamp = ts;
+        return this;
+    }
+
+    /**
+     * When specified, reports aggregations also for empty buckets.
+     *
+     * @return the current {@code MRangeArgs}
+     */
+    public MRangeArgs empty() {
+        this.empty = true;
+        return this;
+    }
+
+    /**
+     * Aggregates results across different time series, grouped by the provided label name.
+     * When combined with AGGREGATION the groupby/reduce is applied post aggregation stage.
+     * <p>
+     * {@code label} is label name to group a series by. A new series for each value is produced.
+     * {@code reducer} is the reducer type used to aggregate series that share the same label value.
+     *
+     * @param label the label, must not be {@code null}
+     * @param reducer the reducer function, must not be {@code null}
+     * @return the current {@code MRangeArgs}
+     */
+    public MRangeArgs groupBy(String label, Reducer reducer) {
+        this.groupByLabel = nonNull(label, "label");
+        this.reducer = nonNull(reducer, "reducer");
+        return this;
+    }
+
+    @Override
+    public List<String> toArgs() {
+        List<String> list = new ArrayList<>();
+
+        if (latest) {
+            list.add("LATEST");
+        }
+
+        if (filterByTimestamps != null && !filterByTimestamps.isEmpty()) {
+            list.add("FILTER_BY_TS");
+            for (Long ts : filterByTimestamps) {
+                list.add(Long.toString(ts));
+            }
+        }
+
+        if (filterByValue) {
+            list.add("FILTER_BY_VALUE");
+            list.add(Double.toString(min)); // TODO Check format
+            list.add(Double.toString(max));
+        }
+
+        if (withLabels) {
+            list.add("WITHLABELS");
+        }
+
+        if (selectedLabels != null && selectedLabels.length != 0) {
+            if (withLabels) {
+                throw new IllegalArgumentException("Cannot combine `WITHLABELS` and `SELECTED_LABELS`");
+            }
+
+            list.add("SELECTED_LABELS");
+            list.addAll(Arrays.asList(selectedLabels));
+        }
+
+        if (count != -1) {
+            list.add("COUNT");
+            list.add(Integer.toString(count));
+        }
+
+        if (aggregation != null) {
+            if (align != null) {
+                list.add("ALIGN");
+                list.add(align);
+            }
+
+            list.add("AGGREGATION");
+            list.add(aggregation.toString());
+            list.add(Long.toString(bucketDuration));
+
+            if (bucketTimestamp != null) {
+                list.add("BUCKETTIMESTAMP");
+                list.add(bucketTimestamp.toString());
+            }
+
+            if (empty) {
+                list.add("EMPTY");
+            }
+        }
+        return list;
+    }
+
+    public List<String> getGroupByClauseArgs() {
+        if (groupByLabel == null) {
+            return List.of();
+        } else {
+            return List.of("GROUPBY", groupByLabel, "REDUCE", reducer.toString());
+        }
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/RangeArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/RangeArgs.java
@@ -1,0 +1,203 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.redis.datasource.RedisCommandExtraArguments;
+
+/**
+ * Represent the {@code TS.RANGE} and {@code TS.REVRANGE} commands optional parameters.
+ */
+public class RangeArgs implements RedisCommandExtraArguments {
+
+    private boolean latest;
+    private List<Long> filterByTimestamps;
+    private boolean filterByValue;
+    private double min;
+    private double max;
+    private int count = -1;
+    private String align;
+    private Aggregation aggregation;
+    private long bucketDuration;
+    private BucketTimestamp bucketTimestamp;
+    private boolean empty;
+
+    /**
+     * Used when a time series is a compaction. With LATEST, TS.MRANGE also reports the compacted value of the latest
+     * possibly partial bucket, given that this bucket's start time falls within [fromTimestamp, toTimestamp].
+     * Without LATEST, TS.MRANGE does not report the latest possibly partial bucket. When a time series is not a
+     * compaction, LATEST is ignored.
+     *
+     * @return the current {@code MRangeArgs}
+     */
+    public RangeArgs latest() {
+        this.latest = true;
+        return this;
+    }
+
+    /**
+     * Filters samples by a list of specific timestamps.
+     * A sample passes the filter if its exact timestamp is specified and falls within [fromTimestamp, toTimestamp].
+     *
+     * @param timestamps the timestamps
+     * @return the current {@code MRangeArgs}
+     */
+    public RangeArgs filterByTimestamp(long... timestamps) {
+        if (filterByTimestamps == null) {
+            filterByTimestamps = new ArrayList<>(timestamps.length);
+        }
+        for (long timestamp : timestamps) {
+            if (timestamp < 0) {
+                throw new IllegalArgumentException("The timestamp must be positive");
+            }
+            filterByTimestamps.add(timestamp);
+        }
+        return this;
+    }
+
+    /**
+     * Filters samples by minimum and maximum values.
+     *
+     * @param min the min value of the sample
+     * @param max the max value of the sample
+     * @return the current {@code MRangeArgs}
+     */
+    public RangeArgs filterByValue(double min, double max) {
+        this.filterByValue = true;
+        this.min = min;
+        this.max = max;
+
+        return this;
+    }
+
+    /**
+     * Limits the number of returned samples.
+     *
+     * @param count the max number of samples to return
+     * @return the current {@code MRangeArgs}
+     */
+    public RangeArgs count(int count) {
+        this.count = count;
+        return this;
+    }
+
+    /**
+     * Set the time bucket alignment control for AGGREGATION.
+     * It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
+     *
+     * @param timestamp the timestamp
+     * @return the current {@code MRangeArgs}
+     */
+    public RangeArgs align(long timestamp) {
+        this.align = Long.toString(timestamp);
+        return this;
+    }
+
+    /**
+     * Set the time bucket alignment control for AGGREGATION to the query start interval time (fromTimestamp).
+     * It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
+     *
+     * @return the current {@code MRangeArgs}
+     */
+    public RangeArgs alignUsingRangeStart() {
+        this.align = "-";
+        return this;
+    }
+
+    /**
+     * Set the time bucket alignment control for AGGREGATION to the query end interval time (toTimestamp).
+     * It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
+     *
+     * @return the current {@code MRangeArgs}
+     */
+    public RangeArgs alignUsingRangeEnd() {
+        this.align = "+";
+        return this;
+    }
+
+    /**
+     * Aggregates results into time buckets.
+     *
+     * @param aggregation the aggregation function, must not be {@code null}
+     * @param bucketDuration the duration of each bucket, must not be {@code null}
+     * @return the current {@code MRangeArgs}
+     */
+    public RangeArgs aggregation(Aggregation aggregation, Duration bucketDuration) {
+        this.aggregation = nonNull(aggregation, "aggregation");
+        this.bucketDuration = positive(nonNull(bucketDuration, "bucketDuration").toMillis(), "bucketDuration");
+        return this;
+    }
+
+    /**
+     * Controls how bucket timestamps are reported.
+     *
+     * @param ts the bucket timestamp configuration, must not be {@code null}
+     * @return the current {@code MRangeArgs}
+     */
+    public RangeArgs bucketTimestamp(BucketTimestamp ts) {
+        this.bucketTimestamp = ts;
+        return this;
+    }
+
+    /**
+     * When specified, reports aggregations also for empty buckets.
+     *
+     * @return the current {@code MRangeArgs}
+     */
+    public RangeArgs empty() {
+        this.empty = true;
+        return this;
+    }
+
+    @Override
+    public List<String> toArgs() {
+        List<String> list = new ArrayList<>();
+
+        if (latest) {
+            list.add("LATEST");
+        }
+
+        if (filterByTimestamps != null && !filterByTimestamps.isEmpty()) {
+            list.add("FILTER_BY_TS");
+            for (Long ts : filterByTimestamps) {
+                list.add(Long.toString(ts));
+            }
+        }
+
+        if (filterByValue) {
+            list.add("FILTER_BY_VALUE");
+            list.add(Double.toString(min)); // TODO Check format
+            list.add(Double.toString(max));
+        }
+
+        if (count != -1) {
+            list.add("COUNT");
+            list.add(Integer.toString(count));
+        }
+
+        if (aggregation != null) {
+            if (align != null) {
+                list.add("ALIGN");
+                list.add(align);
+            }
+
+            list.add("AGGREGATION");
+            list.add(aggregation.toString());
+            list.add(Long.toString(bucketDuration));
+
+            if (bucketTimestamp != null) {
+                list.add("BUCKETTIMESTAMP");
+                list.add(bucketTimestamp.toString());
+            }
+
+            if (empty) {
+                list.add("EMPTY");
+            }
+        }
+        return list;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/ReactiveTimeSeriesCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/ReactiveTimeSeriesCommands.java
@@ -1,0 +1,390 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Allows executing commands from the {@code time series} group (requires the Redis Time Series module from Redis stack).
+ * See <a href="https://redis.io/commands/?group=timeseries">the time series command list</a> for further information
+ * about these commands.
+ * <p>
+ *
+ * @param <K> the type of the key
+ */
+@Experimental("The commands from the time series group are experimental")
+public interface ReactiveTimeSeriesCommands<K> extends ReactiveRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.create/">TS.CREATE</a>.
+     * Summary: Create a new time series
+     * Group: time series
+     *
+     * @param key the key name for the time series must not be {@code null}
+     * @param args the creation arguments.
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsCreate(K key, CreateArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.create/">TS.CREATE</a>.
+     * Summary: Create a new time series
+     * Group: time series
+     *
+     * @param key the key name for the time series must not be {@code null}
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsCreate(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
+     * Summary: Append a sample to a time series
+     * Group: time series
+     *
+     * @param key the key name for the time series must not be {@code null}
+     * @param timestamp the (long) UNIX sample timestamp in milliseconds or {@code -1} to set the timestamp according
+     *        to the server clock.
+     * @param value the numeric data value of the sample.
+     * @param args the creation arguments.
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsAdd(K key, long timestamp, double value, AddArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
+     * Summary: Append a sample to a time series
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param timestamp the (long) UNIX sample timestamp in milliseconds
+     * @param value the numeric data value of the sample
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsAdd(K key, long timestamp, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
+     * Summary: Append a sample to a time series
+     * Group: time series
+     * <p>
+     * Unlike {@link #tsAdd(Object, long, double)}, set the timestamp according to the server clock.
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsAdd(K key, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.alter/">TS.ALTER</a>.
+     * Summary: Update the retention, chunk size, duplicate policy, and labels of an existing time series
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param args the alter parameters, must not be {@code null}
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsAlter(K key, AlterArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.createrule/">TS.CREATERULE</a>.
+     * Summary: Create a compaction rule
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param destKey the key name for destination (compacted) time series. It must be created before TS.CREATERULE
+     *        is called. Must not be {@code null}.
+     * @param aggregation the aggregation function, must not be {@code null}
+     * @param bucketDuration the duration of each bucket, must not be {@code null}
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.createrule/">TS.CREATERULE</a>.
+     * Summary: Create a compaction rule
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param destKey the key name for destination (compacted) time series. It must be created before TS.CREATERULE
+     *        is called. Must not be {@code null}.
+     * @param aggregation the aggregation function, must not be {@code null}
+     * @param bucketDuration the duration of each bucket, must not be {@code null}
+     * @param alignTimestamp when set, ensures that there is a bucket that starts exactly at alignTimestamp and aligns
+     *        all other buckets accordingly. It is expressed in milliseconds. The default value is 0 aligned
+     *        with the epoch. For example, if bucketDuration is 24 hours (24 * 3600 * 1000), setting
+     *        alignTimestamp to 6 hours after the epoch (6 * 3600 * 1000) ensures that each bucket’s
+     *        timeframe is [06:00 .. 06:00).
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration, long alignTimestamp);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.decrby/">TS.DECRBY</a>.
+     * Summary: Decrease the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given decrement
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsDecrBy(K key, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.decrby/">TS.DECRBY</a>.
+     * Summary: Decrease the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given decrement
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @param args the extra command parameters
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsDecrBy(K key, double value, IncrementArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.del/">TS.DEL</a>.
+     * Summary: Delete all samples between two timestamps for a given time series
+     * Group: time series
+     * <p>
+     * The given timestamp interval is closed (inclusive), meaning that samples whose timestamp equals the fromTimestamp
+     * or toTimestamp are also deleted.
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param fromTimestamp the start timestamp for the range deletion.
+     * @param toTimestamp the end timestamp for the range deletion.
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsDel(K key, long fromTimestamp, long toTimestamp);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.deleterule/">TS.DELETERULE</a>.
+     * Summary: Delete a compaction rule
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param destKey the key name for destination (compacted) time series. Note that the command does not delete the
+     *        compacted series. Must not be {@code null}
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsDeleteRule(K key, K destKey);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.get/">TS.GET</a>.
+     * Summary: Get the last sample
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @return A uni emitting a {@code Sample}, i.e. a couple containing the timestamp and the value.
+     **/
+    Uni<Sample> tsGet(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.get/">TS.GET</a>.
+     * Summary: Get the last sample
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param latest used when a time series is a compaction. With LATEST set to {@code true}, TS.MRANGE also reports
+     *        the compacted value of the latest possibly partial bucket, given that this bucket's start time
+     *        falls within [fromTimestamp, toTimestamp]. Without LATEST, TS.MRANGE does not report the latest
+     *        possibly partial bucket. When a time series is not a compaction, LATEST is ignored.
+     * @return A uni emitting a {@code Sample}, i.e. a couple containing the timestamp and the value.
+     **/
+    Uni<Sample> tsGet(K key, boolean latest);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.incrby/">TS.INCRBY</a>.
+     * Summary: Increase the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given increment.
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsIncrBy(K key, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.incrby/">TS.INCRBY</a>.
+     * Summary: Increase the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given increment.
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @param args the extra command parameters
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsIncrBy(K key, double value, IncrementArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.madd/">TS.MADD</a>.
+     * Summary: Append new samples to one or more time series
+     * Group: time series
+     *
+     * @param samples the set of samples to add to the time series.
+     * @return A uni emitting {@code null} when the operation completes
+     **/
+    Uni<Void> tsMAdd(SeriesSample<K>... samples);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mget/">TS.MGET</a>.
+     * Summary: Get the last samples matching a specific filter
+     * Group: time series
+     * <p>
+     *
+     * @param args the extra command parameter, must not be {@code null}
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A uni emitting a Map of {@code String -> SampleGroup}, containing the matching sample grouped by key.
+     *         The key is the string representation of the time series key.
+     **/
+    Uni<Map<String, SampleGroup>> tsMGet(MGetArgs args, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mget/">TS.MGET</a>.
+     * Summary: Get the last samples matching a specific filter
+     * Group: time series
+     * <p>
+     *
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A uni emitting a Map of {@code String -> SampleGroup}, containing the matching sample grouped by key.
+     *         The key is the string representation of the time series key.
+     **/
+    Uni<Map<String, SampleGroup>> tsMGet(Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrange/">TS.MRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A uni emitting a Map of {@code String -> SampleGroup}, containing the matching sample grouped by key.
+     *         The key is the string representation of the time series key.
+     **/
+    Uni<Map<String, SampleGroup>> tsMRange(TimeSeriesRange range, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrange/">TS.MRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A uni emitting a Map of {@code String -> SampleGroup}, containing the matching sample grouped by key.
+     *         The key is the string representation of the time series key.
+     **/
+    Uni<Map<String, SampleGroup>> tsMRange(TimeSeriesRange range, MRangeArgs args, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrevrange/">TS.MREVRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A uni emitting a Map of {@code String -> SampleGroup}, containing the matching sample grouped by key.
+     *         The key is the string representation of the time series key.
+     **/
+    Uni<Map<String, SampleGroup>> tsMRevRange(TimeSeriesRange range, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrevrange/">TS.MREVRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A uni emitting a Map of {@code String -> SampleGroup}, containing the matching sample grouped by key.
+     *         The key is the string representation of the time series key.
+     **/
+    Uni<Map<String, SampleGroup>> tsMRevRange(TimeSeriesRange range, MRangeArgs args, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.queryindex/">TS.QUERYINDEX</a>.
+     * Summary: Get all time series keys matching a filter list
+     * Group: time series
+     *
+     * @param filters the filter, created from the {@link Filter} class. Must not be {@code null}, must not contain
+     *        {@code null}
+     * @return A uni emitting the list of keys containing time series matching the filters
+     **/
+    Uni<List<K>> tsQueryIndex(Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.range/">TS.RANGE</a>.
+     * Summary: Query a range in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @return A uni emitting the list of matching sample
+     **/
+    Uni<List<Sample>> tsRange(K key, TimeSeriesRange range);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.range/">TS.RANGE</a>.
+     * Summary: Query a range in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @return A uni emitting the list of matching sample
+     **/
+    Uni<List<Sample>> tsRange(K key, TimeSeriesRange range, RangeArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.revrange/">TS.REVRANGE</a>.
+     * Summary: Query a range in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @return A uni emitting the list of matching sample
+     **/
+    Uni<List<Sample>> tsRevRange(K key, TimeSeriesRange range);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.revrange/">TS.REVRANGE</a>.
+     * Summary: Query a range in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @return A uni emitting the list of matching sample
+     **/
+    Uni<List<Sample>> tsRevRange(K key, TimeSeriesRange range, RangeArgs args);
+
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/ReactiveTransactionalTimeSeriesCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/ReactiveTransactionalTimeSeriesCommands.java
@@ -1,0 +1,408 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import java.time.Duration;
+
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Allows executing commands from the {@code time series} group (requires the Redis Time Series module from Redis stack).
+ * See <a href="https://redis.io/commands/?group=timeseries">the time series command list</a> for further information
+ * about these commands.
+ * <p>
+ * This API is intended to be used in a Redis transaction ({@code MULTI}), thus, all command methods return {@code Uni<Void>}.
+ *
+ * @param <K> the type of the key
+ */
+public interface ReactiveTransactionalTimeSeriesCommands<K> extends ReactiveTransactionalRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.create/">TS.CREATE</a>.
+     * Summary: Create a new time series
+     * Group: time series
+     *
+     * @param key the key name for the time series must not be {@code null}
+     * @param args the creation arguments.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsCreate(K key, CreateArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.create/">TS.CREATE</a>.
+     * Summary: Create a new time series
+     * Group: time series
+     *
+     * @param key the key name for the time series must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsCreate(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
+     * Summary: Append a sample to a time series
+     * Group: time series
+     *
+     * @param key the key name for the time series must not be {@code null}
+     * @param timestamp the (long) UNIX sample timestamp in milliseconds or {@code -1} to set the timestamp according
+     *        to the server clock.
+     * @param value the numeric data value of the sample.
+     * @param args the creation arguments.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsAdd(K key, long timestamp, double value, AddArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
+     * Summary: Append a sample to a time series
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param timestamp the (long) UNIX sample timestamp in milliseconds
+     * @param value the numeric data value of the sample
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsAdd(K key, long timestamp, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
+     * Summary: Append a sample to a time series
+     * Group: time series
+     * <p>
+     * Unlike {@link #tsAdd(Object, long, double)}, set the timestamp according to the server clock.
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsAdd(K key, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.alter/">TS.ALTER</a>.
+     * Summary: Update the retention, chunk size, duplicate policy, and labels of an existing time series
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param args the alter parameters, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsAlter(K key, AlterArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.createrule/">TS.CREATERULE</a>.
+     * Summary: Create a compaction rule
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param destKey the key name for destination (compacted) time series. It must be created before TS.CREATERULE
+     *        is called. Must not be {@code null}.
+     * @param aggregation the aggregation function, must not be {@code null}
+     * @param bucketDuration the duration of each bucket, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.createrule/">TS.CREATERULE</a>.
+     * Summary: Create a compaction rule
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param destKey the key name for destination (compacted) time series. It must be created before TS.CREATERULE
+     *        is called. Must not be {@code null}.
+     * @param aggregation the aggregation function, must not be {@code null}
+     * @param bucketDuration the duration of each bucket, must not be {@code null}
+     * @param alignTimestamp when set, ensures that there is a bucket that starts exactly at alignTimestamp and aligns
+     *        all other buckets accordingly. It is expressed in milliseconds. The default value is 0 aligned
+     *        with the epoch. For example, if bucketDuration is 24 hours (24 * 3600 * 1000), setting
+     *        alignTimestamp to 6 hours after the epoch (6 * 3600 * 1000) ensures that each bucket’s
+     *        timeframe is [06:00 .. 06:00).
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration, long alignTimestamp);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.decrby/">TS.DECRBY</a>.
+     * Summary: Decrease the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given decrement
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsDecrBy(K key, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.decrby/">TS.DECRBY</a>.
+     * Summary: Decrease the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given decrement
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @param args the extra command parameters
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsDecrBy(K key, double value, IncrementArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.del/">TS.DEL</a>.
+     * Summary: Delete all samples between two timestamps for a given time series
+     * Group: time series
+     * <p>
+     * The given timestamp interval is closed (inclusive), meaning that samples whose timestamp equals the fromTimestamp
+     * or toTimestamp are also deleted.
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param fromTimestamp the start timestamp for the range deletion.
+     * @param toTimestamp the end timestamp for the range deletion.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsDel(K key, long fromTimestamp, long toTimestamp);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.deleterule/">TS.DELETERULE</a>.
+     * Summary: Delete a compaction rule
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param destKey the key name for destination (compacted) time series. Note that the command does not delete the
+     *        compacted series. Must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsDeleteRule(K key, K destKey);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.get/">TS.GET</a>.
+     * Summary: Get the last sample
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsGet(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.get/">TS.GET</a>.
+     * Summary: Get the last sample
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param latest used when a time series is a compaction. With LATEST set to {@code true}, TS.MRANGE also reports
+     *        the compacted value of the latest possibly partial bucket, given that this bucket's start time
+     *        falls within [fromTimestamp, toTimestamp]. Without LATEST, TS.MRANGE does not report the latest
+     *        possibly partial bucket. When a time series is not a compaction, LATEST is ignored.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsGet(K key, boolean latest);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.incrby/">TS.INCRBY</a>.
+     * Summary: Increase the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given increment.
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsIncrBy(K key, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.incrby/">TS.INCRBY</a>.
+     * Summary: Increase the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given increment.
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @param args the extra command parameters
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsIncrBy(K key, double value, IncrementArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.madd/">TS.MADD</a>.
+     * Summary: Append new samples to one or more time series
+     * Group: time series
+     *
+     * @param samples the set of samples to add to the time series.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsMAdd(SeriesSample<K>... samples);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mget/">TS.MGET</a>.
+     * Summary: Get the last samples matching a specific filter
+     * Group: time series
+     * <p>
+     *
+     * @param args the extra command parameter, must not be {@code null}
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsMGet(MGetArgs args, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mget/">TS.MGET</a>.
+     * Summary: Get the last samples matching a specific filter
+     * Group: time series
+     * <p>
+     *
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsMGet(Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrange/">TS.MRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsMRange(TimeSeriesRange range, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrange/">TS.MRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsMRange(TimeSeriesRange range, MRangeArgs args, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrevrange/">TS.MREVRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsMRevRange(TimeSeriesRange range, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrevrange/">TS.MREVRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsMRevRange(TimeSeriesRange range, MRangeArgs args, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.queryindex/">TS.QUERYINDEX</a>.
+     * Summary: Get all time series keys matching a filter list
+     * Group: time series
+     *
+     * @param filters the filter, created from the {@link Filter} class. Must not be {@code null}, must not contain
+     *        {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsQueryIndex(Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.range/">TS.RANGE</a>.
+     * Summary: Query a range in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsRange(K key, TimeSeriesRange range);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.range/">TS.RANGE</a>.
+     * Summary: Query a range in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsRange(K key, TimeSeriesRange range, RangeArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.revrange/">TS.REVRANGE</a>.
+     * Summary: Query a range in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsRevRange(K key, TimeSeriesRange range);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.revrange/">TS.REVRANGE</a>.
+     * Summary: Query a range in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> tsRevRange(K key, TimeSeriesRange range, RangeArgs args);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/Reducer.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/Reducer.java
@@ -1,0 +1,55 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import java.util.Locale;
+
+/**
+ * Time Series Reducer functions
+ */
+public enum Reducer {
+
+    /**
+     * per label value: arithmetic mean of all values
+     */
+    AVG,
+    /**
+     * per label value: sum of all values
+     */
+    SUM,
+    /**
+     * per label value: minimum value
+     */
+    MIN,
+    /**
+     * per label value: maximum value
+     */
+    MAX,
+    /**
+     * per label value: difference between the highest and the lowest value
+     */
+    RANGE,
+    /**
+     * per label value: number of values
+     */
+    COUNT,
+    /**
+     * per label value: population standard deviation of the values
+     */
+    STD_P,
+    /**
+     * per label value: sample standard deviation of the values
+     */
+    STD_S,
+    /**
+     * per label value: population variance of the values
+     */
+    VAR_P,
+    /**
+     * per label value: sample variance of the values
+     */
+    VAR_S;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/Sample.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/Sample.java
@@ -1,0 +1,50 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.positiveOrZero;
+
+import java.util.Objects;
+
+/**
+ * Represents a sample from a time series
+ */
+public class Sample {
+
+    public final long timestamp;
+    public final double value;
+
+    public Sample(long timestamp, double value) {
+        this.timestamp = positiveOrZero(timestamp, "timestamp");
+        this.value = value;
+    }
+
+    public long timestamp() {
+        return timestamp;
+    }
+
+    public double value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "Sample{" +
+                "timestamp=" + timestamp +
+                ", value=" + value +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Sample sample = (Sample) o;
+        return timestamp == sample.timestamp && Double.compare(sample.value, value) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timestamp, value);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/SampleGroup.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/SampleGroup.java
@@ -1,0 +1,32 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represent a group of samples returned by the range of {@code mget} methods.
+ */
+public class SampleGroup {
+
+    private final String group;
+    private final Map<String, String> labels;
+    private final List<Sample> samples;
+
+    public SampleGroup(String group, Map<String, String> labels, List<Sample> samples) {
+        this.group = group;
+        this.labels = labels;
+        this.samples = samples;
+    }
+
+    public String group() {
+        return group;
+    }
+
+    public Map<String, String> labels() {
+        return labels;
+    }
+
+    public List<Sample> samples() {
+        return samples;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/SeriesSample.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/SeriesSample.java
@@ -1,0 +1,26 @@
+package io.quarkus.redis.datasource.timeseries;
+
+/**
+ * Represents a sample to be added to a specific time series {@code key}
+ */
+public class SeriesSample<K> extends Sample {
+
+    public final K key;
+
+    public SeriesSample(K key, long timestamp, double value) {
+        super(timestamp, value);
+        this.key = key;
+    }
+
+    public static <K> SeriesSample<K> from(K k, long ts, double val) {
+        return new SeriesSample<>(k, ts, val);
+    }
+
+    public static <K> SeriesSample<K> from(K k, double val) {
+        return new SeriesSample<>(k, Long.MAX_VALUE, val);
+    }
+
+    public K key() {
+        return key;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/TimeSeriesCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/TimeSeriesCommands.java
@@ -1,0 +1,374 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.RedisCommands;
+import io.smallrye.common.annotation.Experimental;
+
+/**
+ * Allows executing commands from the {@code time series} group (requires the Redis Time Series module from Redis stack).
+ * See <a href="https://redis.io/commands/?group=timeseries">the time series command list</a> for further information
+ * about these commands.
+ * <p>
+ *
+ * @param <K> the type of the key
+ */
+@Experimental("The time series command group is experimental")
+public interface TimeSeriesCommands<K> extends RedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.create/">TS.CREATE</a>.
+     * Summary: Create a new time series
+     * Group: time series
+     *
+     * @param key the key name for the time series must not be {@code null}
+     * @param args the creation arguments.
+     */
+    void tsCreate(K key, CreateArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.create/">TS.CREATE</a>.
+     * Summary: Create a new time series
+     * Group: time series
+     *
+     * @param key the key name for the time series must not be {@code null}
+     */
+    void tsCreate(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
+     * Summary: Append a sample to a time series
+     * Group: time series
+     *
+     * @param key the key name for the time series must not be {@code null}
+     * @param timestamp the (long) UNIX sample timestamp in milliseconds or {@code -1} to set the timestamp according
+     *        to the server clock.
+     * @param value the numeric data value of the sample.
+     * @param args the creation arguments.
+     */
+    void tsAdd(K key, long timestamp, double value, AddArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
+     * Summary: Append a sample to a time series
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param timestamp the (long) UNIX sample timestamp in milliseconds
+     * @param value the numeric data value of the sample
+     */
+    void tsAdd(K key, long timestamp, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
+     * Summary: Append a sample to a time series
+     * Group: time series
+     * <p>
+     * Unlike {@link #tsAdd(Object, long, double)}, set the timestamp according to the server clock.
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     */
+    void tsAdd(K key, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.alter/">TS.ALTER</a>.
+     * Summary: Update the retention, chunk size, duplicate policy, and labels of an existing time series
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param args the alter parameters, must not be {@code null}
+     */
+    void tsAlter(K key, AlterArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.createrule/">TS.CREATERULE</a>.
+     * Summary: Create a compaction rule
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param destKey the key name for destination (compacted) time series. It must be created before TS.CREATERULE
+     *        is called. Must not be {@code null}.
+     * @param aggregation the aggregation function, must not be {@code null}
+     * @param bucketDuration the duration of each bucket, must not be {@code null}
+     */
+    void tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.createrule/">TS.CREATERULE</a>.
+     * Summary: Create a compaction rule
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param destKey the key name for destination (compacted) time series. It must be created before TS.CREATERULE
+     *        is called. Must not be {@code null}.
+     * @param aggregation the aggregation function, must not be {@code null}
+     * @param bucketDuration the duration of each bucket, must not be {@code null}
+     * @param alignTimestamp when set, ensures that there is a bucket that starts exactly at alignTimestamp and aligns
+     *        all other buckets accordingly. It is expressed in milliseconds. The default value is 0 aligned
+     *        with the epoch. For example, if bucketDuration is 24 hours (24 * 3600 * 1000), setting
+     *        alignTimestamp to 6 hours after the epoch (6 * 3600 * 1000) ensures that each bucket’s
+     *        timeframe is [06:00 .. 06:00).
+     */
+    void tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration, long alignTimestamp);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.decrby/">TS.DECRBY</a>.
+     * Summary: Decrease the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given decrement
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     */
+    void tsDecrBy(K key, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.decrby/">TS.DECRBY</a>.
+     * Summary: Decrease the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given decrement
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @param args the extra command parameters
+     */
+    void tsDecrBy(K key, double value, IncrementArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.del/">TS.DEL</a>.
+     * Summary: Delete all samples between two timestamps for a given time series
+     * Group: time series
+     * <p>
+     * The given timestamp interval is closed (inclusive), meaning that samples whose timestamp equals the fromTimestamp
+     * or toTimestamp are also deleted.
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param fromTimestamp the start timestamp for the range deletion.
+     * @param toTimestamp the end timestamp for the range deletion.
+     */
+    void tsDel(K key, long fromTimestamp, long toTimestamp);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.deleterule/">TS.DELETERULE</a>.
+     * Summary: Delete a compaction rule
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param destKey the key name for destination (compacted) time series. Note that the command does not delete the
+     *        compacted series. Must not be {@code null}
+     */
+    void tsDeleteRule(K key, K destKey);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.get/">TS.GET</a>.
+     * Summary: Get the last sample
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @return A uni emitting a {@code Sample}, i.e. a couple containing the timestamp and the value.
+     */
+    Sample tsGet(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.get/">TS.GET</a>.
+     * Summary: Get the last sample
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param latest used when a time series is a compaction. With LATEST set to {@code true}, TS.MRANGE also reports
+     *        the compacted value of the latest possibly partial bucket, given that this bucket's start time
+     *        falls within [fromTimestamp, toTimestamp]. Without LATEST, TS.MRANGE does not report the latest
+     *        possibly partial bucket. When a time series is not a compaction, LATEST is ignored.
+     * @return A uni emitting a {@code Sample}, i.e. a couple containing the timestamp and the value.
+     */
+    Sample tsGet(K key, boolean latest);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.incrby/">TS.INCRBY</a>.
+     * Summary: Increase the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given increment.
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     */
+    void tsIncrBy(K key, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.incrby/">TS.INCRBY</a>.
+     * Summary: Increase the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given increment.
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @param args the extra command parameters
+     */
+    void tsIncrBy(K key, double value, IncrementArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.madd/">TS.MADD</a>.
+     * Summary: Append new samples to one or more time series
+     * Group: time series
+     *
+     * @param samples the set of samples to add to the time series.
+     */
+    @SuppressWarnings("unchecked")
+    void tsMAdd(SeriesSample<K>... samples);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mget/">TS.MGET</a>.
+     * Summary: Get the last samples matching a specific filter
+     * Group: time series
+     * <p>
+     *
+     * @param args the extra command parameter, must not be {@code null}
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A uni emitting a Map of {@code String -> SampleGroup}, containing the matching sample grouped by key.
+     *         The key is the string representation of the time series key.
+     */
+    Map<String, SampleGroup> tsMGet(MGetArgs args, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mget/">TS.MGET</a>.
+     * Summary: Get the last samples matching a specific filter
+     * Group: time series
+     * <p>
+     *
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A uni emitting a Map of {@code String -> SampleGroup}, containing the matching sample grouped by key.
+     *         The key is the string representation of the time series key.
+     */
+    Map<String, SampleGroup> tsMGet(Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrange/">TS.MRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A uni emitting a Map of {@code String -> SampleGroup}, containing the matching sample grouped by key.
+     *         The key is the string representation of the time series key.
+     */
+    Map<String, SampleGroup> tsMRange(TimeSeriesRange range, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrange/">TS.MRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A uni emitting a Map of {@code String -> SampleGroup}, containing the matching sample grouped by key.
+     *         The key is the string representation of the time series key.
+     */
+    Map<String, SampleGroup> tsMRange(TimeSeriesRange range, MRangeArgs args, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrevrange/">TS.MREVRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A uni emitting a Map of {@code String -> SampleGroup}, containing the matching sample grouped by key.
+     *         The key is the string representation of the time series key.
+     */
+    Map<String, SampleGroup> tsMRevRange(TimeSeriesRange range, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrevrange/">TS.MREVRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     * @return A uni emitting a Map of {@code String -> SampleGroup}, containing the matching sample grouped by key.
+     *         The key is the string representation of the time series key.
+     */
+    Map<String, SampleGroup> tsMRevRange(TimeSeriesRange range, MRangeArgs args, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.queryindex/">TS.QUERYINDEX</a>.
+     * Summary: Get all time series keys matching a filter list
+     * Group: time series
+     *
+     * @param filters the filter, created from the {@link Filter} class. Must not be {@code null}, must not contain
+     *        {@code null}
+     * @return A uni emitting the list of keys containing time series matching the filters
+     */
+    List<K> tsQueryIndex(Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.range/">TS.RANGE</a>.
+     * Summary: Query a range in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @return A uni emitting the list of matching sample
+     */
+    List<Sample> tsRange(K key, TimeSeriesRange range);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.range/">TS.RANGE</a>.
+     * Summary: Query a range in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @return A uni emitting the list of matching sample
+     */
+    List<Sample> tsRange(K key, TimeSeriesRange range, RangeArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.revrange/">TS.REVRANGE</a>.
+     * Summary: Query a range in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @return A uni emitting the list of matching sample
+     */
+    List<Sample> tsRevRange(K key, TimeSeriesRange range);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.revrange/">TS.REVRANGE</a>.
+     * Summary: Query a range in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @return A uni emitting the list of matching sample
+     */
+    List<Sample> tsRevRange(K key, TimeSeriesRange range, RangeArgs args);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/TimeSeriesRange.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/TimeSeriesRange.java
@@ -1,0 +1,64 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.positiveOrZero;
+
+import java.util.List;
+
+/**
+ * Represent the range used in the {@code TS.MRANGE} and {@code TS.MREVRANGE} commands.
+ */
+public class TimeSeriesRange {
+
+    private final long start;
+    private final long end;
+
+    private TimeSeriesRange(long s, long e) {
+        this.start = positiveOrZero(s, "start");
+        this.end = positiveOrZero(e, "end");
+    }
+
+    /**
+     * Creates a time series range using the given timestamps
+     *
+     * @param begin the beginning of the range
+     * @param end the end of the range
+     * @return the time series range
+     */
+    public static TimeSeriesRange fromTimestamps(long begin, long end) {
+        return new TimeSeriesRange(begin, end);
+    }
+
+    /**
+     * Creates a time series range using the earliest sample and latest sample of the time series as bound
+     *
+     * @return the time series range
+     */
+    public static TimeSeriesRange fromTimeSeries() {
+        return new TimeSeriesRange(Long.MAX_VALUE, Long.MAX_VALUE);
+    }
+
+    /**
+     * Creates a time series range going from the earliest sample of the series to the given timestamp
+     *
+     * @return the time series range
+     */
+    public static TimeSeriesRange fromEarliestToTimestamp(long end) {
+        return new TimeSeriesRange(Long.MAX_VALUE, end);
+    }
+
+    /**
+     * Creates a time series range going from the given timestamp to the latest sample of the series
+     *
+     * @return the time series range
+     */
+    public static TimeSeriesRange fromTimestampToLatest(long begin) {
+        return new TimeSeriesRange(begin, Long.MAX_VALUE);
+    }
+
+    public List<String> toArgs() {
+        return List.of(
+                start == Long.MAX_VALUE ? "-" : Long.toString(start),
+                end == Long.MAX_VALUE ? "+" : Long.toString(end));
+    }
+
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/TransactionalTimeSeriesCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/TransactionalTimeSeriesCommands.java
@@ -1,0 +1,351 @@
+package io.quarkus.redis.datasource.timeseries;
+
+import java.time.Duration;
+
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
+/**
+ * Allows executing commands from the {@code time series} group (requires the Redis Time Series module from Redis stack).
+ * See <a href="https://redis.io/commands/?group=timeseries">the time series command list</a> for further information
+ * about these commands.
+ * <p>
+ * This API is intended to be used in a Redis transaction ({@code MULTI}), thus, all command methods return {@code void}.
+ *
+ * @param <K> the type of the key
+ */
+public interface TransactionalTimeSeriesCommands<K> extends TransactionalRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.create/">TS.CREATE</a>.
+     * Summary: Create a new time series
+     * Group: time series
+     *
+     * @param key the key name for the time series must not be {@code null}
+     * @param args the creation arguments.
+     */
+    void tsCreate(K key, CreateArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.create/">TS.CREATE</a>.
+     * Summary: Create a new time series
+     * Group: time series
+     *
+     * @param key the key name for the time series must not be {@code null}
+     */
+    void tsCreate(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
+     * Summary: Append a sample to a time series
+     * Group: time series
+     *
+     * @param key the key name for the time series must not be {@code null}
+     * @param timestamp the (long) UNIX sample timestamp in milliseconds or {@code -1} to set the timestamp according
+     *        to the server clock.
+     * @param value the numeric data value of the sample.
+     * @param args the creation arguments.
+     */
+    void tsAdd(K key, long timestamp, double value, AddArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
+     * Summary: Append a sample to a time series
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param timestamp the (long) UNIX sample timestamp in milliseconds
+     * @param value the numeric data value of the sample
+     */
+    void tsAdd(K key, long timestamp, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
+     * Summary: Append a sample to a time series
+     * Group: time series
+     * <p>
+     * Unlike {@link #tsAdd(Object, long, double)}, set the timestamp according to the server clock.
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     */
+    void tsAdd(K key, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.alter/">TS.ALTER</a>.
+     * Summary: Update the retention, chunk size, duplicate policy, and labels of an existing time series
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param args the alter parameters, must not be {@code null}
+     */
+    void tsAlter(K key, AlterArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.createrule/">TS.CREATERULE</a>.
+     * Summary: Create a compaction rule
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param destKey the key name for destination (compacted) time series. It must be created before TS.CREATERULE
+     *        is called. Must not be {@code null}.
+     * @param aggregation the aggregation function, must not be {@code null}
+     * @param bucketDuration the duration of each bucket, must not be {@code null}
+     */
+    void tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.createrule/">TS.CREATERULE</a>.
+     * Summary: Create a compaction rule
+     * Group: time series
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param destKey the key name for destination (compacted) time series. It must be created before TS.CREATERULE
+     *        is called. Must not be {@code null}.
+     * @param aggregation the aggregation function, must not be {@code null}
+     * @param bucketDuration the duration of each bucket, must not be {@code null}
+     * @param alignTimestamp when set, ensures that there is a bucket that starts exactly at alignTimestamp and aligns
+     *        all other buckets accordingly. It is expressed in milliseconds. The default value is 0 aligned
+     *        with the epoch. For example, if bucketDuration is 24 hours (24 * 3600 * 1000), setting
+     *        alignTimestamp to 6 hours after the epoch (6 * 3600 * 1000) ensures that each bucket’s
+     *        timeframe is [06:00 .. 06:00).
+     */
+    void tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration, long alignTimestamp);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.decrby/">TS.DECRBY</a>.
+     * Summary: Decrease the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given decrement
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     */
+    void tsDecrBy(K key, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.decrby/">TS.DECRBY</a>.
+     * Summary: Decrease the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given decrement
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @param args the extra command parameters
+     */
+    void tsDecrBy(K key, double value, IncrementArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.del/">TS.DEL</a>.
+     * Summary: Delete all samples between two timestamps for a given time series
+     * Group: time series
+     * <p>
+     * The given timestamp interval is closed (inclusive), meaning that samples whose timestamp equals the fromTimestamp
+     * or toTimestamp are also deleted.
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param fromTimestamp the start timestamp for the range deletion.
+     * @param toTimestamp the end timestamp for the range deletion.
+     */
+    void tsDel(K key, long fromTimestamp, long toTimestamp);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.deleterule/">TS.DELETERULE</a>.
+     * Summary: Delete a compaction rule
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param destKey the key name for destination (compacted) time series. Note that the command does not delete the
+     *        compacted series. Must not be {@code null}
+     */
+    void tsDeleteRule(K key, K destKey);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.get/">TS.GET</a>.
+     * Summary: Get the last sample
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     */
+    void tsGet(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.get/">TS.GET</a>.
+     * Summary: Get the last sample
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param latest used when a time series is a compaction. With LATEST set to {@code true}, TS.MRANGE also reports
+     *        the compacted value of the latest possibly partial bucket, given that this bucket's start time
+     *        falls within [fromTimestamp, toTimestamp]. Without LATEST, TS.MRANGE does not report the latest
+     *        possibly partial bucket. When a time series is not a compaction, LATEST is ignored.
+     */
+    void tsGet(K key, boolean latest);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.incrby/">TS.INCRBY</a>.
+     * Summary: Increase the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given increment.
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     */
+    void tsIncrBy(K key, double value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.incrby/">TS.INCRBY</a>.
+     * Summary: Increase the value of the sample with the maximum existing timestamp, or create a new sample with a
+     * value equal to the value of the sample with the maximum existing timestamp with a given increment.
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series. must not be {@code null}
+     * @param value the numeric data value of the sample, must not be {@code null}
+     * @param args the extra command parameters
+     */
+    void tsIncrBy(K key, double value, IncrementArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.madd/">TS.MADD</a>.
+     * Summary: Append new samples to one or more time series
+     * Group: time series
+     *
+     * @param samples the set of samples to add to the time series.
+     */
+    void tsMAdd(SeriesSample<K>... samples);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mget/">TS.MGET</a>.
+     * Summary: Get the last samples matching a specific filter
+     * Group: time series
+     * <p>
+     *
+     * @param args the extra command parameter, must not be {@code null}
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     */
+    void tsMGet(MGetArgs args, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mget/">TS.MGET</a>.
+     * Summary: Get the last samples matching a specific filter
+     * Group: time series
+     * <p>
+     *
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     */
+    void tsMGet(Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrange/">TS.MRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     */
+    void tsMRange(TimeSeriesRange range, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrange/">TS.MRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     */
+    void tsMRange(TimeSeriesRange range, MRangeArgs args, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrevrange/">TS.MREVRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     */
+    void tsMRevRange(TimeSeriesRange range, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.mrevrange/">TS.MREVRANGE</a>.
+     * Summary: Query a range across multiple time series by filters in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     * @param filters the filters. Instanced are created using the static methods from {@link Filter}. Must not be
+     *        {@code null}, or contain a {@code null} value.
+     */
+    void tsMRevRange(TimeSeriesRange range, MRangeArgs args, Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.queryindex/">TS.QUERYINDEX</a>.
+     * Summary: Get all time series keys matching a filter list
+     * Group: time series
+     *
+     * @param filters the filter, created from the {@link Filter} class. Must not be {@code null}, must not contain
+     *        {@code null}
+     */
+    void tsQueryIndex(Filter... filters);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.range/">TS.RANGE</a>.
+     * Summary: Query a range in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     */
+    void tsRange(K key, TimeSeriesRange range);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.range/">TS.RANGE</a>.
+     * Summary: Query a range in forward direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     */
+    void tsRange(K key, TimeSeriesRange range, RangeArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.revrange/">TS.REVRANGE</a>.
+     * Summary: Query a range in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     */
+    void tsRevRange(K key, TimeSeriesRange range);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/ts.revrange/">TS.REVRANGE</a>.
+     * Summary: Query a range in reverse direction
+     * Group: time series
+     * <p>
+     *
+     * @param key the key name for the time series, must not be {@code null}
+     * @param range the range, must not be {@code null}
+     * @param args the extra command parameters
+     */
+    void tsRevRange(K key, TimeSeriesRange range, RangeArgs args);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
@@ -16,6 +16,7 @@ import io.quarkus.redis.datasource.search.ReactiveTransactionalSearchCommands;
 import io.quarkus.redis.datasource.set.ReactiveTransactionalSetCommands;
 import io.quarkus.redis.datasource.sortedset.ReactiveTransactionalSortedSetCommands;
 import io.quarkus.redis.datasource.string.ReactiveTransactionalStringCommands;
+import io.quarkus.redis.datasource.timeseries.ReactiveTransactionalTimeSeriesCommands;
 import io.quarkus.redis.datasource.topk.ReactiveTransactionalTopKCommands;
 import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
 import io.smallrye.common.annotation.Experimental;
@@ -451,6 +452,27 @@ public interface ReactiveTransactionalRedisDataSource {
     @Experimental("The Redis auto-suggest support is experimental")
     default ReactiveTransactionalAutoSuggestCommands<String> autosuggest() {
         return autosuggest(String.class);
+    }
+
+    /**
+     * Gets the object to emit commands from the {@code time series} group.
+     * This group requires the <a href="https://redis.io/docs/stack/timeseries/">Redis Time Series module</a>.
+     *
+     * @param <K> the type of keys
+     * @return the object to manipulate time series
+     */
+    @Experimental("The Redis time series support is experimental")
+    <K> ReactiveTransactionalTimeSeriesCommands<K> timeseries(Class<K> redisKeyType);
+
+    /**
+     * Gets the object to emit commands from the {@code time series} group.
+     * This group requires the <a href="https://redis.io/docs/stack/timeseries/">Redis Time Series module</a>.
+     *
+     * @return the object to manipulate time series
+     */
+    @Experimental("The Redis time series support is experimental")
+    default ReactiveTransactionalTimeSeriesCommands<String> timeseries() {
+        return timeseries(String.class);
     }
 
     /**

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
@@ -16,6 +16,7 @@ import io.quarkus.redis.datasource.search.TransactionalSearchCommands;
 import io.quarkus.redis.datasource.set.TransactionalSetCommands;
 import io.quarkus.redis.datasource.sortedset.TransactionalSortedSetCommands;
 import io.quarkus.redis.datasource.string.TransactionalStringCommands;
+import io.quarkus.redis.datasource.timeseries.TransactionalTimeSeriesCommands;
 import io.quarkus.redis.datasource.topk.TransactionalTopKCommands;
 import io.quarkus.redis.datasource.value.TransactionalValueCommands;
 import io.smallrye.common.annotation.Experimental;
@@ -449,6 +450,27 @@ public interface TransactionalRedisDataSource {
     @Experimental("The Redis auto-suggest support is experimental")
     default TransactionalAutoSuggestCommands<String> autosuggest() {
         return autosuggest(String.class);
+    }
+
+    /**
+     * Gets the object to emit commands from the {@code time series} group.
+     * This group requires the <a href="https://redis.io/docs/stack/timeseries/">Redis Time Series module</a>.
+     *
+     * @param <K> the type of keys
+     * @return the object to manipulate time series
+     */
+    @Experimental("The Redis time series support is experimental")
+    <K> TransactionalTimeSeriesCommands<K> timeseries(Class<K> redisKeyType);
+
+    /**
+     * Gets the object to emit commands from the {@code time series} group.
+     * This group requires the <a href="https://redis.io/docs/stack/timeseries/">Redis Time Series module</a>.
+     *
+     * @return the object to manipulate time series
+     */
+    @Experimental("The Redis time series support is experimental")
+    default TransactionalTimeSeriesCommands<String> timeseries() {
+        return timeseries(String.class);
     }
 
     /**

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTimeSeriesCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTimeSeriesCommands.java
@@ -1,0 +1,337 @@
+package io.quarkus.redis.runtime.datasource;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
+
+import java.time.Duration;
+
+import io.quarkus.redis.datasource.timeseries.AddArgs;
+import io.quarkus.redis.datasource.timeseries.Aggregation;
+import io.quarkus.redis.datasource.timeseries.AlterArgs;
+import io.quarkus.redis.datasource.timeseries.CreateArgs;
+import io.quarkus.redis.datasource.timeseries.Filter;
+import io.quarkus.redis.datasource.timeseries.IncrementArgs;
+import io.quarkus.redis.datasource.timeseries.MGetArgs;
+import io.quarkus.redis.datasource.timeseries.MRangeArgs;
+import io.quarkus.redis.datasource.timeseries.RangeArgs;
+import io.quarkus.redis.datasource.timeseries.SeriesSample;
+import io.quarkus.redis.datasource.timeseries.TimeSeriesRange;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Command;
+import io.vertx.mutiny.redis.client.Response;
+
+public class AbstractTimeSeriesCommands<K> extends AbstractRedisCommands {
+
+    AbstractTimeSeriesCommands(RedisCommandExecutor redis, Class<K> k) {
+        super(redis, new Marshaller(k));
+    }
+
+    Uni<Response> _tsCreate(K key, CreateArgs args) {
+        nonNull(key, "key");
+        nonNull(args, "args");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_CREATE).put(marshaller.encode(key)).putArgs(args);
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsCreate(K key) {
+        nonNull(key, "key");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_CREATE).put(marshaller.encode(key));
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsAdd(K key, long timestamp, double value, AddArgs args) {
+        nonNull(key, "key");
+        positive(timestamp, "timestamp");
+        nonNull(args, "args");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_ADD).put(marshaller.encode(key)).put(timestamp).put(value).putArgs(args);
+
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsAdd(K key, long timestamp, double value) {
+        nonNull(key, "key");
+        positive(timestamp, "timestamp");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_ADD).put(marshaller.encode(key)).put(timestamp).put(value);
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsAdd(K key, double value) {
+        nonNull(key, "key");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_ADD).put(marshaller.encode(key)).put("*").put(value);
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsAlter(K key, AlterArgs args) {
+        nonNull(key, "key");
+        nonNull(args, "args");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_ALTER).put(marshaller.encode(key)).putArgs(args);
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration) {
+        nonNull(key, "key");
+        nonNull(destKey, "destKey");
+        nonNull(aggregation, "aggregation");
+        nonNull(bucketDuration, "bucketDuration");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_CREATERULE).put(marshaller.encode(key)).put(marshaller.encode(destKey))
+                .put("AGGREGATION").put(aggregation.toString()).put(bucketDuration.toMillis());
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration, long alignTimestamp) {
+        nonNull(key, "key");
+        nonNull(destKey, "destKey");
+        nonNull(aggregation, "aggregation");
+        nonNull(bucketDuration, "bucketDuration");
+        positive(alignTimestamp, "alignTimestamp");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_CREATERULE)
+                .put(marshaller.encode(key))
+                .put(marshaller.encode(destKey))
+                .put("AGGREGATION")
+                .put(aggregation.toString()).put(bucketDuration.toMillis())
+                .put(alignTimestamp);
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsDecrBy(K key, double value) {
+
+        nonNull(key, "key");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_DECRBY).put(marshaller.encode(key)).put(value);
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsDecrBy(K key, double value, IncrementArgs args) {
+        nonNull(key, "key");
+        nonNull(args, "args");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_DECRBY).put(marshaller.encode(key)).put(value).putArgs(args);
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsDel(K key, long fromTimestamp, long toTimestamp) {
+        nonNull(key, "key");
+        positive(fromTimestamp, "fromTimestamp");
+        positive(toTimestamp, "toTimestamp");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_DEL).put(marshaller.encode(key)).put(fromTimestamp).put(toTimestamp);
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsDeleteRule(K key, K destKey) {
+        nonNull(key, "key");
+        nonNull(destKey, "destKey");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_DELETERULE).put(marshaller.encode(key)).put(marshaller.encode(destKey));
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsGet(K key) {
+        nonNull(key, "key");
+        RedisCommand cmd = RedisCommand.of(Command.TS_GET).put(marshaller.encode(key));
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsGet(K key, boolean latest) {
+        nonNull(key, "key");
+        RedisCommand cmd = RedisCommand.of(Command.TS_GET).put(marshaller.encode(key));
+        if (latest) {
+            cmd.put("LATEST");
+        }
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsIncrBy(K key, double value) {
+        nonNull(key, "key");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_INCRBY).put(marshaller.encode(key)).put(value);
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsIncrBy(K key, double value, IncrementArgs args) {
+        nonNull(key, "key");
+        nonNull(args, "args");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_INCRBY).put(marshaller.encode(key)).put(value).putArgs(args);
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsMAdd(SeriesSample<K>... samples) {
+        doesNotContainNull(samples, "samples");
+        if (samples.length == 0) {
+            throw new IllegalArgumentException("`samples` must not be empty");
+        }
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_MADD);
+        for (SeriesSample<K> sample : samples) {
+            cmd.put(marshaller.encode(sample.key));
+            if (sample.timestamp == Long.MAX_VALUE) {
+                cmd.put("*");
+            } else {
+                cmd.put(sample.timestamp);
+            }
+            cmd.put(sample.value);
+        }
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsMGet(MGetArgs args, Filter... filters) {
+        nonNull(args, "args");
+        doesNotContainNull(filters, "filters");
+        if (filters.length == 0) {
+            throw new IllegalArgumentException("`filters` must not be empty");
+        }
+        RedisCommand cmd = RedisCommand.of(Command.TS_MGET).putArgs(args);
+        cmd.put("FILTER");
+        for (Filter filter : filters) {
+            cmd.put(filter.toString());
+        }
+
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsMGet(Filter... filters) {
+        doesNotContainNull(filters, "filters");
+        if (filters.length == 0) {
+            throw new IllegalArgumentException("`filters` must not be empty");
+        }
+        RedisCommand cmd = RedisCommand.of(Command.TS_MGET);
+        cmd.put("FILTER");
+        for (Filter filter : filters) {
+            cmd.put(filter.toString());
+        }
+
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsMRange(TimeSeriesRange range, Filter... filters) {
+
+        nonNull(range, "range");
+        doesNotContainNull(filters, "filters");
+        if (filters.length == 0) {
+            throw new IllegalArgumentException("`filters` must not be empty");
+        }
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_MRANGE).putAll(range.toArgs());
+        cmd.put("FILTER");
+        for (Filter filter : filters) {
+            cmd.put(filter.toString());
+        }
+
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsMRange(TimeSeriesRange range, MRangeArgs args, Filter... filters) {
+
+        nonNull(range, "range");
+        nonNull(args, "args");
+        doesNotContainNull(filters, "filters");
+        if (filters.length == 0) {
+            throw new IllegalArgumentException("`filters` must not be empty");
+        }
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_MRANGE).putAll(range.toArgs()).putArgs(args);
+        cmd.put("FILTER");
+        for (Filter filter : filters) {
+            cmd.put(filter.toString());
+        }
+        cmd.putAll(args.getGroupByClauseArgs());
+
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsMRevRange(TimeSeriesRange range, Filter... filters) {
+
+        nonNull(range, "range");
+        doesNotContainNull(filters, "filters");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_MREVRANGE).putAll(range.toArgs());
+        cmd.put("FILTER");
+        for (Filter filter : filters) {
+            cmd.put(filter.toString());
+        }
+
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsMRevRange(TimeSeriesRange range, MRangeArgs args, Filter... filters) {
+
+        nonNull(args, "args");
+        nonNull(range, "range");
+        doesNotContainNull(filters, "filters");
+        if (filters.length == 0) {
+            throw new IllegalArgumentException("`filters` must not be empty");
+        }
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_MREVRANGE).putAll(range.toArgs()).putArgs(args);
+
+        cmd.put("FILTER");
+        for (Filter filter : filters) {
+            cmd.put(filter.toString());
+        }
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsQueryIndex(Filter... filters) {
+
+        doesNotContainNull(filters, "filters");
+        if (filters.length == 0) {
+            throw new IllegalArgumentException("`filters` must not be empty");
+        }
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_QUERYINDEX);
+        for (Filter filter : filters) {
+            cmd.put(filter.toString());
+        }
+
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsRange(K key, TimeSeriesRange range) {
+
+        nonNull(key, "key");
+        nonNull(range, "range");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_RANGE).put(marshaller.encode(key)).putAll(range.toArgs());
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsRange(K key, TimeSeriesRange range, RangeArgs args) {
+
+        nonNull(key, "key");
+        nonNull(range, "range");
+        nonNull(args, "args");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_RANGE).put(marshaller.encode(key)).putAll(range.toArgs()).putArgs(args);
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsRevRange(K key, TimeSeriesRange range) {
+
+        nonNull(key, "key");
+        nonNull(range, "range");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_REVRANGE).put(marshaller.encode(key)).putAll(range.toArgs());
+        return execute(cmd);
+    }
+
+    Uni<Response> _tsRevRange(K key, TimeSeriesRange range, RangeArgs args) {
+
+        nonNull(key, "key");
+        nonNull(range, "range");
+        nonNull(args, "args");
+
+        RedisCommand cmd = RedisCommand.of(Command.TS_REVRANGE).put(marshaller.encode(key)).putAll(range.toArgs())
+                .putArgs(args);
+        return execute(cmd);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
@@ -26,6 +26,7 @@ import io.quarkus.redis.datasource.search.SearchCommands;
 import io.quarkus.redis.datasource.set.SetCommands;
 import io.quarkus.redis.datasource.sortedset.SortedSetCommands;
 import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.timeseries.TimeSeriesCommands;
 import io.quarkus.redis.datasource.topk.TopKCommands;
 import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionResult;
@@ -267,6 +268,11 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
     @Override
     public <K> AutoSuggestCommands<K> autosuggest(Class<K> redisKeyType) {
         return new BlockingAutoSuggestCommandsImpl<>(this, reactive.autosuggest(redisKeyType), timeout);
+    }
+
+    @Override
+    public <K> TimeSeriesCommands<K> timeseries(Class<K> redisKeyType) {
+        return new BlockingTimeSeriesCommandsImpl<>(this, reactive.timeseries(redisKeyType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTimeSeriesCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTimeSeriesCommandsImpl.java
@@ -1,0 +1,172 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.datasource.timeseries.AddArgs;
+import io.quarkus.redis.datasource.timeseries.Aggregation;
+import io.quarkus.redis.datasource.timeseries.AlterArgs;
+import io.quarkus.redis.datasource.timeseries.CreateArgs;
+import io.quarkus.redis.datasource.timeseries.Filter;
+import io.quarkus.redis.datasource.timeseries.IncrementArgs;
+import io.quarkus.redis.datasource.timeseries.MGetArgs;
+import io.quarkus.redis.datasource.timeseries.MRangeArgs;
+import io.quarkus.redis.datasource.timeseries.RangeArgs;
+import io.quarkus.redis.datasource.timeseries.ReactiveTimeSeriesCommands;
+import io.quarkus.redis.datasource.timeseries.Sample;
+import io.quarkus.redis.datasource.timeseries.SampleGroup;
+import io.quarkus.redis.datasource.timeseries.SeriesSample;
+import io.quarkus.redis.datasource.timeseries.TimeSeriesCommands;
+import io.quarkus.redis.datasource.timeseries.TimeSeriesRange;
+
+public class BlockingTimeSeriesCommandsImpl<K> extends AbstractRedisCommandGroup implements TimeSeriesCommands<K> {
+
+    private final ReactiveTimeSeriesCommands<K> reactive;
+
+    public BlockingTimeSeriesCommandsImpl(RedisDataSource ds, ReactiveTimeSeriesCommands<K> reactive, Duration timeout) {
+        super(ds, timeout);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public void tsCreate(K key, CreateArgs args) {
+        reactive.tsCreate(key, args).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsCreate(K key) {
+        reactive.tsCreate(key).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsAdd(K key, long timestamp, double value, AddArgs args) {
+        reactive.tsAdd(key, timestamp, value, args).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsAdd(K key, long timestamp, double value) {
+        reactive.tsAdd(key, timestamp, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsAdd(K key, double value) {
+        reactive.tsAdd(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsAlter(K key, AlterArgs args) {
+        reactive.tsAlter(key, args).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration) {
+        reactive.tsCreateRule(key, destKey, aggregation, bucketDuration).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration, long alignTimestamp) {
+        reactive.tsCreateRule(key, destKey, aggregation, bucketDuration, alignTimestamp).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsDecrBy(K key, double value) {
+        reactive.tsDecrBy(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsDecrBy(K key, double value, IncrementArgs args) {
+        reactive.tsDecrBy(key, value, args).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsDel(K key, long fromTimestamp, long toTimestamp) {
+        reactive.tsDel(key, fromTimestamp, toTimestamp).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsDeleteRule(K key, K destKey) {
+        reactive.tsDeleteRule(key, destKey).await().atMost(timeout);
+    }
+
+    @Override
+    public Sample tsGet(K key) {
+        return reactive.tsGet(key).await().atMost(timeout);
+    }
+
+    @Override
+    public Sample tsGet(K key, boolean latest) {
+        return reactive.tsGet(key, latest).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsIncrBy(K key, double value) {
+        reactive.tsIncrBy(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsIncrBy(K key, double value, IncrementArgs args) {
+        reactive.tsIncrBy(key, value, args).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsMAdd(SeriesSample<K>... samples) {
+        reactive.tsMAdd(samples).await().atMost(timeout);
+    }
+
+    @Override
+    public Map<String, SampleGroup> tsMGet(MGetArgs args, Filter... filters) {
+        return reactive.tsMGet(args, filters).await().atMost(timeout);
+    }
+
+    @Override
+    public Map<String, SampleGroup> tsMGet(Filter... filters) {
+        return reactive.tsMGet(filters).await().atMost(timeout);
+    }
+
+    @Override
+    public Map<String, SampleGroup> tsMRange(TimeSeriesRange range, Filter... filters) {
+        return reactive.tsMRange(range, filters).await().atMost(timeout);
+    }
+
+    @Override
+    public Map<String, SampleGroup> tsMRange(TimeSeriesRange range, MRangeArgs args, Filter... filters) {
+        return reactive.tsMRange(range, args, filters).await().atMost(timeout);
+    }
+
+    @Override
+    public Map<String, SampleGroup> tsMRevRange(TimeSeriesRange range, Filter... filters) {
+        return reactive.tsMRevRange(range, filters).await().atMost(timeout);
+    }
+
+    @Override
+    public Map<String, SampleGroup> tsMRevRange(TimeSeriesRange range, MRangeArgs args, Filter... filters) {
+        return reactive.tsMRevRange(range, args, filters).await().atMost(timeout);
+    }
+
+    @Override
+    public List<K> tsQueryIndex(Filter... filters) {
+        return reactive.tsQueryIndex(filters).await().atMost(timeout);
+    }
+
+    @Override
+    public List<Sample> tsRange(K key, TimeSeriesRange range) {
+        return reactive.tsRange(key, range).await().atMost(timeout);
+    }
+
+    @Override
+    public List<Sample> tsRange(K key, TimeSeriesRange range, RangeArgs args) {
+        return reactive.tsRange(key, range, args).await().atMost(timeout);
+    }
+
+    @Override
+    public List<Sample> tsRevRange(K key, TimeSeriesRange range) {
+        return reactive.tsRevRange(key, range).await().atMost(timeout);
+    }
+
+    @Override
+    public List<Sample> tsRevRange(K key, TimeSeriesRange range, RangeArgs args) {
+        return reactive.tsRevRange(key, range, args).await().atMost(timeout);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
@@ -18,6 +18,7 @@ import io.quarkus.redis.datasource.search.TransactionalSearchCommands;
 import io.quarkus.redis.datasource.set.TransactionalSetCommands;
 import io.quarkus.redis.datasource.sortedset.TransactionalSortedSetCommands;
 import io.quarkus.redis.datasource.string.TransactionalStringCommands;
+import io.quarkus.redis.datasource.timeseries.TransactionalTimeSeriesCommands;
 import io.quarkus.redis.datasource.topk.TransactionalTopKCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
@@ -135,6 +136,11 @@ public class BlockingTransactionalRedisDataSourceImpl implements TransactionalRe
     @Override
     public <K> TransactionalAutoSuggestCommands<K> autosuggest(Class<K> redisKeyType) {
         return new BlockingTransactionalAutoSuggestCommandsImpl<>(this, reactive.autosuggest(redisKeyType), timeout);
+    }
+
+    @Override
+    public <K> TransactionalTimeSeriesCommands<K> timeseries(Class<K> redisKeyType) {
+        return new BlockingTransactionalTimeSeriesCommandsImpl<>(this, reactive.timeseries(redisKeyType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalTimeSeriesCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalTimeSeriesCommandsImpl.java
@@ -1,0 +1,170 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+
+import io.quarkus.redis.datasource.timeseries.AddArgs;
+import io.quarkus.redis.datasource.timeseries.Aggregation;
+import io.quarkus.redis.datasource.timeseries.AlterArgs;
+import io.quarkus.redis.datasource.timeseries.CreateArgs;
+import io.quarkus.redis.datasource.timeseries.Filter;
+import io.quarkus.redis.datasource.timeseries.IncrementArgs;
+import io.quarkus.redis.datasource.timeseries.MGetArgs;
+import io.quarkus.redis.datasource.timeseries.MRangeArgs;
+import io.quarkus.redis.datasource.timeseries.RangeArgs;
+import io.quarkus.redis.datasource.timeseries.ReactiveTransactionalTimeSeriesCommands;
+import io.quarkus.redis.datasource.timeseries.SeriesSample;
+import io.quarkus.redis.datasource.timeseries.TimeSeriesRange;
+import io.quarkus.redis.datasource.timeseries.TransactionalTimeSeriesCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
+
+public class BlockingTransactionalTimeSeriesCommandsImpl<K> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalTimeSeriesCommands<K> {
+
+    private final ReactiveTransactionalTimeSeriesCommands<K> reactive;
+
+    public BlockingTransactionalTimeSeriesCommandsImpl(TransactionalRedisDataSource ds,
+            ReactiveTransactionalTimeSeriesCommands<K> reactive, Duration timeout) {
+        super(ds, timeout);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public void tsCreate(K key, CreateArgs args) {
+        reactive.tsCreate(key, args).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsCreate(K key) {
+        reactive.tsCreate(key).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsAdd(K key, long timestamp, double value, AddArgs args) {
+        reactive.tsAdd(key, timestamp, value, args).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsAdd(K key, long timestamp, double value) {
+        reactive.tsAdd(key, timestamp, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsAdd(K key, double value) {
+        reactive.tsAdd(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsAlter(K key, AlterArgs args) {
+        reactive.tsAlter(key, args).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration) {
+        reactive.tsCreateRule(key, destKey, aggregation, bucketDuration).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration, long alignTimestamp) {
+        reactive.tsCreateRule(key, destKey, aggregation, bucketDuration, alignTimestamp).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsDecrBy(K key, double value) {
+        reactive.tsDecrBy(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsDecrBy(K key, double value, IncrementArgs args) {
+        reactive.tsDecrBy(key, value, args).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsDel(K key, long fromTimestamp, long toTimestamp) {
+        reactive.tsDel(key, fromTimestamp, toTimestamp).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsDeleteRule(K key, K destKey) {
+        reactive.tsDeleteRule(key, destKey).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsGet(K key) {
+        reactive.tsGet(key).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsGet(K key, boolean latest) {
+        reactive.tsGet(key, latest).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsIncrBy(K key, double value) {
+        reactive.tsIncrBy(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsIncrBy(K key, double value, IncrementArgs args) {
+        reactive.tsIncrBy(key, value, args).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsMAdd(SeriesSample<K>... samples) {
+        reactive.tsMAdd(samples).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsMGet(MGetArgs args, Filter... filters) {
+        reactive.tsMGet(args, filters).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsMGet(Filter... filters) {
+        reactive.tsMGet(filters).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsMRange(TimeSeriesRange range, Filter... filters) {
+        reactive.tsMRange(range, filters).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsMRange(TimeSeriesRange range, MRangeArgs args, Filter... filters) {
+        reactive.tsMRange(range, args, filters).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsMRevRange(TimeSeriesRange range, Filter... filters) {
+        reactive.tsMRevRange(range, filters).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsMRevRange(TimeSeriesRange range, MRangeArgs args, Filter... filters) {
+        reactive.tsMRevRange(range, args, filters).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsQueryIndex(Filter... filters) {
+        reactive.tsQueryIndex(filters).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsRange(K key, TimeSeriesRange range) {
+        reactive.tsRange(key, range).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsRange(K key, TimeSeriesRange range, RangeArgs args) {
+        reactive.tsRange(key, range, args).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsRevRange(K key, TimeSeriesRange range) {
+        reactive.tsRevRange(key, range).await().atMost(timeout);
+    }
+
+    @Override
+    public void tsRevRange(K key, TimeSeriesRange range, RangeArgs args) {
+        reactive.tsRevRange(key, range, args).await().atMost(timeout);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
@@ -27,6 +27,7 @@ import io.quarkus.redis.datasource.search.ReactiveSearchCommands;
 import io.quarkus.redis.datasource.set.ReactiveSetCommands;
 import io.quarkus.redis.datasource.sortedset.ReactiveSortedSetCommands;
 import io.quarkus.redis.datasource.string.ReactiveStringCommands;
+import io.quarkus.redis.datasource.timeseries.ReactiveTimeSeriesCommands;
 import io.quarkus.redis.datasource.topk.ReactiveTopKCommands;
 import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
@@ -328,6 +329,11 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     @Override
     public <K> ReactiveAutoSuggestCommands<K> autosuggest(Class<K> redisKeyType) {
         return new ReactiveAutoSuggestCommandsImpl<>(this, redisKeyType);
+    }
+
+    @Override
+    public <K> ReactiveTimeSeriesCommands<K> timeseries(Class<K> redisKeyType) {
+        return new ReactiveTimeSeriesCommandsImpl<>(this, redisKeyType);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTimeSeriesCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTimeSeriesCommandsImpl.java
@@ -1,0 +1,255 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.timeseries.AddArgs;
+import io.quarkus.redis.datasource.timeseries.Aggregation;
+import io.quarkus.redis.datasource.timeseries.AlterArgs;
+import io.quarkus.redis.datasource.timeseries.CreateArgs;
+import io.quarkus.redis.datasource.timeseries.Filter;
+import io.quarkus.redis.datasource.timeseries.IncrementArgs;
+import io.quarkus.redis.datasource.timeseries.MGetArgs;
+import io.quarkus.redis.datasource.timeseries.MRangeArgs;
+import io.quarkus.redis.datasource.timeseries.RangeArgs;
+import io.quarkus.redis.datasource.timeseries.ReactiveTimeSeriesCommands;
+import io.quarkus.redis.datasource.timeseries.Sample;
+import io.quarkus.redis.datasource.timeseries.SampleGroup;
+import io.quarkus.redis.datasource.timeseries.SeriesSample;
+import io.quarkus.redis.datasource.timeseries.TimeSeriesRange;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.ResponseType;
+
+public class ReactiveTimeSeriesCommandsImpl<K> extends AbstractTimeSeriesCommands<K>
+        implements ReactiveTimeSeriesCommands<K>, ReactiveRedisCommands {
+
+    private final ReactiveRedisDataSource reactive;
+    protected final Class<K> keyType;
+
+    public ReactiveTimeSeriesCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k) {
+        super(redis, k);
+        this.keyType = k;
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
+    }
+
+    @Override
+    public Uni<Void> tsCreate(K key, CreateArgs args) {
+        return super._tsCreate(key, args)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsCreate(K key) {
+        return super._tsCreate(key)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsAdd(K key, long timestamp, double value, AddArgs args) {
+        return super._tsAdd(key, timestamp, value, args)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsAdd(K key, long timestamp, double value) {
+        return super._tsAdd(key, timestamp, value)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsAdd(K key, double value) {
+        return super._tsAdd(key, value)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsAlter(K key, AlterArgs args) {
+        return super._tsAlter(key, args)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration) {
+        return super._tsCreateRule(key, destKey, aggregation, bucketDuration)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration, long alignTimestamp) {
+        return super._tsCreateRule(key, destKey, aggregation, bucketDuration, alignTimestamp)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsDecrBy(K key, double value) {
+        return super._tsDecrBy(key, value)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsDecrBy(K key, double value, IncrementArgs args) {
+        return super._tsDecrBy(key, value, args)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsDel(K key, long fromTimestamp, long toTimestamp) {
+        return super._tsDel(key, fromTimestamp, toTimestamp)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsDeleteRule(K key, K destKey) {
+        return super._tsDeleteRule(key, destKey)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Sample> tsGet(K key) {
+        return super._tsGet(key)
+                .map(this::decodeSample);
+    }
+
+    Sample decodeSample(Response response) {
+        if (response == null || response.size() == 0) {
+            return null;
+        }
+        return new Sample(response.get(0).toLong(), response.get(1).toDouble());
+    }
+
+    @Override
+    public Uni<Sample> tsGet(K key, boolean latest) {
+        return super._tsGet(key, latest)
+                .map(this::decodeSample);
+    }
+
+    @Override
+    public Uni<Void> tsIncrBy(K key, double value) {
+        return super._tsIncrBy(key, value)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsIncrBy(K key, double value, IncrementArgs args) {
+        return super._tsIncrBy(key, value, args)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsMAdd(SeriesSample<K>... samples) {
+        return super._tsMAdd(samples)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Map<String, SampleGroup>> tsMGet(MGetArgs args, Filter... filters) {
+        return super._tsMGet(args, filters)
+                .map(this::decodeGroup);
+    }
+
+    @Override
+    public Uni<Map<String, SampleGroup>> tsMGet(Filter... filters) {
+        return super._tsMGet(filters)
+                .map(this::decodeGroup);
+    }
+
+    Map<String, SampleGroup> decodeGroup(Response response) {
+        if (response == null) {
+            return null;
+        }
+        if (response.size() == 0) {
+            return Collections.emptyMap();
+        }
+        Map<String, SampleGroup> groups = new HashMap<>();
+        for (Response nested : response) {
+            // this should be the group
+            String group = nested.get(0).toString();
+            Map<String, String> labels = new HashMap<>();
+            List<Sample> samples = new ArrayList<>();
+            // labels are in 1
+            for (Response label : nested.get(1)) {
+                labels.put(label.get(0).toString(), label.get(1).toString());
+            }
+
+            // samples are in 2, either as a tuple or a list
+            for (Response sample : nested.get(2)) {
+                if (sample.type() == ResponseType.MULTI) {
+                    samples.add(decodeSample(sample));
+                } else {
+                    samples.add(new Sample(sample.toLong(), nested.get(2).get(1).toDouble()));
+                    break;
+                }
+            }
+
+            groups.put(group, new SampleGroup(group, labels, samples));
+        }
+
+        return groups;
+    }
+
+    @Override
+    public Uni<Map<String, SampleGroup>> tsMRange(TimeSeriesRange range, Filter... filters) {
+        return super._tsMRange(range, filters)
+                .map(this::decodeGroup);
+    }
+
+    @Override
+    public Uni<Map<String, SampleGroup>> tsMRange(TimeSeriesRange range, MRangeArgs args, Filter... filters) {
+        return super._tsMRange(range, args, filters)
+                .map(this::decodeGroup);
+    }
+
+    @Override
+    public Uni<Map<String, SampleGroup>> tsMRevRange(TimeSeriesRange range, Filter... filters) {
+        return super._tsMRevRange(range, filters)
+                .map(this::decodeGroup);
+    }
+
+    @Override
+    public Uni<Map<String, SampleGroup>> tsMRevRange(TimeSeriesRange range, MRangeArgs args, Filter... filters) {
+        return super._tsMRevRange(range, args, filters)
+                .map(this::decodeGroup);
+    }
+
+    @Override
+    public Uni<List<K>> tsQueryIndex(Filter... filters) {
+        return super._tsQueryIndex(filters)
+                .map(r -> marshaller.decodeAsList(r, keyType));
+    }
+
+    @Override
+    public Uni<List<Sample>> tsRange(K key, TimeSeriesRange range) {
+        return super._tsRange(key, range)
+                .map(r -> marshaller.decodeAsList(r, this::decodeSample));
+    }
+
+    @Override
+    public Uni<List<Sample>> tsRange(K key, TimeSeriesRange range, RangeArgs args) {
+        return super._tsRange(key, range, args)
+                .map(r -> marshaller.decodeAsList(r, this::decodeSample));
+    }
+
+    @Override
+    public Uni<List<Sample>> tsRevRange(K key, TimeSeriesRange range) {
+        return super._tsRevRange(key, range)
+                .map(r -> marshaller.decodeAsList(r, this::decodeSample));
+    }
+
+    @Override
+    public Uni<List<Sample>> tsRevRange(K key, TimeSeriesRange range, RangeArgs args) {
+        return super._tsRevRange(key, range, args)
+                .map(r -> marshaller.decodeAsList(r, this::decodeSample));
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
@@ -21,6 +21,7 @@ import io.quarkus.redis.datasource.search.ReactiveTransactionalSearchCommands;
 import io.quarkus.redis.datasource.set.ReactiveTransactionalSetCommands;
 import io.quarkus.redis.datasource.sortedset.ReactiveTransactionalSortedSetCommands;
 import io.quarkus.redis.datasource.string.ReactiveTransactionalStringCommands;
+import io.quarkus.redis.datasource.timeseries.ReactiveTransactionalTimeSeriesCommands;
 import io.quarkus.redis.datasource.topk.ReactiveTransactionalTopKCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
@@ -157,6 +158,12 @@ public class ReactiveTransactionalRedisDataSourceImpl implements ReactiveTransac
     public <K> ReactiveTransactionalAutoSuggestCommands<K> autosuggest(Class<K> redisKeyType) {
         return new ReactiveTransactionalAutoSuggestCommandsImpl<>(this,
                 (ReactiveAutoSuggestCommandsImpl<K>) this.reactive.autosuggest(redisKeyType), tx);
+    }
+
+    @Override
+    public <K> ReactiveTransactionalTimeSeriesCommands<K> timeseries(Class<K> redisKeyType) {
+        return new ReactiveTransactionalTimeSeriesCommandsImpl<>(this,
+                (ReactiveTimeSeriesCommandsImpl<K>) this.reactive.timeseries(redisKeyType), tx);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalTimeSeriesCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalTimeSeriesCommandsImpl.java
@@ -1,0 +1,200 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+
+import io.quarkus.redis.datasource.timeseries.AddArgs;
+import io.quarkus.redis.datasource.timeseries.Aggregation;
+import io.quarkus.redis.datasource.timeseries.AlterArgs;
+import io.quarkus.redis.datasource.timeseries.CreateArgs;
+import io.quarkus.redis.datasource.timeseries.Filter;
+import io.quarkus.redis.datasource.timeseries.IncrementArgs;
+import io.quarkus.redis.datasource.timeseries.MGetArgs;
+import io.quarkus.redis.datasource.timeseries.MRangeArgs;
+import io.quarkus.redis.datasource.timeseries.RangeArgs;
+import io.quarkus.redis.datasource.timeseries.ReactiveTransactionalTimeSeriesCommands;
+import io.quarkus.redis.datasource.timeseries.SeriesSample;
+import io.quarkus.redis.datasource.timeseries.TimeSeriesRange;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
+import io.smallrye.mutiny.Uni;
+
+public class ReactiveTransactionalTimeSeriesCommandsImpl<K> extends AbstractTransactionalCommands
+        implements ReactiveTransactionalTimeSeriesCommands<K> {
+
+    private final ReactiveTimeSeriesCommandsImpl<K> reactive;
+
+    public ReactiveTransactionalTimeSeriesCommandsImpl(ReactiveTransactionalRedisDataSource ds,
+            ReactiveTimeSeriesCommandsImpl<K> reactive, TransactionHolder tx) {
+        super(ds, tx);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public Uni<Void> tsCreate(K key, CreateArgs args) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsCreate(key, args).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsCreate(K key) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsCreate(key).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsAdd(K key, long timestamp, double value, AddArgs args) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsAdd(key, timestamp, value, args).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsAdd(K key, long timestamp, double value) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsAdd(key, timestamp, value).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsAdd(K key, double value) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsAdd(key, value).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsAlter(K key, AlterArgs args) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsAlter(key, args).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsCreateRule(key, destKey, aggregation, bucketDuration).invoke(this::queuedOrDiscard)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsCreateRule(K key, K destKey, Aggregation aggregation, Duration bucketDuration, long alignTimestamp) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsCreateRule(key, destKey, aggregation, bucketDuration, alignTimestamp)
+                .invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsDecrBy(K key, double value) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsDecrBy(key, value).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsDecrBy(K key, double value, IncrementArgs args) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsDecrBy(key, value, args).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsDel(K key, long fromTimestamp, long toTimestamp) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsDel(key, fromTimestamp, toTimestamp).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsDeleteRule(K key, K destKey) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsDeleteRule(key, destKey).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsGet(K key) {
+        this.tx.enqueue(reactive::decodeSample);
+        return this.reactive._tsGet(key).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsGet(K key, boolean latest) {
+        this.tx.enqueue(reactive::decodeSample);
+        return this.reactive._tsGet(key, latest).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsIncrBy(K key, double value) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsIncrBy(key, value).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsIncrBy(K key, double value, IncrementArgs args) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsIncrBy(key, value, args).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsMAdd(SeriesSample<K>... samples) {
+        this.tx.enqueue(x -> null);
+        return this.reactive._tsMAdd(samples).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsMGet(MGetArgs args, Filter... filters) {
+        this.tx.enqueue(reactive::decodeGroup);
+        return this.reactive._tsMGet(args, filters).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsMGet(Filter... filters) {
+        this.tx.enqueue(reactive::decodeGroup);
+        return this.reactive._tsMGet(filters).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsMRange(TimeSeriesRange range, Filter... filters) {
+        this.tx.enqueue(reactive::decodeGroup);
+        return this.reactive._tsMRange(range, filters).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsMRange(TimeSeriesRange range, MRangeArgs args, Filter... filters) {
+        this.tx.enqueue(reactive::decodeGroup);
+        return this.reactive._tsMRange(range, args, filters).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsMRevRange(TimeSeriesRange range, Filter... filters) {
+        this.tx.enqueue(reactive::decodeGroup);
+        return this.reactive._tsMRevRange(range, filters).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsMRevRange(TimeSeriesRange range, MRangeArgs args, Filter... filters) {
+        this.tx.enqueue(reactive::decodeGroup);
+        return this.reactive._tsMRevRange(range, args, filters).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsQueryIndex(Filter... filters) {
+        this.tx.enqueue(r -> reactive.marshaller.decodeAsList(r, reactive.keyType));
+        return this.reactive._tsQueryIndex(filters).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsRange(K key, TimeSeriesRange range) {
+        this.tx.enqueue(r -> reactive.marshaller.decodeAsList(r, reactive::decodeSample));
+        return this.reactive._tsRange(key, range).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsRange(K key, TimeSeriesRange range, RangeArgs args) {
+        this.tx.enqueue(r -> reactive.marshaller.decodeAsList(r, reactive::decodeSample));
+        return this.reactive._tsRange(key, range, args).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsRevRange(K key, TimeSeriesRange range) {
+        this.tx.enqueue(r -> reactive.marshaller.decodeAsList(r, reactive::decodeSample));
+        return this.reactive._tsRevRange(key, range).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> tsRevRange(K key, TimeSeriesRange range, RangeArgs args) {
+        this.tx.enqueue(r -> reactive.marshaller.decodeAsList(r, reactive::decodeSample));
+        return this.reactive._tsRevRange(key, range, args).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TimeSeriesCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TimeSeriesCommandsTest.java
@@ -1,0 +1,543 @@
+package io.quarkus.redis.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.timeseries.AddArgs;
+import io.quarkus.redis.datasource.timeseries.Aggregation;
+import io.quarkus.redis.datasource.timeseries.AlterArgs;
+import io.quarkus.redis.datasource.timeseries.BucketTimestamp;
+import io.quarkus.redis.datasource.timeseries.CreateArgs;
+import io.quarkus.redis.datasource.timeseries.DuplicatePolicy;
+import io.quarkus.redis.datasource.timeseries.Filter;
+import io.quarkus.redis.datasource.timeseries.IncrementArgs;
+import io.quarkus.redis.datasource.timeseries.MGetArgs;
+import io.quarkus.redis.datasource.timeseries.MRangeArgs;
+import io.quarkus.redis.datasource.timeseries.RangeArgs;
+import io.quarkus.redis.datasource.timeseries.Reducer;
+import io.quarkus.redis.datasource.timeseries.Sample;
+import io.quarkus.redis.datasource.timeseries.SeriesSample;
+import io.quarkus.redis.datasource.timeseries.TimeSeriesCommands;
+import io.quarkus.redis.datasource.timeseries.TimeSeriesRange;
+import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+
+@RequiresCommand("ts.create")
+public class TimeSeriesCommandsTest extends DatasourceTestBase {
+
+    private RedisDataSource ds;
+
+    private TimeSeriesCommands<String> ts;
+
+    @BeforeEach
+    void initialize() {
+        ds = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(1));
+        ts = ds.timeseries();
+    }
+
+    @AfterEach
+    void clear() {
+        ds.flushall();
+    }
+
+    @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(ts.getDataSource());
+    }
+
+    @Test
+    void testCreationAndAddingDataPoint() throws InterruptedException {
+        ts.tsCreate(key);
+        ts.tsCreate("sensor", new CreateArgs().setRetention(Duration.of(2678400000L, ChronoUnit.MILLIS)));
+
+        ts.tsAlter("sensor", new AlterArgs().chunkSize(1024));
+
+        ts.tsAdd(key, 1626434637914L, 26);
+        ts.tsAdd(key, 27);
+
+        Thread.sleep(1); // Do make sure we have a different timestamp
+        ts.tsMAdd(SeriesSample.from(key, 51), SeriesSample.from(key, 1626434637915L, 52), SeriesSample.from("sensor", 22));
+
+        var list = ts.tsRange(key, TimeSeriesRange.fromTimeSeries());
+        assertThat(list).hasSize(4);
+
+        list = ts.tsRange("sensor", TimeSeriesRange.fromTimestampToLatest(0));
+        assertThat(list).hasSize(1);
+    }
+
+    @Test
+    void testCreationWhileAdding() {
+        long timestamp = System.currentTimeMillis() - 1000;
+        ts.tsAdd(key, timestamp, 26, new AddArgs().compressed().label("foo", "bar")
+                .setRetention(Duration.ofDays(1)).chunkSize(1024));
+        ts.tsAdd(key, 27);
+
+        var list = ts.tsRange(key, TimeSeriesRange.fromTimeSeries());
+        assertThat(list).hasSize(2);
+
+        ts.tsAdd(key, timestamp, 25, new AddArgs().onDuplicate(DuplicatePolicy.LAST));
+        list = ts.tsRange(key, TimeSeriesRange.fromTimeSeries());
+        assertThat(list).hasSize(2);
+        assertThat(list.stream().map(s -> s.value).collect(Collectors.toList())).containsExactlyInAnyOrder(27.0, 25.0);
+    }
+
+    @Test
+    void testIncrAndDecr() {
+        ts.tsCreate(key);
+        ts.tsAdd(key, 10, 26);
+        ts.tsAdd(key, 20, 30);
+
+        ts.tsIncrBy(key, 12);
+
+        assertThat(ts.tsGet(key).value).isEqualTo(30 + 12);
+        ts.tsIncrBy(key, 12, new IncrementArgs().label("foo", "bar"));
+        assertThat(ts.tsGet(key).value).isEqualTo(30 + 12 + 12);
+
+        ts.tsDecrBy(key, 2);
+        assertThat(ts.tsGet(key).value).isEqualTo(30 + 12 + 12 - 2);
+        ts.tsDecrBy(key, 2, new IncrementArgs().uncompressed());
+        assertThat(ts.tsGet(key).value).isEqualTo(30 + 12 + 12 - 2 - 2);
+    }
+
+    @Test
+    void testDeletion() {
+        ts.tsCreate(key);
+        ts.tsAdd(key, 500, 50);
+        ts.tsAdd(key, 501, 51);
+        ts.tsAdd(key, 1000, 26);
+        ts.tsAdd(key, 1001, 27);
+        ts.tsAdd(key, 2000, 28);
+        ts.tsAdd(key, 2001, 29);
+
+        var list = ts.tsRange(key, TimeSeriesRange.fromTimeSeries());
+        assertThat(list).hasSize(6);
+
+        ts.tsDel(key, 1000, 1999);
+        list = ts.tsRange(key, TimeSeriesRange.fromTimeSeries());
+        assertThat(list).hasSize(4);
+
+        ts.tsDel(key, 501, 501);
+        list = ts.tsRange(key, TimeSeriesRange.fromTimeSeries());
+        assertThat(list).hasSize(3);
+    }
+
+    @Test
+    void testAggregation() {
+        ts.tsCreate(key);
+        ts.tsCreate("cc");
+        ts.tsCreate("avg");
+
+        ts.tsCreateRule(key, "cc", Aggregation.COUNT, Duration.of(1, ChronoUnit.SECONDS));
+        ts.tsCreateRule(key, "avg", Aggregation.AVG, Duration.of(10, ChronoUnit.MILLIS));
+
+        ts.tsAdd(key, 500, 50);
+        ts.tsAdd(key, 2003, 42);
+        ts.tsAdd(key, 501, 51);
+        ts.tsAdd(key, 1000, 26);
+        ts.tsAdd(key, 1001, 27);
+        ts.tsAdd(key, 2000, 28);
+        ts.tsAdd(key, 2001, 29);
+        ts.tsAdd(key, 1002, 1002339488832.23477);
+        ts.tsAdd(key, 1003, 45.56778);
+        ts.tsAdd(key, 2004, 45);
+        ts.tsAdd(key, 3000, 45);
+
+        var counts = ts.tsRange("cc", TimeSeriesRange.fromEarliestToTimestamp(5000));
+        assertThat(counts).hasSize(3);
+
+        var avg = ts.tsRange("avg", TimeSeriesRange.fromEarliestToTimestamp(5000));
+        assertThat(avg).hasSize(3);
+
+        ts.tsDeleteRule(key, "cc");
+    }
+
+    @Test
+    void testFiltering() {
+        ts.tsCreate(key, new CreateArgs()
+                .label("area", 1)
+                .label("common", "1")
+                .label("foo", "bar"));
+        ts.tsCreate("sensor", new CreateArgs()
+                .label("common", "1")
+                .label("foo", "baz"));
+
+        ts.tsAdd(key, 500, 50, new AddArgs().label("area", 51));
+        ts.tsAdd("sensor", 2003, 42, new AddArgs().label("area", 52));
+        ts.tsAdd("sensor", 501, 51, new AddArgs().label("area", 51));
+        ts.tsAdd(key, 1000, 26, new AddArgs().label("area", 51));
+        ts.tsAdd(key, 1001, 27, new AddArgs().label("area", 32));
+        ts.tsAdd(key, 2000, 28, new AddArgs().label("area", 51).label("name", "h1"));
+        ts.tsAdd("sensor", 2001, 29, new AddArgs().label("area", 52));
+        ts.tsAdd(key, 1002, 1002339488832.23477, new AddArgs().label("area", 53));
+        ts.tsAdd("sensor", 1003, 45.56778, new AddArgs().label("area", 12));
+        ts.tsAdd("sensor", 2004, 45, new AddArgs().label("area", 12));
+        ts.tsAdd(key, 3000, 45, new AddArgs().label("area", 12));
+
+        var map = ts.tsMRange(TimeSeriesRange.fromTimestamps(10, 10000),
+                Filter.withLabel("foo", "bar"));
+        assertThat(map).hasSize(1);
+        assertThat(map.get(key).group()).isEqualTo(key);
+        assertThat(map.get(key).samples()).hasSize(6);
+        assertThat(map.get(key).labels()).isEmpty();
+
+        map = ts.tsMRange(TimeSeriesRange.fromTimestamps(10, 10000), new MRangeArgs().withLabels(),
+                Filter.withLabel("foo", "bar"));
+        assertThat(map).hasSize(1);
+        assertThat(map.get(key).group()).isEqualTo(key);
+        assertThat(map.get(key).samples()).hasSize(6);
+        assertThat(map.get(key).labels()).hasSize(3);
+
+        map = ts.tsMGet(new MGetArgs().withLabels(), Filter.withLabelHavingValueFrom("foo", "bar", "baz"));
+        assertThat(map).hasSize(2);
+
+        map = ts.tsMGet(Filter.withLabelHavingValueFrom("foo", "bar", "baz"));
+        assertThat(map).hasSize(2);
+
+        map = ts.tsMGet(new MGetArgs().selectedLabel("foo"), Filter.withLabelHavingValueFrom("foo", "bar", "baz"));
+        assertThat(map).hasSize(2);
+
+        var l = ts.tsRange(key, TimeSeriesRange.fromTimeSeries(), new RangeArgs().filterByValue(25, 30));
+        assertThat(l).hasSize(3);
+
+        map = ts.tsMRange(TimeSeriesRange.fromTimeSeries(), new MRangeArgs().filterByValue(25, 30),
+                Filter.withLabel("foo", "bar"));
+        assertThat(map.get(key).samples()).hasSize(3);
+
+        map = ts.tsMRange(TimeSeriesRange.fromTimeSeries(), new MRangeArgs().filterByValue(25, 30), Filter.withLabel("foo"),
+                Filter.withLabel("area", 1));
+        assertThat(map).hasSize(0);
+
+        l = ts.tsRange(key, TimeSeriesRange.fromTimeSeries(), new RangeArgs().filterByTimestamp(1000, 1001, 2000, 2005));
+        assertThat(l).hasSize(3);
+
+        map = ts.tsMRange(TimeSeriesRange.fromTimeSeries(), new MRangeArgs().filterByTimestamp(1000, 1001, 2000, 2005),
+                Filter.withLabel("foo", "bar"));
+        assertThat(map.get(key).samples()).hasSize(3);
+    }
+
+    @Test
+    void testAggregationInRange() {
+        ts.tsCreate(key, new CreateArgs()
+                .label("area", 1)
+                .label("common", "1")
+                .label("foo", "bar"));
+        ts.tsCreate("sensor", new CreateArgs()
+                .label("common", "1")
+                .label("foo", "baz"));
+
+        ts.tsAdd(key, 500, 50);
+        ts.tsAdd("sensor", 2003, 42);
+        ts.tsAdd("sensor", 501, 51);
+        ts.tsAdd(key, 1000, 26);
+        ts.tsAdd(key, 1001, 27);
+        ts.tsAdd(key, 2000, 28);
+        ts.tsAdd("sensor", 2001, 29);
+        ts.tsAdd(key, 1002, 1002339488832.23477);
+        ts.tsAdd("sensor", 1003, 45.56778);
+        ts.tsAdd("sensor", 2004, 45);
+        ts.tsAdd(key, 3000, 45);
+
+        var l = ts.tsRange(key, TimeSeriesRange.fromTimeSeries(),
+                new RangeArgs().aggregation(Aggregation.AVG, Duration.ofMillis(3600000)));
+        assertThat(l).hasSize(1);
+
+        var map = ts.tsMRange(TimeSeriesRange.fromTimeSeries(),
+                new MRangeArgs().aggregation(Aggregation.AVG, Duration.ofMillis(3600000)), Filter.withLabel("area", 1));
+        assertThat(map.get(key).samples()).hasSize(1);
+
+        map = ts.tsMRange(TimeSeriesRange.fromTimeSeries(),
+                new MRangeArgs().aggregation(Aggregation.MIN, Duration.ofMillis(3600000)).align(1000),
+                Filter.withLabel("area", 1));
+        assertThat(map.get(key).samples()).hasSize(2);
+    }
+
+    @Test
+    void testAggregationInRevRange() {
+        ts.tsCreate(key, new CreateArgs()
+                .label("area", 1)
+                .label("common", "1")
+                .label("foo", "bar"));
+        ts.tsCreate("sensor", new CreateArgs()
+                .label("common", "1")
+                .label("foo", "baz"));
+
+        ts.tsAdd(key, 500, 50);
+        ts.tsAdd("sensor", 2003, 42);
+        ts.tsAdd("sensor", 501, 51);
+        ts.tsAdd(key, 1000, 26);
+        ts.tsAdd(key, 1001, 27);
+        ts.tsAdd(key, 2000, 28);
+        ts.tsAdd("sensor", 2001, 29);
+        ts.tsAdd(key, 1002, 1002339488832.23477);
+        ts.tsAdd("sensor", 1003, 45.56778);
+        ts.tsAdd("sensor", 2004, 45);
+        ts.tsAdd(key, 3000, 45);
+
+        var l = ts.tsRevRange(key, TimeSeriesRange.fromTimeSeries(),
+                new RangeArgs().aggregation(Aggregation.AVG, Duration.ofMillis(3600000)));
+        assertThat(l).hasSize(1);
+
+        var map = ts.tsMRevRange(TimeSeriesRange.fromTimeSeries(),
+                new MRangeArgs().aggregation(Aggregation.AVG, Duration.ofMillis(3600000)), Filter.withLabel("area", 1));
+        assertThat(map.get(key).samples()).hasSize(1);
+
+        map = ts.tsMRevRange(TimeSeriesRange.fromTimeSeries(),
+                new MRangeArgs().aggregation(Aggregation.MIN, Duration.ofMillis(3600000)).align(1000),
+                Filter.withLabel("area", 1));
+        assertThat(map.get(key).samples()).hasSize(2);
+    }
+
+    @Test
+    void testQueryIndex() {
+        ts.tsCreate("telemetry:study:temperature",
+                new CreateArgs().label("rooms", "study").label("type", "temperature"));
+        ts.tsCreate("telemetry:study:humidity",
+                new CreateArgs().label("rooms", "study").label("type", "humidity"));
+        ts.tsCreate("telemetry:kitchen:temperature",
+                new CreateArgs().label("rooms", "kitchen").label("type", "temperature"));
+        ts.tsCreate("telemetry:kitchen:humidity",
+                new CreateArgs().label("rooms", "kitchen").label("type", "humidity"));
+
+        var list = ts.tsQueryIndex(Filter.withLabel("rooms", "kitchen"));
+        assertThat(list).containsExactlyInAnyOrder("telemetry:kitchen:humidity", "telemetry:kitchen:temperature");
+
+        list = ts.tsQueryIndex(Filter.withLabel("type", "temperature"));
+        assertThat(list).containsExactlyInAnyOrder("telemetry:study:temperature", "telemetry:kitchen:temperature");
+    }
+
+    @Test
+    void testGetAdd() {
+        ts.tsCreate("temp:TLV", new CreateArgs().label("type", "temp").label("location", "TLV"));
+        ts.tsCreate("temp:JLM", new CreateArgs().label("type", "temp").label("location", "JLM"));
+
+        ts.tsMAdd(
+                SeriesSample.from("temp:TLV", 1000, 30),
+                SeriesSample.from("temp:TLV", 1010, 35),
+                SeriesSample.from("temp:TLV", 1020, 9999),
+                SeriesSample.from("temp:TLV", 1030, 40));
+        ts.tsMAdd(
+                SeriesSample.from("temp:JLM", 1005, 30),
+                SeriesSample.from("temp:JLM", 1015, 35),
+                SeriesSample.from("temp:JLM", 1025, 9999),
+                SeriesSample.from("temp:JLM", 1035, 40));
+
+        assertThat(ts.tsGet("temp:JLM").value).isEqualTo(40);
+    }
+
+    @Test
+    void testRevRange() {
+        ts.tsCreate("temp:TLV", new CreateArgs().label("type", "temp").label("location", "TLV"));
+
+        ts.tsMAdd(
+                SeriesSample.from("temp:TLV", 1000, 30),
+                SeriesSample.from("temp:TLV", 1010, 40),
+                SeriesSample.from("temp:TLV", 1030, 35));
+
+        var list = ts.tsRevRange("temp:TLV", TimeSeriesRange.fromTimeSeries());
+        assertThat(list).hasSize(3);
+        assertThat(list.get(0).value).isEqualTo(35);
+
+        var map = ts.tsMRevRange(TimeSeriesRange.fromTimeSeries(), Filter.withLabel("type", "temp"));
+        assertThat(map).hasSize(1);
+        assertThat(map.get("temp:TLV").samples()).hasSize(3);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void groupByAndReducerTest() {
+        String a = "stock:a";
+        String b = "stock:b";
+        ts.tsCreate(a, new CreateArgs().label("type", "stock").label("name", "a"));
+        ts.tsCreate(b, new CreateArgs().label("type", "stock").label("name", "b"));
+
+        ts.tsMAdd(SeriesSample.from(a, 1000, 100), SeriesSample.from(a, 1010, 110), SeriesSample.from(a, 1020, 120));
+        ts.tsMAdd(SeriesSample.from(b, 1000, 110), SeriesSample.from(b, 1010, 110), SeriesSample.from(a, 1020, 100));
+        var res = ts.tsMRange(TimeSeriesRange.fromTimeSeries(),
+                new MRangeArgs().withLabels().groupBy("type", Reducer.MAX),
+                Filter.withLabel("type", "stock"));
+        assertThat(res).hasSize(1);
+        assertThat(res.get("type=stock").labels().get("type")).isEqualTo("stock");
+        assertThat(res.get("type=stock").samples().stream().map(s -> s.value)).containsExactlyInAnyOrder(110.0, 110.0, 120.0);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void groupByReduceAndAggregationTest() {
+        String a = "stock:a";
+        String b = "stock:b";
+        ts.tsCreate(a, new CreateArgs().label("type", "stock").label("name", "a"));
+        ts.tsCreate(b, new CreateArgs().label("type", "stock").label("name", "b"));
+
+        ts.tsMAdd(SeriesSample.from(a, 1000, 100), SeriesSample.from(a, 1010, 110), SeriesSample.from(a, 1020, 120));
+        ts.tsMAdd(SeriesSample.from(b, 1000, 120), SeriesSample.from(b, 1010, 110), SeriesSample.from(a, 1020, 100));
+
+        ts.tsMAdd(SeriesSample.from(a, 2000, 200), SeriesSample.from(a, 2010, 210), SeriesSample.from(a, 2020, 220));
+        ts.tsMAdd(SeriesSample.from(b, 2000, 220), SeriesSample.from(b, 2010, 210), SeriesSample.from(a, 2020, 200));
+
+        ts.tsMAdd(SeriesSample.from(a, 3000, 300), SeriesSample.from(a, 3010, 310), SeriesSample.from(a, 3020, 320));
+        ts.tsMAdd(SeriesSample.from(b, 3000, 320), SeriesSample.from(b, 3010, 310), SeriesSample.from(a, 3020, 300));
+
+        var res = ts.tsMRange(TimeSeriesRange.fromTimeSeries(),
+                new MRangeArgs().withLabels()
+                        .aggregation(Aggregation.AVG, Duration.ofMillis(1000))
+                        .groupBy("type", Reducer.MIN),
+                Filter.withLabel("type", "stock"));
+        assertThat(res).hasSize(1);
+        assertThat(res.get("type=stock").labels().get("type")).isEqualTo("stock");
+        assertThat(res.get("type=stock").samples().stream().map(s -> s.value)).containsExactlyInAnyOrder(110.0, 210.0, 310.0);
+
+        res = ts.tsMRange(TimeSeriesRange.fromTimeSeries(),
+                new MRangeArgs().withLabels()
+                        .aggregation(Aggregation.AVG, Duration.ofMillis(1000)).bucketTimestamp(BucketTimestamp.HIGH)
+                        .groupBy("type", Reducer.MIN),
+                Filter.withLabel("type", "stock"));
+        assertThat(res).hasSize(1);
+        assertThat(res.get("type=stock").labels().get("type")).isEqualTo("stock");
+        assertThat(res.get("type=stock").samples().stream().map(s -> s.value)).containsExactlyInAnyOrder(110.0, 210.0, 310.0);
+
+        res = ts.tsMRange(TimeSeriesRange.fromTimestamps(0, 5000),
+                new MRangeArgs().withLabels()
+                        .alignUsingRangeStart()
+                        .aggregation(Aggregation.AVG, Duration.ofMillis(1000)).count(2)
+                        .groupBy("type", Reducer.MIN),
+                Filter.withLabel("type", "stock"));
+        assertThat(res).hasSize(1);
+        assertThat(res.get("type=stock").labels().get("type")).isEqualTo("stock");
+        assertThat(res.get("type=stock").samples()).hasSize(2);
+
+        res = ts.tsMRange(TimeSeriesRange.fromTimestamps(0, 5000),
+                new MRangeArgs().withLabels()
+                        .alignUsingRangeEnd()
+                        .aggregation(Aggregation.AVG, Duration.ofMillis(1000)).empty()
+                        .groupBy("type", Reducer.MIN),
+                Filter.withLabel("type", "stock"));
+        assertThat(res).hasSize(1);
+    }
+
+    @Test
+    void groupByReturningMultipleGroupTest() {
+        ts.tsAdd("ts1", 1548149180000L, 90, new AddArgs()
+                .label("metric", "cpu").label("metric_name", "system").label("team", "NY"));
+        ts.tsAdd("ts1", 1548149185000L, 45);
+
+        ts.tsAdd("ts2", 1548149180000L, 99, new AddArgs()
+                .label("metric", "cpu").label("metric_name", "user").label("team", "SF"));
+
+        var res = ts.tsMRange(TimeSeriesRange.fromTimeSeries(),
+                new MRangeArgs().withLabels().groupBy("metric_name", Reducer.MAX),
+                Filter.withLabel("metric", "cpu"));
+        assertThat(res).hasSize(2);
+        assertThat(res.get("metric_name=system").samples()).hasSize(2);
+        assertThat(res.get("metric_name=user").samples()).containsExactly(new Sample(1548149180000L, 99));
+
+        // Test query by value
+        res = ts.tsMRange(TimeSeriesRange.fromTimeSeries(),
+                new MRangeArgs().withLabels().filterByValue(90, 100),
+                Filter.withLabel("metric", "cpu"));
+        assertThat(res).hasSize(2);
+        assertThat(res.get("ts1").samples()).containsExactly(new Sample(1548149180000L, 90));
+        assertThat(res.get("ts2").samples()).containsExactly(new Sample(1548149180000L, 99));
+
+        // Test query using label
+        res = ts.tsMRange(TimeSeriesRange.fromTimeSeries(),
+                new MRangeArgs().selectedLabels("team"),
+                Filter.withLabel("metric", "cpu"));
+        assertThat(res).hasSize(2);
+        assertThat(res.get("ts1").labels()).containsExactly(entry("team", "NY"));
+        assertThat(res.get("ts1").samples()).hasSize(2);
+        assertThat(res.get("ts2").labels()).containsExactly(entry("team", "SF"));
+        assertThat(res.get("ts2").samples()).containsExactly(new Sample(1548149180000L, 99));
+    }
+
+    @Test
+    void testSample() {
+        Sample s1 = new Sample(1000, 24.5);
+        Sample s2 = new Sample(1000, 24.5);
+        assertThat(s1.value).isEqualTo(24.5);
+        assertThat(s2.timestamp()).isEqualTo(1000);
+        assertThat(s1).isEqualTo(s2);
+        assertThat(s1.hashCode()).isEqualTo(s2.hashCode());
+    }
+
+    @Test
+    void testRange() {
+        ts.tsCreate("temp", new CreateArgs()
+                .chunkSize(1024).compressed().label("location", "TLV").forever());
+        ts.tsMAdd(
+                SeriesSample.from("temp", 1000, 30),
+                SeriesSample.from("temp", 1010, 35),
+                SeriesSample.from("temp", 1020, 9999),
+                SeriesSample.from("temp", 1030, 40));
+
+        // Filter by value
+        assertThat(ts.tsRange("temp", TimeSeriesRange.fromTimeSeries(), new RangeArgs().filterByValue(-100, 100)))
+                .hasSize(3);
+
+        // With aggregation
+        assertThat(ts.tsRange("temp", TimeSeriesRange.fromTimestamps(0, 2000), new RangeArgs().filterByValue(-100, 100)
+                .aggregation(Aggregation.AVG, Duration.ofSeconds(1)).alignUsingRangeEnd()))
+                .hasSize(1).containsExactly(new Sample(1000, 35));
+    }
+
+    @Test
+    void testRangeWithAlignment() {
+        String a = "stock:a";
+        ts.tsCreate(a, new CreateArgs().label("type", "stock").label("name", "a"));
+
+        ts.tsMAdd(SeriesSample.from(a, 1000, 100), SeriesSample.from(a, 1010, 110), SeriesSample.from(a, 1020, 120));
+        ts.tsMAdd(SeriesSample.from(a, 2000, 200), SeriesSample.from(a, 2010, 210), SeriesSample.from(a, 2020, 220));
+        ts.tsMAdd(SeriesSample.from(a, 3000, 300), SeriesSample.from(a, 3010, 310), SeriesSample.from(a, 3020, 320));
+
+        var list = ts.tsRange(a, TimeSeriesRange.fromTimeSeries(),
+                new RangeArgs().aggregation(Aggregation.MIN, Duration.ofMillis(20)).empty());
+        assertThat(list)
+                .contains(new Sample(1000, 100), new Sample(1020, 120), new Sample(2000, 200),
+                        new Sample(2020, 220), new Sample(3000, 300), new Sample(3020, 320));
+
+        list = ts.tsRange(a, TimeSeriesRange.fromTimeSeries(), new RangeArgs()
+                .align(10).count(2)
+                .aggregation(Aggregation.MIN, Duration.ofMillis(20)).bucketTimestamp(BucketTimestamp.MID));
+        assertThat(list)
+                .hasSize(2)
+                .contains(new Sample(990, 100), new Sample(1010, 110));
+
+        list = ts.tsRange(a, TimeSeriesRange.fromTimestampToLatest(5), new RangeArgs()
+                .alignUsingRangeStart()
+                .aggregation(Aggregation.MIN, Duration.ofMillis(20)));
+        assertThat(list)
+                .contains(new Sample(985, 100), new Sample(1005, 110));
+
+        list = ts.tsRange(a, TimeSeriesRange.fromEarliestToTimestamp(3000), new RangeArgs()
+                .alignUsingRangeEnd()
+                .aggregation(Aggregation.MIN, Duration.ofMillis(20)));
+        assertThat(list)
+                .contains(new Sample(1000, 100), new Sample(2000, 200));
+
+    }
+
+    @Test
+    void testCreation() {
+        ts.tsCreate(key, new CreateArgs().forever().duplicatePolicy(DuplicatePolicy.LAST).uncompressed());
+
+        ts.tsAdd(key, 10, 10);
+        ts.tsAdd(key, 10, 20);
+
+        assertThat(ts.tsGet(key).value()).isEqualTo(20L);
+    }
+
+    @Test
+    void testIncrementWithCreation() {
+        ts.tsIncrBy(key, 10, new IncrementArgs().setTimestamp(1000).label("foo", "bar")
+                .uncompressed().chunkSize(1024).setRetention(Duration.ofDays(1)));
+        assertThat(ts.tsGet(key).value()).isEqualTo(10L);
+        assertThat(ts.tsGet(key).timestamp()).isEqualTo(1000);
+    }
+
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalTimeSeriesCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalTimeSeriesCommandsTest.java
@@ -1,0 +1,123 @@
+package io.quarkus.redis.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.timeseries.AddArgs;
+import io.quarkus.redis.datasource.timeseries.CreateArgs;
+import io.quarkus.redis.datasource.timeseries.Filter;
+import io.quarkus.redis.datasource.timeseries.MGetArgs;
+import io.quarkus.redis.datasource.timeseries.Sample;
+import io.quarkus.redis.datasource.timeseries.SampleGroup;
+import io.quarkus.redis.datasource.timeseries.SeriesSample;
+import io.quarkus.redis.datasource.timeseries.TimeSeriesRange;
+import io.quarkus.redis.datasource.transactions.TransactionResult;
+import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
+
+@RequiresCommand("ts.create")
+public class TransactionalTimeSeriesCommandsTest extends DatasourceTestBase {
+
+    private RedisDataSource blocking;
+    private ReactiveRedisDataSource reactive;
+
+    @BeforeEach
+    void initialize() {
+        blocking = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(60));
+        reactive = new ReactiveRedisDataSourceImpl(vertx, redis, api);
+    }
+
+    @AfterEach
+    public void clear() {
+        blocking.flushall();
+    }
+
+    @Test
+    public void timeSeriesBlocking() {
+
+        TransactionResult result = blocking.withTransaction(tx -> {
+            var ts = tx.timeseries();
+            assertThat(ts.getDataSource()).isEqualTo(tx);
+            ts.tsCreate("ts1");
+            ts.tsAdd("ts2", 10, 1, new AddArgs().label("foo", "bar").compressed().chunkSize(1024));
+            ts.tsCreate("ts3", new CreateArgs().forever().label("foo", "baz"));
+            ts.tsAdd("ts1", 2);
+
+            ts.tsAdd("ts1", 20, 20);
+
+            ts.tsMAdd(
+                    SeriesSample.from("ts1", 30, 3),
+                    SeriesSample.from("ts2", 30, 3),
+                    SeriesSample.from("ts3", 30, 5));
+
+            ts.tsGet("ts3"); // 5
+            ts.tsMGet(Filter.withLabel("foo", "bar")); // ts2
+            ts.tsMGet(new MGetArgs().withLabels(), Filter.withLabel("foo", "baz")); // ts3
+
+            ts.tsRange("ts3", TimeSeriesRange.fromTimeSeries());
+            ts.tsMRange(TimeSeriesRange.fromTimeSeries(), Filter.withLabelHavingValueFrom("foo", "bar", "baz"));
+        });
+
+        assertThat(result.size()).isEqualTo(11);
+        assertThat(result.discarded()).isFalse();
+
+        assertThat((Sample) result.get(6)).isEqualTo(new Sample(30, 5.0));
+        Map<String, SampleGroup> map = result.get(7);
+        assertThat(map).hasSize(1);
+        map = result.get(8);
+        assertThat(map).hasSize(1);
+        assertThat((List<Sample>) result.get(9)).containsExactly(new Sample(30, 5.0));
+        map = result.get(10);
+        assertThat(map).hasSize(2);
+    }
+
+    @Test
+    public void timeseriesReactive() {
+        TransactionResult result = reactive.withTransaction(tx -> {
+            var ts = tx.timeseries();
+            assertThat(ts.getDataSource()).isEqualTo(tx);
+            var u1 = ts.tsCreate("ts1");
+            var u2 = ts.tsAdd("ts2", 10, 1, new AddArgs().label("foo", "bar").compressed().chunkSize(1024));
+            var u3 = ts.tsCreate("ts3", new CreateArgs().forever().label("foo", "baz"));
+            var u4 = ts.tsAdd("ts1", 2);
+
+            var u5 = ts.tsAdd("ts1", 20, 20);
+
+            var u6 = ts.tsMAdd(
+                    SeriesSample.from("ts1", 30, 3),
+                    SeriesSample.from("ts2", 30, 3),
+                    SeriesSample.from("ts3", 30, 5));
+
+            var u7 = ts.tsGet("ts3"); // 5
+            var u8 = ts.tsMGet(Filter.withLabel("foo", "bar")); // ts2
+            var u9 = ts.tsMGet(new MGetArgs().withLabels(), Filter.withLabel("foo", "baz")); // ts3
+
+            var u10 = ts.tsRange("ts3", TimeSeriesRange.fromTimeSeries());
+            var u11 = ts.tsMRange(TimeSeriesRange.fromTimeSeries(), Filter.withLabelHavingValueFrom("foo", "bar", "baz"));
+
+            return u1.chain(() -> u2).chain(() -> u3).chain(() -> u4).chain(() -> u5)
+                    .chain(() -> u6).chain(() -> u7).chain(() -> u8)
+                    .chain(() -> u9).chain(() -> u10).chain(() -> u11);
+        }).await().indefinitely();
+
+        assertThat(result.size()).isEqualTo(11);
+        assertThat(result.discarded()).isFalse();
+
+        assertThat((Sample) result.get(6)).isEqualTo(new Sample(30, 5.0));
+        Map<String, SampleGroup> map = result.get(7);
+        assertThat(map).hasSize(1);
+        map = result.get(8);
+        assertThat(map).hasSize(1);
+        assertThat((List<Sample>) result.get(9)).containsExactly(new Sample(30, 5.0));
+        map = result.get(10);
+        assertThat(map).hasSize(2);
+    }
+
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/generator/RedisApiGenerator.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/generator/RedisApiGenerator.java
@@ -39,7 +39,7 @@ import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
 import io.quarkus.redis.datasource.RedisCommands;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.TransactionalRedisCommands;
-import io.quarkus.redis.datasource.autosuggest.ReactiveAutoSuggestCommands;
+import io.quarkus.redis.datasource.timeseries.ReactiveTimeSeriesCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 import io.quarkus.redis.runtime.datasource.AbstractRedisCommandGroup;
@@ -63,8 +63,8 @@ public class RedisApiGenerator {
 
     public static void main(String[] args) throws FileNotFoundException {
         // PARAMETERS
-        String reactiveApi = ReactiveAutoSuggestCommands.class.getName();
-        String prefix = "ft";
+        String reactiveApi = ReactiveTimeSeriesCommands.class.getName();
+        String prefix = "ts";
         // ---------
 
         File out = new File("extensions/redis-client/runtime/target/generation");


### PR DESCRIPTION
Add the `timeseries()` command group.
Using these commands requires the Redis Time Series module (from Redis Stack).
These commands are marked as experimental until we have more feedback.



This completes the Redis Stack support! 