### PR TITLE
Add HTTPS port in generated containers by Kubernetes

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -770,6 +770,7 @@ To secure the incoming connections, Kubernetes allows enabling https://kubernete
 [source]
 ----
 quarkus.kubernetes.ingress.expose=true
+quarkus.kubernetes.ingress.target-port=https
 ## Ingress TLS configuration:
 quarkus.kubernetes.ingress.tls.my-secret.enabled=true
 ----

--- a/extensions/kubernetes/kind/deployment/src/main/java/io/quarkus/kind/deployment/KindProcessor.java
+++ b/extensions/kubernetes/kind/deployment/src/main/java/io/quarkus/kind/deployment/KindProcessor.java
@@ -84,9 +84,8 @@ public class KindProcessor {
     public List<ConfiguratorBuildItem> createConfigurators(KubernetesConfig config,
             List<KubernetesPortBuildItem> ports) {
         List<ConfiguratorBuildItem> result = new ArrayList<>();
-        KubernetesCommonHelper.combinePorts(ports, config).entrySet().forEach(e -> {
-            result.add(new ConfiguratorBuildItem(new AddPortToKubernetesConfig(e.getValue())));
-        });
+        KubernetesCommonHelper.combinePorts(ports, config).values()
+                .forEach(value -> result.add(new ConfiguratorBuildItem(new AddPortToKubernetesConfig(value))));
         return result;
     }
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyOpenshiftRouteConfigurator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyOpenshiftRouteConfigurator.java
@@ -22,10 +22,7 @@ public class ApplyOpenshiftRouteConfigurator extends Configurator<OpenshiftConfi
                 routeBuilder.withHost(routeConfig.host.get());
             }
 
