### PR TITLE
Refactor to use new SignatureBuilder API by Gizmo in REST Data Panache

### DIFF
--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
@@ -1,7 +1,9 @@
 package io.quarkus.rest.data.panache.deployment.methods;
 
 import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
-import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.ofType;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.param;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.responseType;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.uniType;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -102,9 +104,8 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(METHOD_NAME, classCreator,
-                isNotReactivePanache() ? ofType(Response.class) : ofType(Uni.class, resourceMetadata.getEntityType()),
-                resourceMetadata.getEntityType(), UriInfo.class);
-        methodCreator.setParameterNames(new String[] { "entity", "uriInfo" });
+                isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
+                param("entity", resourceMetadata.getEntityType()), param("uriInfo", UriInfo.class));
 
         // Add method annotations
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
@@ -1,7 +1,8 @@
 package io.quarkus.rest.data.panache.deployment.methods;
 
 import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
-import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.ofType;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.responseType;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.uniType;
 
 import javax.ws.rs.core.Response;
 
@@ -74,7 +75,7 @@ public final class CountMethodImplementor extends StandardMethodImplementor {
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         // Method parameters: sort strings, page index, page size, uri info
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(RESOURCE_METHOD_NAME, classCreator,
-                isNotReactivePanache() ? ofType(Response.class) : ofType(Uni.class, Long.class));
+                isNotReactivePanache() ? responseType() : uniType(Long.class));
 
         // Add method annotations
         addGetAnnotation(methodCreator);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
@@ -1,7 +1,9 @@
 package io.quarkus.rest.data.panache.deployment.methods;
 
 import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
-import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.ofType;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.param;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.responseType;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.uniType;
 
 import javax.ws.rs.core.Response;
 
@@ -82,9 +84,8 @@ public final class DeleteMethodImplementor extends StandardMethodImplementor {
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(METHOD_NAME, classCreator,
-                isNotReactivePanache() ? ofType(Response.class) : ofType(Uni.class, resourceMetadata.getEntityType()),
-                resourceMetadata.getIdType());
-        methodCreator.setParameterNames(new String[] { "id" });
+                isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
+                param("id", resourceMetadata.getIdType()));
 
         // Add method annotations
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_METHOD_NAME), "{id}"));

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
@@ -1,7 +1,9 @@
 package io.quarkus.rest.data.panache.deployment.methods;
 
 import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
-import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.ofType;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.param;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.responseType;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.uniType;
 
 import javax.ws.rs.core.Response;
 
@@ -84,9 +86,8 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(METHOD_NAME, classCreator,
-                isNotReactivePanache() ? ofType(Response.class) : ofType(Uni.class, resourceMetadata.getEntityType()),
-                resourceMetadata.getIdType());
-        methodCreator.setParameterNames(new String[] { "id" });
+                isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
+                param("id", resourceMetadata.getIdType()));
 
         // Add method annotations
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_METHOD_NAME), "{id}"));

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
@@ -9,10 +9,12 @@ import static io.quarkus.arc.processor.DotNames.LONG;
 import static io.quarkus.arc.processor.DotNames.STRING;
 import static io.quarkus.gizmo.MethodDescriptor.ofConstructor;
 import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
+import static io.quarkus.gizmo.Type.intType;
 import static io.quarkus.rest.data.panache.deployment.utils.PaginationImplementor.DEFAULT_PAGE_INDEX;
 import static io.quarkus.rest.data.panache.deployment.utils.PaginationImplementor.DEFAULT_PAGE_SIZE;
-import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.ofType;
 import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.param;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.responseType;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.uniType;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -173,14 +175,14 @@ public class ListMethodImplementor extends StandardMethodImplementor {
         Collection<SignatureMethodCreator.Parameter> compatibleFieldsForQuery = getFieldsToQuery(resourceMetadata);
         List<SignatureMethodCreator.Parameter> parameters = new ArrayList<>();
         parameters.add(param("sort", List.class));
-        parameters.add(param("page", int.class));
-        parameters.add(param("size", int.class));
+        parameters.add(param("page", int.class, intType()));
+        parameters.add(param("size", int.class, intType()));
         parameters.add(param("uriInfo", UriInfo.class));
         parameters.add(param("namedQuery", String.class));
         parameters.addAll(compatibleFieldsForQuery);
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(getMethodName(), classCreator,
-                isNotReactivePanache() ? ofType(Response.class) : ofType(Uni.class, resourceMetadata.getEntityType()),
-                parameters);
+                isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
+                parameters.toArray(new SignatureMethodCreator.Parameter[0]));
 
         // Add method annotations
         addGetAnnotation(methodCreator);
@@ -265,8 +267,8 @@ public class ListMethodImplementor extends StandardMethodImplementor {
         parameters.add(param("namedQuery", String.class));
         parameters.addAll(compatibleFieldsForQuery);
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(getMethodName(), classCreator,
-                isNotReactivePanache() ? ofType(Response.class) : ofType(Uni.class, resourceMetadata.getEntityType()),
-                parameters);
+                isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
+                parameters.toArray(new SignatureMethodCreator.Parameter[0]));
 
         // Add method annotations
         addGetAnnotation(methodCreator);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
@@ -27,6 +27,7 @@ import io.quarkus.gizmo.CatchBlockCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.TryBlock;
+import io.quarkus.gizmo.Type;
 import io.quarkus.rest.data.panache.RestDataPanacheException;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
@@ -233,6 +234,19 @@ public abstract class StandardMethodImplementor implements MethodImplementor {
 
     protected boolean isNotReactivePanache() {
         return !capabilities.isPresent(Capability.HIBERNATE_REACTIVE);
+    }
+
+    public static Type toType(Object object) {
+        if (object instanceof Type) {
+            return (Type) object;
+        } else if (object instanceof String) {
+            return Type.classType((String) object);
+        } else if (object instanceof Class) {
+            return Type.classType((Class<?>) object);
+        }
+
+        throw new IllegalArgumentException("Unsupported object of type " + object.getClass()
+                + ". Supported types are Type, String and Class");
     }
 
     private static Class<?> toClass(String className) {

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
@@ -1,7 +1,9 @@
 package io.quarkus.rest.data.panache.deployment.methods;
 
 import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
-import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.ofType;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.param;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.responseType;
+import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreator.uniType;
 
 import java.lang.annotation.Annotation;
 import java.util.function.Supplier;
@@ -134,9 +136,10 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
     protected void implementInternal(ClassCreator classCreator, ResourceMetadata resourceMetadata,
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(METHOD_NAME, classCreator,
-                isNotReactivePanache() ? ofType(Response.class) : ofType(Uni.class, resourceMetadata.getEntityType()),
-                resourceMetadata.getIdType(), resourceMetadata.getEntityType(), UriInfo.class);
-        methodCreator.setParameterNames(new String[] { "id", "entity", "uriInfo" });
+                isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
+                param("id", resourceMetadata.getIdType()),
+                param("entity", resourceMetadata.getEntityType()),
+                param("uriInfo", UriInfo.class));
 
         // Add method annotations
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_UPDATE_METHOD_NAME), "{id}"));


### PR DESCRIPTION
From https://github.com/quarkusio/gizmo/pull/147, we can use the latest SignatureBuilder API.  

To use the new SignatureBuilder API, I had to deal with the gizmo type class, so more changes than expected were necessary.