### PR TITLE
Enhance KeycloakTestClient to support a client_credentials grant

### DIFF
--- a/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -8,6 +8,8 @@ import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
+import io.quarkus.security.Authenticated;
+
 @Path("/frontend")
 public class FrontendResource {
     @Inject
@@ -27,6 +29,13 @@ public class FrontendResource {
     @RolesAllowed("user")
     public String userNameJwtTokenPropagation() {
         return jwtTokenPropagationService.getUserName();
+    }
+
+    @GET
+    @Path("client-jwt-token-propagation")
+    @Authenticated
+    public String clientUserNameJwtTokenPropagation() {
+        return jwtTokenPropagationService.getClientName();
     }
 
     @GET

--- a/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/JwtTokenPropagationService.java
+++ b/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/JwtTokenPropagationService.java
@@ -14,4 +14,8 @@ public interface JwtTokenPropagationService {
 
     @GET
     String getUserName();
+
+    @GET
+    @Path("client")
+    String getClientName();
 }

--- a/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -21,4 +21,10 @@ public class ProtectedResource {
     public String principalName() {
         return principal.getName();
     }
+
+    @GET
+    @Path("client")
+    public String clientName() {
+        return principal.getName();
+    }
 }

--- a/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
+++ b/integration-tests/oidc-token-propagation/src/test/java/io/quarkus/it/keycloak/OidcTokenPropagationTest.java
@@ -26,6 +26,15 @@ public class OidcTokenPropagationTest {
     }
 
     @Test
+    public void testGetClientNameWithJwtTokenPropagation() {
+        RestAssured.given().auth().oauth2(getClientAccessToken())
+                .when().get("/frontend/client-jwt-token-propagation")
+                .then()
+                .statusCode(200)
+                .body(equalTo("service-account-quarkus-app"));
+    }
+
+    @Test
     public void testGetUserNameWithAccessTokenPropagation() {
         // At the moment it is not possible to configure Keycloak Token Exchange permissions
         // vi the admin API or export the realm with such permissions.
@@ -57,5 +66,9 @@ public class OidcTokenPropagationTest {
 
     public String getAccessToken(String userName) {
         return client.getAccessToken(userName, userName, "quarkus-app", "secret");
+    }
+
+    public String getClientAccessToken() {
+        return client.getClientAccessToken();
     }
 }

--- a/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/client/KeycloakTestClient.java
+++ b/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/client/KeycloakTestClient.java
@@ -35,8 +35,83 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
     }
 
     /**
+     * Get an access token from the default tenant realm using a client_credentials grant.
+     * Realm name is set to `quarkus` unless it has been configured with the `quarkus.keycloak.devservices.realm-name` property.
+     * Client id is set to `quarkus-app` unless it has been configured with the `quarkus.oidc.client-id` property.
+     * Client secret is set to `secret` unless it has been configured with the `quarkus.oidc.credentials.secret` property.
+     */
+    public String getClientAccessToken() {
+        return getClientAccessToken(getClientId());
+    }
+
+    /**
+     * Get an access token from the default tenant realm using a client_credentials grant with a
+     * the provided client id.
+     * Realm name is set to `quarkus` unless it has been configured with the `quarkus.keycloak.devservices.realm-name` property.
+     * Client secret will be to `secret` unless it has been configured with the `quarkus.oidc.credentials.secret` property.
+     */
+    public String getClientAccessToken(String clientId) {
+        return getClientAccessToken(clientId, getClientSecret());
+    }
+
+    /**
+     * Get an access token from the default tenant realm using a client_credentials grant with a
+     * the provided client id and secret.
+     * Realm name is set to `quarkus` unless it has been configured with the `quarkus.keycloak.devservices.realm-name` property.
+     */
+    public String getClientAccessToken(String clientId, String clientSecret) {
+        return getClientAccessToken(clientId, clientSecret, null);
+    }
+
+    /**
+     * Get an access token from the default tenant realm using a client_credentials grant with a
+     * the provided client id and secret, and scopes.
+     * Realm name is set to `quarkus` unless it has been configured with the `quarkus.keycloak.devservices.realm-name` property.
+     */
+    public String getClientAccessToken(String clientId, String clientSecret, List<String> scopes) {
+        return getClientAccessTokenInternal(clientId, clientSecret, scopes, getAuthServerUrl());
+    }
+
+    /**
+     * Get an access token from the provided realm using a client_credentials grant.
+     * Client id is set to `quarkus-app` unless it has been configured with the `quarkus.oidc.client-id` property.
+     * Client secret is set to `secret` unless it has been configured with the `quarkus.oidc.credentials.secret` property.
+     */
+    public String getRealmClientAccessToken(String realm) {
+        return getRealmClientAccessToken(realm, getClientId());
+    }
+
+    /**
+     * Get an access token from the provided realm using a client_credentials grant with a
+     * the provided client id.
+     * Client secret will be to `secret` unless it has been configured with the `quarkus.oidc.credentials.secret` property.
+     */
+    public String getRealmClientAccessToken(String realm, String clientId) {
+        return getRealmClientAccessToken(realm, clientId, getClientSecret());
+    }
+
+    /**
+     * Get an access token from the provided realm using a client_credentials grant with a
+     * the provided client id and secret.
+     */
+    public String getRealmClientAccessToken(String realm, String clientId, String clientSecret) {
+        return getRealmClientAccessToken(realm, clientId, clientSecret, null);
+    }
+
+    /**
+     * Get an access token from the provided realm using a client_credentials grant with a
+     * the provided client id and secret, and scopes.
+     */
+    public String getRealmClientAccessToken(String realm, String clientId, String clientSecret, List<String> scopes) {
+        return getClientAccessTokenInternal(clientId, clientSecret, scopes, getAuthServerBaseUrl() + "/realms/" + realm);
+    }
+
+    /**
      * Get an access token from the default tenant realm using a password grant with a provided user name.
-     * User secret will be the same as the user name, client id will be set to 'quarkus-app' and client secret to 'secret'.
+     * Realm name is set to `quarkus` unless it has been configured with the `quarkus.keycloak.devservices.realm-name` property.
+     * User secret will be the same as the user name.
+     * Client id will be set to `quarkus-app` unless it has been configured with the `quarkus.oidc.client-id` property.
+     * Client secret will be to `secret` unless it has been configured with the `quarkus.oidc.credentials.secret` property.
      */
     public String getAccessToken(String userName) {
         return getAccessToken(userName, getClientId());
@@ -44,7 +119,9 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
 
     /**
      * Get an access token from the default tenant realm using a password grant with the provided user name and client id.
-     * User secret will be the same as the user name, client secret will be set to 'secret'.
+     * Realm name is set to `quarkus` unless it has been configured with the `quarkus.keycloak.devservices.realm-name` property.
+     * User secret will be the same as the user name.
+     * Client secret will be to `secret` unless it has been configured with the `quarkus.oidc.credentials.secret` property.
      */
     public String getAccessToken(String userName, String clientId) {
         return getAccessToken(userName, userName, clientId);
@@ -53,7 +130,8 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
     /**
      * Get an access token from the default tenant realm using a password grant with the provided user name, user secret and
      * client id.
-     * Client secret will be set to 'secret'.
+     * Realm name is set to `quarkus` unless it has been configured with the `quarkus.keycloak.devservices.realm-name` property.
+     * Client secret will be set to `secret` unless it has been configured with the `quarkus.oidc.credentials.secret` propertys.
      */
     public String getAccessToken(String userName, String userSecret, String clientId) {
         return getAccessToken(userName, userSecret, clientId, getClientSecret());
@@ -62,6 +140,7 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
     /**
      * Get an access token from the default tenant realm using a password grant with the provided user name, user secret, client
      * id and secret.
+     * Realm name is set to `quarkus` unless it has been configured with the `quarkus.keycloak.devservices.realm-name` property.
      */
     public String getAccessToken(String userName, String userSecret, String clientId, String clientSecret) {
         return getAccessToken(userName, userSecret, clientId, clientSecret, null);
@@ -78,7 +157,9 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
 
     /**
      * Get a realm access token using a password grant with a provided user name.
-     * User secret will be the same as the user name, client id will be set to 'quarkus-app' and client secret to 'secret'.
+     * User secret will be the same as the user name.
+     * Client id will be set to `quarkus-app` unless it has been configured with the `quarkus.oidc.client-id` property.
+     * Client secret will be to `secret` unless it has been configured with the `quarkus.oidc.credentials.secret` property.
      */
     public String getRealmAccessToken(String realm, String userName) {
         return getRealmAccessToken(realm, userName, getClientId());
@@ -86,7 +167,8 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
 
     /**
      * Get a realm access token using a password grant with the provided user name and client id.
-     * User secret will be the same as the user name, client secret will be set to 'secret'.
+     * User secret will be the same as the user name.
+     * Client secret will be to `secret` unless it has been configured with the `quarkus.oidc.credentials.secret` property.
      */
     public String getRealmAccessToken(String realm, String userName, String clientId) {
         return getRealmAccessToken(realm, userName, userName, clientId);
@@ -94,7 +176,7 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
 
     /**
      * Get a realm access token using a password grant with the provided user name, user secret and client id.
-     * Client secret will be set to 'secret'.
+     * Client secret will be to `secret` unless it has been configured with the `quarkus.oidc.credentials.secret` property.
      */
     public String getRealmAccessToken(String realm, String userName, String userSecret, String clientId) {
         return getRealmAccessToken(realm, userName, userSecret, clientId, getClientSecret());
@@ -124,6 +206,20 @@ public class KeycloakTestClient implements DevServicesContext.ContextAware {
         RequestSpecification requestSpec = RestAssured.given().param("grant_type", "password")
                 .param("username", userName)
                 .param("password", userSecret)
+                .param("client_id", clientId);
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            requestSpec = requestSpec.param("client_secret", clientSecret);
+        }
+        if (scopes != null && !scopes.isEmpty()) {
+            requestSpec = requestSpec.param("scope", urlEncode(String.join(" ", scopes)));
+        }
+        return requestSpec.when().post(authServerUrl + "/protocol/openid-connect/token")
+                .as(AccessTokenResponse.class).getToken();
+    }
+
+    private String getClientAccessTokenInternal(String clientId, String clientSecret,
+            List<String> scopes, String authServerUrl) {
+        RequestSpecification requestSpec = RestAssured.given().param("grant_type", "client_credentials")
                 .param("client_id", clientId);
         if (clientSecret != null && !clientSecret.isBlank()) {
             requestSpec = requestSpec.param("client_secret", clientSecret);


### PR DESCRIPTION
Fixes #29933.

This PR adds 4 `getClientAccessToken` methods making it easy to get the access token using a client_credentials grant from a default realm set up by DevServices for Keycloak, and 4 `getRealmClientAccessToken` to do the same but also letting users  set a realm name as one of the method parameters. 
The same pattern is used with the existing `getAccessToken`/`getRealmAccessToken` methods where a password grant is used.
Also tried to improve the description of how various properties are set.
Update `OidcTokenPropagationTest` - in the existing test the propagated token contains an `alice` name because the token was acquired using a password grant. A new test method acquires a token using a client_credentials grant for a `quarkus-app` client, Keycloak represents it as a `service-account-quarkus-app` in the token issued using client_credentials grant

CC @pedroigor 