### PR TITLE
OIDC Client Reactive Filter - fix register provider with config property

### DIFF
--- a/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/ConfigPropertyOidcClientResource.java
+++ b/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/ConfigPropertyOidcClientResource.java
@@ -13,9 +13,19 @@ public class ConfigPropertyOidcClientResource {
     @RestClient
     ProtectedResourceServiceConfigPropertyOidcClient protectedResourceServiceConfigPropertyOidcClient;
 
+    @Inject
+    @RestClient
+    ProtectedResourceServiceCustomProviderConfigPropOidcClient protectedResourceServiceCustomProviderConfigPropOidcClient;
+
     @GET
-    @Path("user-name")
+    @Path("/annotation/user-name")
     public String userName() {
         return protectedResourceServiceConfigPropertyOidcClient.getUserName();
+    }
+
+    @GET
+    @Path("/custom-provider/user-name")
+    public String customProviderConfigPropertyUserName() {
+        return protectedResourceServiceCustomProviderConfigPropOidcClient.getUserName();
     }
 }

--- a/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/NamedOidcClientFilterDevModeTest.java
+++ b/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/NamedOidcClientFilterDevModeTest.java
@@ -17,6 +17,7 @@ public class NamedOidcClientFilterDevModeTest {
             ProtectedResource.class,
             ProtectedResourceServiceNamedOidcClient.class,
             ProtectedResourceServiceConfigPropertyOidcClient.class,
+            ProtectedResourceServiceCustomProviderConfigPropOidcClient.class,
             NamedOidcClientResource.class,
             ConfigPropertyOidcClientResource.class
     };
