### PR TITLE
Redis data preloading support

### DIFF
--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -656,6 +656,81 @@ The reactive variant returns a `Uni<Response>`.
 
 NOTE: You can also execute custom command in a transaction.
 
+== Preload data into Redis
+
+On startup, you can configure the Redis client to preload data into the Redis database.
+
+=== Load scripts
+
+Specify the _load script_ you want to load using:
+
+[source, properties]
+----
+quarkus.redis.load-script=import.sql # import.sql is the default in dev, no-file is the default in prod
+quarkus.redis.my-redis.load-script=actors.redis, movies.redis
+----
+
+IMPORTANT: `load-script` is a build time property than cannot be overridden at runtime.
+
+Note that each client can have a different script, even a list of scripts.
+In the case of a list, the data is imported in the list order (for example, first `actors.redis`, then `movies.redis` for the `my-redis` client).
+
+=== Load Script format
+
+The `.redis` file follows a _one command per line_ format:
+
+[source, text]
+----
+# Line starting with # and -- are ignored, as well as empty lines
+
+-- One command per line:
+HSET foo field1 abc field2 123
+
+-- Parameters with spaces must be wrapped into single or double quotes
+HSET bar field1 "abc def" field2 '123 456 '
+
+-- Parameters with double quotes must be wrapped into single quotes and the opposite
+SET key1 'A value using "double-quotes"'
+SET key2 "A value using 'single-quotes'"
+----
+
+Quarkus batches all the commands from a single file and sends all the commands.
+The loading process fails if there is any error, but the previous instructions may have been executed.
+To avoid that, you can wrap your command into a Redis _transaction_:
+
+[source, text]
+----
+-- Run inside a transaction
+MULTI
+SET key value
+SET space:key 'another value'
+INCR counter
+EXEC
+----
+
+=== Loading configuration
+
+The data is loaded when the application starts.
+By default, it drops the whole database before importing.
+You can prevent this using `quarkus.redis.flush-before-load=false`.
+
+Also, the import process only runs if the database is empty (no key).
+You can force to import even if there is data using the `quarkus.redis.load-only-if-empty=false`
+
+=== Dev/Test vs. Prod
+
+As mentioned above, in dev and test modes, Quarkus tries to import data by looking for the `src/main/resources/import.redis`.
+This behavior is disabled in _prod_ mode, and if you want to import even in production, add:
+
+[source, properties]
+----
+%prod.quarkus.redis.load-script=import.redis
+----
+
+Before importing in _prod_ mode, mae sure you configured `quarkus.redis.flush-before-load` accordingly.
+
+IMPORTANT: In dev mode, to reload the content of the `.redis` load scripts, you need to add: `%dev.quarkus.vertx.caching=false`
+
 == Vert.x Redis Client
 
 In addition to the high-level API, you can use the Vertx Redis clients directly in your code.

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/RedisBuildTimeConfig.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/RedisBuildTimeConfig.java
@@ -10,6 +10,44 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 
 @ConfigRoot
 public class RedisBuildTimeConfig {
+
+    /**
+     * The default redis client
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    public RedisClientBuildTimeConfig defaultRedisClient;
+
+    /**
+     * Configures additional (named) Redis clients.
+     * <p>
+     * Each client has a unique name which must be identified to select the right client.
+     * For example:
+     * <p>
+     *
+     * <pre>
+     * quarkus.redis.client1.hosts = redis://localhost:6379
+     * quarkus.redis.client2.hosts = redis://localhost:6380
+     * </pre>
+     * <p>
+     * And then use the {@link io.quarkus.redis.client.RedisClientName} annotation to select the
+     * {@link io.vertx.mutiny.redis.client.Redis},
+     * {@link io.vertx.redis.client.Redis}, {@link io.vertx.mutiny.redis.client.RedisAPI} and
+     * {@link io.vertx.redis.client.RedisAPI} beans.
+     * <p>
+     *
+     * <pre>
+     * {
+     *     &#64;code
+     *     &#64;RedisClientName("client1")
+     *     &#64;Inject
+     *     RedisAPI redis;
+     * }
+     * </pre>
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    @ConfigDocMapKey("redis-client-name")
+    public Map<String, RedisClientBuildTimeConfig> namedRedisClients;
+
     /**
      * Whether a health check is published in case the smallrye-health extension is present.
      */

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/RedisClientBuildTimeConfig.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/RedisClientBuildTimeConfig.java
@@ -1,0 +1,42 @@
+package io.quarkus.redis.client.deployment;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConvertWith;
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
+
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@ConfigGroup
+public class RedisClientBuildTimeConfig {
+
+    /**
+     * A list of files allowing to pre-load data into the Redis server.
+     * The file is formatted as follows:
+     * <ul>
+     * <li>One instruction per line</li>
+     * <li>Each instruction is a Redis command and its parameter such as {@code HSET foo field value}</li>
+     * <li>Parameters can be wrapped into double-quotes if they include spaces</li>
+     * <li>Parameters can be wrapped into single-quote if they include spaces</li>
+     * <li>Parameters including double-quotes must be wrapped into single-quotes</li>
+     * </ul>
+     */
+    @ConfigItem(defaultValueDocumentation = "import.redis in DEV, TEST ; no-file otherwise")
+    @ConvertWith(TrimmedStringConverter.class)
+    public Optional<List<String>> loadScript;
+
+    /**
+     * When using {@code redisLoadScript}, indicates if the Redis database must be flushed (erased) before importing.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean flushBeforeLoad;
+
+    /**
+     * When using {@code redisLoadScript}, indicates if the import should only happen if the database is empty (no keys).
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean loadOnlyIfEmpty;
+
+}

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/RedisClientProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/RedisClientProcessor.java
@@ -2,14 +2,19 @@ package io.quarkus.redis.client.deployment;
 
 import static io.quarkus.redis.runtime.client.config.RedisConfig.DEFAULT_CLIENT_NAME;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
@@ -30,9 +35,13 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.redis.client.RedisClient;
 import io.quarkus.redis.client.RedisClientName;
@@ -40,6 +49,9 @@ import io.quarkus.redis.client.RedisHostsProvider;
 import io.quarkus.redis.client.RedisOptionsCustomizer;
 import io.quarkus.redis.client.reactive.ReactiveRedisClient;
 import io.quarkus.redis.runtime.client.RedisClientRecorder;
+import io.quarkus.redis.runtime.client.config.RedisConfig;
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.vertx.deployment.VertxBuildItem;
 import io.vertx.redis.client.impl.types.BulkType;
@@ -103,16 +115,28 @@ public class RedisClientProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public void init(RedisClientRecorder recorder,
+    public void init(
+            List<RequestedRedisClientBuildItem> clients,
+            RedisClientRecorder recorder,
             RedisBuildTimeConfig buildTimeConfig,
             BeanArchiveIndexBuildItem indexBuildItem,
             BeanDiscoveryFinishedBuildItem beans,
             ShutdownContextBuildItem shutdown,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
-            VertxBuildItem vertxBuildItem) {
+            RedisConfig config,
+            VertxBuildItem vertxBuildItem,
+            ApplicationArchivesBuildItem applicationArchivesBuildItem, LaunchModeBuildItem launchMode,
+            BuildProducer<NativeImageResourceBuildItem> nativeImageResources,
+            BuildProducer<HotDeploymentWatchedFileBuildItem> hotDeploymentWatchedFiles) {
 
         // Collect the used redis clients, the unused clients will not be instantiated.
         Set<String> names = new HashSet<>();
+
+        // Add the names from the requested clients.
+        for (RequestedRedisClientBuildItem client : clients) {
+            names.add(client.name);
+        }
+
         IndexView indexView = indexBuildItem.getIndex();
         Collection<AnnotationInstance> clientAnnotations = indexView.getAnnotations(REDIS_CLIENT_ANNOTATION);
         for (AnnotationInstance annotation : clientAnnotations) {
@@ -156,6 +180,18 @@ public class RedisClientProcessor {
         }
 
         recorder.cleanup(shutdown);
+
+        // Handle data import
+        preloadRedisData(DEFAULT_CLIENT_NAME, buildTimeConfig.defaultRedisClient, applicationArchivesBuildItem,
+                launchMode.getLaunchMode(),
+                nativeImageResources, hotDeploymentWatchedFiles, recorder);
+
+        if (buildTimeConfig.namedRedisClients != null) {
+            for (Map.Entry<String, RedisClientBuildTimeConfig> entry : buildTimeConfig.namedRedisClients.entrySet()) {
+                preloadRedisData(entry.getKey(), entry.getValue(), applicationArchivesBuildItem, launchMode.getLaunchMode(),
+                        nativeImageResources, hotDeploymentWatchedFiles, recorder);
+            }
+        }
     }
 
     static Set<String> configuredClientNames(RedisBuildTimeConfig buildTimeConfig, Config config) {
@@ -198,9 +234,75 @@ public class RedisClientProcessor {
         return configurator.done();
     }
 
+    private void preloadRedisData(String name, RedisClientBuildTimeConfig clientConfig,
+            ApplicationArchivesBuildItem applicationArchivesBuildItem,
+            LaunchMode launchMode, BuildProducer<NativeImageResourceBuildItem> nativeImageResources,
+            BuildProducer<HotDeploymentWatchedFileBuildItem> hotDeploymentWatchedFiles, RedisClientRecorder recorder) {
+        List<String> importFiles = getRedisLoadScript(clientConfig, launchMode);
+        List<String> paths = new ArrayList<>();
+        for (String importFile : importFiles) {
+            Path loadScriptPath;
+            try {
+                loadScriptPath = applicationArchivesBuildItem.getRootArchive().getChildPath(importFile);
+            } catch (RuntimeException e) {
+                throw new ConfigurationException(
+                        "Unable to interpret path referenced in '"
+                                + RedisConfig.propertyKey(name, "redis-load-script") + "="
+                                + String.join(",", importFiles)
+                                + "': " + e.getMessage());
+            }
+
+            if (loadScriptPath != null && !Files.isDirectory(loadScriptPath)) {
+                // enlist resource if present
+                nativeImageResources.produce(new NativeImageResourceBuildItem(importFile));
+            } else if (clientConfig != null && clientConfig.loadScript.isPresent()) {
+                //raise exception if explicit file is not present (i.e. not the default)
+                throw new ConfigurationException(
+                        "Unable to find file referenced in '"
+                                + RedisConfig.propertyKey(name, "redis-load-script") + "="
+                                + String.join(", ", clientConfig.loadScript.get())
+                                + "'. Remove property or add file to your path.");
+            }
+            // in dev mode we want to make sure that we watch for changes to file even if it doesn't currently exist
+            // as a user could still add it after performing the initial configuration
+            hotDeploymentWatchedFiles.produce(new HotDeploymentWatchedFileBuildItem(importFile));
+
+            if (loadScriptPath != null) {
+                paths.add(importFile);
+            }
+        }
+
+        if (!paths.isEmpty()) {
+            if (clientConfig != null) {
+                recorder.preload(name, paths, clientConfig.flushBeforeLoad, clientConfig.loadOnlyIfEmpty);
+            } else {
+                recorder.preload(name, paths, true, true);
+            }
+        }
+
+    }
+
     @BuildStep
     HealthBuildItem addHealthCheck(RedisBuildTimeConfig buildTimeConfig) {
         return new HealthBuildItem("io.quarkus.redis.runtime.client.health.RedisHealthCheck",
                 buildTimeConfig.healthEnabled);
+    }
+
+    public static final String NO_REDIS_SCRIPT_FILE = "no-file";
+
+    private static List<String> getRedisLoadScript(RedisClientBuildTimeConfig config, LaunchMode launchMode) {
+        if (config == null) {
+            return List.of("import.redis");
+        }
+        var scripts = config.loadScript;
+        if (scripts.isPresent()) {
+            return scripts.get().stream()
+                    .filter(s -> !NO_REDIS_SCRIPT_FILE.equalsIgnoreCase(s))
+                    .collect(Collectors.toList());
+        } else if (launchMode == LaunchMode.NORMAL) {
+            return Collections.emptyList();
+        } else {
+            return List.of("import.redis");
+        }
     }
 }

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/RequestedRedisClientBuildItem.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/RequestedRedisClientBuildItem.java
@@ -1,0 +1,16 @@
+package io.quarkus.redis.client.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Request the creation of the Redis client with the given name.
+ */
+public final class RequestedRedisClientBuildItem extends MultiBuildItem {
+
+    public final String name;
+
+    public RequestedRedisClientBuildItem(String name) {
+        this.name = name;
+    }
+
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/devmode/IncrementResource.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/devmode/IncrementResource.java
@@ -4,6 +4,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
 import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.datasource.keys.KeyCommands;
 import io.quarkus.redis.datasource.value.ValueCommands;
 
 @Path("/inc")
@@ -11,14 +12,22 @@ public class IncrementResource {
 
     public static final long INCREMENT = 1;
     private final ValueCommands<String, Integer> commands;
+    private final KeyCommands<String> keys;
 
     public IncrementResource(RedisDataSource ds) {
         commands = ds.value(Integer.class);
+        keys = ds.key();
     }
 
     @GET
     public int increment() {
         return (int) commands.incrby("counter-dev-mode", INCREMENT);
+    }
+
+    @GET
+    @Path("/keys")
+    public int verifyPreloading() {
+        return keys.keys("*").size();
     }
 
 }

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/devmode/RedisClientDevModeTestCase.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/devmode/RedisClientDevModeTestCase.java
@@ -31,11 +31,12 @@ public class RedisClientDevModeTestCase {
             });
 
     @Test
-    public void testRedisDevMode() {
+    public void testSourceFileUpdateInDevMode() {
         RestAssured.get("/inc")
                 .then()
                 .statusCode(200)
                 .body(Matchers.equalTo("1"));
+
         RestAssured.get("/inc")
                 .then()
                 .statusCode(200)
@@ -55,5 +56,9 @@ public class RedisClientDevModeTestCase {
                 .statusCode(200)
                 .body(Matchers.equalTo("22"));
 
+        RestAssured.get("/inc")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("32"));
     }
 }

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/devmode/RedisClientPreloadDevModeTestCase.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/devmode/RedisClientPreloadDevModeTestCase.java
@@ -1,0 +1,48 @@
+package io.quarkus.redis.client.deployment.devmode;
+
+import java.io.File;
+import java.util.function.Supplier;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.redis.client.deployment.RedisTestResource;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.restassured.RestAssured;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class RedisClientPreloadDevModeTestCase {
+
+    @RegisterExtension
+    static QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addAsResource(new StringAsset(
+                                    "quarkus.vertx.caching=false\n" +
+                                            "quarkus.redis.hosts=${quarkus.redis.tr}\n" +
+                                            "quarkus.redis.load-only-if-empty=false\n"),
+                                    "application.properties")
+                            .addAsResource(new File("src/test/resources/imports/starwars.redis"), "import.redis")
+                            .addClass(IncrementResource.class);
+                }
+            });
+
+    @Test
+    public void testImportFileUpdateInDevMode() {
+        // Verify preloading
+        int count = Integer.valueOf(RestAssured.get("/inc/keys")
+                .then().statusCode(200).extract().body().asString());
+
+        // Change the import file
+        test.modifyResourceFile("import.redis", s -> s + "\nLPUSH list 1 2 3 4 5");
+        RestAssured.get("/inc/keys")
+                .then().statusCode(200).body(Matchers.equalTo(Integer.toString(count + 1)));
+    }
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/DefaultFileForDefaultClientPreloadingTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/DefaultFileForDefaultClientPreloadingTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.redis.client.deployment.preloading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.redis.client.deployment.RedisTestResource;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class DefaultFileForDefaultClientPreloadingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new File("src/test/resources/imports/import.redis"), "import.redis"))
+            .overrideConfigKey("quarkus.redis.hosts", "${quarkus.redis.tr}");
+
+    @Inject
+    RedisDataSource ds;
+
+    @Test
+    void verifyImport() {
+        var keys = ds.key();
+        var values = ds.value(String.class);
+        var hashes = ds.hash(String.class);
+
+        assertThat(keys.keys("*")).containsExactlyInAnyOrder("foo", "bar", "key1", "key2", "key3", "key4");
+
+        assertThat(hashes.hgetall("foo")).containsOnly(entry("field1", "abc"), entry("field2", "123"));
+        assertThat(hashes.hgetall("bar")).containsOnly(entry("field1", "abc def"), entry("field2", "123 456 "));
+
+        assertThat(values.get("key1")).isEqualTo("A value using \"double-quotes\"");
+        assertThat(values.get("key2")).isEqualTo("A value using 'single-quotes'");
+        assertThat(values.get("key3")).isEqualTo("A value using a single single ' quote");
+        assertThat(values.get("key4")).isEqualTo("A value using a single double \" quote");
+    }
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/MissingFilePreloadTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/MissingFilePreloadTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.redis.client.deployment.preloading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.redis.client.deployment.RedisTestResource;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class MissingFilePreloadTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.redis.hosts=${quarkus.redis.tr}\n" +
+                                    "quarkus.redis.load-script=import/my-import.redis,missing.redis"),
+                            "application.properties")
+                    .addAsResource(new File("src/test/resources/imports/import.redis"), "import/my-import.redis"))
+            .assertException(t -> assertThat(t).hasMessageContaining("Unable to find file referenced"));
+
+    @Inject
+    RedisDataSource ds;
+
+    @Test
+    void test() {
+        // should not run
+    }
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/MultiClientImportPreloadingTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/MultiClientImportPreloadingTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.redis.client.deployment.preloading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.redis.client.RedisClientName;
+import io.quarkus.redis.client.deployment.RedisTestResource;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class MultiClientImportPreloadingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.redis.hosts=${quarkus.redis.tr}\n" +
+                                    "quarkus.redis.load-script=import/my-import.redis\n" +
+                                    "quarkus.redis.my-redis.hosts=${quarkus.redis.tr}\n" +
+                                    "quarkus.redis.my-redis.load-script=sample.redis\n" +
+                                    // Do not erase as it's using the same database
+                                    // And load even if not empty
+                                    "quarkus.redis.my-redis.flush-before-load=false\n" +
+                                    "quarkus.redis.my-redis.load-only-if-empty=false"),
+                            "application.properties")
+                    .addAsResource(new File("src/test/resources/imports/import.redis"), "import/my-import.redis")
+                    .addAsResource(new File("src/test/resources/imports/sample.redis"), "sample.redis")
+
+            );
+
+    @Inject
+    RedisDataSource ds;
+
+    @Inject
+    @RedisClientName("my-redis")
+    RedisDataSource my;
+
+    @Test
+    void verifyImport() {
+        // Both clients are using the same database, by using multiple clients to distinguish.
+        var values = ds.value(String.class);
+        var hashes = ds.hash(String.class);
+
+        assertThat(hashes.hgetall("foo")).containsOnly(entry("field1", "abc"), entry("field2", "123"));
+        assertThat(hashes.hgetall("bar")).containsOnly(entry("field1", "abc def"), entry("field2", "123 456 "));
+
+        assertThat(values.get("key1")).isEqualTo("A value using \"double-quotes\"");
+        assertThat(values.get("key2")).isEqualTo("A value using 'single-quotes'");
+        assertThat(values.get("key3")).isEqualTo("A value using a single single ' quote");
+        assertThat(values.get("key4")).isEqualTo("A value using a single double \" quote");
+
+        values = my.value(String.class);
+        assertThat(values.get("key")).isEqualTo("value");
+        assertThat(values.get("space:key")).isEqualTo("another value");
+        assertThat(values.get("counter")).isEqualTo("1");
+    }
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/MultiClientImportPreloadingWithFlushAllTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/MultiClientImportPreloadingWithFlushAllTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.redis.client.deployment.preloading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.redis.client.RedisClientName;
+import io.quarkus.redis.client.deployment.RedisTestResource;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class MultiClientImportPreloadingWithFlushAllTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.redis.hosts=${quarkus.redis.tr}\n" +
+                                    "quarkus.redis.load-script=import/my-import.redis\n" +
+                                    "quarkus.redis.my-redis.hosts=${quarkus.redis.tr}\n" +
+                                    "quarkus.redis.my-redis.load-script=sample.redis\n" +
+                                    // Erase the data source
+                                    // Bad idea (as it will dropped what we loaded so far), but just to test the behavior
+                                    "quarkus.redis.my-redis.flush-before-load=true"),
+                            "application.properties")
+                    .addAsResource(new File("src/test/resources/imports/import.redis"), "import/my-import.redis")
+                    .addAsResource(new File("src/test/resources/imports/sample.redis"), "sample.redis")
+
+            );
+
+    @Inject
+    RedisDataSource ds;
+
+    @Inject
+    @RedisClientName("my-redis")
+    RedisDataSource my;
+
+    @Test
+    void verifyImport() {
+        // Others have been removed by the `flushall` command
+        assertThat(my.key().keys("*"))
+                .containsOnly("key", "space:key", "counter");
+    }
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/MultiClientImportPreloadingWithOnlyIfEmptyTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/MultiClientImportPreloadingWithOnlyIfEmptyTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.redis.client.deployment.preloading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.redis.client.RedisClientName;
+import io.quarkus.redis.client.deployment.RedisTestResource;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class MultiClientImportPreloadingWithOnlyIfEmptyTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.redis.hosts=${quarkus.redis.tr}\n" +
+                                    "quarkus.redis.load-script=import/my-import.redis\n" +
+                                    "quarkus.redis.my-redis.hosts=${quarkus.redis.tr}\n" +
+                                    "quarkus.redis.my-redis.load-script=sample.redis\n" +
+                                    // Do not erase as it's using the same database
+                                    // As the data base is not empty, the second load will be skipped
+                                    "quarkus.redis.my-redis.flush-before-load=false\n" +
+                                    "quarkus.redis.my-redis.load-only-if-empty=true"),
+                            "application.properties")
+                    .addAsResource(new File("src/test/resources/imports/import.redis"), "import/my-import.redis")
+                    .addAsResource(new File("src/test/resources/imports/sample.redis"), "sample.redis")
+
+            );
+
+    @Inject
+    RedisDataSource ds;
+
+    @Inject
+    @RedisClientName("my-redis")
+    RedisDataSource my;
+
+    @Test
+    void verifyImport() {
+        assertThat(my.key().keys("*"))
+                .containsOnly("foo", "bar", "key1", "key2", "key3", "key4");
+    }
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/MultipleFilesForDefaultClientImportPreloadingTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/MultipleFilesForDefaultClientImportPreloadingTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.redis.client.deployment.preloading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.redis.client.deployment.RedisTestResource;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class MultipleFilesForDefaultClientImportPreloadingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.redis.hosts=${quarkus.redis.tr}\n" +
+                                    "quarkus.redis.load-script=import/my-import.redis, sample.redis"),
+                            "application.properties")
+                    .addAsResource(new File("src/test/resources/imports/import.redis"), "import/my-import.redis")
+                    .addAsResource(new File("src/test/resources/imports/sample.redis"), "sample.redis"));
+
+    @Inject
+    RedisDataSource ds;
+
+    @Test
+    void verifyImport() {
+        var keys = ds.key();
+        var values = ds.value(String.class);
+        var hashes = ds.hash(String.class);
+
+        assertThat(keys.keys("*")).containsExactlyInAnyOrder("foo", "bar", "key1", "key2", "key3",
+                "key4", "space:key", "counter", "key");
+
+        assertThat(hashes.hgetall("foo")).containsOnly(entry("field1", "abc"), entry("field2", "123"));
+        assertThat(hashes.hgetall("bar")).containsOnly(entry("field1", "abc def"), entry("field2", "123 456 "));
+
+        assertThat(values.get("key1")).isEqualTo("A value using \"double-quotes\"");
+        assertThat(values.get("key2")).isEqualTo("A value using 'single-quotes'");
+        assertThat(values.get("key3")).isEqualTo("A value using a single single ' quote");
+        assertThat(values.get("key4")).isEqualTo("A value using a single double \" quote");
+
+        assertThat(values.get("key")).isEqualTo("value");
+        assertThat(values.get("space:key")).isEqualTo("another value");
+        assertThat(values.get("counter")).isEqualTo("1");
+    }
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/NonDefaultFileForDefaultClientImportPreloadingTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/preloading/NonDefaultFileForDefaultClientImportPreloadingTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.redis.client.deployment.preloading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.redis.client.deployment.RedisTestResource;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(RedisTestResource.class)
+public class NonDefaultFileForDefaultClientImportPreloadingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.redis.hosts=${quarkus.redis.tr}\n" +
+                                    "quarkus.redis.load-script=import/my-import.redis"),
+                            "application.properties")
+                    .addAsResource(new File("src/test/resources/imports/import.redis"), "import/my-import.redis"));
+
+    @Inject
+    RedisDataSource ds;
+
+    @Test
+    void verifyImport() {
+        var keys = ds.key();
+        var values = ds.value(String.class);
+        var hashes = ds.hash(String.class);
+
+        assertThat(keys.keys("*")).containsExactlyInAnyOrder("foo", "bar", "key1", "key2", "key3", "key4");
+
+        assertThat(hashes.hgetall("foo")).containsOnly(entry("field1", "abc"), entry("field2", "123"));
+        assertThat(hashes.hgetall("bar")).containsOnly(entry("field1", "abc def"), entry("field2", "123 456 "));
+
+        assertThat(values.get("key1")).isEqualTo("A value using \"double-quotes\"");
+        assertThat(values.get("key2")).isEqualTo("A value using 'single-quotes'");
+        assertThat(values.get("key3")).isEqualTo("A value using a single single ' quote");
+        assertThat(values.get("key4")).isEqualTo("A value using a single double \" quote");
+    }
+}

