### PR TITLE
MongoDb with Panache: Add multi-tenancy support to MongoDb Panache throught dynamic database selection

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -141,8 +141,8 @@ The `quarkus.mongodb.database` property will be used by MongoDB with Panache to 
 
 The `@MongoEntity` annotation allows configuring:
 
-* the name of the client for multi-tenant application, see xref:mongodb.adoc#multiple-mongodb-clients[Multiple MongoDB Clients]. Otherwise, the default client will be used.
-* the name of the database, otherwise, the `quarkus.mongodb.database` property will be used.
+* the name of the client for multitenant application, see xref:mongodb.adoc#multiple-mongodb-clients[Multiple MongoDB Clients]. Otherwise, the default client will be used.
+* the name of the database, otherwise the `quarkus.mongodb.database` property or a link:{mongodb-doc-root-url}#multitenancy[`MongoDatabaseResolver`] implementation will be used.
 * the name of the collection, otherwise the simple name of the class will be used.
 
 For advanced configuration of the MongoDB client, you can follow the xref:mongodb.adoc#configuring-the-mongodb-database[Configuring the MongoDB database guide].
@@ -1238,3 +1238,220 @@ by the presence of the marker file `META-INF/panache-archive.marker`. Panache in
 annotation processor that will automatically create this file in archives that depend on
 Panache (even indirectly). If you have disabled annotation processors you may need to create
 this file manually in some cases.
