### PR TITLE
Codestarts - Fix flattening of log levels

### DIFF
--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandler.java
@@ -79,12 +79,20 @@ final class SmartConfigMergeCodestartFileStrategyHandler implements CodestartFil
     static void flatten(String prefix, Map<String, String> target, Map<String, ?> map) {
         for (Map.Entry entry : map.entrySet()) {
             if (entry.getValue() instanceof Map) {
-                flatten(prefix + entry.getKey() + ".", target, (Map) entry.getValue());
+                flatten(prefix + quote(entry.getKey().toString()) + ".", target, (Map) entry.getValue());
             } else {
                 // TODO: handle different types of values
-                target.put(prefix + entry.getKey(), entry.getValue().toString());
+                target.put(prefix + quote(entry.getKey().toString()), entry.getValue().toString());
             }
         }
+    }
+
+    private static String quote(String key) {
+        if (!key.contains(".")) {
+            return key;
+        }
+
+        return "\"" + key.replaceAll("\"", "\\\"") + "\"";
     }
 
     private static String getConfigType(Map<String, Object> data) {

--- a/independent-projects/tools/codestarts/src/test/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandlerTest.java
+++ b/independent-projects/tools/codestarts/src/test/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandlerTest.java
@@ -34,4 +34,27 @@ class SmartConfigMergeCodestartFileStrategyHandlerTest {
         assertThat(flat).containsEntry("c.c-c.c-c-a", "1");
         assertThat(flat).containsEntry("c.c-c.c-c-b", "2");
     }
+
+    @Test
+    void testLogLevel() {
+        final HashMap<String, Object> level = new HashMap<>();
+        level.put("level", "DEBUG");
+
+        final HashMap<String, Object> categoryName = new HashMap<>();
+        categoryName.put("org.hibernate", level);
+
+        final HashMap<String, Object> category = new HashMap<>();
+        category.put("category", categoryName);
+
+        final HashMap<String, Object> log = new HashMap<>();
+        log.put("log", category);
+
+        final HashMap<String, Object> quarkus = new HashMap<>();
+        quarkus.put("quarkus", log);
+
+        final HashMap<String, String> flat = new HashMap<>();
+        SmartConfigMergeCodestartFileStrategyHandler.flatten("", flat, quarkus);
+
+        assertThat(flat).containsEntry("quarkus.log.category.\"org.hibernate\".level", "DEBUG");
+    }
 }


### PR DESCRIPTION
And in general keys containing a dot.

I got hit by that in Quarkus GitHub Action: if you define a key containing a dot in the codestart YAML file, it is not properly escaped in the generated properties file.