### PR TITLE
Smallrye-reactive-messaging: Support connector config through envvars

### DIFF
--- a/extensions/smallrye-reactive-messaging/deployment/pom.xml
+++ b/extensions/smallrye-reactive-messaging/deployment/pom.xml
@@ -78,6 +78,11 @@
       <artifactId>quarkus-resteasy-deployment</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -92,6 +97,13 @@
               <version>${project.version}</version>
             </path>
           </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
         </configuration>
       </plugin>
     </plugins>

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/config/ConnectorConfigSupportsEnvVarOverridesTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/config/ConnectorConfigSupportsEnvVarOverridesTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.smallrye.reactivemessaging.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+@SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_WAY_IN_TRACING_ENABLED", value = "false")
+public class ConnectorConfigSupportsEnvVarOverridesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(DumbConnector.class, BeanUsingDummyConnector.class))
+            .overrideConfigKey("mp.messaging.incoming.way-in.values", "bonjour")
+            .overrideConfigKey("mp.messaging.incoming.way-in.connector", "dummy");
+
+    @Inject
+    BeanUsingDummyConnector bean;
+
+    @Test
+    public void test() {
+        await().until(() -> bean.getList().size() == 2);
+        assertThat(bean.getList()).containsExactly("bonjour", "BONJOUR");
+    }
+
+    @ApplicationScoped
+    public static class BeanUsingDummyConnector {
+
+        private List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("way-in")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> getList() {
+            return list;
+        }
+
+    }
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/EnvironmentVariableRedefiningConfigSource.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/EnvironmentVariableRedefiningConfigSource.java
@@ -1,0 +1,101 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.smallrye.reactivemessaging.runtime.SmallRyeReactiveMessagingRecorder.SmallRyeReactiveMessagingContext;
+
+public class EnvironmentVariableRedefiningConfigSource implements ConfigSource {
+    private static final String INCOMING_PREFIX = "MP_MESSAGING_INCOMING_";
+
+    private static final Pattern P_NON_ALPHANUM = Pattern.compile("[^a-zA-Z0-9]");
+
+    private static final String OUTGOING_PREFIX = "MP_MESSAGING_OUTGOING_";
+
+    private Set<String> propertyNames;
+
+    @Override
+    public Map<String, String> getProperties() {
+        return ConfigSource.super.getProperties();
+    }
+
+    @Override
+    public int getOrdinal() {
+        return Integer.MIN_VALUE;
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        if (propertyNames == null && Arc.container() != null) {
+            propertyNames = new HashSet<>();
+            try (InstanceHandle<SmallRyeReactiveMessagingContext> contextInstance = Arc.container()
+                    .instance(SmallRyeReactiveMessagingContext.class)) {
+                Map<String, List<String>> prefixes = buildPrefixMap(contextInstance.get());
+
+                for (Map.Entry<String, String> envVarEntry : System.getenv().entrySet()) {
+                    for (Map.Entry<String, List<String>> channelPrefixesEntry : prefixes.entrySet()) {
+                        String matchingPrefix = findMatchingPrefix(envVarEntry.getKey(), channelPrefixesEntry.getValue());
+                        if (matchingPrefix != null) {
+                            String prefix = matchingPrefix
+                                    .substring(0, matchingPrefix.length() - channelPrefixesEntry.getKey().length());
+                            String suffix = envVarEntry.getKey().substring(matchingPrefix.length());
+                            propertyNames
+                                    .add(toDottedLowerCase(prefix) + channelPrefixesEntry.getKey() + toDottedLowerCase(suffix));
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return propertyNames == null ? Collections.emptySet() : propertyNames;
+    }
+
+    private static Map<String, List<String>> buildPrefixMap(SmallRyeReactiveMessagingContext context) {
+        Map<String, List<String>> prefixes = new HashMap<>();
+        Set<String> channels = new HashSet<>();
+        context.getChannelConfigurations().forEach(config -> channels.add(config.channelName));
+        context.getMediatorConfigurations().forEach(config -> {
+            channels.addAll(config.getIncoming());
+            if (config.getOutgoing() != null) {
+                channels.add(config.getOutgoing());
+            }
+        });
+        for (String channelName : channels) {
+            String uppercasedName = P_NON_ALPHANUM.matcher(channelName.toUpperCase()).replaceAll("_");
+            prefixes.put(channelName, List.of(INCOMING_PREFIX + uppercasedName, OUTGOING_PREFIX + uppercasedName));
+        }
+        return prefixes;
+    }
+
+    private static String toDottedLowerCase(String text) {
+        return text.toLowerCase().replaceAll("_", ".");
+    }
+
+    private static String findMatchingPrefix(String toTest, List<String> prefixes) {
+        for (String prefix : prefixes) {
+            if (toTest.startsWith(prefix)) {
+                return prefix;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String getValue(String s) {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return EnvironmentVariableRedefiningConfigSource.class.getSimpleName();
+    }
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,0 +1,1 @@
+io.quarkus.smallrye.reactivemessaging.runtime.EnvironmentVariableRedefiningConfigSource


### PR DESCRIPTION
Fixes #30106

This fix is based on the behaviour of smallrye-config with configuration comming from envvars.
All environment variables are transformed back into actuall config property names with lowercase and underscore to dot.
They are thus redefined in the config structure and returned in getPropertyNames() calls on the SmallryeConfig object.
There is a condition on the redefinition: there must not be another config source that already defines an property with the same lowercased and dotted name.
In this fix we add a new ConfigSource that looks up the SmallryeReactiveMessagingContext.
It looks at the environment variables defined and generates corresponding property names if they look like reactive messaging configuration.
A test doing an override with environment variable is added.
