### PR TITLE
OIDC - Harden conditions for token verification with user info

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -199,7 +199,8 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                             OidcUtils.setSecurityIdentityConfigMetadata(builder, resolvedContext);
                             final String userName;
                             if (result.introspectionResult == null) {
-                                if (resolvedContext.oidcConfig.token.allowJwtIntrospection) {
+                                if (resolvedContext.oidcConfig.token.allowOpaqueTokenIntrospection &&
+                                        resolvedContext.oidcConfig.token.verifyAccessTokenWithUserInfo) {
                                     userName = "";
                                 } else {
                                     // we don't expect this to ever happen

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -74,6 +74,7 @@ quarkus.oidc.code-flow-user-info-github.credentials.secret=AyM1SysPpbyDfgZld3umj
 
 quarkus.oidc.bearer-user-info-github-service.provider=github
 quarkus.oidc.bearer-user-info-github-service.token.verify-access-token-with-user-info=true
+quarkus.oidc.bearer-user-info-github-service.token.allow-jwt-introspection=false
 quarkus.oidc.bearer-user-info-github-service.application-type=service
 quarkus.oidc.bearer-user-info-github-service.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.bearer-user-info-github-service.user-info-path=github/userinfo


### PR DESCRIPTION
#29715 follow-up

I think previous condition was typo and it worked as by default `allow-jwt-introspection` is set to true (which is going to change in the future). We should only allow empty introspection result if that's a way how user info verification says "verification has been successful".

NOTE: AFAICT from code - only time when introspection is null at that line is when we allowed verification with user info, but we should fix the condition anyway in case something goes wrong..