### PR TITLE
Register properly OpenApiConfigMapping at runtime

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -67,6 +67,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigBuilderBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -93,6 +94,7 @@ import io.quarkus.smallrye.openapi.runtime.OpenApiConstants;
 import io.quarkus.smallrye.openapi.runtime.OpenApiDocumentService;
 import io.quarkus.smallrye.openapi.runtime.OpenApiRecorder;
 import io.quarkus.smallrye.openapi.runtime.OpenApiRuntimeConfig;
+import io.quarkus.smallrye.openapi.runtime.RuntimeOnlyBuilder;
 import io.quarkus.smallrye.openapi.runtime.filter.AutoBasicSecurityFilter;
 import io.quarkus.smallrye.openapi.runtime.filter.AutoBearerTokenSecurityFilter;
 import io.quarkus.smallrye.openapi.runtime.filter.AutoUrl;
@@ -173,9 +175,13 @@ public class SmallRyeOpenApiProcessor {
 
     @BuildStep
     void registerNativeImageResources(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
-        // To map from smallrye and mp config to quarkus
-        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(OpenApiConfigMapping.class.getName()));
         serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(OASFactoryResolver.class.getName()));
+    }
+
+    @BuildStep
+    void runtimeOnly(BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
+        // To map from smallrye and mp config to quarkus
+        runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(RuntimeOnlyBuilder.class.getName()));
     }
 
     @BuildStep

--- a/extensions/smallrye-openapi/deployment/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/extensions/smallrye-openapi/deployment/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -1,1 +1,1 @@
-io.quarkus.smallrye.openapi.deployment.OpenApiConfigMapping
+io.quarkus.smallrye.openapi.runtime.OpenApiConfigMapping

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiConfigMapping.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiConfigMapping.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.openapi.deployment;
+package io.quarkus.smallrye.openapi.runtime;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/RuntimeOnlyBuilder.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/RuntimeOnlyBuilder.java
@@ -1,0 +1,11 @@
+package io.quarkus.smallrye.openapi.runtime;
+
+import io.quarkus.runtime.configuration.ConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+public final class RuntimeOnlyBuilder implements ConfigBuilder {
+    @Override
+    public SmallRyeConfigBuilder configBuilder(final SmallRyeConfigBuilder builder) {
+        return builder.withInterceptors(new OpenApiConfigMapping());
+    }
+}


### PR DESCRIPTION
## Motivation

While working on https://github.com/quarkusio/quarkus/pull/29886, we realized that `OpenApiConfigMapping` was located in the deployment module instead of runtime which prevented the mapping to work.

## Modifications:

* Move `OpenApiConfigMapping` from deployment to runtime
* Register `OpenApiConfigMapping` using `ConfigBuilder` instead of relying on the `ServiceLoader` for more flexibility

## Result

The mapping defined in `OpenApiConfigMapping` is properly taken into account.

cc @zakkak @radcortez
