### PR TITLE
Provide option to restrict X-Forwarded-* headers to configured proxy addresses

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -407,7 +407,9 @@ quarkus.http.proxy.proxy-address-forwarding=true
 quarkus.http.proxy.allow-x-forwarded=true
 quarkus.http.proxy.enable-forwarded-host=true
 quarkus.http.proxy.enable-forwarded-prefix=true
+quarkus.http.proxy.trusted-proxies=127.0.0.1 <1>
 ----
+<1> Configure trusted proxy with the IP address `127.0.0.1`. Request headers from any other address are going to be ignored.
 
 Both configurations related to standard and non-standard headers can be combined, although the standard headers configuration will have precedence. However, combining them has security implications as clients can forge requests with a forwarded header that is not overwritten by the proxy. Therefore, proxies should strip unexpected `X-Forwarded` or `X-Forwarded-*` headers from the client.
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedHandlerInitializer.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/ForwardedHandlerInitializer.java
@@ -7,7 +7,7 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.Router;
 
 @ApplicationScoped
-class ForwardedHandlerInitializer {
+public class ForwardedHandlerInitializer {
 
     public void register(@Observes Router router) {
         router.route("/forward").handler(rc -> rc.response()

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/AbstractTrustedXForwarderProxiesTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/AbstractTrustedXForwarderProxiesTest.java
@@ -1,0 +1,64 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+
+public abstract class AbstractTrustedXForwarderProxiesTest {
+
+    static final String SUCCESS = "https|somehost|backend:4444|/path|https://somehost/path";
+
+    protected static QuarkusUnitTest createTrustedProxyUnitTest(String... trustedProxies) {
+        final String trustedProxiesAsStr;
+        if (trustedProxies.length == 0) {
+            trustedProxiesAsStr = "";
+        } else {
+            trustedProxiesAsStr = "quarkus.http.proxy.trusted-proxies=" + String.join(",", trustedProxies) + "\n";
+        }
+        return new QuarkusUnitTest()
+                .withApplicationRoot((jar) -> jar
+                        .addClasses(ForwardedHandlerInitializer.class)
+                        .addAsResource(new StringAsset("quarkus.http.proxy.proxy-address-forwarding=true\n" +
+                                "quarkus.http.proxy.allow-x-forwarded=true\n" +
+                                "quarkus.http.proxy.enable-forwarded-host=true\n" +
+                                "quarkus.http.proxy.enable-forwarded-prefix=true\n" +
+                                trustedProxiesAsStr +
+                                "quarkus.http.proxy.forwarded-host-header=X-Forwarded-Server"),
+                                "application.properties"));
+    }
+
+    protected static ValidatableResponse request() {
+        return RestAssured.given()
+                .header("Forwarded", "proto=http;for=backend2:5555;host=somehost2")
+                .header("X-Forwarded-Ssl", "on")
+                .header("X-Forwarded-For", "backend:4444")
+                .header("X-Forwarded-Server", "somehost")
+                .get("/path")
+                .then();
+    }
+
+    static void assertRequestSuccess() {
+        assertRequestSuccess(request());
+    }
+
+    static void assertRequestSuccess(ValidatableResponse request) {
+        request.body(Matchers.equalTo(SUCCESS));
+    }
+
+    static void assertRequestFailure() {
+        assertRequestFailure(request());
+    }
+
+    static void assertRequestFailure(ValidatableResponse request) {
+        request
+                // we don't check port of 127.0.0.1 as that's subject to change
+                .body(Matchers.startsWith("http|localhost:8081|127.0.0.1:"))
+                .body(Matchers.endsWith("|/path|http://localhost:8081/path"));
+        // without 'quarkus.http.proxy.trusted-proxies=1.2.3.4' config property
+        // response would be: 'https|somehost|backend:4444|/path|https://somehost/path'
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedForwarderProxyFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedForwarderProxyFailureTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+import io.restassured.RestAssured;
+
+public class TrustedForwarderProxyFailureTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ForwardedHandlerInitializer.class)
+                    .addAsResource(new StringAsset("quarkus.http.proxy.proxy-address-forwarding=true\n" +
+                            "quarkus.http.proxy.allow-forwarded=true\n" +
+                            "quarkus.http.proxy.enable-forwarded-host=true\n" +
+                            "quarkus.http.proxy.enable-forwarded-prefix=true\n" +
+                            "quarkus.http.proxy.trusted-proxies=alnoenlqoe334219384nvfeoslcxnxeoanelnsoe9.gov"),
+                            "application.properties"));
+
+    @Test
+    public void testHeadersAreIgnored() {
+        RestAssured.given()
+                .header("Forwarded", "by=proxy;for=\"[2001:db8:cafe::17]:47011\",for=backend:4444;host=somehost;proto=https")
+                .get("/forward")
+                .then()
+                .body(Matchers.startsWith("http|localhost:8081|127.0.0.1:"));
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedForwarderProxyTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedForwarderProxyTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.ForwardedHandlerInitializer;
+import io.restassured.RestAssured;
+
+public class TrustedForwarderProxyTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ForwardedHandlerInitializer.class)
+                    .addAsResource(new StringAsset("quarkus.http.proxy.proxy-address-forwarding=true\n" +
+                            "quarkus.http.proxy.allow-forwarded=true\n" +
+                            "quarkus.http.proxy.enable-forwarded-host=true\n" +
+                            "quarkus.http.proxy.enable-forwarded-prefix=true\n" +
+                            "quarkus.http.proxy.trusted-proxies=localhost"),
+                            "application.properties"));
+
+    @Test
+    public void testHeadersAreUsed() {
+        RestAssured.given()
+                .header("Forwarded", "proto=http;for=backend2:5555;host=somehost2")
+                .get("/path")
+                .then()
+                .body(Matchers.equalTo("http|somehost2|backend2:5555|/path|http://somehost2/path"));
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderMultipleProxiesFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderMultipleProxiesFailureTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TrustedXForwarderMultipleProxiesFailureTest extends AbstractTrustedXForwarderProxiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = createTrustedProxyUnitTest("1.2.3.4", "quarkus.io", "154.5.128.0/17",
+            "::ffff:154.6.99.64/123");
+
+    @Test
+    public void testHeadersAreIgnored() {
+        assertRequestFailure();
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderMultipleProxiesTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderMultipleProxiesTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TrustedXForwarderMultipleProxiesTest extends AbstractTrustedXForwarderProxiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = createTrustedProxyUnitTest("1.2.3.4", "quarkus.io", "vertx.io", "154.6.0.0/15",
+            "::ffff:154.6.99.64/123", "localhost");
+
+    @Test
+    public void testHeadersAreUsed() {
+        // request should succeed as localhost check matches
+        assertRequestSuccess();
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesCidrFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesCidrFailureTest.java
@@ -1,0 +1,18 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TrustedXForwarderProxiesCidrFailureTest extends AbstractTrustedXForwarderProxiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = createTrustedProxyUnitTest("::1/128");
+
+    @Test
+    public void testHeadersAreIgnored() {
+        // headers are ignored as request is sent from IPv4
+        assertRequestFailure();
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesCidrTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesCidrTest.java
@@ -1,0 +1,18 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TrustedXForwarderProxiesCidrTest extends AbstractTrustedXForwarderProxiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = createTrustedProxyUnitTest("127.0.0.0/8");
+
+    @Test
+    public void testHeadersAreUsed() {
+        assertRequestSuccess();
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesFailureTest.java
@@ -1,0 +1,18 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TrustedXForwarderProxiesFailureTest extends AbstractTrustedXForwarderProxiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = createTrustedProxyUnitTest("1.2.3.4");
+
+    @Test
+    public void testHeadersAreIgnored() {
+        assertRequestFailure();
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesHostnameFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesHostnameFailureTest.java
@@ -1,0 +1,18 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TrustedXForwarderProxiesHostnameFailureTest extends AbstractTrustedXForwarderProxiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = createTrustedProxyUnitTest("quarkus.io");
+
+    @Test
+    public void testHeadersAreIgnored() {
+        assertRequestFailure();
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesHostnameTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesHostnameTest.java
@@ -1,0 +1,18 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TrustedXForwarderProxiesHostnameTest extends AbstractTrustedXForwarderProxiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = createTrustedProxyUnitTest("localhost");
+
+    @Test
+    public void testHeadersAreUsed() {
+        assertRequestSuccess();
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesIPTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesIPTest.java
@@ -1,0 +1,18 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TrustedXForwarderProxiesIPTest extends AbstractTrustedXForwarderProxiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = createTrustedProxyUnitTest("127.0.0.1");
+
+    @Test
+    public void testHeadersAreUsed() {
+        assertRequestSuccess();
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesUnknownHostnameFailureTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedXForwarderProxiesUnknownHostnameFailureTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.vertx.http.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TrustedXForwarderProxiesUnknownHostnameFailureTest extends AbstractTrustedXForwarderProxiesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = createTrustedProxyUnitTest(
+            // let's hope this domain is not registered
+            "alnoenlkepdolndqoe334219384nvfeoslcxnxeoanelnsoe9.gov");
+
+    @Test
+    public void testHeadersAreIgnored() {
+        assertRequestFailure();
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedProxyHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedProxyHandler.java
@@ -1,0 +1,161 @@
+package io.quarkus.vertx.http.runtime;
+
+import static io.quarkus.vertx.http.runtime.TrustedProxyCheck.denyAll;
+
+import java.net.InetAddress;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.jboss.logging.Logger;
+import org.wildfly.common.net.Inet;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.dns.DnsClient;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.net.impl.SocketAddressImpl;
+
+/**
+ * Restricts who can send `Forwarded`, `X-Forwarded` or `X-Forwarded-*` headers to trusted proxies
+ * configured through {@link ProxyConfig#trustedProxies}.
+ */
+class ForwardedProxyHandler implements Handler<HttpServerRequest> {
+
+    private static final Logger LOGGER = Logger.getLogger(ForwardedProxyHandler.class.getName());
+
+    private final TrustedProxyCheck.TrustedProxyCheckBuilder proxyCheckBuilder;
+
+    private final Supplier<Vertx> vertx;
+
+    private final Handler<HttpServerRequest> delegate;
+
+    private final ForwardingProxyOptions forwardingProxyOptions;
+
+    ForwardedProxyHandler(TrustedProxyCheck.TrustedProxyCheckBuilder proxyCheckBuilder,
+            Supplier<Vertx> vertx, Handler<HttpServerRequest> delegate,
+            ForwardingProxyOptions forwardingProxyOptions) {
+        this.proxyCheckBuilder = proxyCheckBuilder;
+        this.vertx = vertx;
+        this.delegate = delegate;
+        this.forwardingProxyOptions = forwardingProxyOptions;
+    }
+
+    @Override
+    public void handle(HttpServerRequest event) {
+        if (event.remoteAddress().isDomainSocket()) {
+            // we do not support domain socket proxy checks, ignore the headers
+            LOGGER.debug("Domain socket are not supported, 'Forwarded' and 'X-Forwarded' headers are going to be ignored");
+            handleForwardedServerRequest(event, denyAll());
+        } else {
+            // create proxy check, then handle request
+            if (proxyCheckBuilder.hasHostNames()) {
+                // we need to perform DNS lookup for trusted proxy hostnames
+                lookupHostNamesAndHandleRequest(event,
+                        proxyCheckBuilder.getHostNameToPort().entrySet().iterator(), proxyCheckBuilder,
+                        vertx.get().createDnsClient());
+            } else {
+                resolveProxyIpAndHandleRequest(event, proxyCheckBuilder);
+            }
+        }
+    }
+
+    private void lookupHostNamesAndHandleRequest(HttpServerRequest event,
+            Iterator<Map.Entry<String, Integer>> iterator,
+            TrustedProxyCheck.TrustedProxyCheckBuilder builder,
+            DnsClient dnsClient) {
+        if (iterator.hasNext()) {
+            // perform recursive DNS lookup for all hostnames
+            // we do not cache result as IP address may change, and we advise users to use IP or CIDR
+            final var entry = iterator.next();
+            final String hostName = entry.getKey();
+            dnsClient.lookup(hostName,
+                    new Handler<AsyncResult<String>>() {
+                        @Override
+                        public void handle(AsyncResult<String> stringAsyncResult) {
+                            if (stringAsyncResult.succeeded()) {
+                                var trustedIP = Inet.parseInetAddress(stringAsyncResult.result());
+                                if (trustedIP != null) {
+                                    // create proxy check for resolved IP and proceed with the lookup
+                                    lookupHostNamesAndHandleRequest(event, iterator,
+                                            builder.withTrustedIP(trustedIP, entry.getValue()), dnsClient);
+                                } else {
+                                    logInvalidIpAddress(hostName);
+                                    // ignore this hostname proxy check and proceed with the lookup
+                                    lookupHostNamesAndHandleRequest(event, iterator, builder, dnsClient);
+                                }
+                            } else {
+                                // inform we can't cope without IP
+                                logDnsLookupFailure(hostName);
+                                // ignore this hostname proxy check and proceed with the lookup
+                                lookupHostNamesAndHandleRequest(event, iterator, builder, dnsClient);
+                            }
+                        }
+
+                    });
+        } else {
+            // DNS lookup is done
+            if (builder.hasProxyChecks()) {
+                resolveProxyIpAndHandleRequest(event, builder);
+            } else {
+                // ignore headers as there are no proxy checks
+                handleForwardedServerRequest(event, denyAll());
+            }
+        }
+    }
+
+    private void resolveProxyIpAndHandleRequest(HttpServerRequest event,
+            TrustedProxyCheck.TrustedProxyCheckBuilder builder) {
+        InetAddress proxyIP = ((SocketAddressImpl) event.remoteAddress()).ipAddress();
+        if (proxyIP == null) {
+            // if host is an IP address, proxyIP won't be null
+            proxyIP = Inet.parseInetAddress(event.remoteAddress().host());
+        }
+
+        if (proxyIP == null) {
+            // perform DNS lookup, then create proxy check and handle request
+            final String hostName = Objects.requireNonNull(event.remoteAddress().hostName());
+            vertx.get().createDnsClient().lookup(hostName,
+                    new Handler<AsyncResult<String>>() {
+                        @Override
+                        public void handle(AsyncResult<String> stringAsyncResult) {
+                            TrustedProxyCheck proxyCheck;
+                            if (stringAsyncResult.succeeded()) {
+                                // use resolved IP to build proxy check
+                                final var proxyIP = Inet.parseInetAddress(stringAsyncResult.result());
+                                if (proxyIP != null) {
+                                    proxyCheck = builder.build(proxyIP, event.remoteAddress().port());
+                                } else {
+                                    logInvalidIpAddress(hostName);
+                                    proxyCheck = denyAll();
+                                }
+                            } else {
+                                // we can't cope without IP => ignore headers
+                                logDnsLookupFailure(hostName);
+                                proxyCheck = denyAll();
+                            }
+
+                            handleForwardedServerRequest(event, proxyCheck);
+                        }
+                    });
+        } else {
+            // we have proxy IP => create proxy check and handle request
+            var proxyCheck = builder.build(proxyIP, event.remoteAddress().port());
+            handleForwardedServerRequest(event, proxyCheck);
+        }
+    }
+
+    private void handleForwardedServerRequest(HttpServerRequest event, TrustedProxyCheck proxyCheck) {
+        delegate.handle(new ForwardedServerRequestWrapper(event, forwardingProxyOptions, proxyCheck));
+    }
+
+    private static void logInvalidIpAddress(String hostName) {
+        LOGGER.debugf("Illegal state - DNS server returned invalid IP address for hostname '%s'", hostName);
+    }
+
+    private static void logDnsLookupFailure(String hostName) {
+        LOGGER.debugf("Can't resolve proxy IP address from '%s'", hostName);
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
@@ -40,9 +40,10 @@ class ForwardedServerRequestWrapper extends HttpServerRequestWrapper implements 
     private String uri;
     private String absoluteURI;
 
-    ForwardedServerRequestWrapper(HttpServerRequest request, ForwardingProxyOptions forwardingProxyOptions) {
+    ForwardedServerRequestWrapper(HttpServerRequest request, ForwardingProxyOptions forwardingProxyOptions,
+            TrustedProxyCheck trustedProxyCheck) {
         super((HttpServerRequestInternal) request);
-        forwardedParser = new ForwardedParser(delegate, forwardingProxyOptions);
+        forwardedParser = new ForwardedParser(delegate, forwardingProxyOptions, trustedProxyCheck);
     }
 
     void changeTo(HttpMethod method, String uri) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ProxyConfig.java
@@ -1,9 +1,12 @@
 package io.quarkus.vertx.http.runtime;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConvertWith;
+import io.quarkus.vertx.http.runtime.TrustedProxyCheck.TrustedProxyCheckPart;
 
 /**
  * Holds configuration related with proxy addressing forward.
@@ -33,7 +36,7 @@ public class ProxyConfig {
      * {@code Forwarded} header will be used.
      * In case the standard {@code Forwarded} header is enabled and detected on HTTP requests, the standard header has the
      * precedence.
-     * Activating this together with {@code quarkus.http.proxy.allow-x-forwarded} has security implications as clients can forge
+     * Activating this together with {@code quarkus.http.proxy.allow-forwarded} has security implications as clients can forge
      * requests with a forwarded header that is not overwritten by the proxy. Therefore, proxies should strip unexpected
      * `X-Forwarded` or `X-Forwarded-*` headers from the client.
      */
@@ -63,4 +66,37 @@ public class ProxyConfig {
      */
     @ConfigItem(defaultValue = "X-Forwarded-Prefix")
     public String forwardedPrefixHeader;
+
+    /**
+     * Configure the list of trusted proxy addresses.
+     * Received `Forwarded`, `X-Forwarded` or `X-Forwarded-*` headers from any other proxy address will be ignored.
+     * The trusted proxy address should be specified as the IP address (IPv4 or IPv6), hostname or Classless Inter-Domain
+     * Routing (CIDR) notation. Please note that Quarkus needs to perform DNS lookup for all hostnames during the request.
+     * For that reason, using hostnames is not recommended.
+     *
+     * Examples of a socket address in the form of `host` or `host:port`:
+     *
+     * <ul>
+     * <li>`127.0.0.1:8084`</li>
+     * <li>`[0:0:0:0:0:0:0:1]`</li>
+     * <li>`[0:0:0:0:0:0:0:1]:8084`</li>
+     * <li>`[::]`</li>
+     * <li>`localhost`</li>
+     * <li>`localhost:8084`</li>
+     * </ul>
+     *
+     * Examples of a CIDR notation:
+     *
+     * <ul>
+     * <li>`::/128`</li>
+     * <li>`::/0`</li>
+     * <li>`127.0.0.0/8`</li>
+     * </ul>
+     *
+     * Please bear in mind that IPv4 CIDR won't match request sent from the IPv6 address and the other way around.
+     */
+    @ConfigItem(defaultValueDocumentation = "All proxy addresses are trusted")
+    @ConvertWith(TrustedProxyCheckPartConverter.class)
+    public Optional<List<TrustedProxyCheckPart>> trustedProxies;
+
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/TrustedProxyCheck.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/TrustedProxyCheck.java
@@ -1,0 +1,138 @@
+package io.quarkus.vertx.http.runtime;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiPredicate;
+
+import io.vertx.core.net.SocketAddress;
+
+interface TrustedProxyCheck {
+
+    static TrustedProxyCheck allowAll() {
+        return new TrustedProxyCheck() {
+            @Override
+            public boolean isProxyAllowed() {
+                return true;
+            }
+        };
+    }
+
+    static TrustedProxyCheck denyAll() {
+        return new TrustedProxyCheck() {
+            @Override
+            public boolean isProxyAllowed() {
+                return false;
+            }
+        };
+    }
+
+    /**
+     * User can configure trusted proxies for `Forwarded`, `X-Forwarded` or `X-Forwarded-*` headers.
+     * Headers from untrusted proxies must be ignored.
+     *
+     * @return true if `Forwarded`, `X-Forwarded` or `X-Forwarded-*` headers were sent by trusted {@link SocketAddress}
+     */
+    boolean isProxyAllowed();
+
+    final class TrustedProxyCheckBuilder {
+
+        private final Map<String, Integer> hostNameToPort;
+        private final List<BiPredicate<InetAddress, Integer>> proxyChecks;
+
+        private TrustedProxyCheckBuilder(Map<String, Integer> hostNameToPort,
+                List<BiPredicate<InetAddress, Integer>> proxyChecks) {
+            this.hostNameToPort = hasHostNames(hostNameToPort) ? Map.copyOf(hostNameToPort) : null;
+            this.proxyChecks = List.copyOf(proxyChecks);
+        }
+
+        static TrustedProxyCheckBuilder builder(List<TrustedProxyCheckPart> parts) {
+            final Map<String, Integer> hostNameToPort = new HashMap<>();
+            final List<BiPredicate<InetAddress, Integer>> proxyChecks = new ArrayList<>();
+            for (TrustedProxyCheckPart part : parts) {
+                if (part.proxyCheck != null) {
+                    proxyChecks.add(part.proxyCheck);
+                } else {
+                    hostNameToPort.put(part.hostName, part.port);
+                }
+            }
+            return new TrustedProxyCheckBuilder(hostNameToPort, proxyChecks);
+        }
+
+        TrustedProxyCheckBuilder withTrustedIP(InetAddress trustedIP, int trustedPort) {
+            final List<BiPredicate<InetAddress, Integer>> proxyChecks = new ArrayList<>(this.proxyChecks);
+            proxyChecks.add(createNewIpCheck(trustedIP, trustedPort));
+            return new TrustedProxyCheckBuilder(null, proxyChecks);
+        }
+
+        boolean hasProxyChecks() {
+            return !proxyChecks.isEmpty();
+        }
+
+        TrustedProxyCheck build(InetAddress proxyIP, int proxyPort) {
+            Objects.requireNonNull(proxyIP);
+            return new TrustedProxyCheck() {
+                @Override
+                public boolean isProxyAllowed() {
+                    for (BiPredicate<InetAddress, Integer> proxyCheck : proxyChecks) {
+                        if (proxyCheck.test(proxyIP, proxyPort)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+            };
+        }
+
+        boolean hasHostNames() {
+            return hasHostNames(this.hostNameToPort);
+        }
+
+        private static boolean hasHostNames(Map<String, Integer> hostNameToPort) {
+            return hostNameToPort != null && !hostNameToPort.isEmpty();
+        }
+
+        public Map<String, Integer> getHostNameToPort() {
+            return hostNameToPort;
+        }
+
+    }
+
+    static BiPredicate<InetAddress, Integer> createNewIpCheck(InetAddress trustedIP, int trustedPort) {
+        final boolean doNotCheckPort = trustedPort == 0;
+        return new BiPredicate<>() {
+            @Override
+            public boolean test(InetAddress proxyIP, Integer proxyPort) {
+                return isPortOk(proxyPort) && trustedIP.equals(proxyIP);
+            }
+
+            private boolean isPortOk(int port) {
+                return doNotCheckPort || port == trustedPort;
+            }
+        };
+    }
+
+    final class TrustedProxyCheckPart {
+
+        final BiPredicate<InetAddress, Integer> proxyCheck;
+        final String hostName;
+        final int port;
+
+        TrustedProxyCheckPart(BiPredicate<InetAddress, Integer> proxyCheck) {
+            this.proxyCheck = proxyCheck;
+            this.hostName = null;
+            this.port = 0;
+        }
+
+        TrustedProxyCheckPart(String hostName, int port) {
+            this.proxyCheck = null;
+            this.hostName = hostName;
+            this.port = port;
+        }
+
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/TrustedProxyCheckPartConverter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/TrustedProxyCheckPartConverter.java
@@ -1,0 +1,52 @@
+package io.quarkus.vertx.http.runtime;
+
+import static io.quarkus.runtime.configuration.ConverterSupport.DEFAULT_QUARKUS_CONVERTER_PRIORITY;
+import static io.quarkus.vertx.http.runtime.TrustedProxyCheck.createNewIpCheck;
+
+import java.net.InetAddress;
+import java.util.function.BiPredicate;
+import java.util.regex.Pattern;
+
+import javax.annotation.Priority;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+import io.quarkus.runtime.configuration.CidrAddressConverter;
+import io.quarkus.runtime.configuration.InetSocketAddressConverter;
+
+/**
+ * Converts proxy address into {@link TrustedProxyCheck.TrustedProxyCheckPart}.
+ */
+@Priority(DEFAULT_QUARKUS_CONVERTER_PRIORITY)
+public final class TrustedProxyCheckPartConverter implements Converter<TrustedProxyCheck.TrustedProxyCheckPart> {
+
+    private static final Pattern CIDR_PATTERN = Pattern.compile(".+\\/\\d+");
+
+    @Override
+    public TrustedProxyCheck.TrustedProxyCheckPart convert(String proxyAddress) {
+        if (CIDR_PATTERN.matcher(proxyAddress).matches()) {
+            final var cidrAddress = new CidrAddressConverter().convert(proxyAddress);
+            return new TrustedProxyCheck.TrustedProxyCheckPart(new BiPredicate<>() {
+                @Override
+                public boolean test(InetAddress proxyIP, Integer proxyPort) {
+                    return cidrAddress.matches(proxyIP);
+                }
+            });
+        } else {
+            if ("localhost".equals(proxyAddress)) {
+                // prevents unnecessary localhost lookup, also default DNS does not know localhost
+                proxyAddress = "127.0.0.1";
+            }
+            final var inetSocketAddress = new InetSocketAddressConverter().convert(proxyAddress);
+            final boolean useHostName = inetSocketAddress.isUnresolved() || inetSocketAddress.getAddress() == null;
+            if (useHostName) {
+                return new TrustedProxyCheck.TrustedProxyCheckPart(inetSocketAddress.getHostName(),
+                        inetSocketAddress.getPort());
+            } else {
+                return new TrustedProxyCheck.TrustedProxyCheckPart(
+                        createNewIpCheck(inetSocketAddress.getAddress(), inetSocketAddress.getPort()));
+            }
+        }
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
+++ b/extensions/vertx-http/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
@@ -1,0 +1,1 @@
+io.quarkus.vertx.http.runtime.TrustedProxyCheckPartConverter

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/TrustedProxyCheckPartConverterTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/TrustedProxyCheckPartConverterTest.java
@@ -1,0 +1,106 @@
+package io.quarkus.vertx.http.runtime;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TrustedProxyCheckPartConverterTest {
+
+    private static final TrustedProxyCheckPartConverter CONVERTER = new TrustedProxyCheckPartConverter();
+
+    @Test
+    public void testCidrIPv4() throws UnknownHostException {
+        var part = CONVERTER.convert("10.0.0.0/24");
+        Assertions.assertNull(part.hostName);
+        Assertions.assertNotNull(part.proxyCheck);
+        Assertions.assertEquals(0, part.port);
+        Assertions.assertTrue(part.proxyCheck.test(InetAddress.getByName("10.0.0.0"), 0));
+        Assertions.assertTrue(part.proxyCheck.test(InetAddress.getByName("10.0.0.255"), 0));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("100.100.100.100"), 0));
+    }
+
+    @Test
+    public void testCidrIPv6() throws UnknownHostException {
+        var part = CONVERTER.convert("2001:4860:4860::8888/32");
+        Assertions.assertNull(part.hostName);
+        Assertions.assertNotNull(part.proxyCheck);
+        Assertions.assertEquals(0, part.port);
+        Assertions.assertTrue(part.proxyCheck.test(InetAddress.getByName("2001:4860:4860:0000:0000:0000:0000:8888"), 0));
+        Assertions.assertTrue(part.proxyCheck.test(InetAddress.getByName("2001:4860:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"), 0));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("2005:4860:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"), 0));
+    }
+
+    @Test
+    public void testIPv4() throws UnknownHostException {
+        var part = CONVERTER.convert("10.0.0.0");
+        Assertions.assertNull(part.hostName);
+        Assertions.assertNotNull(part.proxyCheck);
+        Assertions.assertEquals(0, part.port);
+        Assertions.assertTrue(part.proxyCheck.test(InetAddress.getByName("10.0.0.0"), 0));
+        Assertions.assertTrue(part.proxyCheck.test(InetAddress.getByName("10.0.0.0"), 99));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("10.0.0.255"), 0));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("100.100.100.100"), 0));
+    }
+
+    @Test
+    public void testIPv4AndPort() throws UnknownHostException {
+        var part = CONVERTER.convert("10.0.0.0:8085");
+        Assertions.assertNull(part.hostName);
+        Assertions.assertNotNull(part.proxyCheck);
+        Assertions.assertTrue(part.proxyCheck.test(InetAddress.getByName("10.0.0.0"), 8085));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("10.0.0.0"), 8000));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("10.0.0.255"), 8085));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("100.100.100.100"), 8085));
+    }
+
+    @Test
+    public void testIPv6() throws UnknownHostException {
+        var part = CONVERTER.convert("[2001:4860:4860:0000:0000:0000:0000:8888]");
+        Assertions.assertNull(part.hostName);
+        Assertions.assertNotNull(part.proxyCheck);
+        Assertions.assertEquals(0, part.port);
+        Assertions.assertTrue(part.proxyCheck.test(InetAddress.getByName("2001:4860:4860:0000:0000:0000:0000:8888"), 0));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("2001:4860:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"), 0));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("2005:4860:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"), 0));
+
+        // test short form
+        part = CONVERTER.convert("[::]");
+        Assertions.assertNull(part.hostName);
+        Assertions.assertNotNull(part.proxyCheck);
+        Assertions.assertEquals(0, part.port);
+        Assertions.assertTrue(part.proxyCheck.test(InetAddress.getByName("0:0:0:0:0:0:0:0"), 0));
+        Assertions.assertTrue(part.proxyCheck.test(InetAddress.getByName("0:0:0:0:0:0:0:0"), 99));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("2001:4860:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"), 0));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("2005:4860:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"), 0));
+    }
+
+    @Test
+    public void testIPv6AndPort() throws UnknownHostException {
+        var part = CONVERTER.convert("[2001:4860:4860:0000:0000:0000:0000:8888]:8085");
+        Assertions.assertNull(part.hostName);
+        Assertions.assertNotNull(part.proxyCheck);
+        Assertions.assertTrue(part.proxyCheck.test(InetAddress.getByName("2001:4860:4860:0000:0000:0000:0000:8888"), 8085));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("2001:4860:4860:0000:0000:0000:0000:8888"), 8000));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("2001:4860:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"), 8085));
+        Assertions.assertFalse(part.proxyCheck.test(InetAddress.getByName("2005:4860:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"), 8085));
+    }
+
+    @Test
+    public void testHostName() {
+        var part = CONVERTER.convert("quarkus.io");
+        Assertions.assertNull(part.proxyCheck);
+        Assertions.assertNotNull(part.hostName);
+        Assertions.assertEquals(0, part.port);
+    }
+
+    @Test
+    public void testHostNameAndPort() {
+        var part = CONVERTER.convert("quarkus.io:8085");
+        Assertions.assertNull(part.proxyCheck);
+        Assertions.assertNotNull(part.hostName);
+        Assertions.assertEquals(part.port, 8085);
+    }
+
+}


### PR DESCRIPTION
closes: #29888

User can restrict proxy address from which Quarkus accepts `X-Forwarded` and `X-Forwarded-*` headers. It's possible to specify multiple proxy addresses as IPv4, IPv6, CIDR and hostnames. Hostnames must be resolved asynchronously to IP during the request, which makes it less performant option; we don't provide caching and advise users to use IP or CIDR.