### PR TITLE
Return allowed CORS headers in the letter case they were submitted in and update the test

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestCase.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http.cors;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +23,7 @@ public class CORSHandlerTestCase {
     public void corsPreflightTestServlet() {
         String origin = "http://custom.origin.quarkus";
         String methods = "GET,POST";
-        String headers = "X-Custom, content-type";
+        String headers = "X-Custom,content-type";
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
                 .header("Access-Control-Request-Headers", headers)
@@ -36,11 +37,28 @@ public class CORSHandlerTestCase {
     }
 
     @Test
+    public void corsPreflightTestUnmatchedHeader() {
+        String origin = "http://custom.origin.quarkus";
+        String methods = "GET,POST";
+        String headers = "X-Customs,content-types";
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .options("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Credentials", "true")
+                .header("Access-Control-Allow-Headers", nullValue());
+    }
+
+    @Test
     @DisplayName("Handles a direct CORS request correctly")
     public void corsNoPreflightTestServlet() {
         String origin = "http://custom.origin.quarkus";
         String methods = "GET,POST";
-        String headers = "x-custom, CONTENT-TYPE";
+        String headers = "x-custom,CONTENT-TYPE";
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
                 .header("Access-Control-Request-Headers", headers)

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestCase.java
@@ -22,7 +22,7 @@ public class CORSHandlerTestCase {
     public void corsPreflightTestServlet() {
         String origin = "http://custom.origin.quarkus";
         String methods = "GET,POST";
-        String headers = "X-Custom";
+        String headers = "X-Custom, content-type";
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
                 .header("Access-Control-Request-Headers", headers)
@@ -40,7 +40,7 @@ public class CORSHandlerTestCase {
     public void corsNoPreflightTestServlet() {
         String origin = "http://custom.origin.quarkus";
         String methods = "GET,POST";
-        String headers = "X-Custom";
+        String headers = "x-custom, CONTENT-TYPE";
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
                 .header("Access-Control-Request-Headers", headers)

--- a/extensions/vertx-http/deployment/src/test/resources/conf/cors-config.properties
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/cors-config.properties
@@ -2,3 +2,4 @@ quarkus.http.cors=true
 # whitespaces added to test that they are not taken into account config is parsed
 quarkus.http.cors.methods=GET, OPTIONS, POST
 quarkus.http.cors.access-control-allow-credentials=true
+quarkus.http.cors.access-control-allow-headers=x-custom,CONTENT-TYPE

--- a/extensions/vertx-http/deployment/src/test/resources/conf/cors-config.properties
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/cors-config.properties
@@ -2,4 +2,4 @@ quarkus.http.cors=true
 # whitespaces added to test that they are not taken into account config is parsed
 quarkus.http.cors.methods=GET, OPTIONS, POST
 quarkus.http.cors.access-control-allow-credentials=true
-quarkus.http.cors.access-control-allow-headers=x-custom,CONTENT-TYPE
+quarkus.http.cors.headers=x-custom,CONTENT-TYPE

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
@@ -2,7 +2,9 @@ package io.quarkus.vertx.http.runtime.cors;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -98,24 +100,25 @@ public class CORSFilter implements Handler<RoutingContext> {
         if (isConfiguredWithWildcard(corsConfig.headers)) {
             response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, allowHeadersValue);
         } else {
-            List<String> requestedHeaders;
+            Map<String, String> requestedHeaders;
             String[] allowedParts = COMMA_SEPARATED_SPLIT_REGEX.split(allowHeadersValue);
-            requestedHeaders = new ArrayList<>(allowedParts.length);
+            requestedHeaders = new HashMap<>();
             for (String requestedHeader : allowedParts) {
-                requestedHeaders.add(requestedHeader.toLowerCase());
+                requestedHeaders.put(requestedHeader.toLowerCase(), requestedHeader);
             }
 
             List<String> corsConfigHeaders = corsConfig.headers.get();
             StringBuilder allowedHeaders = new StringBuilder();
             boolean isFirst = true;
             for (String configHeader : corsConfigHeaders) {
-                if (requestedHeaders.contains(configHeader.toLowerCase())) {
+                String configHeaderLowerCase = configHeader.toLowerCase();
+                if (requestedHeaders.containsKey(configHeaderLowerCase)) {
                     if (isFirst) {
                         isFirst = false;
                     } else {
                         allowedHeaders.append(',');
                     }
-                    allowedHeaders.append(configHeader);
+                    allowedHeaders.append(requestedHeaders.get(configHeaderLowerCase));
                 }
             }
 


### PR DESCRIPTION
Fixes #16208

This PR updates the CORS test checking that if `quarkus.http.cors.headers` property matches the headers provided in the CORS request then a correct list of headers will be returned.

Additionally, a minor update to the CORS filter was made to ensure the letter case is preserved, example, if the browser sends `Access-Control-Request-Headers: x_custom` and Quarkus approves it using its case-insensitive headers match, then it should get back `Access-Control-Allowed-Headers: x_custom`, not `Access-Control-Allowed-Headers: X_CUSTOM`, the same with `content-type` vs `CONTENT-TYPE` as either the browser or Quarkus can have a lower-case or upper-case header value provided/configured