### PR TITLE
Use prefix and name when matching unrecognized configurations keys

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
@@ -366,7 +366,8 @@ public final class BuildTimeConfigurationReader {
             buildTimeRunTimeValues.putAll(getDefaults(buildTimeRunTimePatternMap));
 
             SmallRyeConfig runtimeDefaultsConfig = getConfigForRuntimeDefaults();
-            Set<String> registeredRoots = allRoots.stream().map(RootDefinition::getPrefix).collect(toSet());
+            Set<String> registeredRoots = allRoots.stream().map(RootDefinition::getName).collect(toSet());
+            registeredRoots.add("quarkus");
             Set<String> allProperties = getAllProperties(registeredRoots);
             Set<String> unknownBuildProperties = new HashSet<>();
             for (String propertyName : allProperties) {

--- a/integration-tests/test-extension/extension/deployment/src/main/resources/application.properties
+++ b/integration-tests/test-extension/extension/deployment/src/main/resources/application.properties
@@ -185,4 +185,8 @@ my.prefix.bt.nested.oov=nested-1234+nested-5678
 another.another-prefix.prop=5678
 another.another-prefix.map.prop=5678
 
+proprietary.root.config.value=1234
+proprietary.mapping.config.value=1234
+proprietary.should.not.report.unknown=1234
+
 unremoveable.value=1234

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownConfigTest.java
@@ -32,6 +32,7 @@ public class UnknownConfigTest {
                         .map(Object::toString).collect(Collectors.toSet());
                 assertTrue(properties.contains("quarkus.unknown.prop"));
                 assertFalse(properties.contains("quarkus.build.unknown.prop"));
+                assertFalse(properties.contains("proprietary.should.not.report.unknown"));
             });
 
     @Inject

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/named/ProprietaryConfig.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/named/ProprietaryConfig.java
@@ -1,0 +1,12 @@
+package io.quarkus.extest.runtime.config.named;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(prefix = "proprietary", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED, name = "root.config")
+public class ProprietaryConfig {
+    /** */
+    @ConfigItem
+    public String value;
+}

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/named/ProprietaryMapping.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/config/named/ProprietaryMapping.java
@@ -1,0 +1,12 @@
+package io.quarkus.extest.runtime.config.named;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "proprietary.mapping.config")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface ProprietaryMapping {
+    /** */
+    String value();
+}


### PR DESCRIPTION
- Fixes #29660