### PR TITLE
Fix the secret length check for PKCE and token encryption

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -677,7 +677,7 @@ quarkus.oidc.authentication.pkce-required=true
 quarkus.oidc.authentication.pkce-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 ----
 
-If you already have a 32 character long client secret then `quarkus.oidc.authentication.pkce-secret` does not have to be set unless you prefer to use a different secret key.
+If you already have a 32 characters long client secret then `quarkus.oidc.authentication.pkce-secret` does not have to be set unless you prefer to use a different secret key.
 
 The secret key is required for encrypting a randomly generated `PKCE` `code_verifier` while the user is being redirected with the `code_challenge` query parameter to OpenID Connect Provider to authenticate. The `code_verifier` will be decrypted when the user is redirected back to Quarkus and sent to the token endpoint alongside the `code`, client secret and other parameters to complete the code exchange. The provider will fail the code exchange if a `SHA256` digest of the `code_verifier` does not match the `code_challenge` provided during the authentication request.
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -50,8 +50,8 @@ public class TenantConfigContext {
             if (pkceSecret == null) {
                 throw new RuntimeException("Secret key for encrypting PKCE code verifier is missing");
             }
-            if (pkceSecret.length() < 32) {
-                throw new RuntimeException("Secret key for encrypting PKCE code verifier must be at least 32 characters long");
+            if (pkceSecret.length() != 32) {
+                throw new RuntimeException("Secret key for encrypting PKCE code verifier must be 32 characters long");
             }
             return KeyUtils.createSecretKeyFromSecret(pkceSecret);
         }
@@ -65,8 +65,8 @@ public class TenantConfigContext {
             if (encSecret == null) {
                 throw new RuntimeException("Secret key for encrypting tokens is missing");
             }
-            if (encSecret.length() < 32) {
-                throw new RuntimeException("Secret key for encrypting tokens must be at least 32 characters long");
+            if (encSecret.length() != 32) {
+                throw new RuntimeException("Secret key for encrypting tokens must be 32 characters long");
             }
             return KeyUtils.createSecretKeyFromSecret(encSecret);
         }


### PR DESCRIPTION
Fix the secret length check for PKCE and token encryption

Docs says "secret must be 32 characters long".

 - https://quarkus.io/guides/security-openid-connect-web-authentication#proof-of-key-for-code-exchange-pkce
 - https://quarkus.io/guides/security-openid-connect-web-authentication#token-state-manager

I played a bit with PKCE case and things were not working when I had 33 characters long secret.
Users should be notified about the real constraints in error message, the length check needs to ensure expected length.