### PR TITLE
Fix timing issue in SearchCommandsTest.testAggregation

### DIFF
--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SearchCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SearchCommandsTest.java
@@ -486,7 +486,7 @@ public class SearchCommandsTest extends DatasourceTestBase {
                             "num_visits"))
                     .sortBy(new AggregateArgs.SortBy().ascending("@day").descending("@country"))
                     .withCursor().cursorCount(2));
-            assertThat(result.count()).isEqualTo(2);
+            assertThat(result.count()).isBetween(1, 2);
             assertThat(result.documents()).allSatisfy(d -> {
                 assertThat(d.property("day").asInteger()).isPositive();
                 assertThat(d.property("country").asString()).isNotNull();
@@ -494,7 +494,7 @@ public class SearchCommandsTest extends DatasourceTestBase {
             });
             assertThat(result.cursor()).isPositive();
             result = search.ftCursorRead("myIndex", result.cursor());
-            assertThat(result.count()).isEqualTo(1);
+            assertThat(result.count()).isBetween(1, 2);
             assertThat(result.documents()).allSatisfy(d -> {
                 assertThat(d.property("day").asInteger()).isPositive();
                 assertThat(d.property("country").asString()).isNotNull();


### PR DESCRIPTION
When the execution runs around midnight, the number of days reported by the aggregation is 2 instead of 1.

Reported by @gsmet.
