### PR TITLE
Remove test case from no-awt native integration test

### DIFF
--- a/integration-tests/no-awt/src/main/java/io/quarkus/awt/it/GraphicsResource.java
+++ b/integration-tests/no-awt/src/main/java/io/quarkus/awt/it/GraphicsResource.java
@@ -59,9 +59,6 @@ public class GraphicsResource {
         } else if ("ConvolveOp".equals(entrypoint)) {
             final ConvolveOp cop = new ConvolveOp(new Kernel(1, 1, new float[] { 0f }), ConvolveOp.EDGE_NO_OP, null);
             LOG.infof("ConvolveOp: %s", cop.toString());
-        } else if ("Font".equals(entrypoint)) {
-            final Font f = new Font("Arial", Font.PLAIN, 16);
-            LOG.infof("Font: %s", f.getFamily());
         } else if ("Path2D".equals(entrypoint)) {
             final Path2D p = new Path2D.Double();
             LOG.infof("Path2D: %s", p.toString());

--- a/integration-tests/no-awt/src/test/java/io/quarkus/awt/it/GraphicsIT.java
+++ b/integration-tests/no-awt/src/test/java/io/quarkus/awt/it/GraphicsIT.java
@@ -37,7 +37,6 @@ public class GraphicsIT {
             "BufferedImage",
             "Transformations",
             "ConvolveOp",
-            "Font",
             "Path2D",
             "ImageReader",
             "ImageWriter"


### PR DESCRIPTION
In Java 20-based builds of GraalVM / Mandrel invoking Font.getFamily() results in `sun.font.SunFontManager` become reachable and initialized at build time, which when initialized results in the following build error:

```
Error: Detected a started Thread in the image heap. Threads running in the image generator are no longer running at image runtime.  To see how this object got instantiated use --trace-object-instantiation=java.lang.Thread. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
Detailed message:
Trace: Object was reached by
  reading field java.util.concurrent.locks.AbstractQueuedSynchronizer$Node.waiter of constant
    java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode@7cd99b6e: java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode@7cd99b6e
  reading field java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.lastWaiter of constant
    java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@32b2749: java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@32b2749
  reading field java.lang.ref.ReferenceQueue.notEmpty of constant
    java.lang.ref.ReferenceQueue@4b839317: java.lang.ref.ReferenceQueue@4b839317
  scanning root java.lang.ref.ReferenceQueue@4b839317: java.lang.ref.ReferenceQueue@4b839317 embedded in
    sun.java2d.Disposer.addObjectRecord(Disposer.java:250)
  parsing method sun.java2d.Disposer.addObjectRecord(Disposer.java:250) reachable via the parsing context
    at sun.font.Type1Font.<init>(Type1Font.java:176)
    at sun.font.SunFontManager.registerFontFile(SunFontManager.java:960)
    at sun.font.SunFontManager.registerFontFile(SunFontManager.java:3226)
    at sun.font.SunFontManager.initCompositeFonts(SunFontManager.java:3137)
    at sun.font.SunFontManager$2.run(SunFontManager.java:445)
    at sun.font.SunFontManager$2.run(SunFontManager.java:309)
    at com.oracle.svm.core.jdk.Target_java_security_AccessController.executePrivileged(SecuritySubstitutions.java:171)
    at java.util.logging.Logger.findResourceBundle(Logger.java:2215)
    at java.util.logging.Logger.setupResourceInfo(Logger.java:2297)
    at java.util.logging.Logger.<init>(Logger.java:566)
    at java.util.logging.Logger.<init>(Logger.java:557)
    at org.jboss.logmanager.Logger.<init>(Logger.java:85)
    at org.jboss.logmanager.LoggerNode.createLogger(LoggerNode.java:200)
    at org.jboss.logmanager.LogContext.getLogger(LogContext.java:161)
    at org.jboss.logmanager.Logger.getLogger(Logger.java:55)
    at io.quarkus.vertx.core.runtime.VertxLogDelegate.<init>(VertxLogDelegate.java:14)
    at io.quarkus.vertx.core.runtime.VertxLogDelegateFactory.createDelegate(VertxLogDelegateFactory.java:14)
```

Note that the aim of `no-awt` is to test the error reports generated by quarkus when we try to use awt without the quarkus-awt extension so removing the "Font" case doesn't reduce coverage or cover up an existing issue.