### PR TITLE
Simplify logic in create-app.adoc and allow to define stream

### DIFF
--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -51,4 +51,6 @@
 :vault-datasource-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/vault-datasource.html
 :micrometer-registry-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-micrometer-registry/dev/index.html
 // .
+:create-app-group-id: org.acme
+// .
 include::_attributes-local.adoc[]

--- a/docs/src/main/asciidoc/_includes/devtools/create-app.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/create-app.adoc
@@ -3,11 +3,10 @@
 ****
 [source,bash,subs=attributes+]
 ----
-ifdef::create-app-group-id[]
-ifdef::create-app-extensions[]
+ifdef::create-app-extensions,create-app-stream[]
 quarkus create app {create-app-group-id}:{create-app-artifact-id} \
 endif::[]
-ifndef::create-app-extensions[]
+ifndef::create-app-extensions,create-app-stream[]
 ifndef::create-app-code[]
 quarkus create app {create-app-group-id}:{create-app-artifact-id} \
 endif::[]
@@ -15,17 +14,16 @@ ifdef::create-app-code[]
 quarkus create app {create-app-group-id}:{create-app-artifact-id}
 endif::[]
 endif::[]
-endif::[]
-ifndef::create-app-group-id[]
+ifdef::create-app-stream[]
 ifdef::create-app-extensions[]
-quarkus create app org.acme:{create-app-artifact-id} \
+    --stream={create-app-stream} \
 endif::[]
 ifndef::create-app-extensions[]
 ifndef::create-app-code[]
-quarkus create app org.acme:{create-app-artifact-id} \
+    --stream={create-app-stream} \
 endif::[]
 ifdef::create-app-code[]
-quarkus create app org.acme:{create-app-artifact-id}
+    --stream={create-app-stream}
 endif::[]
 endif::[]
 endif::[]
@@ -63,12 +61,10 @@ _For more information about how to install the Quarkus CLI and use it, please re
 [source,bash,subs=attributes+]
 ----
 mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
-ifdef::create-app-group-id[]
+ifdef::create-app-stream[]
+    -DplatformVersion={create-app-stream} \
+endif::[]
     -DprojectGroupId={create-app-group-id} \
-endif::[]
-ifndef::create-app-group-id[]
-    -DprojectGroupId=org.acme \
-endif::[]
 ifdef::create-app-extensions[]
     -DprojectArtifactId={create-app-artifact-id} \
 endif::[]


### PR DESCRIPTION
The idea is to define the stream value for older versions so that people can create apps for these versions by running the command.

As for the simplification, I enforce a default `groupId` instead of having a complex logic to test the value and define a default one.