### PR TITLE
Replace bcX-jdk15on:1.70 by bcX-jdk18on:1.71

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -14,7 +14,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <bouncycastle.version>1.70</bouncycastle.version>
+        <bouncycastle.version>1.71</bouncycastle.version>
         <bouncycastle.fips.version>1.0.2.3</bouncycastle.fips.version>
         <bouncycastle.tls.fips.version>1.0.14.1</bouncycastle.tls.fips.version>
         <findbugs.version>3.0.2</findbugs.version>
@@ -2969,22 +2969,22 @@
             <!-- Bouncy Castle -->
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
+                <artifactId>bcprov-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bctls-jdk15on</artifactId>
+                <artifactId>bctls-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
+                <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcutil-jdk15on</artifactId>
+                <artifactId>bcutil-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>

--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -328,7 +328,7 @@ Please note that if you would like to use Elliptic Curve keys with Kubernetes Cl
 ----
 <dependency>
     <groupId>org.bouncycastle</groupId>
-    <artifactId>bcpkix-jdk15on</artifactId>
+    <artifactId>bcpkix-jdk18on</artifactId>
 </dependency>
 ----
 

--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -391,7 +391,7 @@ and add the BouncyCastle provider dependency:
 ----
 <dependency>
     <groupId>org.bouncycastle</groupId>
-    <artifactId>bcprov-jdk15on</artifactId>
+    <artifactId>bcprov-jdk18on</artifactId>
 </dependency>
 ----
 
@@ -426,7 +426,7 @@ and add the BouncyCastle TLS dependency:
 ----
 <dependency>
     <groupId>org.bouncycastle</groupId>
-    <artifactId>bctls-jdk15on</artifactId>
+    <artifactId>bctls-jdk18on</artifactId>
 </dependency>
 ----
 

--- a/extensions/security/deployment/pom.xml
+++ b/extensions/security/deployment/pom.xml
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integration-tests/bouncycastle-jsse/pom.xml
+++ b/integration-tests/bouncycastle-jsse/pom.xml
@@ -30,7 +30,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bctls-jdk15on</artifactId>
+            <artifactId>bctls-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/bouncycastle/pom.xml
+++ b/integration-tests/bouncycastle/pom.xml
@@ -27,7 +27,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/kubernetes-client/pom.xml
+++ b/integration-tests/kubernetes-client/pom.xml
@@ -28,7 +28,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>


### PR DESCRIPTION
there is a new artifact for bouncycastle: `bcX-jdk18on`
it is already the recommended dependency in the [workshop](https://quarkus.io/quarkus-workshops/super-heroes/)