### PR TITLE
JReleaser - Specific configuration for maintenance and preview

### DIFF
--- a/devtools/cli/distribution/jreleaser-maintenance.yml
+++ b/devtools/cli/distribution/jreleaser-maintenance.yml
@@ -1,0 +1,69 @@
+project:
+  name: quarkus
+  description: CLI for Quarkus
+  longDescription: |
+    Create projects, manage extensions and perform build and development tasks for Quarkus,
+    the Kubernetes Native Java stack tailored for OpenJDK HotSpot and GraalVM.
+  authors:
+    - Quarkus Community
+  license: Apache-2.0
+  copyright: Quarkus contributors
+  java:
+    groupId: io.quarkus
+    artifactId: quarkus-cli
+    version : 11
+  tags:
+    - cli
+    - quarkus
+    - java
+  links:
+    homepage: https://quarkus.io
+    license: https://github.com/quarkusio/quarkus/blob/main/LICENSE.txt
+
+release:
+  github:
+    owner: quarkusio
+    name: quarkus
+    tagName: "{{projectVersion}}"
+    overwrite: false
+    update:
+      enabled: true
+      sections:
+        - ASSETS
+    skipTag: true
+    changelog:
+      enabled: false
+    milestone:
+      close: false
+
+distributions:
+  quarkus:
+    type: JAVA_BINARY
+    executable:
+      name: quarkus
+      windowsExtension: bat
+    tags:
+      - quarkus
+      - cli
+    artifacts:
+      - path: target/quarkus-cli-{{projectVersion}}.zip
+      - path: target/quarkus-cli-{{projectVersion}}.tar.gz
+
+packagers:
+  sdkman:
+    active: ALWAYS
+    continueOnError: false
+    connectTimeout: 20
+    readTimeout: 60
+    candidate: quarkus
+  chocolatey:
+    active: ALWAYS
+    continueOnError: true
+    remoteBuild: true
+    iconUrl: https://quarkus.io/assets/images/chocolatey-app-icon.png
+    packageVersion: '{{projectVersionMajor}}.{{projectVersionMinor}}.{{projectVersionPatch}}'
+
+announce:
+  sdkman:
+    active: ALWAYS
+    candidate: quarkus

--- a/devtools/cli/distribution/jreleaser-preview.yml
+++ b/devtools/cli/distribution/jreleaser-preview.yml
@@ -1,0 +1,63 @@
+project:
+  name: quarkus
+  description: CLI for Quarkus
+  longDescription: |
+    Create projects, manage extensions and perform build and development tasks for Quarkus,
+    the Kubernetes Native Java stack tailored for OpenJDK HotSpot and GraalVM.
+  authors:
+    - Quarkus Community
+  license: Apache-2.0
+  copyright: Quarkus contributors
+  java:
+    groupId: io.quarkus
+    artifactId: quarkus-cli
+    version : 11
+  tags:
+    - cli
+    - quarkus
+    - java
+  links:
+    homepage: https://quarkus.io
+    license: https://github.com/quarkusio/quarkus/blob/main/LICENSE.txt
+
+release:
+  github:
+    owner: quarkusio
+    name: quarkus
+    tagName: "{{projectVersion}}"
+    overwrite: false
+    update:
+      enabled: true
+      sections:
+        - ASSETS
+    skipTag: true
+    changelog:
+      enabled: false
+    milestone:
+      close: false
+
+distributions:
+  quarkus:
+    type: JAVA_BINARY
+    executable:
+      name: quarkus
+      windowsExtension: bat
+    tags:
+      - quarkus
+      - cli
+    artifacts:
+      - path: target/quarkus-cli-{{projectVersion}}.zip
+      - path: target/quarkus-cli-{{projectVersion}}.tar.gz
+
+packagers:
+  sdkman:
+    active: ALWAYS
+    continueOnError: false
+    connectTimeout: 20
+    readTimeout: 60
+    candidate: quarkus
+
+announce:
+  sdkman:
+    active: ALWAYS
+    candidate: quarkus

--- a/devtools/cli/distribution/release-cli.sh
+++ b/devtools/cli/distribution/release-cli.sh
@@ -20,6 +20,13 @@ then
     exit 1
 fi
 
+PREVIEW="$4"
+if [ -z "$PREVIEW" ]
+then
+    echo "Must specify preview mode"
+    exit 1
+fi
+
 DIST_DIR="$( dirname "${BASH_SOURCE[0]}" )"
 pushd ${DIST_DIR}
 
@@ -48,14 +55,20 @@ zip -r ${JAVA_BINARY_DIR}.zip ${JAVA_BINARY_DIR}
 tar -zcf ${JAVA_BINARY_DIR}.tar.gz ${JAVA_BINARY_DIR}
 popd
 
+CONFIG_FILE="jreleaser.yml"
 export JRELEASER_PROJECT_VERSION=${VERSION}
 export JRELEASER_BRANCH=${BRANCH}
 if [ "$MAINTENANCE" == "true" ]; then
+    CONFIG_FILE="jreleaser-maintenance.yml"
     export JRELEASER_CHOCOLATEY_GITHUB_BRANCH=${BRANCH}
     export JRELEASER_HOMEBREW_GITHUB_BRANCH=${BRANCH}
 fi
+if [ "$PREVIEW" == "true" ]; then
+    CONFIG_FILE="jreleaser-preview.yml"
+fi
 
 jbang org.jreleaser:jreleaser:1.3.0 full-release \
+  -c ${CONFIG_FILE} \
   --git-root-search \
   -od target
 


### PR DESCRIPTION
- Homebrew version is published to main so we may not publish maintenance releases or we override the current stable
- For previews, same as above plus we may not publish to Chocolatey as the qualifier is dropped so it looks like a final if we publish it.