### PR TITLE
Pass missing properties to Hibernate Reactive startup

### DIFF
--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -310,6 +310,13 @@ public final class HibernateReactiveProcessor {
                 String.valueOf(persistenceUnitConfig.query.inClauseParameterPadding));
 
         // JDBC
+        persistenceUnitConfig.jdbc.timezone.ifPresent(
+                timezone -> desc.getProperties().setProperty(AvailableSettings.JDBC_TIME_ZONE, timezone));
+
+        persistenceUnitConfig.jdbc.statementFetchSize.ifPresent(
+                fetchSize -> desc.getProperties().setProperty(AvailableSettings.STATEMENT_FETCH_SIZE,
+                        String.valueOf(fetchSize)));
+
         persistenceUnitConfig.jdbc.statementBatchSize.ifPresent(
                 statementBatchSize -> desc.getProperties().setProperty(AvailableSettings.STATEMENT_BATCH_SIZE,
                         String.valueOf(statementBatchSize)));


### PR DESCRIPTION
Fixes #29956

@DavideD I'm not sure if this is enough to actually fix the issue given they are properties that are supposed to be passed to the JDBC driver so I have no idea if you try to pass them to the reactive driver.

So feel free to close if it's useless.