### PR TITLE
Limit application.properties lookup to main source set

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -235,9 +235,11 @@ public abstract class QuarkusBuild extends QuarkusTask {
 
     private String getPropValueWithPrecedence(final String propName, final java.util.Optional<String> defaultValue) {
         if (applicationProperties.isEmpty()) {
-            FileCollection classpathFiles = getClasspath()
+            SourceSet mainSourceSet = QuarkusGradleUtils.getSourceSet(getProject(), SourceSet.MAIN_SOURCE_SET_NAME);
+
+            FileCollection configFiles = mainSourceSet.getResources()
                     .filter(file -> "application.properties".equalsIgnoreCase(file.getName()));
-            classpathFiles.forEach(file -> {
+            configFiles.forEach(file -> {
                 FileInputStream appPropsIS = null;
                 try {
                     appPropsIS = new FileInputStream(file.getAbsoluteFile());


### PR DESCRIPTION
When looking for `application.properties` we used to look in the entire classpath. This change limit search to the current source set avoiding the ConcurrentModificationException

close #30453
