### PR TITLE
Introduce `quarkus.datasource.devservices.init-script-path`

### DIFF
--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
@@ -14,6 +14,7 @@ public class DevServicesDatasourceContainerConfig {
     private final Optional<String> dbName;
     private final Optional<String> username;
     private final Optional<String> password;
+    private final Optional<String> initScriptPath;
 
     public DevServicesDatasourceContainerConfig(Optional<String> imageName,
             Map<String, String> containerProperties,
@@ -22,7 +23,8 @@ public class DevServicesDatasourceContainerConfig {
             Optional<String> command,
             Optional<String> dbName,
             Optional<String> username,
-            Optional<String> password) {
+            Optional<String> password,
+            Optional<String> initScriptPath) {
         this.imageName = imageName;
         this.containerProperties = containerProperties;
         this.additionalJdbcUrlProperties = additionalJdbcUrlProperties;
@@ -31,6 +33,7 @@ public class DevServicesDatasourceContainerConfig {
         this.dbName = dbName;
         this.username = username;
         this.password = password;
+        this.initScriptPath = initScriptPath;
     }
 
     public Optional<String> getImageName() {
@@ -63,5 +66,9 @@ public class DevServicesDatasourceContainerConfig {
 
     public Optional<String> getPassword() {
         return password;
+    }
+
+    public Optional<String> getInitScriptPath() {
+        return initScriptPath;
     }
 }

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -275,7 +275,8 @@ public class DevServicesDatasourceProcessor {
                     dataSourceBuildTimeConfig.devservices.command,
                     dataSourceBuildTimeConfig.devservices.dbName,
                     dataSourceBuildTimeConfig.devservices.username,
-                    dataSourceBuildTimeConfig.devservices.password);
+                    dataSourceBuildTimeConfig.devservices.password,
+                    dataSourceBuildTimeConfig.devservices.initScriptPath);
 
             DevServicesDatasourceProvider.RunningDevServicesDatasource datasource = devDbProvider
                     .startDatabase(

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -76,4 +76,12 @@ public class DevServicesBuildTimeConfig {
      */
     @ConfigItem
     public Optional<String> password;
+
+    /**
+     * Path to a SQL script that will be loaded from the classpath and applied to the Dev Service database
+     *
+     * If the provider is not container based (e.g. a H2 or Derby Database) then this has no effect.
+     */
+    @ConfigItem
+    public Optional<String> initScriptPath;
 }

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -53,6 +53,7 @@ public class DB2DevServicesProcessor {
 
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
+                containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
                 container.start();
 
                 LOG.info("Dev Services for IBM Db2 started.");

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -61,6 +61,7 @@ public class MariaDBDevServicesProcessor {
 
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
+                containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
 
                 container.start();
 

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -49,6 +49,7 @@ public class MSSQLDevServicesProcessor {
 
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
+                containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
 
                 container.start();
 

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -60,6 +60,7 @@ public class MySQLDevServicesProcessor {
 
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
+                containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
 
                 container.start();
 

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -63,6 +63,7 @@ public class OracleDevServicesProcessor {
 
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
+                containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
 
                 container.start();
 

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -60,6 +60,7 @@ public class PostgresqlDevServicesProcessor {
 
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);
+                containerConfig.getInitScriptPath().ifPresent(container::withInitScript);
 
                 container.start();
 

--- a/extensions/jdbc/jdbc-postgresql/deployment/src/test/java/io/quarkus/jdbc/postgresql/deployment/DevServicesPostgresqlDatasourceWithInitScriptTestCase.java
+++ b/extensions/jdbc/jdbc-postgresql/deployment/src/test/java/io/quarkus/jdbc/postgresql/deployment/DevServicesPostgresqlDatasourceWithInitScriptTestCase.java
@@ -1,0 +1,42 @@
+package io.quarkus.jdbc.postgresql.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+
+import javax.inject.Inject;
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DevServicesPostgresqlDatasourceWithInitScriptTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(javaArchive -> javaArchive.addAsResource("init-db.sql"))
+            .overrideConfigKey("quarkus.datasource.db-kind", "postgresql")
+            .overrideConfigKey("quarkus.datasource.devservices.init-script-path", "init-db.sql");
+
+    @Inject
+    DataSource ds;
+
+    @Test
+    @DisplayName("Test if init-script-path executed successfully")
+    public void testDatasource() throws Exception {
+        int result = 0;
+        try (Connection con = ds.getConnection();
+                CallableStatement cs = con.prepareCall("SELECT my_func()");
+                ResultSet rs = cs.executeQuery()) {
+            if (rs.next()) {
+                result = rs.getInt(1);
+            }
+        }
+        assertEquals(100, result, "The init script should have been executed");
+    }
+}

--- a/extensions/jdbc/jdbc-postgresql/deployment/src/test/resources/init-db.sql
+++ b/extensions/jdbc/jdbc-postgresql/deployment/src/test/resources/init-db.sql
@@ -1,0 +1,1 @@
+CREATE OR REPLACE FUNCTION my_func() RETURNS integer LANGUAGE plpgsql as $func$ BEGIN return 100; END $func$;


### PR DESCRIPTION
- This enables specifying a SQL initialization script for Dev Services Databases

Added tests
