### PR TITLE
Recompose security-openid-connect-web-authentication.adoc to Diataxis framework

### DIFF
--- a/docs/src/main/asciidoc/security-authentication-mechanisms-concept.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms-concept.adoc
@@ -154,7 +154,7 @@ For more information about OIDC authentication and authorization methods you can
 |====
 |OIDC topic |Quarkus information resource
 |Bearer Token authentication mechanism|xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
-|Authorization Code Flow authentication mechanism|xref:security-openid-connect-web-authentication.adoc[OpenID Connect (OIDC) authorization code flow mechanism]
+|Authorization Code Flow authentication mechanism|xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 |Multiple tenants that can support Bearer Token or Authorization Code Flow mechanisms|xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect (OIDC) multi-tenancy]
 |Using Keycloak to centralize authorization|xref:security-keycloak-authorization.adoc[Using OpenID Connect (OIDC) and Keycloak to centralize authorization]
 |Configuring Keycloak programmatically|xref:security-keycloak-admin-client.adoc[Using the Keycloak admin client]

--- a/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
@@ -589,14 +589,12 @@ After you have completed this tutorial, explore some of the more advanced securi
 Use the following information to learn how you can securely use `OpenID Connect` to provide secure single sign-on access to your Quarkus endpoints:
 
 * xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
-* xref:security-openid-connect-web-authentication.adoc[Using OpenID Connect (OIDC) to Protect Web Applications using Authorization Code Flow
-]
+* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 
 == References
 
 * xref:security-overview-concept.adoc[Quarkus Security overview]
 * xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
-* xref:security-openid-connect-web-authentication.adoc[Using OpenID Connect (OIDC) to Protect Web Applications using Authorization Code Flow
-]
+* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:hibernate-orm-panache.adoc[Simplified Hibernate ORM with Panache]
 * xref:hibernate-orm.adoc[Using Hibernate ORM and JPA]

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -15,7 +15,7 @@ to verify https://tools.ietf.org/html/rfc7519[JSON Web Token]s, represent them a
 and provide secured access to the Quarkus HTTP endpoints using Bearer Token Authorization and https://en.wikipedia.org/wiki/Role-based_access_control[Role-Based Access Control].
 
 NOTE: Quarkus OpenID Connect `quarkus-oidc` extension also supports Bearer Token Authorization and uses `smallrye-jwt` to represent the bearer tokens as `JsonWebToken`, please read the xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication] guide for more information.
-OpenID Connect extension has to be used if the Quarkus application needs to authenticate the users using OIDC Authorization Code Flow, please read xref:security-openid-connect-web-authentication.adoc[Using OpenID Connect to Protect Web Applications] guide for more information.
+OpenID Connect extension has to be used if the Quarkus application needs to authenticate the users using OIDC Authorization Code Flow. For more information, see xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 
 == Prerequisites
 

--- a/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
@@ -201,7 +201,7 @@ include::{generated-dir}/config/quarkus-keycloak-admin-client.adoc[leveloffset=+
 
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * xref:security-keycloak-authorization.adoc[Keycloak Authorization extension]
-* xref:security-openid-connect-web-authentication.adoc[Using OpenID Connect to Protect Web Application]
+* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
 * xref:security-openid-connect-client.adoc[OpenID Connect Client and Token Propagation Quickstart]
 * xref:security-overview-concept.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -17,7 +17,7 @@ It can be used to implement an application authentication mechanism based on tok
 This extension provides a light-weight support for using the opaque Bearer Tokens and validating them by calling an introspection endpoint.
 
 If the OAuth2 Authentication server provides JWT Bearer Tokens then you should consider using either xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication] or xref:security-jwt.adoc[SmallRye JWT] extensions instead.
-OpenID Connect extension has to be used if the Quarkus application needs to authenticate the users using OIDC Authorization Code Flow, please read xref:security-openid-connect-web-authentication.adoc[Using OpenID Connect to Protect Web Applications] guide for more information.
+OpenID Connect extension has to be used if the Quarkus application needs to authenticate the users using OIDC Authorization Code Flow. For more information, see the xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications] guide.
 
 include::{includes}/extension-status.adoc[]
 

--- a/docs/src/main/asciidoc/security-oidc-bearer-authentication-concept.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-authentication-concept.adoc
@@ -37,7 +37,7 @@ image::security-bearer-token-authorization-mechanism-2.png[alt=Bearer authentica
 3. The Client uses the access token to retrieve the service data from the Quarkus service.
 4. The Quarkus service verifies the bearer access token signature using the verification keys, checks the token expiry date and other claims, allows the request to proceed if the token is valid, and returns the service response to the Client.
 
-If you need to authenticate and authorize the users using OpenID Connect Authorization Code Flow, see xref:security-openid-connect-web-authentication.adoc[Using OpenID Connect to Protect Web Applications].
+If you need to authenticate and authorize the users using OpenID Connect Authorization Code Flow, see xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications].
 Also, if you use Keycloak and bearer tokens, see xref:security-keycloak-authorization.adoc[Using Keycloak to Centralize Authorization].
 
 For information about how to support multiple tenants, see xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect Multi-Tenancy].
@@ -313,7 +313,7 @@ Please see xref:security-openid-connect-client-reference.adoc#token-propagation[
 [[oidc-provider-authentication]]
 === Oidc Provider Client Authentication
 
-`quarkus.oidc.runtime.OidcProviderClient` is used when a remote request to an OpenID Connect Provider has to be done. If the bearer token has to be introspected then `OidcProviderClient` has to authenticate to the OpenID Connect Provider. Please see xref:security-openid-connect-web-authentication.adoc#oidc-provider-client-authentication[OidcProviderClient Authentication] for more information about all the supported authentication options.
+`quarkus.oidc.runtime.OidcProviderClient` is used when a remote request to an OpenID Connect Provider has to be done. If the bearer token has to be introspected then `OidcProviderClient` has to authenticate to the OpenID Connect Provider. Please see xref:security-oidc-code-flow-authentication-concept.adoc#oidc-provider-client-authentication[OidcProviderClient Authentication] for more information about all the supported authentication options.
 
 [[integration-testing]]
 === Testing

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-concept.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-concept.adoc
@@ -1,17 +1,21 @@
 ////
-This guide is maintained in the main Quarkus repository
+This document is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= OpenID Connect (OIDC) authorization code flow mechanism
+[id="security-oidc-code-flow-authentication-concept"]
+= OpenID Connect authorization code flow mechanism for protecting web applications
 include::_attributes.adoc[]
-:categories: security
-:summary: This guide demonstrates how to use the OpenID Connect Extension to protect your web application based on the Authorization Code Flow using Quarkus.
+:categories: security,web
+:summary: To protect your web applications, you can use the authorization code flow mechanism provided by the Quarkus OpenID Connect (OIDC extension.
+
+== Overview of the OIDC authorization code flow mechanism
 
 The Quarkus OpenID Connect (OIDC) extension can protect application HTTP endpoints by using the OIDC Authorization Code Flow mechanism supported by OIDC-compliant authorization servers, such as link:https://www.keycloak.org[Keycloak].
 
 The Authorization Code Flow mechanism authenticates users of your web application by redirecting them to an OIDC provider, such as Keycloak, to log in.
-After authentication, the OIDC provider redirects the user back to the application with an authorization code that confirms that authentication was successful. Then, the application exchanges this code with the OIDC provider for an ID token (which represents the authenticated user), an access token, and a refresh token to authorize the user's access to the application.
+After authentication, the OIDC provider redirects the user back to the application with an authorization code that confirms that authentication was successful. 
+Then, the application exchanges this code with the OIDC provider for an ID token (which represents the authenticated user), an access token, and a refresh token to authorize the user's access to the application.
 
 The following diagram outlines the Authorization Code Flow mechanism in Quarkus.
 
@@ -31,248 +35,18 @@ The following tokens are issued:
 * Access token: The Quarkus web-app might use the access token to access the UserInfo API to get additional information about the authenticated user or propagate it to another endpoint.
 * Refresh token: (Optional) If the ID and access tokens expire, the Quarkus web-app can use the refresh token to get new ID and access tokens.
 
+See also the xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties] reference guide.
+
 For information about protecting your applications using Bearer Token authorization, see xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication].
 
-For information about multitenant support, see xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect Multi-Tenancy].
+For information about how to support multiple tenants, see xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect Multi-Tenancy].
 
