### PR TITLE
Bump kubernetes-client-bom from 6.3 to 6.4

### DIFF
--- a/extensions/container-image/container-image-openshift/deployment/pom.xml
+++ b/extensions/container-image/container-image-openshift/deployment/pom.xml
@@ -55,6 +55,10 @@
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/extensions/container-image/container-image-s2i/deployment/pom.xml
+++ b/extensions/container-image/container-image-s2i/deployment/pom.xml
@@ -51,6 +51,10 @@
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/extensions/kubernetes-client/deployment-internal/pom.xml
+++ b/extensions/kubernetes-client/deployment-internal/pom.xml
@@ -33,6 +33,16 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-vertx</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/kubernetes-client/deployment-internal/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientBuildStep.java
+++ b/extensions/kubernetes-client/deployment-internal/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientBuildStep.java
@@ -13,6 +13,6 @@ public class KubernetesClientBuildStep {
 
     @BuildStep
     public KubernetesClientBuildItem process(TlsConfig tlsConfig) {
-        return new KubernetesClientBuildItem(createClient(buildConfig, tlsConfig));
+        return new KubernetesClientBuildItem(createConfig(buildConfig, tlsConfig));
     }
 }

--- a/extensions/kubernetes-client/deployment/pom.xml
+++ b/extensions/kubernetes-client/deployment/pom.xml
@@ -25,6 +25,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-deployment</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/kubernetes-client/runtime-internal/pom.xml
+++ b/extensions/kubernetes-client/runtime-internal/pom.xml
@@ -23,6 +23,17 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
             <scope>provided</scope> <!-- we don't want this ending up on the runtime classpath -->
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-vertx</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientUtils.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientUtils.java
@@ -6,8 +6,8 @@ import org.eclipse.microprofile.config.ConfigProvider;
 
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.quarkus.runtime.TlsConfig;
 
 public class KubernetesClientUtils {
@@ -49,13 +49,13 @@ public class KubernetesClientUtils {
     }
 
     public static KubernetesClient createClient(KubernetesClientBuildConfig buildConfig, TlsConfig tlsConfig) {
-        return new DefaultKubernetesClient(createConfig(buildConfig, tlsConfig));
+        return new KubernetesClientBuilder().withConfig(createConfig(buildConfig, tlsConfig)).build();
     }
 
     public static KubernetesClient createClient() {
         org.eclipse.microprofile.config.Config config = ConfigProvider.getConfig();
         Config base = Config.autoConfigure(null);
-        return new DefaultKubernetesClient(new ConfigBuilder()
+        return new KubernetesClientBuilder().withConfig(new ConfigBuilder()
                 .withTrustCerts(config.getOptionalValue(PREFIX + "trust-certs", Boolean.class).orElse(base.isTrustCerts()))
                 .withWatchReconnectLimit(config.getOptionalValue(PREFIX + "watch-reconnect-limit", Integer.class)
                         .orElse(base.getWatchReconnectLimit()))
@@ -92,6 +92,7 @@ public class KubernetesClientUtils {
                 .withProxyPassword(
                         config.getOptionalValue(PREFIX + "proxy-password", String.class).orElse(base.getProxyPassword()))
                 .withNoProxy(config.getOptionalValue(PREFIX + "no-proxy", String[].class).orElse(base.getNoProxy()))
-                .build());
+                .build())
+                .build();
     }
 }

--- a/extensions/kubernetes-client/runtime/pom.xml
+++ b/extensions/kubernetes-client/runtime/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
             <exclusions>

--- a/extensions/kubernetes-client/runtime/pom.xml
+++ b/extensions/kubernetes-client/runtime/pom.xml
@@ -29,6 +29,16 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-vertx</artifactId>
         </dependency>
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>

--- a/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientProducer.java
+++ b/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientProducer.java
@@ -5,8 +5,8 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.quarkus.arc.DefaultBean;
 
 @Singleton
@@ -18,7 +18,7 @@ public class KubernetesClientProducer {
     @Singleton
     @Produces
     public KubernetesClient kubernetesClient(Config config) {
-        client = new DefaultKubernetesClient(config);
+        client = new KubernetesClientBuilder().withConfig(config).build();
         return client;
     }
 

--- a/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/QuarkusHttpClientFactory.java
+++ b/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/QuarkusHttpClientFactory.java
@@ -1,0 +1,38 @@
+package io.quarkus.kubernetes.client.runtime;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.vertx.VertxHttpClientBuilder;
+import io.vertx.core.Vertx;
+
+import javax.enterprise.inject.spi.CDI;
+
+public class QuarkusHttpClientFactory implements io.fabric8.kubernetes.client.http.HttpClient.Factory {
+
+    private Vertx vertx;
+
+    public QuarkusHttpClientFactory() {
+        // The client might get initialized outside a Quarkus context that can provide the Vert.x instance
+        // This is the case for the MockServer / @KubernetesTestServer where the server provides the KubernetesClient instance
+        try {
+            this.vertx = CDI.current().select(Vertx.class).get();
+        } catch (Exception e) {
+            this.vertx = Vertx.vertx();
+        }
+    }
+
+    @Override
+    public HttpClient.Builder newBuilder(Config config) {
+        return HttpClient.Factory.super.newBuilder(config);
+    }
+
+    @Override
+    public VertxHttpClientBuilder<QuarkusHttpClientFactory> newBuilder() {
+        return new VertxHttpClientBuilder<>(this, vertx);
+    }
+
+    @Override
+    public int priority() {
+        return 1;
+    }
+}

--- a/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/QuarkusHttpClientFactory.java
+++ b/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/QuarkusHttpClientFactory.java
@@ -1,11 +1,11 @@
 package io.quarkus.kubernetes.client.runtime;
 
+import javax.enterprise.inject.spi.CDI;
+
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.vertx.VertxHttpClientBuilder;
 import io.vertx.core.Vertx;
-
-import javax.enterprise.inject.spi.CDI;
 
 public class QuarkusHttpClientFactory implements io.fabric8.kubernetes.client.http.HttpClient.Factory {
 

--- a/extensions/kubernetes-client/runtime/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.http.HttpClient$Factory
+++ b/extensions/kubernetes-client/runtime/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.http.HttpClient$Factory
@@ -1,0 +1,1 @@
+io.quarkus.kubernetes.client.runtime.QuarkusHttpClientFactory

--- a/extensions/kubernetes-client/spi/pom.xml
+++ b/extensions/kubernetes-client/spi/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>kubernetes-client</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>javax.annotation</groupId>
                     <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
@@ -35,6 +39,10 @@
                     <artifactId>jaxb-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-vertx</artifactId>
         </dependency>
 
     </dependencies>

--- a/extensions/kubernetes-client/spi/src/main/java/io/quarkus/kubernetes/client/spi/KubernetesClientBuildItem.java
+++ b/extensions/kubernetes-client/spi/src/main/java/io/quarkus/kubernetes/client/spi/KubernetesClientBuildItem.java
@@ -1,18 +1,26 @@
 package io.quarkus.kubernetes.client.spi;
 
+import java.util.function.Supplier;
+
+import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class KubernetesClientBuildItem extends SimpleBuildItem {
 
-    private final KubernetesClient client;
+    private final Config config;
 
-    public KubernetesClientBuildItem(KubernetesClient client) {
-        this.client = client;
+    public KubernetesClientBuildItem(Config config) {
+        this.config = config;
     }
 
-    public KubernetesClient getClient() {
-        return this.client;
+    public Supplier<KubernetesClient> getClient() {
+        return () -> new KubernetesClientBuilder().withConfig(config).build();
+    }
+
+    public Config getConfig() {
+        return config;
     }
 
 }

--- a/extensions/kubernetes-service-binding/deployment/pom.xml
+++ b/extensions/kubernetes-service-binding/deployment/pom.xml
@@ -43,7 +43,25 @@
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-vertx</artifactId>
         </dependency>
     </dependencies>
 

--- a/extensions/kubernetes/kind/deployment/pom.xml
+++ b/extensions/kubernetes/kind/deployment/pom.xml
@@ -34,6 +34,10 @@
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/extensions/kubernetes/openshift/deployment/pom.xml
+++ b/extensions/kubernetes/openshift/deployment/pom.xml
@@ -38,6 +38,10 @@
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/extensions/kubernetes/vanilla/deployment/pom.xml
+++ b/extensions/kubernetes/vanilla/deployment/pom.xml
@@ -42,6 +42,10 @@
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -57,6 +61,10 @@
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -71,6 +79,10 @@
                 <exclusion>
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeDeployer.java
@@ -17,14 +17,14 @@ public class KnativeDeployer {
     @BuildStep
     public void checkEnvironment(Optional<SelectedKubernetesDeploymentTargetBuildItem> selectedDeploymentTarget,
             List<GeneratedKubernetesResourceBuildItem> resources,
-            KubernetesClientBuildItem client, BuildProducer<KubernetesDeploymentClusterBuildItem> deploymentCluster) {
+            KubernetesClientBuildItem clientSupplier, BuildProducer<KubernetesDeploymentClusterBuildItem> deploymentCluster) {
         selectedDeploymentTarget.ifPresent(target -> {
             if (!KubernetesDeploy.INSTANCE.checkSilently()) {
                 return;
             }
             if (target.getEntry().getName().equals(KNATIVE)) {
-                try (DefaultKnativeClient knativeClient = client.getClient().adapt(DefaultKnativeClient.class)) {
-                    if (knativeClient.isSupported()) {
+                try (DefaultKnativeClient client = clientSupplier.getClient().get().adapt(DefaultKnativeClient.class)) {
+                    if (client.isSupported()) {
                         deploymentCluster.produce(new KubernetesDeploymentClusterBuildItem(KNATIVE));
                     } else {
                         throw new IllegalStateException(

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -102,7 +102,7 @@ public class KubernetesDeployer {
     }
 
     @BuildStep(onlyIf = IsNormalNotRemoteDev.class)
-    public void deploy(KubernetesClientBuildItem kubernetesClient,
+    public void deploy(KubernetesClientBuildItem kubernetesClientSupplier,
             Capabilities capabilities,
             List<KubernetesDeploymentClusterBuildItem> deploymentClusters,
             Optional<SelectedKubernetesDeploymentTargetBuildItem> selectedDeploymentTarget,
@@ -130,10 +130,11 @@ public class KubernetesDeployer {
             return;
         }
 
-        final KubernetesClient client = Clients.fromConfig(kubernetesClient.getClient().getConfiguration());
-        deploymentResult
-                .produce(deploy(selectedDeploymentTarget.get().getEntry(), client, outputTarget.getOutputDirectory(),
-                        openshiftConfig, applicationInfo, optionalResourceDefinitions));
+        try (final KubernetesClient client = Clients.fromConfig(kubernetesClientSupplier.getConfig())) {
+            deploymentResult
+                    .produce(deploy(selectedDeploymentTarget.get().getEntry(), client, outputTarget.getOutputDirectory(),
+                            openshiftConfig, applicationInfo, optionalResourceDefinitions));
+        }
     }
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftDeployer.java
@@ -18,13 +18,13 @@ public class OpenshiftDeployer {
     @BuildStep
     public void checkEnvironment(Optional<SelectedKubernetesDeploymentTargetBuildItem> selectedDeploymentTarget,
             List<GeneratedKubernetesResourceBuildItem> resources,
-            KubernetesClientBuildItem client, BuildProducer<KubernetesDeploymentClusterBuildItem> deploymentCluster) {
+            KubernetesClientBuildItem clientSupplier, BuildProducer<KubernetesDeploymentClusterBuildItem> deploymentCluster) {
         selectedDeploymentTarget.ifPresent(target -> {
             if (!KubernetesDeploy.INSTANCE.checkSilently()) {
                 return;
             }
             if (target.getEntry().getName().equals(OPENSHIFT)) {
-                try (var openShiftClient = client.getClient().adapt(OpenShiftClient.class)) {
+                try (var openShiftClient = clientSupplier.getClient().get().adapt(OpenShiftClient.class)) {
                     if (openShiftClient.isSupported()) {
                         deploymentCluster.produce(new KubernetesDeploymentClusterBuildItem(OPENSHIFT));
                     } else {

--- a/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
+++ b/independent-projects/enforcer-rules/src/main/resources/enforcer-rules/quarkus-banned-dependencies.xml
@@ -102,6 +102,8 @@
                 <exclude>org.javassist:javassist</exclude>
                 <!-- Jandex moved to SmallRye -->
                 <exclude>org.jboss:jandex</exclude>
+                <!-- Ensure Fabric8 Kubernetes Client won't propagate its OkHttp implementation -->
+                <exclude>io.fabric8:kubernetes-httpclient-okhttp</exclude>
             </excludes>
             <includes>
                 <!-- this is for REST Assured -->

--- a/integration-tests/istio/maven-invoker-way/pom.xml
+++ b/integration-tests/istio/maven-invoker-way/pom.xml
@@ -56,23 +56,41 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-httpclient-okhttp</artifactId>
+            <artifactId>kubernetes-httpclient-vertx</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.dekorate</groupId>
             <artifactId>kubernetes-annotations</artifactId>
             <classifier>noapt</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dekorate</groupId>
             <artifactId>openshift-annotations</artifactId>
             <classifier>noapt</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dekorate</groupId>
             <artifactId>knative-annotations</artifactId>
             <classifier>noapt</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/kubernetes/maven-invoker-way/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/pom.xml
@@ -49,16 +49,34 @@
             <groupId>io.dekorate</groupId>
             <artifactId>kubernetes-annotations</artifactId>
             <classifier>noapt</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dekorate</groupId>
             <artifactId>openshift-annotations</artifactId>
             <classifier>noapt</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dekorate</groupId>
             <artifactId>knative-annotations</artifactId>
             <classifier>noapt</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/kubernetes/quarkus-standard-way/pom.xml
+++ b/integration-tests/kubernetes/quarkus-standard-way/pom.xml
@@ -119,6 +119,26 @@
             <groupId>io.dekorate</groupId>
             <artifactId>servicebinding-annotations</artifactId>
             <classifier>noapt</classifier>
+             <exclusions>
+                 <exclusion>
+                     <groupId>io.fabric8</groupId>
+                     <artifactId>kubernetes-client</artifactId>
+                 </exclusion>
+             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-vertx</artifactId>
         </dependency>
 
         <!-- needed for the customization of the build chain -->
@@ -214,7 +234,7 @@
             </exclusions>
         </dependency>
     </dependencies>
-    
+
     <profiles>
         <profile>
             <id>basic-test-suite</id>
@@ -249,5 +269,5 @@
             </build>
         </profile>
     </profiles>
-    
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
         <!-- Dependency versions -->
         <jacoco.version>0.8.8</jacoco.version>
-        <kubernetes-client.version>6.3.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>6.4.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.52.1</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->

--- a/test-framework/kubernetes-client/pom.xml
+++ b/test-framework/kubernetes-client/pom.xml
@@ -46,6 +46,16 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-server-mock</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-vertx</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/test-framework/openshift-client/pom.xml
+++ b/test-framework/openshift-client/pom.xml
@@ -22,8 +22,8 @@
             <artifactId>openshift-server-mock</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>javax.annotation</groupId>


### PR DESCRIPTION
Kubernetes Client ~6.4.0~ 6.4.1 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v6.4.1

This release of the client includes the new Vert.x `HttpClient` implementation. This PR includes changes in the `pom.xml` files to make use of this client instead of the default `OkHttp` implementation. If everything goes well, this should fix #29520

- Added an enforcer rule to ensure ~~OkHttp~~ that the `kubernetes-httpclient-okhttp` module is not mistakenly propagated, however, I'm not sure this is the right place. I can't directly block OkHttp since it is also used (server-side) in the MockServer.
- Modified the kubernetes-extension (creates kubernetes et al manifests and deploys them) to create and close KubernetesClient instances and avoid the leakages mentioned in some of the PR comments
- Modified the kubernetes-client-extension to implement an HttpClient.Factory that reuses the global Vert.x instance (uses CDI to retrieve it, maybe doesn't work, waiting for tests)


/cc @metacosm @maxandersen @shawkins @gastaldi @geoand 

Fix https://github.com/quarkusio/quarkus/issues/30558