### PR TITLE
Add (short) name for class loaders

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CodeGenerator.java
@@ -215,6 +215,7 @@ public class CodeGenerator {
             // we don't want to load config source factories/providers from the current module because they haven't been compiled yet
             QuarkusClassLoader.Builder configClBuilder = QuarkusClassLoader.builder("CodeGenerator Config ClassLoader",
                     deploymentClassLoader, false);
+            configClBuilder.setShortName("codegen-config");
             if (!allowedConfigFactories.isEmpty()) {
                 configClBuilder.addElement(new MemoryClassPathElement(allowedConfigFactories, true));
             }

--- a/core/launcher/src/main/java/io/quarkus/launcher/RuntimeLaunchClassLoader.java
+++ b/core/launcher/src/main/java/io/quarkus/launcher/RuntimeLaunchClassLoader.java
@@ -13,7 +13,7 @@ public class RuntimeLaunchClassLoader extends ClassLoader {
     }
 
     public RuntimeLaunchClassLoader(ClassLoader parent) {
-        super(parent);
+        super("launcher", parent);
     }
 
     @Override

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/ApiLookupProblemDetectedTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/ApiLookupProblemDetectedTest.java
@@ -31,7 +31,7 @@ public class ApiLookupProblemDetectedTest {
                 Formatter fmt = new PatternFormatter("%m");
                 String message = fmt.format(warning);
                 assertTrue(message.contains(
-                        "Stack frame: io.quarkus.arc.test.unused.ApiLookupProblemDetectedTest.testWarning"),
+                        "Stack frame: runtime//io.quarkus.arc.test.unused.ApiLookupProblemDetectedTest.testWarning"),
                         message);
                 assertTrue(message.contains(
                         "Required type: class io.quarkus.arc.test.unused.ApiLookupProblemDetectedTest$Alpha"),

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/ArcLookupProblemDetectedTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/ArcLookupProblemDetectedTest.java
@@ -32,7 +32,7 @@ public class ArcLookupProblemDetectedTest {
                 Formatter fmt = new PatternFormatter("%m");
                 String message = fmt.format(warning);
                 assertTrue(message.contains(
-                        "Stack frame: io.quarkus.arc.test.unused.ArcLookupProblemDetectedTest"),
+                        "Stack frame: runtime//io.quarkus.arc.test.unused.ArcLookupProblemDetectedTest"),
                         message);
                 assertTrue(message.contains(
                         "Required type: class io.quarkus.arc.test.unused.ArcLookupProblemDetectedTest$Alpha"),

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -207,6 +207,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
                     "Augmentation Class Loader: " + quarkusBootstrap.getMode(),
                     quarkusBootstrap.getBaseClassLoader(), !quarkusBootstrap.isIsolateDeployment())
                     .setAssertionsEnabled(quarkusBootstrap.isAssertionsEnabled());
+            builder.setShortName("augment");
             builder.addClassLoaderEventListeners(quarkusBootstrap.getClassLoaderEventListeners());
             //we want a class loader that can load the deployment artifacts and all their dependencies, but not
             //any of the runtime artifacts, or user classes
@@ -252,6 +253,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
                     "Quarkus Base Runtime ClassLoader: " + quarkusBootstrap.getMode(),
                     quarkusBootstrap.getBaseClassLoader(), false)
                     .setAssertionsEnabled(quarkusBootstrap.isAssertionsEnabled());
+            builder.setShortName("base-runtime");
             builder.addClassLoaderEventListeners(quarkusBootstrap.getClassLoaderEventListeners());
 
             if (configuredClassLoading.isFlatTestClassPath()) {
@@ -329,6 +331,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
         QuarkusClassLoader.Builder builder = QuarkusClassLoader
                 .builder("Deployment Class Loader: " + quarkusBootstrap.getMode(),
                         getAugmentClassLoader(), false)
+                .setShortName("deployment")
                 .addClassLoaderEventListeners(quarkusBootstrap.getClassLoaderEventListeners())
                 .setAssertionsEnabled(quarkusBootstrap.isAssertionsEnabled())
                 .setAggregateParentResources(true);
@@ -372,6 +375,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
                         "Quarkus Runtime ClassLoader: " + quarkusBootstrap.getMode() + " restart no:"
                                 + runtimeClassLoaderCount.getAndIncrement(),
                         getBaseRuntimeClassLoader(), false)
+                .setShortName("runtime")
                 .setAssertionsEnabled(quarkusBootstrap.isAssertionsEnabled())
                 .setAggregateParentResources(true);
         builder.setTransformedClasses(transformedClasses);

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -131,7 +132,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
     private volatile boolean driverLoaded;
 
     private QuarkusClassLoader(Builder builder) {
-        super(builder.parent);
+        super(builder.shortName, builder.parent);
         this.name = builder.name;
         this.elements = builder.elements;
         this.bannedElements = builder.bannedElements;
@@ -672,6 +673,7 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         final List<ClassPathElement> parentFirstElements = new ArrayList<>();
         final List<ClassPathElement> lesserPriorityElements = new ArrayList<>();
         final boolean parentFirst;
+        String shortName;
         MemoryClassPathElement resettableElement;
         private Map<String, byte[]> transformedClasses = Collections.emptyMap();
         boolean aggregateParentResources;
@@ -679,9 +681,20 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         private final ArrayList<ClassLoaderEventListener> classLoaderEventListeners = new ArrayList<>(5);
 
         public Builder(String name, ClassLoader parent, boolean parentFirst) {
-            this.name = name;
+            this.name = this.shortName = name;
             this.parent = parent;
             this.parentFirst = parentFirst;
+        }
+
+        /**
+         * Set the short name of the class loader. This is the name which would appear in stack traces.
+         *
+         * @param shortName the short name (must not be {@code null})
+         * @return this builder
+         */
+        public Builder setShortName(final String shortName) {
+            this.shortName = Objects.requireNonNull(shortName, "shortName");
+            return this;
         }
 
         /**
@@ -831,10 +844,4 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
             this.parentFirstResources = parentFirstResources;
         }
     }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
 }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -49,7 +49,7 @@ public final class RunnerClassLoader extends ClassLoader {
     RunnerClassLoader(ClassLoader parent, Map<String, ClassLoadingResource[]> resourceDirectoryMap,
             Set<String> parentFirstPackages, Set<String> nonExistentResources,
             List<String> fullyIndexedDirectories, Map<String, ClassLoadingResource[]> directlyIndexedResourcesIndexMap) {
-        super(parent);
+        super("runner", parent);
         this.resourceDirectoryMap = resourceDirectoryMap;
         this.parentFirstPackages = parentFirstPackages;
         this.nonExistentResources = nonExistentResources;

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -625,6 +625,7 @@ public class QuarkusUnitTest
                             .setBaseClassLoader(
                                     QuarkusClassLoader
                                             .builder("QuarkusUnitTest ClassLoader", getClass().getClassLoader(), false)
+                                            .setShortName("unit-test")
                                             .addClassLoaderEventListeners(this.classLoadListeners)
                                             .addBannedElement(ClassPathElement.fromPath(testLocation, true)).build());
                 }


### PR DESCRIPTION
This sets the name that appears in stack traces for each of our major class loaders.

Also, ensure that the contract for `ClassLoader#getName()` is correctly met: "This method is non-final for compatibility. If this method is overridden, this method must return the same name as specified when this class loader was instantiated."

Qbicc compilation uses class loader name as a key to help with reproducible compilation.