+
+== Multitenancy
+
+"Multitenancy is a software architecture where a single software instance can serve multiple, distinct user groups. Software-as-a-service (SaaS) 
+offerings are an example of multitenant architecture." (link:https://www.redhat.com/en/topics/cloud-computing/what-is-multitenancy#:~:text=Multitenancy%20is%20a%20software%20architecture,an%20example%20of%20multitenant%20architecture.[Red Hat]).
+
+MongoDB with Panache currently supports the database per tenant approach, it's similar to schema per tenant approach when compared to SQL databases.
+
+=== Writing the application
+
+In order to resolve the tenant from incoming requests and map it to a specific database, you must create an implementation 
+of the `io.quarkus.mongodb.panache.common.MongoDatabaseResolver` interface.
+
+[source,java]
+----
+import io.quarkus.mongodb.panache.common.MongoDatabaseResolver;
+import io.vertx.ext.web.RoutingContext;
+
+@RequestScoped // <1>
+public class CustomMongoDatabaseResolver implements MongoDatabaseResolver {
+
+    @Inject
+    RoutingContext context;
+   
+    @Override
+    public String resolve() {
+        return context.request().getHeader("X-Tenant");
+    }
+    
+}
+----
+<1> The bean is made `@RequestScoped` as the tenant resolution depends on the incoming request.
+
+[IMPORTANT]
+====
+The database selection priority order is as follow: `@MongoEntity(database="mizain")`, `MongoDatabaseResolver`, 
+and then `quarkus.mongodb.database` property.
+====
+
+[NOTE]
+====
+If you also use xref:security-openid-connect-multitenancy.adoc[OIDC multitenancy], then if the OIDC tenantID and MongoDB 
+database are the same and must be extracted from the Vert.x `RoutingContext` you can pass the tenant id from the OIDC `TenantResolver` 
+to the MongoDB with Panache `MongoDatabaseResolver` as a `RoutingContext` attribute, for example:
+
+[source,java]
+----
+import io.quarkus.mongodb.panache.common.MongoDatabaseResolver;
+import io.vertx.ext.web.RoutingContext;
+
+@RequestScoped
+public class CustomMongoDatabaseResolver implements MongoDatabaseResolver {
+
+    @Inject
+    RoutingContext context;
+    ...
+    @Override
+    public String resolve() {
+        // OIDC TenantResolver has already calculated the tenant id and saved it as a RoutingContext `tenantId` attribute:
+        return context.get("tenantId");
+    }
+}
+----
+====
+
+Given this entity:
+
+[source,java]
+----
+import org.bson.codecs.pojo.annotations.BsonId;
+import io.quarkus.mongodb.panache.common.MongoEntity;
+
+@MongoEntity(collection = "persons")
+public class Person extends PanacheMongoEntityBase {
+    @BsonId
+    public Long id;
+    public String firstName;
+    public String lastName;
+}
+----
+
+And this resource:
+
+[source,java]
+----
+import java.net.URI;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/persons")
+public class PersonResource {
+
+    @GET
+    @Path("/{id}")
+    public Person getById(Long id) {
+        return Person.findById(id);
+    }
+
+    @POST
+    public Response create(Person person) {
+        Person.persist(person);
+        return Response.created(URI.create(String.format("/persons/%d", person.id))).build();
+    }
+}
+----
+
+From the classes above, we have enough to persist and fetch persons from different databases, so it's possible to see how it works. 
+
+=== Configuring the application
+
+The same mongo connection will be used for all tenants, so a database has to be created for every tenant.
+
+[source,properties]
+----
+quarkus.mongodb.connection-string=mongodb://login:pass@mongo:27017
+# The default database
+quarkus.mongodb.database=sanjoka
+----
+
+=== Testing
+
+You can write your test like this:
+
+[source,java]
+----
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.Method;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
+@QuarkusTest
+public class PanacheMongoMultiTenancyTest {
+
+    public static final String TENANT_HEADER_NAME = "X-Tenant";
+    private static final String TENANT_1 = "Tenant1";
+    private static final String TENANT_2 = "Tenant2";
+
+    @Test
+    public void testMongoDatabaseResolverUsingPersonResource() {
+        Person person1 = new Person();
+        person1.id = 1L;
+        person1.firstname = "Pedro";
+        person1.lastname = "Pereira";
+        person1.status = Status.ALIVE;
+
+        Person person2 = new Person();
+        person2.id = 2L;
+        person2.firstname = "Tibé";
+        person2.lastname = "Venâncio";
+        person2.status = Status.ALIVE;
+
+        String endpoint = "/persons";
+
+        // creating person 1
+        Response createPerson1Response = callCreatePersonEndpoint(endpoint, TENANT_1, person1);
+        assertResponse(createPerson1Response, 201);
+        
+        // checking person 1 creation
+        Response getPerson1ByIdResponse = callGetPersonByIdEndpoint(endpoint, person1.id, TENANT_1);
+        assertResponse(getPerson1ByIdResponse, 200, person1);
+
+        // creating person 2
+        Response createPerson2Response = callCreatePersonEndpoint(endpoint, TENANT_2, person2);
+        assertResponse(createPerson2Response, 201);
+
+        // checking person 2 creation
+        Response getPerson2ByIdResponse = callGetPersonByIdEndpoint(endpoint, person2.id, TENANT_2);
+        assertResponse(getPerson2ByIdResponse, 200, person2);
+    }
+
+    protected Response callCreatePersonEndpoint(String endpoint, String tenant, Object person) {
+        return RestAssured.given()
+                .header("Content-Type", "application/json")
+                .header(TENANT_HEADER_NAME, tenant)
+                .body(person)
+                .post(endpoint)
+                .andReturn();
+    }
+
+    private Response callGetPersonByIdEndpoint(String endpoint, Long resourceId, String tenant) {
+        RequestSpecification request = RestAssured.given()
+                .header("Content-Type", "application/json");
+
+        if (Objects.nonNull(tenant) && !tenant.isBlank()) {
+            request.header(TENANT_HEADER_NAME, tenant);
+        }
+
+        return request.when()
+                .request(Method.GET, endpoint.concat("/{id}"), resourceId)
+                .andReturn();
+    }
+
+    private void assertResponse(Response response, Integer expectedStatusCode) {
+        assertResponse(response, expectedStatusCode, null);
+    }
+
+    private void assertResponse(Response response, Integer expectedStatusCode, Object expectedResponseBody) {
+        assertEquals(expectedStatusCode, response.statusCode());
+        if (Objects.nonNull(expectedResponseBody)) {
+            assertTrue(EqualsBuilder.reflectionEquals(response.as(expectedResponseBody.getClass()), expectedResponseBody));
+        }
+    }
+}
+----

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -308,7 +308,9 @@ A similar technique can be used with `TenantConfigResolver` where a `tenant-id` 
 
 [NOTE]
 ====
