### PR TITLE
Avoid adding the exception itself as a suppressed exception

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -816,8 +816,13 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             runExtensionMethod(invocationContext, extensionContext, true);
             invocation.skip();
         } catch (Throwable t) {
-            for (var i : serverExceptions) {
-                t.addSuppressed(i);
+            for (var serverException : serverExceptions) {
+                if (t == serverException) {
+                    // do not add a suppressed exception to itself
+                    continue;
+                }
+
+                t.addSuppressed(serverException);
             }
             throw t;
         } finally {


### PR DESCRIPTION
As experienced in #30463, it seems it can happen.

@geoand I think this will help with the weird error message the user had in #30463 .