### PR TITLE
Introduce support for GraalVM `--enable-monitoring`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -241,10 +241,19 @@ public class NativeConfig {
     public Optional<List<String>> containerRuntimeOptions;
 
     /**
-     * If the resulting image should allow VM introspection
+     * If the resulting image should allow VM introspection.
+     *
+     * @deprecated Use {@code quarkus.native.monitoring} instead.
      */
     @ConfigItem
+    @Deprecated
     public boolean enableVmInspection;
+
+    /**
+     * Enable monitoring options that allow the VM to be inspected at run time.
+     */
+    @ConfigItem
+    public Optional<List<MonitoringOption>> monitoring;
 
     /**
      * If full stack traces are enabled in the resulting image
@@ -451,5 +460,13 @@ public class NativeConfig {
     public static enum BuilderImageProvider {
         GRAALVM,
         MANDREL;
+    }
+
+    public enum MonitoringOption {
+        HEAPDUMP,
+        JVMSTAT,
+        JFR,
+        ALL,
+        TRUE // only needed to support -Dquarkus.native.monitoring
     }
 }


### PR DESCRIPTION
This also deprecates `-H:+AllowVMInspection` support which GraalVM has replaced with --enable-monitoring

Fixes: #30408