### PR TITLE
Revert --enable-monitoring with no arguments support

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -466,7 +466,6 @@ public class NativeConfig {
         HEAPDUMP,
         JVMSTAT,
         JFR,
-        ALL,
-        TRUE // only needed to support -Dquarkus.native.monitoring
+        ALL
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.SystemUtils;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.util.IoUtils;
@@ -830,17 +829,10 @@ public class NativeImageBuildStep {
 
                 if (nativeConfig.monitoring.isPresent()) {
                     List<NativeConfig.MonitoringOption> monitoringOptions = nativeConfig.monitoring.get();
-                    if (monitoringOptions.stream().anyMatch(o -> o == NativeConfig.MonitoringOption.TRUE
-                            || o == NativeConfig.MonitoringOption.ALL)) {
-                        nativeImageArgs.add("--enable-monitoring");
+                    if (!monitoringOptions.isEmpty()) {
+                        nativeImageArgs.add("--enable-monitoring=" + monitoringOptions.stream()
+                                .map(o -> o.name().toLowerCase(Locale.ROOT)).collect(Collectors.joining(",")));
                     }
-                    nativeImageArgs
-                            .add("--enable-monitoring=" + monitoringOptions.stream().map(o -> o.name().toLowerCase(
-                                    Locale.ROOT)).collect(Collectors.joining(",")));
-                } else if (ConfigProvider.getConfig().getConfigValue("quarkus.native.monitoring").getValue() != null) {
-                    // this only happens when a user has configured 'quarkus.native.monitoring='
-                    // we want to support this use case as GraalVM allows the use of '--enable-monitoring' without an argument
-                    nativeImageArgs.add("--enable-monitoring");
                 }
                 if (nativeConfig.autoServiceLoaderRegistration) {
                     nativeImageArgs.add("-H:+UseServiceLoaderFeature");


### PR DESCRIPTION
GraalVM is going to deprecate `--enable-monitoring` without arguments (see https://github.com/oracle/graal/pull/5792) so (as it turns out) there is no need to support the "equivalent" in Quarkus.

Follow up to https://github.com/quarkusio/quarkus/pull/30410