### PR TITLE
Removed weird `code` tag and fixed formatting

### DIFF
--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -215,7 +215,7 @@ Because we used the `${...}` syntax, the actual value of the parameter will be o
 
 [IMPORTANT]
 ====
-Note that if an interface method contains an argument annotated with `@QueryParam``</code>``, that argument will take
+Note that if an interface method contains an argument annotated with `@QueryParam`, that argument will take
 priority over anything specified in any `@ClientQueryParam` annotation.
 ====
 


### PR DESCRIPTION
In the https://quarkus.io/guides/rest-client-reactive#using-clientqueryparam section of the docs, there's some weird formatting due to the `</code>` tag, and some extra backticks that mess up the colors and the fonts. I'm 95% sure that it's not supposed to look like this, so I made a quick fix.