### PR TITLE
Add Jose4j OctetKeyPairJsonWebKey substitutions

### DIFF
--- a/extensions/smallrye-jwt-build/runtime/src/main/java/io/quarkus/smallrye/jwt/build/runtime/graalvm/Substitutions.java
+++ b/extensions/smallrye-jwt-build/runtime/src/main/java/io/quarkus/smallrye/jwt/build/runtime/graalvm/Substitutions.java
@@ -1,0 +1,29 @@
+package io.quarkus.smallrye.jwt.build.runtime.graalvm;
+
+import java.util.function.BooleanSupplier;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "org.jose4j.jwk.OctetKeyPairJsonWebKey", onlyWith = JavaVersionLessThan17.class)
+final class Target_org_jose4j_jwk_OctetKeyPairJsonWebKey {
+    @Substitute
+    public Target_org_jose4j_jwk_OctetKeyPairJsonWebKey(java.security.PublicKey publicKey) {
+    }
+
+    @Substitute
+    Target_org_jose4j_jwk_OctetKeyPairUtil subtypeKeyUtil() {
+        return null;
+    }
+}
+
+@TargetClass(className = "org.jose4j.keys.OctetKeyPairUtil", onlyWith = JavaVersionLessThan17.class)
+final class Target_org_jose4j_jwk_OctetKeyPairUtil {
+}
+
+class JavaVersionLessThan17 implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        return Runtime.version().version().get(0) < 17;
+    }
+}


### PR DESCRIPTION
Fixes #30112 

@michalvavrik Can you please verify tomorrow with the Windows build ? I've actually reproduced the problem with a Java 11 build on Fedora 37 so these substitutions fixed it for me. Not sure why #30057 passed on Java 11.

FYI, `OctetKeyPairJsonWebKey` has been introduced in Jose4j specifically to deal with EdDsa.
Perhaps, for Java 11, we can later relax these substitutions, and make them also conditional on the presence of BouncyCastle, but right now it is not critical 

