### PR TITLE
Make registrations of removed (in version 3) kafka classes optional

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -228,8 +228,10 @@ public class KafkaProcessor {
         collectImplementors(toRegister, indexBuildItem, Serializer.class);
         collectImplementors(toRegister, indexBuildItem, Deserializer.class);
         collectImplementors(toRegister, indexBuildItem, Partitioner.class);
-        // PartitionAssignor is now deprecated, replaced by ConsumerPartitionAssignor
-        collectImplementors(toRegister, indexBuildItem, PARTITION_ASSIGNER);
+        if (QuarkusClassLoader.isClassPresentAtRuntime(PARTITION_ASSIGNER.toString())) {
+            // PartitionAssignor is now deprecated, replaced by ConsumerPartitionAssignor
+            collectImplementors(toRegister, indexBuildItem, PARTITION_ASSIGNER);
+        }
         collectImplementors(toRegister, indexBuildItem, ConsumerPartitionAssignor.class);
         collectImplementors(toRegister, indexBuildItem, ConsumerInterceptor.class);
         collectImplementors(toRegister, indexBuildItem, ProducerInterceptor.class);


### PR DESCRIPTION
Co-authored-by: @essobedo

Fixes warnings appearing with https://github.com/quarkusio/quarkus/pull/29886