### PR TITLE
Allow transformation of private injected field to allow reflection-free injection

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
@@ -69,6 +69,14 @@ public class ArcConfig {
     public boolean transformUnproxyableClasses;
 
     /**
+     * If set to true, the bytecode of private fields that are injection points will be transformed to package private.
+     * This ensures that field injection can be performed completely reflection-free.
+     * If the value is set to false, then a reflection fallback is used to perform the injection.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean transformPrivateInjectedFields;
+
+    /**
      * If set to true, the build fails if a private method that is neither an observer nor a producer, is annotated with an
      * interceptor binding.
      * An example of this is the use of {@code Transactional} on a private method of a bean.

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -361,6 +361,7 @@ public class ArcProcessor {
             });
         }
         builder.setTransformUnproxyableClasses(arcConfig.transformUnproxyableClasses);
+        builder.setTransformPrivateInjectedFields(arcConfig.transformPrivateInjectedFields);
         builder.setFailOnInterceptedPrivateMethod(arcConfig.failOnInterceptedPrivateMethod);
         builder.setJtaCapabilities(capabilities.isPresent(Capability.TRANSACTIONS));
         builder.setGenerateSources(BootstrapDebug.DEBUG_SOURCES_DIR != null);

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/Bar.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/Bar.java
@@ -1,0 +1,10 @@
+package io.quarkus.arc.test.transform.injectionPoint;
+
+import javax.enterprise.context.Dependent;
+
+import io.quarkus.arc.Unremovable;
+
+@Dependent
+@Unremovable
+public class Bar {
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/DummyBean.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/DummyBean.java
@@ -1,0 +1,11 @@
+package io.quarkus.arc.test.transform.injectionPoint;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class DummyBean {
+
+    public String generateString() {
+        return DummyBean.class.getSimpleName();
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/PrivateFieldInjectionTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/PrivateFieldInjectionTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.arc.test.transform.injectionPoint;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.Unremovable;
+import io.quarkus.arc.test.transform.injectionPoint.diffPackage.Foo;
+import io.quarkus.arc.test.transform.injectionPoint.diffPackage.SomeBean;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that a private field can be injected into even though there is no reflection fallback.
+ * By default, transformation is used and private fields gets changed to package private.
+ * If this option gets turned off, the reflection fallback kicks in.
+ */
+public class PrivateFieldInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Head.class, CombineHarvester.class, FooExtended.class, Foo.class, SomeBean.class, Bar.class)
+                    // this should be on by default but the test states it explicitly to make it clear
+                    .addAsResource(new StringAsset("quarkus.arc.transform-private-injected-fields=true"),
+                            "application.properties"));
+
+    @Test
+    public void testInjection() {
+        assertNotNull(Arc.container().instance(CombineHarvester.class).get().getHead());
+        assertNotNull(Arc.container().instance(CombineHarvester.class).get().getBar());
+        assertNotNull(Arc.container().instance(FooExtended.class).get().getSomeBean());
+    }
+
+    @Dependent
+    static class Head {
+
+    }
+
+    @ApplicationScoped
+    @Unremovable
+    static class CombineHarvester extends BaseHarvester {
+
+        @Inject
+        private Head head;
+
+        public Head getHead() {
+            return head;
+        }
+
+    }
+
+    // Deliberately not a bean but has private injection point
+    // this case is not subject to transformation and requires reflection
+    static class BaseHarvester {
+
+        @Inject
+        private Bar bar;
+
+        public Bar getBar() {
+            return bar;
+        }
+    }
+
+    // this bean extends a bean from another package that has injection into a private field
+    @ApplicationScoped
+    @Unremovable
+    static class FooExtended extends Foo {
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/Simple.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/Simple.java
@@ -1,0 +1,19 @@
+package io.quarkus.arc.test.transform.injectionPoint;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+@Documented
+@InterceptorBinding
+public @interface Simple {
+
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/SomeDecorator.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/SomeDecorator.java
@@ -1,0 +1,25 @@
+package io.quarkus.arc.test.transform.injectionPoint;
+
+import javax.annotation.Priority;
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+@Dependent
+@Priority(1)
+@Decorator
+public class SomeDecorator implements PrivateFieldInjectionTest.DecoratedBean {
+
+    @Inject
+    @Delegate
+    PrivateFieldInjectionTest.DecoratedBean delegate;
+
+    @Inject
+    private DummyBean bean;
+
+    @Override
+    public String ping() {
+        return bean.generateString() + delegate.ping();
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/SomeInterceptor.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/SomeInterceptor.java
@@ -1,0 +1,21 @@
+package io.quarkus.arc.test.transform.injectionPoint;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+@Simple
+@Priority(1)
+@Interceptor
+public class SomeInterceptor {
+
+    @Inject
+    private DummyBean bean;
+
+    @AroundInvoke
+    Object mySuperCoolAroundInvoke(InvocationContext ctx) throws Exception {
+        return ctx.proceed() + bean.generateString();
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/diffPackage/Foo.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/diffPackage/Foo.java
@@ -1,0 +1,15 @@
+package io.quarkus.arc.test.transform.injectionPoint.diffPackage;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class Foo {
+    // this IP is deliberately private
+    @Inject
+    private SomeBean bean;
+
+    public SomeBean getSomeBean() {
+        return bean;
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/diffPackage/SomeBean.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/transform/injectionPoint/diffPackage/SomeBean.java
@@ -1,0 +1,7 @@
+package io.quarkus.arc.test.transform.injectionPoint.diffPackage;
+
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public class SomeBean {
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -461,6 +461,7 @@ public class BeanDeployment {
         List<Throwable> errors = new ArrayList<>();
         // First, validate all beans internally
         validateBeans(errors, bytecodeTransformerConsumer);
+        validateInterceptorsAndDecorators(errors, bytecodeTransformerConsumer);
         ValidationContextImpl validationContext = new ValidationContextImpl(buildContext);
         for (Throwable error : errors) {
             validationContext.addDeploymentProblem(error);
@@ -1292,6 +1293,16 @@ public class BeanDeployment {
             injectionPoints.addAll(decorator.getAllInjectionPoints());
         }
         return decorators;
+    }
+
+    private void validateInterceptorsAndDecorators(List<Throwable> errors,
+            Consumer<BytecodeTransformer> bytecodeTransformerConsumer) {
+        for (InterceptorInfo interceptor : interceptors) {
+            interceptor.validateInterceptorDecorator(errors, bytecodeTransformerConsumer);
+        }
+        for (DecoratorInfo decorator : decorators) {
+            decorator.validateInterceptorDecorator(errors, bytecodeTransformerConsumer);
+        }
     }
 
     private void validateBeans(List<Throwable> errors, Consumer<BytecodeTransformer> bytecodeTransformerConsumer) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -107,6 +107,8 @@ public class BeanDeployment {
 
     final boolean transformUnproxyableClasses;
 
+    final boolean transformPrivateInjectedFields;
+
     final boolean failOnInterceptedPrivateMethod;
 
     private final boolean jtaCapabilities;
@@ -205,6 +207,7 @@ public class BeanDeployment {
         this.delegateInjectionPointResolver = new DelegateInjectionPointResolverImpl(this);
         this.interceptorResolver = new InterceptorResolver(this);
         this.transformUnproxyableClasses = builder.transformUnproxyableClasses;
+        this.transformPrivateInjectedFields = builder.transformPrivateInjectedFields;
         this.failOnInterceptedPrivateMethod = builder.failOnInterceptedPrivateMethod;
         this.jtaCapabilities = builder.jtaCapabilities;
         this.alternativePriorities = builder.alternativePriorities;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -1505,7 +1505,8 @@ public class BeanGenerator extends AbstractGenerator {
                     providerHandle, childCtxHandle);
 
             FieldInfo injectedField = fieldInjection.target.asField();
-            if (isReflectionFallbackNeeded(injectedField, targetPackage)) {
+            // only use reflection fallback if we are not performing transformation
+            if (isReflectionFallbackNeeded(injectedField, targetPackage, bean)) {
                 if (Modifier.isPrivate(injectedField.flags())) {
                     privateMembers.add(isApplicationClass,
                             String.format("@Inject field %s#%s", fieldInjection.target.asField().declaringClass().name(),

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -525,6 +525,11 @@ public class BeanInfo implements InjectionTargetInfo {
         Beans.validateBean(this, errors, bytecodeTransformerConsumer, classesReceivingNoArgsCtor);
     }
 
+    void validateInterceptorDecorator(List<Throwable> errors, Consumer<BytecodeTransformer> bytecodeTransformerConsumer) {
+        // no actual validations done at the moment, but we still want the transformation
+        Beans.validateInterceptorDecorator(this, errors, bytecodeTransformerConsumer);
+    }
+
     void init(List<Throwable> errors, Consumer<BytecodeTransformer> bytecodeTransformerConsumer,
             boolean transformUnproxyableClasses) {
         for (Injection injection : injections) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -471,6 +471,7 @@ public class BeanProcessor {
         boolean generateSources;
         boolean jtaCapabilities;
         boolean transformUnproxyableClasses;
+        boolean transformPrivateInjectedFields;
         boolean failOnInterceptedPrivateMethod;
         boolean allowMocking;
 
@@ -502,6 +503,7 @@ public class BeanProcessor {
             generateSources = false;
             jtaCapabilities = false;
             transformUnproxyableClasses = false;
+            transformPrivateInjectedFields = false;
             failOnInterceptedPrivateMethod = false;
             allowMocking = false;
 
@@ -716,6 +718,17 @@ public class BeanProcessor {
          */
         public Builder setTransformUnproxyableClasses(boolean value) {
             this.transformUnproxyableClasses = value;
+            return this;
+        }
+
+        /**
+         * If set to true the container will transform injected private field of class based beans during validation.
+         *
+         * @param value
+         * @return self
+         */
+        public Builder setTransformPrivateInjectedFields(boolean value) {
+            this.transformPrivateInjectedFields = value;
             return this;
         }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -610,6 +610,20 @@ public final class Beans {
         }
     }
 
+    static void validateInterceptorDecorator(BeanInfo bean, List<Throwable> errors,
+            Consumer<BytecodeTransformer> bytecodeTransformerConsumer) {
+        // transform any private injected fields into package private
+        if (bean.isClassBean() && bean.getDeployment().transformPrivateInjectedFields) {
+            for (Injection injection : bean.getInjections()) {
+                if (injection.isField() && Modifier.isPrivate(injection.getTarget().asField().flags())) {
+                    bytecodeTransformerConsumer
+                            .accept(new BytecodeTransformer(bean.getTarget().get().asClass().name().toString(),
+                                    new PrivateInjectedFieldTransformFunction(injection.getTarget().asField().name())));
+                }
+            }
+        }
+    }
+
     static void validateBean(BeanInfo bean, List<Throwable> errors, Consumer<BytecodeTransformer> bytecodeTransformerConsumer,
             Set<DotName> classesReceivingNoArgsCtor) {
         if (bean.isClassBean()) {


### PR DESCRIPTION
Fixes #12597

This PR adds a configuration (by default enabled) for transformation of private fields that are injection points into package private.
The change allows Arc to operate on them without the need for reflection.

If this option is turned on, there is a DEBUG level logging for each changed injection point (just like with other transformations):
> [io.qua.arc.pro.Beans] (build-5) Changed visibility of an injected private field to package-private. Field name: head in class: io.quarkus.arc.test.transform.injectionPoint.PrivateFieldInjectionTest$CombineHarvester

If you turn the option off, we are still using reflection fallback and the user keeps getting the same INFO logging as before:
> [io.qua.arc.pro.BeanProcessor] (build-6) Found unrecommended usage of private members (use package-private instead) in application beans:
	- @Inject field io.quarkus.arc.test.transform.injectionPoint.PrivateFieldInjectionTest$CombineHarvester#head