### PR TITLE
Fix ClientProxyGenerator

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
@@ -205,7 +205,12 @@ public class ClientProxyGenerator extends AbstractGenerator {
                 // Always use invokevirtual and the original descriptor for java.lang.Object#toString()
                 ret = forward.invokeVirtualMethod(originalMethodDescriptor, delegate, params);
             } else if (isInterface) {
-                ret = forward.invokeInterfaceMethod(method, delegate, params);
+                // make sure we invoke the method upon the provider type, i.e. don't use the original method descriptor
+                MethodDescriptor virtualMethod = MethodDescriptor.ofMethod(providerType.className(),
+                        originalMethodDescriptor.getName(),
+                        originalMethodDescriptor.getReturnType(),
+                        originalMethodDescriptor.getParameterTypes());
+                ret = forward.invokeInterfaceMethod(virtualMethod, delegate, params);
             } else if (isReflectionFallbackNeeded(method, targetPackage)) {
                 // Reflection fallback
                 ResultHandle paramTypesArray = forward.newArray(Class.class, forward.load(method.parametersCount()));

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/packageprivate/BaseInterface.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/packageprivate/BaseInterface.java
@@ -1,0 +1,7 @@
+package io.quarkus.arc.test.clientproxy.packageprivate;
+
+// this interface is intentionally package-private
+interface BaseInterface {
+
+    String ping();
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/packageprivate/MyInterface.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/packageprivate/MyInterface.java
@@ -1,0 +1,5 @@
+package io.quarkus.arc.test.clientproxy.packageprivate;
+
+public interface MyInterface extends BaseInterface {
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/packageprivate/PackagePrivateInterfaceInHierarchyTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/packageprivate/PackagePrivateInterfaceInHierarchyTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.arc.test.clientproxy.packageprivate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.clientproxy.packageprivate.foo.MyInterface2;
+import io.quarkus.arc.test.clientproxy.packageprivate.foo.Producer;
+
+public class PackagePrivateInterfaceInHierarchyTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(BaseInterface.class, MyInterface.class, MyInterface2.class,
+            Producer.class);
+
+    @Test
+    public void testProducer() {
+        assertEquals("quarkus", Arc.container().instance(MyInterface2.class).get().ping());
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/packageprivate/foo/MyInterface2.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/packageprivate/foo/MyInterface2.java
@@ -1,0 +1,7 @@
+package io.quarkus.arc.test.clientproxy.packageprivate.foo;
+
+import io.quarkus.arc.test.clientproxy.packageprivate.MyInterface;
+
+public interface MyInterface2 extends MyInterface {
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/packageprivate/foo/Producer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/packageprivate/foo/Producer.java
@@ -1,0 +1,20 @@
+package io.quarkus.arc.test.clientproxy.packageprivate.foo;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class Producer {
+
+    @Produces
+    @ApplicationScoped
+    public MyInterface2 myInterface2() {
+        return new MyInterface2() {
+            @Override
+            public String ping() {
+                return "quarkus";
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
- make sure that an interface method of an interface-based client proxy is invoked upon the provider type and not the type that declares the method
- fixes #29593