### PR TITLE
AWT: JniRuntimeAccess: freetypeScaler.c calls sun.font.FontUtilities

### DIFF
--- a/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
+++ b/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
@@ -143,6 +143,8 @@ class AwtProcessor {
                 "sun.font.FontConfigManager",
                 "sun.font.FontManagerNativeLibrary",
                 "sun.font.FontStrike",
+                // Added for JDK 19+ due to: https://github.com/openjdk/jdk20/commit/9bc023220 calling FontUtilities
+                "sun.font.FontUtilities",
                 "sun.font.FreetypeFontScaler",
                 "sun.font.GlyphLayout",
                 "sun.font.GlyphLayout$EngineRecord",


### PR DESCRIPTION
fixes #30354 

As of late JDK 18, with [9bc023220](https://github.com/openjdk/jdk20/commit/9bc023220), freetypeScaler.c has started to call sun.font.FontUtilities.

This change marks it for JNI Access for all JDK versions, i.e. superfluously for JDK11 and JDK17.