### PR TITLE
Prevent repeated Quarkus Security exception handling that lead to duplicate headers during OIDC redirect

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/AuthenticationFailedExceptionHeaderTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/AuthenticationFailedExceptionHeaderTest.java
@@ -1,0 +1,100 @@
+package io.quarkus.resteasy.test.security;
+
+import static io.vertx.core.http.HttpHeaders.LOCATION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.security.identity.request.BaseAuthenticationRequest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+public class AuthenticationFailedExceptionHeaderTest {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.auth.permission.default.paths=/*\n" +
+            "quarkus.http.auth.permission.default.policy=authenticated";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties"));
+
+    @Test
+    public void testHeaders() {
+        // case-insensitive test that there is only one location header
+        // there has been duplicate location when both default auth failure handler and auth ex mapper send challenge
+        var response = RestAssured
+                .given()
+                .redirects()
+                .follow(false)
+                .when()
+                .get("/secured-route");
+        response.then().statusCode(302);
+        assertEquals(1, response.headers().asList().stream().map(Header::getName).map(String::toLowerCase)
+                .filter(LOCATION.toString()::equals).count());
+    }
+
+    @Path("/hello")
+    public static class HelloResource {
+        @GET
+        public String hello() {
+            return "hello";
+        }
+    }
+
+    @ApplicationScoped
+    public static class FailingAuthenticator implements HttpAuthenticationMechanism {
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
+            return Uni.createFrom().failure(new AuthenticationFailedException());
+        }
+
+        @Override
+        public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+            return Set.of(BaseAuthenticationRequest.class);
+        }
+
+        @Override
+        public Uni<ChallengeData> getChallenge(RoutingContext context) {
+            return Uni.createFrom().item(new ChallengeData(302, LOCATION, "http://localhost:8080/"));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class BasicIdentityProvider implements IdentityProvider<BaseAuthenticationRequest> {
+
+        @Override
+        public Class<BaseAuthenticationRequest> getRequestType() {
+            return BaseAuthenticationRequest.class;
+        }
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(
+                BaseAuthenticationRequest simpleAuthenticationRequest,
+                AuthenticationRequestContext authenticationRequestContext) {
+            return Uni.createFrom().nothing();
+        }
+    }
+}

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/AuthenticationRedirectExceptionHeaderTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/AuthenticationRedirectExceptionHeaderTest.java
@@ -1,0 +1,109 @@
+package io.quarkus.resteasy.test.security;
+
+import static io.vertx.core.http.HttpHeaders.CACHE_CONTROL;
+import static io.vertx.core.http.HttpHeaders.LOCATION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationRedirectException;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.security.identity.request.BaseAuthenticationRequest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.restassured.response.Response;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+public class AuthenticationRedirectExceptionHeaderTest {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.auth.permission.default.paths=/*\n" +
+            "quarkus.http.auth.permission.default.policy=authenticated";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties"));
+
+    @Test
+    public void testHeaders() {
+        // case-insensitive test that Pragma, cache-control and location headers are only present once
+        // there were duplicate headers when both default auth failure handler and auth ex mapper set headers
+        var response = RestAssured
+                .given()
+                .redirects()
+                .follow(false)
+                .when()
+                .get("/secured-route");
+        response.then().statusCode(302);
+        assertEquals(1, getHeaderCount(response, LOCATION.toString()));
+        assertEquals(1, getHeaderCount(response, CACHE_CONTROL.toString()));
+        assertEquals(1, getHeaderCount(response, "Pragma"));
+    }
+
+    private static int getHeaderCount(Response response, String headerName) {
+        headerName = headerName.toLowerCase();
+        return (int) response.headers().asList().stream().map(Header::getName).map(String::toLowerCase)
+                .filter(headerName::equals).count();
+    }
+
+    @Path("/hello")
+    public static class HelloResource {
+        @GET
+        public String hello() {
+            return "hello";
+        }
+    }
+
+    @ApplicationScoped
+    public static class RedirectingAuthenticator implements HttpAuthenticationMechanism {
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
+            return Uni.createFrom().failure(new AuthenticationRedirectException(302, "https://quarkus.io/"));
+        }
+
+        @Override
+        public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+            return Set.of(BaseAuthenticationRequest.class);
+        }
+
+        @Override
+        public Uni<ChallengeData> getChallenge(RoutingContext context) {
+            return Uni.createFrom().item(new ChallengeData(302, "header-name", "header-value"));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class BasicIdentityProvider implements IdentityProvider<BaseAuthenticationRequest> {
+
+        @Override
+        public Class<BaseAuthenticationRequest> getRequestType() {
+            return BaseAuthenticationRequest.class;
+        }
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(
+                BaseAuthenticationRequest simpleAuthenticationRequest,
+                AuthenticationRequestContext authenticationRequestContext) {
+            return Uni.createFrom().nothing();
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/AuthenticationFailedExceptionHeaderTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/AuthenticationFailedExceptionHeaderTest.java
@@ -1,0 +1,91 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static io.vertx.core.http.HttpHeaders.LOCATION;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.security.identity.request.BaseAuthenticationRequest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+public class AuthenticationFailedExceptionHeaderTest {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.auth.permission.default.paths=/*\n" +
+            "quarkus.http.auth.permission.default.policy=authenticated";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties"));
+
+    @Test
+    public void testHeaders() {
+        // case-insensitive test that there is only one location header
+        // there has been duplicate location when both default auth failure handler and auth ex mapper send challenge
+        var response = RestAssured
+                .given()
+                .redirects()
+                .follow(false)
+                .when()
+                .get("/secured-route");
+        response.then().statusCode(FOUND);
+        assertEquals(1, response.headers().asList().stream().map(Header::getName).map(String::toLowerCase)
+                .filter(LOCATION.toString()::equals).count());
+    }
+
+    @ApplicationScoped
+    public static class FailingAuthenticator implements HttpAuthenticationMechanism {
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
+            return Uni.createFrom().failure(new AuthenticationFailedException());
+        }
+
+        @Override
+        public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+            return Set.of(BaseAuthenticationRequest.class);
+        }
+
+        @Override
+        public Uni<ChallengeData> getChallenge(RoutingContext context) {
+            return Uni.createFrom().item(new ChallengeData(FOUND, LOCATION, "http://localhost:8080/"));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class BasicIdentityProvider implements IdentityProvider<BaseAuthenticationRequest> {
+
+        @Override
+        public Class<BaseAuthenticationRequest> getRequestType() {
+            return BaseAuthenticationRequest.class;
+        }
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(
+                BaseAuthenticationRequest simpleAuthenticationRequest,
+                AuthenticationRequestContext authenticationRequestContext) {
+            return Uni.createFrom().nothing();
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/AuthenticationRedirectExceptionHeaderTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/AuthenticationRedirectExceptionHeaderTest.java
@@ -1,0 +1,100 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static io.vertx.core.http.HttpHeaders.CACHE_CONTROL;
+import static io.vertx.core.http.HttpHeaders.LOCATION;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationRedirectException;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.security.identity.request.BaseAuthenticationRequest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.restassured.response.Response;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+public class AuthenticationRedirectExceptionHeaderTest {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.auth.permission.default.paths=/*\n" +
+            "quarkus.http.auth.permission.default.policy=authenticated";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties"));
+
+    @Test
+    public void testHeaders() {
+        // case-insensitive test that Pragma, cache-control and location headers are only present once
+        // there were duplicate headers when both default auth failure handler and auth ex mapper set headers
+        var response = RestAssured
+                .given()
+                .redirects()
+                .follow(false)
+                .when()
+                .get("/secured-route");
+        response.then().statusCode(FOUND);
+        assertEquals(1, getHeaderCount(response, LOCATION.toString()));
+        assertEquals(1, getHeaderCount(response, CACHE_CONTROL.toString()));
+        assertEquals(1, getHeaderCount(response, "Pragma"));
+    }
+
+    private static int getHeaderCount(Response response, String headerName) {
+        headerName = headerName.toLowerCase();
+        return (int) response.headers().asList().stream().map(Header::getName).map(String::toLowerCase)
+                .filter(headerName::equals).count();
+    }
+
+    @ApplicationScoped
+    public static class RedirectingAuthenticator implements HttpAuthenticationMechanism {
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
+            return Uni.createFrom().failure(new AuthenticationRedirectException(FOUND, "https://quarkus.io/"));
+        }
+
+        @Override
+        public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+            return Set.of(BaseAuthenticationRequest.class);
+        }
+
+        @Override
+        public Uni<ChallengeData> getChallenge(RoutingContext context) {
+            return Uni.createFrom().item(new ChallengeData(FOUND, "header-name", "header-value"));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class BasicIdentityProvider implements IdentityProvider<BaseAuthenticationRequest> {
+
+        @Override
+        public Class<BaseAuthenticationRequest> getRequestType() {
+            return BaseAuthenticationRequest.class;
+        }
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(
+                BaseAuthenticationRequest simpleAuthenticationRequest,
+                AuthenticationRequestContext authenticationRequestContext) {
+            return Uni.createFrom().nothing();
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -318,6 +318,9 @@ public class HttpSecurityRecorder {
 
         @Override
         public void accept(RoutingContext event, Throwable throwable) {
+            if (event.response().ended()) {
+                return;
+            }
             throwable = extractRootCause(throwable);
             //auth failed
             if (throwable instanceof AuthenticationFailedException) {


### PR DESCRIPTION
fixes: #30011

When proactive auth is enabled both default auth failure handler and builtin exception mappers were setting headers, which lead to duplicate headers that some browsers could not handle (Safari). Now repeated Quarkus Security exception handling is prevented as we only handle them (iff proactive = true) when custom exception mappers has been defined. There is no point running built in ex. mappers as they do exactly same as default auth failure handler had done.

I added tests that are independent on auth mechanism, but I checked fix with OIDC in both classic and reactive.