### PR TITLE
Provide a better error message when @RequestScoped bean is null

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
@@ -72,6 +72,11 @@ class RequestContext implements ManagedContext {
             // Bean instance does not exist - create one if we have CreationalContext
             instance = new ContextInstanceHandleImpl<T>((InjectableBean<T>) contextual,
                     contextual.create(creationalContext), creationalContext);
+            if (!instance.isAvailable()) {
+                // this is an issue caused by the bean being null so let's provide a clear message instead of falling through to the misleading ContextNotActiveException
+                throw new IllegalStateException(String
+                        .format("Unable to create bean instance for a client proxy of %s because the bean is null", bean));
+            }
             ctxState.map.put(contextual, instance);
         }
         return instance.get();


### PR DESCRIPTION
Without this change, users are supplied a well-meaning - yet misleading message informing them that the context is not active.
This leads them to think they can actually do something to alleviate the issue by enabling the request context.

I actually encountered this issue in Quarkus code (see https://github.com/quarkusio/quarkus/pull/29772)