### PR TITLE
Ensure that ConfigBuilder classes work in native mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -265,6 +265,11 @@ public class ConfigGenerationBuildStep {
         runtimeMappings.addAll(configItem.getReadResult().getBuildTimeRunTimeMappings());
         runtimeMappings.addAll(configItem.getReadResult().getRunTimeMappings());
 
+        Set<String> runtimeConfigBuilderClassNames = runTimeConfigBuilders.stream()
+                .map(RunTimeConfigBuilderBuildItem::getBuilderClassName).collect(toSet());
+        reflectiveClass
+                .produce(new ReflectiveClassBuildItem(false, false, runtimeConfigBuilderClassNames.toArray(new String[0])));
+
         RunTimeConfigurationGenerator.GenerateOperation
                 .builder()
                 .setBuildTimeReadResult(configItem.getReadResult())
@@ -285,8 +290,7 @@ public class ConfigGenerationBuildStep {
                 .setRuntimeConfigSourceProviders(discoveredConfigSourceProviders)
                 .setRuntimeConfigSourceFactories(discoveredConfigSourceFactories)
                 .setRuntimeConfigMappings(runtimeMappings)
-                .setRuntimeConfigBuilders(
-                        runTimeConfigBuilders.stream().map(RunTimeConfigBuilderBuildItem::getBuilderClassName).collect(toSet()))
+                .setRuntimeConfigBuilders(runtimeConfigBuilderClassNames)
                 .build()
                 .run();
     }


### PR DESCRIPTION
This fix is needed because without it main fails, for example in `io.quarkus.it.resteasy.reactive.elytron.FruitResourceIT` with a CNFE when trying to load
`io.quarkus.security.runtime.QuarkusSecurityRolesAllowedConfigBuilder`

The problem started appearing after https://github.com/quarkusio/quarkus/pull/29935 was merged.