### PR TITLE
Update to Vert.x 4.3.6

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -51,7 +51,7 @@
         <smallrye-context-propagation.version>1.2.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>2.7.0</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>2.28.0</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>2.29.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>3.22.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>1.3.3</smallrye-stork.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
@@ -110,7 +110,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>1.20.1.Final</wildfly-elytron.version>
         <jboss-threads.version>3.4.3.Final</jboss-threads.version>
-        <vertx.version>4.3.5</vertx.version>
+        <vertx.version>4.3.6</vertx.version>
 
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>


### PR DESCRIPTION
Also bump the Vert.x Mutiny bindings to version 2.29.0.
