### PR TITLE
Tweak and optimize vale config

### DIFF
--- a/docs/.vale/fixtures/Quarkus/Spelling/testinvalid.adoc
+++ b/docs/.vale/fixtures/Quarkus/Spelling/testinvalid.adoc
@@ -14,7 +14,6 @@ dns
 dotnet
 endevor
 gluster
-gradle
 Graal VM
 graal vm
 gui
@@ -60,5 +59,4 @@ velero
 webview
 webviews
 woopra
-yaml
 zowe

--- a/docs/.vale/fixtures/Quarkus/Spelling/testvalid.adoc
+++ b/docs/.vale/fixtures/Quarkus/Spelling/testvalid.adoc
@@ -373,6 +373,7 @@ Webviews
 Wildfly
 Woopra
 Wordpress
+YAML
 Yana
 Yeoman
 Zowe

--- a/docs/.vale/styles/Quarkus/Spelling.yml
+++ b/docs/.vale/styles/Quarkus/Spelling.yml
@@ -46,6 +46,7 @@ filters:
   - "[gG]bps"
   - "[gG]etter"
   - "[gG]it"
+  - "[gG]radle"
   - "[gG]rafana"
   - "[hH]ardcoding"
   - "[hH]eatmap"
@@ -159,6 +160,7 @@ filters:
   - "[uU]psell"
   - "[uU]pselling"
   - "[vV]alidator"
+  - "[yY]aml"
   - "Let\'s Encrypt"
   - adoc
   - Agroal

--- a/docs/.vale/vale.ini
+++ b/docs/.vale/vale.ini
@@ -1,13 +1,8 @@
-# Vale configuration file for the https://github.com/redhat-documentation/vale-at-red-hat repository.
-# See: https://docs.errata.ai/vale/config
-
-# Core settings appear at the top (the "global" section).
+# Vale configuration file. 
+# For more information, see: https://docs.errata.ai/vale/config.
 
 # The relative path to the folder containing linting rules (styles).
 StylesPath = ./styles
-
-# Vocab define the exceptions to use in *all* `BasedOnStyles`.
-# See: https://docs.errata.ai/vale/vocab
 
 # Minimum alert level
 # -------------------
@@ -20,14 +15,11 @@ MinAlertLevel = suggestion
 # These tags may occur in an active scope (unlike SkippedScopes, skipped entirely) but their content still will not raise any alerts.
 # Default: ignore `code` and `tt`.
 IgnoredScopes = code, tt, img, url, a, body.id
+
 # SkippedScopes specifies block-level HTML tags to ignore. Ignore any content in these scopes.
 # Default: ignore `script`, `style`, `pre`, and `figure`.
 # For AsciiDoc: by default, listingblock, and literalblock.
 SkippedScopes = script, style, pre, figure, code, tt, blockquote, listingblock, literalblock
-
-[formats]
-# Associate `*.properties` files with the `md` format
-properties = md
 
 # Match AsciiDoc files. See: https://docs.errata.ai/vale/scoping
 # Ignore files in a directory starting by `.`
@@ -35,29 +27,6 @@ properties = md
 [[!.]*.adoc]
 # Styles to load, located in the `StylesPath` folder:
 BasedOnStyles = Quarkus
-; Ignore attributes definition, id statements
+
+# Ignore attributes definition, id statements
 TokenIgnores = (:[^\n]+: [^\n]+), (\[id=[^\n]+)
-
-
-# Match Markdown files. See: https://docs.errata.ai/vale/scoping
-# Match also `*.properties` files (see the `format` section).
-[*.md]
-# Styles to load, located in the `StylesPath` folder:
-BasedOnStyles = Quarkus
-
-# Ignore code surrounded by backticks or plus sign, parameters defaults, URLs.
-TokenIgnores = (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\+[^\n]+\+), (http[^\n]+\[)
-
-# Match Restructured text files
-[*.rst]
-# Styles to load, located in the `StylesPath` folder:
-BasedOnStyles = Quarkus
-
-# Match INI files. See: https://docs.errata.ai/vale/scoping
-[*.ini]
-# Styles to load, located in the `StylesPath` folder:
-BasedOnStyles = Quarkus
-# Ignore code surrounded by backticks or plus sign, parameters defaults, URLs.
-TokenIgnores = (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\+[^\n]+\+), (http[^\n]+\[)
-
-; Disabling rules (NO)


### PR DESCRIPTION
Fixes some issues that were identified in PR #30378 

- In PR #30378, test text was added to trigger vale with new config. In the PR, Vale flagged 'gradle' and 'yaml' as being in  wrong case :heavy_check_mark: AND bad spelling :x: .
  - With this tweak 'yaml' and 'gradle' are flagged as case issues only, reducing Vale diff churn.

- The PR highlighted that some of the vale.ini config was un-necessary.
  - With this tweak, the vale.ini contains only the required Vale config for analyzing AsciiDoc (*.adoc) format doc source files.

cc @maxandersen 