### PR TITLE
Add agroal dataSourceImplementation mode selection 

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -145,4 +145,10 @@ public class DataSourceJdbcRuntimeConfig {
     @ConfigItem
     public DataSourceJdbcTracingRuntimeConfig tracing = new DataSourceJdbcTracingRuntimeConfig();
 
+    /**
+     * choose agroal DataSourceImplementation
+     */
+    @ConfigItem
+    public Optional<String> dataSourceImplementation = Optional.empty();
+
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -8,6 +8,7 @@ import java.util.OptionalInt;
 
 import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
 import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
+import io.agroal.api.configuration.AgroalDataSourceConfiguration.DataSourceImplementation;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -149,6 +150,6 @@ public class DataSourceJdbcRuntimeConfig {
      * choose agroal DataSourceImplementation
      */
     @ConfigItem
-    public Optional<String> dataSourceImplementation = Optional.empty();
+    public Optional<DataSourceImplementation> dataSourceImplementation = Optional.empty();
 
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -209,10 +209,24 @@ public class DataSources {
 
         AgroalDataSourceConfigurationSupplier dataSourceConfiguration = new AgroalDataSourceConfigurationSupplier();
 
-        // Set pool-less mode
-        if (!dataSourceJdbcRuntimeConfig.poolingEnabled) {
-            dataSourceConfiguration.dataSourceImplementation(DataSourceImplementation.AGROAL_POOLLESS);
+        String dataSourceImplementation = dataSourceJdbcRuntimeConfig.dataSourceImplementation.get();
+        if(dataSourceImplementation!=null){
+            if(dataSourceImplementation.equals("agroal")){
+                dataSourceConfiguration.dataSourceImplementation(DataSourceImplementation.AGROAL);
+            }
+            if(dataSourceImplementation.equals("agroal_poolless")){
+                dataSourceConfiguration.dataSourceImplementation(DataSourceImplementation.AGROAL_POOLLESS);
+            }
+            if(dataSourceImplementation.equals("hikari")){
+                dataSourceConfiguration.dataSourceImplementation(DataSourceImplementation.HIKARI);
+            }
         }
+
+        // Set pool-less mode poolingEnabled no need
+//        if (!dataSourceJdbcRuntimeConfig.poolingEnabled) {
+//            dataSourceConfiguration.dataSourceImplementation(DataSourceImplementation.AGROAL_POOLLESS);
+//        }
+
 
         AgroalConnectionPoolConfigurationSupplier poolConfiguration = dataSourceConfiguration.connectionPoolConfiguration();
         AgroalConnectionFactoryConfigurationSupplier connectionFactoryConfiguration = poolConfiguration

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -209,23 +209,15 @@ public class DataSources {
 
         AgroalDataSourceConfigurationSupplier dataSourceConfiguration = new AgroalDataSourceConfigurationSupplier();
 
-        String dataSourceImplementation = dataSourceJdbcRuntimeConfig.dataSourceImplementation.get();
-        if(dataSourceImplementation!=null){
-            if(dataSourceImplementation.equals("agroal")){
-                dataSourceConfiguration.dataSourceImplementation(DataSourceImplementation.AGROAL);
-            }
-            if(dataSourceImplementation.equals("agroal_poolless")){
-                dataSourceConfiguration.dataSourceImplementation(DataSourceImplementation.AGROAL_POOLLESS);
-            }
-            if(dataSourceImplementation.equals("hikari")){
-                dataSourceConfiguration.dataSourceImplementation(DataSourceImplementation.HIKARI);
-            }
+        //choose agroal DataSourceImplementation
+        if(dataSourceJdbcRuntimeConfig.dataSourceImplementation.isPresent()){
+            dataSourceConfiguration.dataSourceImplementation(dataSourceJdbcRuntimeConfig.dataSourceImplementation.get());
         }
 
-        // Set pool-less mode poolingEnabled no need
-//        if (!dataSourceJdbcRuntimeConfig.poolingEnabled) {
-//            dataSourceConfiguration.dataSourceImplementation(DataSourceImplementation.AGROAL_POOLLESS);
-//        }
+        // Set pool-less mode
+        if (!dataSourceJdbcRuntimeConfig.poolingEnabled) {
+            dataSourceConfiguration.dataSourceImplementation(DataSourceImplementation.AGROAL_POOLLESS);
+        }
 
 
         AgroalConnectionPoolConfigurationSupplier poolConfiguration = dataSourceConfiguration.connectionPoolConfiguration();


### PR DESCRIPTION
Hello,
AgroalDataSourceConfigurationSupplier uses DataSourceImplementation.AGROAL to initialize dataSourceImplementation by default. I hope to have more diversified choices through configuration.
Through JMH's test performance comparison, Hikari's performance is far better than agroal, and agroal also supports the packaging of Hikari-related packages, so I want to add dataSourceImplementation parameters in DataSourceJdbcRuntimeConfig,
"agroal", "agroal_poolless" and "hikari" three parameters to select different data pools. PoolingEnable in DataSourceJdbcRuntimeConfig can also remove this parameter if it is not used elsewhere.

jmh test result: [https://github.com/zhouzhou19950825/somedemo/blob/main/jmhtest.jpg](url)

hope to be adopted，Thanks！