### PR TITLE
Arc - compare types declared by @Typed with unrestricted bean types instead of actual types

### DIFF
--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +43,7 @@ public class TypesTest {
         Set<Type> bazTypes = Types.getTypeClosure(index.getClassByName(bazName), null,
                 Collections.emptyMap(),
                 dummyDeployment,
-                resolvedTypeVariables::put);
+                resolvedTypeVariables::put, new HashSet<>());
         assertEquals(3, bazTypes.size());
         assertTrue(bazTypes.contains(Type.create(bazName, Kind.CLASS)));
         assertTrue(bazTypes.contains(ParameterizedType.create(fooName,


### PR DESCRIPTION
This should fix the RR TCK execution discussed in https://github.com/quarkusio/quarkus/pull/30501 (at least locally it does for me).

The comparison of types declared in `@Typed` now includes even types that will be removed from actual bean types (such as types with wildcard).
CDI spec part - https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html#restricting_bean_types

> If a bean class or producer method or field specifies a `@Typed` annotation, and the value member specifies a class which does not correspond to a type in the unrestricted set of bean types of a bean, the container automatically detects the problem and treats it as a definition error.

Fixes #30540