### PR TITLE
Allow defining additional data passed to codestarts for project creation

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
@@ -3,6 +3,7 @@ package io.quarkus.cli;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.quarkus.cli.common.DataOptions;
 import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.common.TargetQuarkusVersionGroup;
 import io.quarkus.cli.create.BaseCreateCommand;
@@ -51,6 +52,9 @@ public class CreateApp extends BaseCreateCommand {
     CodeGenerationGroup codeGeneration = new CodeGenerationGroup();
 
     @CommandLine.ArgGroup(order = 6, exclusive = false, validate = false)
+    DataOptions dataOptions = new DataOptions();
+
+    @CommandLine.ArgGroup(order = 7, exclusive = false, validate = false)
     PropertiesOptions propertiesOptions = new PropertiesOptions();
 
     @Override
@@ -72,6 +76,7 @@ public class CreateApp extends BaseCreateCommand {
             setCodegenOptions(codeGeneration);
             setValue(CreateProjectKey.PROJECT_NAME, name);
             setValue(CreateProjectKey.PROJECT_DESCRIPTION, description);
+            setValue(CreateProjectKey.DATA, dataOptions.data);
 
             QuarkusCommandInvocation invocation = build(buildTool, targetQuarkusVersion,
                     propertiesOptions.properties, extensions);
@@ -112,6 +117,7 @@ public class CreateApp extends BaseCreateCommand {
                 + ", name=" + name
                 + ", description=" + description
                 + ", project=" + super.toString()
+                + ", data=" + dataOptions.data
                 + ", properties=" + propertiesOptions.properties
                 + '}';
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
@@ -32,29 +32,29 @@ public class CreateApp extends BaseCreateCommand {
             "--extension", "--extensions" }, description = "Extension(s) to add to the project.", split = ",")
     Set<String> extensions = new HashSet<>();
 
-    @CommandLine.Option(paramLabel = "NAME", names = { "--name" }, description = "Name of the project.")
+    @CommandLine.Option(order = 2, paramLabel = "NAME", names = { "--name" }, description = "Name of the project.")
     String name;
 
-    @CommandLine.Option(paramLabel = "DESCRIPTION", names = {
+    @CommandLine.Option(order = 3, paramLabel = "DESCRIPTION", names = {
             "--description" }, description = "Description of the project.")
     String description;
 
-    @CommandLine.ArgGroup(order = 2, heading = "%nQuarkus version:%n")
+    @CommandLine.ArgGroup(order = 4, heading = "%nQuarkus version:%n")
     TargetQuarkusVersionGroup targetQuarkusVersion = new TargetQuarkusVersionGroup();
 
-    @CommandLine.ArgGroup(order = 3, heading = "%nBuild tool (Maven):%n")
+    @CommandLine.ArgGroup(order = 5, heading = "%nBuild tool (Maven):%n")
     TargetBuildToolGroup targetBuildTool = new TargetBuildToolGroup();
 
-    @CommandLine.ArgGroup(order = 4, exclusive = false, heading = "%nTarget language:%n")
+    @CommandLine.ArgGroup(order = 6, exclusive = false, heading = "%nTarget language:%n")
     TargetLanguageGroup targetLanguage = new TargetLanguageGroup();
 
-    @CommandLine.ArgGroup(order = 5, exclusive = false, heading = "%nCode Generation:%n")
+    @CommandLine.ArgGroup(order = 7, exclusive = false, heading = "%nCode Generation:%n")
     CodeGenerationGroup codeGeneration = new CodeGenerationGroup();
 
-    @CommandLine.ArgGroup(order = 6, exclusive = false, validate = false)
+    @CommandLine.ArgGroup(order = 8, exclusive = false, validate = false)
     DataOptions dataOptions = new DataOptions();
 
-    @CommandLine.ArgGroup(order = 7, exclusive = false, validate = false)
+    @CommandLine.ArgGroup(order = 9, exclusive = false, validate = false)
     PropertiesOptions propertiesOptions = new PropertiesOptions();
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
@@ -3,6 +3,7 @@ package io.quarkus.cli;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.quarkus.cli.common.DataOptions;
 import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.common.TargetQuarkusVersionGroup;
 import io.quarkus.cli.create.BaseCreateCommand;
@@ -10,6 +11,7 @@ import io.quarkus.cli.create.CodeGenerationGroup;
 import io.quarkus.cli.create.TargetBuildToolGroup;
 import io.quarkus.cli.create.TargetGAVGroup;
 import io.quarkus.cli.create.TargetLanguageGroup;
+import io.quarkus.devtools.commands.CreateProject.CreateProjectKey;
 import io.quarkus.devtools.commands.SourceType;
 import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
 import io.quarkus.devtools.commands.handlers.CreateJBangProjectCommandHandler;
@@ -43,6 +45,9 @@ public class CreateCli extends BaseCreateCommand {
     CodeGenerationGroup codeGeneration = new CodeGenerationGroup();
 
     @CommandLine.ArgGroup(order = 6, exclusive = false, validate = false)
+    DataOptions dataOptions = new DataOptions();
+
+    @CommandLine.ArgGroup(order = 7, exclusive = false, validate = false)
     PropertiesOptions propertiesOptions = new PropertiesOptions();
 
     @Override
@@ -64,6 +69,7 @@ public class CreateCli extends BaseCreateCommand {
             setJavaVersion(sourceType, targetLanguage.getJavaVersion());
             setSourceTypeExtensions(extensions, sourceType);
             setCodegenOptions(codeGeneration);
+            setValue(CreateProjectKey.DATA, dataOptions.data);
 
             QuarkusCommandInvocation invocation = build(buildTool, targetQuarkusVersion,
                     propertiesOptions.properties, extensions);
@@ -101,6 +107,7 @@ public class CreateCli extends BaseCreateCommand {
                 + ", codeGeneration=" + codeGeneration
                 + ", extensions=" + extensions
                 + ", project=" + super.toString()
+                + ", data=" + dataOptions.data
                 + ", properties=" + propertiesOptions.properties
                 + '}';
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
@@ -32,22 +32,29 @@ public class CreateCli extends BaseCreateCommand {
             "--extension", "--extensions" }, description = "Extension(s) to add to the project.", split = ",")
     Set<String> extensions = new HashSet<>();
 
-    @CommandLine.ArgGroup(order = 2, heading = "%nQuarkus version:%n")
+    @CommandLine.Option(order = 2, paramLabel = "NAME", names = { "--name" }, description = "Name of the project.")
+    String name;
+
+    @CommandLine.Option(order = 3, paramLabel = "DESCRIPTION", names = {
+            "--description" }, description = "Description of the project.")
+    String description;
+
+    @CommandLine.ArgGroup(order = 4, heading = "%nQuarkus version:%n")
     TargetQuarkusVersionGroup targetQuarkusVersion = new TargetQuarkusVersionGroup();
 
-    @CommandLine.ArgGroup(order = 3, heading = "%nBuild tool (Maven):%n")
+    @CommandLine.ArgGroup(order = 5, heading = "%nBuild tool (Maven):%n")
     TargetBuildToolGroup targetBuildTool = new TargetBuildToolGroup();
 
-    @CommandLine.ArgGroup(order = 4, exclusive = false, heading = "%nTarget language:%n")
+    @CommandLine.ArgGroup(order = 6, exclusive = false, heading = "%nTarget language:%n")
     TargetLanguageGroup targetLanguage = new TargetLanguageGroup();
 
-    @CommandLine.ArgGroup(order = 5, exclusive = false, heading = "%nCode Generation:%n")
+    @CommandLine.ArgGroup(order = 7, exclusive = false, heading = "%nCode Generation:%n")
     CodeGenerationGroup codeGeneration = new CodeGenerationGroup();
 
-    @CommandLine.ArgGroup(order = 6, exclusive = false, validate = false)
+    @CommandLine.ArgGroup(order = 8, exclusive = false, validate = false)
     DataOptions dataOptions = new DataOptions();
 
-    @CommandLine.ArgGroup(order = 7, exclusive = false, validate = false)
+    @CommandLine.ArgGroup(order = 9, exclusive = false, validate = false)
     PropertiesOptions propertiesOptions = new PropertiesOptions();
 
     @Override
@@ -69,6 +76,8 @@ public class CreateCli extends BaseCreateCommand {
             setJavaVersion(sourceType, targetLanguage.getJavaVersion());
             setSourceTypeExtensions(extensions, sourceType);
             setCodegenOptions(codeGeneration);
+            setValue(CreateProjectKey.PROJECT_NAME, name);
+            setValue(CreateProjectKey.PROJECT_DESCRIPTION, description);
             setValue(CreateProjectKey.DATA, dataOptions.data);
 
             QuarkusCommandInvocation invocation = build(buildTool, targetQuarkusVersion,

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/DataOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/DataOptions.java
@@ -1,0 +1,21 @@
+package io.quarkus.cli.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import picocli.CommandLine;
+
+public class DataOptions {
+
+    public Map<String, String> data = new HashMap<>();
+
+    @CommandLine.Option(names = "--data", mapFallbackValue = "", description = "Additional data")
+    void setData(Map<String, String> data) {
+        this.data = data;
+    }
+
+    @Override
+    public String toString() {
+        return data.toString();
+    }
+}

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliCreateExtensionTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliCreateExtensionTest.java
@@ -172,7 +172,7 @@ public class CliCreateExtensionTest {
         Assertions.assertTrue(pom.toFile().exists(),
                 "pom.xml should exist: " + pom.toAbsolutePath().toString());
 
-        String pomContent = CliDriver.readFileAsString(project, pom);
+        String pomContent = CliDriver.readFileAsString(pom);
         Assertions.assertTrue(pomContent.contains("<groupId>" + group + "</groupId>"),
                 pom + " should contain group id " + group + ":\n" + pomContent);
         Assertions.assertTrue(pomContent.contains("<artifactId>" + artifact + "</artifactId>"),

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliDriver.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliDriver.java
@@ -250,7 +250,7 @@ public class CliDriver {
         Assertions.assertFalse(path.toFile().exists());
     }
 
-    public static String readFileAsString(Path projectRoot, Path path) throws Exception {
+    public static String readFileAsString(Path path) throws Exception {
         return new String(Files.readAllBytes(path));
     }
 
@@ -293,7 +293,7 @@ public class CliDriver {
         Assertions.assertTrue(result.stdout.contains("quarkus-qute"),
                 "Expected quarkus-qute to be in the list of extensions. Result:\n" + result);
 
-        String content = readFileAsString(projectRoot, file);
+        String content = readFileAsString(file);
         Assertions.assertTrue(content.contains("quarkus-qute"),
                 "quarkus-qute should be listed as a dependency. Result:\n" + content);
 
@@ -311,7 +311,7 @@ public class CliDriver {
         Assertions.assertFalse(result.stdout.contains("quarkus-qute"),
                 "Expected quarkus-qute to be missing from the list of extensions. Result:\n" + result);
 
-        String content = readFileAsString(projectRoot, file);
+        String content = readFileAsString(file);
         Assertions.assertFalse(content.contains("quarkus-qute"),
                 "quarkus-qute should not be listed as a dependency. Result:\n" + content);
 
@@ -333,7 +333,7 @@ public class CliDriver {
         Assertions.assertTrue(result.stdout.contains("quarkus-jackson"),
                 "Expected quarkus-jackson to be in the list of extensions. Result:\n" + result);
 
-        String content = CliDriver.readFileAsString(projectRoot, file);
+        String content = CliDriver.readFileAsString(file);
         Assertions.assertTrue(content.contains("quarkus-qute"),
                 "quarkus-qute should still be listed as a dependency. Result:\n" + content);
         Assertions.assertTrue(content.contains("quarkus-amazon-lambda-http"),
@@ -359,7 +359,7 @@ public class CliDriver {
         Assertions.assertFalse(result.stdout.contains("quarkus-jackson"),
                 "quarkus-jackson should not be in the list of extensions. Result:\n" + result);
 
-        String content = CliDriver.readFileAsString(projectRoot, file);
+        String content = CliDriver.readFileAsString(file);
         Assertions.assertFalse(content.contains("quarkus-qute"),
                 "quarkus-qute should not be listed as a dependency. Result:\n" + content);
         Assertions.assertFalse(content.contains("quarkus-amazon-lambda-http"),
@@ -455,7 +455,7 @@ public class CliDriver {
         Path properties = projectRoot.resolve("src/main/resources/application.properties");
         Assertions.assertTrue(properties.toFile().exists(),
                 "application.properties should exist: " + properties.toAbsolutePath().toString());
-        String propertiesFile = CliDriver.readFileAsString(projectRoot, properties);
+        String propertiesFile = CliDriver.readFileAsString(properties);
         configs.forEach(conf -> Assertions.assertTrue(propertiesFile.contains(conf),
                 "Properties file should contain " + conf + ". Found:\n" + propertiesFile));
     }

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
@@ -207,7 +207,7 @@ public class CliProjectGradleTest {
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path buildGradle = project.resolve("build.gradle");
-        String buildGradleContent = CliDriver.readFileAsString(project, buildGradle);
+        String buildGradleContent = CliDriver.readFileAsString(buildGradle);
         Assertions.assertFalse(buildGradleContent.contains("quarkus-qute"),
                 "Dependencies should not contain qute extension by default. Found:\n" + buildGradleContent);
 
@@ -379,7 +379,7 @@ public class CliProjectGradleTest {
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path buildGradle = project.resolve("build.gradle");
-        String buildGradleContent = CliDriver.readFileAsString(project, buildGradle);
+        String buildGradleContent = CliDriver.readFileAsString(buildGradle);
         Assertions.assertTrue(buildGradleContent.contains("sourceCompatibility = JavaVersion.VERSION_11"),
                 "Java 11 should be used when specified. Found:\n" + buildGradle);
     }
@@ -394,7 +394,7 @@ public class CliProjectGradleTest {
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path buildGradle = project.resolve("build.gradle");
-        String buildGradleContent = CliDriver.readFileAsString(project, buildGradle);
+        String buildGradleContent = CliDriver.readFileAsString(buildGradle);
 
         Assertions.assertTrue(buildGradleContent.contains("sourceCompatibility = JavaVersion.VERSION_17"),
                 "Java 17 should be used when specified. Found:\n" + buildGradleContent);
@@ -405,7 +405,7 @@ public class CliProjectGradleTest {
         Assertions.assertTrue(buildGradle.toFile().exists(),
                 "build.gradle should exist: " + buildGradle.toAbsolutePath().toString());
 
-        String buildContent = CliDriver.readFileAsString(project, buildGradle);
+        String buildContent = CliDriver.readFileAsString(buildGradle);
         Assertions.assertTrue(buildContent.contains("group '" + group + "'"),
                 "build.gradle should include the group id:\n" + buildContent);
         Assertions.assertTrue(buildContent.contains("version '" + version + "'"),
@@ -414,7 +414,7 @@ public class CliProjectGradleTest {
         Path settings = project.resolve("settings.gradle");
         Assertions.assertTrue(settings.toFile().exists(),
                 "settings.gradle should exist: " + settings.toAbsolutePath().toString());
-        String settingsContent = CliDriver.readFileAsString(project, settings);
+        String settingsContent = CliDriver.readFileAsString(settings);
         Assertions.assertTrue(settingsContent.contains(artifact),
                 "settings.gradle should include the artifact id:\n" + settingsContent);
 
@@ -426,7 +426,7 @@ public class CliProjectGradleTest {
         Assertions.assertTrue(buildGradle.toFile().exists(),
                 "build.gradle.kts should exist: " + buildGradle.toAbsolutePath().toString());
 
-        String buildContent = CliDriver.readFileAsString(project, buildGradle);
+        String buildContent = CliDriver.readFileAsString(buildGradle);
         Assertions.assertTrue(buildContent.contains("group = \"" + group + "\""),
                 "build.gradle.kts should include the group id:\n" + buildContent);
         Assertions.assertTrue(buildContent.contains("version = \"" + version + "\""),
@@ -435,7 +435,7 @@ public class CliProjectGradleTest {
         Path settings = project.resolve("settings.gradle.kts");
         Assertions.assertTrue(settings.toFile().exists(),
                 "settings.gradle.kts should exist: " + settings.toAbsolutePath().toString());
-        String settingsContent = CliDriver.readFileAsString(project, settings);
+        String settingsContent = CliDriver.readFileAsString(settings);
         Assertions.assertTrue(settingsContent.contains(artifact),
                 "settings.gradle.kts should include the artifact id:\n" + settingsContent);
 

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectJBangTest.java
@@ -53,7 +53,7 @@ public class CliProjectJBangTest {
 
         Path javaMain = valdiateJBangSourcePackage(project, ""); // no package name
 
-        String source = CliDriver.readFileAsString(project, javaMain);
+        String source = CliDriver.readFileAsString(javaMain);
         Assertions.assertTrue(source.contains("quarkus-resteasy"),
                 "Generated source should reference resteasy. Found:\n" + source);
 
@@ -89,7 +89,7 @@ public class CliProjectJBangTest {
         validateBasicIdentifiers(project, "silly", "my-project", "0.1.0");
         Path javaMain = valdiateJBangSourcePackage(project, "");
 
-        String source = CliDriver.readFileAsString(project, javaMain);
+        String source = CliDriver.readFileAsString(javaMain);
         Assertions.assertTrue(source.contains("quarkus-reactive-routes"),
                 "Generated source should reference quarkus-reactive-routes. Found:\n" + source);
 
@@ -114,7 +114,7 @@ public class CliProjectJBangTest {
 
         Path javaMain = valdiateJBangSourcePackage(project, ""); // no package name
 
-        String source = CliDriver.readFileAsString(project, javaMain);
+        String source = CliDriver.readFileAsString(javaMain);
         Assertions.assertFalse(source.contains("quarkus-resteasy"),
                 "Generated source should reference resteasy. Found:\n" + source);
         Assertions.assertTrue(source.contains("quarkus-picocli"),
@@ -178,7 +178,7 @@ public class CliProjectJBangTest {
 
         Path javaMain = valdiateJBangSourcePackage(project, ""); // no package name
 
-        String source = CliDriver.readFileAsString(project, javaMain);
+        String source = CliDriver.readFileAsString(javaMain);
         Assertions.assertTrue(source.contains("//JAVA 11"),
                 "Generated source should contain //JAVA 11. Found:\n" + source);
     }
@@ -193,7 +193,7 @@ public class CliProjectJBangTest {
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path javaMain = valdiateJBangSourcePackage(project, ""); // no package name
-        String source = CliDriver.readFileAsString(project, javaMain);
+        String source = CliDriver.readFileAsString(javaMain);
         Assertions.assertTrue(source.contains("//JAVA 17"),
                 "Generated source should contain //JAVA 17. Found:\n" + source);
     }

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -77,11 +77,13 @@ public class CliProjectMavenTest {
 
         List<String> configs = Arrays.asList("custom.app.config1=val1",
                 "custom.app.config2=val2", "lib.config=val3");
+        List<String> data = Arrays.asList("resteasy-reactive-codestart.resource.response=An awesome response");
 
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--verbose", "-e", "-B",
                 "--no-wrapper", "--package-name=custom.pkg",
                 "--output-directory=" + nested,
                 "--app-config=" + String.join(",", configs),
+                "--data=" + String.join(",", data),
                 "-x resteasy-reactive,micrometer-registry-prometheus",
                 "silly:my-project:0.1.0");
 
@@ -110,6 +112,10 @@ public class CliProjectMavenTest {
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code. " + result);
         Assertions.assertTrue(result.stdout.contains("WARN"),
                 "Expected a warning that the directory already exists. " + result);
+
+        String greetingResource = CliDriver.readFileAsString(project,
+                project.resolve("src/main/java/custom/pkg/GreetingResource.java"));
+        Assertions.assertTrue(greetingResource.contains("return \"An awesome response\";"));
     }
 
     @Test

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -113,8 +113,7 @@ public class CliProjectMavenTest {
         Assertions.assertTrue(result.stdout.contains("WARN"),
                 "Expected a warning that the directory already exists. " + result);
 
-        String greetingResource = CliDriver.readFileAsString(project,
-                project.resolve("src/main/java/custom/pkg/GreetingResource.java"));
+        String greetingResource = CliDriver.readFileAsString(project.resolve("src/main/java/custom/pkg/GreetingResource.java"));
         Assertions.assertTrue(greetingResource.contains("return \"An awesome response\";"));
     }
 
@@ -124,7 +123,7 @@ public class CliProjectMavenTest {
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path pom = project.resolve("pom.xml");
-        String pomContent = CliDriver.readFileAsString(project, pom);
+        String pomContent = CliDriver.readFileAsString(pom);
         Assertions.assertFalse(pomContent.contains("quarkus-qute"),
                 "Dependencies should not contain qute extension by default. Found:\n" + pomContent);
 
@@ -335,7 +334,7 @@ public class CliProjectMavenTest {
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path pom = project.resolve("pom.xml");
-        String pomContent = CliDriver.readFileAsString(project, pom);
+        String pomContent = CliDriver.readFileAsString(pom);
 
         Assertions.assertTrue(pomContent.contains("maven.compiler.release>11<"),
                 "Java 11 should be used when specified. Found:\n" + pomContent);
@@ -351,7 +350,7 @@ public class CliProjectMavenTest {
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode, "Expected OK return code." + result);
 
         Path pom = project.resolve("pom.xml");
-        String pomContent = CliDriver.readFileAsString(project, pom);
+        String pomContent = CliDriver.readFileAsString(pom);
 
         Assertions.assertTrue(pomContent.contains("maven.compiler.release>17<"),
                 "Java 17 should be used when specified. Found:\n" + pomContent);
@@ -383,7 +382,7 @@ public class CliProjectMavenTest {
 
         Assertions.assertTrue(pom.toFile().exists(),
                 "pom.xml should exist: " + pom.toAbsolutePath().toString());
-        String pomContent = CliDriver.readFileAsString(project, pom);
+        String pomContent = CliDriver.readFileAsString(pom);
         Assertions.assertTrue(pomContent.contains("<groupId>" + group + "</groupId>"),
                 "pom.xml should contain group id:\n" + pomContent);
         Assertions.assertTrue(pomContent.contains("<artifactId>" + artifact + "</artifactId>"),

--- a/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -187,6 +187,9 @@ public class CreateProjectMojo extends AbstractMojo {
     @Parameter(property = "appConfig")
     private String appConfig;
 
+    @Parameter(property = "data")
+    private String data;
+
     @Override
     public void execute() throws MojoExecutionException {
 
@@ -304,7 +307,8 @@ public class CreateProjectMojo extends AbstractMojo {
                     .resourcePath(path)
                     .example(example)
                     .noCode(noCode)
-                    .appConfig(appConfig);
+                    .appConfig(appConfig)
+                    .data(data);
 
             success = createProject.execute().isSuccess();
             if (success && parentPomModel != null && BuildTool.MAVEN.equals(buildToolEnum)) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProject.java
@@ -48,6 +48,8 @@ public class CreateProject {
         String NO_CODE = "codegen.no-code";
         String EXAMPLE = "codegen.example";
         String EXTRA_CODESTARTS = "codegen.extra-codestarts";
+
+        String DATA = "data";
     }
 
     private QuarkusProject quarkusProject;
@@ -193,6 +195,13 @@ public class CreateProject {
 
     public CreateProject noDockerfiles() {
         return noDockerfiles(true);
+    }
+
+    public CreateProject data(String dataAsString) {
+        setValue(DATA, StringUtils.isNoneBlank(dataAsString) ? ToolsUtils.stringToMap(dataAsString, ",", "=")
+                : Collections.emptyMap());
+
+        return this;
     }
 
     public CreateProject setValue(String name, Object value) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -1,5 +1,6 @@
 package io.quarkus.devtools.commands.handlers;
 
+import static io.quarkus.devtools.commands.CreateProject.CreateProjectKey.DATA;
 import static io.quarkus.devtools.commands.CreateProject.CreateProjectKey.EXAMPLE;
 import static io.quarkus.devtools.commands.CreateProject.CreateProjectKey.EXTENSIONS;
 import static io.quarkus.devtools.commands.CreateProject.CreateProjectKey.EXTRA_CODESTARTS;
@@ -149,6 +150,7 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
                     .noDockerfiles(invocation.getValue(NO_DOCKERFILES, false))
                     .addData(platformData)
                     .addData(toCodestartData(invocation.getValues()))
+                    .addData(invocation.getValue(DATA, Collections.emptyMap()))
                     .messageWriter(invocation.log())
                     .build();
             invocation.log().info("-----------");


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/28372

Also fixes a few minor oversights in my previous patch in follow-up commits.

@ia3andy I tested things manually but I'm unsure how practical it would be to test the new `data` feature as we would need a specific codestart to test it actually works. I think it goes a bit beyond what I'm ready to invest in this feature but maybe you have a better idea?