### PR TITLE
Take into account @Produces annotations from interfaces and superclasses in JaxrsEndPointValidationInterceptor

### DIFF
--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/JaxrsEndPointValidationInterceptor.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/JaxrsEndPointValidationInterceptor.java
@@ -1,7 +1,7 @@
 package io.quarkus.hibernate.validator.runtime.jaxrs;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -12,9 +12,8 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 import javax.validation.ConstraintViolationException;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import org.jboss.resteasy.util.MediaTypeHelper;
 
 import io.quarkus.hibernate.validator.runtime.interceptor.AbstractMethodValidationInterceptor;
 
@@ -34,7 +33,13 @@ public class JaxrsEndPointValidationInterceptor extends AbstractMethodValidation
         try {
             return super.validateMethodInvocation(ctx);
         } catch (ConstraintViolationException e) {
-            throw new ResteasyViolationExceptionImpl(e.getConstraintViolations(), getProduces(ctx.getMethod()));
+            List<MediaType> producedMediaTypes = getProduces(ctx.getMethod());
+
+            if (producedMediaTypes.isEmpty() && resteasyConfigSupport.isJsonDefault()) {
+                producedMediaTypes = JSON_MEDIA_TYPE_LIST;
+            }
+
+            throw new ResteasyViolationExceptionImpl(e.getConstraintViolations(), producedMediaTypes);
         }
     }
 
@@ -44,17 +49,75 @@ public class JaxrsEndPointValidationInterceptor extends AbstractMethodValidation
         super.validateConstructorInvocation(ctx);
     }
 
-    private List<MediaType> getProduces(Method method) {
-        MediaType[] producedMediaTypes = MediaTypeHelper.getProduces(method.getDeclaringClass(), method);
+    /**
+     * Ideally, we would be able to get the information from RESTEasy so that we can follow strictly the inheritance rules.
+     * But, given RESTEasy Reactive is our new default REST layer, I think we can live with this limitation.
+     * <p>
+     * Superclass method annotations have precedence, then interface methods and finally class annotations.
+     */
+    private List<MediaType> getProduces(Method originalMethod) {
+        Class<?> currentClass = originalMethod.getDeclaringClass();
+        List<Class<?>> interfaces = new ArrayList<>();
 
-        if (producedMediaTypes == null) {
-            if (resteasyConfigSupport.isJsonDefault()) {
-                return JSON_MEDIA_TYPE_LIST;
+        do {
+            List<MediaType> classMethodProducedMediaTypes = getProducesFromMethod(currentClass, originalMethod);
+            if (!classMethodProducedMediaTypes.isEmpty()) {
+                return classMethodProducedMediaTypes;
             }
 
+            for (Class<?> interfaze : currentClass.getInterfaces()) {
+                interfaces.add(interfaze);
+            }
+
+            currentClass = currentClass.getSuperclass();
+        } while (!Object.class.equals(currentClass));
+
+        for (Class<?> interfaze : interfaces) {
+            List<MediaType> interfaceMethodProducedMediaTypes = getProducesFromMethod(interfaze, originalMethod);
+            if (!interfaceMethodProducedMediaTypes.isEmpty()) {
+                return interfaceMethodProducedMediaTypes;
+            }
+        }
+
+        List<MediaType> classProducedMediaTypes = getProduces(originalMethod.getDeclaringClass().getAnnotation(Produces.class));
+        if (!classProducedMediaTypes.isEmpty()) {
+            return classProducedMediaTypes;
+        }
+
+        for (Class<?> interfaze : interfaces) {
+            List<MediaType> interfaceProducedMediaTypes = getProduces(interfaze.getAnnotation(Produces.class));
+            if (!interfaceProducedMediaTypes.isEmpty()) {
+                return interfaceProducedMediaTypes;
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<MediaType> getProducesFromMethod(Class<?> currentClass, Method originalMethod) {
+        if (currentClass.equals(originalMethod.getDeclaringClass())) {
+            return getProduces(originalMethod.getAnnotation(Produces.class));
+        }
+
+        try {
+            return getProduces(currentClass
+                    .getMethod(originalMethod.getName(), originalMethod.getParameterTypes()).getAnnotation(Produces.class));
+        } catch (NoSuchMethodException | SecurityException e) {
+            // we don't have a visible method around, let's ignore this class
+            return Collections.emptyList();
+        }
+    }
+
+    public static List<MediaType> getProduces(Produces produces) {
+        if (produces == null) {
             return Collections.emptyList();
         }
 
-        return Arrays.asList(producedMediaTypes);
+        MediaType[] mediaTypes = new MediaType[produces.value().length];
+        for (int i = 0; i < produces.value().length; i++) {
+            mediaTypes[i] = MediaType.valueOf(produces.value()[i]);
+        }
+
+        return mediaTypes.length != 0 ? List.of(mediaTypes) : Collections.emptyList();
     }
 }

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -49,6 +49,7 @@ import io.quarkus.runtime.StartupEvent;
 
 @Path("/hibernate-validator/test")
 public class HibernateValidatorTestResource
+        extends HibernateValidatorTestResourceSuperclass
         implements HibernateValidatorTestResourceGenericInterface<Integer>, HibernateValidatorTestResourceInterface {
 
     @Inject
@@ -162,6 +163,13 @@ public class HibernateValidatorTestResource
     @Override
     @SomeInterceptorBindingAnnotation
     public String testRestEndPointInterfaceValidationWithAnnotationOnImplMethod(String id) {
+        return id;
+    }
+
+    // all JAX-RS annotations are defined in the superclass
+    @Override
+    @SomeInterceptorBindingAnnotation
+    public String testRestEndPointInterfaceValidationWithAnnotationOnOverriddenMethod(String id) {
         return id;
     }
 

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResourceSuperclass.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResourceSuperclass.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.hibernate.validator;
+
+import javax.validation.constraints.Digits;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+public class HibernateValidatorTestResourceSuperclass {
+
+    @GET
+    @Path("/rest-end-point-interface-validation-annotation-on-overridden-method/{id}/")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testRestEndPointInterfaceValidationWithAnnotationOnOverriddenMethod(
+            @Digits(integer = 5, fraction = 0) @PathParam("id") String id) {
+        return id;
+    }
+}

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -278,11 +278,29 @@ public class HibernateValidatorFunctionalityTest {
                 .get("/hibernate-validator/test/rest-end-point-interface-validation-annotation-on-impl-method/plop/")
                 .then()
                 .statusCode(400)
+                .contentType(ContentType.TEXT)
                 .body(containsString("numeric value out of bounds"));
 
         RestAssured.when()
                 .get("/hibernate-validator/test/rest-end-point-interface-validation-annotation-on-impl-method/42/")
                 .then()
+                .contentType(ContentType.TEXT)
+                .body(is("42"));
+    }
+
+    @Test
+    public void testRestEndPointInterfaceValidationWithAnnotationOnOverriddenMethod() {
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-interface-validation-annotation-on-overridden-method/plop/")
+                .then()
+                .statusCode(400)
+                .contentType(ContentType.TEXT)
+                .body(containsString("numeric value out of bounds"));
+
+        RestAssured.when()
+                .get("/hibernate-validator/test/rest-end-point-interface-validation-annotation-on-overridden-method/42/")
+                .then()
+                .contentType(ContentType.TEXT)
                 .body(is("42"));
     }
 


### PR DESCRIPTION
Note that we are not following strictly the JAX-RS specification but we try to analyze the @Produces annotations on a best effort basis. Hopefully, it will be good enough.

Fixes #29253