### PR TITLE
Drop and ban commons-io dependency from quarkus-core-deployment

### DIFF
--- a/.forbiddenapis/banned-signatures-common.txt
+++ b/.forbiddenapis/banned-signatures-common.txt
@@ -1,2 +1,6 @@
 @defaultMessage Never use Type#toString() as it's almost always the wrong thing to do. Usually org.jboss.jandex.DotName#toString() is what is needed
 org.jboss.jandex.Type#toString()
+
+@defaultMessage Replace this by using InputStream.transferTo(OutputStream)
+org.apache.commons.io.IOUtils#copy(java.io.InputStream,java.io.OutputStream)
+org.apache.commons.compress.utils.IOUtils#copy(java.io.InputStream,java.io.OutputStream)

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -159,7 +159,7 @@
         <revapi.buildFailureMessage>Run "jbang revapi-update" to update api-changes.xml file and also add the justification for those changes in that file.</revapi.buildFailureMessage>
 
         <!-- Forbidden API checks -->
-        <forbiddenapis-maven-plugin.version>3.1</forbiddenapis-maven-plugin.version>
+        <forbiddenapis-maven-plugin.version>3.4</forbiddenapis-maven-plugin.version>
 
         <!-- platform properties - this is a floating tag -->
         <platform.quarkus.native.builder-image>mandrel</platform.quarkus.native.builder-image>

--- a/core/deployment/banned-signatures.txt
+++ b/core/deployment/banned-signatures.txt
@@ -1,5 +1,8 @@
 @defaultMessage Don't use Maven classes. They won't be available when using Gradle.
 org.apache.maven.**
 org.codehaus.plexus.**
+
 @defaultMessage Never use Type#toString() as it's almost always the wrong thing to do. Usually org.jboss.jandex.DotName#toString() is what is needed
 org.jboss.jandex.Type#toString()
+
+org.apache.commons.io.** @ Don't use commons-io dependency

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -139,10 +139,6 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -20,11 +20,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.io.FilenameUtils;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.ConfigValue;
@@ -407,7 +407,7 @@ public class ConfigGenerationBuildStep {
                 if (!Files.isDirectory(path)) {
                     configWatchedFiles.add(path.toString());
                     for (String profile : config.getProfiles()) {
-                        configWatchedFiles.add(appendProfileToFilename(path.toString(), profile));
+                        configWatchedFiles.add(appendProfileToFilename(path, profile));
                     }
                 }
             }
@@ -425,9 +425,23 @@ public class ConfigGenerationBuildStep {
         configRecorder.handleNativeProfileChange(config.getProfiles());
     }
 
