### PR TITLE
Do not close the managed ValidatorFactory

### DIFF
--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/ValidatorFactoryFromValidationTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/ValidatorFactoryFromValidationTest.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 import javax.validation.Validation;
 import javax.validation.ValidatorFactory;
 
+import org.hibernate.validator.HibernateValidatorFactory;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -23,9 +24,10 @@ public class ValidatorFactoryFromValidationTest {
             .create(JavaArchive.class));
 
     @Test
-    public void testOverrideConstraintValidatorConstraint() {
+    public void testValidatorFactoryManuallyCreatedIsManagedByQuarkus() {
         ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
-        assertThat(validatorFactoryFromInjection).isSameAs(validatorFactory);
+        // we need to unwrap here as we have a small wrapper around the manually created one
+        assertThat(validatorFactoryFromInjection).isSameAs(validatorFactory.unwrap(HibernateValidatorFactory.class));
     }
 
 }

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/CloseAsNoopValidatorFactoryWrapper.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/CloseAsNoopValidatorFactoryWrapper.java
@@ -1,0 +1,93 @@
+package io.quarkus.hibernate.validator.runtime;
+
+import java.time.Duration;
+
+import javax.validation.ClockProvider;
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.MessageInterpolator;
+import javax.validation.ParameterNameProvider;
+import javax.validation.TraversableResolver;
+import javax.validation.Validator;
+
+import org.hibernate.validator.HibernateValidatorContext;
+import org.hibernate.validator.HibernateValidatorFactory;
+import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
+import org.hibernate.validator.spi.properties.GetterPropertySelectionStrategy;
+import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
+
+/**
+ * Wrapper used to avoid closing the managed ValidatorFactory.
+ */
+class CloseAsNoopValidatorFactoryWrapper implements HibernateValidatorFactory {
+
+    private final HibernateValidatorFactory validatorFactory;
+
+    CloseAsNoopValidatorFactoryWrapper(HibernateValidatorFactory validatorFactory) {
+        this.validatorFactory = validatorFactory;
+    }
+
+    @Override
+    public void close() {
+        // do not close the wrapped ValidatorFactory as it is managed by Quarkus
+    }
+
+    @Override
+    public Validator getValidator() {
+        return validatorFactory.getValidator();
+    }
+
+    @Override
+    public MessageInterpolator getMessageInterpolator() {
+        return validatorFactory.getMessageInterpolator();
+    }
+
+    @Override
+    public TraversableResolver getTraversableResolver() {
+        return validatorFactory.getTraversableResolver();
+    }
+
+    @Override
+    public ConstraintValidatorFactory getConstraintValidatorFactory() {
+        return validatorFactory.getConstraintValidatorFactory();
+    }
+
+    @Override
+    public ParameterNameProvider getParameterNameProvider() {
+        return validatorFactory.getParameterNameProvider();
+    }
+
+    @Override
+    public ClockProvider getClockProvider() {
+        return validatorFactory.getClockProvider();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> type) {
+        return validatorFactory.unwrap(type);
+    }
+
+    @Override
+    public ScriptEvaluatorFactory getScriptEvaluatorFactory() {
+        return validatorFactory.getScriptEvaluatorFactory();
+    }
+
+    @Override
+    public Duration getTemporalValidationTolerance() {
+        return validatorFactory.getTemporalValidationTolerance();
+    }
+
+    @Override
+    public GetterPropertySelectionStrategy getGetterPropertySelectionStrategy() {
+        return validatorFactory.getGetterPropertySelectionStrategy();
+    }
+
+    @Override
+    public PropertyNodeNameProvider getPropertyNodeNameProvider() {
+        return validatorFactory.getPropertyNodeNameProvider();
+    }
+
+    @Override
+    public HibernateValidatorContext usingContext() {
+        return validatorFactory.usingContext();
+    }
+}

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
@@ -14,6 +14,7 @@ import javax.validation.Validation;
 import javax.validation.ValidatorFactory;
 import javax.validation.valueextraction.ValueExtractor;
 
+import org.hibernate.validator.HibernateValidatorFactory;
 import org.hibernate.validator.PredefinedScopeHibernateValidator;
 import org.hibernate.validator.PredefinedScopeHibernateValidatorConfiguration;
 import org.hibernate.validator.internal.engine.resolver.JPATraversableResolver;
@@ -160,7 +161,7 @@ public class HibernateValidatorRecorder {
                 }
 
                 ValidatorFactory validatorFactory = configuration.buildValidatorFactory();
-                ValidatorHolder.initialize(validatorFactory);
+                ValidatorHolder.initialize(validatorFactory.unwrap(HibernateValidatorFactory.class));
 
                 // Close the ValidatorFactory on shutdown
                 shutdownContext.addShutdownTask(new Runnable() {

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/ValidationSupport.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/ValidationSupport.java
@@ -3,6 +3,8 @@ package io.quarkus.hibernate.validator.runtime;
 import javax.validation.Validation;
 import javax.validation.ValidatorFactory;
 
+import org.hibernate.validator.HibernateValidatorFactory;
+
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
@@ -12,19 +14,18 @@ public final class ValidationSupport {
     private ValidationSupport() {
     }
 
-    @SuppressWarnings("unused")
     public static ValidatorFactory buildDefaultValidatorFactory() {
         ArcContainer container = Arc.container();
         if (container == null) {
             return fallback();
         }
 
-        InstanceHandle<ValidatorFactory> instance = container.instance(ValidatorFactory.class);
+        InstanceHandle<HibernateValidatorFactory> instance = container.instance(HibernateValidatorFactory.class);
         if (!instance.isAvailable()) {
             return fallback();
         }
 
-        return instance.get();
+        return new CloseAsNoopValidatorFactoryWrapper(instance.get());
     }
 
     // the point of having this is to support non-Quarkus tests that could be using Hibernate Validator

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/ValidatorHolder.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/ValidatorHolder.java
@@ -1,20 +1,21 @@
 package io.quarkus.hibernate.validator.runtime;
 
 import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+
+import org.hibernate.validator.HibernateValidatorFactory;
 
 public class ValidatorHolder {
 
-    private static ValidatorFactory validatorFactory;
+    private static HibernateValidatorFactory validatorFactory;
 
     private static Validator validator;
 
-    static void initialize(ValidatorFactory validatorFactory) {
+    static void initialize(HibernateValidatorFactory validatorFactory) {
         ValidatorHolder.validatorFactory = validatorFactory;
         ValidatorHolder.validator = validatorFactory.getValidator();
     }
 
-    static ValidatorFactory getValidatorFactory() {
+    static HibernateValidatorFactory getValidatorFactory() {
         return validatorFactory;
     }
 

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/ValidatorProvider.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/ValidatorProvider.java
@@ -4,7 +4,8 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+
+import org.hibernate.validator.HibernateValidatorFactory;
 
 @Singleton
 public class ValidatorProvider {
@@ -12,7 +13,7 @@ public class ValidatorProvider {
     @Produces
     @Named("quarkus-hibernate-validator-factory")
     @Singleton
-    public ValidatorFactory factory() {
+    public HibernateValidatorFactory factory() {
         return ValidatorHolder.getValidatorFactory();
     }
 


### PR DESCRIPTION
When creating ValidatorFactory manually, we now returns the Quarkus-managed instance. We need to be careful not to close it, thus why we now wrap it to make close() a noop.

Fix #29965