### PR TITLE
Add jakarta migration for kotlin codestart using Gradle with Groovy DSL

### DIFF
--- a/jakarta/transform.sh
+++ b/jakarta/transform.sh
@@ -78,6 +78,7 @@ transform_kotlin_module () {
     local newPackage=${package/javax/jakarta}
     find $1 -name '*.kt' | xargs --no-run-if-empty sed -i "s@import ${package}@import ${newPackage}@g"
     find $1 -name '*.kts' | xargs --no-run-if-empty sed -i "s@annotation(\"${package}@annotation(\"${newPackage}@g"
+    find $1 -name '*.gradle' | xargs --no-run-if-empty sed -i "s@annotation(\"${package}@annotation(\"${newPackage}@g"
   done
 }
 


### PR DESCRIPTION
This adds a migration for allopen kotlin plugin in gradle file such as : https://github.com/quarkusio/quarkus/blob/main/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/kotlin/build.tpl.qute.gradle

As mentioned by @gastaldi it looks like it has already been addressed.

close #30582 