### PR TITLE
Fix for native builds with Quarkus CLI

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
@@ -184,7 +184,7 @@ public class MavenRunner implements BuildSystemRunner {
         args.add(action);
 
         if (buildOptions.buildNative) {
-            args.add("-Dnative");
+            args.add("-Pnative");
         }
         if (buildOptions.skipTests()) {
             setSkipTests(args);

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -162,8 +162,8 @@ public class CliProjectMavenTest {
         Assertions.assertFalse(result.stdout.contains("-Dmaven.test.skip=true"),
                 "mvn command should not specify -Dmaven.test.skip=true\n" + result);
 
-        Assertions.assertTrue(result.stdout.contains("-Dnative"),
-                "mvn command should specify -Dnative\n" + result);
+        Assertions.assertTrue(result.stdout.contains("-Pnative"),
+                "mvn command should specify -Pnative\n" + result);
 
         Assertions.assertTrue(result.stdout.contains("--offline"),
                 "mvn command should specify --offline\n" + result);
@@ -180,8 +180,8 @@ public class CliProjectMavenTest {
         Assertions.assertTrue(result.stdout.contains("-Dmaven.test.skip=true"),
                 "mvn command should specify -Dmaven.test.skip=true\n" + result);
 
-        Assertions.assertFalse(result.stdout.contains("-Dnative"),
-                "mvn command should not specify -Dnative\n" + result);
+        Assertions.assertFalse(result.stdout.contains("-Pnative"),
+                "mvn command should not specify -Pnative\n" + result);
 
         Assertions.assertFalse(result.stdout.contains("--offline"),
                 "mvn command should not specify --offline\n" + result);

--- a/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageMavenTest.java
@@ -47,6 +47,10 @@ public class CliImageMavenTest {
         // 1 image --dry-run
         result = CliDriver.execute(project, "image", "--dry-run");
         assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        result = CliDriver.execute(project, "image", "--native", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertTrue(result.getStdout().contains("-Pnative"));
+
         // 2 image build --dry-run
         result = CliDriver.execute(project, "image", "build", "--dry-run");
         assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
@@ -55,6 +59,9 @@ public class CliImageMavenTest {
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.group=mygroup"));
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.name=myname"));
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.tag=1.0"));
+        result = CliDriver.execute(project, "image", "build", "--native", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertTrue(result.getStdout().contains("-Pnative"));
 
         // 3 image push --dry-run
         result = CliDriver.execute(project, "image", "push", "--dry-run");


### PR DESCRIPTION
This should fix a bug that causes the --native flag to be ignored when doing native builds with Maven through the Quarkus CLI  (eg. `quarkus build --native` or `quarkus image build --native` )