### PR TITLE
Update the performance guide with respect to Quarkus default GraalVM GC

### DIFF
--- a/docs/src/main/asciidoc/performance-measure.adoc
+++ b/docs/src/main/asciidoc/performance-measure.adoc
@@ -224,13 +224,6 @@ all services it's able to find on the classpath.
 
 We prefer listing services explicitly as it produces better optimised binaries. Disable it as well by setting `-H:-UseServiceLoaderFeature`.
 
-=== Better default for Garbage Collection implementation
-
-The default in GraalVM seems meant to optimise for short-lived processes.
-
-Quarkus defaults to server applications, so we switch to a better default by setting
- `-H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime`.
-
 === Others ...
 
 This section is provided as high level guidance, but can't presume to be comprehensive as some flags are controlled


### PR DESCRIPTION
Since https://github.com/quarkusio/quarkus/pull/28295 this section is no more accurate and must be deleted