### PR TITLE
Fix ElasticSearch Dev Services container restart

### DIFF
--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchDevServicesBuildTimeConfig.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchDevServicesBuildTimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.elasticsearch.restclient.common.deployment;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -65,4 +66,24 @@ public class ElasticsearchDevServicesBuildTimeConfig {
      */
     @ConfigItem(defaultValue = "elasticsearch")
     public String serviceName;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ElasticsearchDevServicesBuildTimeConfig that = (ElasticsearchDevServicesBuildTimeConfig) o;
+        return Objects.equals(shared, that.shared)
+                && Objects.equals(enabled, that.enabled)
+                && Objects.equals(port, that.port)
+                && Objects.equals(imageName, that.imageName)
+                && Objects.equals(javaOpts, that.javaOpts)
+                && Objects.equals(serviceName, that.serviceName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, port, imageName, javaOpts, shared, serviceName);
+    }
 }


### PR DESCRIPTION
DevServices for ElasticSearch checks for a configuration change to decide if the container must be restarted.  The error is that the configuration class does not actually implement `equals()` nor `hashCode()` and always indicates that the configuration changed when really no comparison was ever made.

Fixes #30384 

This should be able to be applied to various 2.x and 3.x branches as the affected code has been stable for some time.