### PR TITLE
Look for test classes in the model loaded from the Gradle tooling

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/ArtifactSources.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/ArtifactSources.java
@@ -4,13 +4,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.paths.EmptyPathTree;
 import io.quarkus.paths.MultiRootPathTree;
 import io.quarkus.paths.PathTree;
 
 public interface ArtifactSources {
 
-    String MAIN = "";
+    String MAIN = ArtifactCoords.DEFAULT_CLASSIFIER;
     String TEST = "tests";
 
     static ArtifactSources main(SourceDir sources, SourceDir resources) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/utils/BuildToolHelper.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/utils/BuildToolHelper.java
@@ -21,7 +21,7 @@ public class BuildToolHelper {
     private static final Logger log = Logger.getLogger(BuildToolHelper.class);
 
     private final static String[] DEVMODE_REQUIRED_TASKS = new String[] { "classes" };
-    private final static String[] TEST_REQUIRED_TASKS = new String[] { "classes", "testClasses" };
+    private final static String[] TEST_REQUIRED_TASKS = new String[] { "classes", "testClasses", "integrationTestClasses" };
     private final static List<String> ENABLE_JAR_PACKAGING = Collections
             .singletonList("-Dorg.gradle.java.compile-classpath-packaging=true");
 
@@ -108,6 +108,7 @@ public class BuildToolHelper {
     public static ApplicationModel enableGradleAppModel(Path projectRoot, String mode, List<String> jvmArgs, String... tasks)
             throws IOException, AppModelResolverException {
         if (isGradleProject(projectRoot)) {
+            log.infof("Loading Quarkus Gradle application model for %s", projectRoot);
             final ApplicationModel model = QuarkusGradleModelFactory.create(
                     getBuildFile(projectRoot, BuildTool.GRADLE).toFile(),
                     mode, jvmArgs, tasks);

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
@@ -1,7 +1,6 @@
 package io.quarkus.bootstrap.resolver;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 import org.gradle.tooling.GradleConnector;
@@ -14,7 +13,7 @@ import io.quarkus.bootstrap.model.ApplicationModel;
 public class QuarkusGradleModelFactory {
 
     public static ApplicationModel create(File projectDir, String mode, String... tasks) {
-        return create(projectDir, mode, Collections.emptyList(), tasks);
+        return create(projectDir, mode, List.of(), tasks);
     }
 
     public static ApplicationModel create(File projectDir, String mode, List<String> jvmArgs, String... tasks) {

--- a/integration-tests/gradle/src/main/resources/builder/simple-module-project/src/test/java/Dummy.java
+++ b/integration-tests/gradle/src/main/resources/builder/simple-module-project/src/test/java/Dummy.java
@@ -1,0 +1,2 @@
+public class Dummy {
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/builder/QuarkusModelBuilderTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/builder/QuarkusModelBuilderTest.java
@@ -46,7 +46,7 @@ class QuarkusModelBuilderTest {
     @Test
     public void shouldLoadSimpleModuleDevModel() throws URISyntaxException, IOException {
         File projectDir = getResourcesProject("builder/simple-module-project");
-        final ApplicationModel quarkusModel = QuarkusGradleModelFactory.create(projectDir, "DEVELOPMENT");
+        final ApplicationModel quarkusModel = QuarkusGradleModelFactory.create(projectDir, "DEVELOPMENT", "testClasses");
 
         assertNotNull(quarkusModel);
         assertNotNull(quarkusModel.getApplicationModule());
@@ -63,7 +63,8 @@ class QuarkusModelBuilderTest {
     public void shouldLoadMultiModuleTestModel() throws URISyntaxException, IOException {
         File projectDir = getResourcesProject("builder/multi-module-project");
 
-        final ApplicationModel quarkusModel = QuarkusGradleModelFactory.create(new File(projectDir, "application"), "TEST");
+        final ApplicationModel quarkusModel = QuarkusGradleModelFactory.create(new File(projectDir, "application"), "TEST",
+                "testClasses");
 
         assertNotNull(quarkusModel);
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestClassIndexer.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestClassIndexer.java
@@ -29,8 +29,11 @@ public final class TestClassIndexer {
     }
 
     public static Index indexTestClasses(Class<?> testClass) {
+        return indexTestClasses(getTestClassesLocation(testClass));
+    }
+
+    public static Index indexTestClasses(final Path testClassesLocation) {
         final Indexer indexer = new Indexer();
-        final Path testClassesLocation = getTestClassesLocation(testClass);
         try {
             if (Files.isDirectory(testClassesLocation)) {
                 indexTestClassesDir(indexer, testClassesLocation);
@@ -48,7 +51,11 @@ public final class TestClassIndexer {
     }
 
     public static void writeIndex(Index index, Class<?> testClass) {
-        try (FileOutputStream fos = new FileOutputStream(indexPath(testClass).toFile(), false)) {
+        writeIndex(index, getTestClassesLocation(testClass), testClass);
+    }
+
+    public static void writeIndex(Index index, Path testClassLocation, Class<?> testClass) {
+        try (FileOutputStream fos = new FileOutputStream(indexPath(testClassLocation, testClass).toFile(), false)) {
             IndexWriter indexWriter = new IndexWriter(fos);
             indexWriter.write(index);
         } catch (IOException ignored) {
@@ -58,7 +65,11 @@ public final class TestClassIndexer {
     }
 
     public static Index readIndex(Class<?> testClass) {
-        Path path = indexPath(testClass);
+        return readIndex(getTestClassesLocation(testClass), testClass);
+    }
+
+    public static Index readIndex(Path testClassLocation, Class<?> testClass) {
+        Path path = indexPath(testClassLocation, testClass);
         if (path.toFile().exists()) {
             try (FileInputStream fis = new FileInputStream(path.toFile())) {
                 return new IndexReader(fis).read();
@@ -75,7 +86,11 @@ public final class TestClassIndexer {
     }
 
     private static Path indexPath(Class<?> testClass) {
-        return PathTestHelper.getTestClassesLocation(testClass).resolve(testClass.getSimpleName() + ".idx");
+        return indexPath(PathTestHelper.getTestClassesLocation(testClass), testClass);
+    }
+
+    private static Path indexPath(Path testClassLocation, Class<?> testClass) {
+        return testClassLocation.resolve(testClass.getSimpleName() + ".idx");
     }
 
     private static void indexTestClassesDir(Indexer indexer, final Path testClassesLocation) throws IOException {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -4,6 +4,7 @@ import java.io.Closeable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -56,6 +57,13 @@ public class TestResourceManager implements Closeable {
     public TestResourceManager(Class<?> testClass, Class<?> profileClass, List<TestResourceClassEntry> additionalTestResources,
             boolean disableGlobalTestResources, Map<String, String> devServicesProperties,
             Optional<String> containerNetworkId) {
+        this(testClass, profileClass, additionalTestResources, disableGlobalTestResources, devServicesProperties,
+                containerNetworkId, PathTestHelper.getTestClassesLocation(testClass));
+    }
+
+    public TestResourceManager(Class<?> testClass, Class<?> profileClass, List<TestResourceClassEntry> additionalTestResources,
+            boolean disableGlobalTestResources, Map<String, String> devServicesProperties,
+            Optional<String> containerNetworkId, Path testClassLocation) {
         this.parallelTestResourceEntries = new ArrayList<>();
         this.sequentialTestResourceEntries = new ArrayList<>();
 
@@ -65,7 +73,8 @@ public class TestResourceManager implements Closeable {
         if (disableGlobalTestResources) {
             uniqueEntries = new HashSet<>(additionalTestResources);
         } else {
-            uniqueEntries = getUniqueTestResourceClassEntries(testClass, profileClass, additionalTestResources);
+            uniqueEntries = getUniqueTestResourceClassEntries(testClassLocation, testClass, profileClass,
+                    additionalTestResources);
         }
         Set<TestResourceClassEntry> remainingUniqueEntries = initParallelTestResources(uniqueEntries);
         initSequentialTestResources(remainingUniqueEntries);
@@ -247,9 +256,10 @@ public class TestResourceManager implements Closeable {
         }
     }
 
-    private Set<TestResourceClassEntry> getUniqueTestResourceClassEntries(Class<?> testClass, Class<?> profileClass,
+    private Set<TestResourceClassEntry> getUniqueTestResourceClassEntries(Path testClassLocation, Class<?> testClass,
+            Class<?> profileClass,
             List<TestResourceClassEntry> additionalTestResources) {
-        IndexView index = TestClassIndexer.readIndex(testClass);
+        IndexView index = TestClassIndexer.readIndex(testClassLocation, testClass);
         Set<TestResourceClassEntry> uniqueEntries = new LinkedHashSet<>();
         // reload the test and profile classes in the right CL
         Class<?> testClassFromTCCL;

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -225,12 +225,12 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
 
             //must be done after the TCCL has been set
             testResourceManager = (Closeable) startupAction.getClassLoader().loadClass(TestResourceManager.class.getName())
-                    .getConstructor(Class.class, Class.class, List.class, boolean.class, Map.class, Optional.class)
+                    .getConstructor(Class.class, Class.class, List.class, boolean.class, Map.class, Optional.class, Path.class)
                     .newInstance(requiredTestClass,
                             profile != null ? profile : null,
                             getAdditionalTestResources(profileInstance, startupAction.getClassLoader()),
                             profileInstance != null && profileInstance.disableGlobalTestResources(),
-                            startupAction.getDevServicesProperties(), Optional.empty());
+                            startupAction.getDevServicesProperties(), Optional.empty(), result.testClassLocation);
             testResourceManager.getClass().getMethod("init", String.class).invoke(testResourceManager,
                     profile != null ? profile.getName() : null);
             Map<String, String> properties = (Map<String, String>) testResourceManager.getClass().getMethod("start")
@@ -1251,7 +1251,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         public List<Consumer<BuildChainBuilder>> apply(Map<String, Object> stringObjectMap) {
             Path testLocation = (Path) stringObjectMap.get(TEST_LOCATION);
             // the index was written by the extension
-            Index testClassesIndex = TestClassIndexer.readIndex((Class<?>) stringObjectMap.get(TEST_CLASS));
+            Index testClassesIndex = TestClassIndexer.readIndex(testLocation, (Class<?>) stringObjectMap.get(TEST_CLASS));
 
             List<Consumer<BuildChainBuilder>> allCustomizers = new ArrayList<>(1);
             Consumer<BuildChainBuilder> defaultCustomizer = new Consumer<BuildChainBuilder>() {


### PR DESCRIPTION
With this change, when Quarkus tests are launched from an IDE for Gradle projects as "JUnit tests", test classes will be looked up in directories provided by the application model loaded with the Gradle tooling API.

This kind of class look up should be done for all cases, including Maven. I guess this could be the first step towards that refactoring.