### PR TITLE
Properly read the value of testcontainers.reuse.enable

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
@@ -88,7 +88,7 @@ public class IsDockerWorking implements BooleanSupplier {
                         .loadClass("org.testcontainers.utility.TestcontainersConfiguration");
                 Object configurationInstance = configurationClass.getMethod("getInstance").invoke(null);
                 String oldReusePropertyValue = (String) configurationClass
-                        .getMethod("getUserProperty", String.class, String.class)
+                        .getMethod("getEnvVarOrUserProperty", String.class, String.class)
                         .invoke(configurationInstance, "testcontainers.reuse.enable", "false"); // use the default provided in TestcontainersConfiguration#environmentSupportsReuse
                 Method updateUserConfigMethod = configurationClass.getMethod("updateUserConfig", String.class, String.class);
                 // this will ensure that testcontainers does not start ryuk - see https://github.com/quarkusio/quarkus/issues/25852 for why this is important


### PR DESCRIPTION
As mentioned by @LaunchPairs in the analysis of #30059, the use of `TestcontainersConfiguration#getUserProperty` results in using only environment variables as the source for reading the `testcontainers.reuse.enable`.
We should instead also read the value of `~/.testcontainers.properties` in order to ensure we write back the proper value when restoring

Fixes: #30059