-If you also use xref:hibernate-orm.adoc#multitenancy[Hibernate ORM multitenancy] and both OIDC and Hibernate ORM tenant IDs are the same and must be extracted from the Vert.x `RoutingContext` then you can pass the tenant id from the OIDC Tenant Resolver to the Hibernate ORM Tenant Resolver as a `RoutingContext` attribute, for example:
+If you also use xref:hibernate-orm.adoc#multitenancy[Hibernate ORM multitenancy] or xref:mongodb-panache.adoc#multitenancy[MongoDB with Panache multitenancy] and both tenant IDs are the same 
+and must be extracted from the Vert.x `RoutingContext` you can pass the tenant id from the OIDC Tenant Resolver to the Hibernate ORM Tenant Resolver or MongoDB with Panache Mongo Database Resolver 
+as a `RoutingContext` attribute, for example:
 
 [source,java]
 ----

--- a/extensions/panache/mongodb-panache-common/deployment/pom.xml
+++ b/extensions/panache/mongodb-panache-common/deployment/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/panache/mongodb-panache-common/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/BasePanacheMongoResourceProcessor.java
+++ b/extensions/panache/mongodb-panache-common/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/BasePanacheMongoResourceProcessor.java
@@ -28,6 +28,7 @@ import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
@@ -68,6 +69,8 @@ public abstract class BasePanacheMongoResourceProcessor {
     public static final DotName BSON_ID = createSimple(BsonId.class.getName());
     public static final DotName BSON_IGNORE = createSimple(BsonIgnore.class.getName());
     public static final DotName BSON_PROPERTY = createSimple(BsonProperty.class.getName());
+    public static final DotName MONGO_DATABASE_RESOLVER = createSimple(
+            io.quarkus.mongodb.panache.common.MongoDatabaseResolver.class.getName());
     public static final DotName MONGO_ENTITY = createSimple(io.quarkus.mongodb.panache.common.MongoEntity.class.getName());
     public static final DotName PROJECTION_FOR = createSimple(io.quarkus.mongodb.panache.common.ProjectionFor.class.getName());
     public static final String BSON_PACKAGE = "org.bson.";
@@ -81,7 +84,7 @@ public abstract class BasePanacheMongoResourceProcessor {
             List<PanacheMethodCustomizerBuildItem> methodCustomizersBuildItems) {
 
         List<PanacheMethodCustomizer> methodCustomizers = methodCustomizersBuildItems.stream()
-                .map(bi -> bi.getMethodCustomizer()).collect(Collectors.toList());
+                .map(PanacheMethodCustomizerBuildItem::getMethodCustomizer).collect(Collectors.toList());
 
         MetamodelInfo modelInfo = new MetamodelInfo();
         processTypes(index, transformers, reflectiveClass, reflectiveHierarchy, propertyMappingClass, getImperativeTypeBundle(),
@@ -98,7 +101,7 @@ public abstract class BasePanacheMongoResourceProcessor {
             BuildProducer<BytecodeTransformerBuildItem> transformers,
             List<PanacheMethodCustomizerBuildItem> methodCustomizersBuildItems) {
         List<PanacheMethodCustomizer> methodCustomizers = methodCustomizersBuildItems.stream()
-                .map(bi -> bi.getMethodCustomizer()).collect(Collectors.toList());
+                .map(PanacheMethodCustomizerBuildItem::getMethodCustomizer).collect(Collectors.toList());
 
         MetamodelInfo modelInfo = new MetamodelInfo();
         processTypes(index, transformers, reflectiveClass, reflectiveHierarchy, propertyMappingClass, getReactiveTypeBundle(),
@@ -410,6 +413,11 @@ public abstract class BasePanacheMongoResourceProcessor {
     @BuildStep
     public void unremovableClients(BuildProducer<MongoUnremovableClientsBuildItem> unremovable) {
         unremovable.produce(new MongoUnremovableClientsBuildItem());
+    }
+
+    @BuildStep
+    protected void unremovableMongoDatabaseResolvers(BuildProducer<UnremovableBeanBuildItem> unremovable) {
+        unremovable.produce(UnremovableBeanBuildItem.beanTypes(MONGO_DATABASE_RESOLVER));
     }
 
     @BuildStep

--- a/extensions/panache/mongodb-panache-common/deployment/src/test/java/io/quarkus/mongodb/panache/common/MongoDatabaseResolverTest.java
+++ b/extensions/panache/mongodb-panache-common/deployment/src/test/java/io/quarkus/mongodb/panache/common/MongoDatabaseResolverTest.java
@@ -1,0 +1,199 @@
+package io.quarkus.mongodb.panache.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.bson.Document;
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+
+import io.quarkus.mongodb.panache.common.reactive.runtime.ReactiveMongoOperations;
+import io.quarkus.mongodb.panache.common.runtime.MongoOperations;
+import io.quarkus.mongodb.reactive.ReactiveMongoClient;
+import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.mongodb.MongoReplicaSetTestResource;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@QuarkusTestResource(MongoReplicaSetTestResource.class)
+@DisabledOnOs(OS.WINDOWS)
+public class MongoDatabaseResolverTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(
+                            "quarkus.arc.remove-unused-beans=false\n" +
+                                    "quarkus.mongodb.connection-string=mongodb://localhost:27017,localhost:27018\n" +
+                                    "quarkus.mongodb.devservices.enabled=false"),
+                            "application.properties"));
+
+    protected static final MongoOperations<Object, PanacheUpdate> OPERATIONS = new CustomMongoOperations();
+    protected static final ReactiveMongoOperations<Object, PanacheUpdate> REACTIVE_OPERATIONS = new CustomReactiveMongoOperations();
+
+    @Inject
+    MongoClient mongoClient;
+
+    @Inject
+    ReactiveMongoClient reactiveMongoClient;
+
+    @Test
+    public void resolveUsingTwoTenantsImperative() {
+        resolveUsingTwoTenantsTest(false);
+    }
+
+    @Test
+    public void resolveUsingTwoTenantsReactive() {
+        resolveUsingTwoTenantsTest(true);
+    }
+
+    private void resolveUsingTwoTenantsTest(final boolean isReactive) {
+        // arrange
+        Person personTenant1 = new Person();
+        personTenant1.id = 1L;
+        personTenant1.firstname = "Pedro";
+        personTenant1.lastname = "Pereira";
+
+        Person personTenant2 = new Person();
+        personTenant2.id = 1L;
+        personTenant2.firstname = "Tibé";
+        personTenant2.lastname = "Venâncio";
+
+        String TENANT_1 = isReactive ? "reactive-sanjoka" : "sanjoka";
+        String TENANT_2 = isReactive ? "reactive-mizain" : "mizain";
+
+        persistPerson(isReactive, personTenant1, TENANT_1);
+        persistPerson(isReactive, personTenant2, TENANT_2);
+
+        // act
+        CustomMongoDatabaseResolver.DATABASE = TENANT_1;
+        final Object result1 = findPersonByIdUsingMongoOperations(isReactive, personTenant1.id);
+
+        CustomMongoDatabaseResolver.DATABASE = TENANT_2;
+        final Object result2 = findPersonByIdUsingMongoOperations(isReactive, personTenant2.id);
+
+        // assert
+        assertPerson(personTenant1, (Person) result1);
+        assertPerson(personTenant2, (Person) result2);
+    }
+
+    private void persistPerson(final boolean isReactive, final Person person, final String databaseName) {
+        final Document document = new Document()
+                .append("_id", person.id)
+                .append("firstname", person.firstname)
+                .append("lastname", person.lastname);
+
+        if (isReactive) {
+            reactiveMongoClient.getDatabase(databaseName)
+                    .getCollection("persons")
+                    .insertOne(document)
+                    .await()
+                    .indefinitely();
+            return;
+        }
+
+        mongoClient.getDatabase(databaseName)
+                .getCollection("persons")
+                .insertOne(document);
+    }
+
+    private Person findPersonByIdUsingMongoOperations(final boolean isReactive, final Long id) {
+        return isReactive
+                ? (Person) REACTIVE_OPERATIONS.findById(Person.class, id).await().indefinitely()
+                : (Person) OPERATIONS.findById(Person.class, id);
+    }
+
+    private void assertPerson(final Person expected, final Person value) {
+        assertNotNull(value);
+        assertEquals(expected.id, value.id);
+        assertEquals(expected.firstname, value.firstname);
+        assertEquals(expected.lastname, value.lastname);
+    }
+
+    @SuppressWarnings({ "rawtypes" })
+    private static class CustomMongoOperations extends MongoOperations<Object, PanacheUpdate> {
+
+        @Override
+        protected Object createQuery(MongoCollection<?> collection, ClientSession session, Document query, Document sortDoc) {
+            return null;
+        }
+
+        @Override
+        protected PanacheUpdate createUpdate(MongoCollection collection, Class<?> entityClass, Document docUpdate) {
+            return null;
+        }
+
+        @Override
+        protected List<?> list(Object queryType) {
+            return null;
+        }
+
+        @Override
+        protected Stream<?> stream(Object queryType) {
+            return null;
+        }
+
+    }
+
+    @SuppressWarnings({ "rawtypes" })
+    private static class CustomReactiveMongoOperations extends ReactiveMongoOperations<Object, PanacheUpdate> {
+
+        @Override
+        protected Object createQuery(ReactiveMongoCollection collection, Document query, Document sortDoc) {
+            return null;
+        }
+
+        @Override
+        protected PanacheUpdate createUpdate(ReactiveMongoCollection<?> collection, Class<?> entityClass, Document docUpdate) {
+            return null;
+        }
+
+        @Override
+        protected Uni<?> list(Object query) {
+            return null;
+        }
+
+        @Override
+        protected Multi<?> stream(Object query) {
+            return null;
+        }
+
+    }
+
+    @MongoEntity(collection = "persons")
+    protected static class Person {
+        @BsonId
+        public Long id;
+        public String firstname;
+        public String lastname;
+    }
+
+    @ApplicationScoped
+    private static class CustomMongoDatabaseResolver implements MongoDatabaseResolver {
+
+        public static String DATABASE;
+
+        @Override
+        public String resolve() {
+            return DATABASE;
+        }
+
+    }
+
+}

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/MongoDatabaseResolver.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/MongoDatabaseResolver.java
@@ -1,0 +1,8 @@
+package io.quarkus.mongodb.panache.common;
+
+/*
+ * This interface can be used to resolve the MongoDB database name at runtime, it allows to implement multi-tenancy using a tenant per database approach.
+ */
+public interface MongoDatabaseResolver {
+    String resolve();
+}

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/runtime/ReactiveMongoOperations.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/runtime/ReactiveMongoOperations.java
@@ -3,6 +3,7 @@ package io.quarkus.mongodb.panache.common.reactive.runtime;
 import static io.quarkus.mongodb.panache.common.runtime.BeanUtils.beanName;
 import static io.quarkus.mongodb.panache.common.runtime.BeanUtils.clientFromArc;
 import static io.quarkus.mongodb.panache.common.runtime.BeanUtils.getDatabaseName;
+import static io.quarkus.mongodb.panache.common.runtime.BeanUtils.getDatabaseNameFromResolver;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -315,7 +316,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
         if (mongoEntity != null && !mongoEntity.database().isEmpty()) {
             return mongoClient.getDatabase(mongoEntity.database());
         }
-        String databaseName = getDefaultDatabaseName(mongoEntity);
+        String databaseName = getDatabaseNameFromResolver().orElseGet(() -> getDefaultDatabaseName(mongoEntity));
         return mongoClient.getDatabase(databaseName);
     }
 

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/runtime/ReactiveMongoOperations.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/runtime/ReactiveMongoOperations.java
@@ -26,6 +26,7 @@ import com.mongodb.client.model.InsertOneModel;
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.WriteModel;
+import com.mongodb.client.result.DeleteResult;
 
 import io.quarkus.mongodb.panache.common.MongoEntity;
 import io.quarkus.mongodb.panache.common.binder.NativeQueryBinder;
@@ -74,7 +75,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
                 objects.add(entity);
             }
 
-            if (objects.size() > 0) {
+            if (!objects.isEmpty()) {
                 // get the first entity to be able to retrieve the collection with it
                 Object firstEntity = objects.get(0);
                 ReactiveMongoCollection collection = mongoCollection(firstEntity);
@@ -99,7 +100,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
     public Uni<Void> persist(Stream<?> entities) {
         return Uni.createFrom().deferred(() -> {
             List<Object> objects = entities.collect(Collectors.toList());
-            if (objects.size() > 0) {
+            if (!objects.isEmpty()) {
                 // get the first entity to be able to retrieve the collection with it
                 Object firstEntity = objects.get(0);
                 ReactiveMongoCollection collection = mongoCollection(firstEntity);
@@ -122,7 +123,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
                 objects.add(entity);
             }
 
-            if (objects.size() > 0) {
+            if (!objects.isEmpty()) {
                 // get the first entity to be able to retrieve the collection with it
                 Object firstEntity = objects.get(0);
                 ReactiveMongoCollection collection = mongoCollection(firstEntity);
@@ -147,7 +148,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
     public Uni<Void> update(Stream<?> entities) {
         return Uni.createFrom().deferred(() -> {
             List<Object> objects = entities.collect(Collectors.toList());
-            if (objects.size() > 0) {
+            if (!objects.isEmpty()) {
                 // get the first entity to be able to retrieve the collection with it
                 Object firstEntity = objects.get(0);
                 ReactiveMongoCollection collection = mongoCollection(firstEntity);
@@ -170,7 +171,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
                 objects.add(entity);
             }
 
-            if (objects.size() > 0) {
+            if (!objects.isEmpty()) {
                 // get the first entity to be able to retrieve the collection with it
                 Object firstEntity = objects.get(0);
                 ReactiveMongoCollection collection = mongoCollection(firstEntity);
@@ -195,7 +196,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
     public Uni<Void> persistOrUpdate(Stream<?> entities) {
         return Uni.createFrom().deferred(() -> {
             List<Object> objects = entities.collect(Collectors.toList());
-            if (objects.size() > 0) {
+            if (!objects.isEmpty()) {
                 // get the first entity to be able to retrieve the collection with it
                 Object firstEntity = objects.get(0);
                 ReactiveMongoCollection collection = mongoCollection(firstEntity);
@@ -345,7 +346,6 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
         return find(entityClass, query, null, params);
     }
 
-    @SuppressWarnings("rawtypes")
     public QueryType find(Class<?> entityClass, String query, Sort sort, Object... params) {
         String bindQuery = bindFilter(entityClass, query, params);
         Document docQuery = Document.parse(bindQuery);
@@ -445,7 +445,6 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
         return find(entityClass, query, null, params);
     }
 
-    @SuppressWarnings("rawtypes")
     public QueryType find(Class<?> entityClass, String query, Sort sort, Map<String, Object> params) {
         String bindQuery = bindFilter(entityClass, query, params);
         Document docQuery = Document.parse(bindQuery);
@@ -462,7 +461,6 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
         return find(entityClass, query, sort, params.map());
     }
 
-    @SuppressWarnings("rawtypes")
     public QueryType find(Class<?> entityClass, Document query, Sort sort) {
         ReactiveMongoCollection collection = mongoCollection(entityClass);
         Document sortDoc = sortToDocument(sort);
@@ -546,13 +544,11 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
         return stream(find(entityClass, query, sort));
     }
 
-    @SuppressWarnings("rawtypes")
     public QueryType findAll(Class<?> entityClass) {
         ReactiveMongoCollection collection = mongoCollection(entityClass);
         return createQuery(collection, null, null);
     }
 
-    @SuppressWarnings("rawtypes")
     public QueryType findAll(Class<?> entityClass, Sort sort) {
         ReactiveMongoCollection collection = mongoCollection(entityClass);
         Document sortDoc = sortToDocument(sort);
@@ -621,7 +617,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
 
     public Uni<Long> deleteAll(Class<?> entityClass) {
         ReactiveMongoCollection<?> collection = mongoCollection(entityClass);
-        return collection.deleteMany(new Document()).map(deleteResult -> deleteResult.getDeletedCount());
+        return collection.deleteMany(new Document()).map(DeleteResult::getDeletedCount);
     }
 
     public Uni<Boolean> deleteById(Class<?> entityClass, Object id) {
@@ -634,14 +630,14 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
         String bindQuery = bindFilter(entityClass, query, params);
         BsonDocument docQuery = BsonDocument.parse(bindQuery);
         ReactiveMongoCollection<?> collection = mongoCollection(entityClass);
-        return collection.deleteMany(docQuery).map(deleteResult -> deleteResult.getDeletedCount());
+        return collection.deleteMany(docQuery).map(DeleteResult::getDeletedCount);
     }
 
     public Uni<Long> delete(Class<?> entityClass, String query, Map<String, Object> params) {
         String bindQuery = bindFilter(entityClass, query, params);
         BsonDocument docQuery = BsonDocument.parse(bindQuery);
         ReactiveMongoCollection<?> collection = mongoCollection(entityClass);
-        return collection.deleteMany(docQuery).map(deleteResult -> deleteResult.getDeletedCount());
+        return collection.deleteMany(docQuery).map(DeleteResult::getDeletedCount);
     }
 
     public Uni<Long> delete(Class<?> entityClass, String query, Parameters params) {
@@ -651,7 +647,7 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
     //specific Mongo query
     public Uni<Long> delete(Class<?> entityClass, Document query) {
         ReactiveMongoCollection<?> collection = mongoCollection(entityClass);
-        return collection.deleteMany(query).map(deleteResult -> deleteResult.getDeletedCount());
+        return collection.deleteMany(query).map(DeleteResult::getDeletedCount);
     }
 
     public UpdateType update(Class<?> entityClass, String update, Map<String, Object> params) {

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/BeanUtils.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/BeanUtils.java
@@ -1,12 +1,16 @@
 package io.quarkus.mongodb.panache.common.runtime;
 
 import java.lang.annotation.Annotation;
+import java.util.Optional;
+import java.util.function.Predicate;
 
 import javax.inject.Named;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableInstance;
 import io.quarkus.arc.InstanceHandle;
+import io.quarkus.mongodb.panache.common.MongoDatabaseResolver;
 import io.quarkus.mongodb.panache.common.MongoEntity;
 import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 import io.quarkus.mongodb.runtime.MongoClientConfig;
@@ -81,5 +85,13 @@ public final class BeanUtils {
         throw new IllegalArgumentException(String.format(
                 "The database attribute was not set for the @MongoEntity annotation neither was the database property configured for the named Mongo Client (via 'quarkus.mongodb.%s.database')",
                 mongoEntity.clientName()));
+    }
+
+    public static Optional<String> getDatabaseNameFromResolver() {
+        return Optional.of(Arc.container().select(MongoDatabaseResolver.class))
+                .filter(Predicate.not(InjectableInstance::isUnsatisfied))
+                .map(InjectableInstance::get)
+                .map(MongoDatabaseResolver::resolve)
+                .filter(Predicate.not(String::isBlank));
     }
 }

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
@@ -112,7 +112,7 @@ public abstract class MongoOperations<QueryType, UpdateType> {
             objects.add(entity);
         }
 
-        if (objects.size() > 0) {
+        if (!objects.isEmpty()) {
             // get the first entity to be able to retrieve the collection with it
             Object firstEntity = objects.get(0);
             MongoCollection collection = mongoCollection(firstEntity);
@@ -134,7 +134,7 @@ public abstract class MongoOperations<QueryType, UpdateType> {
 
     public void update(Stream<?> entities) {
         List<Object> objects = entities.collect(Collectors.toList());
-        if (objects.size() > 0) {
+        if (!objects.isEmpty()) {
             // get the first entity to be able to retrieve the collection with it
             Object firstEntity = objects.get(0);
             MongoCollection collection = mongoCollection(firstEntity);
@@ -214,7 +214,7 @@ public abstract class MongoOperations<QueryType, UpdateType> {
     }
 
     private void persist(List<Object> entities) {
-        if (entities.size() > 0) {
+        if (!entities.isEmpty()) {
             // get the first entity to be able to retrieve the collection with it
             Object firstEntity = entities.get(0);
             MongoCollection collection = mongoCollection(firstEntity);
@@ -383,7 +383,7 @@ public abstract class MongoOperations<QueryType, UpdateType> {
         if (mongoEntity != null && !mongoEntity.database().isEmpty()) {
             return mongoClient.getDatabase(mongoEntity.database());
         }
-        String databaseName = getDefaultDatabaseName(mongoEntity);
+        String databaseName = BeanUtils.getDefaultDatabaseName(mongoEntity);
         return mongoClient.getDatabase(databaseName);
     }
 
@@ -414,7 +414,6 @@ public abstract class MongoOperations<QueryType, UpdateType> {
         return find(entityClass, query, null, params);
     }
 
-    @SuppressWarnings("rawtypes")
     public QueryType find(Class<?> entityClass, String query, Sort sort, Object... params) {
         String bindQuery = bindFilter(entityClass, query, params);
         Document docQuery = Document.parse(bindQuery);
@@ -511,7 +510,6 @@ public abstract class MongoOperations<QueryType, UpdateType> {
         return find(entityClass, query, null, params);
     }
 
-    @SuppressWarnings("rawtypes")
     public QueryType find(Class<?> entityClass, String query, Sort sort, Map<String, Object> params) {
         String bindQuery = bindFilter(entityClass, query, params);
         Document docQuery = Document.parse(bindQuery);
@@ -529,7 +527,6 @@ public abstract class MongoOperations<QueryType, UpdateType> {
         return find(entityClass, query, sort, params.map());
     }
 
-    @SuppressWarnings("rawtypes")
     public QueryType find(Class<?> entityClass, Document query, Sort sort) {
         MongoCollection collection = mongoCollection(entityClass);
         Document sortDoc = sortToDocument(sort);
@@ -615,14 +612,12 @@ public abstract class MongoOperations<QueryType, UpdateType> {
         return stream(find(entityClass, query, sort));
     }
 
-    @SuppressWarnings("rawtypes")
     public QueryType findAll(Class<?> entityClass) {
         MongoCollection collection = mongoCollection(entityClass);
         ClientSession session = getSession(entityClass);
         return createQuery(collection, session, null, null);
     }
 
-    @SuppressWarnings("rawtypes")
     public QueryType findAll(Class<?> entityClass, Sort sort) {
         MongoCollection collection = mongoCollection(entityClass);
         Document sortDoc = sortToDocument(sort);

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
@@ -383,7 +383,7 @@ public abstract class MongoOperations<QueryType, UpdateType> {
         if (mongoEntity != null && !mongoEntity.database().isEmpty()) {
             return mongoClient.getDatabase(mongoEntity.database());
         }
-        String databaseName = BeanUtils.getDefaultDatabaseName(mongoEntity);
+        String databaseName = BeanUtils.getDatabaseNameFromResolver().orElseGet(() -> getDefaultDatabaseName(mongoEntity));
         return mongoClient.getDatabase(databaseName);
     }
 


### PR DESCRIPTION
Based on #14789

It consists in a interface called MongoDatabaseResolver that can be implemented to get the database name to be used on mongo operations execution
So if I have a MongoDatabaseResolver implementation the database to be used in the current mongo operation will be the return of resolve() method, but the resolver will be successful only for the entities that doesn't specify the database through the @MongoEntity(database="")

Disclaimer:
After this PR be approved I can help to provide a detailed documentation
My other PR #29192 was closed accidentaly

@loicmathieu @evanchooly @geoand 