### PR TITLE
Cache programmatic API - invalidate entries whose keys match a predicate

### DIFF
--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ProgrammaticApiTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ProgrammaticApiTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.cache.test.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -212,10 +213,22 @@ public class ProgrammaticApiTest {
         }
     }
 
+    @Test
+    public void testInvalidatePredicate() throws Exception {
+        String key = "bravo";
+        String val = cache.get(key, k -> "charlie").await().indefinitely();
+        assertEquals("charlie", val);
+        assertKeySetContains(key);
+        assertGetIfPresent(key, val);
+        cache.invalidateIf(k -> k.equals("bravo")).await().indefinitely();
+        assertFalse(cache.as(CaffeineCache.class).keySet().contains(key));
+        assertNull(cache.as(CaffeineCache.class).getIfPresent(key));
+    }
+
     private void assertKeySetContains(Object... expectedKeys) {
         Set<Object> expectedKeySet = new HashSet<>(Arrays.asList(expectedKeys));
         Set<Object> actualKeySet = cache.as(CaffeineCache.class).keySet();
-        assertEquals(expectedKeySet, actualKeySet);
+        assertTrue(actualKeySet.containsAll(expectedKeySet));
     }
 
     private void assertGetIfPresent(Object key, Object value) throws Exception {

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/SpecializedCacheTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/SpecializedCacheTest.java
@@ -3,6 +3,7 @@ package io.quarkus.cache.test.runtime;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -72,6 +73,11 @@ public class SpecializedCacheTest {
 
         @Override
         public Uni<Void> invalidateAll() {
+            throw new UnsupportedOperationException("This method is not tested here");
+        }
+
+        @Override
+        public Uni<Void> invalidateIf(Predicate<Object> predicate) {
             throw new UnsupportedOperationException("This method is not tested here");
         }
 

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/Cache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/Cache.java
@@ -1,6 +1,7 @@
 package io.quarkus.cache;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import io.smallrye.mutiny.Uni;
 
@@ -53,6 +54,13 @@ public interface Cache {
      * Removes all entries from the cache.
      */
     Uni<Void> invalidateAll();
+
+    /**
+     * Removes all cache entries whose keys match the given predicate.
+     *
+     * @param predicate
+     */
+    Uni<Void> invalidateIf(Predicate<Object> predicate);
 
     /**
      * Returns this cache as an instance of the provided type if possible.

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
@@ -189,6 +190,17 @@ public class CaffeineCacheImpl extends AbstractCache implements CaffeineCache {
             @Override
             public Void get() {
                 cache.synchronous().invalidateAll();
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public Uni<Void> invalidateIf(Predicate<Object> predicate) {
+        return Uni.createFrom().item(new Supplier<Void>() {
+            @Override
+            public Void get() {
+                cache.asMap().keySet().removeIf(predicate);
                 return null;
             }
         });

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/noop/NoOpCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/noop/NoOpCache.java
@@ -1,6 +1,7 @@
 package io.quarkus.cache.runtime.noop;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import io.quarkus.cache.runtime.AbstractCache;
@@ -36,6 +37,11 @@ public class NoOpCache extends AbstractCache {
 
     @Override
     public Uni<Void> invalidateAll() {
+        return Uni.createFrom().voidItem();
+    }
+
+    @Override
+    public Uni<Void> invalidateIf(Predicate<Object> predicate) {
         return Uni.createFrom().voidItem();
     }
 


### PR DESCRIPTION
Currently, you would need to make use of `CaffeineCache`, then iterate over the key set and finally remove an entry if it matches a predicate/condition.