### PR TITLE
Shielding local context true -> true safe transition

### DIFF
--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/context/VertxContextSafetyToggle.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/context/VertxContextSafetyToggle.java
@@ -120,6 +120,10 @@ public final class VertxContextSafetyToggle {
             throw new IllegalStateException(
                     "Can't set the context safety flag: the current context is not a duplicated context");
         } else {
+            // save storm of true -> true transitions by shielding it
+            if (safe && context.getLocal(ACCESS_TOGGLE_KEY) == Boolean.TRUE) {
+                return;
+            }
             context.putLocal(ACCESS_TOGGLE_KEY, Boolean.valueOf(safe));
         }
     }


### PR DESCRIPTION
It happens frequently to call `VertxContextSafetyToggle.setContextSafe(context, true)` several times causing:
- G1 intergenerational barriers to be issued while (re)assigning `Boolean.TRUE` to the value entry's map of `ConcurrentHashMap` (see [CHM::put logic](https://github.com/openjdk/jdk/blob/536c9a512ea90d97a1ae5310453410d55db98bdd/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java#L1042) and https://shipilev.net/jvm/anatomy-quarks/13-intergenerational-barriers/ )
- `ConcurrentHashMap`'s put requires [synchronizing](https://github.com/openjdk/jdk/blob/536c9a512ea90d97a1ae5310453410d55db98bdd/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java#L1031) on the Entry each time

In addition, although the lock on the entry shouldn't be contended, the card mark table is still a shared data structure with gross granularity (if compared to the whole heap) and can cause false sharing due to "noisy neighbors" (ie values that keep on updating the same cards over and over) creating some scalability issue depending to the size of the cards (-> that's dependent by the size of the heap).

This should be saved by using appropriate `CHM` methods, but those methods eg `compute` requires creating capturing lambdas, hence the simplest sub-optimal solution is the one tried here: perform a lock-free CHM::get upfront on the special case we should like to shield ie true -> true transitions.

A downside of such approach (although the next flamegraphs taken from JDK 19, that has already deprecated Biased locks, won't show that) is that using the CHM within vertx ctx requires a `synchronized` access, always uncontended (AFAIK), but is a minor if compared to much more wasteful work happening in the hot path.