### PR TITLE
Feature/OTEL JAX-RS (Resteasy) Span Code function

### DIFF
--- a/extensions/opentelemetry/deployment/pom.xml
+++ b/extensions/opentelemetry/deployment/pom.xml
@@ -45,6 +45,14 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc-common-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-common-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-spi-deployment</artifactId>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryHttpCDILegacyTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryHttpCDILegacyTest.java
@@ -3,6 +3,7 @@ package io.quarkus.opentelemetry.deployment;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.quarkus.opentelemetry.deployment.common.TestSpanExporter.getSpanByKindAndParentId;
+import static io.quarkus.opentelemetry.deployment.common.TestUtil.assertStringAttribute;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,7 +23,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.opentelemetry.extension.annotations.WithSpan;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import io.quarkus.opentelemetry.deployment.common.TestSpanExporter;
+import io.quarkus.opentelemetry.deployment.common.TestUtil;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
@@ -31,6 +34,7 @@ public class OpenTelemetryHttpCDILegacyTest {
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .setArchiveProducer(
                     () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClass(TestUtil.class)
                             .addClass(HelloResource.class)
                             .addClass(HelloBean.class)
                             .addClass(TestSpanExporter.class));
@@ -55,6 +59,10 @@ public class OpenTelemetryHttpCDILegacyTest {
         SpanData server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
         assertEquals("/hello", server.getName());
         assertEquals(SERVER, server.getKind());
+        // verify that OpenTelemetryServerFilter took place
+        assertStringAttribute(server, SemanticAttributes.CODE_NAMESPACE,
+                "io.quarkus.opentelemetry.deployment.OpenTelemetryHttpCDILegacyTest$HelloResource");
+        assertStringAttribute(server, SemanticAttributes.CODE_FUNCTION, "hello");
 
         SpanData internal = getSpanByKindAndParentId(spans, INTERNAL, server.getSpanId());
         assertEquals("HelloBean.hello", internal.getName());

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/TestUtil.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/common/TestUtil.java
@@ -1,15 +1,19 @@
 package io.quarkus.opentelemetry.deployment.common;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.quarkus.arc.Unremovable;
 
@@ -59,5 +63,9 @@ public final class TestUtil {
         Field privatePropagatorsField = textMapPropagator.getClass().getDeclaredField("textMapPropagators");
         privatePropagatorsField.setAccessible(true);
         return (TextMapPropagator[]) privatePropagatorsField.get(textMapPropagator);
+    }
+
+    public static void assertStringAttribute(SpanData spanData, AttributeKey<String> attributeKey, String expectedValue) {
+        assertEquals(expectedValue, spanData.getAttributes().get(attributeKey), "Attribute Key Named:" + attributeKey.getKey());
     }
 }

--- a/extensions/opentelemetry/runtime/pom.xml
+++ b/extensions/opentelemetry/runtime/pom.xml
@@ -35,6 +35,11 @@
             <artifactId>smallrye-common-vertx-context</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus.resteasy.reactive</groupId>
+            <artifactId>resteasy-reactive</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
             <scope>provided</scope>

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/resteasy/OpenTelemetryClassicServerFilter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/resteasy/OpenTelemetryClassicServerFilter.java
@@ -1,0 +1,31 @@
+package io.quarkus.opentelemetry.runtime.tracing.intrumentation.resteasy;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.ext.Provider;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.instrumentation.api.instrumenter.LocalRootSpan;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+
+/**
+ * Handles RESTEasy Classic
+ */
+@Provider
+public class OpenTelemetryClassicServerFilter implements ContainerRequestFilter {
+
+    @Context
+    ResourceInfo resourceInfo;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        Span localRootSpan = LocalRootSpan.current();
+
+        localRootSpan.setAttribute(SemanticAttributes.CODE_NAMESPACE, resourceInfo.getResourceClass().getName());
+        localRootSpan.setAttribute(SemanticAttributes.CODE_FUNCTION, resourceInfo.getResourceMethod().getName());
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/resteasy/OpenTelemetryReactiveServerFilter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/resteasy/OpenTelemetryReactiveServerFilter.java
@@ -1,0 +1,32 @@
+package io.quarkus.opentelemetry.runtime.tracing.intrumentation.resteasy;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.server.SimpleResourceInfo;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.instrumentation.api.instrumenter.LocalRootSpan;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+
+/**
+ * Handles RESTEasy Reactive (via Vert.x)
+ */
+@Provider
+public class OpenTelemetryReactiveServerFilter implements ContainerRequestFilter {
+
+    @Context
+    SimpleResourceInfo resourceInfo;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        Span localRootSpan = LocalRootSpan.current();
+
+        localRootSpan.setAttribute(SemanticAttributes.CODE_NAMESPACE, resourceInfo.getResourceClass().getName());
+        localRootSpan.setAttribute(SemanticAttributes.CODE_FUNCTION, resourceInfo.getMethodName());
+    }
+}


### PR DESCRIPTION
Add the [standard attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#source-code-attributes) `code.function` and `code.namespace` to [Local Root Span](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/LocalRootSpan.java) using JAX-RS filter

this PR is proposed based on [this extension discussion](https://github.com/quarkusio/quarkus/issues/29864#issuecomment-1352608138)

replacing PR #29939