### PR TITLE
Import properties from build.gradle and remove hardcoded quarkus.package.output-directory

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -3,12 +3,15 @@ package io.quarkus.gradle.extension;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
 
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -34,6 +37,8 @@ public class QuarkusPluginExtension {
     private final Project project;
 
     private final Property<String> finalName;
+
+    private Map<String, String> quarkusBuildProperties;
     private final SourceSetExtension sourceSetExtension;
 
     public QuarkusPluginExtension(Project project) {
@@ -43,6 +48,7 @@ public class QuarkusPluginExtension {
         finalName.convention(project.provider(() -> String.format("%s-%s", project.getName(), project.getVersion())));
 
         this.sourceSetExtension = new SourceSetExtension();
+        quarkusBuildProperties = new HashMap<>();
     }
 
     public void beforeTest(Test task) {
@@ -182,4 +188,13 @@ public class QuarkusPluginExtension {
         }
         return classesDir;
     }
+
+    public Map<String, String> getQuarkusBuildProperties() {
+        return quarkusBuildProperties;
+    }
+
+    public void set(String name, @Nullable String value) {
+        quarkusBuildProperties.put(String.format("quarkus.%s", name), value);
+    }
+
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
@@ -36,6 +36,12 @@ public abstract class QuarkusTask extends DefaultTask {
                 realProperties.setProperty(key, (String) value);
             }
         }
+        if (!extension().getQuarkusBuildProperties().isEmpty()) {
+            extension().getQuarkusBuildProperties().entrySet().stream().filter(entry -> entry.getKey().startsWith("quarkus."))
+                    .forEach(entry -> {
+                        realProperties.put(entry.getKey(), entry.getValue());
+                    });
+        }
         realProperties.putIfAbsent("quarkus.application.name", appArtifact.getArtifactId());
         realProperties.putIfAbsent("quarkus.application.version", appArtifact.getVersion());
         return realProperties;

--- a/integration-tests/gradle/src/main/resources/build-configuration/build.gradle
+++ b/integration-tests/gradle/src/main/resources/build-configuration/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'java'
+    id 'io.quarkus' apply false
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
+    mavenCentral()
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}
+
+group = 'io.quarkus.gradle.test'
+version = '1.0'

--- a/integration-tests/gradle/src/main/resources/build-configuration/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/build-configuration/gradle.properties
@@ -1,0 +1,3 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus
+quarkusPluginId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/build-configuration/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/build-configuration/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id "${quarkusPluginId}" version "${quarkusPluginVersion}"
+    }
+}
+
+include 'with-application-properties'
+include 'with-build-configuration'
+include 'without-configuration'

--- a/integration-tests/gradle/src/main/resources/build-configuration/with-application-properties/build.gradle
+++ b/integration-tests/gradle/src/main/resources/build-configuration/with-application-properties/build.gradle
@@ -1,0 +1,44 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+quarkus {
+    properties {
+        set("package.type", "fast-jar")
+        set("package.output-directory", "build-gradle-output-dir")
+    }
+}
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/build-configuration/with-application-properties/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/build-configuration/with-application-properties/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id "${quarkusPluginId}" version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='with-application-properties'

--- a/integration-tests/gradle/src/main/resources/build-configuration/with-application-properties/src/main/java/org/acme/ExampleResource.java
+++ b/integration-tests/gradle/src/main/resources/build-configuration/with-application-properties/src/main/java/org/acme/ExampleResource.java
@@ -1,0 +1,19 @@
+package org.acme;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/hello")
+public class ExampleResource {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+
+}

--- a/integration-tests/gradle/src/main/resources/build-configuration/with-application-properties/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/build-configuration/with-application-properties/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# Configuration file
+# key = value
+my-app-name=${quarkus.application.name}
+quarkus.package.type=uber-jar
+quarkus.package.output-directory=application-properties-output-dir

--- a/integration-tests/gradle/src/main/resources/build-configuration/with-application-properties/src/test/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/build-configuration/with-application-properties/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+# Configuration file
+# key = value
+example.message=Hello from Test
+test-only=Test only

--- a/integration-tests/gradle/src/main/resources/build-configuration/with-build-configuration/build.gradle
+++ b/integration-tests/gradle/src/main/resources/build-configuration/with-build-configuration/build.gradle
@@ -1,0 +1,44 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+quarkus {
+    properties {
+        set("package.type", "uber-jar")
+        set("package.output-directory", "build-gradle-output-dir")
+    }
+}
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/build-configuration/with-build-configuration/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/build-configuration/with-build-configuration/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id "${quarkusPluginId}" version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='with-build-configuration'

