### PR TITLE
ArC - introduce immutable bean archive index

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -277,7 +277,8 @@ public class ArcProcessor {
             }
         });
 
-        builder.setBeanArchiveIndex(index);
+        builder.setComputingBeanArchiveIndex(index);
+        builder.setImmutableBeanArchiveIndex(beanArchiveIndex.getImmutableIndex());
         builder.setApplicationIndex(combinedIndex.getIndex());
         List<BeanDefiningAnnotation> beanDefiningAnnotations = additionalBeanDefiningAnnotations.stream()
                 .map((s) -> new BeanDefiningAnnotation(s.getName(), s.getDefaultScope())).collect(Collectors.toList());

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveIndexBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveIndexBuildItem.java
@@ -14,26 +14,42 @@ import io.quarkus.builder.item.SimpleBuildItem;
  * Compared to {@link io.quarkus.deployment.builditem.CombinedIndexBuildItem} this index can contain additional classes
  * that were indexed while bean discovery was in progress.
  *
- * It also holds information about all programmatically registered beans and all generated bean classes.
- *
  * @see GeneratedBeanBuildItem
- * @see AdditionalBeanBuildItem
  * @see io.quarkus.deployment.builditem.CombinedIndexBuildItem
  */
 public final class BeanArchiveIndexBuildItem extends SimpleBuildItem {
 
     private final IndexView index;
+    private final IndexView immutableIndex;
     private final Set<DotName> generatedClassNames;
 
-    public BeanArchiveIndexBuildItem(IndexView index, Set<DotName> generatedClassNames) {
+    public BeanArchiveIndexBuildItem(IndexView index, IndexView immutableIndex, Set<DotName> generatedClassNames) {
         this.index = index;
+        this.immutableIndex = immutableIndex;
         this.generatedClassNames = generatedClassNames;
     }
 
+    /**
+     * This index is built on top of the immutable index.
+     *
+     * @return the computing index that can also index classes on demand
+     */
     public IndexView getIndex() {
         return index;
     }
 
+    /**
+     *
+     * @return an immutable index that represents the bean archive
+     */
+    public IndexView getImmutableIndex() {
+        return immutableIndex;
+    }
+
+    /**
+     *
+     * @return the set of classes generated via {@link GeneratedBeanBuildItem}
+     */
     public Set<DotName> getGeneratedClassNames() {
         return generatedClassNames;
     }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
@@ -84,12 +84,12 @@ public class BeanArchiveProcessor {
             additionalClasses.put(knownMissingClass, Optional.empty());
         }
 
-        // Finally, index ArC/CDI API built-in classes
-        return new BeanArchiveIndexBuildItem(
-                BeanArchives.buildBeanArchiveIndex(Thread.currentThread().getContextClassLoader(), additionalClasses,
-                        applicationIndex,
-                        additionalBeanIndexer.complete()),
-                generatedClassNames);
+        IndexView immutableBeanArchiveIndex = BeanArchives.buildImmutableBeanArchiveIndex(applicationIndex,
+                additionalBeanIndexer.complete());
+        IndexView computingBeanArchiveIndex = BeanArchives.buildComputingBeanArchiveIndex(
+                Thread.currentThread().getContextClassLoader(),
+                additionalClasses, immutableBeanArchiveIndex);
+        return new BeanArchiveIndexBuildItem(computingBeanArchiveIndex, immutableBeanArchiveIndex, generatedClassNames);
     }
 
     private IndexView buildApplicationIndex(ArcConfig config, ApplicationArchivesBuildItem applicationArchivesBuildItem,

--- a/extensions/spring-di/deployment/src/test/java/io/quarkus/spring/di/deployment/SpringDIProcessorTest.java
+++ b/extensions/spring-di/deployment/src/test/java/io/quarkus/spring/di/deployment/SpringDIProcessorTest.java
@@ -205,7 +205,8 @@ class SpringDIProcessorTest {
     private IndexView getIndex(final Class<?>... classes) {
         try {
             Index index = Index.of(classes);
-            return BeanArchives.buildBeanArchiveIndex(getClass().getClassLoader(), new ConcurrentHashMap<>(), index);
+            return BeanArchives.buildComputingBeanArchiveIndex(getClass().getClassLoader(), new ConcurrentHashMap<>(),
+                    BeanArchives.buildImmutableBeanArchiveIndex(index));
         } catch (IOException e) {
             throw new IllegalStateException("Failed to index classes", e);
         }

--- a/extensions/spring-scheduled/deployment/src/test/java/io/quarkus/spring/scheduled/deployment/SpringScheduledProcessorTest.java
+++ b/extensions/spring-scheduled/deployment/src/test/java/io/quarkus/spring/scheduled/deployment/SpringScheduledProcessorTest.java
@@ -115,7 +115,8 @@ public class SpringScheduledProcessorTest {
     private IndexView getIndex(final Class<?>... classes) {
         try {
             Index index = Index.of(classes);
-            return BeanArchives.buildBeanArchiveIndex(getClass().getClassLoader(), new ConcurrentHashMap<>(), index);
+            return BeanArchives.buildComputingBeanArchiveIndex(getClass().getClassLoader(), new ConcurrentHashMap<>(),
+                    BeanArchives.buildImmutableBeanArchiveIndex(index));
         } catch (IOException e) {
             throw new IllegalStateException("Failed to index classes", e);
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralProcessor.java
@@ -46,7 +46,7 @@ public class AnnotationLiteralProcessor {
                 generateAnnotationLiteralClassName(key.annotationName()),
                 applicationClassPredicate.test(key.annotationName()),
                 key.annotationClass));
-        this.beanArchiveIndex = beanArchiveIndex;
+        this.beanArchiveIndex = Objects.requireNonNull(beanArchiveIndex);
     }
 
     boolean hasLiteralsToGenerate() {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanArchives.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanArchives.java
@@ -52,14 +52,23 @@ public final class BeanArchives {
     /**
      *
      * @param applicationIndexes
-     * @return the final bean archive index
+     * @return the immutable bean archive index
      */
-    public static IndexView buildBeanArchiveIndex(ClassLoader deploymentClassLoader,
-            Map<DotName, Optional<ClassInfo>> additionalClasses, IndexView... applicationIndexes) {
+    public static IndexView buildImmutableBeanArchiveIndex(IndexView... applicationIndexes) {
         List<IndexView> indexes = new ArrayList<>();
         Collections.addAll(indexes, applicationIndexes);
         indexes.add(buildAdditionalIndex());
-        return new IndexWrapper(CompositeIndex.create(indexes), deploymentClassLoader, additionalClasses);
+        return CompositeIndex.create(indexes);
+    }
+
+    /**
+     *
+     * @param wrappedIndexes
+     * @return the computing bean archive index
+     */
+    public static IndexView buildComputingBeanArchiveIndex(ClassLoader deploymentClassLoader,
+            Map<DotName, Optional<ClassInfo>> additionalClasses, IndexView immutableIndex) {
+        return new IndexWrapper(immutableIndex, deploymentClassLoader, additionalClasses);
     }
 
     private static IndexView buildAdditionalIndex() {

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoInjectionsTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoInjectionsTest.java
@@ -42,7 +42,7 @@ public class BeanInfoInjectionsTest {
         Type listStringType = ParameterizedType.create(name(List.class),
                 new Type[] { Type.create(name(String.class), Kind.CLASS) }, null);
 
-        BeanDeployment deployment = BeanProcessor.builder().setBeanArchiveIndex(index).build().getBeanDeployment();
+        BeanDeployment deployment = BeanProcessor.builder().setImmutableBeanArchiveIndex(index).build().getBeanDeployment();
         deployment.registerCustomContexts(Collections.emptyList());
         deployment.registerBeans(Collections.emptyList());
         BeanInfo barBean = deployment.getBeans().stream().filter(b -> b.getTarget().get().equals(barClass)).findFirst().get();

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoQualifiersTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoQualifiersTest.java
@@ -37,7 +37,7 @@ public class BeanInfoQualifiersTest {
         ClassInfo fooClass = index.getClassByName(fooName);
 
         BeanInfo bean = Beans.createClassBean(fooClass,
-                BeanProcessor.builder().setBeanArchiveIndex(index).build().getBeanDeployment(),
+                BeanProcessor.builder().setImmutableBeanArchiveIndex(index).build().getBeanDeployment(),
                 null);
 
         AnnotationInstance requiredFooQualifier = index.getAnnotations(fooQualifierName).stream()

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoTypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoTypesTest.java
@@ -37,7 +37,7 @@ public class BeanInfoTypesTest {
                 Collection.class, List.class,
                 Iterable.class, Object.class, String.class);
 
-        BeanDeployment deployment = BeanProcessor.builder().setBeanArchiveIndex(index).build().getBeanDeployment();
+        BeanDeployment deployment = BeanProcessor.builder().setImmutableBeanArchiveIndex(index).build().getBeanDeployment();
         DotName fooName = name(Foo.class);
 
         ClassInfo fooClass = index.getClassByName(fooName);

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
@@ -32,7 +32,8 @@ public class TypesTest {
         DotName producerName = DotName.createSimple(Producer.class.getName());
         ClassInfo fooClass = index.getClassByName(fooName);
         Map<ClassInfo, Map<String, Type>> resolvedTypeVariables = new HashMap<>();
-        BeanDeployment dummyDeployment = BeanProcessor.builder().setBeanArchiveIndex(index).build().getBeanDeployment();
+        BeanDeployment dummyDeployment = BeanProcessor.builder().setImmutableBeanArchiveIndex(index).build()
+                .getBeanDeployment();
 
         // Baz, Foo<String>, Object
         Set<Type> bazTypes = Types.getTypeClosure(index.getClassByName(bazName), null,


### PR DESCRIPTION
- this is index is mandatory and is used to discover beans
- the computing index is optional and can be used for other tasks, e.g. during type-safe resolution
- if the computing index is not present the immutable index is used instead
- fixes #29575