### PR TITLE
Make kotlin load parent first (revert PR which changes that)

### DIFF
--- a/extensions/kotlin/runtime/pom.xml
+++ b/extensions/kotlin/runtime/pom.xml
@@ -25,6 +25,7 @@
                         <parentFirstArtifact>org.jetbrains.kotlin:kotlin-reflect</parentFirstArtifact>
                         <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib</parentFirstArtifact>
                         <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-common</parentFirstArtifact>
+                        <parentFirstArtifact>org.jetbrains:annotations</parentFirstArtifact>
                     </parentFirstArtifacts>
                     <runnerParentFirstArtifacts>
                         <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk8</runnerParentFirstArtifact>
@@ -32,6 +33,7 @@
                         <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-reflect</runnerParentFirstArtifact>
                         <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib</runnerParentFirstArtifact>
                         <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-common</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>org.jetbrains:annotations</runnerParentFirstArtifact>
                     </runnerParentFirstArtifacts>
                     <lesserPriorityArtifacts>
                         <!--

--- a/extensions/kotlin/runtime/pom.xml
+++ b/extensions/kotlin/runtime/pom.xml
@@ -19,6 +19,20 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <configuration>
+                    <parentFirstArtifacts>
+                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk8</parentFirstArtifact>
+                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk7</parentFirstArtifact>
+                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-reflect</parentFirstArtifact>
+                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib</parentFirstArtifact>
+                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-common</parentFirstArtifact>
+                    </parentFirstArtifacts>
+                    <runnerParentFirstArtifacts>
+                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk8</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk7</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-reflect</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib</runnerParentFirstArtifact>
+                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-common</runnerParentFirstArtifact>
+                    </runnerParentFirstArtifacts>
                     <lesserPriorityArtifacts>
                         <!--
                         see https://github.com/quarkusio/quarkus/issues/8405


### PR DESCRIPTION
I think the changes in #29697 may save a lot of headaches, but they also have the potential to break users of the kotlin extension. We should hold off on making them to a major version boundary. 

Discussion here (in the earlier messages): https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Review.20of.20.22make.20this.20Kotlin-y.20library.20work.20in.20dev.20mode.22/near/315122157

cc @stuartwdouglas @aloubyansky 

