### PR TITLE
Change quarkus-cache config phase from BUILD_TIME to RUN_TIME

### DIFF
--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheDeploymentConstants.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheDeploymentConstants.java
@@ -44,9 +44,6 @@ public class CacheDeploymentConstants {
     // Annotations parameters.
     public static final String CACHE_NAME_PARAM = "cacheName";
 
-    // Caffeine.
-    public static final String CAFFEINE_CACHE_TYPE = "caffeine";
-
     private static DotName dotName(Class<?> annotationClass) {
         return DotName.createSimple(annotationClass.getName());
     }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheConfig.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheConfig.java
@@ -1,4 +1,6 @@
-package io.quarkus.cache.deployment;
+package io.quarkus.cache.runtime;
+
+import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
 
 import java.time.Duration;
 import java.util.Map;
@@ -11,8 +13,10 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot
+@ConfigRoot(phase = RUN_TIME)
 public class CacheConfig {
+
+    public static final String CAFFEINE_CACHE_TYPE = "caffeine";
 
     /**
      * Whether or not the cache extension is enabled.
@@ -23,13 +27,14 @@ public class CacheConfig {
     /**
      * Cache type.
      */
-    @ConfigItem(defaultValue = CacheDeploymentConstants.CAFFEINE_CACHE_TYPE)
-    String type;
+    @ConfigItem(defaultValue = CAFFEINE_CACHE_TYPE)
+    public String type;
 
     /**
      * Caffeine configuration.
      */
-    CaffeineConfig caffeine;
+    @ConfigItem
+    public CaffeineConfig caffeine;
 
     @ConfigGroup
     public static class CaffeineConfig {
@@ -39,7 +44,7 @@ public class CacheConfig {
          */
         @ConfigItem(name = ConfigItem.PARENT)
         @ConfigDocMapKey("cache-name")
-        Map<String, CaffeineNamespaceConfig> namespace;
+        public Map<String, CaffeineNamespaceConfig> namespace;
 
         @ConfigGroup
         public static class CaffeineNamespaceConfig {
@@ -49,7 +54,7 @@ public class CacheConfig {
              * avoids the need for expensive resizing operations later, but setting this value unnecessarily high wastes memory.
              */
             @ConfigItem
-            OptionalInt initialCapacity;
+            public OptionalInt initialCapacity;
 
             /**
              * Maximum number of entries the cache may contain. Note that the cache <b>may evict an entry before this limit is
@@ -58,27 +63,28 @@ public class CacheConfig {
              * it hasn't been used recently or very often.
              */
             @ConfigItem
-            OptionalLong maximumSize;
+            public OptionalLong maximumSize;
 
             /**
              * Specifies that each entry should be automatically removed from the cache once a fixed duration has elapsed after
              * the entry's creation, or the most recent replacement of its value.
              */
             @ConfigItem
-            Optional<Duration> expireAfterWrite;
+            public Optional<Duration> expireAfterWrite;
 
             /**
              * Specifies that each entry should be automatically removed from the cache once a fixed duration has elapsed after
              * the entry's creation, the most recent replacement of its value, or its last read.
              */
             @ConfigItem
-            Optional<Duration> expireAfterAccess;
+            public Optional<Duration> expireAfterAccess;
 
             /**
              * Whether or not metrics are recorded if the application depends on the Micrometer extension. Setting this
              * value to {@code true} will enable the accumulation of cache stats inside Caffeine.
              */
-            boolean metricsEnabled;
+            @ConfigItem
+            public boolean metricsEnabled;
         }
     }
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheManagerInitializer.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheManagerInitializer.java
@@ -1,17 +1,16 @@
 package io.quarkus.cache.runtime;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.Initialized;
 import javax.enterprise.event.Observes;
 
 import io.quarkus.cache.CacheManager;
+import io.quarkus.runtime.StartupEvent;
 
 /**
- * This class is used to eagerly create the {@link CacheManager} bean instance at STATIC_INIT execution time.
+ * This class is used to eagerly create the {@link CacheManager} bean instance at RUNTIME_INIT execution time.
  */
 public class CacheManagerInitializer {
 
-    private static void onStaticInit(@Observes @Initialized(ApplicationScoped.class) Object event, CacheManager cacheManager) {
+    private static void onStartup(@Observes StartupEvent event, CacheManager cacheManager) {
         cacheManager.getCacheNames();
     }
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheManagerRecorder.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/CacheManagerRecorder.java
@@ -1,0 +1,57 @@
+package io.quarkus.cache.runtime;
+
+import static io.quarkus.cache.runtime.CacheConfig.CAFFEINE_CACHE_TYPE;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.enterprise.inject.spi.DeploymentException;
+
+import io.quarkus.cache.CacheManager;
+import io.quarkus.cache.runtime.caffeine.CaffeineCacheManagerBuilder;
+import io.quarkus.cache.runtime.noop.NoOpCacheManagerBuilder;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class CacheManagerRecorder {
+
+    private final CacheConfig cacheConfig;
+
+    public CacheManagerRecorder(CacheConfig cacheConfig) {
+        this.cacheConfig = cacheConfig;
+    }
+
+    public Supplier<CacheManager> getCacheManagerSupplierWithMicrometerMetrics(Set<String> cacheNames) {
+        Supplier<Supplier<CacheManager>> caffeineCacheManagerSupplier = new Supplier<Supplier<CacheManager>>() {
+            @Override
+            public Supplier<CacheManager> get() {
+                return CaffeineCacheManagerBuilder.buildWithMicrometerMetrics(cacheNames, cacheConfig);
+            }
+        };
+        return getCacheManagerSupplier(cacheNames, caffeineCacheManagerSupplier);
+    }
+
+    public Supplier<CacheManager> getCacheManagerSupplierWithoutMetrics(Set<String> cacheNames) {
+        Supplier<Supplier<CacheManager>> caffeineCacheManagerSupplier = new Supplier<Supplier<CacheManager>>() {
+            @Override
+            public Supplier<CacheManager> get() {
+                return CaffeineCacheManagerBuilder.buildWithoutMetrics(cacheNames, cacheConfig);
+            }
+        };
+        return getCacheManagerSupplier(cacheNames, caffeineCacheManagerSupplier);
+    }
+
+    private Supplier<CacheManager> getCacheManagerSupplier(Set<String> cacheNames,
+            Supplier<Supplier<CacheManager>> caffeineCacheManagerSupplier) {
+        if (cacheConfig.enabled) {
+            switch (cacheConfig.type) {
+                case CAFFEINE_CACHE_TYPE:
+                    return caffeineCacheManagerSupplier.get();
+                default:
+                    throw new DeploymentException("Unknown cache type: " + cacheConfig.type);
+            }
+        } else {
+            return NoOpCacheManagerBuilder.build(cacheNames);
+        }
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheInfoBuilder.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheInfoBuilder.java
@@ -1,11 +1,11 @@
-package io.quarkus.cache.deployment;
+package io.quarkus.cache.runtime.caffeine;
 
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import io.quarkus.cache.deployment.CacheConfig.CaffeineConfig.CaffeineNamespaceConfig;
-import io.quarkus.cache.runtime.caffeine.CaffeineCacheInfo;
+import io.quarkus.cache.runtime.CacheConfig;
+import io.quarkus.cache.runtime.CacheConfig.CaffeineConfig.CaffeineNamespaceConfig;
 
 public class CaffeineCacheInfoBuilder {
 

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheManagerBuilder.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheManagerBuilder.java
@@ -3,7 +3,6 @@ package io.quarkus.cache.runtime.caffeine;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -11,18 +10,27 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.cache.Cache;
 import io.quarkus.cache.CacheManager;
+import io.quarkus.cache.runtime.CacheConfig;
 import io.quarkus.cache.runtime.CacheManagerImpl;
 import io.quarkus.cache.runtime.caffeine.metrics.MetricsInitializer;
-import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.cache.runtime.caffeine.metrics.MicrometerMetricsInitializer;
+import io.quarkus.cache.runtime.caffeine.metrics.NoOpMetricsInitializer;
 
-@Recorder
-public class CaffeineCacheBuildRecorder {
+public class CaffeineCacheManagerBuilder {
 
-    private static final Logger LOGGER = Logger.getLogger(CaffeineCacheBuildRecorder.class);
+    private static final Logger LOGGER = Logger.getLogger(CaffeineCacheManagerBuilder.class);
 
-    public Supplier<CacheManager> getCacheManagerSupplier(Set<CaffeineCacheInfo> cacheInfos,
+    public static Supplier<CacheManager> buildWithMicrometerMetrics(Set<String> cacheNames, CacheConfig cacheConfig) {
+        return build(cacheNames, cacheConfig, new MicrometerMetricsInitializer());
+    }
+
+    public static Supplier<CacheManager> buildWithoutMetrics(Set<String> cacheNames, CacheConfig cacheConfig) {
+        return build(cacheNames, cacheConfig, new NoOpMetricsInitializer());
+    }
+
+    private static Supplier<CacheManager> build(Set<String> cacheNames, CacheConfig cacheConfig,
             MetricsInitializer metricsInitializer) {
-        Objects.requireNonNull(cacheInfos);
+        Set<CaffeineCacheInfo> cacheInfos = CaffeineCacheInfoBuilder.build(cacheNames, cacheConfig);
         return new Supplier<CacheManager>() {
             @Override
             public CacheManager get() {

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/noop/NoOpCacheManagerBuilder.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/noop/NoOpCacheManagerBuilder.java
@@ -10,12 +10,10 @@ import java.util.function.Supplier;
 import io.quarkus.cache.Cache;
 import io.quarkus.cache.CacheManager;
 import io.quarkus.cache.runtime.CacheManagerImpl;
-import io.quarkus.runtime.annotations.Recorder;
 
-@Recorder
-public class NoOpCacheBuildRecorder {
+public class NoOpCacheManagerBuilder {
 
-    public Supplier<CacheManager> getCacheManagerSupplier(Set<String> cacheNames) {
+    public static Supplier<CacheManager> build(Set<String> cacheNames) {
         Objects.requireNonNull(cacheNames);
         return new Supplier<CacheManager>() {
             @Override


### PR DESCRIPTION
Fixes #29934.

This PR changes the entire `quarkus-cache` config phase from `BUILD_TIME` to `RUN_TIME`. To make that possible, I had to refactor the bytecode recording a bit and move its execution time from `STATIC_INIT` to `RUNTIME_INIT`.