### PR TITLE
Update gitflow-incremental-builder from 4.2.0 to 4.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <gitflow-incremental-builder.version>4.2.0</gitflow-incremental-builder.version>
+        <gitflow-incremental-builder.version>4.3.0</gitflow-incremental-builder.version>
         <quarkus-platform-bom-plugin.version>0.0.51</quarkus-platform-bom-plugin.version>
 
         <skipDocs>false</skipDocs>


### PR DESCRIPTION
Since Quarkus is affected by https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/issues/603  (but only the TCKs build, AFAICS) and dependabot often times out, I'm doing the update manually.
Please note that I do not know yet whether or not this update affects https://github.com/quarkusio/quarkus/pull/30035#pullrequestreview-1228411257 (GIB not detecting any of those test-extension modules as being impacted). I have yet to take a closer look.

---
https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/releases/tag/v4.3.0

Most notable changes are:

- Fix `NullPointerException` when using `test-jar` execution without `configuration`: [#607](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/issues/607)
- Fix `-pl`-selected project(s) not being detected as impacted when non-selected transitive dependency/parent is changed and `disableSelectedProjectsHandling` is enabled: [#603](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/issues/603)
- Update JGit from 6.3.0 to 6.4.0: [#613](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/issues/613)

**Full Changelog**: https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/compare/v4.2.0...v4.3.0