### PR TITLE
Revert the jQuery upgrade in MicroProfile TCKs

### DIFF
--- a/tcks/pom.xml
+++ b/tcks/pom.xml
@@ -78,7 +78,7 @@
                 <groupId>org.webjars</groupId>
                 <artifactId>jquery</artifactId>
                 <!-- /!\ this version should not be upgraded, TestNG requires this particular version -->
-                <version>3.6.3</version>
+                <version>3.5.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
The old version is required by TestNG version used in the Jakarta branch.

See the comment in the pom file.

/cc @phillip-kruger FYI