### PR TITLE
Remove QuarkusTestExtension.class from @QuarkusIntegrationTest

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTest.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTest.java
@@ -30,7 +30,7 @@ import io.quarkus.test.common.DevServicesContext;
  * {@link @QuarkusTest} so the test class structure must take this into account.
  */
 @Target(ElementType.TYPE)
-@ExtendWith({ DisabledOnIntegrationTestCondition.class, QuarkusTestExtension.class, QuarkusIntegrationTestExtension.class })
+@ExtendWith({ DisabledOnIntegrationTestCondition.class, QuarkusIntegrationTestExtension.class })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface QuarkusIntegrationTest {
 


### PR DESCRIPTION
Without this fix, if an integration test fails it results in the application being restarted

Relates to: https://github.com/quarkusio/quarkus/issues/23612