### PR TITLE
Update musl and zlib versions in the documentation

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -653,7 +653,7 @@ Just add your application on top of this image, and you will get a tiny containe
 
 Distroless images should not be used in production without rigorous testing.
 
-=== Using a scratch base image
+=== Build a container image from scratch
 
 IMPORTANT: Scratch image support is experimental.
 
@@ -671,9 +671,9 @@ COPY --chown=quarkus:quarkus mvnw /code/mvnw
 COPY --chown=quarkus:quarkus .mvn /code/.mvn
 COPY --chown=quarkus:quarkus pom.xml /code/
 RUN mkdir /musl && \
-    curl -L -o musl.tar.gz https://more.musl.cc/10.2.1/x86_64-linux-musl/x86_64-linux-musl-native.tgz && \
+    curl -L -o musl.tar.gz https://more.musl.cc/11.2.1/x86_64-linux-musl/x86_64-linux-musl-native.tgz && \
     tar -xvzf musl.tar.gz -C /musl --strip-components 1 && \
-    curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.12.tar.gz && \
+    curl -L -o zlib.tar.gz https://www.zlib.net/zlib-1.2.13.tar.gz && \
     mkdir zlib && tar -xvzf zlib.tar.gz -C zlib --strip-components 1 && \
     cd zlib && ./configure --static --prefix=/musl && \
     make && make install && \
@@ -683,17 +683,20 @@ USER quarkus
 WORKDIR /code
 RUN ./mvnw -B org.apache.maven.plugins:maven-dependency-plugin:3.1.2:go-offline
 COPY src /code/src
-RUN ./mvnw package -Pnative -Dquarkus.native.additional-build-args="--static","--libc=musl"
+RUN ./mvnw package -Pnative -DskipTests -Dquarkus.native.additional-build-args="--static","--libc=musl"
 
-## Stage 2 : create the docker final image
+## Stage 2 : create the final image
 FROM scratch
 COPY --from=build /code/target/*-runner /application
+EXPOSE 8080
 ENTRYPOINT [ "/application" ]
 ----
 
 Scratch images should not be used in production without rigorous testing.
 
-=== Native executable compression
+NOTE: The versions of musl and zlib may need to be updated to meet the native-image executable requirements (and UPX if you use native image compression).
+
+=== Compress native images
 
 Quarkus can compress the produced native executable using UPX.
 More details on xref:./upx.adoc[UPX Compression documentation].


### PR DESCRIPTION
Update the musl and zlib versions in the documentation explaining how to build a container image from scratch.

Fix https://github.com/quarkusio/quarkus/issues/29857