### PR TITLE
Allow token verification with user info when no introspection endpoint is available

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -49,6 +49,8 @@ quarkus.oidc.client-id=<Client ID>
 quarkus.oidc.credentials.secret=<Secret>
 ----
 
+TIP: You can also use GitHub provider with `quarkus.oidc.application-type=service`, just set `quarkus.oidc.verify-access-token-with-user-info` configuration property to `true`.
+
 === Google
 
 In order to set up OIDC for Google you need to create a new project in your https://console.cloud.google.com/projectcreate[Google Cloud Platform console]:

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OpaqueTokenVerificationWithUserInfoValidationTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OpaqueTokenVerificationWithUserInfoValidationTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.oidc.test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OpaqueTokenVerificationWithUserInfoValidationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset("quarkus.oidc.token.verify-access-token-with-user-info=true\n"),
+                            "application.properties"))
+            .assertException(t -> {
+                Throwable e = t;
+                ConfigurationException te = null;
+                while (e != null) {
+                    if (e instanceof ConfigurationException) {
+                        te = (ConfigurationException) e;
+                        break;
+                    }
+                    e = e.getCause();
+                }
+                assertNotNull(te);
+                // assert UserInfo is required
+                assertTrue(
+                        te.getMessage()
+                                .contains("UserInfo is not required but 'verifyAccessTokenWithUserInfo' is enabled"),
+                        te.getMessage());
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail();
+    }
+
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.Set;
 
 import io.quarkus.oidc.common.runtime.OidcCommonConfig;
 import io.quarkus.oidc.common.runtime.OidcConstants;
@@ -1188,6 +1187,16 @@ public class OidcTenantConfig extends OidcCommonConfig {
          */
         @ConfigItem(defaultValue = "true")
         public boolean allowOpaqueTokenIntrospection = true;
+
+        /**
+         * Indirectly verify that the opaque (binary) access token is valid by using it to request UserInfo.
+         * Opaque access token is considered valid if the provider accepted this token and returned a valid UserInfo.
+         * You should only enable this option if the opaque access tokens have to be accepted but OpenId Connect
+         * provider does not have a token introspection endpoint.
+         * This property will have no effect when JWT tokens have to be verified.
+         */
+        @ConfigItem(defaultValue = "false")
+        public boolean verifyAccessTokenWithUserInfo;
 
         public Optional<String> getIssuer() {
             return issuer;

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -214,6 +214,23 @@ public class OidcRecorder {
             }
         }
 
+        if (oidcConfig.token.verifyAccessTokenWithUserInfo) {
+            if (!oidcConfig.authentication.isUserInfoRequired().orElse(false)) {
+                throw new ConfigurationException(
+                        "UserInfo is not required but 'verifyAccessTokenWithUserInfo' is enabled");
+            }
+            if (!oidcConfig.isDiscoveryEnabled().orElse(true)) {
+                if (oidcConfig.userInfoPath.isEmpty()) {
+                    throw new ConfigurationException(
+                            "UserInfo path is missing but 'verifyAccessTokenWithUserInfo' is enabled");
+                }
+                if (oidcConfig.introspectionPath.isPresent()) {
+                    throw new ConfigurationException(
+                            "Introspection path is configured and 'verifyAccessTokenWithUserInfo' is enabled, these options are mutually exclusive");
+                }
+            }
+        }
+
         return createOidcProvider(oidcConfig, tlsConfig, vertx)
                 .onItem().transform(p -> new TenantConfigContext(p, oidcConfig));
     }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.keycloak;
 
+import javax.annotation.security.PermitAll;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -47,5 +48,12 @@ public class CodeFlowUserInfoResource {
     @Path("/code-flow-user-info-dynamic-github")
     public String accessDynamicGitHub() {
         return access();
+    }
+
+    @GET
+    @PermitAll
+    @Path("/clear-token-cache")
+    public void clearTokenCache() {
+        tokenCache.clearCache();
     }
 }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
@@ -21,6 +21,7 @@ public class CustomSecurityIdentityAugmentor implements SecurityIdentityAugmento
         if (routingContext != null &&
                 (routingContext.normalizedPath().endsWith("code-flow-user-info-only")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-github")
+                        || routingContext.normalizedPath().endsWith("bearer-user-info-github-service")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-dynamic-github")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-github-cached-in-idtoken"))) {
             QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -32,6 +32,9 @@ public class CustomTenantResolver implements TenantResolver {
         if (path.endsWith("code-flow-user-info-github")) {
             return "code-flow-user-info-github";
         }
+        if (path.endsWith("bearer-user-info-github-service")) {
+            return "bearer-user-info-github-service";
+        }
         if (path.endsWith("code-flow-user-info-github-cached-in-idtoken")) {
             return "code-flow-user-info-github-cached-in-idtoken";
         }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OpaqueGithubResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OpaqueGithubResource.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.keycloak;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.oidc.UserInfo;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+
+@Authenticated
+@Path("/bearer-user-info-github-service")
+public class OpaqueGithubResource {
+
+    @Inject
+    UserInfo userInfo;
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    AccessTokenCredential accessTokenCredential;
+
+    @GET
+    public String access() {
+        return String.format("%s:%s:%s", identity.getPrincipal().getName(), userInfo.getString("preferred_username"),
+                accessTokenCredential.getToken());
+    }
+
+}

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -72,6 +72,14 @@ quarkus.oidc.code-flow-user-info-github.code-grant.headers.X-Custom=XCustomHeade
 quarkus.oidc.code-flow-user-info-github.client-id=quarkus-web-app
 quarkus.oidc.code-flow-user-info-github.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 
+quarkus.oidc.bearer-user-info-github-service.provider=github
+quarkus.oidc.bearer-user-info-github-service.token.verify-access-token-with-user-info=true
+quarkus.oidc.bearer-user-info-github-service.application-type=service
+quarkus.oidc.bearer-user-info-github-service.auth-server-url=${keycloak.url}/realms/quarkus/
+quarkus.oidc.bearer-user-info-github-service.user-info-path=github/userinfo
+quarkus.oidc.bearer-user-info-github-service.client-id=quarkus-web-app
+quarkus.oidc.bearer-user-info-github-service.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.provider=github
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.authorization-path=/

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerOpaqueTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerOpaqueTokenAuthorizationTest.java
@@ -1,5 +1,9 @@
 package io.quarkus.it.keycloak;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.util.Arrays;
@@ -7,14 +11,21 @@ import java.util.Arrays;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.oidc.server.OidcWireMock;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
 
 @QuarkusTest
 @QuarkusTestResource(OidcWiremockTestResource.class)
 public class BearerOpaqueTokenAuthorizationTest {
+
+    @OidcWireMock
+    WireMockServer wireMockServer;
 
     @Test
     public void testSecureAccessSuccessPreferredUsername() {
@@ -60,6 +71,56 @@ public class BearerOpaqueTokenAuthorizationTest {
         RestAssured.given()
                 .header("Authorization", "Bearer " + "expired")
                 .get("/opaque/api/users/me/bearer")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void testGitHubBearerTokenSuccess() {
+        final String validToken = OidcConstants.BEARER_SCHEME + " ghu_XirRniLaPuW53pDylNnAPOPBm14taM0C9HP4";
+        wireMockServer.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus/github/userinfo"))
+                        .withHeader("Authorization", matching(validToken))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n" +
+                                        "      \"preferred_username\": \"alice\""
+                                        + "}")));
+
+        RestAssured.given()
+                .header("Authorization", validToken)
+                .get("/bearer-user-info-github-service")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("alice:alice:ghu_XirRniLaPuW53pDylNnAPOPBm14taM0C9HP4"));
+    }
+
+    @Test
+    public void testGitHubBearerTokenUnauthorized() {
+        final String invalidToken = OidcConstants.BEARER_SCHEME + " Invalid";
+        wireMockServer.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus/github/userinfo"))
+                        .withHeader("Authorization", matching(invalidToken))
+                        .willReturn(aResponse().withStatus(401)));
+
+        RestAssured.given()
+                .header("Authorization", invalidToken)
+                .get("/bearer-user-info-github-service")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void testGitHubBearerTokenNullUserInfo() {
+        final String validToken = OidcConstants.BEARER_SCHEME + " ghu_AAAAniLaPuW53pDylNnAPOPBm14ta7777777";
+        wireMockServer.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus/github/userinfo"))
+                        .withHeader("Authorization", matching(validToken))
+                        .willReturn(aResponse().withStatus(200).withBody((String) null)));
+
+        RestAssured.given()
+                .header("Authorization", validToken)
+                .get("/bearer-user-info-github-service")
                 .then()
                 .statusCode(401);
     }

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Set;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
@@ -43,6 +44,17 @@ public class CodeFlowAuthorizationTest {
 
     @OidcWireMock
     WireMockServer wireMockServer;
+
+    @BeforeAll
+    public static void clearCache() {
+        // clear token cache to make tests idempotent as we experienced failures
+        // on Windows when BearerTokenAuthorizationTest run before CodeFlowAuthorizationTest
+        RestAssured
+                .given()
+                .get("http://localhost:8081/clear-token-cache")
+                .then()
+                .statusCode(204);
+    }
 
     @Test
     public void testCodeFlow() throws IOException {


### PR DESCRIPTION
closes: #20911

Makes it possible to use user-info endpoint with providers that does not provide introspection endpoint for Bearer token indirect verification, so that providers like GitHub may be used with service endpoints. I tested it with real GitHub application (not mock).