### PR TITLE
give more explicit pointer to the contribute guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+## Quarkus Documentation
+
+This is the main folder for Quarkus documentation. 
+
+The contents of this folder are used to publish documentation to the quarkus.io website.
+The [main documentation README.adoc](src/main/asciidoc/README.adoc) is in the `src/main/asciidoc` folder that also contains the `.adoc` source files for the published documentation.


### PR DESCRIPTION
I would prefer the relevant `mvn` commands to use/run was documented in the repo rather than "off-site" but with this there is at least a chance to discover the documentation.

