### PR TITLE
Fix locales integration test to pass with JDK 20

### DIFF
--- a/integration-tests/locales/src/test/java/io/quarkus/locales/it/LocalesIT.java
+++ b/integration-tests/locales/src/test/java/io/quarkus/locales/it/LocalesIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.locales.it;
 
+import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;
 
 import org.apache.http.HttpStatus;
@@ -80,7 +81,7 @@ public class LocalesIT {
                 .get("/timeZone")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body(is(zln[2]))
+                .body(equalToIgnoringCase(zln[2]))
                 .log().all();
     }
 


### PR DESCRIPTION
The string changed to lower case in JDK 20
https://github.com/openjdk/jdk20u/commit/5b3de6e143e370272c36383adac3e31f359bc686#diff-a537a5da6e6049d6c24fec137e55e4769e440787df5549126af6a585ceebf376L9004-R9232