### PR TITLE
Reduce some object allocations during bytecode recording

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/BlockingOperationRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/BlockingOperationRecorder.java
@@ -2,12 +2,13 @@ package io.quarkus.runtime;
 
 import java.util.List;
 
+import io.quarkus.runtime.annotations.ReadOnly;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class BlockingOperationRecorder {
 
-    public void control(List<IOThreadDetector> detectors) {
+    public void control(@ReadOnly List<IOThreadDetector> detectors) {
         BlockingOperationControl.setIoThreadDetector(detectors.toArray(new IOThreadDetector[0]));
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/ReadOnly.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/ReadOnly.java
@@ -1,0 +1,21 @@
+package io.quarkus.runtime.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation that allows Quarkus to know that a Collection or Map passed to a recorder (either directly or as part a
+ * field of bean type object)
+ * is only read via that recorder and never altered.
+ * Quarkus uses this information in order to create optimized Collections and Maps of the recorded values.
+ *
+ * Extensions writers should NOT rely on Quarkus to always create an immutable Collection or Map even if the annotation is used,
+ * and thus recorder logic should not be dependent on the type of Collection or Map passed on by Quarkus, as Quarkus only makes
+ * a best-effort attempt to do create such immutable objects but cannot guarantee it.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PARAMETER })
+public @interface ReadOnly {
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -46,6 +46,7 @@ import io.quarkus.dev.console.CurrentAppExceptionHighlighter;
 import io.quarkus.dev.testing.ExceptionReporting;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.ReadOnly;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigInstantiator;
 import io.quarkus.runtime.console.ConsoleRuntimeConfig;
@@ -87,13 +88,13 @@ public class LoggingSetupRecorder {
 
     public ShutdownListener initializeLogging(LogConfig config, LogBuildTimeConfig buildConfig,
             DiscoveredLogComponents discoveredLogComponents,
-            final Map<String, InheritableLevel> categoryDefaultMinLevels,
+            @ReadOnly final Map<String, InheritableLevel> categoryDefaultMinLevels,
             final boolean enableWebStream,
             final RuntimeValue<Optional<Handler>> devUiConsoleHandler,
-            final List<RuntimeValue<Optional<Handler>>> additionalHandlers,
-            final List<RuntimeValue<Map<String, Handler>>> additionalNamedHandlers,
-            final List<RuntimeValue<Optional<Formatter>>> possibleConsoleFormatters,
-            final List<RuntimeValue<Optional<Formatter>>> possibleFileFormatters,
+            @ReadOnly final List<RuntimeValue<Optional<Handler>>> additionalHandlers,
+            @ReadOnly final List<RuntimeValue<Map<String, Handler>>> additionalNamedHandlers,
+            @ReadOnly final List<RuntimeValue<Optional<Formatter>>> possibleConsoleFormatters,
+            @ReadOnly final List<RuntimeValue<Optional<Formatter>>> possibleFileFormatters,
             final RuntimeValue<Optional<Supplier<String>>> possibleBannerSupplier,
             LaunchMode launchMode,
             boolean validateFilters) {

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
@@ -25,6 +25,7 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
+import io.quarkus.runtime.annotations.ReadOnly;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.test.TestApplicationClassPredicate;
 
@@ -62,7 +63,7 @@ public class ArcRecorder {
         supplierMap.putAll(beans);
     }
 
-    public BeanContainer initBeanContainer(ArcContainer container, List<BeanContainerListener> listeners)
+    public BeanContainer initBeanContainer(ArcContainer container, @ReadOnly List<BeanContainerListener> listeners)
             throws Exception {
         if (container == null) {
             throw new IllegalArgumentException("Arc container was null");

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -50,6 +50,7 @@ import io.quarkus.runtime.ExecutorRecorder;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
+import io.quarkus.runtime.annotations.ReadOnly;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.security.AuthenticationCompletionException;
 import io.quarkus.security.AuthenticationFailedException;
@@ -128,7 +129,7 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
         return currentDeployment;
     }
 
-    public RuntimeValue<Deployment> createDeployment(DeploymentInfo info,
+    public RuntimeValue<Deployment> createDeployment(@ReadOnly DeploymentInfo info,
             BeanContainer beanContainer,
             ShutdownContext shutdownContext, HttpBuildTimeConfig vertxConfig,
             RequestContextFactory contextFactory,

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -285,7 +285,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
             }
             List<ResourceMethod> methods = createEndpoints(classInfo, classInfo, new HashSet<>(), new HashSet<>(),
                     clazz.getPathParameters(), clazz.getPath(), considerApplication);
-            clazz.getMethods().addAll(methods);
+            clazz.setMethods(methods);
 
             // get an InjectableBean view of our class
             InjectableBean injectableBean = scanInjectableBean(classInfo, classInfo,

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceClass.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceClass.java
@@ -1,6 +1,5 @@
 package org.jboss.resteasy.reactive.common.model;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,7 +29,7 @@ public class ResourceClass {
     /**
      * The resource methods
      */
-    private final List<ResourceMethod> methods = new ArrayList<>();
+    private List<ResourceMethod> methods = Collections.emptyList();
 
     private BeanFactory<Object> factory;
     private boolean perRequestResource;
@@ -43,7 +42,7 @@ public class ResourceClass {
      * Contains class level exception mappers
      * The key is the exception type and the value is the exception mapper class
      */
-    private Map<String, String> classLevelExceptionMappers = new HashMap<>();
+    private Map<String, String> classLevelExceptionMappers = Collections.emptyMap();
 
     public String getClassName() {
         return className;
@@ -78,6 +77,10 @@ public class ResourceClass {
 
     public List<ResourceMethod> getMethods() {
         return methods;
+    }
+
+    public void setMethods(List<ResourceMethod> methods) {
+        this.methods = methods;
     }
 
     public boolean isPerRequestResource() {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/DeploymentInfo.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/DeploymentInfo.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.reactive.server.core;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -33,7 +33,7 @@ public class DeploymentInfo {
     private ResteasyReactiveConfig resteasyReactiveConfig;
     private Function<Object, Object> clientProxyUnwrapper;
     private String applicationPath;
-    private List<HandlerChainCustomizer> globalHandlerCustomizers = new ArrayList<>();
+    private List<HandlerChainCustomizer> globalHandlerCustomizers = Collections.emptyList();
     private boolean developmentMode;
     private boolean resumeOn404;
 


### PR DESCRIPTION
The idea behind the PR is that in most cases of bytecode recording,
the recorders simply read their input and don't change it.
By leveraging this insight, we can eliminate the allocations of
lists and maps that are empty by using the empty versions
of these types.

To make Quarkus do this however, we introduce the `@ReadOnly`
which extension developers need to add to recorder parameters
in order to let Quarkus know that it is safe to apply this
optimization

Although this doesn't save too much, we could potentially in the future save the calls to `add` / `put` when encountering non-empty objects and instead just instantiate in one go. Again that wouldn't save a ton, but it's not a bad thing to do either.