### PR TITLE
Change quarkus-cache extension status to stable

### DIFF
--- a/extensions/cache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/cache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,6 +8,6 @@ metadata:
   guide: "https://quarkus.io/guides/cache"
   categories:
   - "data"
-  status: "preview"
+  status: "stable"
   config:
   - "quarkus.cache."


### PR DESCRIPTION
As discussed in a recent email conversation, `quarkus-cache` is currently marked as both `Supported` and `Preview` [here](https://code.quarkus.redhat.com/?extension-search=origin:platform%20quarkus-cache) which sends a mixed message. The extension is stable enough to be marked as `stable` which will remove the `Preview` tag.

cc @geoand @aloubyansky @cescoffier