### PR TITLE
Scheduler API - make it possible to schedule a job programmatically

### DIFF
--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -141,7 +141,8 @@ public class TaskBean {
 
 === Scheduling Jobs Programmatically
 
-It is also possible to leverage the Quartz API directly.
+An injected `io.quarkus.scheduler.Scheduler` can be used to <<scheduler-reference.adoc#programmatic_scheduling,schedule a job programmatically>>.
+However, it is also possible to leverage the Quartz API directly.
 You can inject the underlying `org.quartz.Scheduler` in any bean:
 
 [source,java]

--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -15,7 +15,7 @@ Modern applications often need to run specific tasks periodically.
 There are two scheduler extensions in Quarkus.
 The `quarkus-scheduler` extension brings the API and a lightweight in-memory scheduler implementation.
 The `quarkus-quartz` extension implements the API from the `quarkus-scheduler` extension and contains a scheduler implementation based on the Quartz library.
-You will only need `quarkus-quartz` for more advanced scheduling use cases, such as persistent tasks, clustering and programmatic scheduling of jobs.
+You will only need `quarkus-quartz` for more advanced scheduling use cases, such as persistent tasks and clustering.
 
 NOTE: If you add the `quarkus-quartz` dependency to your project the lightweight scheduler implementation from the `quarkus-scheduler` extension is automatically disabled. 
 
@@ -334,34 +334,44 @@ class MyService {
 <6> Get Trigger metadata for a specific scheduled job by its identity.
 <7> You can configure the grace period for isOverdue() with quarkus.scheduler.overdue-grace-period
 
+[[programmatic_scheduling]]
 == Programmatic Scheduling
 
-If you need to schedule a job programmatically you'll need to add the xref:quartz.adoc[Quartz extension] and use the Quartz API directly.
+An injected `io.quarkus.scheduler.Scheduler` can be also used to schedule a job programmatically.
 
-.Programmatic Scheduling with Quartz API
+.Programmatic Scheduling
 [source,java]
 ----
-import org.quartz.Scheduler;
+import io.quarkus.scheduler.Scheduler;
 
+@ApplicationScoped
 class MyJobs {
 
-    void onStart(@Observes StartupEvent event, Scheduler quartz) throws SchedulerException {
-        JobDetail job = JobBuilder.newJob(SomeJob.class)
-                .withIdentity("myJob", "myGroup")
-                .build();
-        Trigger trigger = TriggerBuilder.newTrigger()
-                .withIdentity("myTrigger", "myGroup")
-                .startNow()
-                .withSchedule(SimpleScheduleBuilder.simpleSchedule()
-                        .withIntervalInSeconds(1)
-                        .repeatForever())
-                .build();
-        quartz.scheduleJob(job, trigger);
+    @Inject
+    Scheduler scheduler;
+
+    void addMyJob() { <1>
+        scheduler.newJob("myJob")
+            .setCron("0/5 * * * * ?")
+            .setTask(executionContext -> { <2>
+                // do something important every 5 seconds
+            })
+            .schedule(); <3>
     }
+    
+    void removeMyJob() {
+        scheduler.unscheduleJob("myJob"); <4>
+    } 
 }
 ----
+<1> This is a programmatic alternative to a method annotated with `@Scheduled(identity = "myJob", cron = "0/5 * * * * ?")`.
+<2> The business logic is defined in a callback.
+<3> The job is scheduled once the `JobDefinition#schedule()` method is called.
+<4> A job that was added programmatically can be also removed.
 
-NOTE: By default, the scheduler is not started unless a `@Scheduled` business method is found. You may need to force the start of the scheduler for "pure" programmatic scheduling. See also <<quartz.adoc#quartz-configuration-reference,Quartz Configuration Reference>>.
+NOTE: By default, the scheduler is not started unless a `@Scheduled` business method is found. You may need to force the start of the scheduler for "pure" programmatic scheduling via `quarkus.scheduler.start-mode=forced`.
+
+NOTE: If the xref:quartz.adoc[Quartz extension] is present then the Quartz API can be also used to schedule a job programmatically.
 
 == Scheduled Methods and Testing
 

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/programmatic/ForcedStartModeJobsTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/programmatic/ForcedStartModeJobsTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.quartz.test.programmatic;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ForcedStartModeJobsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addAsResource(new StringAsset("quarkus.scheduler.start-mode=forced"),
+                            "application.properties"));
+
+    @Inject
+    Scheduler scheduler;
+
+    static final CountDownLatch SYNC_LATCH = new CountDownLatch(1);
+
+    @Test
+    public void testScheduler() throws InterruptedException {
+        assertTrue(scheduler.isRunning());
+
+        scheduler.newJob("foo")
+                .setInterval("1s")
+                .setTask(ec -> ForcedStartModeJobsTest.SYNC_LATCH.countDown())
+                .schedule();
+
+        assertTrue(ForcedStartModeJobsTest.SYNC_LATCH.await(5, TimeUnit.SECONDS));
+    }
+
+}

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/programmatic/HaltedStartModeJobsTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/programmatic/HaltedStartModeJobsTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.quartz.test.programmatic;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class HaltedStartModeJobsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addAsResource(new StringAsset("quarkus.scheduler.start-mode=halted"),
+                            "application.properties"));
+
+    @Inject
+    Scheduler scheduler;
+
+    static final CountDownLatch SYNC_LATCH = new CountDownLatch(1);
+
+    @Test
+    public void testScheduler() throws InterruptedException {
+        assertFalse(scheduler.isRunning());
+
+        scheduler.newJob("foo")
+                .setInterval("1s")
+                .setTask(ec -> HaltedStartModeJobsTest.SYNC_LATCH.countDown())
+                .schedule();
+
+        scheduler.resume();
+        assertTrue(scheduler.isRunning());
+        assertTrue(HaltedStartModeJobsTest.SYNC_LATCH.await(5, TimeUnit.SECONDS));
+    }
+
+}

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/programmatic/ProgrammaticJobsTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/programmatic/ProgrammaticJobsTest.java
@@ -1,0 +1,122 @@
+package io.quarkus.quartz.test.programmatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.scheduler.Scheduler.JobDefinition;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+
+public class ProgrammaticJobsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Jobs.class));
+
+    @Inject
+    Scheduler scheduler;
+
+    @Inject
+    MyService myService;
+
+    static final CountDownLatch SYNC_LATCH = new CountDownLatch(1);
+    static final CountDownLatch ASYNC_LATCH = new CountDownLatch(1);
+
+    @Test
+    public void testJobs() throws InterruptedException {
+        Scheduler.JobDefinition job1 = scheduler.newJob("foo")
+                .setInterval("1s")
+                .setTask(ec -> {
+                    assertTrue(Arc.container().requestContext().isActive());
+                    myService.countDown(SYNC_LATCH);
+                });
+
+        assertEquals("Sync task was already set",
+                assertThrows(IllegalStateException.class, () -> job1.setAsyncTask(ec -> null)).getMessage());
+
+        Scheduler.JobDefinition job2 = scheduler.newJob("foo").setCron("0/5 * * * * ?");
+        assertEquals("Either sync or async task must be set",
+                assertThrows(IllegalStateException.class, () -> job2.schedule()).getMessage());
+        job2.setTask(ec -> {
+        });
+
+        job1.schedule();
+        assertTrue(ProgrammaticJobsTest.SYNC_LATCH.await(5, TimeUnit.SECONDS));
+
+        assertEquals("Cannot modify a job that was already scheduled",
+                assertThrows(IllegalStateException.class, () -> job1.setCron("fff")).getMessage());
+
+        // Since job1 was already scheduled - job2 defines a non-unique identity
+        assertEquals("A job with this identity is already scheduled: foo",
+                assertThrows(IllegalStateException.class, () -> job2.schedule()).getMessage());
+
+        // Identity must be unique
+        assertEquals("A job with this identity is already scheduled: foo",
+                assertThrows(IllegalStateException.class, () -> scheduler.newJob("foo")).getMessage());
+        assertEquals("A job with this identity is already scheduled: bar",
+                assertThrows(IllegalStateException.class, () -> scheduler.newJob("bar")).getMessage());
+
+        // No-op
+        assertNull(scheduler.unscheduleJob("bar"));
+        assertNull(scheduler.unscheduleJob("nonexisting"));
+
+        assertNotNull(scheduler.unscheduleJob("foo"));
+        assertEquals(1, scheduler.getScheduledJobs().size());
+    }
+
+    @Test
+    public void testAsyncJob() throws InterruptedException {
+        JobDefinition asyncJob = scheduler.newJob("fooAsync")
+                .setInterval("1s")
+                .setAsyncTask(ec -> {
+                    assertTrue(Context.isOnEventLoopThread() && VertxContext.isOnDuplicatedContext());
+                    assertTrue(Arc.container().requestContext().isActive());
+                    myService.countDown(ASYNC_LATCH);
+                    return Uni.createFrom().voidItem();
+                });
+
+        assertEquals("Async task was already set",
+                assertThrows(IllegalStateException.class, () -> asyncJob.setTask(ec -> {
+                })).getMessage());
+
+        asyncJob.schedule();
+
+        assertTrue(ProgrammaticJobsTest.ASYNC_LATCH.await(5, TimeUnit.SECONDS));
+        assertNotNull(scheduler.unscheduleJob("fooAsync"));
+    }
+
+    static class Jobs {
+
+        @Scheduled(identity = "bar", every = "60m")
+        static void dummy() {
+        }
+    }
+
+    @RequestScoped
+    static class MyService {
+
+        void countDown(CountDownLatch latch) {
+            latch.countDown();
+        }
+
+    }
+
+}

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.quartz.runtime;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
@@ -66,9 +67,12 @@ public class QuartzRuntimeConfig {
      * Additionally, setting it to "halted" will behave just like forced mode but the scheduler will not start
      * triggering jobs until an explicit start is called from the main scheduler.
      * This is useful to programmatically register listeners before scheduler starts performing some work.
+     *
+     * @deprecated Use {@code quarkus.scheduler.start-mode} instead.
      */
-    @ConfigItem(defaultValue = "normal")
-    public QuartzStartMode startMode;
+    @ConfigItem
+    @Deprecated
+    public Optional<QuartzStartMode> startMode;
 
     /**
      * The maximum amount of time Quarkus will wait for currently running jobs to finish.

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzStartMode.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzStartMode.java
@@ -1,8 +1,13 @@
 package io.quarkus.quartz.runtime;
 
+import io.quarkus.scheduler.runtime.SchedulerRuntimeConfig;
+
 /**
  * Defines starting modes of Quartz scheduler
+ *
+ * @deprecated Use {@link SchedulerRuntimeConfig.StartMode} instead.
  */
+@Deprecated(forRemoval = true)
 public enum QuartzStartMode {
 
     /**

--- a/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Scheduler.java
+++ b/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Scheduler.java
@@ -1,6 +1,12 @@
 package io.quarkus.scheduler;
 
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import io.quarkus.scheduler.Scheduled.ConcurrentExecution;
+import io.quarkus.scheduler.Scheduled.SkipPredicate;
+import io.smallrye.mutiny.Uni;
 
 /**
  * The container provides a built-in bean with bean type {@link Scheduler} and qualifier
@@ -57,4 +63,117 @@ public interface Scheduler {
      * @return the trigger of a specific job or null for non-existent identity.
      */
     Trigger getScheduledJob(String identity);
+
+    /**
+     * Creates a new job definition. The job is not scheduled until the {@link JobDefinition#schedule()} method is called.
+     * <p>
+     * The properties of the job definition have the same semantics as their equivalents in the {@link Scheduled}
+     * annotation.
+     *
+     * @param identity The identity must be unique for the scheduler
+     * @return a new job definition
+     * @see Scheduled#identity()
+     */
+    JobDefinition newJob(String identity);
+
+    /**
+     * Removes the job previously added via {@link #newJob(String)}.
+     * <p>
+     * It is a no-op if the identified job was not added programmatically.
+     *
+     * @param identity
+     * @return the trigger or {@code null} if no such job exists
+     */
+    Trigger unscheduleJob(String identity);
+
+    /**
+     * The job definition is a builder-like API that can be used to define a job programmatically.
+     * <p>
+     * No job is scheduled until the {@link #setTask(Consumer)} or {@link #setAsyncTask(Function)} method is called.
+     * <p>
+     * The implementation is not thread-safe and should not be reused.
+     */
+    interface JobDefinition {
+
+        /**
+         * The schedule is defined either by {@link #setCron(String)} or by {@link #setInterval(String)}. If both methods are
+         * used, then the cron expression takes precedence.
+         * <p>
+         * {@link Scheduled#cron()}
+         *
+         * @param cron
+         * @return self
+         * @see Scheduled#cron()
+         */
+        JobDefinition setCron(String cron);
+
+        /**
+         * The schedule is defined either by {@link #setCron(String)} or by {@link #setInterval(String)}. If both methods are
+         * used, then the cron expression takes precedence.
+         * <p>
+         * {@link Scheduled#every()}
+         *
+         * @param every
+         * @return self
+         * @see Scheduled#every()
+         */
+        JobDefinition setInterval(String every);
+
+        /**
+         * {@link Scheduled#delayed()}
+         *
+         * @param period
+         * @return self
+         * @see Scheduled#delayed()
+         */
+        JobDefinition setDelayed(String period);
+
+        /**
+         * {@link Scheduled#concurrentExecution()}
+         *
+         * @param concurrentExecution
+         * @return self
+         * @see Scheduled#concurrentExecution()
+         */
+        JobDefinition setConcurrentExecution(ConcurrentExecution concurrentExecution);
+
+        /**
+         * {@link Scheduled#skipExecutionIf()}
+         *
+         * @param skipPredicate
+         * @return self
+         * @see Scheduled#skipExecutionIf()
+         */
+        JobDefinition setSkipPredicate(SkipPredicate skipPredicate);
+
+        /**
+         * {@link Scheduled#overdueGracePeriod()}
+         *
+         * @param period
+         * @return self
+         * @see Scheduled#overdueGracePeriod()
+         */
+        JobDefinition setOverdueGracePeriod(String period);
+
+        /**
+         *
+         * @param task
+         * @return self
+         */
+        JobDefinition setTask(Consumer<ScheduledExecution> task);
+
+        /**
+         *
+         * @param asyncTask
+         * @return self
+         */
+        JobDefinition setAsyncTask(Function<ScheduledExecution, Uni<Void>> asyncTask);
+
+        /**
+         * Attempts to schedule the job.
+         *
+         * @return the trigger
+         */
+        Trigger schedule();
+    }
 }

--- a/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/AbstractJobDefinition.java
+++ b/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/AbstractJobDefinition.java
@@ -1,0 +1,97 @@
+package io.quarkus.scheduler.common.runtime;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import io.quarkus.scheduler.Scheduled.ConcurrentExecution;
+import io.quarkus.scheduler.Scheduled.SkipPredicate;
+import io.quarkus.scheduler.ScheduledExecution;
+import io.quarkus.scheduler.Scheduler.JobDefinition;
+import io.smallrye.mutiny.Uni;
+
+public abstract class AbstractJobDefinition implements JobDefinition {
+
+    protected final String identity;
+    protected String cron = "";
+    protected String every = "";
+    protected String delayed = "";
+    protected String overdueGracePeriod = "";
+    protected ConcurrentExecution concurrentExecution = ConcurrentExecution.PROCEED;
+    protected SkipPredicate skipPredicate = null;
+    protected Consumer<ScheduledExecution> task;
+    protected Function<ScheduledExecution, Uni<Void>> asyncTask;
+    protected boolean scheduled = false;
+
+    public AbstractJobDefinition(String identity) {
+        this.identity = identity;
+    }
+
+    @Override
+    public JobDefinition setCron(String cron) {
+        checkScheduled();
+        this.cron = cron;
+        return this;
+    }
+
+    @Override
+    public JobDefinition setInterval(String every) {
+        checkScheduled();
+        this.every = every;
+        return this;
+    }
+
+    @Override
+    public JobDefinition setDelayed(String period) {
+        checkScheduled();
+        this.delayed = period;
+        return this;
+    }
+
+    @Override
+    public JobDefinition setConcurrentExecution(ConcurrentExecution concurrentExecution) {
+        checkScheduled();
+        this.concurrentExecution = concurrentExecution;
+        return this;
+    }
+
+    @Override
+    public JobDefinition setSkipPredicate(SkipPredicate skipPredicate) {
+        checkScheduled();
+        this.skipPredicate = skipPredicate;
+        return this;
+    }
+
+    @Override
+    public JobDefinition setOverdueGracePeriod(String period) {
+        checkScheduled();
+        this.overdueGracePeriod = period;
+        return this;
+    }
+
+    @Override
+    public JobDefinition setTask(Consumer<ScheduledExecution> task) {
+        checkScheduled();
+        if (asyncTask != null) {
+            throw new IllegalStateException("Async task was already set");
+        }
+        this.task = task;
+        return this;
+    }
+
+    @Override
+    public JobDefinition setAsyncTask(Function<ScheduledExecution, Uni<Void>> asyncTask) {
+        checkScheduled();
+        if (task != null) {
+            throw new IllegalStateException("Sync task was already set");
+        }
+        this.asyncTask = asyncTask;
+        return this;
+    }
+
+    protected void checkScheduled() {
+        if (scheduled) {
+            throw new IllegalStateException("Cannot modify a job that was already scheduled");
+        }
+    }
+
+}

--- a/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/SyntheticScheduled.java
+++ b/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/SyntheticScheduled.java
@@ -1,0 +1,83 @@
+package io.quarkus.scheduler.common.runtime;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+import io.quarkus.scheduler.Scheduled;
+
+public final class SyntheticScheduled extends AnnotationLiteral<Scheduled> implements Scheduled {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String identity;
+    private final String cron;
+    private final String every;
+    private final long delay;
+    private final TimeUnit delayUnit;
+    private final String delayed;
+    private final String overdueGracePeriod;
+    private final ConcurrentExecution concurrentExecution;
+    private final SkipPredicate skipPredicate;
+
+    public SyntheticScheduled(String identity, String cron, String every, long delay, TimeUnit delayUnit, String delayed,
+            String overdueGracePeriod, ConcurrentExecution concurrentExecution,
+            SkipPredicate skipPredicate) {
+        this.identity = Objects.requireNonNull(identity);
+        this.cron = Objects.requireNonNull(cron);
+        this.every = Objects.requireNonNull(every);
+        this.delay = delay;
+        this.delayUnit = Objects.requireNonNull(delayUnit);
+        this.delayed = Objects.requireNonNull(delayed);
+        this.overdueGracePeriod = Objects.requireNonNull(overdueGracePeriod);
+        this.concurrentExecution = Objects.requireNonNull(concurrentExecution);
+        this.skipPredicate = skipPredicate;
+    }
+
+    @Override
+    public String identity() {
+        return identity;
+    }
+
+    @Override
+    public String cron() {
+        return cron;
+    }
+
+    @Override
+    public String every() {
+        return every;
+    }
+
+    @Override
+    public long delay() {
+        return delay;
+    }
+
+    @Override
+    public TimeUnit delayUnit() {
+        return delayUnit;
+    }
+
+    @Override
+    public String delayed() {
+        return delayed;
+    }
+
+    @Override
+    public ConcurrentExecution concurrentExecution() {
+        return concurrentExecution;
+    }
+
+    @Override
+    public Class<? extends SkipPredicate> skipExecutionIf() {
+        return skipPredicate != null ? skipPredicate.getClass() : Never.class;
+    }
+
+    @Override
+    public String overdueGracePeriod() {
+        return overdueGracePeriod;
+    }
+
+}

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/programmatic/ForcedStartModeJobsTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/programmatic/ForcedStartModeJobsTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.scheduler.test.programmatic;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ForcedStartModeJobsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addAsResource(new StringAsset("quarkus.scheduler.start-mode=forced"),
+                            "application.properties"));
+
+    @Inject
+    Scheduler scheduler;
+
+    static final CountDownLatch SYNC_LATCH = new CountDownLatch(1);
+
+    @Test
+    public void testScheduler() throws InterruptedException {
+        assertTrue(scheduler.isRunning());
+
+        scheduler.newJob("foo")
+                .setInterval("1s")
+                .setTask(ec -> ForcedStartModeJobsTest.SYNC_LATCH.countDown())
+                .schedule();
+
+        assertTrue(ForcedStartModeJobsTest.SYNC_LATCH.await(5, TimeUnit.SECONDS));
+    }
+
+}

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/programmatic/HaltedStartModeJobsTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/programmatic/HaltedStartModeJobsTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.scheduler.test.programmatic;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class HaltedStartModeJobsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addAsResource(new StringAsset("quarkus.scheduler.start-mode=halted"),
+                            "application.properties"));
+
+    @Inject
+    Scheduler scheduler;
+
+    static final CountDownLatch SYNC_LATCH = new CountDownLatch(1);
+
+    @Test
+    public void testScheduler() throws InterruptedException {
+        assertFalse(scheduler.isRunning());
+
+        scheduler.newJob("foo")
+                .setInterval("1s")
+                .setTask(ec -> HaltedStartModeJobsTest.SYNC_LATCH.countDown())
+                .schedule();
+
+        scheduler.resume();
+        assertTrue(scheduler.isRunning());
+        assertTrue(HaltedStartModeJobsTest.SYNC_LATCH.await(5, TimeUnit.SECONDS));
+    }
+
+}

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/programmatic/ProgrammaticJobsTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/programmatic/ProgrammaticJobsTest.java
@@ -1,0 +1,122 @@
+package io.quarkus.scheduler.test.programmatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.scheduler.Scheduler.JobDefinition;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+
+public class ProgrammaticJobsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Jobs.class));
+
+    @Inject
+    Scheduler scheduler;
+
+    @Inject
+    MyService myService;
+
+    static final CountDownLatch SYNC_LATCH = new CountDownLatch(1);
+    static final CountDownLatch ASYNC_LATCH = new CountDownLatch(1);
+
+    @Test
+    public void testJobs() throws InterruptedException {
+        Scheduler.JobDefinition job1 = scheduler.newJob("foo")
+                .setInterval("1s")
+                .setTask(ec -> {
+                    assertTrue(Arc.container().requestContext().isActive());
+                    myService.countDown(SYNC_LATCH);
+                });
+
+        assertEquals("Sync task was already set",
+                assertThrows(IllegalStateException.class, () -> job1.setAsyncTask(ec -> null)).getMessage());
+
+        Scheduler.JobDefinition job2 = scheduler.newJob("foo").setCron("0/5 * * * * ?");
+        assertEquals("Either sync or async task must be set",
+                assertThrows(IllegalStateException.class, () -> job2.schedule()).getMessage());
+        job2.setTask(ec -> {
+        });
+
+        job1.schedule();
+        assertTrue(ProgrammaticJobsTest.SYNC_LATCH.await(5, TimeUnit.SECONDS));
+
+        assertEquals("Cannot modify a job that was already scheduled",
+                assertThrows(IllegalStateException.class, () -> job1.setCron("fff")).getMessage());
+
+        // Since job1 was already scheduled - job2 defines a non-unique identity
+        assertEquals("A job with this identity is already scheduled: foo",
+                assertThrows(IllegalStateException.class, () -> job2.schedule()).getMessage());
+
+        // Identity must be unique
+        assertEquals("A job with this identity is already scheduled: foo",
+                assertThrows(IllegalStateException.class, () -> scheduler.newJob("foo")).getMessage());
+        assertEquals("A job with this identity is already scheduled: bar",
+                assertThrows(IllegalStateException.class, () -> scheduler.newJob("bar")).getMessage());
+
+        // No-op
+        assertNull(scheduler.unscheduleJob("bar"));
+        assertNull(scheduler.unscheduleJob("nonexisting"));
+
+        assertNotNull(scheduler.unscheduleJob("foo"));
+        assertEquals(1, scheduler.getScheduledJobs().size());
+    }
+
+    @Test
+    public void testAsyncJob() throws InterruptedException {
+        JobDefinition asyncJob = scheduler.newJob("fooAsync")
+                .setInterval("1s")
+                .setAsyncTask(ec -> {
+                    assertTrue(Context.isOnEventLoopThread() && VertxContext.isOnDuplicatedContext());
+                    assertTrue(Arc.container().requestContext().isActive());
+                    myService.countDown(ASYNC_LATCH);
+                    return Uni.createFrom().voidItem();
+                });
+
+        assertEquals("Async task was already set",
+                assertThrows(IllegalStateException.class, () -> asyncJob.setTask(ec -> {
+                })).getMessage());
+
+        asyncJob.schedule();
+
+        assertTrue(ProgrammaticJobsTest.ASYNC_LATCH.await(5, TimeUnit.SECONDS));
+        assertNotNull(scheduler.unscheduleJob("fooAsync"));
+    }
+
+    static class Jobs {
+
+        @Scheduled(identity = "bar", every = "60m")
+        static void dummy() {
+        }
+    }
+
+    @RequestScoped
+    static class MyService {
+
+        void countDown(CountDownLatch latch) {
+            latch.countDown();
+        }
+
+    }
+
+}

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerRuntimeConfig.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerRuntimeConfig.java
@@ -1,10 +1,12 @@
 package io.quarkus.scheduler.runtime;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.scheduler.Scheduler;
 
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public class SchedulerRuntimeConfig {
@@ -20,4 +22,34 @@ public class SchedulerRuntimeConfig {
      */
     @ConfigItem(defaultValue = "1")
     public Duration overdueGracePeriod;
+
+    /**
+     * Scheduler can be started in different modes. By default, the scheduler is not started unless a
+     * {@link io.quarkus.scheduler.Scheduled} business method is found.
+     */
+    @ConfigItem
+    public Optional<StartMode> startMode;
+
+    public enum StartMode {
+
+        /**
+         * The scheduler is not started unless a {@link io.quarkus.scheduler.Scheduled} business method is found.
+         */
+        NORMAL,
+
+        /**
+         * The scheduler will be started even if no scheduled business methods are found.
+         * <p>
+         * This is necessary for "pure" programmatic scheduling.
+         */
+        FORCED,
+
+        /**
+         * Just like the {@link #FORCED} mode but the scheduler will not start triggering jobs until {@link Scheduler#resume()}
+         * is called.
+         * <p>
+         * This can be useful to run some intialization logic that needs to be performed before the scheduler starts.
+         */
+        HALTED;
+    }
 }


### PR DESCRIPTION
The simple scheduler impl does support adding jobs programmaticaly. Many users asked for this feature and `quarkus-quartz` with Quartz-specific APIs was the only option.

This API change aims to provide a programmatic alternative to `@Scheduled` methods with the exactly same semantics.

A programmatic alternative to:
```java
@ApplicationScoped
class MyService {
    @Scheduled(cron = "0/5 * * * * ?")
     void check() {
         // do something important every 5 seconds
     }
 }
```
would be something like:
```java
@ApplicationScoped
class MyService {
   
   @Inject
   Scheduler scheduler;    

   void addJob() {
         scheduler.newJob("check").setCron("0/5 * * * * ?").setTask(ec -> {
            // do something important every 5 seconds
        }).schedule();
     }
 }
```

TODO:
- [x] API prototype
- [x] Simple impl
- [x] Polish API and functionality
- [x] Add `quarkus.scheduler.start-mode` (and maybe deprecate `quarkus.quartz.start-mode`)
- [x] Test coverage
- [x] docs
- [x] Quartz impl + test coverage + docs

Open questions:
- [x] Q: Should `Scheduler#unschedule()` only work for jobs added programmatically?, A: Yes, it should.