### PR TITLE
add trustServerCertificate prop to MSSQL driver extension

### DIFF
--- a/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/MsSQLAgroalConnectionConfigurer.java
+++ b/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/MsSQLAgroalConnectionConfigurer.java
@@ -11,7 +11,9 @@ public class MsSQLAgroalConnectionConfigurer implements AgroalConnectionConfigur
 
     @Override
     public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {
-        dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration().jdbcProperty("encrypt", "false");
+        dataSourceConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration()
+                .jdbcProperty("trustServerCertificate", "true")
+                .jdbcProperty("encrypt", "false");
     }
 
     @Override


### PR DESCRIPTION
This issue aims to resolve the need to manually add the property:
`quarkus.datasource.jdbs.additional-jdbc-properties.trustservercertificate=true`

When using the quarkus-jdbc-mssql, the end-user is often not aware of the underlying mssql driver specifics, and expects the vendor/implementor to handle the specifics. In our organization we experienced issues when moving from Quarkus 2.9.2 --> 2.14.2 that suddenly our MSSQL connections were failing with a PKIX path building error.

```
Datasource '<default>': The driver could not establish a secure connection to SQL Server by using Secure Sockets Layer (SSL) encryption. Error: "PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target". ClientConnectionId:f2088dcd-2276-40b0-b7e4-90aac3a88eef
com.microsoft.sqlserver.jdbc.SQLServerException: The driver could not establish a secure connection to SQL Server by using Secure Sockets Layer (SSL) encryption. Error: "PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target". ClientConnectionId:f2088dcd-2276-40b0-b7e4-90aac3a88eef
        at com.microsoft.sqlserver.jdbc.SQLServerConnection.terminate(SQLServerConnection.java:3806)
        at com.microsoft.sqlserver.jdbc.TDSChannel.enableSSL(IOBuffer.java:1906)
        at com.microsoft.sqlserver.jdbc.SQLServerConnection.connectHelper(SQLServerConnection.java:3329)
        at com.microsoft.sqlserver.jdbc.SQLServerConnection.login(SQLServerConnection.java:2950)
        at com.microsoft.sqlserver.jdbc.SQLServerConnection.connectInternal(SQLServerConnection.java:2790)
        at com.microsoft.sqlserver.jdbc.SQLServerConnection.connect(SQLServerConnection.java:1663)
        at com.microsoft.sqlserver.jdbc.SQLServerDriver.connect(SQLServerDriver.java:1064)
        at io.agroal.pool.ConnectionFactory.createConnection(ConnectionFactory.java:226)
        at io.agroal.pool.ConnectionPool$CreateConnectionTask.call(ConnectionPool.java:535)
        at io.agroal.pool.ConnectionPool$CreateConnectionTask.call(ConnectionPool.java:516)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at io.agroal.pool.util.PriorityScheduledExecutor.beforeExecute(PriorityScheduledExecutor.java:75)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1134)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
```

I may be in the wrong, but I assume that whenever we are using the MSSQL JDBC driver in tandemn with the quarkus-jdbc-mssql extension, it should default to using the server certificates for TLS hand-shakes. Whereas edge-cases should be handled as.. well.. edge cases. I.e when an override is required (maybe due to requiring a speicific keystore/certificate) then it's natural to expect the developer having to resort to the driver specific docs.

Please let me know if you agree @Sanne.

Connected to the issue here:
https://github.com/quarkusio/quarkus/issues/27330

