### PR TITLE
Support quoted and indexed properties during container launch

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 
 import io.quarkus.runtime.util.ContainerRuntimeUtil;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
+import io.smallrye.config.common.utils.StringUtil;
 
 public class DefaultDockerContainerLauncher implements DockerContainerArtifactLauncher {
 
@@ -196,13 +197,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
     }
 
     private String convertPropertyToEnvVar(String property) {
-        return property.toUpperCase()
-                .replace('-', '_')
-                .replace('.', '_')
-                .replace('/', '_')
-                .replace('"', '_')
-                .replace('[', '_')
-                .replace(']', '_');
+        return StringUtil.replaceNonAlphanumericByUnderscores(property).toUpperCase();
     }
 
     @Override

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -189,14 +189,20 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         if ((property != null) && (!property.isEmpty())) {
             List<String> result = new ArrayList<>(2);
             result.add("--env");
-            result.add(String.format("%s=%s", convertPropertyToEnVar(property), value));
+            result.add(String.format("%s=%s", convertPropertyToEnvVar(property), value));
             return result;
         }
         return Collections.emptyList();
     }
 
-    private String convertPropertyToEnVar(String property) {
-        return property.toUpperCase().replace('-', '_').replace('.', '_').replace('/', '_');
+    private String convertPropertyToEnvVar(String property) {
+        return property.toUpperCase()
+                .replace('-', '_')
+                .replace('.', '_')
+                .replace('/', '_')
+                .replace('"', '_')
+                .replace('[', '_')
+                .replace(']', '_');
     }
 
     @Override


### PR DESCRIPTION
Before launching a container, Quarkus converts property names to environment variables. These environment variables are then injected during the container launch.

Currently, Quarkus does not correctly convert quoted and indexed properties to their corresponding environment variables based on SmallRye Config's [environment variable names conversion rules](https://smallrye.io/smallrye-config/3.1.1/config/environment-variables/).