### PR TITLE
Provide proper error message for missing URL with Keycloak Admin client bean

### DIFF
--- a/extensions/keycloak-admin-client-reactive/runtime/src/main/java/io/quarkus/keycloak/admin/client/reactive/runtime/ResteasyReactiveKeycloakAdminClientRecorder.java
+++ b/extensions/keycloak-admin-client-reactive/runtime/src/main/java/io/quarkus/keycloak/admin/client/reactive/runtime/ResteasyReactiveKeycloakAdminClientRecorder.java
@@ -30,10 +30,11 @@ public class ResteasyReactiveKeycloakAdminClientRecorder {
         final KeycloakAdminClientConfig config = keycloakAdminClientConfigRuntimeValue.getValue();
         validate(config);
         if (config.serverUrl.isEmpty()) {
-            return new Supplier<Keycloak>() {
+            return new Supplier<>() {
                 @Override
                 public Keycloak get() {
-                    return null;
+                    throw new IllegalStateException(
+                            "'quarkus.keycloak.admin-client.server-url' must be set in order to use the Keycloak admin client as a CDI bean");
                 }
             };
         }

--- a/extensions/keycloak-admin-client/runtime/src/main/java/io/quarkus/keycloak/adminclient/ResteasyKeycloakAdminClientRecorder.java
+++ b/extensions/keycloak-admin-client/runtime/src/main/java/io/quarkus/keycloak/adminclient/ResteasyKeycloakAdminClientRecorder.java
@@ -31,10 +31,11 @@ public class ResteasyKeycloakAdminClientRecorder {
         final KeycloakAdminClientConfig config = keycloakAdminClientConfigRuntimeValue.getValue();
         validate(config);
         if (config.serverUrl.isEmpty()) {
-            return new Supplier<Keycloak>() {
+            return new Supplier<>() {
                 @Override
                 public Keycloak get() {
-                    return null;
+                    throw new IllegalStateException(
+                            "'quarkus.keycloak.admin-client.server-url' must be set in order to use the Keycloak admin client as a CDI bean");
                 }
             };
         }


### PR DESCRIPTION
I ran into this when looking at https://github.com/quarkusio/quarkus/issues/29712. Without this change, users are presented with a totally misleading `ContextNotActiveException`

_Edit_

Fixes: #29958