### PR TITLE
CI should use -Dno-format to execute other plugins too

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/build.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/build.yml
@@ -45,4 +45,4 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn -B formatter:validate clean install --file pom.xml
+        run: mvn -B clean verify -Dno-format

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/build.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/build.yml
@@ -46,3 +46,6 @@ jobs:
 
       - name: Build with Maven
         run: mvn -B clean verify -Dno-format
+
+      - name: Build with Maven (Native)
+        run: mvn -B verify -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
@@ -55,7 +55,7 @@ public class CreateExtension {
 
     public static final String DEFAULT_QUARKIVERSE_PARENT_GROUP_ID = "io.quarkiverse";
     public static final String DEFAULT_QUARKIVERSE_PARENT_ARTIFACT_ID = "quarkiverse-parent";
-    public static final String DEFAULT_QUARKIVERSE_PARENT_VERSION = "10";
+    public static final String DEFAULT_QUARKIVERSE_PARENT_VERSION = "12";
     public static final String DEFAULT_QUARKIVERSE_NAMESPACE_ID = "quarkus-";
     public static final String DEFAULT_QUARKIVERSE_GUIDE_URL = "https://quarkiverse.github.io/quarkiverse-docs/%s/dev/";
 

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/SnapshotTesting.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/SnapshotTesting.java
@@ -174,7 +174,7 @@ public class SnapshotTesting {
 
             final String snapshotNotFoundDescription = "corresponding snapshot file not found for " + snapshotIdentifier
                     + " (Use -Dsnap to create it automatically)";
-            final String description = "Snapshot is not matching (use -Dsnap to udpate it automatically): "
+            final String description = "Snapshot is not matching (use -Dsnap to update it automatically): "
                     + snapshotIdentifier;
             if (isUTF8File(fileToCheck)) {
                 assertThat(snapshotFile).as(snapshotNotFoundDescription).isRegularFile();
@@ -264,7 +264,7 @@ public class SnapshotTesting {
                     .collect(toList());
 
             return assertThat(tree)
-                    .as("Snapshot is not matching (use -Dsnap to udpate it automatically):" + snapshotName)
+                    .as("Snapshot is not matching (use -Dsnap to update it automatically):" + snapshotName)
                     .containsExactlyInAnyOrderElementsOf(content);
         });
     }

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_pom.xml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/quarkus-my-quarkiverse-ext_pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.quarkiverse</groupId>
     <artifactId>quarkiverse-parent</artifactId>
-    <version>10</version>
+    <version>12</version>
   </parent>
   <groupId>io.quarkiverse.my-quarkiverse-ext</groupId>
   <artifactId>quarkus-my-quarkiverse-ext-parent</artifactId>


### PR DESCRIPTION
The `impsort` plugin is never triggered. Instead of adding it, the build should simply reuse the existing profiles that are already declared in the `quarkiverse-parent`. 

- Depends on https://github.com/quarkiverse/quarkiverse-parent/pull/69
- Depends on https://github.com/quarkiverse/quarkiverse-parent/pull/70