@@ -35,8 +36,14 @@ public class NamedOidcClientFilterDevModeTest {
                 .statusCode(200)
                 .body(equalTo("jdoe"));
 
-        // OidcClient selected via `quarkus.oidc-client-filter.client-name=config-property`
-        RestAssured.when().get("/config-property-oidc-client/user-name")
+        // @OidcClientFilter: OidcClient selected via `quarkus.oidc-client-filter.client-name=config-property`
+        RestAssured.when().get("/config-property-oidc-client/annotation/user-name")
+                .then()
+                .statusCode(200)
+                .body(equalTo("alice"));
+
+        // @RegisterProvider(OidcClientRequestFilter.class): OidcClient selected via `quarkus.oidc-client-filter.client-name=config-property`
+        RestAssured.when().get("/config-property-oidc-client/custom-provider/user-name")
                 .then()
                 .statusCode(200)
                 .body(equalTo("alice"));

--- a/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/ProtectedResourceServiceCustomProviderConfigPropOidcClient.java
+++ b/extensions/oidc-client-filter/deployment/src/test/java/io/quarkus/oidc/client/filter/ProtectedResourceServiceCustomProviderConfigPropOidcClient.java
@@ -1,0 +1,16 @@
+package io.quarkus.oidc.client.filter;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterProvider(OidcClientRequestFilter.class)
+@RegisterRestClient
+@Path("/")
+public interface ProtectedResourceServiceCustomProviderConfigPropOidcClient {
+
+    @GET
+    String getUserName();
+}

--- a/extensions/oidc-client-filter/deployment/src/test/resources/application-named-oidc-client-filter.properties
+++ b/extensions/oidc-client-filter/deployment/src/test/resources/application-named-oidc-client-filter.properties
@@ -21,3 +21,4 @@ quarkus.oidc-client.named.grant-options.password.password=jdoe
 
 io.quarkus.oidc.client.filter.ProtectedResourceServiceNamedOidcClient/mp-rest/url=http://localhost:8080/protected
 io.quarkus.oidc.client.filter.ProtectedResourceServiceConfigPropertyOidcClient/mp-rest/url=http://localhost:8080/protected
+io.quarkus.oidc.client.filter.ProtectedResourceServiceCustomProviderConfigPropOidcClient/mp-rest/url=http://localhost:8080/protected

--- a/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
@@ -40,9 +40,6 @@ public class OidcClientReactiveFilterBuildStep {
     void oidcClientFilterSupport(CombinedIndexBuildItem indexBuildItem, BuildProducer<GeneratedBeanBuildItem> generatedBean,
             BuildProducer<RegisterProviderAnnotationInstanceBuildItem> producer) {
         final var helper = new OidcClientFilterDeploymentHelper<>(AbstractOidcClientRequestReactiveFilter.class, generatedBean);
-        final var defaultFilter = oidcClientReactiveFilterConfig.clientName.isPresent()
-                ? helper.getOrCreateFilter(oidcClientReactiveFilterConfig.clientName.get())
-                : OIDC_CLIENT_REQUEST_REACTIVE_FILTER;
 
         Collection<AnnotationInstance> instances = indexBuildItem.getIndex().getAnnotations(OIDC_CLIENT_FILTER);
         for (AnnotationInstance instance : instances) {
@@ -50,13 +47,13 @@ public class OidcClientReactiveFilterBuildStep {
             // get client name from annotation @OidcClientFilter("clientName")
             final String clientName = OidcClientFilterDeploymentHelper.getClientName(instance);
             final AnnotationValue valueAttr;
-            if (clientName != null) {
+            if (clientName != null && !clientName.equals(oidcClientReactiveFilterConfig.clientName.orElse(null))) {
                 // create and use custom filter for named OidcClient
                 // we generate exactly one custom filter for each named client specified through annotation
                 valueAttr = createClassValue(helper.getOrCreateFilter(clientName));
             } else {
                 // use default filter for either default OidcClient or the client configured with config properties
-                valueAttr = createClassValue(defaultFilter);
+                valueAttr = createClassValue(OIDC_CLIENT_REQUEST_REACTIVE_FILTER);
             }
 
             final AnnotationValue priorityAttr = AnnotationValue.createIntegerValue("priority", Priorities.AUTHENTICATION);

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/NamedOidcClientFilterDevModeTest.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/NamedOidcClientFilterDevModeTest.java
@@ -17,6 +17,7 @@ public class NamedOidcClientFilterDevModeTest {
             ProtectedResource.class,
             ProtectedResourceServiceAnnotationOidcClient.class,
             ProtectedResourceServiceConfigPropertyOidcClient.class,
+            ProtectedResourceServiceCustomProviderConfigPropOidcClient.class,
             OidcClientResource.class
     };
 
@@ -36,8 +37,14 @@ public class NamedOidcClientFilterDevModeTest {
                 .statusCode(200)
                 .body(equalTo("jdoe"));
 
-        // OidcClient selected via `quarkus.oidc-client-filter.client-name=config-property`
+        // @OidcClientFilter: OidcClient selected via `quarkus.oidc-client-filter.client-name=config-property`
         RestAssured.when().get("/oidc-client/config-property/user-name")
+                .then()
+                .statusCode(200)
+                .body(equalTo("alice"));
+
+        // @RegisterProvider(OidcClientRequestReactiveFilter.class): OidcClient selected via `quarkus.oidc-client-filter.client-name=config-property`
+        RestAssured.when().get("/oidc-client/custom-provider-config-property/user-name")
                 .then()
                 .statusCode(200)
                 .body(equalTo("alice"));

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/OidcClientResource.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/OidcClientResource.java
@@ -17,6 +17,10 @@ public class OidcClientResource {
     @RestClient
     ProtectedResourceServiceConfigPropertyOidcClient protectedResourceServiceConfigPropertyOidcClient;
 
+    @Inject
+    @RestClient
+    ProtectedResourceServiceCustomProviderConfigPropOidcClient protectedResourceServiceCustomProviderConfigPropOidcClient;
+
     @GET
     @Path("/annotation/user-name")
     public String annotationUserName() {
@@ -27,5 +31,11 @@ public class OidcClientResource {
     @Path("/config-property/user-name")
     public String configPropertyUserName() {
         return protectedResourceServiceConfigPropertyOidcClient.getUserName();
+    }
+
+    @GET
+    @Path("/custom-provider-config-property/user-name")
+    public String customProviderConfigPropertyUserName() {
+        return protectedResourceServiceCustomProviderConfigPropOidcClient.getUserName();
     }
 }

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/ProtectedResourceServiceCustomProviderConfigPropOidcClient.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/java/io/quarkus/oidc/client/reactive/filter/ProtectedResourceServiceCustomProviderConfigPropOidcClient.java
@@ -1,0 +1,16 @@
+package io.quarkus.oidc.client.reactive.filter;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterProvider(OidcClientRequestReactiveFilter.class)
+@RegisterRestClient
+@Path("/")
+public interface ProtectedResourceServiceCustomProviderConfigPropOidcClient {
+
+    @GET
+    String getUserName();
+}

--- a/extensions/oidc-client-reactive-filter/deployment/src/test/resources/application-oidc-client-reactive-filter.properties
+++ b/extensions/oidc-client-reactive-filter/deployment/src/test/resources/application-oidc-client-reactive-filter.properties
@@ -21,3 +21,4 @@ quarkus.oidc-client.annotation.grant-options.password.password=jdoe
 
 io.quarkus.oidc.client.reactive.filter.ProtectedResourceServiceAnnotationOidcClient/mp-rest/url=http://localhost:8080/protected
 io.quarkus.oidc.client.reactive.filter.ProtectedResourceServiceConfigPropertyOidcClient/mp-rest/url=http://localhost:8080/protected
+io.quarkus.oidc.client.reactive.filter.ProtectedResourceServiceCustomProviderConfigPropOidcClient/mp-rest/url=http://localhost:8080/protected

--- a/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestReactiveFilter.java
+++ b/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestReactiveFilter.java
@@ -1,11 +1,22 @@
 package io.quarkus.oidc.client.reactive.filter;
 
+import java.util.Optional;
+
 import javax.annotation.Priority;
+import javax.inject.Inject;
 import javax.ws.rs.Priorities;
 
 import io.quarkus.oidc.client.reactive.filter.runtime.AbstractOidcClientRequestReactiveFilter;
+import io.quarkus.oidc.client.reactive.filter.runtime.OidcClientReactiveFilterConfig;
 
 @Priority(Priorities.AUTHENTICATION)
 public class OidcClientRequestReactiveFilter extends AbstractOidcClientRequestReactiveFilter {
 
+    @Inject
+    OidcClientReactiveFilterConfig config;
+
+    @Override
+    protected Optional<String> clientId() {
+        return config.clientName;
+    }
 }


### PR DESCRIPTION
#29788 follow-up

I re-checked PR amd mentioned regression for combination of `@RegisterProvider(OidcClientRequestReactiveFilter.class)` and `quarkus.oidc-client-reactive-filter.client-name` config property. Classic is ok, but I added test anyway.