### PR TITLE
OutboundSseEvent is not correctly serialized

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/StreamResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/StreamResource.java
@@ -8,7 +8,10 @@ import java.util.concurrent.TimeUnit;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.sse.OutboundSseEvent;
+import javax.ws.rs.sse.Sse;
 
 import org.jboss.resteasy.reactive.common.util.MultiCollectors;
 import org.reactivestreams.Publisher;
@@ -151,5 +154,14 @@ public class StreamResource {
     @Produces(MediaType.SERVER_SENT_EVENTS)
     public Multi<String> sseThrows() {
         throw new IllegalStateException("STOP");
+    }
+
+    @Path("sse/raw")
+    @GET
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public Multi<OutboundSseEvent> sseRaw(@Context Sse sse) {
+        return Multi.createFrom().items(sse.newEventBuilder().id("one").data("uno").name("eins").build(),
+                sse.newEventBuilder().id("two").data("dos").name("zwei").build(),
+                sse.newEventBuilder().id("three").data("tres").name("drei").build());
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/PublisherResponseHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/PublisherResponseHandler.java
@@ -11,6 +11,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.sse.OutboundSseEvent;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.common.util.RestMediaType;
@@ -49,7 +50,12 @@ public class PublisherResponseHandler implements ServerRestHandler {
 
         @Override
         public void onNext(Object item) {
-            OutboundSseEventImpl event = new OutboundSseEventImpl.BuilderImpl().data(item).build();
+            OutboundSseEvent event;
+            if (item instanceof OutboundSseEvent) {
+                event = (OutboundSseEvent) item;
+            } else {
+                event = new OutboundSseEventImpl.BuilderImpl().data(item).build();
+            }
             SseUtil.send(requestContext, event, customizers).whenComplete(new BiConsumer<Object, Throwable>() {
                 @Override
                 public void accept(Object v, Throwable t) {


### PR DESCRIPTION
Closes #10673

This request allows special server sent events in the form of

```java
  @GET
  @Produces(MediaType.SERVER_SENT_EVENTS)
  public Multi<OutboundSseEvent> consume(@Context Sse sse) {
    return Multi.createFrom()
        .item(sse.newEventBuilder().id(UUID.randomUUID().toString())
            .mediaType(MediaType.TEXT_HTML_TYPE).name("whatever").data("<h3>EVENT DATA</h3>")
            .reconnectDelay(3000).build());
  }

```
I'd like to write a test for that, but there is no existing one for the changed class. That's probably due to the static access of SseUtil.send() which is impossible to mock (as far as I know).