### PR TITLE
Allow configuring instanceId and instanceIdGenerator

### DIFF
--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -417,6 +417,27 @@ include::{includes}/devtools/build-native.adoc[]
 
 WARNING: It's the responsibility of the deployer to clear/remove the previous state, i.e. stale jobs and triggers. Moreover, the applications that form the "Quartz cluster" should be identical, otherwise an unpredictable result may occur.
 
+[[quartz-configure-instance-id]]
+== Configuring the Instance ID
+
+By default, the scheduler is configured with a simple instance ID generator using the machine hostname and the current timestamp, so you don't need to worry about setting a appropriate `instance-id` for each node when running in clustered mode. However, you can define a specific `instance-id` by yourself setting a configuration property reference or using other generators.
+
+[source,properties]
+----
+quarkus.quartz.instance-id=${HOST:AUTO} <1>
+----
+<1> This will expand the `HOST` environment variable and use `AUTO` as the default value if `HOST` is not set.
+
+The example below configure the generator `org.quartz.simpl.HostnameInstanceIdGenerator` named as `hostname`, so you can use its name as `instance-id` to be used. That generator uses just the machine hostname and can be appropriate in environments providing unique names for the nodes.
+
+[source,properties]
+----
+quarkus.quartz.instance-id=hostname
+quarkus.quartz.instance-id-generators.hostname.class=org.quartz.simpl.HostnameInstanceIdGenerator
+----
+
+WARNING: It's the responsibility of the deployer to define appropriate instance identifiers. Moreover, the applications that form the "Quartz cluster" should contain unique instance identifiers, otherwise an unpredictable result may occur. It's recommended to use an appropriate instance ID generator rather than specifying explicit identifiers.
+
 [[quartz-register-plugin-listeners]]
 == Registering Plugin and Listeners
 

--- a/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
+++ b/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
@@ -30,6 +30,7 @@ import org.quartz.impl.triggers.SimpleTriggerImpl;
 import org.quartz.simpl.CascadingClassLoadHelper;
 import org.quartz.simpl.SimpleInstanceIdGenerator;
 import org.quartz.simpl.SimpleThreadPool;
+import org.quartz.spi.InstanceIdGenerator;
 import org.quartz.spi.SchedulerPlugin;
 
 import io.quarkus.agroal.spi.JdbcDataSourceBuildItem;
@@ -170,6 +171,8 @@ public class QuartzProcessor {
                     .add(new ReflectiveClassBuildItem(true, false, QuarkusQuartzConnectionPoolProvider.class.getName()));
         }
 
