### PR TITLE
Bump Keycloak version to 20.0.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5597,6 +5597,12 @@
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-adapter-core</artifactId>
                 <version>${keycloak.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -179,7 +179,7 @@
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.10.1</antlr.version><!-- needs to align with same property in build-parent/pom.xml -->
         <quarkus-security.version>1.1.4.Final</quarkus-security.version>
-        <keycloak.version>19.0.3</keycloak.version>
+        <keycloak.version>20.0.1</keycloak.version>
         <logstash-gelf.version>1.15.0</logstash-gelf.version>
         <checker-qual.version>3.28.0</checker-qual.version>
         <error-prone-annotations.version>2.16</error-prone-annotations.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -97,9 +97,10 @@
 
         <!-- The image to use for tests that run Keycloak -->
         <!-- IMPORTANT: If this is changed you must also update bom/application/pom.xml and KeycloakBuildTimeConfig/DevServicesConfig in quarkus-oidc/deployment to match the version -->
-        <keycloak.version>19.0.3</keycloak.version>
+        <keycloak.version>20.0.1</keycloak.version>
+        <keycloak.wildfly.version>19.0.3</keycloak.wildfly.version>
         <keycloak.docker.image>quay.io/keycloak/keycloak:${keycloak.version}</keycloak.docker.image>
-        <keycloak.docker.legacy.image>quay.io/keycloak/keycloak:${keycloak.version}-legacy</keycloak.docker.legacy.image>
+        <keycloak.docker.legacy.image>quay.io/keycloak/keycloak:${keycloak.wildfly.version}-legacy</keycloak.docker.legacy.image>
 
         <unboundid-ldap.version>6.0.7</unboundid-ldap.version>
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -217,8 +217,9 @@ Please see xref:security-openid-connect.adoc#integration-testing-keycloak-devser
 [[keycloak-initialization]]
 === Keycloak Initialization
 
-The `quay.io/keycloak/keycloak:19.0.2` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
-`quarkus.keycloak.devservices.image-name` can be used to change the Keycloak image name. For example, set it to `quay.io/keycloak/keycloak:19.0.2-legacy` to use a Keycloak distribution powered by WildFly.
+The `quay.io/keycloak/keycloak:20.0.1` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
+`quarkus.keycloak.devservices.image-name` can be used to change the Keycloak image name. For example, set it to `quay.io/keycloak/keycloak:19.0.3-legacy` to use a Keycloak distribution powered by WildFly.
+Note that only a Quarkus based Keycloak distribution is available starting from Keycloak `20.0.0`.
 
 `Dev Services for Keycloak` will initialize a launched Keycloak server next.
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -35,7 +35,7 @@ public class DevServicesConfig {
      * string.
      * Set 'quarkus.keycloak.devservices.keycloak-x-image' to override this check.
      */
-    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:19.0.3")
+    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:20.0.1")
     public String imageName;
 
     /**

--- a/integration-tests/oidc-code-flow/pom.xml
+++ b/integration-tests/oidc-code-flow/pom.xml
@@ -13,10 +13,6 @@
     <name>Quarkus - Integration Tests - OpenID Connect Adapter Code Flow</name>
     <description>Module that contains OpenID Connect Code Flow related tests</description>
 
-    <properties>
-        <keycloak.url>http://localhost:8180/auth</keycloak.url>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -48,6 +44,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-keycloak-server</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -201,18 +202,12 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -223,89 +218,6 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>docker-keycloak</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <properties>
-                <keycloak.url>http://localhost:8180/auth</keycloak.url>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${keycloak.docker.legacy.image}</name>
-                                    <alias>quarkus-test-keycloak</alias>
-                                    <run>
-                                        <ports>
-                                            <port>8180:8080</port>
-                                        </ports>
-                                        <env>
-                                            <KEYCLOAK_USER>admin</KEYCLOAK_USER>
-                                            <KEYCLOAK_PASSWORD>admin</KEYCLOAK_PASSWORD>
-                                        </env>
-                                        <log>
-                                            <prefix>Keycloak:</prefix>
-                                            <date>default</date>
-                                            <color>cyan</color>
-                                        </log>
-                                        <wait>
-                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
-                                            <http>
-                                                <url>http://localhost:8180</url>
-                                            </http>
-                                            <time>100000</time>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -1,5 +1,5 @@
+quarkus.keycloak.devservices.create-realm=false
 # Default tenant configurationf
-quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
 quarkus.oidc.authentication.scopes=profile,email,phone
@@ -18,7 +18,7 @@ quarkus.oidc-client.credentials.secret=${quarkus.oidc.credentials.secret}
 quarkus.oidc-client.grant.type=code
 
 # Tenant listener configuration for testing that the login event has been captured
-quarkus.oidc.tenant-listener.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-listener.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-listener.client-id=quarkus-app
 quarkus.oidc.tenant-listener.credentials.secret=secret
 # Redirect parameters are dropped by redirecting the authenticated user but this final redirect loses the login event message
@@ -27,45 +27,45 @@ quarkus.oidc.tenant-listener.authentication.remove-redirect-parameters=false
 quarkus.oidc.tenant-listener.application-type=web-app
 
 # Tenant which does not need to restore a request path after redirect, client_secret_post method
-quarkus.oidc.tenant-1.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-1.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-1.client-id=quarkus-app
 quarkus.oidc.tenant-1.credentials.client-secret.value=secret
 quarkus.oidc.tenant-1.credentials.client-secret.method=post
-quarkus.oidc.tenant-1.token.issuer=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-1.token.issuer=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-1.authentication.redirect-path=/web-app/callback-after-redirect
 quarkus.oidc.tenant-1.application-type=web-app
 
 # Tenant with client which needs to use client_secret_jwt method
-quarkus.oidc.tenant-jwt.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-jwt.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-jwt.client-id=quarkus-app-jwt
 quarkus.oidc.tenant-jwt.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
-quarkus.oidc.tenant-jwt.token.issuer=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-jwt.token.issuer=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-jwt.authentication.redirect-path=/web-app/callback-jwt-after-redirect
 quarkus.oidc.tenant-jwt.application-type=web-app
 
 # Tenant with client which needs to use client_secret_jwt but uses client_secret_post
-quarkus.oidc.tenant-jwt-not-used.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-jwt-not-used.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-jwt-not-used.client-id=quarkus-app-jwt
 quarkus.oidc.tenant-jwt-not-used.credentials.client-secret.value=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 quarkus.oidc.tenant-jwt-not-used.credentials.client-secret.method=post
-quarkus.oidc.tenant-jwt-not-used.token.issuer=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-jwt-not-used.token.issuer=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-jwt-not-used.authentication.redirect-path=/web-app/callback-jwt-not-used-after-redirect
 quarkus.oidc.tenant-jwt-not-used.application-type=web-app
 
 # Tenant which does not need to restore a request path after redirect with a different redirect path root
-quarkus.oidc.tenant-2.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-2.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-2.client-id=quarkus-app
 quarkus.oidc.tenant-2.credentials.client-secret.value=secret
-quarkus.oidc.tenant-2.token.issuer=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-2.token.issuer=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-2.authentication.redirect-path=/web-app2/name
 quarkus.oidc.tenant-2.authentication.cookie-path=/web-app2
 quarkus.oidc.tenant-2.application-type=web-app
 
 # Tenant which is only used to test that the failed token request will not cause a redirect loop.
-quarkus.oidc.tenant-3.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-3.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-3.client-id=quarkus-app
 quarkus.oidc.tenant-3.credentials.secret=secret
-quarkus.oidc.tenant-3.token.issuer=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-3.token.issuer=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-3.authentication.redirect-path=/web-app3
 quarkus.oidc.tenant-3.application-type=web-app
 
@@ -85,7 +85,7 @@ quarkus.oidc.tenant-refresh.authentication.cookie-path=/tenant-refresh
 quarkus.oidc.tenant-refresh.authentication.session-age-extension=2M
 quarkus.oidc.tenant-refresh.token.refresh-expired=true
 
-quarkus.oidc.tenant-autorefresh.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-autorefresh.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-autorefresh.client-id=quarkus-app
 quarkus.oidc.tenant-autorefresh.credentials.secret=secret
 quarkus.oidc.tenant-autorefresh.application-type=web-app
@@ -95,7 +95,7 @@ quarkus.oidc.tenant-autorefresh.token.refresh-token-time-skew=30S
 quarkus.oidc.tenant-autorefresh.authentication.remove-redirect-parameters=false
 
 # Tenant which is used to test that the redirect_uri https scheme is enforced.
-quarkus.oidc.tenant-https.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-https.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-https.client-id=quarkus-app
 quarkus.oidc.tenant-https.credentials.secret=secret
 quarkus.oidc.tenant-https.authentication.scopes=profile,email,phone
@@ -108,38 +108,38 @@ quarkus.oidc.tenant-https.authentication.error-path=/tenant-https/error
 quarkus.oidc.tenant-https.authentication.pkce-required=true
 quarkus.oidc.tenant-https.authentication.pkce-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 
-quarkus.oidc.tenant-javascript.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-javascript.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-javascript.client-id=quarkus-app
 quarkus.oidc.tenant-javascript.credentials.secret=secret
 quarkus.oidc.tenant-javascript.authentication.java-script-auto-redirect=false
 quarkus.oidc.tenant-javascript.application-type=web-app
 
-quarkus.oidc.tenant-cookie-path-header.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-cookie-path-header.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-cookie-path-header.client-id=quarkus-app
 quarkus.oidc.tenant-cookie-path-header.credentials.secret=secret
 quarkus.oidc.tenant-cookie-path-header.authentication.cookie-path-header=X-Forwarded-Prefix
 quarkus.oidc.tenant-cookie-path-header.application-type=web-app
 
-quarkus.oidc.tenant-idtoken-only.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-idtoken-only.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-idtoken-only.client-id=quarkus-app
 quarkus.oidc.tenant-idtoken-only.credentials.secret=secret
 quarkus.oidc.tenant-idtoken-only.token-state-manager.strategy=id-token
 quarkus.oidc.tenant-idtoken-only.application-type=web-app
 
-quarkus.oidc.tenant-id-refresh-token.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-id-refresh-token.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-id-refresh-token.client-id=quarkus-app
 quarkus.oidc.tenant-id-refresh-token.credentials.secret=secret
 quarkus.oidc.tenant-id-refresh-token.token-state-manager.strategy=id-refresh-tokens
 quarkus.oidc.tenant-id-refresh-token.application-type=web-app
 
-quarkus.oidc.tenant-split-id-refresh-token.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-split-id-refresh-token.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-split-id-refresh-token.client-id=quarkus-app
 quarkus.oidc.tenant-split-id-refresh-token.credentials.secret=secret
 quarkus.oidc.tenant-split-id-refresh-token.token-state-manager.strategy=id-refresh-tokens
 quarkus.oidc.tenant-split-id-refresh-token.token-state-manager.split-tokens=true
 quarkus.oidc.tenant-split-id-refresh-token.application-type=web-app
 
-quarkus.oidc.tenant-split-tokens.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.tenant-split-tokens.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-split-tokens.client-id=quarkus-app
 quarkus.oidc.tenant-split-tokens.credentials.secret=secret
 quarkus.oidc.tenant-split-tokens.token-state-manager.split-tokens=true

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -33,6 +33,7 @@ import com.gargoylesoftware.htmlunit.util.Cookie;
 import io.quarkus.oidc.runtime.OidcUtils;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.restassured.RestAssured;
 import io.smallrye.jwt.util.KeyUtils;
 import io.vertx.core.json.JsonObject;
@@ -43,6 +44,8 @@ import io.vertx.core.json.JsonObject;
 @QuarkusTest
 @QuarkusTestResource(KeycloakRealmResourceManager.class)
 public class CodeFlowTest {
+
+    KeycloakTestClient client = new KeycloakTestClient();
 
     @Test
     public void testCodeFlowNoConsent() throws IOException {
@@ -78,7 +81,7 @@ public class CodeFlowTest {
             page = webClient.getPage("http://localhost:8081/web-app/configMetadataIssuer");
 
             assertEquals(
-                    KeycloakRealmResourceManager.KEYCLOAK_SERVER_URL + "/realms/" + KeycloakRealmResourceManager.KEYCLOAK_REALM,
+                    client.getAuthServerUrl(),
                     page.asText());
 
             page = webClient.getPage("http://localhost:8081/web-app/configMetadataScopes");
@@ -346,7 +349,7 @@ public class CodeFlowTest {
     }
 
     private void verifyLocationHeader(WebClient webClient, String loc, String tenant, String path, boolean httpsScheme) {
-        assertTrue(loc.startsWith("http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/auth"));
+        assertTrue(loc.startsWith(client.getAuthServerUrl() + "/protocol/openid-connect/auth"));
         String scheme = httpsScheme ? "https" : "http";
         assertTrue(loc.contains("redirect_uri=" + scheme + "%3A%2F%2Flocalhost%3A8081%2F" + path));
         assertTrue(loc.contains("state=" + getStateCookieStateParam(webClient, tenant)));

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -1,75 +1,45 @@
 package io.quarkus.it.keycloak;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.RolesRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.util.JsonSerialization;
 
+import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.restassured.RestAssured;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
 
-public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager {
+public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
 
-    public static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180/auth");
-    public static final String KEYCLOAK_REALM = "quarkus";
+    private static final String KEYCLOAK_REALM = "quarkus";
+    final KeycloakTestClient client = new KeycloakTestClient();
+
     private List<RealmRepresentation> realms = new ArrayList<>();
 
     @Override
     public Map<String, String> start() {
 
-        try {
+        RealmRepresentation realm = createRealm(KEYCLOAK_REALM);
+        client.createRealm(realm);
+        realms.add(realm);
 
-            RealmRepresentation realm = createRealm(KEYCLOAK_REALM);
-            createRealmInKeycloak(realm);
-            realms.add(realm);
-
-            RealmRepresentation logoutRealm = createRealm("logout-realm");
-            // revoke refresh tokens so that they can only be used once
-            logoutRealm.setRevokeRefreshToken(true);
-            logoutRealm.setRefreshTokenMaxReuse(0);
-            logoutRealm.setSsoSessionMaxLifespan(15);
-            logoutRealm.setAccessTokenLifespan(5);
-            createRealmInKeycloak(logoutRealm);
-            realms.add(logoutRealm);
-
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        RealmRepresentation logoutRealm = createRealm("logout-realm");
+        // revoke refresh tokens so that they can only be used once
+        logoutRealm.setRevokeRefreshToken(true);
+        logoutRealm.setRefreshTokenMaxReuse(0);
+        logoutRealm.setSsoSessionMaxLifespan(15);
+        logoutRealm.setAccessTokenLifespan(5);
+        client.createRealm(logoutRealm);
+        realms.add(logoutRealm);
         return Collections.emptyMap();
-    }
-
-    private static String getAdminAccessToken() {
-        return RestAssured
-                .given()
-                .param("grant_type", "password")
-                .param("username", "admin")
-                .param("password", "admin")
-                .param("client_id", "admin-cli")
-                .when()
-                .post(KEYCLOAK_SERVER_URL + "/realms/master/protocol/openid-connect/token")
-                .as(AccessTokenResponse.class).getToken();
-    }
-
-    private static void createRealmInKeycloak(RealmRepresentation realm) throws IOException {
-        RestAssured
-                .given()
-                .auth().oauth2(getAdminAccessToken())
-                .contentType("application/json")
-                .body(JsonSerialization.writeValueAsBytes(realm))
-                .when()
-                .post(KEYCLOAK_SERVER_URL + "/admin/realms").then()
-                .statusCode(201);
     }
 
     private static RealmRepresentation createRealm(String name) {
@@ -147,11 +117,13 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
     @Override
     public void stop() {
         for (RealmRepresentation realm : realms) {
-            RestAssured
-                    .given()
-                    .auth().oauth2(getAdminAccessToken())
-                    .when()
-                    .delete(KEYCLOAK_SERVER_URL + "/admin/realms/" + realm.getRealm()).thenReturn().prettyPrint();
+            client.deleteRealm(realm);
         }
     }
+
+    @Override
+    public void setIntegrationTestContext(DevServicesContext context) {
+        client.setIntegrationTestContext(context);
+    }
+
 }

--- a/integration-tests/oidc-tenancy/pom.xml
+++ b/integration-tests/oidc-tenancy/pom.xml
@@ -13,10 +13,6 @@
     <name>Quarkus - Integration Tests - Multi-Tenant OpenID Connect Adapter</name>
     <description>Module that contains OpenID Connect Multi-Tenancy related tests</description>
 
-    <properties>
-        <keycloak.url>http://localhost:8180/auth</keycloak.url>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -54,6 +50,11 @@
         </dependency>
 
         <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-keycloak-server</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
@@ -182,18 +183,12 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.url>${keycloak.url}</keycloak.url>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -204,89 +199,6 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>docker-keycloak</id>
-            <activation>
-                <property>
-                    <name>start-containers</name>
-                </property>
-            </activation>
-            <properties>
-                <keycloak.url>http://localhost:8180/auth</keycloak.url>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <name>${keycloak.docker.legacy.image}</name>
-                                    <alias>quarkus-test-keycloak</alias>
-                                    <run>
-                                        <ports>
-                                            <port>8180:8080</port>
-                                        </ports>
-                                        <env>
-                                            <KEYCLOAK_USER>admin</KEYCLOAK_USER>
-                                            <KEYCLOAK_PASSWORD>admin</KEYCLOAK_PASSWORD>
-                                        </env>
-                                        <log>
-                                            <prefix>Keycloak:</prefix>
-                                            <date>default</date>
-                                            <color>cyan</color>
-                                        </log>
-                                        <wait>
-                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
-                                            <http>
-                                                <url>http://localhost:8180</url>
-                                            </http>
-                                            <time>100000</time>
-                                        </wait>
-                                    </run>
-                                </image>
-                            </images>
-                            <allContainers>true</allContainers>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>docker-start</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>docker-stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>docker-prune</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${docker-prune.location}</executable>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -5,6 +5,8 @@ import java.util.function.Supplier;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
@@ -34,9 +36,9 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                 String tenantId = path.split("/")[2];
                 if ("tenant-d".equals(tenantId)) {
                     OidcTenantConfig config = new OidcTenantConfig();
-                    config.setTenantId("tenant-d");
+                    config.setTenantId("tenant-c");
                     config.setAuthServerUrl(getIssuerUrl() + "/realms/quarkus-d");
-                    config.setClientId("quarkus-d");
+                    config.setClientId("quarkus-app-d");
                     config.getCredentials().setSecret("secret");
                     config.getToken().setIssuer(getIssuerUrl() + "/realms/quarkus-d");
                     config.getAuthentication().setUserInfoRequired(true);
@@ -158,6 +160,6 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
     }
 
     private String getIssuerUrl() {
-        return System.getProperty("keycloak.url", "http://localhost:8180/auth");
+        return ConfigProvider.getConfig().getValue("keycloak.url", String.class);
     }
 }

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -1,9 +1,11 @@
+quarkus.keycloak.devservices.create-realm=false
+quarkus.keycloak.devservices.realm-name=quarkus-a
+
 quarkus.http.cors=true
 
 quarkus.oidc.token-cache.max-size=3
 
 # Default Tenant
-quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus-a
 quarkus.oidc.client-id=quarkus-app-a
 quarkus.oidc.credentials.secret=secret
 quarkus.oidc.application-type=service

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -1,28 +1,26 @@
 package io.quarkus.it.keycloak;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.RolesRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.util.JsonSerialization;
 
+import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.restassured.RestAssured;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
 
-public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager {
+public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
 
-    private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180/auth");
     private static final String KEYCLOAK_REALM = "quarkus-";
+    final KeycloakTestClient client = new KeycloakTestClient();
 
     @Override
     public Map<String, String> start() {
@@ -37,32 +35,9 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
             realm.getUsers().add(createUser("admin", "user", "admin"));
             realm.getUsers().add(createUser("jdoe", "user", "confidential"));
 
-            try {
-                RestAssured
-                        .given()
-                        .auth().oauth2(getAdminAccessToken())
-                        .contentType("application/json")
-                        .body(JsonSerialization.writeValueAsBytes(realm))
-                        .when()
-                        .post(KEYCLOAK_SERVER_URL + "/admin/realms").then()
-                        .statusCode(201);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            client.createRealm(realm);
         }
         return Collections.emptyMap();
-    }
-
-    private static String getAdminAccessToken() {
-        return RestAssured
-                .given()
-                .param("grant_type", "password")
-                .param("username", "admin")
-                .param("password", "admin")
-                .param("client_id", "admin-cli")
-                .when()
-                .post(KEYCLOAK_SERVER_URL + "/realms/master/protocol/openid-connect/token")
-                .as(AccessTokenResponse.class).getToken();
     }
 
     private static RealmRepresentation createRealm(String name) {
@@ -127,12 +102,16 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
     @Override
     public void stop() {
         for (String realmId : Arrays.asList("a", "b", "c", "d", "webapp", "webapp2", "hybrid")) {
-            RestAssured
-                    .given()
-                    .auth().oauth2(getAdminAccessToken())
-                    .when()
-                    .delete(KEYCLOAK_SERVER_URL + "/admin/realms/" + KEYCLOAK_REALM + realmId).then().statusCode(204);
-        }
+            try {
+                client.deleteRealm(realmId);
+            } catch (Throwable t) {
 
+            }
+        }
+    }
+
+    @Override
+    public void setIntegrationTestContext(DevServicesContext context) {
+        client.setIntegrationTestContext(context);
     }
 }

--- a/integration-tests/oidc-token-propagation/pom.xml
+++ b/integration-tests/oidc-token-propagation/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>keycloak-adapter-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <exclusions>

--- a/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/AccessTokenPropagationService.java
+++ b/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/AccessTokenPropagationService.java
@@ -7,7 +7,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import io.quarkus.oidc.token.propagation.AccessToken;
 
-@RegisterRestClient
+@RegisterRestClient(configKey = "access-token-propagation")
 @AccessToken
 @Path("/")
 public interface AccessTokenPropagationService {

--- a/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/JwtTokenPropagationService.java
+++ b/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/JwtTokenPropagationService.java
@@ -7,7 +7,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import io.quarkus.oidc.token.propagation.JsonWebToken;
 
-@RegisterRestClient
+@RegisterRestClient(configKey = "jwt-token-propagation")
 @JsonWebToken
 @Path("/")
 public interface JwtTokenPropagationService {

--- a/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/ServiceAccountService.java
+++ b/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/ServiceAccountService.java
@@ -7,7 +7,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import io.quarkus.oidc.client.filter.OidcClientFilter;
 
-@RegisterRestClient
+@RegisterRestClient(configKey = "service-account-service")
 @OidcClientFilter
 @Path("/")
 public interface ServiceAccountService {

--- a/integration-tests/oidc-token-propagation/src/main/resources/application.properties
+++ b/integration-tests/oidc-token-propagation/src/main/resources/application.properties
@@ -21,6 +21,9 @@ quarkus.oidc-client.exchange-token.grant-options.exchange.audience=quarkus-app-e
 quarkus.oidc-token-propagation.exchange-token=true
 quarkus.oidc-token-propagation.client-name=exchange-token
 
-io.quarkus.it.keycloak.JwtTokenPropagationService/mp-rest/uri=http://localhost:8081/protected
-io.quarkus.it.keycloak.AccessTokenPropagationService/mp-rest/uri=http://localhost:8081/protected
-io.quarkus.it.keycloak.ServiceAccountService/mp-rest/uri=http://localhost:8081/protected
+quarkus.rest-client.jwt-token-propagation.uri=http://localhost:8081/protected
+quarkus.rest-client.jwt-token-propagation.verify-host=false
+quarkus.rest-client.access-token-propagation.uri=http://localhost:8081/protected
+quarkus.rest-client.access-token-propagation.verify-host=false
+quarkus.rest-client.service-account-service.uri=http://localhost:8081/protected
+quarkus.rest-client.service-account-service.verify-host=false

--- a/integration-tests/smallrye-jwt-token-propagation/src/main/resources/application.properties
+++ b/integration-tests/smallrye-jwt-token-propagation/src/main/resources/application.properties
@@ -1,7 +1,6 @@
 mp.jwt.verify.publickey.location=${keycloak.url}/realms/quarkus/protocol/openid-connect/certs
 mp.jwt.verify.issuer=${keycloak.url}/realms/quarkus
 smallrye.jwt.path.groups=realm_access/roles
-
 io.quarkus.it.keycloak.JwtTokenPropagationService/mp-rest/uri=http://localhost:8081/jwt-resigned-protected
 io.quarkus.it.keycloak.AccessTokenPropagationService/mp-rest/uri=http://localhost:8081/protected
 

--- a/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/client/KeycloakTestClient.java
+++ b/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/client/KeycloakTestClient.java
@@ -3,6 +3,9 @@ package io.quarkus.test.keycloak.client;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.keycloak.representations.AccessTokenResponse;
@@ -59,10 +62,18 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
     /**
      * Get an access token from the default tenant realm using a password grant with the provided user name, user secret, client
      * id and secret.
-     * Set the client secret to an empty string or null if it is not required.
      */
     public String getAccessToken(String userName, String userSecret, String clientId, String clientSecret) {
-        return getAccessTokenInternal(userName, userSecret, clientId, clientSecret, getAuthServerUrl());
+        return getAccessToken(userName, userSecret, clientId, clientSecret, null);
+    }
+
+    /**
+     * Get an access token from the default tenant realm using a password grant with the provided user name, user secret, client
+     * id and secret, and scopes.
+     */
+    public String getAccessToken(String userName, String userSecret, String clientId, String clientSecret,
+            List<String> scopes) {
+        return getAccessTokenInternal(userName, userSecret, clientId, clientSecret, scopes, getAuthServerUrl());
     }
 
     /**
@@ -94,18 +105,31 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
      * Set the client secret to an empty string or null if it is not required.
      */
     public String getRealmAccessToken(String realm, String userName, String userSecret, String clientId, String clientSecret) {
-        return getAccessTokenInternal(userName, userSecret, clientId, clientSecret,
+        return getRealmAccessToken(realm, userName, userSecret, clientId, clientSecret, null);
+    }
+
+    /**
+     * Get a realm access token using a password grant with the provided user name, user secret, client id and secret, and
+     * scopes.
+     * Set the client secret to an empty string or null if it is not required.
+     */
+    public String getRealmAccessToken(String realm, String userName, String userSecret, String clientId, String clientSecret,
+            List<String> scopes) {
+        return getAccessTokenInternal(userName, userSecret, clientId, clientSecret, scopes,
                 getAuthServerBaseUrl() + "/realms/" + realm);
     }
 
     private String getAccessTokenInternal(String userName, String userSecret, String clientId, String clientSecret,
-            String authServerUrl) {
+            List<String> scopes, String authServerUrl) {
         RequestSpecification requestSpec = RestAssured.given().param("grant_type", "password")
                 .param("username", userName)
                 .param("password", userSecret)
                 .param("client_id", clientId);
         if (clientSecret != null && !clientSecret.isBlank()) {
             requestSpec = requestSpec.param("client_secret", clientSecret);
+        }
+        if (scopes != null && !scopes.isEmpty()) {
+            requestSpec = requestSpec.param("scope", urlEncode(String.join(" ", scopes)));
         }
         return requestSpec.when().post(authServerUrl + "/protocol/openid-connect/token")
                 .as(AccessTokenResponse.class).getToken();
@@ -123,7 +147,7 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
      * Get an admin access token which can be used to create Keycloak realms and perform other Keycloak administration tasks.
      */
     public String getAdminAccessToken() {
-        return getAccessTokenInternal("admin", "admin", "admin-cli", null, getAuthServerBaseUrl() + "/realms/master");
+        return getAccessTokenInternal("admin", "admin", "admin-cli", null, null, getAuthServerBaseUrl() + "/realms/master");
     }
 
     /**
@@ -209,5 +233,13 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
     @Override
     public void setIntegrationTestContext(DevServicesContext context) {
         this.testContext = context;
+    }
+
+    private static String urlEncode(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
     }
 }

--- a/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/client/KeycloakTestClient.java
+++ b/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/client/KeycloakTestClient.java
@@ -189,6 +189,13 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
                 .delete(getAuthServerBaseUrl() + "/admin/realms/" + realm).then().statusCode(204);
     }
 
+    /**
+     * Delete a realm
+     */
+    public void deleteRealm(RealmRepresentation realm) {
+        deleteRealm(realm.getRealm());
+    }
+
     private String getPropertyValue(String prop, String defaultValue) {
         return ConfigProvider.getConfig().getOptionalValue(prop, String.class)
                 .orElseGet(() -> getDevProperty(prop, defaultValue));


### PR DESCRIPTION
This PR bumps Keycloak version to 20.0.1, updates `integration-tests/oidc-code-flow` and `oidc-tenancy` to use DevServices for Keycloak, keeps about 30% of the tests running against the last Keycloak version (19.0.3) which supports a WildFly distribution to keep some coverage as Quarkus will be expected to work such a distribution for a while.

Updating `integration-tests/oidc-tenancy` required fixing the way the test acquires the tokens - since now Keycloak will fail UserInfo acquisition (those tests check) if no `openid` token scope is requested during the token acquisition.
