### PR TITLE
Distinct generated count method from interface in REST Data with Panache

### DIFF
--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
@@ -4,6 +4,7 @@ import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
 import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.ofType;
 
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.ClassCreator;
@@ -41,9 +42,9 @@ public final class CountMethodImplementor extends StandardMethodImplementor {
      * {@code
      * &#64;GET
      * &#64;Path("/count")
-     * public long count() {
+     * public Response count(UriInfo uriInfo) {
      *     try {
-     *         return resource.count();
+     *         return Response.ok(resource.count());
      *     } catch (Throwable t) {
      *         throw new RestDataPanacheException(t);
      *     }
@@ -74,10 +75,13 @@ public final class CountMethodImplementor extends StandardMethodImplementor {
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         // Method parameters: sort strings, page index, page size, uri info
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(RESOURCE_METHOD_NAME, classCreator,
-                isNotReactivePanache() ? ofType(Response.class) : ofType(Uni.class, Long.class));
+                isNotReactivePanache() ? ofType(Response.class) : ofType(Uni.class, Long.class),
+                UriInfo.class);
+        methodCreator.setParameterNames(new String[] { "uriInfo" });
 
         // Add method annotations
         addGetAnnotation(methodCreator);
+        addContextAnnotation(methodCreator.getParameterAnnotations(0));
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_METHOD_NAME), RESOURCE_METHOD_NAME));
         addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));


### PR DESCRIPTION
The native compilation fails because it detects that the generated method "count" does not match the method "count" from the interface. To solve this issue and to follow the same logic in the other generated methods, I've added a contextual uriInfo parameter, so the native compilation can't detect this method is the same as in the interface.

Moreover, I'm unsure why this is only spotted when using the elytron-security-properties-file module.

Fix https://github.com/quarkusio/quarkus/issues/30515