### PR TITLE
Fix PostgreSQL XA mode in native images

### DIFF
--- a/extensions/jdbc/jdbc-postgresql/deployment/src/main/java/io/quarkus/jdbc/postgresql/deployment/PostgreSQLJDBCReflections.java
+++ b/extensions/jdbc/jdbc-postgresql/deployment/src/main/java/io/quarkus/jdbc/postgresql/deployment/PostgreSQLJDBCReflections.java
@@ -19,6 +19,9 @@ public final class PostgreSQLJDBCReflections {
         //We register it for the sake of other users.
         final String driverName = "org.postgresql.Driver";
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, driverName));
+
+        // Needed when quarkus.datasource.jdbc.transactions=xa for the setting of the username and password
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, true, false, "org.postgresql.ds.common.BaseDataSource"));
     }
 
 }


### PR DESCRIPTION
When using XA transactions in native images with PostgreSQL, an additional reflective items needs to be registered, otherwise the setUser() and setPassword() on the XA datasource is not recognized, and quarkus cannot connect to postgres.

Reproduce: `quarkus.datasource.jdbc.transactions=xa` and generate a native image, use postgres with standard password authentication, application will fail to connect as username and password are missing from the connect.

When this is not set to XA, the bug is not occuring, as the XA datasource is not used.