### PR TITLE
Fix Quarkus Vale linter warning on words 'UNIX', 'Redis', and 'using'

### DIFF
--- a/docs/.vale/fixtures/Quarkus/CaseSensitiveTerms/testinvalid.adoc
+++ b/docs/.vale/fixtures/Quarkus/CaseSensitiveTerms/testinvalid.adoc
@@ -223,7 +223,7 @@ uid
 UltraSparc
 ULTRASPARC
 unix
-Unix
+unix Socket
 UNIX-like
 url
 var

--- a/docs/.vale/fixtures/Quarkus/CaseSensitiveTerms/testvalid.adoc
+++ b/docs/.vale/fixtures/Quarkus/CaseSensitiveTerms/testvalid.adoc
@@ -131,7 +131,7 @@ SysV
 TTL
 UID
 UltraSPARC
-UNIX
+Unix socket
 URL
 VAR
 VDSM

--- a/docs/.vale/styles/Quarkus/CaseSensitiveTerms.yml
+++ b/docs/.vale/styles/Quarkus/CaseSensitiveTerms.yml
@@ -32,6 +32,7 @@ swap:
   Disk druid|disk druid|diskdruid: Disk Druid
   dns: DNS
   DVD burner|burner: DVD writer
+  Etcd|ETCD: etcd
   Exec Shield: Exec-Shield
   EXIF|exif: Exif
   Faq|faq|F.A.Q: FAQ
@@ -113,6 +114,7 @@ swap:
   Red Hat Satellite Capsule server: Red Hat Satellite Capsule Server
   Red Hat Network Satellite server: Red Hat Network Satellite Server
   Redboot|Red Boot: RedBoot
+  redis: Redis
   RESTEASY|resteasy|Resteasy: RESTEasy
   Rom|rom: ROM
   rpm: RPM
@@ -139,7 +141,7 @@ swap:
   ttl: TTL
   uid: UID
   ULTRASPARC|UltraSparc: UltraSPARC
-  Unix|unix|UNIX-like: UNIX
+  unix socket|unix Socket|UNIX Socket: Unix socket
   url: URL
   "(?<!/)var": VAR
   VI: vi

--- a/docs/.vale/styles/Quarkus/Headings.yml
+++ b/docs/.vale/styles/Quarkus/Headings.yml
@@ -170,11 +170,11 @@ exceptions:
   - qeth
   - Quarkiverse
   - Quarkus
-  
   - Quarkus Security
   - Quiltflower
   - Qute
   - Red Hat
+  - Redis
   - RedBoot
   - Redistributions
   - RESTEasy

--- a/docs/.vale/styles/Quarkus/Spelling.yml
+++ b/docs/.vale/styles/Quarkus/Spelling.yml
@@ -117,6 +117,7 @@ filters:
   - "[sS]erverless"
   - "[sS]ervlet"
   - "[sS]harding"
+  - "[sS]ysctl"
   - "[Ss]u"
   - "[sS]ubcommand"
   - "[sS]ubcommands"
@@ -304,6 +305,7 @@ filters:
   - Quarkus
   - Qute
   - Quiltflower
+  - Redis
   - Redistributions
   - Restic
   - RESTEasy

--- a/docs/.vale/styles/Quarkus/TermsErrors.yml
+++ b/docs/.vale/styles/Quarkus/TermsErrors.yml
@@ -166,7 +166,6 @@ swap:
   insure: ensure
   Internet address: IP address|URL|Internet email address|web address
   irrecoverable: unrecoverable
-  jar: compress|archive
   keep in mind: remember
   kernelspace: kernel-space
   knowledgebase: knowledge base

--- a/docs/.vale/styles/Quarkus/TermsSuggestions.yml
+++ b/docs/.vale/styles/Quarkus/TermsSuggestions.yml
@@ -8,7 +8,6 @@ source: Quarkus contributor guide
 action:
   name: replace
 swap:
-  "(?<!by) using": by using|that uses
   ", that": ", which (non restrictive clause preceded by a comma)|that (restrictive clause without a comma)"
   "(?<!,) which": ", which (non restrictive clause preceded by a comma)|that (restrictive clause without a comma)"
   and so on: "appropriate descriptive wording, unless you list a clear sequence of elements"


### PR DESCRIPTION
This PR includes some tweaks to the Quarkus ruleset for Vale to reduce some of the linter  _noise_ that was encountered in PR https://github.com/quarkusio/quarkus/pull/29893.


