### PR TITLE
[2.13] Disable DuplicatedContextTest#testThatBlockingEventConsumersAreCalledOnDuplicatedContext on Windows

### DIFF
--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/DuplicatedContextTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/DuplicatedContextTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
@@ -116,6 +118,7 @@ public class DuplicatedContextTest {
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Failing on Windows very often")
     public void testThatBlockingEventConsumersAreCalledOnDuplicatedContext() {
         // Creates a bunch of requests that will be executed concurrently.
         // So, we are sure that event loops are reused.


### PR DESCRIPTION
This was already done in 2.15 and main. The test is unstable on the Windows CI.