### PR TITLE
Do not support any Origin by default if CORS is enabled

### DIFF
--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagCorsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagCorsTest.java
@@ -25,6 +25,7 @@ public class UriTagCorsTest {
             .overrideConfigKey("quarkus.micrometer.binder.vertx.enabled", "true")
             .overrideConfigKey("quarkus.http.cors", "true")
             .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
+            .overrideConfigKey("quarkus.http.cors.origins", "*")
             .withApplicationRoot((jar) -> jar
                     .addClasses(Util.class,
                             VertxWebEndpoint.class,

--- a/extensions/reactive-routes/deployment/src/test/resources/conf/cors-config.properties
+++ b/extensions/reactive-routes/deployment/src/test/resources/conf/cors-config.properties
@@ -1,3 +1,4 @@
 quarkus.http.cors=true
+quarkus.http.cors.origins=*
 # whitespaces added to test that they are not taken into account config is parsed
 quarkus.http.cors.methods=GET, OPTIONS, POST

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/resources/cors-config.properties
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/resources/cors-config.properties
@@ -1,1 +1,2 @@
 quarkus.http.cors=true
+quarkus.http.cors.origins=*

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootDefaultPathTestCase.java
@@ -16,7 +16,8 @@ public class OpenApiHttpRootDefaultPathTestCase {
             .withApplicationRoot((jar) -> jar
                     .addClasses(OpenApiRoute.class)
                     .addAsResource(new StringAsset("quarkus.http.root-path=/foo\n" +
-                            "quarkus.http.cors=true"), "application.properties"));
+                            "quarkus.http.cors=true\n"
+                            + "quarkus.http.cors.origins=*"), "application.properties"));
 
     @Test
     public void testOpenApiPathAccessResource() {

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootPathCorsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootPathCorsTestCase.java
@@ -15,6 +15,7 @@ public class OpenApiHttpRootPathCorsTestCase {
             .withApplicationRoot((jar) -> jar
                     .addClasses(OpenApiRoute.class)
                     .addAsResource(new StringAsset("quarkus.http.cors=true\n" +
+                            "quarkus.http.cors.origins=*\n" +
                             "quarkus.http.non-application-root-path=/api/q\n" +
                             "quarkus.http.root-path=/api"), "application.properties"));
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSecurityTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSecurityTestCase.java
@@ -22,6 +22,7 @@ public class CORSSecurityTestCase {
 
     private static final String APP_PROPS = "" +
             "quarkus.http.cors=true\n" +
+            "quarkus.http.cors.origins=*\n" +
             "quarkus.http.cors.methods=GET, OPTIONS, POST\n" +
             "quarkus.http.auth.basic=true\n" +
             "quarkus.http.auth.policy.r1.roles-allowed=test\n" +

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardSecurityTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardSecurityTestCase.java
@@ -22,6 +22,7 @@ public class CORSWildcardSecurityTestCase {
 
     private static final String APP_PROPS = "" +
             "quarkus.http.cors=true\n" +
+            "quarkus.http.cors.origins=*\n" +
             "quarkus.http.auth.basic=true\n" +
             "quarkus.http.auth.policy.r1.roles-allowed=test\n" +
             "quarkus.http.auth.permission.roles1.paths=/test\n" +

--- a/extensions/vertx-http/deployment/src/test/resources/conf/cors-config.properties
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/cors-config.properties
@@ -1,4 +1,5 @@
 quarkus.http.cors=true
+quarkus.http.cors.origins=*
 # whitespaces added to test that they are not taken into account config is parsed
 quarkus.http.cors.methods=GET, OPTIONS, POST
 quarkus.http.cors.access-control-allow-credentials=true

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
@@ -18,9 +18,6 @@ public class CORSConfig {
      * Comma separated list of valid URLs, e.g.: http://www.quarkus.io,http://localhost:3000
      * In case an entry of the list is surrounded by forward slashes,
      * it is interpreted as a regular expression.
-     * The filter allows any origin if this is not set.
-     *
-     * default: returns any requested origin as valid
      */
     @ConfigItem
     @ConvertWith(TrimmedStringConverter.class)

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -166,6 +166,7 @@ quarkus.http.auth.permission.post-logout.paths=/tenant-logout/post-logout
 quarkus.http.auth.permission.post-logout.policy=permit
 
 quarkus.http.cors=true
+quarkus.http.cors.origins=*
 quarkus.http.auth.proactive=false
 quarkus.http.proxy.enable-forwarded-prefix=true
 quarkus.http.proxy.allow-forwarded=true

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -2,6 +2,7 @@ quarkus.keycloak.devservices.create-realm=false
 quarkus.keycloak.devservices.realm-name=quarkus-a
 
 quarkus.http.cors=true
+quarkus.http.cors.origins=*
 
 quarkus.oidc.token-cache.max-size=3
 

--- a/integration-tests/oidc/src/main/resources/application.properties
+++ b/integration-tests/oidc/src/main/resources/application.properties
@@ -12,6 +12,7 @@ quarkus.oidc.tls.key-store-password=password
 quarkus.native.additional-build-args=-H:IncludeResources=.*\\.jks
 
 quarkus.http.cors=true
+quarkus.http.cors.origins=*
 
 quarkus.http.auth.basic=true
 quarkus.security.users.embedded.enabled=true


### PR DESCRIPTION
If CORS is enabled then the users have to take an action and enable the wildcard if they really need to, as opposed to Quarkus doing it by default. This update will hopefully encourage users take CORS configuration more seriously. 
DevUI is not expected to be affected.

Note I'm adding the wildcard to the tests to have them passing again, which also shows that the users who need a wildcard will only have to add one more property. 
The migration guide update will follow.