### PR TITLE
gRPC Dev UI - fix problems when reusing the existing HTTP server

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/devmode/GrpcDevConsoleProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/devmode/GrpcDevConsoleProcessor.java
@@ -56,11 +56,13 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.grpc.deployment.DelegatingGrpcBeanBuildItem;
 import io.quarkus.grpc.deployment.GrpcDotNames;
 import io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator;
+import io.quarkus.grpc.runtime.config.GrpcConfiguration;
 import io.quarkus.grpc.runtime.devmode.CollectStreams;
 import io.quarkus.grpc.runtime.devmode.DelegatingGrpcBeansStorage;
 import io.quarkus.grpc.runtime.devmode.GrpcDevConsoleRecorder;
 import io.quarkus.grpc.runtime.devmode.GrpcServices;
 import io.quarkus.grpc.runtime.devmode.StreamCollectorInterceptor;
+import io.quarkus.vertx.http.runtime.HttpConfiguration;
 
 public class GrpcDevConsoleProcessor {
 
@@ -145,8 +147,9 @@ public class GrpcDevConsoleProcessor {
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep(onlyIf = IsDevelopment.class)
-    public DevConsoleRouteBuildItem createWebSocketEndpoint(GrpcDevConsoleRecorder recorder) {
-        recorder.setServerConfiguration();
+    public DevConsoleRouteBuildItem createWebSocketEndpoint(GrpcDevConsoleRecorder recorder,
+            HttpConfiguration httpConfiguration, GrpcConfiguration grpcConfiguration) {
+        recorder.setServerConfiguration(httpConfiguration, grpcConfiguration);
         return DevConsoleRouteBuildItem.builder().path("grpc-test").method("GET").handler(recorder.handler()).build();
     }
 

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -41,6 +41,7 @@ import io.grpc.ServerInterceptors;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
 import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.Subclass;
 import io.quarkus.grpc.runtime.config.GrpcConfiguration;
 import io.quarkus.grpc.runtime.config.GrpcServerConfiguration;
@@ -173,6 +174,8 @@ public class GrpcServerRecorder {
             }
         });
         shutdown.addShutdownTask(route::remove); // remove this route at shutdown, this should reset it
+
+        initHealthStorage();
     }
 
     // TODO -- handle Avro, plain text ... when supported / needed
@@ -225,12 +228,15 @@ public class GrpcServerRecorder {
     }
 
     private void initHealthStorage() {
-        GrpcHealthStorage storage = Arc.container().instance(GrpcHealthStorage.class).get();
-        storage.setStatus(GrpcHealthStorage.DEFAULT_SERVICE_NAME,
-                HealthOuterClass.HealthCheckResponse.ServingStatus.SERVING);
-        for (GrpcServiceDefinition service : services) {
-            storage.setStatus(service.definition.getServiceDescriptor().getName(),
+        InstanceHandle<GrpcHealthStorage> storageHandle = Arc.container().instance(GrpcHealthStorage.class);
+        if (storageHandle.isAvailable()) {
+            GrpcHealthStorage storage = storageHandle.get();
+            storage.setStatus(GrpcHealthStorage.DEFAULT_SERVICE_NAME,
                     HealthOuterClass.HealthCheckResponse.ServingStatus.SERVING);
+            for (GrpcServiceDefinition service : services) {
+                storage.setStatus(service.definition.getServiceDescriptor().getName(),
+                        HealthOuterClass.HealthCheckResponse.ServingStatus.SERVING);
+            }
         }
     }
 

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/devmode/GrpcDevConsoleRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/devmode/GrpcDevConsoleRecorder.java
@@ -5,13 +5,13 @@ import java.util.Map;
 
 import org.jboss.logging.Logger;
 
-import io.quarkus.arc.Arc;
-import io.quarkus.arc.InstanceHandle;
 import io.quarkus.dev.console.DevConsoleManager;
 import io.quarkus.dev.testing.GrpcWebSocketProxy;
 import io.quarkus.grpc.runtime.config.GrpcConfiguration;
 import io.quarkus.grpc.runtime.config.GrpcServerConfiguration;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.HttpConfiguration.InsecureRequests;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
@@ -20,17 +20,22 @@ import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class GrpcDevConsoleRecorder {
-    private static final Logger log = Logger.getLogger(GrpcDevConsoleRecorder.class);
 
-    public void setServerConfiguration() {
-        try (InstanceHandle<GrpcConfiguration> config = Arc.container().instance(GrpcConfiguration.class)) {
-            GrpcServerConfiguration serverConfig = config.get().server;
-            Map<String, Object> map = new HashMap<>();
+    private static final Logger LOG = Logger.getLogger(GrpcDevConsoleRecorder.class);
+
+    public void setServerConfiguration(HttpConfiguration httpConfiguration, GrpcConfiguration grpcConfiguration) {
+        GrpcServerConfiguration serverConfig = grpcConfiguration.server;
+        Map<String, Object> map = new HashMap<>();
+        if (serverConfig.useSeparateServer) {
             map.put("host", serverConfig.host);
             map.put("port", serverConfig.port);
             map.put("ssl", serverConfig.ssl.certificate.isPresent() || serverConfig.ssl.keyStore.isPresent());
-            DevConsoleManager.setGlobal("io.quarkus.grpc.serverConfig", map);
+        } else {
+            map.put("host", httpConfiguration.host);
+            map.put("port", httpConfiguration.port);
+            map.put("ssl", httpConfiguration.insecureRequests != InsecureRequests.ENABLED);
         }
+        DevConsoleManager.setGlobal("io.quarkus.grpc.serverConfig", map);
     }
 
     public Handler<RoutingContext> handler() {
@@ -39,12 +44,12 @@ public class GrpcDevConsoleRecorder {
             public void handle(RoutingContext context) {
                 context.request().toWebSocket(webSocket -> {
                     if (webSocket.failed()) {
-                        log.error("failed to connect web socket", webSocket.cause());
+                        LOG.error("failed to connect web socket", webSocket.cause());
                     } else {
                         ServerWebSocket serverWebSocket = webSocket.result();
                         Integer socketId = GrpcWebSocketProxy.addWebSocket(
                                 message -> serverWebSocket.writeTextMessage(message)
-                                        .onFailure(e -> log
+                                        .onFailure(e -> LOG
                                                 .info("failed to send back message to the gRPC Dev Console WebSocket", e)),
                                 runnable -> {
                                     if (!serverWebSocket.isClosed()) {
@@ -60,7 +65,7 @@ public class GrpcDevConsoleRecorder {
                                 });
 
                         if (socketId == null) {
-                            log.error("No gRPC dev console WebSocketListener");
+                            LOG.error("No gRPC dev console WebSocketListener");
                             serverWebSocket.close();
                             return;
                         }


### PR DESCRIPTION
- i.e. when quarkus.grpc.server.use-separate-server=false is used
- fixes #30244