### PR TITLE
Throw a CreationException if a normal scoped synthetic bean creates null

### DIFF
--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/NormalScopedSyntheticBeanProducedNullTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/NormalScopedSyntheticBeanProducedNullTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.CreationException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class NormalScopedSyntheticBeanProducedNullTest {
+
+    public static volatile boolean beanDestroyerInvoked = false;
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanRegistrars(new TestRegistrar()).build();
+
+    @Test
+    public void testCreationException() {
+        CreationException e = assertThrows(CreationException.class, () -> {
+            Arc.container().instance(CharSequence.class).get().length();
+        });
+        assertTrue(e.getMessage().contains("Null contextual instance was produced by a normal scoped synthetic bean"),
+                e.getMessage());
+    }
+
+    static class TestRegistrar implements BeanRegistrar {
+
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(CharSequence.class).types(CharSequence.class).unremovable().scope(ApplicationScoped.class)
+                    .creator(CharSequenceCreator.class).done();
+        }
+
+    }
+
+    public static class CharSequenceCreator implements BeanCreator<CharSequence> {
+
+        @Override
+        public CharSequence create(CreationalContext<CharSequence> creationalContext, Map<String, Object> params) {
+            return null;
+        }
+
+    }
+
+}


### PR DESCRIPTION
- follow the rules defined for normal scoped producer methods and fields where an IllegalProductException must be thrown instead

This pull request should supersede https://github.com/quarkusio/quarkus/pull/29773