### PR TITLE
Verify code flow access token first if no UserInfo precondition exists

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -24,6 +24,7 @@ public final class OidcConstants {
     public static final String INTROSPECTION_TOKEN = "token";
     public static final String INTROSPECTION_TOKEN_ACTIVE = "active";
     public static final String INTROSPECTION_TOKEN_EXP = "exp";
+    public static final String INTROSPECTION_TOKEN_IAT = "iat";
     public static final String INTROSPECTION_TOKEN_USERNAME = "username";
     public static final String INTROSPECTION_TOKEN_SUB = "sub";
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1147,9 +1147,9 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public Optional<String> principalClaim = Optional.empty();
 
         /**
-         * Refresh expired ID tokens.
-         * If this property is enabled then a refresh token request will be performed if the ID token has expired
-         * and, if successful, the local session will be updated with the new set of tokens.
+         * Refresh expired authorization code flow ID or access tokens.
+         * If this property is enabled then a refresh token request will be performed if the authorization code
+         * ID or access token has expired and, if successful, the local session will be updated with the new set of tokens.
          * Otherwise, the local session will be invalidated and the user redirected to the OpenID Provider to re-authenticate.
          * In this case the user may not be challenged again if the OIDC provider session is still active.
          *
@@ -1164,8 +1164,9 @@ public class OidcTenantConfig extends OidcCommonConfig {
         /**
          * Refresh token time skew in seconds.
          * If this property is enabled then the configured number of seconds is added to the current time
-         * when checking whether the access token should be refreshed. If the sum is greater than this access token's
-         * expiration time then a refresh is going to happen.
+         * when checking if the authorization code ID or access token should be refreshed.
+         * If the sum is greater than the authorization code ID or access token's expiration time then a refresh is going to
+         * happen.
          *
          * This property will be ignored if the 'refresh-expired' property is not enabled.
          */

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
@@ -5,6 +5,8 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
 import io.quarkus.oidc.UserInfo;
 import io.quarkus.oidc.runtime.DefaultTokenIntrospectionUserInfoCache;
 import io.quarkus.security.Authenticated;
@@ -21,6 +23,9 @@ public class CodeFlowUserInfoResource {
     SecurityIdentity identity;
 
     @Inject
+    JsonWebToken accessToken;
+
+    @Inject
     DefaultTokenIntrospectionUserInfoCache tokenCache;
 
     @GET
@@ -28,7 +33,8 @@ public class CodeFlowUserInfoResource {
     public String access() {
         int cacheSize = tokenCache.getCacheSize();
         tokenCache.clearCache();
-        return identity.getPrincipal().getName() + ":" + userInfo.getString("preferred_username") + ", cache size: "
+        return identity.getPrincipal().getName() + ":" + userInfo.getString("preferred_username") + ":" + accessToken.getName()
+                + ", cache size: "
                 + cacheSize;
     }
 

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -86,9 +86,13 @@ quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.provider=github
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.authorization-path=/
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.user-info-path=protocol/openid-connect/userinfo
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.jwks-path=${keycloak.url}/realms/quarkus/protocol/openid-connect/certs
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.code-grant.extra-params.extra-param=extra-param-value
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.code-grant.headers.X-Custom=XCustomHeaderValue
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.cache-user-info-in-idtoken=true
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.token.refresh-expired=true
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.token.refresh-token-time-skew=298
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.authentication.verify-access-token=true
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.client-id=quarkus-web-app
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 


### PR DESCRIPTION
Fixes #30208.

This PR restores a correct order of the code flow access token verification when requesting UserInfo is not a prerequisite for verifying it.
Before 2.16.0.CR1 it was exactly the following order: 1) optionally verify code flow access token 2) get user info 3) verify id token - this works for the vast majority of cases - where the code flow access token can be verified either locally or via the introspection endpoint.
In 2.16.0.CR1, on my proposal, it was changed to 1) get user info 2) optionally verify code flow access token 3) verify id token, to support the indirect binary access token verification via the userinfo acquisition, for both the bearer and code flow access tokens - to support cases like GitHub returning binary access tokens, offering no public keys and no introspection endpoint but only allowing to use the access token to retrieve the user info, with GitHib performing itself an indirect access token verification.

But changing the order this way makes it impossible to fix #30208, since for the code flow access token to be refreshed before it can be used to acquire the userinfo it has to be verified first.

So this PR does the following:
- keep the order introduced in 2.16.0.CR1 only if the indirect binary access token verification is required to support GitHub and similar providers
- restores the pre-2.16.0.CR1 order for all other cases
- Improves the the pre-2.16.0.CR1 code flow access token verification code to check if it can be refreshed and does so the same way it can do it for ID token
- Also improves the remote introspection check a bit to support the token refreshment too
- adds a test: it checks that a code flow access token can be refreshed