### PR TITLE
Add native compilation section to Hibernate Validator guide

### DIFF
--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -487,14 +487,24 @@ To configure the `ValidatorFactory`, use the exposed configuration properties an
 
 Consequently, the only way to define constraints in Quarkus is by annotating your classes.
 
-=== Native compilation
+=== ValidatorFactory and native executables
 
-Building a `Validator` using the `ValidatorFactory` is not possible in native mode. You will end in an 
-error similar to `javax.validation.NoProviderFoundException: Unable to create a Configuration, because no 
+Quarkus provides a default `ValidatorFactory` that you can customize using configuration properties.
+This `ValidatorFactory` is carefully initialized to support native executables
+using a bootstrap that is Quarkus-specific.
+
+Creating a `ValidatorFactory` by yourself it not supported in native executables
+and if you try to do so,
+you will get an  error similar to `javax.validation.NoProviderFoundException: Unable to create a Configuration, because no 
 Jakarta Bean Validation provider could be found. Add a provider like Hibernate Validator (RI) to your 
-classpath.`
+classpath.` when running your native executable.
 
-Always use an injected `Validator`. If you have to configure the `ValidatorFactory` follow the guide at  
+Thus why you should always use the Quarkus-managed `ValidatorFactory` by injecting an instance of
+`ValidatorFactory` or directly an instance of `Validator` using CDI injection.
+
+To support some external libraries that are creating a `ValidatorFactory` using the default bootstrap,
+Quarkus returns the `ValidatorFactory` managed by Quarkus when `Validation.buildDefaultValidatorFactory()`
+is called.
 
 [[configuration-reference]]
 == Hibernate Validator Configuration Reference

--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -487,6 +487,15 @@ To configure the `ValidatorFactory`, use the exposed configuration properties an
 
 Consequently, the only way to define constraints in Quarkus is by annotating your classes.
 
+=== Native compilation
+
+Building a `Validator` using the `ValidatorFactory` is not possible in native mode. You will end in an 
+error similar to `javax.validation.NoProviderFoundException: Unable to create a Configuration, because no 
+Jakarta Bean Validation provider could be found. Add a provider like Hibernate Validator (RI) to your 
+classpath.`
+
+Always use an injected `Validator`. If you have to configure the `ValidatorFactory` follow the guide at  
+
 [[configuration-reference]]
 == Hibernate Validator Configuration Reference
 


### PR DESCRIPTION
I'd like to propose an additional section `Native compilation` describing how to use the `Validator` to avoid running into https://github.com/quarkusio/quarkus/issues/7686