-    private String appendProfileToFilename(String path, String activeProfile) {
-        String pathWithoutExtension = FilenameUtils.removeExtension(path);
-        return String.format("%s-%s.%s", pathWithoutExtension, activeProfile, FilenameUtils.getExtension(path));
+    private String appendProfileToFilename(Path path, String activeProfile) {
+        String pathWithoutExtension = getPathWithoutExtension(path);
+        return String.format("%s-%s.%s", pathWithoutExtension, activeProfile, getFileExtension(path));
+    }
+
+    private static String getFileExtension(Path path) {
+        Objects.requireNonNull(path, "path should not be null");
+        String fileName = path.getFileName().toString();
+        int dotIndex = fileName.lastIndexOf('.');
+        return (dotIndex == -1) ? "" : fileName.substring(dotIndex + 1);
+    }
+
+    private static String getPathWithoutExtension(Path path) {
+        Objects.requireNonNull(path, "path should not be null");
+        String fileName = path.toString();
+        int dotIndex = fileName.lastIndexOf('.');
+        return (dotIndex == -1) ? fileName : fileName.substring(0, dotIndex);
     }
 
     private static void generateDefaultsConfigSource(

--- a/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/FunctionZipProcessor.java
+++ b/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/FunctionZipProcessor.java
@@ -12,7 +12,6 @@ import java.util.stream.Stream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
-import org.apache.commons.compress.utils.IOUtils;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.IsNormal;
@@ -145,7 +144,7 @@ public class FunctionZipProcessor {
     private void copyZipEntry(ZipArchiveOutputStream zip, InputStream zinput, ZipArchiveEntry from) throws Exception {
         ZipArchiveEntry entry = new ZipArchiveEntry(from);
         zip.putArchiveEntry(entry);
-        IOUtils.copy(zinput, zip);
+        zinput.transferTo(zip);
         zip.closeArchiveEntry();
     }
 
@@ -154,7 +153,7 @@ public class FunctionZipProcessor {
         entry.setUnixMode(mode);
         zip.putArchiveEntry(entry);
         try (InputStream i = Files.newInputStream(path)) {
-            IOUtils.copy(i, zip);
+            i.transferTo(zip);
         }
         zip.closeArchiveEntry();
     }

--- a/extensions/hibernate-orm/pom.xml
+++ b/extensions/hibernate-orm/pom.xml
@@ -44,24 +44,31 @@
                                     <!-- The jdk-reflection is not yet something we can avoid -->
                                     <!--<bundledSignature>jdk-reflection</bundledSignature>-->
 
-                                    <!-- All following signatures should be replicated for each target JDK version we intend to support -->
-                                    <bundledSignature>jdk-unsafe-11</bundledSignature>
-                                    <bundledSignature>jdk-unsafe-12</bundledSignature>
-                                    <bundledSignature>jdk-unsafe-13</bundledSignature>
-                                    <bundledSignature>jdk-unsafe-14</bundledSignature>
-                                    <bundledSignature>jdk-unsafe-15</bundledSignature>
+                                    <!-- These signatures can safely be limited to the current JDK;
+                                         see https://github.com/policeman-tools/forbidden-apis/issues/197#issuecomment-1080370368
+                                     -->
+                                    <bundledSignature>jdk-unsafe</bundledSignature>
 
+                                    <!-- All following signatures should be replicated for each target JDK version we intend to support -->
                                     <bundledSignature>jdk-deprecated-11</bundledSignature>
                                     <bundledSignature>jdk-deprecated-12</bundledSignature>
                                     <bundledSignature>jdk-deprecated-13</bundledSignature>
                                     <bundledSignature>jdk-deprecated-14</bundledSignature>
                                     <bundledSignature>jdk-deprecated-15</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-16</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-17</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-18</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-19</bundledSignature>
 
                                     <bundledSignature>jdk-internal-11</bundledSignature>
                                     <bundledSignature>jdk-internal-12</bundledSignature>
                                     <bundledSignature>jdk-internal-13</bundledSignature>
                                     <bundledSignature>jdk-internal-14</bundledSignature>
                                     <bundledSignature>jdk-internal-15</bundledSignature>
+                                    <bundledSignature>jdk-internal-16</bundledSignature>
+                                    <bundledSignature>jdk-internal-17</bundledSignature>
+                                    <bundledSignature>jdk-internal-18</bundledSignature>
+                                    <bundledSignature>jdk-internal-19</bundledSignature>
                                 </bundledSignatures>
                                 <signaturesFiles>
                                     <signaturesFile>./banned-signatures.txt</signaturesFile>
@@ -81,7 +88,10 @@
                                 <failOnUnsupportedJava>false</failOnUnsupportedJava>
                                 <ignoreSignaturesOfMissingClasses>true</ignoreSignaturesOfMissingClasses>
                                 <bundledSignatures>
-                                    <!-- This will automatically choose the right signatures based on 'targetVersion': -->
+                                    <!--
+                                      This will automatically choose the right
+                                      signatures based on 'maven.compiler.release':
+                                    -->
                                     <bundledSignature>jdk-unsafe</bundledSignature>
                                     <bundledSignature>jdk-deprecated</bundledSignature>
                                     <bundledSignature>jdk-non-portable</bundledSignature>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -70,7 +70,7 @@
         <smallrye-mutiny-vertx-core.version>2.25.0</smallrye-mutiny-vertx-core.version>
 
         <!-- Forbidden API checks -->
-        <forbiddenapis-maven-plugin.version>3.1</forbiddenapis-maven-plugin.version>
+        <forbiddenapis-maven-plugin.version>3.4</forbiddenapis-maven-plugin.version>
     </properties>
 
     <modules>

--- a/test-framework/common/pom.xml
+++ b/test-framework/common/pom.xml
@@ -30,6 +30,10 @@
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
         <!-- Needed for RestAssured -->
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -24,7 +24,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.TeeInputStream;
 import org.apache.commons.lang3.RandomStringUtils;
 
@@ -155,7 +154,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         // the log itself is written inside the container
         Process quarkusProcess = new ProcessBuilder(args).redirectError(PIPE).redirectOutput(PIPE).start();
         InputStream tee = new TeeInputStream(quarkusProcess.getInputStream(), new FileOutputStream(logFile.toFile()));
-        executorService.submit(() -> IOUtils.copy(tee, containerLogOutputStream));
+        executorService.submit(() -> tee.transferTo(containerLogOutputStream));
 
         if (startedFunction != null) {
             IntegrationTestStartedNotifier.Result result = waitForStartedFunction(startedFunction, quarkusProcess,


### PR DESCRIPTION
Remove the dependency `commons-io` from `quarkus-core-deployment` and add a ban in the module.

This also update forbiddenapis to 3.4 and substitute calls to `org.apache.commons.io.IOUtils#copy(java.io.InputStream,java.io.OutputStream)` and `org.apache.commons.compress.utils.IOUtils#copy(java.io.InputStream,java.io.OutputStream)` using `java.io.InputStream#transferTo(java.io.OutputStream)`