### PR TITLE
Bump smallrye-jwt version to 3.6.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -50,7 +50,7 @@
         <smallrye-graphql.version>1.9.0</smallrye-graphql.version>
         <smallrye-opentracing.version>2.1.1</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.6.0</smallrye-fault-tolerance.version>
-        <smallrye-jwt.version>3.5.4</smallrye-jwt.version>
+        <smallrye-jwt.version>3.6.0</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.2.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>2.7.0</smallrye-reactive-types-converter.version>


### PR DESCRIPTION
This PR bumps the version, with Quarkus Java17 users will now be able to start signing/encrypting JWT tokens with the EDDSA algorithms courtesy of Jose4j. (Interoperable with Nimbus JWT, etc) and follow the lead of GitHub for ex.

There are a few resources around but this one captures it quite well:
https://curity.io/resources/learn/jwt-signatures/#eddsa-vs-rsa-and-ecdsa

I've added tests to smallrye-jwt, but since they won't work on Java 11 I thought I'd avoid java version dependent tests in Quarkus as well.