### PR TITLE
Fix auth-server-url for keycloak

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -14,7 +14,7 @@ public class OidcCommonConfig {
      * The base URL of the OpenID Connect (OIDC) server, for example, `https://host:port/auth`.
      * OIDC discovery endpoint will be called by default by appending a '.well-known/openid-configuration' path to this URL.
      * Note if you work with Keycloak OIDC server, make sure the base URL is in the following format:
-     * `https://host:port/auth/realms/{realm}` where `{realm}` has to be replaced by the name of the Keycloak realm.
+     * `https://host:port/realms/{realm}` where `{realm}` has to be replaced by the name of the Keycloak realm.
      */
     @ConfigItem
     public Optional<String> authServerUrl = Optional.empty();


### PR DESCRIPTION
When using `quarkus.oidc.auth-server-url=https://host:port/auth/realms/{realm}` with keycloak , I get the following error : 

> io.qua.oid.dep.dev.OidcDevConsoleProcessor] (build-17) OIDC metadata discovery failed: {"error":"RESTEASY003210: Could not find resource for full path: http://localhost:8081/auth/realms/test/.well-known/openid-configuration"}

The property value should be `https://host:port/realms/{realm}` instead of `https://host:port/auth/realms/{realm}`