### PR TITLE
build: dont fail when vale gets overwhelmed.

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Vale Linter
+        continue-on-error: true
         uses: errata-ai/vale-action@reviewdog
         with:
           fail_on_error: false


### PR DESCRIPTION
in https://github.com/quarkusio/quarkus/pull/29026 vale execution fails and fails the PR even though its a vale bug not due to actual blocking issues.

Adding continue-on-error: true makes it so the step should not result in error even when the container fails to start/run and fail hard and ignore its own fail_on_error setting.