### PR TITLE
RESTEasy classic servlets - add RoutingContext to active request context

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/RolesAllowedResource.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/RolesAllowedResource.java
@@ -2,8 +2,11 @@ package io.quarkus.resteasy.test.security;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+
+import io.quarkus.security.identity.CurrentIdentityAssociation;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
@@ -11,6 +14,10 @@ import javax.ws.rs.Path;
 @Path("/roles")
 @PermitAll
 public class RolesAllowedResource {
+
+    @Inject
+    CurrentIdentityAssociation currentIdentityAssociation;
+
     @GET
     @RolesAllowed({ "user", "admin" })
     public String defaultSecurity() {
@@ -24,4 +31,10 @@ public class RolesAllowedResource {
         return "admin";
     }
 
+    @Path("/admin/security-identity")
+    @RolesAllowed("admin")
+    @GET
+    public String getSecurityIdentity() {
+        return currentIdentityAssociation.getIdentity().getPrincipal().getName();
+    }
 }

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/SecurityIdentityAugmentorTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/SecurityIdentityAugmentorTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.resteasy.test.security;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.control.ActivateRequestContext;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.mutiny.Uni;
+
+public class SecurityIdentityAugmentorTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset("quarkus.http.auth.basic=true\n"), "application.properties")
+                    .addClasses(TestIdentityProvider.class, RolesAllowedResource.class, TestIdentityController.class))
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-undertow", Version.getVersion())));
+
+    @BeforeAll
+    public static void setupUsers() {
+        TestIdentityController.resetRoles().add("admin", "admin");
+    }
+
+    @Test
+    public void testSecurityIdentityAugmentor() {
+        RestAssured.given().auth().basic("admin", "admin").get("/roles/admin/security-identity").then().statusCode(200)
+                .body(Matchers.is("admin"));
+    }
+
+    @ApplicationScoped
+    public static class CustomAugmentor implements SecurityIdentityAugmentor {
+
+        @Override
+        public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
+            if (identity.isAnonymous()) {
+                return Uni.createFrom().item(identity);
+            }
+            return context.runBlocking(build(identity));
+        }
+
+        @ActivateRequestContext
+        Supplier<SecurityIdentity> build(SecurityIdentity identity) {
+            QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
+            builder.addRole("admin");
+            return builder::build;
+        }
+
+    }
+
+}


### PR DESCRIPTION
fixes: #30405

Starting with Quarkus 2.13.0.Final request context may come activated instead of being activated by Undertow when `@ActivateRequestContext` is used. As `RestFilter` down the stream requires the routing event to be part of the current Vert.x context, NPE was thrown.

I failed to identify actual change (PR) that brings this behavior (no NPE in 2.12.3.Final), I'm out of ideas after inspecting all 2.13 changes in Security, Arc, Undertow, RESTEasy Classic and Vert.x HTTP, but I'm happy to look again if you have a good idea where to look.