### PR TITLE
Don't load Kotlin parent first

### DIFF
--- a/extensions/kotlin/runtime/pom.xml
+++ b/extensions/kotlin/runtime/pom.xml
@@ -19,20 +19,6 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <configuration>
-                    <parentFirstArtifacts>
-                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk8</parentFirstArtifact>
-                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk7</parentFirstArtifact>
-                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-reflect</parentFirstArtifact>
-                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib</parentFirstArtifact>
-                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-common</parentFirstArtifact>
-                    </parentFirstArtifacts>
-                    <runnerParentFirstArtifacts>
-                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk8</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk7</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-reflect</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-common</runnerParentFirstArtifact>
-                    </runnerParentFirstArtifacts>
                     <lesserPriorityArtifacts>
                         <!--
                         see https://github.com/quarkusio/quarkus/issues/8405

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -447,6 +447,15 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         }
     }
 
+    protected URL findResource(String name) {
+        return getResource(name);
+    }
+
+    @Override
+    protected Enumeration<URL> findResources(String name) throws IOException {
+        return getResources(name);
+    }
+
     @Override
     public Class<?> loadClass(String name) throws ClassNotFoundException {
         return loadClass(name, false);


### PR DESCRIPTION
A test PR to see what breaks if we stop loading Kotlin parent first.

I think a lot of the reasons why we needed to do this originally may no longer apply, lets try it out and see what breaks.