### PR TITLE
Dev Services for Kafka configuration for image providers

### DIFF
--- a/docs/src/main/asciidoc/kafka-dev-services.adoc
+++ b/docs/src/main/asciidoc/kafka-dev-services.adoc
@@ -50,15 +50,31 @@ Note that the Kafka advertised address is automatically configured with the chos
 [[configuring-the-image]]
 == Configuring the image
 
-Dev Services for Kafka supports https://redpanda.com[Redpanda] and https://strimzi.io[Strimzi] (in https://github.com/apache/kafka/blob/trunk/config/kraft/README.md[Kraft] mode).
+Dev Services for Kafka supports https://redpanda.com[Redpanda], https://github/ozangunalp/kafka-native[kafka-native]
+and https://strimzi.io[Strimzi] (in https://github.com/apache/kafka/blob/trunk/config/kraft/README.md[Kraft] mode)  images.
 
-Redpanda is a Kafka compatible event streaming platform.
-Because it provides a faster startup time dev services defaults to `vectorized/redpanda` images.
+**Redpanda** is a Kafka compatible event streaming platform.
+Because it provides a fast startup times, dev services defaults to Redpanda images from `vectorized/redpanda`.
 You can select any version from https://hub.docker.com/r/vectorized/redpanda.
 
-Strimzi provides container images and Operators for running Apache Kafka on Kubernetes.
+**kafka-native** provides images of standard Apache Kafka distribution compiled to native binary using Quarkus and GraalVM.
+While still being _experimental_, it provides very fast startup times with small footprint.
+
+Image type can be configured using
+
+[source, properties]
+----
+quarkus.kafka.devservices.provider=kafka-native
+----
+
+**Strimzi** provides container images and Operators for running Apache Kafka on Kubernetes.
 While Strimzi is optimized for Kubernetes, the images work perfectly in classic container environments.
 Strimzi container images run "genuine" Kafka broker on JVM, which is slower to start.
