### PR TITLE
Implement output-name/add-runner-suffix on Gradle

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -129,12 +129,12 @@ public abstract class QuarkusBuild extends QuarkusTask {
 
     @OutputFile
     public File getRunnerJar() {
-        return new File(getProject().getBuildDir(), extension().finalName() + "-runner.jar");
+        return new File(getProject().getBuildDir(), String.format("%s.jar", extension().buildNativeRunnerName(Map.of())));
     }
 
     @OutputFile
     public File getNativeRunner() {
-        return new File(getProject().getBuildDir(), extension().finalName() + "-runner");
+        return new File(getProject().getBuildDir(), extension().buildNativeRunnerName(Map.of()));
     }
 
     @OutputDirectory

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/nativeimage/NativeIntegrationTestIT.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/nativeimage/NativeIntegrationTestIT.java
@@ -19,4 +19,22 @@ public class NativeIntegrationTestIT extends QuarkusNativeGradleITBase {
         assertThat(testResult.getTasks().get(":testNative")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
     }
 
+    @Test
+    public void runNativeTestsWithOutputName() throws Exception {
+        final File projectDir = getProjectDir("it-test-basic-project");
+
+        final BuildResult testResult = runGradleWrapper(projectDir, "clean", "testNative",
+                "-Dquarkus.package.output-name=test");
+        assertThat(testResult.getTasks().get(":testNative")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+    }
+
+    @Test
+    public void runNativeTestsWithoutRunnerSuffix() throws Exception {
+        final File projectDir = getProjectDir("it-test-basic-project");
+
+        final BuildResult testResult = runGradleWrapper(projectDir, "clean", "testNative",
+                "-Dquarkus.package.add-runner-suffix=false");
+        assertThat(testResult.getTasks().get(":testNative")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+    }
+
 }


### PR DESCRIPTION
Implements the `quarkus.package.output-name` and `quarkus.package.add-runner-suffix` properties on Gradle.

Closes #30101 

Reproducer and fix tested on [jacobdotcosta/quarkus-issue-30101](https://github.com/jacobdotcosta/quarkus-issue-30101) repository.

Replacement for the #30149 PR.