### PR TITLE
Add MySQL/MariaDB pipelining-limit and use-affected-rows config properties

### DIFF
--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/DataSourceReactiveMySQLConfig.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/DataSourceReactiveMySQLConfig.java
@@ -53,4 +53,18 @@ public class DataSourceReactiveMySQLConfig {
      */
     @ConfigItem(defaultValueDocumentation = "default")
     public Optional<MySQLAuthenticationPlugin> authenticationPlugin = Optional.empty();
+
+    /**
+     * The maximum number of inflight database commands that can be pipelined.
+     * By default, pipelining is disabled.
+     */
+    @ConfigItem
+    public OptionalInt pipeliningLimit = OptionalInt.empty();
+
+    /**
+     * Whether to return the number of rows matched by the <em>WHERE</em> clause in <em>UPDATE</em> statements, instead of the
+     * number of rows actually changed.
+     */
+    @ConfigItem(defaultValueDocumentation = "false")
+    public Optional<Boolean> useAffectedRows = Optional.empty();
 }

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
@@ -173,6 +173,14 @@ public class MySQLPoolRecorder {
             mysqlConnectOptions.setCollation(dataSourceReactiveMySQLConfig.collation.get());
         }
 
+        if (dataSourceReactiveMySQLConfig.pipeliningLimit.isPresent()) {
+            mysqlConnectOptions.setPipeliningLimit(dataSourceReactiveMySQLConfig.pipeliningLimit.getAsInt());
+        }
+
+        if (dataSourceReactiveMySQLConfig.useAffectedRows.isPresent()) {
+            mysqlConnectOptions.setUseAffectedRows(dataSourceReactiveMySQLConfig.useAffectedRows.get());
+        }
+
         if (dataSourceReactiveMySQLConfig.sslMode.isPresent()) {
             final SslMode sslMode = dataSourceReactiveMySQLConfig.sslMode.get();
             mysqlConnectOptions.setSslMode(sslMode);


### PR DESCRIPTION
- pipelining limit controls the maximum number of inflight queries (disabled by default)
- affected rows changes how rows are counted when executing UPDATE queries