### PR TITLE
Add further details about podman

### DIFF
--- a/docs/src/main/asciidoc/podman.adoc
+++ b/docs/src/main/asciidoc/podman.adoc
@@ -71,23 +71,8 @@ This action only needs to be done once.
 === Linux
 
 The Podman package is available in several Linux distributions.
-Podman can be used the same way as Docker with the `podman-docker` package.
-To install it for your OS, please refer to the  https://podman.io/getting-started/installation[Podman installation guide].
-Below is the short installation instruction for popular Linux distributions:
-
-==== Fedora
-
-[source,bash]
-----
-sudo dnf install podman podman-docker docker-compose
-----
-
-==== Ubuntu (21.04 and later)
-
-[source,bash]
-----
-sudo apt install podman podman-docker docker-compose
-----
+Podman can in most cases be used as an drop-in-replacement for Docker, either with the `podman-docker` package, or using an alias (`alias docker=podman`).
+To install it for your Linux OS, please refer to the https://podman.io/getting-started/installation#installing-on-linux[Podman installation guide].
 
 === Setting DOCKER_HOST on Linux
 
@@ -96,17 +81,24 @@ On Linux, the REST API Unix socket is, by default, restricted to only allow the 
 This prevents someone from using a container to achieve a privilege escalation on the system.
 While these restrictions can be softened to allow a special group instead of just root, the recommended approach is to use rootless Podman on Linux.
 To use rootless Podman, you need to set a `DOCKER_HOST` environment variable to point to the user-specific socket.
-In both cases, you need to start the REST API by enabling the Podman socket service through systemd.
 
-[source]
+NOTE: In both cases, you need to start the REST API by enabling the Podman socket service through systemd, or at least by making sure Podman is running as a service.
+
+[source,bash]
 ----
-# Enable the podman socket with Docker REST API (only needs to be done once)
+# Example 1: Enable the podman socket with Docker REST API with systemd (only needs to be done once)
 systemctl --user enable podman.socket --now
+----
+
+[source,bash]
+----
+# Example 2: Enable the podman socket with Docker REST API on a system where systemd is not running (WSL etc)
+podman system service --time=0
 ----
 
 Then, you can obtain the path of the socket with the following command:
 
-[source]
+[source,bash]
 ----
 $ podman info | grep -A2 'remoteSocket'
 
@@ -117,7 +109,7 @@ remoteSocket:
 
 Setting the `DOCKER_HOST` environment variable must be done every time or added to the profile:
 
-[source]
+[source,bash]
 ----
 export DOCKER_HOST=unix:///path/to/podman.sock <1>
 ----


### PR DESCRIPTION
This adds further details about the fix and the discussion in https://github.com/quarkusio/quarkus/pull/29562. It clearifies that alias is also fine instead of podman-docker, just redirects the user to podman for install instructions ( they change over time, and more linux variant are shown there, no need duplicate and maintain), and finally,
it shows a way of running podman as service without systemd (relevant on wsl up until recently for example, and users a most likely stuck with slightly older wsl's in a few places).

Signed-off-by: Josef Andersson <josef.andersson@gmail.com>