### PR TITLE
Move log4j-api to correct quarkus module and add condition for jackson-module-jaxb-annotations registrations

### DIFF
--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchRestClientProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchRestClientProcessor.java
@@ -4,7 +4,6 @@ import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
 class ElasticsearchRestClientProcessor {
 
@@ -14,10 +13,4 @@ class ElasticsearchRestClientProcessor {
         extensionSslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(Feature.ELASTICSEARCH_REST_CLIENT_COMMON));
     }
 
-    @BuildStep
-    public ReflectiveClassBuildItem registerForReflection() {
-        return new ReflectiveClassBuildItem(true, true,
-                "org.apache.logging.log4j.message.ReusableMessageFactory",
-                "org.apache.logging.log4j.message.DefaultFlowMessageFactory");
-    }
 }

--- a/extensions/elasticsearch-rest-high-level-client/deployment/src/main/java/io/quarkus/elasticsearch/restclient/highlevel/deployment/ElasticsearchHighLevelClientProcessor.java
+++ b/extensions/elasticsearch-rest-high-level-client/deployment/src/main/java/io/quarkus/elasticsearch/restclient/highlevel/deployment/ElasticsearchHighLevelClientProcessor.java
@@ -4,6 +4,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.elasticsearch.restclient.highlevel.runtime.ElasticsearchRestHighLevelClientProducer;
 
 class ElasticsearchHighLevelClientProcessor {
@@ -16,6 +17,13 @@ class ElasticsearchHighLevelClientProcessor {
     @BuildStep()
     AdditionalBeanBuildItem build() {
         return AdditionalBeanBuildItem.unremovableOf(ElasticsearchRestHighLevelClientProducer.class);
+    }
+
+    @BuildStep
+    public ReflectiveClassBuildItem registerForReflection() {
+        return new ReflectiveClassBuildItem(true, false,
+                "org.apache.logging.log4j.message.ReusableMessageFactory",
+                "org.apache.logging.log4j.message.DefaultFlowMessageFactory");
     }
 
 }


### PR DESCRIPTION
log4j-api is a dependency of elasticsearch-rest-high-level-client

`log4j-api` is not always present when using the
elasticsearch-rest-client-common extension as it's not a dependency of
it. Instead, it is a dependency of elasticsearch-rest-high-level-client:

```
+- io.quarkus:quarkus-elasticsearch-rest-high-level-client:jar:999-SNAPSHOT:compile
|  +- ...
|  +- org.jboss.logmanager:log4j2-jboss-logmanager:jar:1.1.1.Final:compile
|  |  \- org.apache.logging.log4j:log4j-api:jar:2.19.0:compile
```

`com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector` is not
always present when using the quarkus-jackson extension as it's not a
dependency of it. Instead, it is a dependency of
quarkus-resteasy-jackson:

```
+- io.quarkus:quarkus-resteasy-jackson:jar:999-SNAPSHOT:compile
|  +- ...
|  +- org.jboss.resteasy:resteasy-jackson2-provider:jar:4.7.7.Final:compile
|  |  +- ...
|  |  +- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.14.1:compile
|  |  |  +- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.14.1:compile
|  |  |  \- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.14.1:compile
```

This results in failed attempts to register the class for reflection
when using the `quarkus-jackson` extension without
`jackson-module-jaxb-annotations` in the classpath.

Since we expect users to manually include the artifact in their
dependencies even when not using `quarkus-resteasy-jackson` we maintain
the registration in the `quarkus-jackson` extension but only perform it
when the artifact is present in the classpath.

cc @essobedo 

Fixes warnings appearing with https://github.com/quarkusio/quarkus/pull/29886