### PR TITLE
Add default implementation for REST Data interfaces

### DIFF
--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/ReactiveRestDataResource.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/ReactiveRestDataResource.java
@@ -26,12 +26,16 @@ public interface ReactiveRestDataResource<Entity, ID> {
      * @param sort Panache sort instance that should be used in a query.
      * @return A response with an entities JSON array.
      */
-    Uni<List<Entity>> list(Page page, Sort sort);
+    default Uni<List<Entity>> list(Page page, Sort sort) {
+        throw new RuntimeException("Not implemented yet");
+    }
 
     /**
      * @return the total number of entities.
      */
-    Uni<Long> count();
+    default Uni<Long> count() {
+        throw new RuntimeException("Not implemented yet");
+    }
 
     /**
      * Return an entity as a JSON object.
@@ -40,7 +44,9 @@ public interface ReactiveRestDataResource<Entity, ID> {
      * @param id Entity identifier.
      * @return A response with a JSON object representing an entity.
      */
-    Uni<Entity> get(ID id);
+    default Uni<Entity> get(ID id) {
+        throw new RuntimeException("Not implemented yet");
+    }
 
     /**
      * Create a new entity from the provided JSON object.
@@ -50,7 +56,9 @@ public interface ReactiveRestDataResource<Entity, ID> {
      * @param entity Entity to be created
      * @return A response with a JSON object representing an entity and a location header of the new entity.
      */
-    Uni<Entity> add(Entity entity);
+    default Uni<Entity> add(Entity entity) {
+        throw new RuntimeException("Not implemented yet");
+    }
 
     /**
      * Update an existing entity or create a new one from the provided JSON object.
@@ -62,7 +70,9 @@ public interface ReactiveRestDataResource<Entity, ID> {
      * @return A response with no-content status in case of the update.
      *         A response with a JSON object representing an entity and a location header in case of the create.
      */
-    Uni<Entity> update(ID id, Entity entity);
+    default Uni<Entity> update(ID id, Entity entity) {
+        throw new RuntimeException("Not implemented yet");
+    }
 
     /**
      * Delete an entity.
@@ -70,5 +80,7 @@ public interface ReactiveRestDataResource<Entity, ID> {
      * @param id Entity identifier.
      * @return A boolean indicated whether the entity was deleted or not.
      */
-    Uni<Boolean> delete(ID id);
+    default Uni<Boolean> delete(ID id) {
+        throw new RuntimeException("Not implemented yet");
+    }
 }

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/RestDataResource.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/RestDataResource.java
@@ -25,12 +25,16 @@ public interface RestDataResource<Entity, ID> {
      * @param sort Panache sort instance that should be used in a query.
      * @return A response with an entities JSON array.
      */
-    List<Entity> list(Page page, Sort sort);
+    default List<Entity> list(Page page, Sort sort) {
+        throw new RuntimeException("Not implemented yet");
+    }
 
     /**
      * @return the total number of entities.
      */
-    long count();
+    default long count() {
+        throw new RuntimeException("Not implemented yet");
+    }
 
     /**
      * Return an entity as a JSON object.
@@ -39,7 +43,9 @@ public interface RestDataResource<Entity, ID> {
      * @param id Entity identifier.
      * @return A response with a JSON object representing an entity.
      */
-    Entity get(ID id);
+    default Entity get(ID id) {
+        throw new RuntimeException("Not implemented yet");
+    }
 
     /**
      * Create a new entity from the provided JSON object.
@@ -49,7 +55,9 @@ public interface RestDataResource<Entity, ID> {
      * @param entity Entity to be created
      * @return A response with a JSON object representing an entity and a location header of the new entity.
      */
-    Entity add(Entity entity);
+    default Entity add(Entity entity) {
+        throw new RuntimeException("Not implemented yet");
+    }
 
     /**
      * Update an existing entity or create a new one from the provided JSON object.
@@ -61,7 +69,9 @@ public interface RestDataResource<Entity, ID> {
      * @return A response with no-content status in case of the update.
      *         A response with a JSON object representing an entity and a location header in case of the create.
      */
-    Entity update(ID id, Entity entity);
+    default Entity update(ID id, Entity entity) {
+        throw new RuntimeException("Not implemented yet");
+    }
 
     /**
      * Delete an entity.
@@ -69,5 +79,7 @@ public interface RestDataResource<Entity, ID> {
      * @param id Entity identifier.
      * @return A boolean indicated whether the entity was deleted or not.
      */
-    boolean delete(ID id);
+    default boolean delete(ID id) {
+        throw new RuntimeException("Not implemented yet");
+    }
 }


### PR DESCRIPTION
The linked issue is caused by Arc because the method interfaces are automatically proxied when there are security annotations. And the problem is that the methods of the interface are not implemented.

However, we can't implement these methods since the generated resources take care also of the response codes. 

I've tried to investigate any other solution to avoid touching these interfaces, but I don't see any easier solution. Having said that, these changes do not add breaking changes, so I think it's the way to go. 

Fix https://github.com/quarkusio/quarkus/issues/30515