### PR TITLE
Use proper Openshift annotation for VCS

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -76,7 +76,7 @@ The full source of the `kubernetes.json` file looks something like this:
     "kind" : "Deployment",
     "metadata" : {
       "annotations": {
-       "app.quarkus.io/vcs-url" : "<some url>",
+       "app.quarkus.io/vcs-uri" : "<some url>",
        "app.quarkus.io/commit-id" : "<some git SHA>",
       },
       "labels" : {
@@ -123,7 +123,7 @@ The full source of the `kubernetes.json` file looks something like this:
   "kind" : "Service",
     "metadata" : {
       "annotations": {
-       "app.quarkus.io/vcs-url" : "<some url>",
+       "app.quarkus.io/vcs-uri" : "<some url>",
        "app.quarkus.io/commit-id" : "<some git SHA>",
       },
       "labels" : {
@@ -305,7 +305,7 @@ Out of the box, the generated resources will be annotated with version control r
 [source,json]
 ----
   "annotations": {
-    "app.quarkus.io/vcs-url" : "<some url>",
+    "app.quarkus.io/vcs-uri" : "<some url>",
     "app.quarkus.io/commit-id" : "<some git SHA>",
    }
 ----
@@ -1065,7 +1065,7 @@ The full source of the `knative.json` file looks something like this:
     "kind" : "Service",
     "metadata" : {
       "annotations": {
-       "app.quarkus.io/vcs-url" : "<some url>",
+       "app.quarkus.io/vcs-uri" : "<some url>",
        "app.quarkus.io/commit-id" : "<some git SHA>"
       },
       "labels" : {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
@@ -41,7 +41,7 @@ public final class Constants {
     static final String QUARKUS = "quarkus";
 
     static final String QUARKUS_ANNOTATIONS_COMMIT_ID = "app.quarkus.io/commit-id";
-    static final String QUARKUS_ANNOTATIONS_VCS_URL = "app.quarkus.io/vcs-url";
+    static final String QUARKUS_ANNOTATIONS_VCS_URL = "app.quarkus.io/vcs-uri";
     static final String QUARKUS_ANNOTATIONS_BUILD_TIMESTAMP = "app.quarkus.io/build-timestamp";
 
     public static final String HTTP_PORT = "http";


### PR DESCRIPTION
According to [this](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html-single/building_applications/index#odc-labels-and-annotations-used-for-topology-view_viewing-application-composition-using-topology-view), the proper annotation uses /vcs-uri instead of /vcs-url

Fixes: #29873