### PR TITLE
Test: Enable Backchannel logout test

### DIFF
--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -99,6 +99,7 @@ public class CodeFlowAuthorizationTest {
         }
     }
 
+    @Test
     public void testCodeFlowFormPostAndBackChannelLogout() throws IOException {
         defineCodeFlowLogoutStub();
         try (final WebClient webClient = createWebClient()) {


### PR DESCRIPTION
Enables `CodeFlowAuthorizationTest#testCodeFlowFormPostAndBackChannelLogout`. https://github.com/quarkusio/quarkus/pull/25343/files#diff-341822cbaa9c7618961ea161cd2719276ac63f06c167bee4b525c5122a979ad2 removed `@Test` and I don't understand from context why as it is green when running locally. It is also only backchannel logout test I could find, therefore I am proposing to run it.