### PR TITLE
Update reflection registrations of vertx mail classes

### DIFF
--- a/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerProcessor.java
+++ b/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerProcessor.java
@@ -22,6 +22,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.mailer.MailTemplate;
 import io.quarkus.mailer.runtime.BlockingMailerImpl;
 import io.quarkus.mailer.runtime.MailBuildTimeConfig;
@@ -68,16 +69,15 @@ public class MailerProcessor {
     }
 
     @BuildStep
-    NativeImageConfigBuildItem registerAuthClass(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+    NativeImageConfigBuildItem registerAuthClass(CurateOutcomeBuildItem curateOutcomeBuildItem,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+
         // We must register the auth provider used by the Vert.x mail clients
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true,
-                "io.vertx.ext.mail.impl.sasl.AuthDigestMD5",
-                "io.vertx.ext.mail.impl.sasl.AuthCramSHA256",
-                "io.vertx.ext.mail.impl.sasl.AuthCramSHA1",
-                "io.vertx.ext.mail.impl.sasl.AuthCramMD5",
-                "io.vertx.ext.mail.impl.sasl.AuthDigestMD5",
-                "io.vertx.ext.mail.impl.sasl.AuthPlain",
-                "io.vertx.ext.mail.impl.sasl.AuthLogin"));
+                "io.vertx.ext.mail.impl.sasl.AuthCram",
+                "io.vertx.ext.mail.impl.sasl.AuthDigest",
+                "io.vertx.ext.mail.impl.sasl.AuthLogin",
+                "io.vertx.ext.mail.impl.sasl.AuthPlain"));
 
         // Register io.vertx.ext.mail.impl.sasl.NTLMEngineImpl to be initialized at runtime, it uses a static random.
         NativeImageConfigBuildItem.Builder builder = NativeImageConfigBuildItem.builder();


### PR DESCRIPTION
It looks like the version used is 4.3.6 (in which the available classes have changed) and we don't have to worry about other versions as the dependency is pulled due to the following dependency tree:

```
[INFO] +- io.quarkus:quarkus-mailer:jar:999-SNAPSHOT:compile
[INFO] |  +- io.quarkus:quarkus-vertx:jar:999-SNAPSHOT:compile
[INFO] |  |  ...
[INFO] |  \- io.smallrye.reactive:smallrye-mutiny-vertx-mail-client:jar:2.29.0:compile
[INFO] |     \- io.vertx:vertx-mail-client:jar:4.3.6:compile
```

@cescoffier WDYT? 
Do we still need to register these classes for reflection? It looks like they were not being registered for quiet a while without anyone noticing...

Co-authored-by: @essobedo

Fixes warnings appearing with #29886