### PR TITLE
Remove OpenApi CORS default support

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiDefaultPathTestCase.java
@@ -42,6 +42,6 @@ public class OpenApiDefaultPathTestCase {
 
         RestAssured.given()
                 .when().options(OPEN_API_PATH)
-                .then().header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
+                .then().header("Allow", "GET, HEAD, OPTIONS");
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiDefaultPathTestCase.java
@@ -34,20 +34,4 @@ public class OpenApiDefaultPathTestCase {
                 .body("info.title", Matchers.equalTo("quarkus-smallrye-openapi-deployment API"))
                 .body("paths", Matchers.hasKey("/resource"));
     }
-
-    @Test
-    public void testDefaultOpenApiCorsProperties() {
-        // make sure default CORS properties are present
-        RestAssured
-                .given()
-                .header("Origin", "https://quarkus.io")
-                .get(OPEN_API_PATH)
-                .then()
-                .statusCode(200)
-                .header("access-control-allow-methods", "GET, HEAD, OPTIONS")
-                .header("access-control-allow-headers", "Content-Type, Authorization")
-                .header("access-control-max-age", "86400")
-                .header("access-control-allow-origin", "*")
-                .header("access-control-allow-credentials", "true");
-    }
 }

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiHandler.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiHandler.java
@@ -5,12 +5,10 @@ import java.util.List;
 import io.quarkus.arc.Arc;
 import io.smallrye.openapi.runtime.io.Format;
 import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -21,20 +19,8 @@ public class OpenApiHandler implements Handler<RoutingContext> {
     private volatile OpenApiDocumentService openApiDocumentService;
     private static final String ALLOWED_METHODS = "GET, HEAD, OPTIONS";
     private static final String QUERY_PARAM_FORMAT = "format";
-    private static final MultiMap RESPONSE_HEADERS = new HeadersMultiMap();
 
-    static {
-        RESPONSE_HEADERS.add("access-control-allow-origin", "*");
-        RESPONSE_HEADERS.add("access-control-allow-credentials", "true");
-        RESPONSE_HEADERS.add("access-control-allow-methods", ALLOWED_METHODS);
-        RESPONSE_HEADERS.add("access-control-allow-headers", "Content-Type, Authorization");
-        RESPONSE_HEADERS.add("access-control-max-age", "86400");
-    }
-
-    final boolean corsEnabled;
-
-    public OpenApiHandler(boolean corsEnabled) {
-        this.corsEnabled = corsEnabled;
+    public OpenApiHandler() {
     }
 
     @Override
@@ -43,10 +29,6 @@ public class OpenApiHandler implements Handler<RoutingContext> {
         HttpServerResponse resp = event.response();
 
         if (req.method().equals(HttpMethod.OPTIONS)) {
-            if (!corsEnabled) {
-                //if the cors filter is enabled we let it set the headers
-                resp.headers().addAll(RESPONSE_HEADERS);
-            }
             resp.headers().set("Allow", ALLOWED_METHODS);
             event.next();
         } else {
@@ -74,10 +56,6 @@ public class OpenApiHandler implements Handler<RoutingContext> {
                 }
             }
 
-            if (!corsEnabled) {
-                //if the cors filter is enabled we let it set the headers
-                resp.headers().addAll(RESPONSE_HEADERS);
-            }
             resp.headers().set("Content-Type", format.getMimeType() + ";charset=UTF-8");
             byte[] schemaDocument = getOpenApiDocumentService().getDocument(format);
             resp.end(Buffer.buffer(schemaDocument));

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
@@ -11,7 +11,6 @@ import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.spi.OASFactoryResolver;
 import org.jboss.logging.Logger;
 
-import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
@@ -44,13 +43,7 @@ public class OpenApiRecorder {
 
     public Handler<RoutingContext> handler(OpenApiRuntimeConfig runtimeConfig) {
         if (runtimeConfig.enable) {
-            if (!configuration.getValue().corsEnabled && LaunchMode.NORMAL == LaunchMode.current()) {
-                log.info(
-                        "CORS filtering is disabled and cross-origin resource sharing is allowed without restriction, which is not recommended in production."
-                                + " Please configure the CORS filter through 'quarkus.http.cors.*' properties."
-                                + " For more information, see Quarkus HTTP CORS documentation");
-            }
-            return new OpenApiHandler(configuration.getValue().corsEnabled);
+            return new OpenApiHandler();
         } else {
             return new OpenApiNotFoundHandler();
         }


### PR DESCRIPTION
Fixes #28397

Users should set CORS Filter properties themselves (example, `quarkus.http.cors.enabled=true` and `quarkus.http.cors.origins=*` or `quarkus.http.cors.origins=http://localhost:8080,http://quarkus.io`, etc) if they want to access an OpenApi endpoint which requires CORS protection.
Migration note will follow