### PR TITLE
Actually forbid simultaneous use of persistence.xml and `quarkus.hibernate-orm.*` properties

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
@@ -75,11 +75,13 @@ public class HibernateOrmConfig {
     @ConfigItem(name = "metrics.enabled")
     public boolean metricsEnabled;
 
-    public boolean isAnyPropertySet() {
+    public boolean isAnyNonPersistenceXmlPropertySet() {
+        // Do NOT include persistenceXml in here.
         return defaultPersistenceUnit.isAnyPropertySet() ||
                 !persistenceUnits.isEmpty() ||
                 log.isAnyPropertySet() ||
                 statistics.isPresent() ||
+                logSessionMetrics.isPresent() ||
                 metricsEnabled;
     }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -880,6 +880,17 @@ public final class HibernateOrmProcessor {
                                 + "To use persistence.xml files, remove all '" + HIBERNATE_ORM_CONFIG_PREFIX
                                 + "*' properties from the Quarkus config file.");
             } else {
+                // It's theoretically possible to use the Quarkus Hibernate ORM extension
+                // without setting any build-time configuration property,
+                // so the condition above might not catch all attempts to use persistence.xml and Quarkus-configured PUs
+                // at the same time.
+                // At that point, the only thing we can do is log something,
+                // so that hopefully people in that situation will notice that their Quarkus configuration is being ignored.
+                LOG.infof(
+                        "A legacy persistence.xml file is present in the classpath. This file will be used to configure JPA/Hibernate ORM persistence units,"
+                                + " and any configuration of the Hibernate ORM extension will be ignored."
+                                + " To ignore persistence.xml files instead, set the configuration property"
+                                + " 'quarkus.hibernate-orm.persistence-xml.ignore' to 'true'.");
                 return;
             }
         }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -350,15 +350,7 @@ public final class HibernateOrmProcessor {
     @BuildStep
     public ImpliedBlockingPersistenceUnitTypeBuildItem defineTypeOfImpliedPU(
             List<JdbcDataSourceBuildItem> jdbcDataSourcesBuildItem, //This is from Agroal SPI: safe to use even for Hibernate Reactive
-            List<PersistenceXmlDescriptorBuildItem> actualXmlDescriptors,
             Capabilities capabilities) {
-
-        //We won't generate an implied PU if there are explicitly configured PUs
-        if (actualXmlDescriptors.isEmpty() == false) {
-            //when we have any explicitly provided Persistence Unit, disable the automatically generated ones.
-            return ImpliedBlockingPersistenceUnitTypeBuildItem.none();
-        }
-
         // If we have some blocking datasources defined, we can have an implied PU
         if (jdbcDataSourcesBuildItem.size() == 0 && capabilities.isPresent(Capability.HIBERNATE_REACTIVE)) {
             // if we don't have any blocking datasources and Hibernate Reactive is present,
@@ -879,11 +871,14 @@ public final class HibernateOrmProcessor {
             BuildProducer<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptors,
             List<DatabaseKindDialectBuildItem> dbKindMetadataBuildItems) {
         if (!descriptors.isEmpty()) {
-            if (hibernateOrmConfig.isAnyPropertySet() || !hibernateOrmConfig.persistenceUnits.isEmpty()) {
+            if (hibernateOrmConfig.isAnyNonPersistenceXmlPropertySet() || !hibernateOrmConfig.persistenceUnits.isEmpty()) {
                 throw new ConfigurationException(
-                        "Hibernate ORM configuration present in persistence.xml and Quarkus config file at the same time\n"
-                                + "If you use persistence.xml remove all " + HIBERNATE_ORM_CONFIG_PREFIX
-                                + "* properties from the Quarkus config file.");
+                        "A legacy persistence.xml file is present in the classpath, but Hibernate ORM is also configured through the Quarkus config file.\n"
+                                + "Legacy persistence.xml files and Quarkus configuration cannot be used at the same time.\n"
+                                + "To ignore persistence.xml files, set the configuration property"
+                                + " 'quarkus.hibernate-orm.persistence-xml.ignore' to 'true'.\n"
+                                + "To use persistence.xml files, remove all '" + HIBERNATE_ORM_CONFIG_PREFIX
+                                + "*' properties from the Quarkus config file.");
             } else {
                 return;
             }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/PersistenceUnitDescriptorBuildItem.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/PersistenceUnitDescriptorBuildItem.java
@@ -74,6 +74,10 @@ public final class PersistenceUnitDescriptorBuildItem extends MultiBuildItem {
         return descriptor.getName();
     }
 
+    public String getConfigurationName() {
+        return configurationName;
+    }
+
     public Optional<String> getDataSource() {
         return dataSource;
     }
@@ -88,6 +92,10 @@ public final class PersistenceUnitDescriptorBuildItem extends MultiBuildItem {
 
     public boolean hasXmlMappings() {
         return !xmlMappings.isEmpty();
+    }
+
+    public boolean isFromPersistenceXml() {
+        return fromPersistenceXml;
     }
 
     public QuarkusPersistenceUnitDefinition asOutputPersistenceUnitDefinition(

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/persistence/PersistenceXmlAndQuarkusConfigTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/persistence/PersistenceXmlAndQuarkusConfigTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.hibernate.orm.xml.persistence;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class PersistenceXmlAndQuarkusConfigTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .assertException(e -> Assertions.assertThat(e)
+                    .isInstanceOf(ConfigurationException.class)
+                    .hasMessageContainingAll(
+                            "A legacy persistence.xml file is present in the classpath, but Hibernate ORM is also configured through the Quarkus config file",
+                            "Legacy persistence.xml files and Quarkus configuration cannot be used at the same time",
+                            "To ignore persistence.xml files, set the configuration property 'quarkus.hibernate-orm.persistence-xml.ignore' to 'true'",
+                            "To use persistence.xml files, remove all 'quarkus.hibernate-orm.*' properties from the Quarkus config file."))
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(MyEntity.class)
+                    .addAsManifestResource("META-INF/some-persistence.xml", "persistence.xml"))
+            .withConfigurationResource("application.properties")
+            // Unfortunately the minimal config is not enough to detect that a PU is configured in Quarkus's application.properties
+            // -- we're paying the price of our "zero config" approach.
+            // We can only detect something is wrong if some optional properties are set.
+            .overrideConfigKey("quarkus.hibernate-orm.fetch.max-depth", "2");
+
+    @Test
+    public void test() {
+        // should not be called, deployment exception should happen first:
+        // it's illegal to have Hibernate configuration properties in both the
+        // application.properties and in the persistence.xml
+        Assertions.fail("Application should not start");
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/persistence/PersistenceXmlTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/persistence/PersistenceXmlTest.java
@@ -1,11 +1,16 @@
 package io.quarkus.hibernate.orm.xml.persistence;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.cfg.AvailableSettings.PERSISTENCE_UNIT_NAME;
+
+import java.util.logging.Formatter;
+import java.util.logging.Level;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 
+import org.jboss.logmanager.formatters.PatternFormatter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -19,8 +24,19 @@ import io.quarkus.test.QuarkusUnitTest;
  */
 public class PersistenceXmlTest {
 
+    private static final Formatter LOG_FORMATTER = new PatternFormatter("%s");
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setLogRecordPredicate(record -> record.getLevel().equals(Level.INFO))
+            .assertLogRecords(records -> assertThat(records)
+                    .as("Logs on startup")
+                    .anySatisfy(record -> {
+                        assertThat(LOG_FORMATTER.formatMessage(record))
+                                .contains("A legacy persistence.xml file is present in the classpath",
+                                        "any configuration of the Hibernate ORM extension will be ignored",
+                                        "To ignore persistence.xml files",
+                                        "set the configuration property 'quarkus.hibernate-orm.persistence-xml.ignore' to 'true'");
+                    }))
             .withApplicationRoot((jar) -> jar
                     .addClass(SmokeTestUtils.class)
                     .addClass(MyEntity.class)


### PR DESCRIPTION
Fixes #16589 

This _sort of_ breaks backwards compatibility: we used to *document* that using `persistence.xml` alongside `quarkus.hibernate-orm.*` properties was forbidden and would fail, but in practice we were more lenient and such situation just resulted in `quarkus.hibernate-orm.*` properties being ignored. Now, we will properly fail.

I also added an INFO log when using `persistence.xml`, because we cannot always detect that users mean to use Quarkus-configured PUs (since we tend to allow zero-config), so in some cases we might still just ignore Quarkus-configured PUs in favor of `persistence.xml`...