### PR TITLE
OpenShift IT run on Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci-kubernetes.yml
+++ b/.github/workflows/ci-kubernetes.yml
@@ -91,7 +91,7 @@ jobs:
   openshift:
     name: OpenShift Integration Tests
     needs: cache
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "github.repository == 'quarkusio/quarkus' || github.event_name == 'workflow_dispatch'"
     strategy:
       fail-fast: false


### PR DESCRIPTION
GitHub is rolling out Ubuntu 22.04 as the latest Ubuntu version in the GitHub-hosted runners [[1](https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/)].

Unfortunately, [actions-setup-openshift](https://github.com/manusa/actions-setup-openshift) (still) doesn't work in Ubuntu 22.

This PR changes the `runs-on` configuration to make sure to make sure Ubuntu 20.04 is used regardless of the `latest` default.


[1] https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/