--- a/extensions/redis-client/deployment/src/test/resources/imports/import.redis
+++ b/extensions/redis-client/deployment/src/test/resources/imports/import.redis
@@ -1,0 +1,13 @@
+# Line starting with # and -- are ignored, as well as empty lines
+
+-- One command per line:
+HSET foo field1 abc field2 123
+
+-- Parameters with spaces must be wrapped into single or double quotes
+HSET bar field1 "abc def" field2 '123 456 '
+
+-- Parameters with double quotes must be wrapped into single quotes and the opposite
+SET key1 'A value using "double-quotes"'
+SET key2 "A value using 'single-quotes'"
+SET key3 "A value using a single single ' quote"
+SET key4 'A value using a single double " quote'

--- a/extensions/redis-client/deployment/src/test/resources/imports/sample.redis
+++ b/extensions/redis-client/deployment/src/test/resources/imports/sample.redis
@@ -1,0 +1,6 @@
+-- Run inside a transaction
+MULTI
+SET key value
+SET space:key 'another value'
+INCR counter
+EXEC

--- a/extensions/redis-client/deployment/src/test/resources/imports/starwars.redis
+++ b/extensions/redis-client/deployment/src/test/resources/imports/starwars.redis
@@ -1,0 +1,6 @@
+HSET people:1 firstName "luke" lastName "skywalker"
+HSET people:2 firstName "leia" lastName "organa"
+HSET people:3 firstName "anakin" lastName "skywalker"
+HSET people:4 firstName "c-3po" lastName ""
+HSET people:5 firstName "r2-d2" lastName ""
+HSET people:6 firstName "owen" lastName "lars"

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisDataLoader.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisDataLoader.java
@@ -1,0 +1,136 @@
+package io.quarkus.redis.runtime.client;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.redis.client.Command;
+import io.vertx.mutiny.redis.client.Redis;
+import io.vertx.mutiny.redis.client.Request;
+
+public class RedisDataLoader {
+
+    static final Logger LOGGER = Logger.getLogger("RedisDataLoader");
+
+    static void load(Vertx vertx, Redis redis, String path) {
+        LOGGER.infof("Importing Redis data from %s", path);
+
+        Buffer buffer = vertx.fileSystem().readFileBlocking(path);
+        if (buffer == null) {
+            throw new ConfigurationException("Unable to read the " + path + " file");
+        }
+        List<Request> batch = read(buffer.toString().lines().collect(Collectors.toList()));
+        redis.batch(batch).await().atMost(Duration.ofMinutes(1));
+    }
+
+    private enum State {
+        COMMAND,
+        ARGUMENTS,
+        PARAM,
+        PARAM_IN_QUOTES,
+        PARAM_IN_DOUBLE_QUOTES
+    }
+
+    private static boolean isComment(String line) {
+        return line.startsWith("--") || line.startsWith("#");
+    }
+
+    private static List<Request> read(List<String> lines) {
+        List<Request> requests = new ArrayList<>();
+        int lineNumber = 0;
+        for (int i = 0; i < lines.size(); i++) {
+            lineNumber++;
+            var line = lines.get(i);
+            if (line.trim().length() != 0 && !isComment(line.trim())) {
+                var req = read(lineNumber, line.trim());
+                if (req != null) {
+                    requests.add(req);
+                }
+            }
+        }
+        return requests;
+    }
+
+    private static Request read(int lineNumber, String line) {
+        State state = State.COMMAND;
+
+        StringBuffer current = new StringBuffer();
+        Request request = null;
+
+        int pos = 0;
+
+        for (char c : line.toCharArray()) {
+            pos++;
+
+            if (state == State.COMMAND) {
+                if (Character.isSpaceChar(c)) {
+                    request = Request.cmd(Command.create(getAndClear(current)));
+                    state = State.ARGUMENTS;
+                } else {
+                    current.append(c);
+                }
+            } else if (state == State.ARGUMENTS) {
+                if (!Character.isSpaceChar(c)) {
+                    if (c == '\"') {
+                        state = State.PARAM_IN_DOUBLE_QUOTES;
+                    } else if (c == '\'') {
+                        state = State.PARAM_IN_QUOTES;
+                    } else {
+                        state = State.PARAM;
+                        current.append(c);
+                    }
+                }
+            } else if (state == State.PARAM) {
+                if (!Character.isSpaceChar(c)) {
+                    current.append(c);
+                } else {
+                    request.arg(getAndClear(current));
+                    state = State.ARGUMENTS;
+                }
+            } else if (state == State.PARAM_IN_QUOTES) {
+                if (c != '\'') {
+                    current.append(c);
+                } else {
+                    request.arg(getAndClear(current));
+                    state = State.ARGUMENTS;
+                }
+            } else if (state == State.PARAM_IN_DOUBLE_QUOTES) {
+                if (c != '"') {
+                    current.append(c);
+                } else {
+                    request.arg(getAndClear(current));
+                    state = State.ARGUMENTS;
+                }
+            } else {
+                throw new IllegalStateException("Unexpected character at " + lineNumber + ":" + pos
+                        + ", current state is " + state.name());
+            }
+        }
+
+        if (current.length() > 0) {
+            if (state == State.COMMAND) {
+                request = Request.cmd(Command.create(getAndClear(current)));
+            } else if (state == State.PARAM) {
+                request.arg(getAndClear(current));
+            } else {
+                throw new IllegalStateException("End of line unexpected at " + lineNumber + ":" + pos);
+            }
+        }
+
+        return request;
+
+    }
+
+    private static String getAndClear(StringBuffer buffer) {
+        var content = buffer.toString();
+        buffer.setLength(0);
+        return content;
+    }
+
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
@@ -178,4 +178,5 @@ public class RedisClientConfig {
                 ", tls=" + tls +
                 '}';
     }
+
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisConfig.java
@@ -53,4 +53,11 @@ public class RedisConfig {
         return DEFAULT_CLIENT_NAME.equalsIgnoreCase(name);
     }
 
+    public static String propertyKey(String name, String radical) {
+        String prefix = DEFAULT_CLIENT_NAME.equals(name)
+                ? "quarkus.redis."
+                : "quarkus.redis.\"" + name + "\".";
+        return prefix + radical;
+    }
+
 }

