### PR TITLE
Fix RestAssured URL handling and unexpected restarts in QuarkusProdModeTest

### DIFF
--- a/test-framework/junit5-internal/pom.xml
+++ b/test-framework/junit5-internal/pom.xml
@@ -59,6 +59,11 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/test-framework/junit5-internal/src/test/java/io/quarkus/test/QuarkusProdModeTestExpectExitTest.java
+++ b/test-framework/junit5-internal/src/test/java/io/quarkus/test/QuarkusProdModeTestExpectExitTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+import io.quarkus.runtime.annotations.QuarkusMain;
+import io.quarkus.test.common.RestAssuredURLManager;
+
+@TestMethodOrder(OrderAnnotation.class)
+public class QuarkusProdModeTestExpectExitTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest simpleApp = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.addClass(Main.class))
+            .setApplicationName("simple-app")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .setExpectExit(true)
+            .setRun(true);
+
+    private static String startupConsoleOutput;
+
+    @BeforeAll
+    static void captureStartupConsoleLog() {
+        startupConsoleOutput = simpleApp.getStartupConsoleOutput();
+        assertNotNull(startupConsoleOutput, "Missing startupConsoleOutput");
+    }
+
+    @Test
+    @Order(1)
+    public void shouldStartManually() {
+        thenAppIsNotRunning();
+        thenAppWasNotRestarted();
+
+        try (var urlMgrMock = Mockito.mockStatic(RestAssuredURLManager.class)) {
+            whenStartApp();
+            thenAppIsNotRunning();
+            thenAppWasRestarted();
+
+            urlMgrMock.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    @Order(2)
+    public void shouldNotBeRestartedInSubsequentTest() {
+        thenAppIsNotRunning();
+        thenAppWasNotRestarted();
+    }
+
+    private void whenStartApp() {
+        simpleApp.start();
+    }
+
+    private void thenAppIsNotRunning() {
+        assertNotNull(simpleApp.getExitCode(), "App is running");
+    }
+
+    private void thenAppWasNotRestarted() {
+        assertEquals(startupConsoleOutput, simpleApp.getStartupConsoleOutput(), "App was restarted");
+    }
+
+    private void thenAppWasRestarted() {
+        var newStartupConsoleOutput = simpleApp.getStartupConsoleOutput();
+        assertNotEquals(startupConsoleOutput, newStartupConsoleOutput, "App was not restarted");
+        startupConsoleOutput = newStartupConsoleOutput;
+    }
+
+    @QuarkusMain
+    public static class Main {
+
+        public static void main(String[] args) {
+            System.out.printf("current nano time: %s%n", System.nanoTime());
+        }
+    }
+}

--- a/test-framework/junit5-internal/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/test-framework/junit5-internal/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This is fixing an issue we had over at https://github.com/quarkiverse/quarkus-cxf/pull/669#issuecomment-1382911655 (cc @shumonsharif @ppalaga).

Without this fix QuarkusProdModeTest does the following when `run` and `expectExit` are enabled:
- `beforeAll`:
  - start the app _and wait for it to exit_
  - setup RestAssured URL (`RestAssuredURLManager` stores the previous port)
- `beforeEach` :
  - _again_ start the app and wait for it to exit
  - _again_  setup RestAssured URL, loosing the initially stored port to restore
- `afterAll`:
  - clear the RestAssured URL, but not with the initially stored port

This fix:
- makes sure that the app is not stared again for each test method when `expectExit` is enabled
- does not even set up RestAssured URL when `expectExit` is enabled (App will have exited anyway)
- make setup/clean of RestAssured URL consistent with (manual) `start()`/`stop()`

Please note that there can still be inconsistencies w.r.t. to the URL when using multiple `QuarkusProdModeTest`s because there is only one static URL Manager, not one for each extension.