--- a/integration-tests/gradle/src/main/resources/build-configuration/with-build-configuration/src/main/java/org/acme/ExampleResource.java
+++ b/integration-tests/gradle/src/main/resources/build-configuration/with-build-configuration/src/main/java/org/acme/ExampleResource.java
@@ -1,0 +1,19 @@
+package org.acme;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/hello")
+public class ExampleResource {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+
+}

--- a/integration-tests/gradle/src/main/resources/build-configuration/with-build-configuration/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/build-configuration/with-build-configuration/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+# Configuration file
+# key = value
+my-app-name=${quarkus.application.name}

--- a/integration-tests/gradle/src/main/resources/build-configuration/with-build-configuration/src/test/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/build-configuration/with-build-configuration/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+# Configuration file
+# key = value
+example.message=Hello from Test
+test-only=Test only

--- a/integration-tests/gradle/src/main/resources/build-configuration/without-configuration/build.gradle
+++ b/integration-tests/gradle/src/main/resources/build-configuration/without-configuration/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}
+
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/build-configuration/without-configuration/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/build-configuration/without-configuration/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id "${quarkusPluginId}" version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='with-application-properties'

--- a/integration-tests/gradle/src/main/resources/build-configuration/without-configuration/src/main/java/org/acme/ExampleResource.java
+++ b/integration-tests/gradle/src/main/resources/build-configuration/without-configuration/src/main/java/org/acme/ExampleResource.java
@@ -1,0 +1,19 @@
+package org.acme;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/hello")
+public class ExampleResource {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+
+}

--- a/integration-tests/gradle/src/main/resources/build-configuration/without-configuration/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/build-configuration/without-configuration/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+# Configuration file
+# key = value
+my-app-name=${quarkus.application.name}

