### PR TITLE
Fix erroneous resource matching in RESTEasy Reactive

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
@@ -116,8 +116,11 @@ public class RequestMapper<T> {
             boolean doPrefixMatch = false;
             if (!fullMatch) {
                 //according to the spec every template ends with (/.*)?
-                doPrefixMatch = (matchPos == 1 || path.charAt(matchPos) == '/') //matchPos == 1 corresponds to '/' as a root level match
-                        && (prefixAllowed || matchPos == pathLength - 1); //if prefix is allowed, or the remainder is only a trailing /
+                if (matchPos == 1) { //matchPos == 1 corresponds to '/' as a root level match
+                    doPrefixMatch = prefixAllowed || pathLength == 1; //if prefix is allowed, or we've matched the whole thing
+                } else if (path.charAt(matchPos) == '/') {
+                    doPrefixMatch = prefixAllowed || matchPos == pathLength - 1; //if prefix is allowed, or the remainder is only a trailing /
+                }
             }
             if (fullMatch || doPrefixMatch) {
                 String remaining;

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/EndingSlashTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/EndingSlashTest.java
@@ -39,6 +39,14 @@ public class EndingSlashTest {
                 .then()
                 .statusCode(200)
                 .body(equalTo("Hello World!"));
+
+        get("/hello/world/1")
+                .then()
+                .statusCode(404);
+
+        get("/hello/world/22")
+                .then()
+                .statusCode(404);
     }
 
     @Path("/hello")


### PR DESCRIPTION
The behavior is now the same as RESTEasy Classic

Fixes: #29983