### PR TITLE
Change avro.codegen.stringType default from String to CharSequence

### DIFF
--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -780,7 +780,7 @@ You can use the following configuration properties to alter how it works:
 importable by subsequently compiled schemas. Note that imported files should not reference each other. All paths should be relative
 to the `src/[main|test]/avro` directory, or `avro` sub-directory in any source directory configured by the build system. Passed as a comma-separated list.
 - `avro.codegen.stringType` - the Java type to use for Avro strings. May be one of `CharSequence`, `String` or
-`Utf8`. Defaults to `String`
+`Utf8`. Defaults to `CharSequence`
 - `avro.codegen.createOptionalGetters` - enables generating the `getOptional...`
 methods that return an Optional of the requested type. Defaults to `false`
 - `avro.codegen.enableDecimalLogicalType` - determines whether to use Java classes for decimal types, defaults to `false`

--- a/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroCodeGenProviderBase.java
+++ b/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroCodeGenProviderBase.java
@@ -162,7 +162,7 @@ public abstract class AvroCodeGenProviderBase implements CodeGenProvider {
             this.config = config;
             this.imports = getImports(config);
 
-            stringType = GenericData.StringType.valueOf(prop("avro.codegen.stringType", "String"));
+            stringType = GenericData.StringType.valueOf(prop("avro.codegen.stringType", "CharSequence"));
             createOptionalGetters = getBooleanProperty("avro.codegen.createOptionalGetters", false);
             enableDecimalLogicalType = getBooleanProperty("avro.codegen.enableDecimalLogicalType", false);
             createSetters = getBooleanProperty("avro.codegen.createSetters", true);


### PR DESCRIPTION
This is a proposition to change `avro.codegen.stringType`'s default from `String` to `CharSequence`.
There are 2 reasons for this:
- `CharSequence` is already the default value in the official avro maven plugin: https://github.com/apache/avro/blob/master/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java#L112
- `String` has side effects on the generated classes that do not play nice with the registry

on the second point, when you use `String`, the main generated class contains metadata `{\"type\":\"string\",\"avro.java.string\":\"String\"}` for `String` types, even if the original schema does not contain it:
```
public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",...,\"fields\":[{\"name\":\"a\",\"type\":\"int\"},{\"name\":\"b\",\"type\":{\"type\":\"string\",\"avro.java.string\":\"String\"}},{\"name\":\"c\",\"type\":{\"type\":\"string\",\"avro.java.string\":\"String\"}}]}");
```

if you register the original schema in the schema registry, the client will try to match its own view of the schema (with the metadata) against the schema in the registry (without the metadata), and fail to find its schema in the registry.

this can be solved by registering the schema with the metadata in the schema registry, but then this makes the schema technology specific, and might cause other technologies to fail if they have a view of the schema without `java` metadata.

for that reason, it sounds that `CharSequence` is a much better default value, inline with the behavior of the other java technologies using the maven plugin, such as SpringBoot.