### PR TITLE
Move TestNG outside of the BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -133,7 +133,6 @@
         <rest-assured.version>4.5.1</rest-assured.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <junit-pioneer.version>1.5.0</junit-pioneer.version>
-        <testng.version>6.14.2</testng.version>
         <infinispan.version>14.0.5.Final</infinispan.version>
         <infinispan.protostream.version>4.5.1.Final</infinispan.protostream.version>
         <caffeine.version>3.1.1</caffeine.version>
@@ -4047,11 +4046,6 @@
                 <groupId>org.jboss.spec.javax.ws.rs</groupId>
                 <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
                 <version>${jboss-jaxrs-api_2.1_spec.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>${testng.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.qpid</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,8 @@
         <protobuf-java.version>${protoc.version}</protobuf-java.version>
         <proto-google-common-protos.version>2.11.0</proto-google-common-protos.version>
 
+        <!-- TestNG version: we don't enforce it in the BOM as it is mostly used in the MP TCKs and we need to use the version from the TCKs -->
+        <testng.version>6.14.2</testng.version>
     </properties>
 
     <modules>

--- a/tcks/pom.xml
+++ b/tcks/pom.xml
@@ -73,6 +73,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${testng.version}</version>
+            </dependency>
             <!-- Enforce jQuery version that is compatible with TestNG 7.4.0 -->
             <dependency>
                 <groupId>org.webjars</groupId>

--- a/test-framework/arquillian/pom.xml
+++ b/test-framework/arquillian/pom.xml
@@ -90,6 +90,8 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <!-- This version is not enforced in the BOM as we need to use the version enforced by the TCKs and it might be an old version -->
+            <version>${testng.version}</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
We have to enforce a version that is compatible with the Eclipse MicroProfile TCKs and it might definitely not be the latest.

Doing that now because we have a security issue with TestNG and it's probably not a good idea to enforce an old version to all our users.

Related to https://github.com/quarkusio/quarkus/pull/30471