### PR TITLE
Fail by default when encountering interceptor annotations on private methods

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
@@ -77,12 +77,12 @@ public class ArcConfig {
     public boolean transformPrivateInjectedFields;
 
     /**
-     * If set to true, the build fails if a private method that is neither an observer nor a producer, is annotated with an
-     * interceptor binding.
+     * If set to true (the default), the build fails if a private method that is neither an observer nor a producer, is
+     * annotated with an interceptor binding.
      * An example of this is the use of {@code Transactional} on a private method of a bean.
      * If set to false, Quarkus simply logs a warning that the annotation will be ignored.
      */
-    @ConfigItem(defaultValue = "false")
+    @ConfigItem(defaultValue = "true")
     public boolean failOnInterceptedPrivateMethod;
 
     /**

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/FailingPrivateInterceptedMethodTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/FailingPrivateInterceptedMethodTest.java
@@ -3,6 +3,7 @@ package io.quarkus.arc.test.interceptor;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -27,7 +28,10 @@ public class FailingPrivateInterceptedMethodTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(SimpleBean.class, SimpleInterceptor.class, Simple.class))
-            .setExpectedException(DeploymentException.class);
+            .assertException(e -> assertThat(e).isInstanceOf(DeploymentException.class)
+                    .hasMessageContainingAll("@Simple will have no effect on method " + SimpleBean.class.getName() + ".foo",
+                            "Either remove the annotation from the method",
+                            "or turn this exception into a simple warning by setting configuration property 'quarkus.arc.fail-on-intercepted-private-method' to 'false'"));
 
     @Test
     public void testDeploymentFailed() {

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/FailingPrivateInterceptedMethodTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/FailingPrivateInterceptedMethodTest.java
@@ -16,7 +16,6 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InterceptorBinding;
 import jakarta.interceptor.InvocationContext;
 
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -27,9 +26,7 @@ public class FailingPrivateInterceptedMethodTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(SimpleBean.class, SimpleInterceptor.class, Simple.class)
-                    .addAsResource(new StringAsset("quarkus.arc.fail-on-intercepted-private-method=true"),
-                            "application.properties"))
+                    .addClasses(SimpleBean.class, SimpleInterceptor.class, Simple.class))
             .setExpectedException(DeploymentException.class);
 
     @Test

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/IgnoredPrivateInterceptedMethodTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/IgnoredPrivateInterceptedMethodTest.java
@@ -3,11 +3,14 @@ package io.quarkus.arc.test.interceptor;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
@@ -17,6 +20,7 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InterceptorBinding;
 import jakarta.interceptor.InvocationContext;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -30,7 +34,12 @@ public class IgnoredPrivateInterceptedMethodTest {
             .withApplicationRoot((jar) -> jar
                     .addClasses(SimpleBean.class, SimpleInterceptor.class, Simple.class)
                     .addAsResource(new StringAsset("quarkus.arc.fail-on-intercepted-private-method=false"),
-                            "application.properties"));
+                            "application.properties"))
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+            .assertLogRecords(records -> assertThat(records)
+                    .anySatisfy(record -> assertThat(record)
+                            .extracting(LogRecord::getMessage, InstanceOfAssertFactories.STRING)
+                            .contains("@Simple will have no effect on method " + SimpleBean.class.getName() + ".foo")));
 
     @Inject
     SimpleBean simpleBean;

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/IgnoredPrivateInterceptedMethodTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/IgnoredPrivateInterceptedMethodTest.java
@@ -17,6 +17,7 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InterceptorBinding;
 import jakarta.interceptor.InvocationContext;
 
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -27,7 +28,9 @@ public class IgnoredPrivateInterceptedMethodTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(SimpleBean.class, SimpleInterceptor.class, Simple.class));
+                    .addClasses(SimpleBean.class, SimpleInterceptor.class, Simple.class)
+                    .addAsResource(new StringAsset("quarkus.arc.fail-on-intercepted-private-method=false"),
+                            "application.properties"));
 
     @Inject
     SimpleBean simpleBean;

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/PrivateMethodExceptionsTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/PrivateMethodExceptionsTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.cache.test.deployment;
+
+import static java.util.Arrays.stream;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.stream.Stream;
+
+import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.cache.deployment.exception.PrivateMethodTargetException;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * This class tests {@link DeploymentException} causes related to caching annotations on private methods.
+ */
+public class PrivateMethodExceptionsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(TestResource.class)
+                    // These checks are only useful if Arc's more generic check is disabled.
+                    .addAsResource(new StringAsset("quarkus.arc.fail-on-intercepted-private-method=false"),
+                            "application.properties"))
+            .assertException(t -> {
+                assertEquals(DeploymentException.class, t.getClass());
+                assertEquals(3, t.getSuppressed().length);
+                assertPrivateMethodTargetException(t, "shouldThrowPrivateMethodTargetException", 1);
+                assertPrivateMethodTargetException(t, "shouldAlsoThrowPrivateMethodTargetException", 2);
+            });
+
+    private static void assertPrivateMethodTargetException(Throwable t, String expectedMethodName, long expectedCount) {
+        assertEquals(expectedCount, filterSuppressed(t, PrivateMethodTargetException.class)
+                .filter(s -> expectedMethodName.equals(s.getMethodInfo().name())).count());
+    }
+
+    private static <T extends RuntimeException> Stream<T> filterSuppressed(Throwable t, Class<T> filterClass) {
+        return stream(t.getSuppressed()).filter(filterClass::isInstance).map(filterClass::cast);
+    }
+
+    @Test
+    public void shouldNotBeInvoked() {
+        fail("This method should not be invoked");
+    }
+
+    @Path("/test")
+    static class TestResource {
+
+        @GET
+        // Single annotation test.
+        @CacheInvalidateAll(cacheName = "should-throw-private-method-target-exception")
+        private void shouldThrowPrivateMethodTargetException() {
+        }
+
+        @GET
+        // Repeated annotations test.
+        @CacheInvalidate(cacheName = "should-throw-private-method-target-exception")
+        @CacheInvalidate(cacheName = "should-throw-private-method-target-exception")
+        private void shouldAlsoThrowPrivateMethodTargetException() {
+        }
+
+    }
+
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -281,16 +281,17 @@ final class Methods {
                     && !Annotations.contains(methodAnnotations, DotNames.OBSERVES_ASYNC)) {
                 String message;
                 if (methodLevelBindings.size() == 1) {
-                    message = String.format("%s will have no effect on method %s.%s() because the method is private",
+                    message = String.format("%s will have no effect on method %s.%s() because the method is private.",
                             methodLevelBindings.iterator().next(), classInfo.name(), method.name());
                 } else {
                     message = String.format(
-                            "Annotations %s will have no effect on method %s.%s() because the method is private",
+                            "Annotations %s will have no effect on method %s.%s() because the method is private.",
                             methodLevelBindings.stream().map(AnnotationInstance::toString).collect(Collectors.joining(",")),
                             classInfo.name(), method.name());
                 }
                 if (beanDeployment.failOnInterceptedPrivateMethod) {
-                    throw new DeploymentException(message);
+                    throw new DeploymentException(message
+                            + " Either remove the annotation from the method, or turn this exception into a simple warning by setting configuration property 'quarkus.arc.fail-on-intercepted-private-method' to 'false'.");
                 } else {
                     LOGGER.warn(message);
                 }


### PR DESCRIPTION
Cf. https://groups.google.com/g/quarkus-dev/c/ukQEujtlRbs

I didn't run the full test suite locally though, let's see how it goes...