### PR TITLE
Bump kubernetes-client-bom from 6.2.0 to 6.3.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -155,7 +155,7 @@
         <kotlin.version>1.7.22</kotlin.version>
         <kotlin.coroutine.version>1.6.4</kotlin.coroutine.version>
         <kotlin-serialization.version>1.4.1</kotlin-serialization.version>
-        <kubernetes-client.version>6.2.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>6.3.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <dekorate.version>3.1.3</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
@@ -220,10 +220,11 @@ public class KubernetesClientProcessor {
             log.debugv("Model Classes:\n{0}", String.join("\n", modelClasses));
         }
 
-        // Register the default HttpClient implementation
-        serviceProviderProducer.produce(new ServiceProviderBuildItem(
-                HttpClient.Factory.class.getName(), "io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory"));
-
+        // Register all HttpClient implementations
+        serviceProviderProducer.produce(ServiceProviderBuildItem.allProvidersFromClassPath(HttpClient.Factory.class.getName()));
+        // Register all KubernetesResource providers (needed for the KubernetesDeserializer)
+        serviceProviderProducer.produce(ServiceProviderBuildItem.allProvidersFromClassPath(KubernetesResource.class.getName()));
+        // Register all KubernetesClient extensions
         serviceProviderProducer.produce(ServiceProviderBuildItem.allProvidersFromClassPath(ExtensionAdapter.class.getName()));
 
         // Enable SSL support by default

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithAutoPostgresBindingTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithAutoPostgresBindingTest.java
@@ -6,10 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.dekorate.servicebinding.model.ServiceBinding;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.quarkus.builder.Version;
@@ -59,26 +60,18 @@ public class KubernetesWithAutoPostgresBindingTest {
             });
         });
 
-        assertThat(kubernetesList).filteredOn(i -> "ServiceBinding".equals(i.getKind())).singleElement().satisfies(i -> {
-            assertThat(i).isInstanceOfSatisfying(ServiceBinding.class, s -> {
-                assertThat(s.getMetadata()).satisfies(m -> {
-                    assertThat(m.getName()).isEqualTo("kubernetes-with-auto-postgres-binding-postgresql");
-                });
-                assertThat(s.getSpec()).satisfies(spec -> {
-                    assertThat(spec.getApplication()).satisfies(a -> {
-                        assertThat(a.getGroup()).isEqualTo("apps");
-                        assertThat(a.getVersion()).isEqualTo("v1");
-                        assertThat(a.getKind()).isEqualTo("Deployment");
-                    });
-
-                    assertThat(spec.getServices()).hasOnlyOneElementSatisfying(service -> {
-                        assertThat(service.getGroup()).isEqualTo("postgres-operator.crunchydata.com");
-                        assertThat(service.getVersion()).isEqualTo("v1beta1");
-                        assertThat(service.getKind()).isEqualTo("PostgresCluster");
-                        assertThat(service.getName()).isEqualTo("postgresql");
-                    });
-                });
-            });
-        });
+        assertThat(kubernetesList).filteredOn(i -> "ServiceBinding".equals(i.getKind())).singleElement()
+                .isInstanceOfSatisfying(GenericKubernetesResource.class, sb -> assertThat(sb)
+                        .hasFieldOrPropertyWithValue("metadata.name", "kubernetes-with-auto-postgres-binding-postgresql")
+                        .returns("apps", s -> s.get("spec", "application", "group"))
+                        .returns("v1", s -> s.get("spec", "application", "version"))
+                        .returns("Deployment", s -> s.get("spec", "application", "kind"))
+                        .extracting(s -> s.get("spec", "services"))
+                        .asList()
+                        .singleElement().asInstanceOf(InstanceOfAssertFactories.MAP)
+                        .containsEntry("group", "postgres-operator.crunchydata.com")
+                        .containsEntry("version", "v1beta1")
+                        .containsEntry("kind", "PostgresCluster")
+                        .containsEntry("name", "postgresql"));
     }
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSemiAutoPostgresBindingTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSemiAutoPostgresBindingTest.java
@@ -6,10 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.dekorate.servicebinding.model.ServiceBinding;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.quarkus.builder.Version;
@@ -59,26 +60,18 @@ public class KubernetesWithSemiAutoPostgresBindingTest {
             });
         });
 
