### PR TITLE
Support QUARKUS_TEST_PROFILE environment variable

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ProfileManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ProfileManager.java
@@ -22,6 +22,7 @@ public class ProfileManager {
     public static final String QUARKUS_PROFILE_ENV = "QUARKUS_PROFILE";
     public static final String QUARKUS_PROFILE_PROP = "quarkus.profile";
     public static final String QUARKUS_TEST_PROFILE_PROP = "quarkus.test.profile";
+    public static final String QUARKUS_TEST_PROFILE_ENV = "QUARKUS_TEST_PROFILE";
     private static final String BACKWARD_COMPATIBLE_QUARKUS_PROFILE_PROP = "quarkus-profile";
 
     private static volatile LaunchMode launchMode = LaunchMode.NORMAL;
@@ -49,6 +50,10 @@ public class ProfileManager {
     public static String getActiveProfile() {
         if (launchMode == LaunchMode.TEST) {
             String profile = System.getProperty(QUARKUS_TEST_PROFILE_PROP);
+            if (profile != null) {
+                return profile;
+            }
+            profile = System.getenv(QUARKUS_TEST_PROFILE_ENV);
             if (profile != null) {
                 return profile;
             }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/BootstrapProfile.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/BootstrapProfile.java
@@ -10,6 +10,7 @@ public class BootstrapProfile {
     public static final String QUARKUS_PROFILE_ENV = "QUARKUS_PROFILE";
     public static final String QUARKUS_PROFILE_PROP = "quarkus.profile";
     public static final String QUARKUS_TEST_PROFILE_PROP = "quarkus.test.profile";
+    public static final String QUARKUS_TEST_PROFILE_ENV = "QUARKUS_TEST_PROFILE";
     private static final String BACKWARD_COMPATIBLE_QUARKUS_PROFILE_PROP = "quarkus-profile";
     public static final String DEV = "dev";
     public static final String PROD = "prod";
@@ -24,6 +25,10 @@ public class BootstrapProfile {
     public static String getActiveProfile(QuarkusBootstrap.Mode mode) {
         if (mode == QuarkusBootstrap.Mode.TEST) {
             String profile = System.getProperty(QUARKUS_TEST_PROFILE_PROP);
+            if (profile != null) {
+                return profile;
+            }
+            profile = System.getenv(QUARKUS_TEST_PROFILE_ENV);
             if (profile != null) {
                 return profile;
             }


### PR DESCRIPTION
The config [entry](https://quarkus.io/guides/continuous-testing#quarkus-test-dev-testing-test-config_quarkus.test.profile) mentions the environment variable, so let's support it

Fixes: #29944