+        reflectiveClasses
+                .addAll(getAdditionalConfigurationReflectiveClasses(config.instanceIdGenerators, InstanceIdGenerator.class));
         reflectiveClasses.addAll(getAdditionalConfigurationReflectiveClasses(config.triggerListeners, TriggerListener.class));
         reflectiveClasses.addAll(getAdditionalConfigurationReflectiveClasses(config.jobListeners, JobListener.class));
         reflectiveClasses.addAll(getAdditionalConfigurationReflectiveClasses(config.plugins, SchedulerPlugin.class));

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/ConfigureInstanceIdTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/ConfigureInstanceIdTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.quartz.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigureInstanceIdTest {
+
+    @Inject
+    Scheduler quartzScheduler;
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Jobs.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.quartz.instance-id=myInstanceId"),
+                            "application.properties"));
+
+    @Test
+    public void testSchedulerStarted() throws SchedulerException {
+        assertEquals("myInstanceId", quartzScheduler.getSchedulerInstanceId());
+    }
+
+    static class Jobs {
+        @Scheduled(every = "1s")
+        void checkEverySecond() {
+            // no op
+        }
+    }
+
+}

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzBuildTimeConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzBuildTimeConfig.java
@@ -69,6 +69,14 @@ public class QuartzBuildTimeConfig {
     public Optional<String> selectWithLockSql;
 
     /**
+     * Instance ID generators.
+     */
+    @ConfigItem
+    @ConfigDocMapKey("generator-name")
+    @ConfigDocSection
+    public Map<String, QuartzExtensionPointConfig> instanceIdGenerators;
+
+    /**
      * Trigger listeners.
      */
     @ConfigItem

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
@@ -20,6 +20,15 @@ public class QuartzRuntimeConfig {
     public String instanceName;
 
     /**
+     * The identifier of Quartz instance that must be unique for all schedulers working as if they are the same
+     * <em>logical</em> Scheduler within a cluster. Use the default value {@code AUTO} or some of the configured
+     * <a href="https://quarkus.io/guides/quartz#quarkus-quartz_quarkus.quartz.instance-id-generators-instance-id-generators">
+     * instance ID generators</a> if you wish the identifier to be generated for you.
+     */
+    @ConfigItem(defaultValue = "AUTO")
+    public String instanceId;
+
+    /**
      * The amount of time in milliseconds that a trigger is allowed to be acquired and fired ahead of its scheduled fire time.
      */
     @ConfigItem(defaultValue = "0")

--- a/integration-tests/quartz/src/main/java/io/quarkus/it/quartz/FixedInstanceIdGenerator.java
+++ b/integration-tests/quartz/src/main/java/io/quarkus/it/quartz/FixedInstanceIdGenerator.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.quartz;
+
+import org.quartz.SchedulerException;
+import org.quartz.spi.InstanceIdGenerator;
+
+public class FixedInstanceIdGenerator implements InstanceIdGenerator {
+
+    private String instanceId;
+
+    @Override
+    public String generateInstanceId() throws SchedulerException {
+        return instanceId;
+    }
+
+    public String getInstanceId() {
+        return this.instanceId;
+    }
+
+    public void setInstanceId(String instanceId) {
+        this.instanceId = instanceId;
+    }
+
+}

--- a/integration-tests/quartz/src/main/java/io/quarkus/it/quartz/FixedInstanceIdResource.java
+++ b/integration-tests/quartz/src/main/java/io/quarkus/it/quartz/FixedInstanceIdResource.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.quartz;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+@Path("/scheduler/instance-id")
+public class FixedInstanceIdResource {
+
+    @Inject
+    Scheduler quartzScheduler;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getInstanceId() throws SchedulerException {
+        return quartzScheduler.getSchedulerInstanceId();
+    }
+
+}

--- a/integration-tests/quartz/src/main/resources/application.properties
+++ b/integration-tests/quartz/src/main/resources/application.properties
@@ -15,6 +15,11 @@ quarkus.flyway.baseline-on-migrate=true
 quarkus.flyway.baseline-version=1.0
 quarkus.flyway.baseline-description=Quartz
 
+# Use a instance ID generator
+quarkus.quartz.instance-id=fixed
+quarkus.quartz.instance-id-generators.fixed.class=io.quarkus.it.quartz.FixedInstanceIdGenerator
+quarkus.quartz.instance-id-generators.fixed.properties.instanceId=myInstanceId
+
 # Register de LoggingJobHistoryPlugin for testing
 quarkus.quartz.plugins.jobHistory.class=org.quartz.plugins.history.LoggingJobHistoryPlugin
 quarkus.quartz.plugins.jobHistory.properties.jobSuccessMessage=Job [{1}.{0}] execution complete and reports: {8}

--- a/integration-tests/quartz/src/test/java/io/quarkus/it/quartz/QuartzTestCase.java
+++ b/integration-tests/quartz/src/test/java/io/quarkus/it/quartz/QuartzTestCase.java
@@ -28,6 +28,11 @@ public class QuartzTestCase {
         assertEmptyValueForDisabledMethod("/scheduler/disabled/every");
     }
 
+    @Test
+    public void testFixedInstanceIdGenerator() {
+        assertExpectedBodyString("/scheduler/instance-id", "myInstanceId");
+    }
+
     private void assertCounter(String counterPath) {
         Response response = given().when().get(counterPath);
         String body = response.asString();
@@ -39,9 +44,13 @@ public class QuartzTestCase {
     }
 
     private void assertEmptyValueForDisabledMethod(String path) {
+        assertExpectedBodyString(path, "");
+    }
+
+    private void assertExpectedBodyString(String path, String expectedBody) {
         Response response = given().when().get(path);
         String body = response.asString();
-        assertEquals("", body);
+        assertEquals(expectedBody, body);
         response
                 .then()
                 .statusCode(200);


### PR DESCRIPTION
When using Quartz extension in cluster mode and DB store, the name of active instances can be checked in the corresponding `scheduler_state` table. The default generator use the machine hostname and current timestamp in millis to closely ensure unique identifiers. But that generated ids can difficult pairing with the container id on the cluster orchestration tools.

Per [Quartz official documentation](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/configuration/ConfigMain.html#configure-main-scheduler-settings) the instance ID generator can be defined by setting:

**`org.quartz.scheduler.instanceId`**
Can be any string, but must be unique for all schedulers working as if they are the same _logical_ Scheduler within a cluster. You may use the value `AUTO` as the `instanceId` if you wish the Id to be generated for you. Or the value `SYS_PROP` if you want the value to come from the system property `org.quartz.scheduler.instanceId`.

**`org.quartz.scheduler.instanceIdGenerator.class`**
Only used if `org.quartz.scheduler.instanceId` is set to `AUTO`. Defaults to `org.quartz.simpl.SimpleInstanceIdGenerator`, which generates an instance id based upon hostname and timestamp. Other `InstanceIdGenerator` implementations include `SystemPropertyInstanceIdGenerator` (which gets the instance id from the system property `"org.quartz.scheduler.instanceId"`, and `HostnameInstanceIdGenerator` which uses the local hostname (`InetAddress.getLocalHost().getHostName()`). You can also implement the `InstanceIdGenerator` interface your self.

**`org.quartz.scheduler.instanceIdGenerator.<propName>`**
Not documented but allow setting any properties on the _instanceId_ generator.

Considering Quarkus/quartz does not expose these properties as configurable, would it be possible to expose the above configuration.

The proposed implementation will allow that `instanceId` generators can be configured instead of the default `SimpleInstanceIdGenerator` when `instanceId` is `AUTO`. The configuration `quarkus.quartz.instance-id` can specify the explicit identifier or some of the configured `instaceId` generators.

### Configuration examples

Use the expansion of `HOST` environment variable or its default `AUTO` if `HOST` is not set.

```properties
quarkus.quartz.instance-id=${HOST:AUTO}
```
Use the builtin `HostnameInstanceIdGenerator` that use the machine hostname as identifier.

```properties
quarkus.quartz.instance-id=hostname
quarkus.quartz.instance-id-generators.hostname.class=org.quartz.simpl.HostnameInstanceIdGenerator
```

Use the builtin `SystemPropertyInstanceIdGenerator` that use the system property `jvmNode` as identifier.

```properties
quarkus.quartz.instance-id=jvm-node-sysprop
quarkus.quartz.instance-id-generators.jvm-node-sysprop.class=org.quartz.simpl.SystemPropertyInstanceIdGenerator
quarkus.quartz.instance-id-generators.jvm-node-sysprop.properties.systemPropertyName=jvmNode
```

### Considerations

The property `instance-id` was created as runtime configuration and the `instance-id-generators` group was created as build time configuration. This allows configuring multiple _instanceId_ generators being included as reflective class and the selection of proper generator in runtime.