+
+[source, properties]
+----
+quarkus.kafka.devservices.provider=strimzi
+----
 
 For Strimzi, you can select any image with a Kafka version which has Kraft support (2.8.1 and higher) from https://quay.io/repository/strimzi-test-container/test-container?tab=tags
 

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -28,15 +28,9 @@ public class KafkaDevServicesBuildTimeConfig {
     public Optional<Integer> port;
 
     /**
-     * The Kafka container image to use.
+     * Kafka dev service container type.
      * <p>
-     * Only Redpanda and Strimzi images are supported.
-     * Default image is Redpanda.
-     * <p>
-     * Note that Strimzi images are launched in Kraft mode.
-     * In order to use a Strimzi image you need to set a compatible image name such as
-     * {@code quay.io/strimzi-test-container/test-container:0.100.0-kafka-3.1.0} or
-     * {@code quay.io/strimzi/kafka:0.27.1-kafka-3.0.0}
+     * Redpanda, Strimzi and kafka-native container providers are supported. Default is redpanda.
      * <p>
      * For Redpanda:
      * See https://vectorized.io/docs/quick-start-docker/ and https://hub.docker.com/r/vectorized/redpanda
@@ -44,9 +38,37 @@ public class KafkaDevServicesBuildTimeConfig {
      * For Strimzi:
      * See https://github.com/strimzi/test-container and https://quay.io/repository/strimzi-test-container/test-container
      * <p>
+     * For Kafka Native:
+     * See https://github.com/ozangunalp/kafka-native and https://quay.io/repository/ogunalp/kafka-native
+     * <p>
+     * Note that Strimzi and Kafka Native images are launched in Kraft mode.
      */
-    @ConfigItem(defaultValue = "docker.io/vectorized/redpanda:v22.3.4")
-    public String imageName;
+    @ConfigItem(defaultValue = "redpanda")
+    public Provider provider = Provider.REDPANDA;
+
+    public enum Provider {
+        REDPANDA("docker.io/vectorized/redpanda:v22.3.4"),
+        STRIMZI("quay.io/strimzi-test-container/test-container:latest-kafka-3.2.1"),
+        KAFKA_NATIVE("quay.io/ogunalp/kafka-native:latest");
+
+        private final String defaultImageName;
+
+        Provider(String imageName) {
+            this.defaultImageName = imageName;
+        }
+
+        public String getDefaultImageName() {
+            return defaultImageName;
+        }
+    }
+
+    /**
+     * The Kafka container image to use.
+     * <p>
+     * Dependent on the provider.
+     */
+    @ConfigItem
+    public Optional<String> imageName;
 
     /**
      * Indicates if the Kafka broker managed by Quarkus Dev Services is shared.

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaNativeContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaNativeContainer.java
@@ -1,0 +1,99 @@
+package io.quarkus.kafka.client.deployment;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.utility.DockerImageName;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+
+import io.quarkus.devservices.common.ConfigureUtil;
+
+public class KafkaNativeContainer extends GenericContainer<KafkaNativeContainer> {
+
+    private static final String STARTER_SCRIPT = "/work/run.sh";
+
+    private final Integer fixedExposedPort;
+    private final boolean useSharedNetwork;
+
+    private String additionalArgs = null;
+    private int exposedPort = -1;
+
+    private String hostName = null;
+
+    public KafkaNativeContainer(DockerImageName dockerImageName, int fixedExposedPort, String serviceName,
+            boolean useSharedNetwork) {
+        super(dockerImageName);
+        this.fixedExposedPort = fixedExposedPort;
+        this.useSharedNetwork = useSharedNetwork;
+        if (serviceName != null) {
+            withLabel(DevServicesKafkaProcessor.DEV_SERVICE_LABEL, serviceName);
+        }
+        String cmd = String.format("while [ ! -f %s ]; do sleep 0.1; done; sleep 0.1; %s", STARTER_SCRIPT, STARTER_SCRIPT);
+        withCommand("sh", "-c", cmd);
+        waitingFor(Wait.forLogMessage(".*Kafka broker started.*", 1));
+    }
+
+    @Override
+    protected void containerIsStarting(InspectContainerResponse containerInfo, boolean reused) {
+        super.containerIsStarting(containerInfo, reused);
+        // Set exposed port
+        this.exposedPort = getMappedPort(DevServicesKafkaProcessor.KAFKA_PORT);
+        // follow output
+        // Start and configure the advertised address
+        String cmd = "#!/bin/bash\n";
+        cmd += "/work/kafka";
+        cmd += " -Dkafka.advertised.listeners=" + getBootstrapServers();
+        if (useSharedNetwork) {
+            cmd += " -Dkafka.listeners=BROKER://:9093,PLAINTEXT://:9092,CONTROLLER://:9094";
+            cmd += " -Dkafka.interbroker.listener.name=BROKER";
+            cmd += " -Dkafka.controller.listener.names=CONTROLLER";
+            cmd += " -Dkafka.listener.security.protocol.map=BROKER:PLAINTEXT,CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT";
+            cmd += " -Dkafka.early.start.listeners=BROKER,CONTROLLER,PLAINTEXT";
+        }
+        if (additionalArgs != null) {
+            cmd += " " + additionalArgs;
+        }
+
+        //noinspection OctalInteger
+        copyFileToContainer(
+                Transferable.of(cmd.getBytes(StandardCharsets.UTF_8), 0777),
+                STARTER_SCRIPT);
+    }
+
+    private String getKafkaAdvertisedListeners() {
+        List<String> addresses = new ArrayList<>();
+        if (useSharedNetwork) {
+            addresses.add(String.format("BROKER://%s:9093", hostName));
+        }
+        // See https://github.com/quarkusio/quarkus/issues/21819
+        // Kafka is always exposed to the Docker host network
+        addresses.add(String.format("PLAINTEXT://%s:%d", getHost(), getExposedKafkaPort()));
+        return String.join(",", addresses);
+    }
+
+    public int getExposedKafkaPort() {
+        return exposedPort;
+    }
+
+    @Override
+    protected void configure() {
+        super.configure();
+
+        addExposedPort(DevServicesKafkaProcessor.KAFKA_PORT);
+        hostName = ConfigureUtil.configureSharedNetwork(this, "kafka");
+
+        if (fixedExposedPort != null) {
+            addFixedExposedPort(fixedExposedPort, DevServicesKafkaProcessor.KAFKA_PORT);
+        }
+    }
+
+    public String getBootstrapServers() {
+        return getKafkaAdvertisedListeners();
+    }
+
+}

--- a/integration-tests/kafka-devservices/src/main/resources/application.properties
+++ b/integration-tests/kafka-devservices/src/main/resources/application.properties
@@ -5,6 +5,7 @@ quarkus.log.category.\"org.apache.zookeeper\".level=WARN
 # enable health check
 quarkus.kafka.health.enabled=true
 
+quarkus.kafka.devservices.provider=kafka-native
 quarkus.kafka.devservices.topic-partitions.test=2
 quarkus.kafka.devservices.topic-partitions.test-consumer=3
 quarkus.kafka.devservices.topic-partitions-timeout=4S


### PR DESCRIPTION
Adds option for using https://github.com/ozangunalp/kafka-native images.

Fixes #28194

Default images for providers
- redpanda docker.io/vectorized/redpanda:v22.3.4
- strimzi quay.io/strimzi-test-container/test-container:latest-kafka-3.2.1
- kafka-native quay.io/ogunalp/kafka-native:latest