### PR TITLE
Generate a Versions java class for fabric8 dependencies

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -155,7 +155,6 @@
         <kotlin.version>1.7.22</kotlin.version>
         <kotlin.coroutine.version>1.6.4</kotlin.coroutine.version>
         <kotlin-serialization.version>1.4.1</kotlin-serialization.version>
-        <kubernetes-client.version>6.3.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <dekorate.version>3.2.0</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -198,7 +198,6 @@
         <avro.version>1.11.1</avro.version>
         <apicurio-registry.version>2.3.1.Final</apicurio-registry.version>
         <apicurio-common-rest-client.version>0.1.13.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
-        <jacoco.version>0.8.8</jacoco.version>
         <testcontainers.version>1.17.6</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
         <docker-java.version>3.2.13</docker-java.version> <!-- must be the version Testcontainers use -->
         <com.dajudge.kindcontainer>1.3.0</com.dajudge.kindcontainer>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -114,8 +114,6 @@
 
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine></jacoco.agent.argLine>
-        <!-- Note: this version is also set in quarkus-bom but BOMs don't contribute to pluginManagement or properties -->
-        <jacoco.version>0.8.8</jacoco.version>
 
         <asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>
         <docker-maven-plugin.version>0.40.3</docker-maven-plugin.version>

--- a/extensions/kubernetes-client/deployment/pom.xml
+++ b/extensions/kubernetes-client/deployment/pom.xml
@@ -41,6 +41,19 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>templating-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <id>filtering-java-templates</id>
+                        <goals>
+                            <goal>filter-sources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/kubernetes-client/deployment/src/main/java-templates/io/quarkus/kubernetes/client/deployment/Versions.java
+++ b/extensions/kubernetes-client/deployment/src/main/java-templates/io/quarkus/kubernetes/client/deployment/Versions.java
@@ -1,0 +1,13 @@
+package io.quarkus.kubernetes.client.deployment;
+
+import io.smallrye.common.annotation.Experimental;
+
+@Experimental("This Versions API is experimental")
+public class Versions {
+
+  private Versions() {}
+
+  public static final String QUARKUS = "${project.version}";
+  public static final String KUBERNETES_CLIENT = "${kubernetes-client.version}";
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <skip.gradle.tests>false</skip.gradle.tests>
 
         <!-- Dependency versions -->
+        <kubernetes-client.version>6.3.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.51.1</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <skip.gradle.tests>false</skip.gradle.tests>
 
         <!-- Dependency versions -->
+        <jacoco.version>0.8.8</jacoco.version>
         <kubernetes-client.version>6.3.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->


### PR DESCRIPTION
ref: https://github.com/quarkiverse/quarkus-operator-sdk/pull/460

Generating a `Versions` files make this information available to the Quarkus Operator Extension, so that we can actually cross-check that everything is aligned, in the extension itself and at build time on the user classpath.

Please let me know if this approach is sound.
cc. @metacosm 