### PR TITLE
When disabling name and version for label selected in k8s, don't remove from labels

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
@@ -55,7 +55,6 @@ import io.dekorate.kubernetes.decorator.ApplyWorkingDirDecorator;
 import io.dekorate.kubernetes.decorator.RemoveAnnotationDecorator;
 import io.dekorate.kubernetes.decorator.RemoveFromMatchingLabelsDecorator;
 import io.dekorate.kubernetes.decorator.RemoveFromSelectorDecorator;
-import io.dekorate.kubernetes.decorator.RemoveLabelDecorator;
 import io.dekorate.project.BuildInfo;
 import io.dekorate.project.FileProjectFactory;
 import io.dekorate.project.Project;
@@ -208,13 +207,11 @@ public class KubernetesCommonHelper {
         });
 
         if (!config.isAddVersionToLabelSelectors()) {
-            result.add(new DecoratorBuildItem(target, new RemoveLabelDecorator(name, Labels.VERSION)));
             result.add(new DecoratorBuildItem(target, new RemoveFromSelectorDecorator(name, Labels.VERSION)));
             result.add(new DecoratorBuildItem(target, new RemoveFromMatchingLabelsDecorator(name, Labels.VERSION)));
         }
 
         if (!config.isAddNameToLabelSelectors()) {
-            result.add(new DecoratorBuildItem(target, new RemoveLabelDecorator(name, Labels.NAME)));
             result.add(new DecoratorBuildItem(target, new RemoveFromSelectorDecorator(name, Labels.NAME)));
             result.add(new DecoratorBuildItem(target, new RemoveFromMatchingLabelsDecorator(name, Labels.NAME)));
         }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithApplicationPropertiesTest.java
@@ -48,7 +48,8 @@ public class KubernetesWithApplicationPropertiesTest {
             assertThat(i).isInstanceOfSatisfying(Deployment.class, d -> {
                 assertThat(d.getMetadata()).satisfies(m -> {
                     assertThat(m.getName()).isEqualTo("test-it");
-                    assertThat(m.getLabels()).contains(entry("foo", "bar"));
+                    assertThat(m.getLabels()).contains(entry("foo", "bar"))
+                            .containsKey("app.kubernetes.io/version"); // make sure the version was not removed from the labels
                     assertThat(m.getNamespace()).isEqualTo("applications");
                 });
 

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithApplicationPropertiesTest.java
@@ -45,7 +45,8 @@ public class OpenshiftWithApplicationPropertiesTest {
         assertThat(openshiftList).filteredOn(h -> "DeploymentConfig".equals(h.getKind())).singleElement().satisfies(h -> {
             assertThat(h.getMetadata()).satisfies(m -> {
                 assertThat(m.getName()).isEqualTo("test-it");
-                assertThat(m.getLabels()).contains(entry("foo", "bar"));
+                assertThat(m.getLabels()).contains(entry("foo", "bar"))
+                        .containsKey("app.kubernetes.io/version"); // make sure the version was not removed from the labels
                 assertThat(m.getNamespace()).isEqualTo("applications");
             });
             AbstractObjectAssert<?, ?> specAssert = assertThat(h).extracting("spec");


### PR DESCRIPTION
The version label should remain, only the labels in the selectors should be removed

Fixes: #30100