### PR TITLE
Improve header in README.md based on name and description

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/base/README.tpl.qute.md
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/base/README.tpl.qute.md
@@ -1,4 +1,13 @@
-# {project.artifact-id} Project
+{#if readme.include-default-content}
+{#if project.name}
+# {project.name}
+{#else}
+# {project.artifact-id}
+{/if}
+{#if project.description}
+
+> {project.description}
+{/if}
 
 This project uses Quarkus, the Supersonic Subatomic Java Framework.
 
@@ -59,4 +68,5 @@ If you want to learn more about building native executables, please consult {bui
 {#if input.provided-code}
 
 ## Provided Code
+{/if}
 {/if}

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/codestart.yml
@@ -25,5 +25,7 @@ language:
         artifact-id: quarkus-project
         version: 1.0.0-SNAPSHOT
         package-name: org.acme
+      readme:
+        include-default-content: true
     dependencies:
       - io.quarkus:quarkus-arc

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/README.md
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/README.md
@@ -1,4 +1,4 @@
-# test-codestart Project
+# test-codestart
 
 This project uses Quarkus, the Supersonic Subatomic Java Framework.
 


### PR DESCRIPTION
And also allows to not include the default content with a particular extension.

@ia3andy I did two changes here:
- now that we have the name and the description of the project, we can use them in the README.md
- I also included a boolean to be able to disable the default content. I agree that it's only to be used in very specific cases but I don't think it hurts as it's pretty straightforward

I think that there are extensions that really redefines what the project is about such as my Quarkus GitHub Action thing, but also lambdas where we will probably want a completely different content in the README.

Maybe we could think about allowing that more cleanly but in the meantime having this simple hack would help (in my case, I don't expect any additional extensions providing content to the README so it works pretty much OK).

If you really feel strongly about the second change, I can go back to just the first one.

Keeping as draft until I have your opinion.