### PR TITLE
Propagate security annotations in the Spring Data Rest for all methods

### DIFF
--- a/docs/src/main/asciidoc/spring-data-rest.adoc
+++ b/docs/src/main/asciidoc/spring-data-rest.adoc
@@ -417,6 +417,24 @@ It is important to annotate the correct method in order to customize its REST en
 |`void deleteById(ID id)`
 |===
 
+==== Securing endpoints
+
+This extension will automatically use the Security annotations within the package `javax.annotation.security` that are defined on your resource interfaces:
+
+[source,java]
+----
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.RolesAllowed;
+
+@DenyAll
+public interface FruitResource extends CrudRepository<Fruit, Long> {
+    @RolesAllowed("superuser")
+    Iterable<Fruit> findAll();
+}
+----
+
+Note that this feature is provided by the REST Data with Panache extension that this extension is using under the hood. So, pure Spring Boot applications might not behave the same way.
+
 === What is currently unsupported
 
 * Only the repository methods listed above are supported. No other standard or custom methods are supported.

--- a/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/ResourcePropertiesProvider.java
+++ b/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/ResourcePropertiesProvider.java
@@ -119,17 +119,15 @@ public abstract class ResourcePropertiesProvider {
         }
         for (MethodInfo method : classInfo.methods()) {
             if (methodPredicate.test(method)) {
+                MethodWithAnnotation found = new MethodWithAnnotation();
+                found.method = method;
                 if (method.hasAnnotation(REPOSITORY_REST_RESOURCE_ANNOTATION)) {
-                    MethodWithAnnotation found = new MethodWithAnnotation();
-                    found.method = method;
                     found.annotation = method.annotation(REPOSITORY_REST_RESOURCE_ANNOTATION);
-                    return found;
                 } else if (method.hasAnnotation(REST_RESOURCE_ANNOTATION)) {
-                    MethodWithAnnotation found = new MethodWithAnnotation();
-                    found.method = method;
                     found.annotation = method.annotation(REST_RESOURCE_ANNOTATION);
-                    return found;
                 }
+
+                return found;
             }
         }
         if (classInfo.superName() != null) {

--- a/integration-tests/spring-data-rest/src/main/java/io/quarkus/it/spring/data/rest/AuthorsRepository.java
+++ b/integration-tests/spring-data-rest/src/main/java/io/quarkus/it/spring/data/rest/AuthorsRepository.java
@@ -1,11 +1,20 @@
 package io.quarkus.it.spring.data.rest;
 
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.rest.core.annotation.RestResource;
 
+@PermitAll
 public interface AuthorsRepository extends CrudRepository<Author, Long> {
 
+    @Override
+    @RolesAllowed("user")
+    Iterable<Author> findAll();
+
     @RestResource(exported = false)
+    @RolesAllowed("superuser")
     <S extends Author> S save(S author);
 
     @RestResource(exported = false)


### PR DESCRIPTION
Before these changes, the security annotations were only propagated to the generated resource if and only if the method was annotated with either the `@RestResource` or `@RepositoryRestResource` annotation. 

In contract, the pure REST Data with Panache does not have this limitation (propagate these annotations regardless the annotation present). 

I've also updated the documentation to mention this feature. 
Fix https://github.com/quarkusio/quarkus/issues/30358