### PR TITLE
Websockets client - set the current security identity

### DIFF
--- a/extensions/websockets/client/runtime/src/main/java/io/quarkus/websockets/client/runtime/WebsocketCoreRecorder.java
+++ b/extensions/websockets/client/runtime/src/main/java/io/quarkus/websockets/client/runtime/WebsocketCoreRecorder.java
@@ -169,12 +169,12 @@ public class WebsocketCoreRecorder {
                                 boolean required = !requestContext.isActive();
                                 if (required) {
                                     requestContext.activate();
-                                    Principal p = session.getUserPrincipal();
-                                    if (p instanceof WebSocketPrincipal) {
-                                        var current = getCurrentIdentityAssociation();
-                                        if (current != null) {
-                                            current.setIdentity(((WebSocketPrincipal) p).getSecurityIdentity());
-                                        }
+                                }
+                                Principal p = session.getUserPrincipal();
+                                if (p instanceof WebSocketPrincipal) {
+                                    var current = getCurrentIdentityAssociation();
+                                    if (current != null) {
+                                        current.setIdentity(((WebSocketPrincipal) p).getSecurityIdentity());
                                     }
                                 }
                                 try {


### PR DESCRIPTION
- even if the CDI request context is active
- resolves #29919 