### PR TITLE
Add console port to container execution for AMQP dev services

### DIFF
--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesBuildTimeConfig.java
@@ -32,13 +32,13 @@ public class AmqpDevServicesBuildTimeConfig {
      *
      * Check https://quay.io/repository/artemiscloud/activemq-artemis-broker to find the available versions.
      */
-    @ConfigItem(defaultValue = "quay.io/artemiscloud/activemq-artemis-broker:0.1.2")
+    @ConfigItem(defaultValue = "quay.io/artemiscloud/activemq-artemis-broker:1.0.11")
     public String imageName;
 
     /**
      * The value of the {@code AMQ_EXTRA_ARGS} environment variable to pass to the container.
      */
-    @ConfigItem(defaultValue = "--no-autotune --mapped --no-fsync")
+    @ConfigItem(defaultValue = "--no-autotune --mapped --no-fsync --relax-jolokia --http-host 0.0.0.0")
     public String extraArgs;
 
     /**

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
@@ -50,6 +50,7 @@ public class AmqpDevServicesProcessor {
     private static final String DEV_SERVICE_LABEL = "quarkus-dev-service-amqp";
 
     private static final int AMQP_PORT = 5672;
+    private static final int AMQP_CONSOLE_PORT = 8161;
 
     private static final ContainerLocator amqpContainerLocator = new ContainerLocator(DEV_SERVICE_LABEL, AMQP_PORT);
     private static final String AMQP_HOST_PROP = "amqp-host";
@@ -277,7 +278,7 @@ public class AmqpDevServicesProcessor {
             super(dockerImageName);
             this.port = fixedExposedPort;
             withNetwork(Network.SHARED);
-            withExposedPorts(AMQP_PORT);
+            withExposedPorts(AMQP_PORT, AMQP_CONSOLE_PORT);
             withEnv("AMQ_USER", DEFAULT_USER);
             withEnv("AMQ_PASSWORD", DEFAULT_PASSWORD);
             withEnv("AMQ_EXTRA_ARGS", extra);


### PR DESCRIPTION
This change updates the devservice container for amqp to enable the console available in artemiscloud image.

Follow up to [#22976](https://github.com/quarkusio/quarkus/issues/22976)