### PR TITLE
Fix some typos in the building native image documentation

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -326,7 +326,7 @@ Adding `<argLine>--enable-preview</argLine>` to its `configuration` section is o
 
 === Excluding tests when running as a native executable
 
-When running tests this way, the only things that actually run natively are you application endpoints, which
+When running tests this way, the only things that actually run natively are your application endpoints, which
 you can only test via HTTP calls. Your test code does not actually run natively, so if you are testing code
 that does not call your HTTP endpoints, it's probably not a good idea to run them as part of native tests.
 
@@ -484,7 +484,7 @@ Then, if you didn't delete the generated native executable, you can build the do
 
 [source,bash]
 ----
-docker build -f src/main/docker/Dockerfile.native -t quarkus-quickstart/getting-started .
+docker build -f src/main/docker/Dockerfile.native-micro -t quarkus-quickstart/getting-started .
 ----
 
 And finally, run it with:


### PR DESCRIPTION
As I'm learning how to work through some of the quarkus stuff I've found a couple typos in the documentation. The two changes in this request are straightforward.

1. Fix grammar in referencing application endpoints
2. The section that talks about building a container using the native-micro Dockerfile wasn't using the same file in the examples