-            if (routeConfig.targetPort.isPresent()) {
-                routeBuilder.withTargetPort(routeConfig.targetPort.get());
-            }
-
+            routeBuilder.withTargetPort(routeConfig.targetPort);
             routeBuilder.endRoute();
         }
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RouteConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RouteConfig.java
@@ -23,9 +23,10 @@ public class RouteConfig {
 
     /**
      * The target named port. If not provided, it will be deducted from the Service resource ports.
+     * Options are: "http" and "https".
      */
-    @ConfigItem
-    Optional<String> targetPort;
+    @ConfigItem(defaultValue = "http")
+    String targetPort;
 
     /**
      * Custom annotations to add to exposition (route or ingress) resources

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BasicKubernetesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BasicKubernetesTest.java
@@ -79,8 +79,7 @@ public class BasicKubernetesTest {
                         assertThat(podSpec.getSecurityContext()).isNull();
                         assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                             assertThat(container.getImagePullPolicy()).isEqualTo("Always"); // expect the default value
-                            assertThat(container.getPorts()).singleElement().satisfies(p -> {
-
+                            assertThat(container.getPorts()).hasSize(2).anySatisfy(p -> {
                                 assertThat(p.getContainerPort()).isEqualTo(8080);
                             });
                         });
@@ -97,9 +96,14 @@ public class BasicKubernetesTest {
                 assertThat(spec.getSelector()).containsOnly(entry("app.kubernetes.io/name", "basic"),
                         entry("app.kubernetes.io/version", "0.1-SNAPSHOT"));
 
-                assertThat(spec.getPorts()).hasSize(1).singleElement().satisfies(p -> {
+                assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
                     assertThat(p.getPort()).isEqualTo(80);
                     assertThat(p.getTargetPort().getIntVal()).isEqualTo(8080);
+                });
+
+                assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
+                    assertThat(p.getPort()).isEqualTo(443);
+                    assertThat(p.getTargetPort().getIntVal()).isEqualTo(8443);
                 });
             });
         });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KindWithDefaultsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KindWithDefaultsTest.java
@@ -71,7 +71,7 @@ public class KindWithDefaultsTest {
 
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("NodePort", spec.getType());
-                    assertThat(spec.getPorts()).hasSize(1).singleElement().satisfies(p -> {
+                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
                         assertThat(p.getNodePort()).isNotNull();
                     });
                 });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithHealthTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithHealthTest.java
@@ -54,7 +54,7 @@ public class KnativeWithHealthTest {
                     assertThat(spec.getTemplate()).satisfies(template -> {
                         assertThat(template.getSpec()).satisfies(templateSpec -> {
                             assertThat(templateSpec.getContainers()).hasSize(1).singleElement().satisfies(c -> {
-                                assertThat(c.getPorts()).hasSize(1).singleElement().satisfies(p -> {
+                                assertThat(c.getPorts()).hasSize(1).anySatisfy(p -> {
                                     assertThat(p.getName()).isEqualTo("http1");
                                 });
                                 assertThat(c.getReadinessProbe()).isNotNull().satisfies(p -> {

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesAndMinikubeWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesAndMinikubeWithApplicationPropertiesTest.java
@@ -72,7 +72,7 @@ public class KubernetesAndMinikubeWithApplicationPropertiesTest {
             assertThat(i).isInstanceOfSatisfying(Service.class, s -> {
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("ClusterIP", spec.getType());
-                    assertThat(spec.getPorts()).hasSize(1).singleElement().satisfies(p -> {
+                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
                         assertThat(p.getNodePort()).isNull();
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(9090);
@@ -109,7 +109,7 @@ public class KubernetesAndMinikubeWithApplicationPropertiesTest {
             assertThat(i).isInstanceOfSatisfying(Service.class, s -> {
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("NodePort", spec.getType());
-                    assertThat(spec.getPorts()).hasSize(1).singleElement().satisfies(p -> {
+                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
                         assertThat(p.getNodePort()).isNotNull();
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(9090);

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesServiceMappingTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesServiceMappingTest.java
@@ -55,15 +55,15 @@ public class KubernetesServiceMappingTest {
                 assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         List<ContainerPort> ports = podSpec.getContainers().get(0).getPorts();
-                        assertThat(ports.size()).isEqualTo(2);
+                        assertThat(ports.size()).isEqualTo(3);
                         assertTrue(ports.stream().anyMatch(port -> "http".equals(port.getName())
                                 && port.getContainerPort() == 8080
                                 && "TCP".equals(port.getProtocol())),
-                                () -> "http port not found in the pod containers!");
+                                "http port not found in the pod containers!");
                         assertTrue(ports.stream().anyMatch(port -> "debug".equals(port.getName())
                                 && port.getContainerPort() == 5005
                                 && "UDP".equals(port.getProtocol())),
-                                () -> "debug port not found in the pod containers!");
+                                "debug port not found in the pod containers!");
                     });
                 });
             });
@@ -74,7 +74,7 @@ public class KubernetesServiceMappingTest {
                 assertThat(m.getName()).isEqualTo("kubernetes-service-mapping");
             });
             assertThat(s.getSpec()).satisfies(serviceSpec -> {
-                assertThat(serviceSpec.getPorts().size()).isEqualTo(2);
+                assertThat(serviceSpec.getPorts().size()).isEqualTo(3);
                 assertTrue(serviceSpec.getPorts().stream().anyMatch(port -> "http".equals(port.getName())
                         && port.getTargetPort().getIntVal() == 8080
                         && "TCP".equals(port.getProtocol())

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithApplicationPropertiesTest.java
@@ -72,7 +72,7 @@ public class KubernetesWithApplicationPropertiesTest {
 
                                 assertThat(container.getImage())
                                         .isEqualTo("quay.io/grp/kubernetes-with-application-properties:0.1-SNAPSHOT");
-                                assertThat(container.getPorts()).singleElement().satisfies(p -> {
+                                assertThat(container.getPorts()).anySatisfy(p -> {
                                     assertThat(p.getContainerPort()).isEqualTo(9090);
                                 });
                                 assertThat(container.getImagePullPolicy()).isEqualTo("IfNotPresent");
@@ -93,7 +93,7 @@ public class KubernetesWithApplicationPropertiesTest {
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("NodePort", spec.getType());
                     assertThat(spec.getSelector()).containsOnly(entry("app.kubernetes.io/name", "test-it"));
-                    assertThat(spec.getPorts()).hasSize(1).singleElement().satisfies(p -> {
+                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(9090);
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithCustomResourcesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithCustomResourcesTest.java
@@ -89,7 +89,7 @@ public class KubernetesWithCustomResourcesTest {
                         assertThat(spec.getSelector()).containsOnly(entry("app.kubernetes.io/name", "custom-resources"),
                                 entry("app.kubernetes.io/version", "0.1-SNAPSHOT"));
 
-                        assertThat(spec.getPorts()).hasSize(1).singleElement().satisfies(p -> {
+                        assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
                             assertThat(p.getPort()).isEqualTo(80);
                             assertThat(p.getTargetPort().getIntVal()).isEqualTo(8080);
                         });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithIngressTargetPortTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithIngressTargetPortTest.java
@@ -1,0 +1,67 @@
+
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithIngressTargetPortTest {
+
+    private static final String APP_NAME = "kubernetes-with-ingress-target-port";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(APP_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource(APP_NAME + ".properties")
+            .setLogFileName("k8s.log")
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo(APP_NAME);
+            });
+        });
+
+        assertThat(kubernetesList).filteredOn(i -> "Ingress".equals(i.getKind())).singleElement().satisfies(item -> {
+            assertThat(item).isInstanceOfSatisfying(Ingress.class, ingress -> {
+                assertThat(ingress.getMetadata()).satisfies(m -> {
+                    assertThat(m.getName()).isEqualTo(APP_NAME);
+                });
+
+                assertThat(ingress.getSpec().getRules()).allSatisfy(rule -> {
+                    assertThat(rule.getHttp().getPaths()).allSatisfy(path -> {
+                        assertThat(path.getBackend().getService().getPort().getName()).isEqualTo("https");
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMultiplePortsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMultiplePortsTest.java
@@ -50,9 +50,11 @@ public class KubernetesWithMultiplePortsTest {
                     assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
                         assertThat(t.getSpec()).satisfies(podSpec -> {
                             assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
-                                assertThat(container.getPorts()).hasSize(2);
+                                assertThat(container.getPorts()).hasSize(3);
                                 assertThat(container.getPorts()).filteredOn(cp -> cp.getContainerPort() == 8080).singleElement()
                                         .satisfies(c -> assertThat(c.getName()).isEqualTo("http"));
+                                assertThat(container.getPorts()).filteredOn(cp -> cp.getContainerPort() == 8443).singleElement()
+                                        .satisfies(c -> assertThat(c.getName()).isEqualTo("https"));
                                 assertThat(container.getPorts()).filteredOn(cp -> cp.getContainerPort() == 5005).singleElement()
                                         .satisfies(c -> assertThat(c.getName()).isEqualTo("remote"));
                             });
@@ -66,7 +68,7 @@ public class KubernetesWithMultiplePortsTest {
             assertThat(i).isInstanceOfSatisfying(Service.class, s -> {
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("NodePort", spec.getType());
-                    assertThat(spec.getPorts()).hasSize(2);
+                    assertThat(spec.getPorts()).hasSize(3);
                     assertThat(spec.getPorts()).filteredOn(sp -> sp.getPort() == 8080).singleElement().satisfies(p -> {
                         assertThat(p.getNodePort()).isEqualTo(30000);
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSidecarAndJibTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSidecarAndJibTest.java
@@ -66,7 +66,7 @@ public class KubernetesWithSidecarAndJibTest {
                     assertThat(c.getArgs()).isEmpty();
                     assertThat(c.getWorkingDir()).isNull();
                     assertThat(c.getVolumeMounts()).isEmpty();
-                    assertThat(c.getPorts()).singleElement().satisfies(p -> assertThat(p.getContainerPort()).isEqualTo(8080));
+                    assertThat(c.getPorts()).anySatisfy(p -> assertThat(p.getContainerPort()).isEqualTo(8080));
                     assertThat(c.getEnv()).allSatisfy(e -> assertThat(e.getName()).isNotEqualToIgnoringCase("foo"));
                 });
     }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithApplicationPropertiesTest.java
@@ -72,7 +72,7 @@ public class MinikubeWithApplicationPropertiesTest {
 
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("NodePort", spec.getType());
-                    assertThat(spec.getPorts()).hasSize(1).singleElement().satisfies(p -> {
+                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
                         assertThat(p.getNodePort()).isEqualTo(31999);
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(9090);

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithDefaultsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithDefaultsTest.java
@@ -70,8 +70,14 @@ public class MinikubeWithDefaultsTest {
 
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("NodePort", spec.getType());
-                    assertThat(spec.getPorts()).hasSize(1).singleElement().satisfies(p -> {
+                    assertThat(spec.getPorts()).hasSize(2);
+                    assertThat(spec.getPorts()).anySatisfy(p -> {
+                        assertThat(p.getName()).isEqualTo("http");
                         assertThat(p.getNodePort()).isNotNull();
+                    });
+                    assertThat(spec.getPorts()).anySatisfy(p -> {
+                        assertThat(p.getName()).isEqualTo("https");
+                        assertThat(p.getNodePort()).isNull();
                     });
                 });
             });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithApplicationPropertiesTest.java
@@ -72,7 +72,7 @@ public class OpenshiftWithApplicationPropertiesTest {
 
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertThat(spec.getSelector()).containsOnly(entry("app.kubernetes.io/name", "test-it"));
-                    assertThat(spec.getPorts()).hasSize(1).singleElement().satisfies(p -> {
+                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(9090);
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRoutePropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRoutePropertiesTest.java
@@ -45,7 +45,7 @@ public class OpenshiftWithRoutePropertiesTest {
 
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertThat(spec.getSelector()).contains(entry("app.kubernetes.io/name", "test-it"));
-                    assertThat(spec.getPorts()).hasSize(1).singleElement().satisfies(p -> {
+                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(9090);
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithS2iTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithS2iTest.java
@@ -102,7 +102,7 @@ public class OpenshiftWithS2iTest {
         assertThat(openshiftList).filteredOn(h -> "Service".equals(h.getKind())).singleElement().satisfies(h -> {
             assertThat(h).isInstanceOfSatisfying(Service.class, s -> {
                 assertThat(s.getSpec()).satisfies(spec -> {
-                    assertThat(spec.getPorts()).hasSize(1).singleElement().satisfies(p -> {
+                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(8080);
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-ingress-target-port.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-ingress-target-port.properties
@@ -1,0 +1,2 @@
+quarkus.kubernetes.ingress.expose=true
+quarkus.kubernetes.ingress.target-port=https


### PR DESCRIPTION
These changes will add an additional container port HTTPS in the generated manifests:

```yaml
containers:
        - image: ...
          imagePullPolicy: IfNotPresent
          name: kubernetes-kind
          ports:
            - containerPort: 8080
              name: http
              protocol: TCP
            - containerPort: 8443
              name: https
              protocol: TCP
```

By default, the Ingress and Route resources will use the "http" port. However, as part of these changes, I've added a new property to select between "https" or "http", or any other that user might have added as part of the configuration. Example:

```
quarkus.kubernetes.ingress.target-port=https
quarkus.openshift.route.target-port=https
```

Finally, note that the https container won't be added for the Knative resources since there seems to be a limitation at Knative side where only one port can be used.

Fix https://github.com/quarkusio/quarkus/issues/29999