-Also see the xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties] reference guide.
-
-== Quickstart
-
-=== Prerequisites
-
-:prerequisites-docker:
-include::{includes}/prerequisites.adoc[]
-
-=== Architecture
-
-In this example, we build a very simple web application with a single page:
-
-* `/index.html`
-
-This page is protected and can only be accessed by authenticated users.
-
-=== Solution
-
-We recommend that you follow the instructions in the next sections and create the application step by step.
-However, you can go right to the completed example.
-
-Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
-
-The solution is located in the `security-openid-connect-web-authentication-quickstart` {quickstarts-tree-url}/security-openid-connect-web-authentication-quickstart[directory].
-
-=== Creating the Maven Project
-
-First, we need a new project. Create a new project with the following command:
-
-:create-app-artifact-id: security-openid-connect-web-authentication-quickstart
-:create-app-extensions: resteasy-reactive,oidc
-include::{includes}/devtools/create-app.adoc[]
-
-If you already have your Quarkus project configured, you can add the `oidc` extension
-to your project by running the following command in your project base directory:
-
-:add-extension-extensions: oidc
-include::{includes}/devtools/extension-add.adoc[]
-
-This will add the following to your build file:
-
-[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
-.pom.xml
-----
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-oidc</artifactId>
-</dependency>
-----
-
-[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
-.build.gradle
-----
-implementation("io.quarkus:quarkus-oidc")
-----
-
-=== Writing the application
-
-Let's write a simple JAX-RS resource which has all the tokens returned in the authorization code grant response injected:
-
-[source,java]
-----
-package org.acme.security.openid.connect.web.authentication;
-
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-
-import org.eclipse.microprofile.jwt.JsonWebToken;
-
-import io.quarkus.oidc.IdToken;
-import io.quarkus.oidc.RefreshToken;
-
-@Path("/tokens")
-public class TokenResource {
-
-    /**
-     * Injection point for the ID Token issued by the OpenID Connect Provider
-     */
-    @Inject
-    @IdToken
-    JsonWebToken idToken;
-
-    /**
-     * Injection point for the Access Token issued by the OpenID Connect Provider
-     */
-    @Inject
-    JsonWebToken accessToken;
-
-    /**
-     * Injection point for the Refresh Token issued by the OpenID Connect Provider
-     */
-    @Inject
-    RefreshToken refreshToken;
-
-    /**
-     * Returns the tokens available to the application. This endpoint exists only for demonstration purposes, you should not
-     * expose these tokens in a real application.
-     *
-     * @return a HTML page containing the tokens available to the application
-     */
-    @GET
-    @Produces("text/html")
-    public String getTokens() {
-        StringBuilder response = new StringBuilder().append("<html>")
-                .append("<body>")
-                .append("<ul>");
-
-        Object userName = this.idToken.getClaim("preferred_username");
-
-        if (userName != null) {
-            response.append("<li>username: ").append(userName.toString()).append("</li>");
-        }
-
-        Object scopes = this.accessToken.getClaim("scope");
-
-        if (scopes != null) {
-            response.append("<li>scopes: ").append(scopes.toString()).append("</li>");
-        }
-
-        response.append("<li>refresh_token: ").append(refreshToken.getToken() != null).append("</li>");
-
-        return response.append("</ul>").append("</body>").append("</html>").toString();
-    }
-}
-----
-
-This endpoint has ID, access and refresh tokens injected. It returns a `preferred_username` claim from the ID token, a `scope` claim from the access token and also a refresh token availability status.
-
-Note that you do not have to inject the tokens - it is only required if the endpoint needs to use the ID token to interact with the currently authenticated user or use the access token to access a downstream service on behalf of this user.
-
-Please see <<access_id_and_access_tokens,Access ID and Access Tokens>> section below for more information.
-
-=== Configuring the application
-
-The OpenID Connect extension allows you to define the configuration using the `application.properties` file which should be located at the `src/main/resources` directory.
-
-[source,properties]
-----
-quarkus.oidc.auth-server-url=http://localhost:8180/realms/quarkus
-quarkus.oidc.client-id=frontend
-quarkus.oidc.credentials.secret=secret
-quarkus.oidc.application-type=web-app
-quarkus.http.auth.permission.authenticated.paths=/*
-quarkus.http.auth.permission.authenticated.policy=authenticated
-----
-
-This is the simplest configuration you can have when enabling authentication to your application.
-
-The `quarkus.oidc.client-id` property references the `client_id` issued by the OIDC provider and the `quarkus.oidc.credentials.secret` property sets the client secret.
-
-When the `quarkus.oidc.application-type` property is set to `web-app`, this intructs Quarkus to enable the OIDC Authorization Code Flow, so that your users get redirected to the OIDC provider to authenticate.
-
-The `quarkus.http.auth.permission.authenticated` property tells Quarkus about the paths that you want to protect. 
-In the example provided, all paths are being protected by a policy that ensures that only `authenticated` users are allowed to access.
-For more information, see xref:security-authorize-web-endpoints-reference.adoc[Authorization of web endpoints].
-
-=== Starting and Configuring the Keycloak Server
-
-To start a Keycloak Server you can use Docker and just run the following command:
-
-[source,bash,subs=attributes+]
-----
-docker run --name keycloak -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
-----
-
-where `keycloak.version` should be set to `17.0.0` or higher.
-
-You should be able to access your Keycloak Server at http://localhost:8180[localhost:8180].
-
-Log in as the `admin` user to access the Keycloak Administration Console. Username should be `admin` and password `admin`.
-
-Import the {quickstarts-tree-url}/security-openid-connect-web-authentication-quickstart/config/quarkus-realm.json[realm configuration file] to create a new realm. For more details, see the Keycloak documentation about how to https://www.keycloak.org/docs/latest/server_admin/index.html#_create-realm[create a new realm].
-
-=== Running the Application in Dev and JVM modes
-
-To run the application in a dev mode, use:
-
-include::{includes}/devtools/dev.adoc[]
-
-When you're done playing with dev mode you can run it as a standard Java application.
-
-First compile it:
-
-include::{includes}/devtools/build.adoc[]
-
-Then run it:
-
-[source,bash]
-----
-java -jar target/quarkus-app/quarkus-run.jar
-----
-
-=== Running the Application in Native Mode
-
-This same demo can be compiled into native code: no modifications required.
-
-This implies that you no longer need to install a JVM on your
-production environment, as the runtime technology is included in
-the produced binary, and optimized to run with minimal resource overhead.
-
-Compilation will take a bit longer, so this step is disabled by default;
-let's build again by enabling the native build:
-
-include::{includes}/devtools/build-native.adoc[]
-
-After getting a cup of coffee, you'll be able to run this binary directly:
-
-[source,bash]
-----
-./target/security-openid-connect-web-authentication-quickstart-runner
-----
-
-=== Testing the Application
-
-To test the application, you should open your browser and access the following URL:
-
-* http://localhost:8080/tokens[http://localhost:8080/tokens]
-
-If everything is working as expected, you should be redirected to the Keycloak server to authenticate.
-
-In order to authenticate to the application you should type the following credentials when at the Keycloak login page:
-
-* Username: *alice*
-* Password: *alice*
-
-After clicking the `Login` button you should be redirected back to the application.
-
-Please also see the <<integration-testing-keycloak-devservices, Dev Services for Keycloak>> section below about writing the integration tests which depend on `Dev Services for Keycloak`.
-
-== Reference Guide
+== Using the authorization code flow mechanism
 
 [[access_id_and_access_tokens]]
-=== Accessing ID and Access Tokens
-
-OIDC Code Authentication Mechanism acquires three tokens during the authorization code flow: https://openid.net/specs/openid-connect-core-1_0.html#IDToken[IDToken], Access Token and Refresh Token.
+=== Accessing ID and access tokens
+//SJ: new concept topic to describe the different token types and usage proposed in next iteration
+The OIDC code authentication mechanism acquires three tokens during the authorization code flow: https://openid.net/specs/openid-connect-core-1_0.html#IDToken[IDToken], Access Token, and Refresh Token.
 
 ID Token is always a JWT token and is used to represent a user authentication with the JWT claims.
 One can access ID Token claims by injecting `JsonWebToken` with an `IdToken` qualifier:
@@ -338,23 +112,23 @@ Injection of the `JsonWebToken` and `AccessTokenCredential` is supported in both
 RefreshToken is only used to refresh the current ID and access tokens as part of its <<session-management,session management>> process.
 
 [[user-info]]
-=== User Info
+=== User info
 
-If IdToken does not provide enough information about the currently authenticated user then you can set a `quarkus.oidc.authentication.user-info-required=true` property for a https://openid.net/specs/openid-connect-core-1_0.html#UserInfo[UserInfo] JSON object from the OIDC userinfo endpoint to be requested.
+If the ID token does not provide enough information about the currently-authenticated user, then you can set a `quarkus.oidc.authentication.user-info-required=true` property for a https://openid.net/specs/openid-connect-core-1_0.html#UserInfo[UserInfo] JSON object from the OIDC userinfo endpoint to be requested.
 
 A request will be sent to the OpenID Provider UserInfo endpoint using the access token returned with the authorization code grant response and an `io.quarkus.oidc.UserInfo` (a simple `javax.json.JsonObject` wrapper) object will be created. `io.quarkus.oidc.UserInfo` can be either injected or accessed as a SecurityIdentity `userinfo` attribute.
 
 [[config-metadata]]
-=== Configuration Metadata
+=== Configuration metadata
 
 The current tenant's discovered link:https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata[OpenID Connect Configuration Metadata] is represented by `io.quarkus.oidc.OidcConfigurationMetadata` and can be either injected or accessed as a `SecurityIdentity` `configuration-metadata` attribute.
 
 The default tenant's `OidcConfigurationMetadata` is injected if the endpoint is public.
 
 [[token-claims-roles]]
-=== Token Claims And SecurityIdentity Roles
+=== Token claims and SecurityIdentity roles
 
-The way the roles are mapped to the SecurityIdentity roles from the verified tokens is identical to how it is done for the xref:security-oidc-bearer-authentication-concept.adoc[Bearer tokens] with the only difference being is that https://openid.net/specs/openid-connect-core-1_0.html#IDToken[ID Token] is used as a source of the roles by default.
+The way the roles are mapped to the SecurityIdentity roles from the verified tokens is identical to how it is done for the xref:security-oidc-bearer-authentication-concept.adoc[Bearer tokens] with the only difference being that https://openid.net/specs/openid-connect-core-1_0.html#IDToken[ID Token] is used as a source of the roles by default.
 
 Note if you use Keycloak then you should set a Microprofile JWT client scope for ID token to contain a `groups` claim, please see the https://www.keycloak.org/docs/latest/server_admin/#protocol[Keycloak Server Administration Guide] for more information.
 
@@ -365,40 +139,40 @@ If UserInfo is the source of the roles then set `quarkus.oidc.authentication.use
 Additionally, a custom `SecurityIdentityAugmentor` can also be used to add the roles. For more information, see xref:security-customization.adoc#security-identity-customization[SecurityIdentity customization].
 
 [[token-verification-introspection]]
-=== Token Verification And Introspection
+=== Token verification and introspection
 
 Please see xref:security-oidc-bearer-authentication-concept.adoc#token-verification-introspection[Token Verification And Introspection] for details about how the tokens are verified and introspected.
 
-Note that in case of `web-app` applications only `IdToken` is verified by default since the access token is not used by default to access the current Quarkus `web-app` endpoint and instead meant to be propagated to the services expecting this access token, for example, to the OpenID Connect Provider's UserInfo endpoint, etc. However, if you expect the access token to contain the roles required to access the current Quarkus endpoint (`quarkus.oidc.roles.source=accesstoken`) then it will also be verified.
+Note that in case of `web-app` applications only `IdToken` is verified by default since the access token is not used by default to access the current Quarkus `web-app` endpoint and instead meant to be propagated to the services expecting this access token, for example, to the OpenID Connect Provider's UserInfo endpoint, and so on. However, if you expect the access token to contain the roles required to access the current Quarkus endpoint (`quarkus.oidc.roles.source=accesstoken`) then it will also be verified.
 
 [[token-introspection-userinfo-cache]]
-=== Token Introspection and UserInfo Cache
+=== Token introspection and UserInfo cache
 
 Code flow access tokens are not introspected unless they are expected to be the source of roles but will be used to get `UserInfo`. So there will be one or two remote calls with the code flow access token, if the token introspection and/or `UserInfo` are required.
 
 Please see xref:security-oidc-bearer-authentication-concept.adoc#token-introspection-userinfo-cache[Token Introspection and UserInfo cache] for more information about using a default token cache or registering a custom cache implementation.
 
 [[jwt-claim-verification]]
-=== JSON Web Token Claim Verification
+=== JSON web token claim verification
 
 Please see xref:security-oidc-bearer-authentication-concept.adoc#jwt-claim-verification[JSON Web Token Claim verification] section about the claim verification, including the `iss` (issuer) claim.
 It applies to ID tokens but also to access tokens in a JWT format if the `web-app` application has requested the access token verification.
 
 === Redirection
 
-When the user is redirected to the OpenID Connect Provider to authenticate, the redirect URL includes a `redirect_uri` query parameter which indicates to the Provider where the user has to be redirected to once the authentication has been completed.
+When the user is redirected to the OpenID Connect Provider to authenticate, the redirect URL includes a `redirect_uri` query parameter which indicates to the provider where the user has to be redirected to once the authentication has been completed.
 
 Quarkus will set this parameter to the current request URL by default. For example, if the user is trying to access a Quarkus service endpoint at `http://localhost:8080/service/1` then the `redirect_uri` parameter will be set to `http://localhost:8080/service/1`. Similarly, if the request URL is `http://localhost:8080/service/2` then the `redirect_uri` parameter will be set to `http://localhost:8080/service/2`, etc.
 
 OpenID Connect Providers may be configured to require the `redirect_uri` parameter to have the same value (e.g. `http://localhost:8080/service/callback`) for all the redirect URLs.
-In such cases a `quarkus.oidc.authentication.redirect-path` property has to be set, for example, `quarkus.oidc.authentication.redirect-path=/service/callback`, and Quarkus will set the `redirect_uri` parameter to an absolute URL such as `http://localhost:8080/service/callback` which will be the same regardless of the current request URL.
+In such cases, a `quarkus.oidc.authentication.redirect-path` property has to be set, for example, `quarkus.oidc.authentication.redirect-path=/service/callback`, and Quarkus will set the `redirect_uri` parameter to an absolute URL such as `http://localhost:8080/service/callback` which will be the same regardless of the current request URL.
 
-If `quarkus.oidc.authentication.redirect-path` is set but the original request URL has to be restored after the user has been redirected back to a callback URL such as `http://localhost:8080/service/callback` then a `quarkus.oidc.authentication.restore-path-after-redirect` property has to be set to `true` which will restore the request URL such as `http://localhost:8080/service/1`, etc.
+If `quarkus.oidc.authentication.redirect-path` is set but the original request URL has to be restored after the user has been redirected back to a callback URL such as `http://localhost:8080/service/callback` then a `quarkus.oidc.authentication.restore-path-after-redirect` property has to be set to `true` which will restore the request URL such as `http://localhost:8080/service/1`, and so on.
 
 [[oidc-cookies]]
-=== Dealing with Cookies
+=== Cookies
 
-The OIDC adapter uses cookies to keep the session, code flow and post logout state.
+The OIDC adapter uses cookies to keep the session, code flow, and post-logout state.
 
 `quarkus.oidc.authentication.cookie-path` property is used to ensure the cookies are visible especially when you access the protected resources with overlapping or different roots, for example:
 
@@ -419,6 +193,7 @@ If your application is deployed across multiple domains, make sure to set a `qua
 * https://another.address.company.net/
 
 then the `quarkus.oidc.authentication.cookie-domain` property must be set to `company.net`.
+//SJ: In next iteration, propose to recompose Logout information into a new concept topic
 
 === Logout
 
@@ -427,7 +202,7 @@ By default, the logout is based on the expiration time of the ID Token issued by
 The current user session may be automatically extended by enabling a `quarkus.oidc.token.refresh-expired` property. If it is set to `true` then when the current ID Token expires a Refresh Token Grant will be used to refresh ID Token as well as Access and Refresh Tokens.
 
 [[user-initiated-logout]]
-==== User-Initiated Logout
+==== User-initiated logout
 
 Users can request a logout by sending a request to the Quarkus endpoint logout path set with a `quarkus.oidc.logout.path` property.
 For example, if the endpoint address is `https://application.com/webapp` and the `quarkus.oidc.logout.path` is set to "/logout" then the logout request has to be sent to `https://application.com/webapp/logout`.
@@ -438,7 +213,7 @@ The user will be returned to the endpoint post logout page once the logout has b
 
 If the `quarkus.oidc.logout.post-logout-path` is set then a `q_post_logout` cookie will be created and a matching `state` query parameter will be added to the logout redirect URI and the OpenID Connect Provider will return this `state` once the logout has been completed. It is recommended for the Quarkus `web-app` applications to check that a `state` query parameter matches the value of the `q_post_logout` cookie which can be done for example in a JAX-RS filter.
 
-Note that a cookie name will vary when using xref:security-openid-connect-multitenancy.adoc[OpenID Connect Multi-Tenancy]. For example, it will be named `q_post_logout_tenant_1` for a tenant with a `tenant_1` id, etc.
+Note that a cookie name will vary when using xref:security-openid-connect-multitenancy.adoc[OpenID Connect Multi-Tenancy]. For example, it will be named `q_post_logout_tenant_1` for a tenant with a `tenant_1` ID, and so on.
 
 Here is an example of how to configure an RP initiated logout flow:
 
@@ -463,7 +238,7 @@ quarkus.http.auth.permission.public.policy=permit
 ----
 
 You may also need to set `quarkus.oidc.authentication.cookie-path` to a path value common to all the application resources which is `/` in this example.
-See <<oidc-cookies, Dealing with Cookies>> for more information.
+For more information, see the <<oidc-cookies, Cookies>> section.
 
 Note that some OpenID Connect providers do not support https://openid.net/specs/openid-connect-session-1_0.html#RPLogout[RP-Initiated Logout] specification (possibly because it is still technically a draft) and do not return an OpenID Connect well-known `end_session_endpoint` metadata property. However, it should not be a problem since these providers' specific logout mechanisms may only differ in how the logout URL query parameters are named.
 
@@ -492,7 +267,7 @@ quarkus.oidc.logout.extra-params.client_id=${quarkus.oidc.client-id}
 ----
 
 [[back-channel-logout]]
-==== Back-Channel Logout
+==== Back-channel logout
 
 link:https://openid.net/specs/openid-connect-backchannel-1_0.html[Back-Channel Logout] is used by OpenID Connect providers to log out the current user from all the applications this user is currently logged in, bypassing the user agent.
 
@@ -513,7 +288,7 @@ Absolute `Back-Channel Logout` URL is calculated by adding `quarkus.oidc.back-ch
 Note that you will also need to configure a token age property for the logout token verification to succeed if your OpenID Connect Provider does not set an expiry claim in the current logout token, for example, `quarkus.oidc.token.age=10S` sets a number of seconds that must not elapse since the logout token's `iat` (issued at) time to 10.
 
 [[front-channel-logout]]
-==== Front-Channel Logout
+==== Front-channel logout
 
 link:https://openid.net/specs/openid-connect-frontchannel-1_0.html[Front-Channel Logout] can be used to logout the current user directly from the user agent.
 
@@ -532,9 +307,9 @@ quarkus.oidc.logout.frontchannel.path=/front-channel-logout
 This path will be compared against the current request's path and the user will be logged out if these paths match.
 
 [[local-logout]]
-==== Local Logout
+==== Local logout
 
-If you work with a social provider such as Google and are concerned that the users can be logged out from all their Google applications with the <<user-initiated-logout,User-Initiated Logout>> which redirects the users to the provider's logout endpoint then you can support a local logout with the help of the <<oidc-session,OidcSession>> which only clears the local session cookie, for example:
+If you work with a social provider such as Google and are concerned that the users can be logged out from all their Google applications with the <<user-initiated-logout,User-initiated logout>> which redirects the users to the provider's logout endpoint then you can support a local logout with the help of the <<oidc-session,OidcSession>> which only clears the local session cookie, for example:
 
 [source,java]
 ----
@@ -558,9 +333,8 @@ public class ServiceResource {
     }
 ----
 
-
 [[session-management]]
-=== Session Management
+=== Session management
 
 If you have a xref:security-oidc-bearer-authentication-concept.adoc#single-page-applications[Single Page Application for Service Applications] where your OpenID Connect Provider script such as `keycloak.js` is managing an authorization code flow then that script will also control the SPA authentication session lifespan.
 
@@ -583,7 +357,7 @@ Note this user session can not be extended forever - the returning user with the
 [[oidc-session]]
 ==== OidcSession
 
-`io.quarkus.oidc.OidcSession` is a wrapper around the current `IdToken`. It can help to perform a <<local-logout, Local Logout>>, retrieve the current session's tenant identifier and check when the session will expire. More useful methods will be added to it over time.
+`io.quarkus.oidc.OidcSession` is a wrapper around the current `IdToken`. It can help to perform a <<local-logout, Local logout>>, retrieve the current session's tenant identifier and check when the session will expire. More useful methods will be added to it over time.
 
 [[token-state-manager]]
 ==== TokenStateManager
@@ -667,9 +441,9 @@ public class CustomTokenStateManager implements TokenStateManager {
 }
 ----
 
-=== Proof Of Key for Code Exchange (PKCE)
+=== Proof key for code exchange (PKCE)
 
-link:https://datatracker.ietf.org/doc/html/rfc7636[Proof Of Key for Code Exchange] (PKCE) minimizes the risk of the authorization code interception.
+link:https://datatracker.ietf.org/doc/html/rfc7636[Proof Key for Code Exchange] (PKCE) minimizes the risk of the authorization code interception.
 
 While `PKCE` is of primary importance to the public OpenID Connect clients (such as the SPA scripts running in a browser), it can also provide an extra level of protection to Quarkus OIDC `web-app` applications which are confidential OpenID Connect clients capable of securely storing the client secret and using it to exchange the code for the tokens.
 
@@ -710,11 +484,11 @@ public class SecurityEventListener {
 }
 ----
 
-=== Single Page Applications
+=== Single-page applications
 
-Please check if implementing SPAs the way it is suggested in the xref:security-oidc-bearer-authentication-concept.adoc#single-page-applications[Single Page Applications for Service Applications] section can meet your requirements.
+Check if implementing SPAs the way it is suggested in the xref:security-oidc-bearer-authentication-concept.adoc#single-page-applications[Single-page Applications for Service Applications] section can meet your requirements.
 
-If you prefer to use SPA and JavaScript API such as `Fetch` or `XMLHttpRequest`(XHR) with Quarkus web applications, please be aware that OpenID Connect Providers may not support CORS for Authorization endpoints where the users are authenticated after a redirect from Quarkus. This will lead to authentication failures if the Quarkus application and the OpenID Connect Provider are hosted on the different HTTP domains/ports.
+If you prefer to use SPA and JavaScript API such as `Fetch` or `XMLHttpRequest`(XHR) with Quarkus web applications, be aware that OpenID Connect Providers may not support CORS for Authorization endpoints where the users are authenticated after a redirect from Quarkus. This will lead to authentication failures if the Quarkus application and the OpenID Connect Provider are hosted on the different HTTP domains/ports.
 
 In such cases, set the `quarkus.oidc.authentication.java-script-auto-redirect` property to `false` which will instruct Quarkus to return a `499` status code and `WWW-Authenticate` header with the `OIDC` value. The browser script also needs to be updated to set `X-Requested-With` header with the `JavaScript` value and reload the last requested page in case of `499`, for example:
 
@@ -733,9 +507,9 @@ Future<void> callQuarkusService() async {
   }
 ----
 
-=== Cross Origin Resource Sharing
+=== Cross-origin resource sharing
 
-If you plan to consume this application from a Single Page Application running on a different domain, you will need to configure CORS (Cross-Origin Resource Sharing). Please read the xref:http-reference.adoc#cors-filter[HTTP CORS documentation] for more details.
+If you plan to consume this application from a Single-page application running on a different domain, you will need to configure CORS (Cross-Origin Resource Sharing). For more information, see the xref:http-reference.adoc#cors-filter[HTTP CORS documentation].
 
 [[oauth2]]
 === Integration with GitHub and other OAuth2 providers
@@ -749,7 +523,7 @@ OAuth2 providers such as GitHub do not return `IdToken`, the fact of the user au
 For example, when working with GitHub, the Quarkus endpoint can acquire an `access` token which will allow it to request a GitHub profile of the current user.
 In fact this is exactly how a standard OpenID Connect `UserInfo` acquisition also works - by authenticating into your OpenID Connect provider you also give a permission to Quarkus application to acquire your <<user-info,UserInfo>> on your behalf - and it also shows what is meant by OpenID Connect being built on top of OAuth2.
 
-In order to support the integration with such OAuth2 servers, `quarkus-oidc` needs to be configured to allow the authorization code flow responses without `IdToken`: `quarkus.oidc.authentication.id-token-required=false`.
+To support the integration with such OAuth2 servers, `quarkus-oidc` needs to be configured to allow the authorization code flow responses without `IdToken`: `quarkus.oidc.authentication.id-token-required=false`.
 
 It is required because `quarkus-oidc` expects that not only `access` and `refresh` tokens but also `IdToken` will be returned once the authorization code flow completes.
 
@@ -762,7 +536,7 @@ Configuring the endpoint to request <<user-info,UserInfo>> is the only way `quar
 
 Note that requiring <<user-info,UserInfo>> involves making a remote call on every request - therefore you may want to consider caching `UserInfo` data, see xref:security-oidc-bearer-authentication-concept.adoc#token-introspection-userinfo-cache[Token Introspection and UserInfo cache] for more details.
 
-Alternatively, you may want to request that `UserInfo` is embedded into the internal generated `IdToken` with the `quarkus.oidc.cache-user-info-in-idtoken=true` property - the advantage of this approach is that by default no cached `UserInfo` state will be kept with the endpoint - instead it will be stored in a session cookie. You may also want to consider encrypting `IdToken` in this case if `UserInfo` contains sensitive data, please see <<token-state-manager,Encrypt Tokens With TokenStateManager>> for more information.
+Alternatively, you may want to request that `UserInfo` is embedded into the internal generated `IdToken` with the `quarkus.oidc.cache-user-info-in-idtoken=true` property - the advantage of this approach is that by default no cached `UserInfo` state will be kept with the endpoint - instead it will be stored in a session cookie. You may also want to consider encrypting `IdToken` in this case if `UserInfo` contains sensitive data. For more information, see <<token-state-manager,Encrypt tokens with TokenStateManager>>.
 
 Also, OAuth2 servers may not support a well-known configuration endpoint in which case the discovery has to be disabled and the authorization, token, and introspection and/or userinfo endpoint paths have to be configured manually.
 
@@ -785,9 +559,9 @@ quarkus.oidc.credentials.secret=github_app_clientsecret
 # quarkus.oidc.cache-user-info-in-idtoken=true
 ----
 
-See xref:security-openid-connect-providers.adoc[Well Known OpenID Connect providers] for more details about configuring other well-known providers.
+See xref:security-openid-connect-providers.adoc[OpenID Connect providers] for more details about configuring other well-known providers.
 
-This is all what is needed for an endpoint like this one to return the currently authenticated user's profile with `GET http://localhost:8080/github/userinfo` and access it as the individual `UserInfo` properties:
+This is all what is needed for an endpoint like this one to return the currently-authenticated user's profile with `GET http://localhost:8080/github/userinfo` and access it as the individual `UserInfo` properties:
 
 [source,java]
 ----
@@ -897,7 +671,7 @@ Possibly a simpler alternative is to inject both `@IdToken JsonWebToken` and `Us
 
 The last important point is to make sure the callback path you enter in the GitHub OAuth application configuration matches the endpoint path where you'd like the user be redirected to after a successful GitHub authentication and application authorization, in this case it has to be set to `http:localhost:8080/github/userinfo`.
 
-=== Cloud Services
+=== Cloud services
 
 ==== Google Cloud
 
@@ -932,7 +706,7 @@ quarkus.oidc.credentials.secret={GOOGLE_CLIENT_SECRET}
 quarkus.oidc.token.issuer=https://accounts.google.com
 ----
 
-=== Provider Endpoint configuration
+=== Provider endpoint configuration
 
 OIDC `web-app` application needs to know OpenID Connect provider's authorization, token, `JsonWebKey` (JWK) set and possibly `UserInfo`, introspection and end session (RP-initiated logout) endpoint addresses.
 
@@ -958,7 +732,7 @@ quarkus.oidc.introspection-path=/protocol/openid-connect/token/introspect
 quarkus.oidc.end-session-path=/protocol/openid-connect/logout
 ----
 
-Sometimes your OpenId Connect provider supports a metadata discovery but does not return all the endpoint URLs required for the authorization code flow to complete or for the application to support the additional functions such as a user logout. In such cases you can simply configure a missing endpoint URL locally:
+Sometimes, your OpenId Connect provider supports a metadata discovery but does not return all the endpoint URLs required for the authorization code flow to complete or for the application to support the additional functions such as a user logout. In such cases, you can simply configure a missing endpoint URL locally:
 
 [source, properties]
 ----
@@ -972,11 +746,11 @@ quarkus.oidc.end-session-path=logout
 
 Exactly the same configuration can be used to override a discovered endpoint URL if that URL does not work for the local Quarkus endpoint and a more specific value is required. For example, one can imagine that in the above example, a provider which supports both global and application specific end-session endpoints returns a global end-session URL such as `http://localhost:8180/oidcprovider/account/global-logout` which will logout the user from all the applications this user is currently logged in, while the current application only wants to get this user logged out from this application, therefore, `quarkus.oidc.end-session-path=logout` is used to override the global end-session URL.
 
-=== Token Propagation
-Please see xref:security-openid-connect-client-reference.adoc#token-propagation[Token Propagation] section about the Authorization Code Flow access token propagation to the downstream services.
+=== Token propagation
+For information about Authorization Code Flow access token propagation to the downstream services, see the xref:security-openid-connect-client-reference.adoc#token-propagation[Token Propagation] section.
 
 [[oidc-provider-client-authentication]]
-=== Oidc Provider Client Authentication
+=== OIDC provider client authentication
 
 `quarkus.oidc.runtime.OidcProviderClient` is used when a remote request to an OpenID Connect Provider has to be done. It has to authenticate to the OpenID Connect Provider when the authorization code has to be exchanged for the ID, access and refresh tokens, when the ID and access tokens have to be refreshed or introspected.
 
@@ -1070,9 +844,9 @@ quarkus.oidc.credentials.jwt.key-id=mykeyAlias
 
 Using `client_secret_jwt` or `private_key_jwt` authentication methods ensures that no client secret goes over the wire.
 
-==== Additional JWT Authentication options
+==== Additional JWT authentication options
 
-If `client_secret_jwt`, `private_key_jwt` authentication methods are used or an Apple `post_jwt` method is used then the JWT signature algorithm, key identifier, audience, subject and issuer can be customized, for example:
+If `client_secret_jwt`, `private_key_jwt` authentication methods are used or an Apple `post_jwt` method is used, then the JWT signature algorithm, key identifier, audience, subject and issuer can be customized, for example:
 
 [source,properties]
 ----
@@ -1120,9 +894,9 @@ quarkus.oidc.credentials.jwt.subject=${apple.subject}
 quarkus.oidc.credentials.jwt.issuer=${apple.issuer}
 ----
 
-==== Mutual TLS
+==== Mutual TLS (mTLS)
 
-Some OpenID Connect Providers may require that a client is authenticated as part of the `Mutual TLS` (`mTLS`) authentication process.
+Some OpenID Connect providers may require that a client is authenticated as part of the `Mutual TLS` authentication process.
 
 `quarkus-oidc` can be configured as follows to support `mTLS`:
 
@@ -1145,11 +919,11 @@ quarkus.oidc.tls.trust-store-password=${trust-store-password}
 #quarkus.oidc.tls.trust-store-alias=certAlias
 ----
 
-=== Introspection Endpoint Authentication
+=== Introspection endpoint authentication
 
-Some OpenID Connect Providers may require authenticating to its introspection endpoint using Basic Authentication with the credentials different to `client_id` and `client_secret` which may have already been configured to support `client_secret_basic` or `client_secret_post` client authentication methods described in the <<oidc-provider-client-authentication, Oidc Provider Client Authentication>> section.
+Some OpenID Connect Providers may require authenticating to its introspection endpoint using Basic authentication with the credentials different to `client_id` and `client_secret` which may have already been configured to support `client_secret_basic` or `client_secret_post` client authentication methods described in the <<oidc-provider-client-authentication, OIDC provider client authentication>> section.
 
-If the tokens have to be introspected and the introspection endpoint specific authentication mechanism is required then you can configure `quarkus-oidc` like this:
+If the tokens have to be introspected and the introspection endpoint specific authentication mechanism is required, then you can configure `quarkus-oidc` like this:
 
 [source,properties]
 ----
@@ -1275,12 +1049,12 @@ Additionally, `OidcWiremockTestResource` set token issuer and audience to `https
 `OidcWiremockTestResource` can be used to emulate all OpenID Connect providers.
 
 [[integration-testing-keycloak-devservices]]
-==== Dev Services for Keycloak
+==== Dev services for Keycloak
 
 Using xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak] is recommended for the integration testing against Keycloak.
 `Dev Services for Keycloak` will launch and initialize a test container: it will create a `quarkus` realm, a `quarkus-app` client (`secret` secret) and add `alice` (`admin` and `user` roles) and `bob` (`user` role) users, where all of these properties can be customized.
 
-First prepare `application.properties`. You can start with a completely empty `application.properties` as `Dev Services for Keycloak` will register `quarkus.oidc.auth-server-url` pointing to the running test container as well as `quarkus.oidc.client-id=quarkus-app` and `quarkus.oidc.credentials.secret=secret`.
+First, prepare `application.properties`. You can start with a completely empty `application.properties` as `Dev Services for Keycloak` will register `quarkus.oidc.auth-server-url` pointing to the running test container as well as `quarkus.oidc.client-id=quarkus-app` and `quarkus.oidc.credentials.secret=secret`.
 
 But if you already have all the required `quarkus-oidc` properties configured then you only need to associate `quarkus.oidc.auth-server-url` with the `prod` profile for `Dev Services for Keycloak`to start a container, for example:
 
@@ -1297,7 +1071,7 @@ If a custom realm file has to be imported into Keycloak before running the tests
 quarkus.keycloak.devservices.realm-path=quarkus-realm.json
 ----
 
-Finally, write a test code the same way as it is described in the <<integration-testing-wiremock, Wiremock>> section above.
+Finally, write a test code the same way as it is described in the <<integration-testing-wiremock, Wiremock>> section.
 The only difference is that `@QuarkusTestResource` is no longer needed:
 
 [source, java]
@@ -1308,10 +1082,10 @@ public class CodeFlowAuthorizationTest {
 ----
 
 [[integration-testing-keycloak]]
-==== KeycloakTestResourceLifecycleManager
+==== Using KeycloakTestResourceLifecycleManager
 
-If you need to do the integration testing against Keycloak then you are encouraged to do it with <<integration-testing-keycloak-devservices,Dev Services For Keycloak>>.
 Use `KeycloakTestResourceLifecycleManager` for your tests only if there is a good reason not to use `Dev Services for Keycloak`.
+If you need to do the integration testing against Keycloak then you are encouraged to do it with <<integration-testing-keycloak-devservices,Dev services For Keycloak>>.
 
 Start with adding the following dependency:
 
@@ -1354,7 +1128,7 @@ And configure the Maven Surefire plugin as follows:
 
 (and similarly the Maven Failsafe plugin when testing in native image).
 
-And now set the configuration and write the test code the same way as it is described in the <<integration-testing-wiremock, Wiremock>> section above.
+And now set the configuration and write the test code the same way as it is described in the <<integration-testing-wiremock, Wiremock>> section.
 The only difference is the name of `QuarkusTestResource`:
 
 [source, java]
@@ -1375,11 +1149,11 @@ Default realm name is `quarkus` and client id - `quarkus-web-app` - set `keycloa
 [[integration-testing-security-annotation]]
 ==== TestSecurity annotation
 
-Please see xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-security-annotation[Use TestingSecurity with injected JsonWebToken] section for more information about using `@TestSecurity` and `@OidcSecurity` annotations for testing the `web-app` application endpoint code which depends on the injected ID and access `JsonWebToken` as well as `UserInfo` and `OidcConfigurationMetadata`.
+See xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-security-annotation[Use TestingSecurity with injected JsonWebToken] section for more information about using `@TestSecurity` and `@OidcSecurity` annotations for testing the `web-app` application endpoint code which depends on the injected ID and access `JsonWebToken` as well as `UserInfo` and `OidcConfigurationMetadata`.
 
-=== How to check the errors in the logs
+=== Checking errors in the logs
 
-Please enable `io.quarkus.oidc.runtime.OidcProvider` `TRACE` level logging to see more details about the token verification errors:
+To see details about the token verification errors, you must enable `io.quarkus.oidc.runtime.OidcProvider` `TRACE` level logging:
 
 [source, properties]
 ----
@@ -1387,7 +1161,7 @@ quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".min-level=TRACE
 ----
 
-Please enable `io.quarkus.oidc.runtime.OidcRecorder` `TRACE` level logging to see more details about the OidcProvider client initialization errors:
+To see details about the OidcProvider client initialization errors, enable `io.quarkus.oidc.runtime.OidcRecorder` `TRACE` level logging:
 
 [source, properties]
 ----
@@ -1395,11 +1169,11 @@ quarkus.log.category."io.quarkus.oidc.runtime.OidcRecorder".level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.OidcRecorder".min-level=TRACE
 ----
 
-=== Running behind a reverse proxy
+=== Running Quarkus application behind a reverse proxy
 
 OIDC authentication mechanism can be affected if your Quarkus application is running behind a reverse proxy/gateway/firewall when HTTP `Host` header may be reset to the internal IP address, HTTPS connection may be terminated, etc. For example, an authorization code flow `redirect_uri` parameter may be set to the internal host instead of the expected external one.
 
-In such cases configuring Quarkus to recognize the original headers forwarded by the proxy will be required, see xref:http-reference.adoc#reverse-proxy[Running behind a reverse proxy] Vert.x documentation section for more information.
+In such cases configuring Quarkus to recognize the original headers forwarded by the proxy will be required, for more information, see the xref:http-reference.adoc#reverse-proxy[Running behind a reverse proxy] Vert.x documentation section.
 
 For example, if your Quarkus endpoint runs in a cluster behind Kubernetes Ingress then a redirect from the OpenID Connect Provider back to this endpoint may not work since the calculated `redirect_uri` parameter may point to the internal endpoint address. This problem can be resolved with the following configuration:
 
@@ -1415,7 +1189,7 @@ where `X-ORIGINAL-HOST` is set by Kubernetes Ingress to represent the external e
 
 `quarkus.oidc.authentication.force-redirect-https-scheme` property may also be used when the Quarkus application is running behind an SSL terminating reverse proxy.
 
-=== External and Internal Access to OpenID Connect Provider
+=== External and internal access to the OIDC provider
 
 Note that the OpenID Connect Provider externally accessible authorization, logout and other endpoints may have different HTTP(S) URLs compared to the URLs auto-discovered or configured relative to `quarkus.oidc.auth-server-url` internal URL.
 In such cases an issuer verification failure may be reported by the endpoint and redirects to the externally accessible Connect Provider endpoints may fail.
@@ -1423,7 +1197,7 @@ In such cases an issuer verification failure may be reported by the endpoint and
 In such cases, if you work with Keycloak then please start it with a `KEYCLOAK_FRONTEND_URL` system property set to the externally accessible base URL.
 If you work with other Openid Connect providers then please check your provider's documentation.
 
-=== Customize authentication requests
+=== Customizing authentication requests
 
 By default, only the `response_type` (set to `code`), `scope` (set to 'openid'), `client_id`, `redirect_uri` and `state` properties are passed as HTTP query parameters to the OpenID Connect provider's authorization endpoint when the user is redirected to it to authenticate.
 
@@ -1434,7 +1208,7 @@ You can add more properties to it with `quarkus.oidc.authentication.extra-params
 quarkus.oidc.authentication.extra-params.response_mode=query
 ----
 
-=== Customize authentication error response
+=== Customizing the authentication error response
 
 If the user authentication has failed at the OpenID Connect Authorization endpoint, for example, due to an invalid scope or other invalid parameters included in the redirect to the provider, then the provider will redirect the user back to Quarkus not with the `code` but `error` and `error_description` parameters.
 
@@ -1453,12 +1227,13 @@ It is important that this error endpoint is a public resource to avoid the user 
 == References
 
 * xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties]
-* https://www.keycloak.org/documentation.html[Keycloak Documentation]
-* https://openid.net/connect/[OpenID Connect]
-* https://tools.ietf.org/html/rfc7519[JSON Web Token]
-* xref:security-openid-connect-providers.adoc[Well Known OpenID Connect providers].
+* xref:security-openid-connect-providers.adoc[OpenID Connect providers]
 * xref:security-openid-connect-client-reference.adoc[OpenID Connect and OAuth2 Client and Filters Reference Guide]
 * xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak]
 * xref:security-authentication-mechanisms.adoc#oidc-jwt-oauth2-comparison[Choosing between OpenID Connect, SmallRye JWT, and OAuth2 authentication mechanisms]
 * xref:security-authentication-mechanisms.adoc#combining-authentication-mechanisms[Combining authentication mechanisms]
 * xref:security-overview-concept.adoc[Quarkus Security overview]
+* https://www.keycloak.org/documentation.html[Keycloak Documentation]
+* https://openid.net/connect/[OpenID Connect]
+* https://tools.ietf.org/html/rfc7519[JSON Web Token]
+

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -1,0 +1,264 @@
+[id="security-oidc-code-flow-authentication-tutorial"]
+= Protect a web application by using OIDC authorization code flow mechanism
+include::_attributes.adoc[]
+:categories: security,web
+
+With the Quarkus OpenID Connect (OIDC) extension, you can protect application HTTP endpoints by using the OIDC Authorization Code Flow mechanism.
+
+To learn more about the OIDC authorization code flow mechanism, see xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications] or to learn about other authentication mechanisms, see xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[authentication mechanisms]. 
+
+== Prerequisites
+
+:prerequisites-docker:
+include::{includes}/prerequisites.adoc[]
+
+== Architecture
+
+In this example, we build a very simple web application with a single page:
+
+* `/index.html`
+
+This page is protected and can only be accessed by authenticated users.
+
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `security-openid-connect-web-authentication-quickstart` {quickstarts-tree-url}/security-openid-connect-web-authentication-quickstart[directory].
+
+== Procedure
+
+=== Create the Maven project
+
+First, we need a new project.
+Create a new project with the following command:
+
+:create-app-artifact-id: security-openid-connect-web-authentication-quickstart
+:create-app-extensions: resteasy-reactive,oidc
+include::{includes}/devtools/create-app.adoc[]
+
+If you already have your Quarkus project configured, you can add the `oidc` extension to your project by running the following command in your project base directory:
+
+:add-extension-extensions: oidc
+include::{includes}/devtools/extension-add.adoc[]
+
+This will add the following to your build file:
+
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<dependency>
+   <groupId>io.quarkus</groupId>
+   <artifactId>quarkus-oidc</artifactId>
+</dependency>
+----
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.quarkus:quarkus-oidc")
+----
+
+=== Write the application
+
+Let's write a simple JAX-RS resource which has all the tokens returned in the authorization code grant response injected:
+
+[source,java]
+----
+package org.acme.security.openid.connect.web.authentication;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import io.quarkus.oidc.IdToken;
+import io.quarkus.oidc.RefreshToken;
+
+@Path("/tokens")
+public class TokenResource {
+   
+   /**
+    * Injection point for the ID Token issued by the OpenID Connect Provider
+    */
+   @Inject
+   @IdToken
+   JsonWebToken idToken;
+   
+   /**
+    * Injection point for the Access Token issued by the OpenID Connect Provider
+    */
+   @Inject
+   JsonWebToken accessToken;
+
+   /**
+    * Injection point for the Refresh Token issued by the OpenID Connect Provider
+    */
+   @Inject
+   RefreshToken refreshToken;
+
+   /**
+    * Returns the tokens available to the application. This endpoint exists only for demonstration purposes, you should not
+    * expose these tokens in a real application.
+    *
+    * @return a HTML page containing the tokens available to the application
+    */
+   @GET
+   @Produces("text/html")
+   public String getTokens() {
+       StringBuilder response = new StringBuilder().append("<html>")
+               .append("<body>")
+               .append("<ul>");
+
+
+       Object userName = this.idToken.getClaim("preferred_username");
+
+       if (userName != null) {
+           response.append("<li>username: ").append(userName.toString()).append("</li>");
+       }
+
+       Object scopes = this.accessToken.getClaim("scope");
+
+       if (scopes != null) {
+           response.append("<li>scopes: ").append(scopes.toString()).append("</li>");
+       }
+
+       response.append("<li>refresh_token: ").append(refreshToken.getToken() != null).append("</li>");
+
+       return response.append("</ul>").append("</body>").append("</html>").toString();
+   }
+}
+----
+
+This endpoint has ID, access, and refresh tokens injected.
+It returns a `preferred_username` claim from the ID token, a `scope` claim from the access token, and also a refresh token availability status.
+
+Note that you do not have to inject the tokens - it is only required if the endpoint needs to use the ID token to interact with the currently authenticated user or use the access token to access a downstream service on behalf of this user.
+
+// SJ: TO DO - update link to point to new reference guide. For more information, see <<access_id_and_access_tokens,Access ID and Access Tokens>> section.
+
+=== Configure the application
+
+The OIDC extension allows you to define the configuration using the `application.properties` file which should be located at the `src/main/resources` directory.
+
+[source,properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/realms/quarkus
+quarkus.oidc.client-id=frontend
+quarkus.oidc.credentials.secret=secret
+quarkus.oidc.application-type=web-app
+quarkus.http.auth.permission.authenticated.paths=/*
+quarkus.http.auth.permission.authenticated.policy=authenticated
+----
+
+This is the simplest configuration you can have when enabling authentication to your application.
+
+The `quarkus.oidc.client-id` property references the `client_id` issued by the OIDC provider and the `quarkus.oidc.credentials.secret` property sets the client secret.
+
+The `quarkus.oidc.application-type` property is set to `web-app` in order to tell Quarkus that you want to enable the OIDC authorization code flow, so that your users are redirected to the OIDC provider to authenticate.
+
+Finally, the `quarkus.http.auth.permission.authenticated` permission is set to tell Quarkus about the paths you want to protect.
+In this case, all paths are being protected by a policy that ensures that only `authenticated` users are allowed to access.
+For more information, see xref:security-authorization-of-web-endpoints-reference.adoc[Security Authorization Guide].
+
+=== Start and configure the Keycloak server
+
+To start a Keycloak server, use Docker and run the following command:
+
+[source,bash,subs=attributes+]
+----
+docker run --name keycloak -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
+----
+
+where `keycloak.version` should be set to `17.0.0` or higher.
+
+You should be able to access your Keycloak Server at http://localhost:8180[localhost:8180].
+
+To access the Keycloak Administration Console, log in as the `admin` user.
+Username should be `admin` and password `admin`.
+
+Import the {quickstarts-tree-url}/security-openid-connect-web-authentication-quickstart/config/quarkus-realm.json[realm configuration file] to create a new realm.
+For more information, see the Keycloak documentation about how to https://www.keycloak.org/docs/latest/server_admin/index.html#_create-realm[create a new realm].
+
+=== Run the application in dev and JVM modes
+
+To run the application in a dev mode, use:
+
+include::{includes}/devtools/dev.adoc[]
+
+When you're done playing with dev mode, you can run it as a standard Java application.
+
+First, compile it:
+
+include::{includes}/devtools/build.adoc[]
+
+Then, run it:
+
+[source,bash]
+----
+java -jar target/quarkus-app/quarkus-run.jar
+----
+
+=== Run the application in Native mode
+
+This same demo can be compiled into native code. 
+No modifications are required.
+
+This implies that you no longer need to install a JVM on your production environment, as the runtime technology is included in
+the produced binary, and optimized to run with minimal resource overhead.
+
+Compilation will take a bit longer, so this step is disabled by default.
+You can build again by enabling the native build:
+
+include::{includes}/devtools/build-native.adoc[]
+
+After getting a cup of coffee, you can run this binary directly:
+
+[source,bash]
+----
+./target/security-openid-connect-web-authentication-quickstart-runner
+----
+
+=== Test the application
+
+To test the application, open your browser and access the following URL:
+
+
+* http://localhost:8080/tokens[http://localhost:8080/tokens]
+
+If everything is working as expected, you are redirected to the Keycloak server to authenticate.
+
+To authenticate to the application, type the following credentials when at the Keycloak login page:
+
+* Username: *alice*
+* Password: *alice*
+
+After clicking the `Login` button, you are redirected back to the application.
+
+For more information about writing the integration tests that depend on `Dev Services for Keycloak`, see the <<integration-testing-keycloak-devservices, Dev Services for Keycloak>> section.
+
+== Summary
+
+Congratulations!
+You have learned how to set up and use the OIDC authorization code flow mechanism to protect and test application HTTP endpoints.
+After you have completed this tutorial, explore some of the other security mechanisms in Quarkus.
+
+* xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-overview-concept.adoc[Quarkus Security overview]
+
+
+== References
+* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
+* https://www.keycloak.org/documentation.html[Keycloak Documentation]
+* https://openid.net/connect/[OpenID Connect]
+* https://tools.ietf.org/html/rfc7519[JSON Web Token]
+* xref:security-openid-connect-client-reference.adoc[OpenID Connect and OAuth2 Client and Filters Reference Guide]
+* xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak]
+* xref:security-jwt-build.adoc[Sign and encrypt JWT tokens with SmallRye JWT Build]
+* xref:security-authentication-mechanisms-concept.adoc#oidc-jwt-oauth2-comparison[Choosing between OpenID Connect, SmallRye JWT, and OAuth2 authentication mechanisms]
+* xref:security-keycloak-admin-client.adoc[Quarkus Keycloak Admin Client]

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -125,7 +125,7 @@ and then you can use `OidcClient.refreshTokens` method with a provided refresh t
 
 Using the `urn:ietf:params:oauth:grant-type:token-exchange` or `urn:ietf:params:oauth:grant-type:jwt-bearer` grants may be required if you are building a complex microservices application and would like to avoid the same `Bearer` token be propagated to and used by more than one service. Please see <<token-propagation-reactive,Token Propagation in MicroProfile RestClient Reactive filter>> and <<token-propagation,Token Propagation in MicroProfile RestClient filter>> for more details.
 
-Using `OidcClient` to support the `authorization code` grant might be required if for some reasons you can not use the xref:security-openid-connect-web-authentication.adoc[Quarkus OpenID Connect extension] to support Authorization Code Flow. If there is a very good reason for you to implement Authorization Code Flow then you can configure `OidcClient` as follows:
+Using `OidcClient` to support the `authorization code` grant might be required if for some reason you cannot use the xref:security-oidc-code-flow-authentication-concept.adoc[Quarkus OIDC extension] to support Authorization Code Flow. If there is a very good reason for you to implement Authorization Code Flow then you can configure `OidcClient` as follows:
 
 [source,properties]
 ----
@@ -861,7 +861,7 @@ quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".min-lev
 [[token-propagation-reactive]]
 == Token Propagation Reactive
 
-The `quarkus-oidc-token-propagation-reactive` extension provides RestEasy Reactive Client `io.quarkus.oidc.token.propagation.reactive.AccessTokenRequestReactiveFilter` that simplifies the propagation of authentication information by propagating the xref:security-oidc-bearer-authentication-concept.adoc[Bearer token] present in the current active request or the token acquired from the xref:security-openid-connect-web-authentication.adoc[Authorization Code Flow], as the HTTP `Authorization` header's `Bearer` scheme value.
+The `quarkus-oidc-token-propagation-reactive` extension provides RestEasy Reactive Client `io.quarkus.oidc.token.propagation.reactive.AccessTokenRequestReactiveFilter` that simplifies the propagation of authentication information by propagating the xref:security-oidc-bearer-authentication-concept.adoc[Bearer token] present in the current active request or the token acquired from the xref:security-oidc-code-flow-authentication-concept.adoc[Authorization code flow mechanism], as the HTTP `Authorization` header's `Bearer` scheme value.
 
 You can selectively register `AccessTokenRequestReactiveFilter` by using either `io.quarkus.oidc.token.propagation.AccessToken` or `org.eclipse.microprofile.rest.client.annotation.RegisterProvider` annotation, for example:
 
@@ -937,7 +937,7 @@ quarkus.oidc-token-propagation-reactive.exchange-token=true
 == Token Propagation
 
 The `quarkus-oidc-token-propagation` extension provides two JAX-RS `javax.ws.rs.client.ClientRequestFilter` class implementations that simplify the propagation of authentication information.
-`io.quarkus.oidc.token.propagation.AccessTokenRequestFilter` propagates the xref:security-oidc-bearer-authentication-concept.adoc[Bearer token] present in the current active request or the token acquired from the xref:security-openid-connect-web-authentication.adoc[Authorization Code Flow], as the HTTP `Authorization` header's `Bearer` scheme value.
+`io.quarkus.oidc.token.propagation.AccessTokenRequestFilter` propagates the xref:security-oidc-bearer-authentication-concept.adoc[Bearer token] present in the current active request or the token acquired from the xref:security-oidc-code-flow-authentication-concept.adoc[Authorization code flow mechanism], as the HTTP `Authorization` header's `Bearer` scheme value.
 The `io.quarkus.oidc.token.propagation.JsonWebTokenRequestFilter` provides the same functionality, but in addition provides support for JWT tokens.
 
 When you need to propagate the current Authorization Code Flow access token then the immediate token propagation will work well - as the code flow access tokens (as opposed to ID tokens) are meant to be propagated for the current Quarkus endpoint to access the remote services on behalf of the currently authenticated user.
@@ -1110,5 +1110,5 @@ However, these features may be added in the future.
 
 * xref:security-openid-connect-client.adoc[OpenID Connect Client and Token Propagation Quickstart]
 * xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
-* xref:security-openid-connect-web-authentication.adoc[Quarkus - Using OpenID Connect to Protect Web Applications using Authorization Code Flow]
+* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:security-overview-concept.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -174,7 +174,7 @@ Select a realm, enter the client id and secret, a relative service endpoint path
 [[develop-web-app-applications]]
 === Developing OpenID Connect Web App Applications
 
-If you develop a xref:security-openid-connect-web-authentication.adoc[Quarkus OIDC web-app application] then you should set `quarkus.oidc.application-type=web-app` in `application.properties` before starting the application.
+If you develop a xref:security-oidc-web-authentication-concept.adoc[Quarkus OIDC web-app application], then you should set `quarkus.oidc.application-type=web-app` in `application.properties` before starting the application.
 
 You will see a screen like this one:
 
@@ -212,7 +212,7 @@ It will ensure that if you access the application from the browser in dev mode, 
 You can run the tests against a Keycloak container started in a test mode in a xref:continuous-testing.adoc[Continuous Testing] mode.
 
 It is also recommended to run the integration tests against Keycloak using `Dev Services for Keycloak`.
-Please see xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-keycloak-devservices[Testing OpenID Connect Service Applications with Dev Services] and xref:security-openid-connect-web-authentication.adoc#integration-testing-keycloak-devservices[Testing OpenID Connect WebApp Applications with Dev Services] for more information.
+For more information, see xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-keycloak-devservices[Testing OpenID onnect Service Applications with Dev Services] and xref:security-oidc-web-authentication-concept.adoc#integration-testing-keycloak-devservices[Testing OpenID Connect WebApp Applications with Dev Services].
 
 [[keycloak-initialization]]
 === Keycloak Initialization
@@ -312,7 +312,7 @@ If you work with other providers then a Dev UI experience described in the <<key
 The current access token is used by default to test the service with `Swagger UI` or `GrapghQL UI`. If the provider (other than Keycloak) returns a binary access token then it will be used with `Swagger UI` or `GrapghQL UI` only if this provider has a token introspection endpoint otherwise an `IdToken` which is always in a JWT format will be passed to `Swagger UI` or `GrapghQL UI`. In such cases you can verify with the manual Dev UI test that `401` will always be returned for the current binary access token. Also note that using `IdToken` as a fallback with either of these UIs is only possible with the authorization code flow.
 ====
 
-Some providers such as `Auth0` do not support a standard RP initiated logout so the provider specific logout properties will have to be configured for a logout option be visible, please see xref:security-openid-connect-web-authentication.adoc#user-initiated-logout[OpenID Connect User-Initiated Logout] for more information.
+Some providers such as `Auth0` do not support a standard RP initiated logout so the provider specific logout properties will have to be configured for a logout option be visible. For more information, see xref:security-oidc-web-authentication-concept.adoc#user-initiated-logout[OpenID Connect User-Initiated Logout].
 
 Similarly, if you'd like to use a `password` or `client_credentials` grant for Dev UI to acquire the tokens then you may have to configure some extra provider specific properties, for example:
 
@@ -409,5 +409,5 @@ This document refers to the `http://localhost:8080/q/dev` Dev UI URL in several 
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * https://openid.net/connect/[OpenID Connect]
 * xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
-* xref:security-openid-connect-web-authentication.adoc[Quarkus - Using OpenID Connect to Protect Web Applications using Authorization Code Flow]
+* xref:security-oidc-web-authentication-concept.adoc[Web authentication using OIDC authorization code flow]
 * xref:security-overview-concept.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -14,7 +14,7 @@ When serving multiple customers from the same application (e.g.: SaaS), each cus
 
 Please read the xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication] guide if you need to authorize a tenant using Bearer Token Authorization.
 
-Please read the xref:security-openid-connect-web-authentication.adoc[Using OpenID Connect to Protect Web Applications] guide if you need to authenticate and authorize a tenant using OpenID Connect Authorization Code Flow.
+If you need to authenticate and authorize a tenant using OpenID Connect Authorization Code Flow, read the xref:security-oidc-web-authentication-concept.adoc[Web authentication using OIDC authorization code flow] guide.
 
 Also see the xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties] reference guide.
 

--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -9,9 +9,9 @@ include::_attributes.adoc[]
 
 == Introduction
 
-If you use xref:security-openid-connect-web-authentication.adoc[OpenID Connect Authorization Code Flow] to protect Quarkus endpoints then you need to configure Quarkus to tell it how to connect to OpenID Connect providers, how to authenticate to such providers, which scopes to use, etc.
+If you use xref:security-oidc-web-authentication-concept.adoc[OpenID Connect Authorization Code Flow] to protect Quarkus endpoints, then you need to configure Quarkus to tell it how to connect to OpenID Connect providers, how to authenticate to such providers, which scopes to use, etc.
 
-Sometimes you need to use the configuration to work around the fact that some providers do not implement OpenID Connect completely or when they are in fact xref:security-openid-connect-web-authentication.adoc#oauth2[OAuth2 providers only].
+Sometimes you need to use the configuration to work around the fact that some providers do not implement OpenID Connect completely or when they are in fact xref:security-oidc-web-authentication-concept.adoc#oauth2[OAuth2 providers only].
 
 The configuration of such providers can become complex, very technical and difficult to understand.
 
@@ -364,5 +364,5 @@ quarkus.oidc.credentials.secret=<Client Secret>
 
 == References
 
-* xref:security-openid-connect-web-authentication.adoc[Using OpenID Connect to Protect Web Applications]
+* xref:security-oidc-web-authentication-concept.adoc[Web authentication using OIDC authorization code flow]
 * xref:security-overview-concept.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-testing.adoc
+++ b/docs/src/main/asciidoc/security-testing.adoc
@@ -89,7 +89,7 @@ This will run the test with an identity with the given username and roles. Note 
 disable authorization while also providing an identity to run the test under, which can be useful if the endpoint expects an
 identity to be present.
 
-See xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-security-annotation[OpenID Connect Bearer Token Integration testing], xref:security-openid-connect-web-authentication.adoc#integration-testing-security-annotation[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-security-annotation[SmallRye JWT Integration testing] for more details about testing the endpoint code which depends on the injected `JsonWebToken`.
+See xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-security-annotation[OpenID Connect Bearer Token Integration testing], xref:security-oidc-web-authentication-concept.adoc#integration-testing-security-annotation[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-security-annotation[SmallRye JWT Integration testing] for more details about testing the endpoint code which depends on the injected `JsonWebToken`.
 
 [WARNING]
 ====
@@ -122,7 +122,7 @@ for example by setting `quarkus.http.auth.basic=true` or `%test.quarkus.http.aut
 == Use Wiremock for Integration Testing
 
 You can also use Wiremock to mock the authorization OAuth2 and OIDC services:
-See xref:security-oauth2.adoc#integration-testing[OAuth2 Integration testing], xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-wiremock[OpenID Connect Bearer Token Integration testing], xref:security-openid-connect-web-authentication.adoc#integration-testing-wiremock[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-wiremock[SmallRye JWT Integration testing] for more details.
+See xref:security-oauth2.adoc#integration-testing[OAuth2 Integration testing], xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-wiremock[OpenID Connect Bearer Token Integration testing], xref:security-oidc-web-authentication-concept.adoc#integration-testing-wiremock[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-wiremock[SmallRye JWT Integration testing] for more details.
 
 == References
 


### PR DESCRIPTION
Recompose the guide USING OPENID CONNECT (OIDC) TO PROTECT WEB APPLICATIONS USING AUTHORIZATION CODE FLOW (security-openid-connect-web-authentication.adoc) into the Diataxis framework. 

The focus of this PR is to move and restructure the content into the topics. Further iterations are needed to further recomposition and style/editing changes

The following updates were made:
- Moved the overview, OIDC diagram, and all sections under ==Reference guide into a new file called xref:security-oidc-code-flow-authentication-concept.adoc 
- Moved all elements in the ==Quickstart section into a new file called xref:security-oidc-code-flow-authentication-tutorial.adoc
- Updated and fixed links to point to new topics and moved content- 
- Completed minor style changes and identified further enhancements needed
- Fixed existing links to the content that was moved.

Closes: https://issues.redhat.com/browse/QDOCS-85 
(and subtasks  https://issues.redhat.com/browse/QDOCS-109 and  https://issues.redhat.com/browse/QDOCS-110)