--- a/integration-tests/gradle/src/main/resources/build-configuration/without-configuration/src/test/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/build-configuration/without-configuration/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+# Configuration file
+# key = value
+example.message=Hello from Test
+test-only=Test only

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/BuildConfigurationTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/BuildConfigurationTest.java
@@ -1,0 +1,108 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public class BuildConfigurationTest extends QuarkusGradleWrapperTestBase {
+
+    private static final String WITHOUT_CONFIGURATION_PROJECT_NAME = "without-configuration";
+
+    private static final String ROOT_PROJECT_NAME = "build-configuration";
+
+    private static final String BUILD_GRADLE_PROJECT_NAME = "with-build-configuration";
+
+    private static final String BUILD_GRADLE_OUTPUT_DIR = "build-gradle-output-dir";
+
+    private static final String BUILD_GRADLE_UBER_JAR_FILE = "with-build-configuration-1.0.0-SNAPSHOT-runner.jar";
+
+    private static final String APPLICATION_PROPERTIES_PROJECT_NAME = "with-application-properties";
+
+    private static final String APPLICATION_PROPERTIES_OUTPUT_DIR = "application-properties-output-dir";
+    private static final String APPLICATION_PROPERTIES_UBER_JAR_FILE = "with-application-properties-1.0.0-SNAPSHOT-runner.jar";
+
+    @Test
+    public void buildUseApplicationPropertiesUberJar() throws IOException, InterruptedException, URISyntaxException {
+        final File projectDir = getProjectDir(ROOT_PROJECT_NAME);
+        runGradleWrapper(projectDir, "clean", "quarkusBuild");
+        final Path projectPath = projectDir.toPath();
+        final Path buildDirPath = projectPath.resolve(APPLICATION_PROPERTIES_PROJECT_NAME).resolve("build");
+        assertThat(buildDirPath.resolve(APPLICATION_PROPERTIES_OUTPUT_DIR)).exists();
+        final Path quarkusAppPath = buildDirPath.resolve(APPLICATION_PROPERTIES_OUTPUT_DIR);
+        final Path jar = quarkusAppPath.resolve(APPLICATION_PROPERTIES_UBER_JAR_FILE);
+        assertThat(jar).exists();
+    }
+
+    @Test
+    public void applicationPropertiesWithDPropsFastJar()
+            throws IOException, InterruptedException, URISyntaxException {
+        final File projectDir = getProjectDir(ROOT_PROJECT_NAME);
+        runGradleWrapper(projectDir, "clean", "quarkusBuild", "-Dquarkus.package.type=fast-jar");
+        final Path projectPath = projectDir.toPath();
+        final Path buildDirPath = projectPath.resolve(APPLICATION_PROPERTIES_PROJECT_NAME).resolve("build");
+        assertThat(buildDirPath.resolve(APPLICATION_PROPERTIES_OUTPUT_DIR)).exists();
+        final Path quarkusAppPath = buildDirPath.resolve(APPLICATION_PROPERTIES_OUTPUT_DIR);
+        assertThat(quarkusAppPath.resolve("quarkus-run.jar")).exists();
+        assertThat(quarkusAppPath.resolve(APPLICATION_PROPERTIES_UBER_JAR_FILE)).doesNotExist();
+        final Path deploymentDirPath = quarkusAppPath.resolve("lib").resolve("deployment");
+        assertThat(deploymentDirPath).doesNotExist();
+    }
+
+    @Test
+    public void applicationPropertiesWithDPropsUnmutableJar()
+            throws IOException, InterruptedException, URISyntaxException {
+        final File projectDir = getProjectDir(ROOT_PROJECT_NAME);
+        runGradleWrapper(projectDir, "clean", "quarkusBuild", "-Dquarkus.package.type=mutable-jar");
+        final Path projectPath = projectDir.toPath();
+        final Path buildDirPath = projectPath.resolve(APPLICATION_PROPERTIES_PROJECT_NAME).resolve("build");
+        assertThat(buildDirPath.resolve(APPLICATION_PROPERTIES_OUTPUT_DIR)).exists();
+        final Path quarkusAppPath = buildDirPath.resolve(APPLICATION_PROPERTIES_OUTPUT_DIR);
+        assertThat(quarkusAppPath.resolve("quarkus-run.jar")).exists();
+        assertThat(quarkusAppPath.resolve(APPLICATION_PROPERTIES_UBER_JAR_FILE)).doesNotExist();
+        final Path deploymentDirPath = quarkusAppPath.resolve("lib").resolve("deployment");
+        assertThat(deploymentDirPath).exists();
+    }
+
+    @Test
+    public void buildConfigUberJar() throws IOException, URISyntaxException, InterruptedException {
+        final File projectDir = getProjectDir(ROOT_PROJECT_NAME);
+        runGradleWrapper(projectDir, "clean", "quarkusBuild");
+        final Path projectPath = projectDir.toPath();
+        final Path buildDirPath = projectPath.resolve(BUILD_GRADLE_PROJECT_NAME).resolve("build");
+        assertThat(buildDirPath.resolve(BUILD_GRADLE_OUTPUT_DIR)).exists();
+        final Path quarkusAppPath = buildDirPath.resolve(BUILD_GRADLE_OUTPUT_DIR);
+        final Path jar = quarkusAppPath.resolve(BUILD_GRADLE_UBER_JAR_FILE);
+        assertThat(jar).exists();
+    }
+
+    @Test
+    public void buildConfigFastJarOverride() throws IOException, URISyntaxException, InterruptedException {
+        final File projectDir = getProjectDir(ROOT_PROJECT_NAME);
+        runGradleWrapper(projectDir, "clean", "quarkusBuild", "-Dquarkus.package.type=fast-jar");
+        final Path projectPath = projectDir.toPath();
+        final Path buildDirPath = projectPath.resolve(BUILD_GRADLE_PROJECT_NAME).resolve("build");
+        assertThat(buildDirPath.resolve(BUILD_GRADLE_OUTPUT_DIR)).exists();
+        final Path quarkusAppPath = buildDirPath.resolve(BUILD_GRADLE_OUTPUT_DIR);
+        assertThat(quarkusAppPath.resolve("quarkus-run.jar")).exists();
+        assertThat(quarkusAppPath.resolve(BUILD_GRADLE_UBER_JAR_FILE)).doesNotExist();
+        final Path deploymentDirPath = quarkusAppPath.resolve("lib").resolve("deployment");
+        assertThat(deploymentDirPath).doesNotExist();
+    }
+
+    @Test
+    public void withoutConfigurationBuildsDefaults() throws IOException, InterruptedException, URISyntaxException {
+        final File projectDir = getProjectDir(ROOT_PROJECT_NAME);
+        runGradleWrapper(projectDir, "clean", "quarkusBuild");
+        final Path projectPath = projectDir.toPath();
+        final Path buildDirPath = projectPath.resolve(WITHOUT_CONFIGURATION_PROJECT_NAME).resolve("build");
+        assertThat(buildDirPath.resolve("quarkus-app")).exists();
+        final Path quarkusAppPath = buildDirPath.resolve("quarkus-app");
+        final Path jar = quarkusAppPath.resolve("quarkus-run.jar");
+        assertThat(jar).exists();
+    }
+}


### PR DESCRIPTION
* Import properties defined in the `build.gradle` file using the syntax described below
* Replace the hard-coded output location if a `quarkus.package.output-directory` value is passed through configuration

`build.gradle` quarkus property definition:
```groovy
quarkus {
    properties {
        set("package.type", "uber-jar")
        set("package.output-directory", "build-gradle-output-dir")
    }
}
```

Closes #28897
Closes #28896 