-        assertThat(kubernetesList).filteredOn(i -> "ServiceBinding".equals(i.getKind())).singleElement().satisfies(i -> {
-            assertThat(i).isInstanceOfSatisfying(ServiceBinding.class, s -> {
-                assertThat(s.getMetadata()).satisfies(m -> {
-                    assertThat(m.getName()).isEqualTo("kubernetes-with-semi-auto-postgres-binding-postgresql");
-                });
-                assertThat(s.getSpec()).satisfies(spec -> {
-                    assertThat(spec.getApplication()).satisfies(a -> {
-                        assertThat(a.getGroup()).isEqualTo("apps");
-                        assertThat(a.getVersion()).isEqualTo("v1");
-                        assertThat(a.getKind()).isEqualTo("Deployment");
-                    });
-
-                    assertThat(spec.getServices()).hasOnlyOneElementSatisfying(service -> {
-                        assertThat(service.getGroup()).isEqualTo("my.custom-operator.com");
-                        assertThat(service.getVersion()).isEqualTo("v1alpha1");
-                        assertThat(service.getKind()).isEqualTo("Postgres");
-                        assertThat(service.getName()).isEqualTo("postgresql");
-                    });
-                });
-            });
-        });
+        assertThat(kubernetesList).filteredOn(i -> "ServiceBinding".equals(i.getKind())).singleElement()
+                .isInstanceOfSatisfying(GenericKubernetesResource.class, sb -> assertThat(sb)
+                        .hasFieldOrPropertyWithValue("metadata.name", "kubernetes-with-semi-auto-postgres-binding-postgresql")
+                        .returns("apps", s -> s.get("spec", "application", "group"))
+                        .returns("v1", s -> s.get("spec", "application", "version"))
+                        .returns("Deployment", s -> s.get("spec", "application", "kind"))
+                        .extracting(s -> s.get("spec", "services"))
+                        .asList()
+                        .singleElement().asInstanceOf(InstanceOfAssertFactories.MAP)
+                        .containsEntry("group", "my.custom-operator.com")
+                        .containsEntry("version", "v1alpha1")
+                        .containsEntry("kind", "Postgres")
+                        .containsEntry("name", "postgresql"));
     }
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithServiceBindingTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithServiceBindingTest.java
@@ -7,10 +7,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.dekorate.servicebinding.model.ServiceBinding;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.quarkus.builder.Version;
@@ -58,26 +59,18 @@ public class KubernetesWithServiceBindingTest {
             });
         });
 
-        assertThat(kubernetesList).filteredOn(i -> "ServiceBinding".equals(i.getKind())).singleElement().satisfies(i -> {
-            assertThat(i).isInstanceOfSatisfying(ServiceBinding.class, s -> {
-                assertThat(s.getMetadata()).satisfies(m -> {
-                    assertThat(m.getName()).isEqualTo("kubernetes-with-service-binding-my-db");
-                });
-                assertThat(s.getSpec()).satisfies(spec -> {
-                    assertThat(spec.getApplication()).satisfies(a -> {
-                        assertThat(a.getGroup()).isEqualTo("apps");
-                        assertThat(a.getVersion()).isEqualTo("v1");
-                        assertThat(a.getKind()).isEqualTo("Deployment");
-                    });
-
-                    assertThat(spec.getServices()).hasOnlyOneElementSatisfying(service -> {
-                        assertThat(service.getGroup()).isEqualTo("apps");
-                        assertThat(service.getVersion()).isEqualTo("v1");
-                        assertThat(service.getKind()).isEqualTo("Deployment");
-                        assertThat(service.getName()).isEqualTo("my-postgres");
-                    });
-                });
-            });
-        });
+        assertThat(kubernetesList).filteredOn(i -> "ServiceBinding".equals(i.getKind())).singleElement()
+                .isInstanceOfSatisfying(GenericKubernetesResource.class, sb -> assertThat(sb)
+                        .hasFieldOrPropertyWithValue("metadata.name", "kubernetes-with-service-binding-my-db")
+                        .returns("apps", s -> s.get("spec", "application", "group"))
+                        .returns("v1", s -> s.get("spec", "application", "version"))
+                        .returns("Deployment", s -> s.get("spec", "application", "kind"))
+                        .extracting(s -> s.get("spec", "services"))
+                        .asList()
+                        .singleElement().asInstanceOf(InstanceOfAssertFactories.MAP)
+                        .containsEntry("group", "apps")
+                        .containsEntry("version", "v1")
+                        .containsEntry("kind", "Deployment")
+                        .containsEntry("name", "my-postgres"));
     }
 }


### PR DESCRIPTION
Kubernetes Client 6.3.0 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v6.3.0

Just speeding up the dependabot process to see if CI reports any issue.

/cc @metacosm