### PR TITLE
Arc - remove wildcard types from bean types of class-based beans

### DIFF
--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
@@ -1,10 +1,11 @@
 package io.quarkus.hibernate.validator.runtime;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import javax.enterprise.util.TypeLiteral;
 import javax.validation.ClockProvider;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.MessageInterpolator;
@@ -36,11 +37,8 @@ import io.quarkus.runtime.annotations.Recorder;
 @Recorder
 public class HibernateValidatorRecorder {
 
-    private static final TypeLiteral<ValueExtractor<?>> TYPE_LITERAL_VALUE_EXTRACTOR_WITH_WILDCARD = new TypeLiteral<ValueExtractor<?>>() {
-    };
-
     public BeanContainerListener initializeValidatorFactory(Set<Class<?>> classesToBeValidated,
-            Set<String> detectedBuiltinConstraints,
+            Set<String> detectedBuiltinConstraints, Set<Class<?>> valueExtractorClasses,
             boolean hasXmlConfiguration, boolean jpaInClasspath,
             ShutdownContext shutdownContext, LocalesBuildTimeConfig localesBuildTimeConfig,
             HibernateValidatorBuildTimeConfig hibernateValidatorBuildTimeConfig) {
@@ -143,11 +141,15 @@ public class HibernateValidatorRecorder {
                 }
 
                 // Automatically add all the values extractors declared as beans
-                for (ValueExtractor<?> valueExtractor : Arc.container().beanManager().createInstance()
-                        // Apparently passing ValueExtractor.class
-                        // won't match beans implementing ValueExtractor<NotAWildcard>,
-                        // so we need a type literal here.
-                        .select(TYPE_LITERAL_VALUE_EXTRACTOR_WITH_WILDCARD)) {
+                for (ValueExtractor<?> valueExtractor : HibernateValidatorRecorder
+                        // We cannot do something like `instance(...).select(ValueExtractor.class)`,
+                        // because `ValueExtractor` is usually implemented
+                        // as a parameterized type with wildcards,
+                        // and the CDI spec does not consider such types as bean types.
+                        // We work around that by listing all classes implementing `ValueExtractor` at build time,
+                        // then retrieving all bean instances implementing those types here.
+                        // See https://github.com/quarkusio/quarkus/pull/30447
+                        .<ValueExtractor<?>> uniqueBeanInstances(valueExtractorClasses)) {
                     configuration.addValueExtractor(valueExtractor);
                 }
 
@@ -174,6 +176,35 @@ public class HibernateValidatorRecorder {
         };
 
         return beanContainerListener;
+    }
+
+    // Ideally we'd retrieve all instances of a set of bean types
+    // simply by calling something like ArcContainer#select(Set<Type>)
+    // but that method does not exist.
+    // This method acts as a replacement.
+    private static <T> Iterable<T> uniqueBeanInstances(Set<Class<?>> classes) {
+        Set<String> beanIds = new HashSet<>();
+        for (Class<?> clazz : classes) {
+            for (InstanceHandle<?> handle : Arc.container().select(clazz).handles()) {
+                if (!handle.isAvailable()) {
+                    continue;
+                }
+                // A single bean can have multiple types.
+                // To avoid returning duplicate instances of the same bean,
+                // we first retrieve all bean IDs, deduplicate those,
+                // then retrieve the instance for each bean.
+                // Note that just retrieving all instances and putting them in a identity-based Set
+                // would not work, because beans can have the dependent pseudo-scope,
+                // in which case we'd have two instances of the same bean.
+                beanIds.add(handle.getBean().getIdentifier());
+            }
+        }
+        List<T> instances = new ArrayList<>();
+        for (String beanId : beanIds) {
+            var arcContainer = Arc.container();
+            instances.add(arcContainer.instance(arcContainer.<T> bean(beanId)).get());
+        }
+        return instances;
     }
 
     public Supplier<ResteasyConfigSupport> resteasyConfigSupportSupplier(boolean jsonDefault) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
@@ -433,17 +433,15 @@ public final class Types {
     }
 
     /**
-     * Detects wildcard for given producer method/field.
-     * Based on the boolean parameter, it either throws a {@link DefinitionException} of performs logging.
+     * Detects wildcard for given type.
+     * In case this is related to a producer field or method, it either logs or throws a {@link DefinitionException}
+     * based on the boolean parameter.
      * Returns true if a wildcard is detected, false otherwise.
      */
-    static boolean isProducerWithWildcard(Type type, AnnotationTarget producerFieldOrMethod, boolean throwIfDetected) {
-        if (producerFieldOrMethod == null) {
-            // not a producer, no further analysis required
-            return false;
-        }
+    static boolean containsWildcard(Type type, AnnotationTarget producerFieldOrMethod, boolean throwIfDetected) {
         if (type.kind().equals(Kind.WILDCARD_TYPE)) {
-            if (throwIfDetected) {
+            if (throwIfDetected && producerFieldOrMethod != null) {
+                // a producer method that has wildcard directly in its return type
                 throw new DefinitionException("Producer " +
                         (producerFieldOrMethod.kind().equals(AnnotationTarget.Kind.FIELD) ? "field " : "method ") +
                         producerFieldOrMethod +
@@ -454,18 +452,22 @@ public final class Types {
                         +
                         " contains a parameterized type with a wildcard. This type is not a legal bean type" +
                         " according to CDI specification.");
-            } else {
+            } else if (producerFieldOrMethod != null) {
+                // a producer method with wildcard in the type hierarchy of the return type
                 LOGGER.info("Producer " +
                         (producerFieldOrMethod.kind().equals(AnnotationTarget.Kind.FIELD) ? "field " : "method ") +
                         producerFieldOrMethod +
                         " contains a parameterized typed with a wildcard. This type is not a legal bean type" +
                         " according to CDI specification and will be ignored during bean resolution.");
                 return true;
+            } else {
+                // wildcard detection for class-based beans, these still need to be skipped as they aren't valid bean types
+                return true;
             }
         } else if (type.kind().equals(Kind.PARAMETERIZED_TYPE)) {
             for (Type t : type.asParameterizedType().arguments()) {
                 // recursive check of all parameterized types
-                return isProducerWithWildcard(t, producerFieldOrMethod, throwIfDetected);
+                return containsWildcard(t, producerFieldOrMethod, throwIfDetected);
             }
         }
         return false;
@@ -491,7 +493,7 @@ public final class Types {
                 // for producers, wildcard is not a legal bean type and results in a definition error
                 // see https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#legal_bean_types
                 // NOTE: wildcard can be nested, such as List<Set<? extends Number>>
-                skipThisType = isProducerWithWildcard(typeParams[i], producerFieldOrMethod, throwOnProducerWildcard);
+                skipThisType = containsWildcard(typeParams[i], producerFieldOrMethod, throwOnProducerWildcard);
             }
             if (resolvedTypeVariablesConsumer != null) {
                 Map<String, Type> resolved = new HashMap<>();

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
@@ -2,6 +2,7 @@ package io.quarkus.arc.processor;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -82,10 +83,24 @@ public class TypesTest {
         // now assert following ones do NOT throw, the wildcard in the hierarchy is just ignored
         final String wildcardInTypeHierarchy = "eagleProducer";
         assertDoesNotThrow(
-                () -> Types.getProducerMethodTypeClosure(producerClass.method(wildcardInTypeHierarchy), dummyDeployment));
+                () -> verifyEagleTypes(
+                        Types.getProducerMethodTypeClosure(producerClass.method(wildcardInTypeHierarchy), dummyDeployment)));
         assertDoesNotThrow(
-                () -> Types.getProducerFieldTypeClosure(producerClass.field(wildcardInTypeHierarchy), dummyDeployment));
+                () -> verifyEagleTypes(
+                        Types.getProducerFieldTypeClosure(producerClass.field(wildcardInTypeHierarchy), dummyDeployment)));
+        // now do the same for a non-producer scenario with Eagle class
+        assertDoesNotThrow(
+                () -> verifyEagleTypes(Types.getClassBeanTypeClosure(index.getClassByName(DotName.createSimple(Eagle.class)),
+                        dummyDeployment)));
+    }
 
+    private void verifyEagleTypes(Set<Type> types) {
+        for (Type type : types) {
+            if (type.kind().equals(Kind.PARAMETERIZED_TYPE)) {
+                assertNotEquals(DotName.createSimple(AnimalHolder.class), type.name());
+            }
+        }
+        assertEquals(3, types.size());
     }
 
     static class Foo<T> {


### PR DESCRIPTION
A complementary fix to #30412 and https://github.com/quarkusio/quarkus/pull/30415

I originally forgot to address a scenario where a class based bean was able to retain wildcard type as its bean type.
This is against CDI specification and should not occur (the TCK covers that as well).