### PR TITLE
Reactive Rest Client: Process paths before sub resources

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/subresource/SubResourceTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/subresource/SubResourceTest.java
@@ -62,6 +62,14 @@ public class SubResourceTest {
     }
 
     @Test
+    void shouldPassPathParamsToSubSubResource() {
+        // should result in sending GET /path/rt/mthd/sub/s/ss
+        RootClient rootClient = RestClientBuilder.newBuilder().baseUri(baseUri).build(RootClient.class);
+        String result = rootClient.sub("rt", "mthd").sub("s").get("ss");
+        assertThat(result).isEqualTo("rt/mthd/sub/s/ss");
+    }
+
+    @Test
     void shouldDoMultiplePosts() {
         RootClient rootClient = RestClientBuilder.newBuilder().baseUri(baseUri).build(RootClient.class);
         SubClient sub = rootClient.sub("rt", "mthd");
@@ -129,6 +137,9 @@ public class SubResourceTest {
         @Path("/sub")
         SubSubClient sub();
 
+        @Path("/sub/{methodParam}")
+        SubSubClient sub(@PathParam("methodParam") String methodParam);
+
         @POST
         @ClientHeaderParam(name = "overridable", value = "SubClient")
         @ClientHeaderParam(name = "fromSubMethod", value = "{fillingMethod}")
@@ -145,6 +156,10 @@ public class SubResourceTest {
         @GET
         @Path("/subSimple")
         String simpleSub();
+
+        @GET
+        @Path("/{methodParam}")
+        String get(@PathParam("methodParam") String methodParam);
 
         @POST
         @ClientHeaderParam(name = "overridable", value = "SubSubClient")


### PR DESCRIPTION
With these changes, we will apply the `@PathParam` parameters to the web target before passing it to the sub-resource instance.

Fix https://github.com/quarkusio/quarkus/issues/29712