### PR TITLE
Don't run JUnit's  test failure watcher methods for wrong test type

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractQuarkusTestWithContextExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractQuarkusTestWithContextExtension.java
@@ -13,35 +13,49 @@ public abstract class AbstractQuarkusTestWithContextExtension extends AbstractTe
 
     @Override
     public void handleAfterAllMethodExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
-        markTestAsFailed(context, throwable);
+        if (shouldMarkFailure(context)) {
+            markTestAsFailed(context, throwable);
+        }
 
         throw throwable;
     }
 
     @Override
     public void handleAfterEachMethodExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
-        markTestAsFailed(context, throwable);
+        if (shouldMarkFailure(context)) {
+            markTestAsFailed(context, throwable);
+        }
 
         throw throwable;
     }
 
     @Override
     public void handleBeforeAllMethodExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
-        markTestAsFailed(context, throwable);
+        if (shouldMarkFailure(context)) {
+            markTestAsFailed(context, throwable);
+        }
 
         throw throwable;
     }
 
     @Override
     public void handleBeforeEachMethodExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
-        markTestAsFailed(context, throwable);
+        if (shouldMarkFailure(context)) {
+            markTestAsFailed(context, throwable);
+        }
 
         throw throwable;
     }
 
     @Override
     public void testFailed(ExtensionContext context, Throwable cause) {
-        markTestAsFailed(context, cause);
+        if (shouldMarkFailure(context)) {
+            markTestAsFailed(context, cause);
+        }
+    }
+
+    protected boolean shouldMarkFailure(ExtensionContext context) {
+        return false;
     }
 
     protected QuarkusTestExtensionState getState(ExtensionContext context) {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -303,6 +303,11 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
         invocation.proceed();
     }
 
+    @Override
+    protected boolean shouldMarkFailure(ExtensionContext context) {
+        return !isIntegrationTest(context.getRequiredTestClass());
+    }
+
     private boolean isIntegrationTest(Class<?> clazz) {
         for (Class<?> i : currentTestClassStack) {
             if (i.isAnnotationPresent(QuarkusMainIntegrationTest.class)) {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -1200,6 +1200,11 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                 + "' disabled because 'quarkus.profile.test.tags' don't match the tags of '" + testProfile + "'");
     }
 
+    @Override
+    protected boolean shouldMarkFailure(ExtensionContext context) {
+        return !isNativeOrIntegrationTest(context.getRequiredTestClass());
+    }
+
     public class ExtensionState extends QuarkusTestExtensionState {
 
         public ExtensionState(Closeable testResourceManager, Closeable resource) {


### PR DESCRIPTION
Without this fix, if an integration test fails it results in the application being restarted

Relates to: #23612