### PR TITLE
Test all gRPC combos wrt exception handling, msgs, etc

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/Channels.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/Channels.java
@@ -235,6 +235,7 @@ public class Channels {
             return builder.build();
         } else {
             HttpClientOptions options = new HttpClientOptions(); // TODO options
+            options.setHttp2ClearTextUpgrade(false); // this fixes i30379
 
             if (!plainText) {
                 if (config.ssl.trustStore.isPresent()) {

--- a/integration-tests/grpc-exceptions/pom.xml
+++ b/integration-tests/grpc-exceptions/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-grpc-exceptions</artifactId>
+    <name>Quarkus - Integration Tests - gRPC - Exceptions</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-grpc</artifactId>
+            <version>${project.version}</version> <!--kept here to not pollute the BOM-->
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-code</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/grpc-exceptions/src/main/java/com/example/grpc/exc/LegacyHelloGrpcService.java
+++ b/integration-tests/grpc-exceptions/src/main/java/com/example/grpc/exc/LegacyHelloGrpcService.java
@@ -1,0 +1,16 @@
+package com.example.grpc.exc;
+
+import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.stub.StreamObserver;
+import io.quarkus.grpc.GrpcService;
+
+@GrpcService
+public class LegacyHelloGrpcService extends LegacyHelloGrpcGrpc.LegacyHelloGrpcImplBase {
+    @Override
+    public void legacySayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
+        // it NEEDS to be plain StatusException, and NOT StatusRuntimeException ?!
+        final StatusException t = new StatusException(Status.INVALID_ARGUMENT);
+        responseObserver.onError(t);
+    }
+}

--- a/integration-tests/grpc-exceptions/src/main/java/com/example/grpc/exc/SmallryeHelloGrpcService.java
+++ b/integration-tests/grpc-exceptions/src/main/java/com/example/grpc/exc/SmallryeHelloGrpcService.java
@@ -1,0 +1,14 @@
+package com.example.grpc.exc;
+
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class SmallryeHelloGrpcService implements HelloGrpc {
+
+    @Override
+    public Uni<HelloReply> sayHello(HelloRequest request) {
+        throw new IllegalArgumentException("test");
+    }
+
+}

--- a/integration-tests/grpc-exceptions/src/main/proto/hello.proto
+++ b/integration-tests/grpc-exceptions/src/main/proto/hello.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.example.grpc.exc";
+option java_outer_classname = "HelloGrpcProto";
+
+package hello;
+
+service HelloGrpc {
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+service LegacyHelloGrpc {
+  rpc LegacySayHello (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}

--- a/integration-tests/grpc-exceptions/src/main/resources/application.properties
+++ b/integration-tests/grpc-exceptions/src/main/resources/application.properties
@@ -1,8 +1,10 @@
-quarkus.grpc.server.port=9001
+## --- servers
 
 %vertx.quarkus.grpc.server.use-separate-server=false
 %n2o.quarkus.grpc.server.use-separate-server=true
 %o2n.quarkus.grpc.server.use-separate-server=false
+
+## --- clients
 
 quarkus.grpc.clients.hello.host=localhost
 quarkus.grpc.clients.hello.port=9001
@@ -15,3 +17,15 @@ quarkus.grpc.clients.hello.port=9001
 
 %o2n.quarkus.grpc.clients.hello.port=8081
 %o2n.quarkus.grpc.clients.hello.use-quarkus-grpc-client=false
+
+quarkus.grpc.clients.stub.host=localhost
+quarkus.grpc.clients.stub.port=9001
+
+%vertx.quarkus.grpc.clients.stub.port=8081
+%vertx.quarkus.grpc.clients.stub.use-quarkus-grpc-client=true
+
+%n2o.quarkus.grpc.clients.stub.port=9001
+%n2o.quarkus.grpc.clients.stub.use-quarkus-grpc-client=true
+
+%o2n.quarkus.grpc.clients.stub.port=8081
+%o2n.quarkus.grpc.clients.stub.use-quarkus-grpc-client=false

--- a/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/LegacyHelloGrpcServiceTest.java
+++ b/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/LegacyHelloGrpcServiceTest.java
@@ -1,0 +1,7 @@
+package com.example.grpc.exc;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class LegacyHelloGrpcServiceTest extends LegacyHelloGrpcServiceTestBase {
+}

--- a/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/LegacyHelloGrpcServiceTestBase.java
+++ b/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/LegacyHelloGrpcServiceTestBase.java
@@ -1,0 +1,24 @@
+package com.example.grpc.exc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.quarkus.grpc.GrpcClient;
+
+class LegacyHelloGrpcServiceTestBase {
+    @SuppressWarnings("CdiInjectionPointsInspection")
+    @GrpcClient
+    LegacyHelloGrpcGrpc.LegacyHelloGrpcBlockingStub stub;
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    void legacySayHello() {
+        final StatusRuntimeException exception = assertThrows(StatusRuntimeException.class,
+                () -> stub.legacySayHello(HelloRequest.newBuilder().setName("Neo").build()));
+        assertEquals(Status.Code.INVALID_ARGUMENT, exception.getStatus().getCode());
+    }
+}

--- a/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/N2OLegacyHelloGrpcServiceTest.java
+++ b/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/N2OLegacyHelloGrpcServiceTest.java
@@ -1,0 +1,10 @@
+package com.example.grpc.exc;
+
+import io.quarkus.grpc.test.utils.N2OGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(N2OGRPCTestProfile.class)
+class N2OLegacyHelloGrpcServiceTest extends LegacyHelloGrpcServiceTestBase {
+}

--- a/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/N2OSmallryeHelloGrpcServiceTest.java
+++ b/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/N2OSmallryeHelloGrpcServiceTest.java
@@ -1,0 +1,10 @@
+package com.example.grpc.exc;
+
+import io.quarkus.grpc.test.utils.N2OGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(N2OGRPCTestProfile.class)
+public class N2OSmallryeHelloGrpcServiceTest extends SmallryeHelloGrpcServiceTestBase {
+}

--- a/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/O2NLegacyHelloGrpcServiceTest.java
+++ b/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/O2NLegacyHelloGrpcServiceTest.java
@@ -1,0 +1,10 @@
+package com.example.grpc.exc;
+
+import io.quarkus.grpc.test.utils.O2NGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(O2NGRPCTestProfile.class)
+class O2NLegacyHelloGrpcServiceTest extends LegacyHelloGrpcServiceTestBase {
+}

--- a/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/O2NSmallryeHelloGrpcServiceTest.java
+++ b/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/O2NSmallryeHelloGrpcServiceTest.java
@@ -1,0 +1,10 @@
+package com.example.grpc.exc;
+
+import io.quarkus.grpc.test.utils.O2NGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(O2NGRPCTestProfile.class)
+public class O2NSmallryeHelloGrpcServiceTest extends SmallryeHelloGrpcServiceTestBase {
+}

--- a/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/SmallryeHelloGrpcServiceTest.java
+++ b/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/SmallryeHelloGrpcServiceTest.java
@@ -1,0 +1,7 @@
+package com.example.grpc.exc;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class SmallryeHelloGrpcServiceTest extends SmallryeHelloGrpcServiceTestBase {
+}

--- a/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/SmallryeHelloGrpcServiceTestBase.java
+++ b/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/SmallryeHelloGrpcServiceTestBase.java
@@ -1,0 +1,28 @@
+package com.example.grpc.exc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.quarkus.grpc.GrpcClient;
+
+public class SmallryeHelloGrpcServiceTestBase {
+
+    @SuppressWarnings("CdiInjectionPointsInspection")
+    @GrpcClient
+    HelloGrpc hello;
+
+    @Test
+    public void testHello() {
+        final StatusRuntimeException exception = assertThrows(StatusRuntimeException.class, () -> hello
+                .sayHello(HelloRequest.newBuilder().setName("Neo").build()).await()
+                .atMost(Duration.ofSeconds(5)));
+        assertEquals(Status.Code.INVALID_ARGUMENT, exception.getStatus().getCode());
+    }
+
+}

--- a/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/VertxLegacyHelloGrpcServiceTest.java
+++ b/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/VertxLegacyHelloGrpcServiceTest.java
@@ -1,0 +1,10 @@
+package com.example.grpc.exc;
+
+import io.quarkus.grpc.test.utils.VertxGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(VertxGRPCTestProfile.class)
+class VertxLegacyHelloGrpcServiceTest extends LegacyHelloGrpcServiceTestBase {
+}

--- a/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/VertxSmallryeHelloGrpcServiceTest.java
+++ b/integration-tests/grpc-exceptions/src/test/java/com/example/grpc/exc/VertxSmallryeHelloGrpcServiceTest.java
@@ -1,0 +1,10 @@
+package com.example.grpc.exc;
+
+import io.quarkus.grpc.test.utils.VertxGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(VertxGRPCTestProfile.class)
+public class VertxSmallryeHelloGrpcServiceTest extends SmallryeHelloGrpcServiceTestBase {
+}

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/N2OHelloWorldEndpointIT.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/N2OHelloWorldEndpointIT.java
@@ -1,0 +1,11 @@
+package io.quarkus.grpc.example.interceptors;
+
+import io.quarkus.grpc.test.utils.N2OGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusIntegrationTest
+@TestProfile(N2OGRPCTestProfile.class)
+class N2OHelloWorldEndpointIT extends HelloWorldEndpointTestBase {
+
+}

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/N2OHelloWorldEndpointTest.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/N2OHelloWorldEndpointTest.java
@@ -1,0 +1,11 @@
+package io.quarkus.grpc.example.interceptors;
+
+import io.quarkus.grpc.test.utils.N2OGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(N2OGRPCTestProfile.class)
+class N2OHelloWorldEndpointTest extends HelloWorldEndpointTestBase {
+
+}

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/O2NHelloWorldEndpointIT.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/O2NHelloWorldEndpointIT.java
@@ -1,0 +1,11 @@
+package io.quarkus.grpc.example.interceptors;
+
+import io.quarkus.grpc.test.utils.O2NGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusIntegrationTest
+@TestProfile(O2NGRPCTestProfile.class)
+class O2NHelloWorldEndpointIT extends HelloWorldEndpointTestBase {
+
+}

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/O2NHelloWorldEndpointTest.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/O2NHelloWorldEndpointTest.java
@@ -1,0 +1,11 @@
+package io.quarkus.grpc.example.interceptors;
+
+import io.quarkus.grpc.test.utils.O2NGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(O2NGRPCTestProfile.class)
+class O2NHelloWorldEndpointTest extends HelloWorldEndpointTestBase {
+
+}

--- a/integration-tests/grpc-vertx/src/main/resources/application.properties
+++ b/integration-tests/grpc-vertx/src/main/resources/application.properties
@@ -1,5 +1,17 @@
-quarkus.grpc.clients.hello.host=localhost
-quarkus.grpc.clients.hello.port=8081
-quarkus.grpc.clients.hello.use-quarkus-grpc-client=true
+quarkus.grpc.server.port=9001
 
-quarkus.grpc.server.use-separate-server=false
+%vertx.quarkus.grpc.server.use-separate-server=false
+%n2o.quarkus.grpc.server.use-separate-server=true
+%o2n.quarkus.grpc.server.use-separate-server=false
+
+quarkus.grpc.clients.hello.host=localhost
+quarkus.grpc.clients.hello.port=9001
+
+%vertx.quarkus.grpc.clients.hello.port=8081
+%vertx.quarkus.grpc.clients.hello.use-quarkus-grpc-client=true
+
+%n2o.quarkus.grpc.clients.hello.port=9001
+%n2o.quarkus.grpc.clients.hello.use-quarkus-grpc-client=true
+
+%o2n.quarkus.grpc.clients.hello.port=8081
+%o2n.quarkus.grpc.clients.hello.use-quarkus-grpc-client=false

--- a/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldN2OServiceIT.java
+++ b/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldN2OServiceIT.java
@@ -1,17 +1,17 @@
 package io.quarkus.grpc.examples.hello;
 
 import io.quarkus.grpc.test.utils.GRPCTestUtils;
-import io.quarkus.grpc.test.utils.VertxGRPCTestProfile;
+import io.quarkus.grpc.test.utils.N2OGRPCTestProfile;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
 import io.vertx.core.Vertx;
 
 @QuarkusIntegrationTest
-@TestProfile(VertxGRPCTestProfile.class)
-class HelloWorldVertxServiceIT extends HelloWorldNewServiceTestBase {
+@TestProfile(N2OGRPCTestProfile.class)
+class HelloWorldN2OServiceIT extends HelloWorldNewServiceTestBase {
     @Override
     protected int port() {
-        return 8081;
+        return 9001;
     }
 
     @Override

--- a/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldN2OServiceTest.java
+++ b/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldN2OServiceTest.java
@@ -2,14 +2,14 @@ package io.quarkus.grpc.examples.hello;
 
 import javax.inject.Inject;
 
-import io.quarkus.grpc.test.utils.VertxGRPCTestProfile;
+import io.quarkus.grpc.test.utils.N2OGRPCTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.vertx.core.Vertx;
 
 @QuarkusTest
-@TestProfile(VertxGRPCTestProfile.class)
-class HelloWorldVertxServiceTest extends HelloWorldNewServiceTestBase {
+@TestProfile(N2OGRPCTestProfile.class)
+class HelloWorldN2OServiceTest extends HelloWorldNewServiceTestBase {
 
     @Inject
     Vertx vertx;
@@ -21,6 +21,6 @@ class HelloWorldVertxServiceTest extends HelloWorldNewServiceTestBase {
 
     @Override
     protected int port() {
-        return 8081;
+        return 9001;
     }
 }

--- a/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewEndpointTest.java
+++ b/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewEndpointTest.java
@@ -1,25 +1,7 @@
 package io.quarkus.grpc.examples.hello;
 
-import static io.restassured.RestAssured.get;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.jupiter.api.Test;
-
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-class HelloWorldNewEndpointTest {
-
-    @Test
-    public void testHelloWorldServiceUsingBlockingStub() {
-        String response = get("/hello/blocking/neo").asString();
-        assertThat(response).isEqualTo("Hello neo");
-    }
-
-    @Test
-    public void testHelloWorldServiceUsingMutinyStub() {
-        String response = get("/hello/mutiny/neo-mutiny").asString();
-        assertThat(response).isEqualTo("Hello neo-mutiny");
-    }
-
+class HelloWorldNewEndpointTest extends HelloWorldNewEndpointTestBase {
 }

--- a/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewEndpointTestBase.java
+++ b/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewEndpointTestBase.java
@@ -1,0 +1,22 @@
+package io.quarkus.grpc.examples.hello;
+
+import static io.restassured.RestAssured.get;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class HelloWorldNewEndpointTestBase {
+
+    @Test
+    public void testHelloWorldServiceUsingBlockingStub() {
+        String response = get("/hello/blocking/neo").asString();
+        assertThat(response).isEqualTo("Hello neo");
+    }
+
+    @Test
+    public void testHelloWorldServiceUsingMutinyStub() {
+        String response = get("/hello/mutiny/neo-mutiny").asString();
+        assertThat(response).isEqualTo("Hello neo-mutiny");
+    }
+
+}

--- a/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewServiceIT.java
+++ b/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewServiceIT.java
@@ -4,5 +4,8 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
 class HelloWorldNewServiceIT extends HelloWorldNewServiceTestBase {
-
+    @Override
+    protected int port() {
+        return 9001;
+    }
 }

--- a/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewServiceTest.java
+++ b/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewServiceTest.java
@@ -4,4 +4,8 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 class HelloWorldNewServiceTest extends HelloWorldNewServiceTestBase {
+    @Override
+    protected int port() {
+        return 9001;
+    }
 }

--- a/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewServiceTestBase.java
+++ b/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewServiceTestBase.java
@@ -28,10 +28,12 @@ abstract class HelloWorldNewServiceTestBase {
     protected void close(Vertx vertx) {
     }
 
+    protected abstract int port();
+
     @BeforeEach
     public void init() {
         _vertx = vertx();
-        channel = GRPCTestUtils.channel(_vertx, 8081); // always use http 8081
+        channel = GRPCTestUtils.channel(_vertx, port());
     }
 
     @AfterEach

--- a/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldO2NServiceIT.java
+++ b/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldO2NServiceIT.java
@@ -1,0 +1,14 @@
+package io.quarkus.grpc.examples.hello;
+
+import io.quarkus.grpc.test.utils.O2NGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusIntegrationTest
+@TestProfile(O2NGRPCTestProfile.class)
+class HelloWorldO2NServiceIT extends HelloWorldNewServiceTestBase {
+    @Override
+    protected int port() {
+        return 8081;
+    }
+}

--- a/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldO2NServiceTest.java
+++ b/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldO2NServiceTest.java
@@ -1,0 +1,14 @@
+package io.quarkus.grpc.examples.hello;
+
+import io.quarkus.grpc.test.utils.O2NGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(O2NGRPCTestProfile.class)
+class HelloWorldO2NServiceTest extends HelloWorldNewServiceTestBase {
+    @Override
+    protected int port() {
+        return 8081;
+    }
+}

--- a/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/N2OHelloWorldNewEndpointTest.java
+++ b/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/N2OHelloWorldNewEndpointTest.java
@@ -1,0 +1,10 @@
+package io.quarkus.grpc.examples.hello;
+
+import io.quarkus.grpc.test.utils.N2OGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(N2OGRPCTestProfile.class)
+class N2OHelloWorldNewEndpointTest extends HelloWorldNewEndpointTestBase {
+}

--- a/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/O2NHelloWorldNewEndpointTest.java
+++ b/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/O2NHelloWorldNewEndpointTest.java
@@ -1,0 +1,10 @@
+package io.quarkus.grpc.examples.hello;
+
+import io.quarkus.grpc.test.utils.O2NGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(O2NGRPCTestProfile.class)
+class O2NHelloWorldNewEndpointTest extends HelloWorldNewEndpointTestBase {
+}

--- a/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/VertxHelloWorldNewEndpointTest.java
+++ b/integration-tests/grpc-vertx/src/test/java/io/quarkus/grpc/examples/hello/VertxHelloWorldNewEndpointTest.java
@@ -1,0 +1,10 @@
+package io.quarkus.grpc.examples.hello;
+
+import io.quarkus.grpc.test.utils.VertxGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(VertxGRPCTestProfile.class)
+class VertxHelloWorldNewEndpointTest extends HelloWorldNewEndpointTestBase {
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -342,6 +342,7 @@
                 <module>grpc-external-proto</module>
                 <module>grpc-external-proto-test</module>
                 <module>grpc-stork-response-time</module>
+                <module>grpc-exceptions</module>
                 <module>google-cloud-functions-http</module>
                 <module>google-cloud-functions</module>
                 <module>istio</module>

--- a/test-framework/grpc/src/main/java/io/quarkus/grpc/test/utils/GRPCTestUtils.java
+++ b/test-framework/grpc/src/main/java/io/quarkus/grpc/test/utils/GRPCTestUtils.java
@@ -1,5 +1,8 @@
 package io.quarkus.grpc.test.utils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -12,6 +15,7 @@ import io.vertx.grpc.client.GrpcClient;
 import io.vertx.grpc.client.GrpcClientChannel;
 
 public class GRPCTestUtils {
+    private static final Logger log = LoggerFactory.getLogger(GRPCTestUtils.class);
 
     public static Channel channel(Vertx vertx) {
         int port = vertx != null ? 8081 : 9001;
@@ -19,13 +23,16 @@ public class GRPCTestUtils {
     }
 
     public static Channel channel(Vertx vertx, int port) {
+        Channel channel;
         if (vertx != null) {
             GrpcClient client = GrpcClient.client(vertx);
-            GrpcClientChannel channel = new GrpcClientChannel(client, SocketAddress.inetSocketAddress(port, "localhost"));
-            return new InternalChannel(channel, client);
+            GrpcClientChannel gcc = new GrpcClientChannel(client, SocketAddress.inetSocketAddress(port, "localhost"));
+            channel = new InternalChannel(gcc, client);
         } else {
-            return ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build();
+            channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build();
         }
+        log.info("Channel: {}, port: {}", channel, port);
+        return channel;
     }
 
     public static void close(Channel channel) {
@@ -68,6 +75,11 @@ public class GRPCTestUtils {
 
         void close() {
             GRPCTestUtils.close(client);
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
         }
     }
 }

--- a/test-framework/grpc/src/main/java/io/quarkus/grpc/test/utils/N2OGRPCTestProfile.java
+++ b/test-framework/grpc/src/main/java/io/quarkus/grpc/test/utils/N2OGRPCTestProfile.java
@@ -1,0 +1,10 @@
+package io.quarkus.grpc.test.utils;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class N2OGRPCTestProfile implements QuarkusTestProfile {
+    @Override
+    public String getConfigProfile() {
+        return "n2o"; // new Vert.x gRPC client --> old Netty gRPC server
+    }
+}

--- a/test-framework/grpc/src/main/java/io/quarkus/grpc/test/utils/O2NGRPCTestProfile.java
+++ b/test-framework/grpc/src/main/java/io/quarkus/grpc/test/utils/O2NGRPCTestProfile.java
@@ -1,0 +1,10 @@
+package io.quarkus.grpc.test.utils;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class O2NGRPCTestProfile implements QuarkusTestProfile {
+    @Override
+    public String getConfigProfile() {
+        return "o2n"; // old Netty gRPC client --> new Vert.x gRPC server
+    }
+}


### PR DESCRIPTION
Add a simple Vert.x gRPC client fix - Http2ClearTextUpgrade = false.
* this fixes unexpected HTTP/1.1 usage
@vietj ^^

Also add a few new gRPC tests -- missing mixtures:
* old Netty client -> new Vert.x server
* new Vert.x client -> old Netty server

LegacyHelloGrpcServiceTest needs a workaround by not throwing trailers as part of observer::onError.
This is something that needs to be investigated and fixed, but for now we at least have workaround.