### PR TITLE
Force quarkus grpc xds dependency for the istio integration test

### DIFF
--- a/integration-tests/istio/maven-invoker-way/pom.xml
+++ b/integration-tests/istio/maven-invoker-way/pom.xml
@@ -28,6 +28,11 @@
             <artifactId>quarkus-container-image-jib</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-xds</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/actions/runs/3964176398/jobs/6792794068

This dependency was added in https://github.com/quarkusio/quarkus/pull/29251, but the dependency was never setup in the istio maven pom file, so when building Quarkus, this is not built and hence it's failing. 