### PR TITLE
Drop ':z' bind option when using MacOS and Podman

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -116,8 +116,14 @@ public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContai
             volumeOutputPath = FileUtil.translateToVolumePath(volumeOutputPath);
         }
 
+        String selinuxBindOption = ":z";
+        if (SystemUtils.IS_OS_MAC
+                && ContainerRuntimeUtil.detectContainerRuntime() == ContainerRuntimeUtil.ContainerRuntime.PODMAN) {
+            selinuxBindOption = "";
+        }
+
         Collections.addAll(containerRuntimeArgs, "-v",
-                volumeOutputPath + ":" + NativeImageBuildStep.CONTAINER_BUILD_VOLUME_PATH + ":z");
+                volumeOutputPath + ":" + NativeImageBuildStep.CONTAINER_BUILD_VOLUME_PATH + selinuxBindOption);
         return containerRuntimeArgs;
     }
 


### PR DESCRIPTION
When running the following build command on MacOS with Podman

```bash
$ ./gradlew build -Dquarkus.package.type=native -Dquarkus.native.container-build=true
```

the following error is thrown

```
Error: preparing container c96068474ff1b0fcf87bcca369f795f4ba2ef842d56f1f0551914c74a7369e97 for attach: lsetxattr /Users/<trimmed-path>-1.0.0-SNAPSHOT-native-image-source-jar/lib: operation not supported
```

This PR fixes the above issue.

Related:
* https://github.com/containers/podman/issues/13631
* https://github.com/kubevirt/kubevirt/pull/8841

MacOS version: 13.1
Podman version: 4.3.1