--- a/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisResource.java
+++ b/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.redis.it;
 
+import java.util.List;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -8,6 +10,7 @@ import javax.ws.rs.PathParam;
 
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.datasource.keys.ReactiveKeyCommands;
 import io.quarkus.redis.datasource.value.ReactiveValueCommands;
 import io.quarkus.redis.datasource.value.ValueCommands;
 import io.smallrye.mutiny.Uni;
@@ -18,11 +21,13 @@ public class RedisResource {
 
     private final ValueCommands<String, String> blocking;
     private final ReactiveValueCommands<String, String> reactive;
+    private final ReactiveKeyCommands<String> keys;
 
     public RedisResource(RedisDataSource ds,
             ReactiveRedisDataSource reactiveDs) {
         blocking = ds.value(String.class);
         reactive = reactiveDs.value(String.class);
+        keys = reactiveDs.key();
     }
 
     // synchronous
@@ -49,6 +54,12 @@ public class RedisResource {
     @Path("/reactive/{key}")
     public Uni<Void> setReactive(@PathParam("key") String key, String value) {
         return this.reactive.set(key, value);
+    }
+
+    @GET
+    @Path("/import")
+    public Uni<Integer> startWarsKey() {
+        return keys.keys("people:*").map(List::size);
     }
 
 }

--- a/integration-tests/redis-client/src/main/resources/application.properties
+++ b/integration-tests/redis-client/src/main/resources/application.properties
@@ -7,3 +7,5 @@ quarkus.redis.parameter-injection.hosts=redis://localhost:6379/2
 quarkus.redis.instance-client.hosts=redis://localhost:6379/5
 # use DB 3
 quarkus.redis.provided-hosts.hosts-provider-name=test-hosts-provider
+
+quarkus.redis.load-script=starwars.redis

--- a/integration-tests/redis-client/src/main/resources/starwars.redis
+++ b/integration-tests/redis-client/src/main/resources/starwars.redis
@@ -1,0 +1,6 @@
+HSET people:1 firstName "luke" lastName "skywalker"
+HSET people:2 firstName "leia" lastName "organa"
+HSET people:3 firstName "anakin" lastName "skywalker"
+HSET people:4 firstName "c-3po" lastName ""
+HSET people:5 firstName "r2-d2" lastName ""
+HSET people:6 firstName "owen" lastName "lars"

--- a/integration-tests/redis-client/src/test/java/io/quarkus/redis/it/QuarkusRedisTest.java
+++ b/integration-tests/redis-client/src/test/java/io/quarkus/redis/it/QuarkusRedisTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.redis.it;
 
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -77,5 +78,12 @@ class QuarkusRedisTest {
                     .statusCode(200)
                     .body(CoreMatchers.is(REACTIVE_VALUE));
         }
+    }
+
+    @Test
+    public void testPreloading() {
+        RestAssured.get("/quarkus-redis/import").then()
+                .statusCode(200)
+                .body(Matchers.equalTo("6"));
     }
 }


### PR DESCRIPTION
Allows importing data into Redis as you would with import.sql, but with an import.redis.

Supports:

- list of scripts
- different script per client
- flushall before import (can be disabled), import only if empty (can be disabled)
- works in dev/test and prod (including native) - in prod, as for hibernate you need explicit configuration

The format is the following:

```text
# Line starting with # and -- are ignored, as well as empty lines

-- One command per line:
HSET foo field1 abc field2 123

-- Parameters with spaces must be wrapped into single or double quotes
HSET bar field1 "abc def" field2 '123 456 '

-- Parameters with double quotes must be wrapped into single quotes and the opposite
SET key1 'A value using "double-quotes"'
SET key2 "A value using 'single-quotes'"
SET key3 "A value using a single single ' quote"
SET key4 'A value using a single double " quote'
```

Fix #29086
