### PR TITLE
Allow setting the deployment target directly in the deploy option

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -1014,6 +1014,22 @@ OpenShift's users might want to use `oc` rather than `kubectl`:
 oc apply -f target/kubernetes/openshift.json
 ----
 
+For users that prefer to keep the `application.properties` independent of the deployment platform, the deployment target can be specified directly in the deploy command by adding `-Dquarkus.kubernetes.deployment-target=openshift`
+in addition to `-Dquarkus.kubernetes.deploy=true`. Furthermore, Quarkus allows collapsing the two properties into one: `-Dquarkus.openshift.deploy=true`.
+
+[source,bash]
+----
+./mvnw clean package -Dquarkus.openshift.deploy=true
+----
+
+The equivalent with gradle:
+
+[source,bash]
+----
+./gradlew build -Dquarkus.openshift.deploy=true
+----
+
+In case that both properties are used with conflicting values `quarkus.kubernetes.deployment-target` is used.
 
 NOTE: Quarkus also provides the xref:deploying-to-openshift.adoc[OpenShift] extension. This extension is basically a wrapper around the Kubernetes extension and
 relieves OpenShift users of the necessity of setting the `deployment-target` property to `openshift`
@@ -1097,6 +1113,23 @@ and deployed to a cluster (if `quarkus.kubernetes.deploy` has been set to `true`
 By default, when no `deployment-target` is set, then only vanilla Kubernetes resources are generated and deployed. When multiple values are set (for example
 `quarkus.kubernetes.deployment-target=kubernetes,openshift`) then the resources for all targets are generated, but only the resources
 that correspond to the *first* target are applied to the cluster (if deployment is enabled).
+
+For users that prefer to keep the `application.properties` independent of the deployment platform, the deployment target can be specified directly in the deploy command by adding `-Dquarkus.kubernetes.deployment-target=knative`
+in addition to `-Dquarkus.knative.deploy=true`. Furthermore, Quarkus allows collapsing the two properties into one: `-Dquarkus.knative.deploy=true`.
+
+[source,bash]
+----
+./mvnw clean package -Dquarkus.knative.deploy=true
+----
+
+The equivalent with gradle:
+
+[source,bash]
+----
+./gradlew build -Dquarkus.knative.deploy=true
+----
+
+In case that both properties are used with conflicting values `-Dquarkus.kubernetes.deployment-target` is used.
 
 In the case of wrapper extensions like OpenShift and Minikube, when these extensions have been explicitly added to the project, the default `deployment-target`
 is set by those extensions. For example if `quarkus-minikube` has been added to a project, then `minikube` becomes the default deployment target and its

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
@@ -486,6 +486,12 @@ public class KnativeConfig implements PlatformConfiguration {
     @ConfigItem
     SecurityContextConfig securityContext;
 
+    /**
+     * If set to true, Quarkus will attempt to deploy the application to the target knative cluster
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean deploy;
+
     public Optional<String> getAppSecret() {
         return this.appSecret;
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeploy.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeploy.java
@@ -1,14 +1,10 @@
 
 package io.quarkus.kubernetes.deployment;
 
-import static io.quarkus.kubernetes.deployment.Constants.DEPLOY;
-
 import java.util.Optional;
 
 import javax.net.ssl.SSLHandshakeException;
 
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -50,8 +46,7 @@ public class KubernetesDeploy {
     }
 
     private Result doCheck() {
-        Config config = ConfigProvider.getConfig();
-        if (!config.getOptionalValue(DEPLOY, Boolean.class).orElse(false)) {
+        if (!KubernetesConfigUtil.isDeploymentEnabled()) {
             return Result.notConfigured();
         }
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -78,8 +78,8 @@ public class KubernetesDeployer {
             return;
         }
 
-        final DeploymentTargetEntry selectedTarget = determineDeploymentTarget(
-                containerImageInfo, targets, activeContainerImageCapability.get(), containerImageConfig);
+        final DeploymentTargetEntry selectedTarget = determineDeploymentTarget(containerImageInfo, targets,
+                activeContainerImageCapability.get(), containerImageConfig);
         selectedDeploymentTarget.produce(new SelectedKubernetesDeploymentTargetBuildItem(selectedTarget));
         if (MINIKUBE.equals(selectedTarget.getName()) || KIND.equals(selectedTarget.getName())) {
             preventImplicitContainerImagePush.produce(new PreventImplicitContainerImagePushBuildItem());

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -558,6 +558,12 @@ public class OpenshiftConfig implements PlatformConfiguration {
      */
     DebugConfig remoteDebug;
 
+    /**
+     * If set to true, Quarkus will attempt to deploy the application to the target Openshift cluster
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean deploy;
+
     public Optional<String> getAppSecret() {
         return this.appSecret;
     }


### PR DESCRIPTION
Currently we use `quarkus.kubernetes.deploy` to trigger deployment.
To deploy to knative or openshfit we require an addtional option: 
- `-Dquarkus.kubernetes.deployment-target=knative`
- `-Dquarkus.kubernetes.deployment-target=openshift`

This pull request enables users to just use:

-  `-Dquarkus.knative.deploy=true` instead of `-Dquarkus.kubernetes.deploy=true -Dquarkus.kubernetes.deploymet-target=knative`
-  `-Dquarkus.openshift.deploy=true` instead of `-Dquarkus.kubernetes.deploy=true -Dquarkus.kubernetes.deploymet-target=openshift`

What's interesting with this approach is that besides the obvious UX improvement, it also opens the way of using this approach for non-kubernetes deployments.
