### PR TITLE
Add reflection configuration for JDK provided LoginModules

### DIFF
--- a/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
+++ b/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
@@ -61,7 +61,11 @@ class ElytronSecurityLdapProcessor {
     }
 
     @BuildStep
-    ReflectiveClassBuildItem enableReflection() {
-        return new ReflectiveClassBuildItem(true, true, QuarkusDirContextFactory.INITIAL_CONTEXT_FACTORY);
+    void registerForReflection(BuildProducer<ReflectiveClassBuildItem> reflection) {
+        // All JDK provided InitialContextFactory impls via the module descriptors:
+        // com.sun.jndi.ldap.LdapCtxFactory, com.sun.jndi.dns.DnsContextFactory and com.sun.jndi.rmi.registry.RegistryContextFactory
+        reflection.produce(new ReflectiveClassBuildItem(true, true, QuarkusDirContextFactory.INITIAL_CONTEXT_FACTORY));
+        reflection.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jndi.dns.DnsContextFactory"));
+        reflection.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jndi.rmi.registry.RegistryContextFactory"));
     }
 }

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleNativeImage.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleNativeImage.java
@@ -25,7 +25,14 @@ public final class OracleNativeImage {
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, driverName));
 
         // for ldap style jdbc urls. e.g. jdbc:oracle:thin:@ldap://oid:5000/mydb1,cn=OracleContext,dc=myco,dc=com
+        //
+        // Note that all JDK provided InitialContextFactory impls from the JDK registered via module descriptors
+        // available at build time need to be reflectively accessible via ServiceLoader for runtime consistency.
+        // These are:
+        // com.sun.jndi.ldap.LdapCtxFactory, com.sun.jndi.dns.DnsContextFactory and com.sun.jndi.rmi.registry.RegistryContextFactory
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jndi.ldap.LdapCtxFactory"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jndi.dns.DnsContextFactory"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jndi.rmi.registry.RegistryContextFactory"));
     }
 
     @BuildStep

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -433,9 +433,23 @@ public class KafkaProcessor {
         for (ClassInfo loginModule : index.getIndex().getAllKnownImplementors(LOGIN_MODULE)) {
             reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, loginModule.name().toString()));
         }
+        // Kafka oauth login internally iterates over all ServiceLoader available LoginModule's
+        registerJDKLoginModules(reflectiveClass);
         for (ClassInfo authenticateCallbackHandler : index.getIndex().getAllKnownImplementors(AUTHENTICATE_CALLBACK_HANDLER)) {
             reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, authenticateCallbackHandler.name().toString()));
         }
+    }
+
+    private void registerJDKLoginModules(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+        // jdk.security.auth module provided LoginModule's
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.security.auth.module.Krb5LoginModule"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.security.auth.module.UnixLoginModule"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.security.auth.module.JndiLoginModule"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.security.auth.module.KeyStoreLoginModule"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.security.auth.module.LdapLoginModule"));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.security.auth.module.NTLoginModule"));
+        // java.management module provided LoginModule's
+        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jmx.remote.security.FileLoginModule"));
     }
 
     private static void collectImplementors(Set<DotName> set, CombinedIndexBuildItem indexBuildItem, Class<?> cls) {


### PR DESCRIPTION
Previous to https://github.com/oracle/graal/pull/5601 `java.util.ServiceLoader$ModuleServicesLookupIterator` would be substituted and unconditionally return `false`. As a result there is a difference in JVM behaviour and native. That has been rectified and is the reason why quarkus native integration tests started failing.

After https://github.com/oracle/graal/pull/5601 build and runtime behaviour needs to match and therefore requires reflective registrations of certain ServiceLoader provided implementations (declared via module descriptors).

Test run of graal master and quarkus native tests with this fix:
https://github.com/graalvm/mandrel/actions/runs/3752270963

Closes #30010