### PR TITLE
Make kotlin not load parent first, and stop handling pact parent-first configuration in core quarkus

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -194,26 +194,6 @@
                         <parentFirstArtifact>org.opentest4j:opentest4j</parentFirstArtifact>
                         <parentFirstArtifact>org.junit.platform:junit-platform-commons</parentFirstArtifact>
 
-                        <!-- Pact[<4.1.0] support. It would be great if there was somewhere better to put this-->
-                        <parentFirstArtifact>au.com.dius:pact-jvm-provider-junit5</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius:pact-jvm-provider</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius:pact-jvm-core-support</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius:pact-jvm-core-pact-broker</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius:pact-jvm-core-model</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius:pact-jvm-core-matchers</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius:pact-jvm-junit5</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius:pact-jvm-consumer-java8</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius:pact-jvm-consumer</parentFirstArtifact>
-                        <!-- Pact[>=4.1.0] support.-->
-                        <parentFirstArtifact>au.com.dius.pact.provider:junit5</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius.pact:provider</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius.pact.core:support</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius.pact.core:pactbroker</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius.pact.core:model</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius.pact.core:matcher</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius.pact.consumer:junit5</parentFirstArtifact>
-                        <parentFirstArtifact>au.com.dius.pact:consumer</parentFirstArtifact>
-
                         <!-- Make use of byteman frictionless -->
                         <parentFirstArtifact>org.jboss.byteman:byteman</parentFirstArtifact>
                     </parentFirstArtifacts>

--- a/extensions/kotlin/runtime/pom.xml
+++ b/extensions/kotlin/runtime/pom.xml
@@ -19,22 +19,6 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <configuration>
-                    <parentFirstArtifacts>
-                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk8</parentFirstArtifact>
-                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk7</parentFirstArtifact>
-                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-reflect</parentFirstArtifact>
-                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib</parentFirstArtifact>
-                        <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-common</parentFirstArtifact>
-                        <parentFirstArtifact>org.jetbrains:annotations</parentFirstArtifact>
-                    </parentFirstArtifacts>
-                    <runnerParentFirstArtifacts>
-                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk8</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk7</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-reflect</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-common</runnerParentFirstArtifact>
-                        <runnerParentFirstArtifact>org.jetbrains:annotations</runnerParentFirstArtifact>
-                    </runnerParentFirstArtifacts>
                     <lesserPriorityArtifacts>
                         <!--
                         see https://github.com/quarkusio/quarkus/issues/8405


### PR DESCRIPTION
These changes reinstate @stuartwdouglas's  changes from #29697. They’re breaking changes, so they were reverted, but it’s appropriate to apply them in a 3.0 branch.

This PR also has some changes of mine. We always felt a bit uncomfortable having lots of pact configuration in quarkus core, and now that we have a pact extension we can move that config to a more targeted place.

Note that the changes in #29697 break the pact extension. The second set changes in this PR are mine. They half-fix the pact support, but they also need https://github.com/holly-cummins/quarkus-pact/tree/pact-for-quarkus-3 to be applied to the pact extension for things to work fully properly. 

When @gsmet is doing the patch-y sync-y magic, could we please 
- rebase against main *before* applying this change ... that should (if I did git right) change the number of commits from 4 to 2, and change the 'files changed' to 2 from 1
- manually check https://github.com/quarkusio/quarkus/blob/jakarta-10-misc/extensions/kotlin/runtime/pom.xml to see if I did git right

Why so convoluted? The `extensions/kotlin/runtime/pom.xml` had some changes made, and then reverted, and this changeset reinstates them. But the original change is in the branch I’m basing this change against, and the reversion isn’t. I’ve cherry-picked the reversion in to this branch, and then reverted the reversion … confused yet? My assumption is that git could also get confused by all this, so we should check the output by eye. 

At the end, the maven plugin config in the kotlin `pom.xml` should be something like this (no parent-first artefacts):

```
<artifactId>quarkus-extension-maven-plugin</artifactId>
                <configuration>
                    <lesserPriorityArtifacts>
                        <!--
                        see https://github.com/quarkusio/quarkus/issues/8405
                        -->
                        <lesserPriorityArtifact>org.jetbrains.kotlin:kotlin-compiler</lesserPriorityArtifact>
                    </lesserPriorityArtifacts>
                    <capabilities>
                        <provides>io.quarkus.kotlin</provides>
                    </capabilities>
                </configuration>
```

For background, these are the relevant changes in the history.

https://github.com/quarkusio/quarkus/pull/29697/commits (in the branch)
https://github.com/quarkusio/quarkus/pull/29869/commits (not in the branch)