### PR TITLE
Arc - Using @Typed with illegal values should throw an exception

### DIFF
--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/BrokenTypedBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/BrokenTypedBeanTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.arc.test.resolution.broken;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class BrokenTypedBeanTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(MyBean.class, MyOtherBean.class).shouldFail()
+            .build();
+
+    @Test
+    public void testFailure() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/BrokenTypedProducerFieldTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/BrokenTypedProducerFieldTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.arc.test.resolution.broken;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class BrokenTypedProducerFieldTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(FieldProducerBean.class, MyOtherBean.class, ProducedBean.class).shouldFail()
+            .build();
+
+    @Test
+    public void testFailure() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/BrokenTypedProducerMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/BrokenTypedProducerMethodTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.arc.test.resolution.broken;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class BrokenTypedProducerMethodTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MethodProducerBean.class, MyOtherBean.class, ProducedBean.class).shouldFail()
+            .build();
+
+    @Test
+    public void testFailure() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/FieldProducerBean.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/FieldProducerBean.java
@@ -1,0 +1,15 @@
+package io.quarkus.arc.test.resolution.broken;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.Typed;
+
+@Dependent
+public class FieldProducerBean {
+
+    @Produces
+    @Typed(value = MyOtherBean.class)
+    public ProducedBean produceBean() {
+        return new ProducedBean();
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/MethodProducerBean.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/MethodProducerBean.java
@@ -1,0 +1,15 @@
+package io.quarkus.arc.test.resolution.broken;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.Typed;
+
+@Dependent
+public class MethodProducerBean {
+
+    @Produces
+    @Typed(value = MyOtherBean.class)
+    public ProducedBean produceBean() {
+        return new ProducedBean();
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/MyBean.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/MyBean.java
@@ -1,0 +1,9 @@
+package io.quarkus.arc.test.resolution.broken;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Typed;
+
+@Dependent
+@Typed(value = MyOtherBean.class)
+public class MyBean {
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/MyOtherBean.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/MyOtherBean.java
@@ -1,0 +1,7 @@
+package io.quarkus.arc.test.resolution.broken;
+
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public class MyOtherBean {
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/ProducedBean.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/resolution/broken/ProducedBean.java
@@ -1,0 +1,4 @@
+package io.quarkus.arc.test.resolution.broken;
+
+public class ProducedBean {
+}


### PR DESCRIPTION
ATM, Arc allows you to use `@Typed` with arbitrary values and it simply ignores any that aren't part of the transitive closure of bean types.

However, this conflicts [the specification](https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html):

> If a bean class or producer method or field specifies a @Typed annotation, and the value member specifies a class which does not correspond to a type in the unrestricted set of bean types of a bean, the container automatically detects the problem and treats it as a definition error.

Therefore, we are now throwing a `DefinitionException` that looks like this:
> javax.enterprise.inject.spi.DefinitionException: Cannot limit bean types to types outside of the transitive closure of bean types. Bean: io.quarkus.arc.test.resolution.broken.ProducedBean produceBean() illegal bean types: [io.quarkus.arc.test.resolution.broken.MyOtherBean]

As usual, the PR also contains tests that showcase it.

Related to https://github.com/quarkusio/quarkus/issues/28558