### PR TITLE
Cache - introduce the dev-spi module

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2744,6 +2744,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-cache-deployment-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-google-cloud-functions</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -137,4 +137,6 @@ public interface Capability {
 
     String SMALLRYE_REACTIVE_MESSAGING = QUARKUS_PREFIX + "smallrye.reactive.messaging";
     String REDIS_CLIENT = QUARKUS_PREFIX + "redis";
+
+    String CACHE = QUARKUS_PREFIX + "cache";
 }

--- a/extensions/cache/deployment-spi/pom.xml
+++ b/extensions/cache/deployment-spi/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-cache-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-cache-deployment-spi</artifactId>
+    <name>Quarkus - Cache - Deployment - SPI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+    </dependencies>
+    
+</project>

--- a/extensions/cache/deployment-spi/src/main/java/io/quarkus/cache/deployment/spi/AdditionalCacheNameBuildItem.java
+++ b/extensions/cache/deployment-spi/src/main/java/io/quarkus/cache/deployment/spi/AdditionalCacheNameBuildItem.java
@@ -1,4 +1,4 @@
-package io.quarkus.cache.deployment;
+package io.quarkus.cache.deployment.spi;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
@@ -6,11 +6,7 @@ import io.quarkus.builder.item.MultiBuildItem;
  * Build item used to ensure that a cache of the specified name is created at runtime.
  * <p>
  * This is used in order to create caches when means other than the standard cache annotations are used.
- *
- * @deprecated Use {@link io.quarkus.cache.deployment.spi.AdditionalCacheNameBuildItem} instead. This build item will be removed
- *             at some time after Quarkus 3.0.
  */
-@Deprecated(forRemoval = true)
 public final class AdditionalCacheNameBuildItem extends MultiBuildItem {
 
     private final String name;

--- a/extensions/cache/deployment/pom.xml
+++ b/extensions/cache/deployment/pom.xml
@@ -18,6 +18,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-cache</artifactId>
         </dependency>
+         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-cache-deployment-spi</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheProcessor.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheProcessor.java
@@ -52,6 +52,7 @@ import io.quarkus.cache.deployment.exception.KeyGeneratorConstructorException;
 import io.quarkus.cache.deployment.exception.PrivateMethodTargetException;
 import io.quarkus.cache.deployment.exception.UnsupportedRepeatedAnnotationException;
 import io.quarkus.cache.deployment.exception.VoidReturnTypeTargetException;
+import io.quarkus.cache.deployment.spi.AdditionalCacheNameBuildItem;
 import io.quarkus.cache.runtime.CacheInvalidateAllInterceptor;
 import io.quarkus.cache.runtime.CacheInvalidateInterceptor;
 import io.quarkus.cache.runtime.CacheManagerRecorder;
@@ -86,7 +87,9 @@ class CacheProcessor {
 
     @BuildStep
     void validateCacheAnnotationsAndProduceCacheNames(CombinedIndexBuildItem combinedIndex,
-            List<AdditionalCacheNameBuildItem> additionalCacheNames, BuildProducer<ValidationErrorBuildItem> validationErrors,
+            List<AdditionalCacheNameBuildItem> additionalCacheNames,
+            List<io.quarkus.cache.deployment.AdditionalCacheNameBuildItem> additionalCacheNamesDeprecated,
+            BuildProducer<ValidationErrorBuildItem> validationErrors,
             BuildProducer<CacheNamesBuildItem> cacheNames, BeanDiscoveryFinishedBuildItem beanDiscoveryFinished) {
 
         // Validation errors produced by this build step.
@@ -153,6 +156,9 @@ class CacheProcessor {
 
         // Finally, additional cache names provided by other extensions must be added to the cache names collection.
         for (AdditionalCacheNameBuildItem additionalCacheName : additionalCacheNames) {
+            names.add(additionalCacheName.getName());
+        }
+        for (io.quarkus.cache.deployment.AdditionalCacheNameBuildItem additionalCacheName : additionalCacheNamesDeprecated) {
             names.add(additionalCacheName.getName());
         }
         cacheNames.produce(new CacheNamesBuildItem(names));

--- a/extensions/cache/pom.xml
+++ b/extensions/cache/pom.xml
@@ -17,6 +17,7 @@
 
     <modules>
         <module>deployment</module>
+        <module>deployment-spi</module>
         <module>runtime</module>
     </modules>
 </project>

--- a/extensions/cache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/cache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,3 +11,6 @@ metadata:
   status: "stable"
   config:
   - "quarkus.cache."
+  capabilities:
+    provides:
+    - "io.quarkus.cache"

--- a/extensions/spring-cache/deployment/src/main/java/io/quarkus/spring/cache/SpringCacheProcessor.java
+++ b/extensions/spring-cache/deployment/src/main/java/io/quarkus/spring/cache/SpringCacheProcessor.java
@@ -1,6 +1,6 @@
 package io.quarkus.spring.cache;
 
-import static io.quarkus.spring.cache.SpringCacheUtil.*;
+import static io.quarkus.spring.cache.SpringCacheUtil.getSpringCacheName;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,7 +20,7 @@ import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
-import io.quarkus.cache.deployment.AdditionalCacheNameBuildItem;
+import io.quarkus.cache.deployment.spi.AdditionalCacheNameBuildItem;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;


### PR DESCRIPTION
- deprecate the io.quarkus.cache.deployment.AdditionalCacheNameBuildItem; io.quarkus.cache.deployment.spi.AdditionalCacheNameBuildItem should be used instead
- also provide the io.quarkus.cache capability

NOTE: I'm working on the `quarkus-cache` integration in qute so that it's possible to cache parts of a template and I need the dev-spi module to make the dependency on `quarkus-cache`  optional.