### PR TITLE
Add OIDC property for configuring internal ID token lifespan

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -795,6 +795,13 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public Optional<Boolean> idTokenRequired = Optional.empty();
 
         /**
+         * Internal ID token lifespan.
+         * This property is only checked when an internal IdToken is generated when Oauth2 providers do not return IdToken.
+         */
+        @ConfigItem(defaultValueDocumentation = "5M")
+        public Optional<Duration> internalIdTokenLifespan = Optional.empty();
+
+        /**
          * Requires that a Proof Key for Code Exchange (PKCE) is used.
          */
         @ConfigItem(defaultValueDocumentation = "false")
@@ -807,6 +814,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
          */
         @ConfigItem
         public Optional<String> pkceSecret = Optional.empty();
+
+        public Optional<Duration> getInternalIdTokenLifespan() {
+            return internalIdTokenLifespan;
+        }
+
+        public void setInternalIdTokenLifespan(Duration internalIdTokenLifespan) {
+            this.internalIdTokenLifespan = Optional.of(internalIdTokenLifespan);
+        }
 
         public Optional<Boolean> isPkceRequired() {
             return pkceRequired;

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -743,6 +743,9 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         if (userInfo != null) {
             builder.claim(OidcUtils.USER_INFO_ATTRIBUTE, userInfo.getJsonObject());
         }
+        if (oidcConfig.authentication.internalIdTokenLifespan.isPresent()) {
+            builder.expiresIn(oidcConfig.authentication.internalIdTokenLifespan.get().getSeconds());
+        }
         return builder.jws().header(INTERNAL_IDTOKEN_HEADER, true)
                 .sign(KeyUtils.createSecretKeyFromSecret(OidcCommonUtils.clientSecret(oidcConfig.credentials)));
     }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.keycloak;
 
+import java.time.Duration;
 import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -40,6 +41,7 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     .setSecret("AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow");
             config.getCodeGrant().setHeaders(Map.of("X-Custom", "XCustomHeaderValue"));
             config.getCodeGrant().setExtraParams(Map.of("extra-param", "extra-param-value"));
+            config.getAuthentication().setInternalIdTokenLifespan(Duration.ofSeconds(301));
             return Uni.createFrom().item(config);
         }
 

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -64,6 +64,7 @@ quarkus.oidc.code-flow-user-info-only.credentials.secret=AyM1SysPpbyDfgZld3umj1q
 quarkus.oidc.code-flow-user-info-only.application-type=web-app
 
 quarkus.oidc.code-flow-user-info-github.provider=github
+quarkus.oidc.code-flow-user-info-github.authentication.internal-id-token-lifespan=6M
 quarkus.oidc.code-flow-user-info-github.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-user-info-github.authorization-path=/
 quarkus.oidc.code-flow-user-info-github.user-info-path=protocol/openid-connect/userinfo


### PR DESCRIPTION
Fixes #30111.

Simple PR to allow configuring an internal ID token lifespan with the OIDC specific property since relying on the global smallrye jwt property may not always be possible.

Internal ID tokens are generated when GitHub or other OAuth2 only providers do not provide them. Default lifespan is 5 mins which is not a problem if a browser is used directly to authenticate to Quarkus via GitHub because after it expires and the redirect to GitHub is initiated GitHub does not itself challenge since as its own session is still valid (at least it was the case the last time I tried it). But it poses a problem for Ajax/SPA based applications.

Therefore it makes sense to let users configure the internal ID token lifespan at the OIDC level to a large enough value, and then use a local logout technique whenever the token age exceeds the acceptable limits.

Updated the wiremock test to confirm `300` (5 min) is a default lifespan for the internal id tokens, but can be changed if needed (ex to 301 as in the test)

CC @kucharzyk