### PR TITLE
Qute validation - improve hierarchy indexing to fix assignability issues

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -88,6 +88,7 @@ import io.quarkus.qute.deployment.QuteProcessor.LookupConfig;
 import io.quarkus.qute.deployment.QuteProcessor.Match;
 import io.quarkus.qute.deployment.TemplatesAnalysisBuildItem.TemplateAnalysis;
 import io.quarkus.qute.deployment.Types.AssignableInfo;
+import io.quarkus.qute.deployment.Types.HierarchyIndexer;
 import io.quarkus.qute.generator.Descriptors;
 import io.quarkus.qute.generator.ValueResolverGenerator;
 import io.quarkus.qute.i18n.Localized;
@@ -428,6 +429,7 @@ public class MessageBundleProcessor {
 
         LookupConfig lookupConfig = new QuteProcessor.FixedLookupConfig(index, QuteProcessor.initDefaultMembersFilter(), false);
         Map<DotName, AssignableInfo> assignableCache = new HashMap<>();
+        HierarchyIndexer hierarchyIndexer = new HierarchyIndexer(index);
 
         // bundle name -> (key -> method)
         Map<String, Map<String, MethodInfo>> bundleMethodsMap = new HashMap<>();
@@ -546,8 +548,8 @@ public class MessageBundleProcessor {
                                             results, excludes, incorrectExpressions, expression, index,
                                             implicitClassToMembersUsed, templateIdToPathFun, generatedIdsToMatches,
                                             extensionMethodExcludes, checkedTemplate, lookupConfig, namedBeans,
-                                            namespaceTemplateData,
-                                            regularExtensionMethods, namespaceExtensionMethods, assignableCache);
+                                            namespaceTemplateData, regularExtensionMethods, namespaceExtensionMethods,
+                                            assignableCache, hierarchyIndexer);
                                     Match match = results.get(param.toOriginalString());
                                     if (match != null && !match.isEmpty() && !Types.isAssignableFrom(match.type(),
                                             methodParams.get(idx), index, assignableCache)) {

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -125,6 +125,7 @@ import io.quarkus.qute.deployment.TemplatesAnalysisBuildItem.TemplateAnalysis;
 import io.quarkus.qute.deployment.TypeCheckExcludeBuildItem.TypeCheck;
 import io.quarkus.qute.deployment.TypeInfos.Info;
 import io.quarkus.qute.deployment.Types.AssignableInfo;
+import io.quarkus.qute.deployment.Types.HierarchyIndexer;
 import io.quarkus.qute.generator.ExtensionMethodGenerator;
 import io.quarkus.qute.generator.ExtensionMethodGenerator.NamespaceResolverCreator;
 import io.quarkus.qute.generator.ExtensionMethodGenerator.NamespaceResolverCreator.ResolveCreator;
@@ -856,6 +857,7 @@ public class QuteProcessor {
 
         LookupConfig lookupConfig = new FixedLookupConfig(index, initDefaultMembersFilter(), false);
         Map<DotName, AssignableInfo> assignableCache = new HashMap<>();
+        HierarchyIndexer hierarchyIndexer = new HierarchyIndexer(index);
         int expressionsValidated = 0;
 
         for (TemplateAnalysis templateAnalysis : templatesAnalysis.getAnalysis()) {
@@ -884,7 +886,7 @@ public class QuteProcessor {
                         incorrectExpressions, expression, index, implicitClassToMembersUsed, templateIdToPathFun,
                         generatedIdsToMatches, extensionMethodExcludes,
                         checkedTemplate, lookupConfig, namedBeans, namespaceTemplateData, regularExtensionMethods,
-                        namespaceExtensionMethods, assignableCache);
+                        namespaceExtensionMethods, assignableCache, hierarchyIndexer);
                 generatedIdsToMatches.put(expression.getGeneratedId(), match);
             }
 
@@ -894,7 +896,7 @@ public class QuteProcessor {
                 if (defaultValue != null) {
                     Match match;
                     if (defaultValue.isLiteral()) {
-                        match = new Match(index, assignableCache);
+                        match = new Match(hierarchyIndexer, assignableCache);
                         setMatchValues(match, defaultValue, generatedIdsToMatches, index);
                     } else {
                         match = generatedIdsToMatches.get(defaultValue.getGeneratedId());
@@ -1001,7 +1003,7 @@ public class QuteProcessor {
             Map<String, TemplateDataBuildItem> namespaceTemplateData,
             List<TemplateExtensionMethodBuildItem> regularExtensionMethods,
             Map<String, List<TemplateExtensionMethodBuildItem>> namespaceExtensionMethods,
-            Map<DotName, AssignableInfo> assignableCache) {
+            Map<DotName, AssignableInfo> assignableCache, HierarchyIndexer hierarchyIndexer) {
 
         LOGGER.debugf("Validate %s from %s", expression, expression.getOrigin());
 
@@ -1017,13 +1019,14 @@ public class QuteProcessor {
                         validateNestedExpressions(config, templateAnalysis, null, results, excludes,
                                 incorrectExpressions, param, index, implicitClassToMembersUsed, templateIdToPathFun,
                                 generatedIdsToMatches, extensionMethodExcludes, checkedTemplate, lookupConfig, namedBeans,
-                                namespaceTemplateData, regularExtensionMethods, namespaceExtensionMethods, assignableCache);
+                                namespaceTemplateData, regularExtensionMethods, namespaceExtensionMethods, assignableCache,
+                                hierarchyIndexer);
                     }
                 }
             }
         }
 
-        Match match = new Match(index, assignableCache);
+        Match match = new Match(hierarchyIndexer, assignableCache);
 
         String namespace = expression.getNamespace();
         TypeInfos.TypeInfo dataNamespaceExpTypeInfo = null;
@@ -2365,14 +2368,14 @@ public class QuteProcessor {
 
     static class Match {
 
-        private final IndexView index;
+        private final HierarchyIndexer indexer;
         private final Map<DotName, AssignableInfo> assignableCache;
 
         private ClassInfo clazz;
         private Type type;
 
-        Match(IndexView index, Map<DotName, AssignableInfo> assignableCache) {
-            this.index = index;
+        Match(HierarchyIndexer indexer, Map<DotName, AssignableInfo> assignableCache) {
+            this.indexer = indexer;
             this.assignableCache = assignableCache;
         }
 
@@ -2428,19 +2431,20 @@ public class QuteProcessor {
         void autoExtractType() {
             if (clazz != null) {
                 // Make sure that hierarchy of the matching class is indexed
-                Types.indexHierarchy(clazz, index);
-                boolean hasCompletionStage = Types.isAssignableFrom(Names.COMPLETION_STAGE, clazz.name(), index,
+                indexer.indexHierarchy(clazz);
+                boolean hasCompletionStage = Types.isAssignableFrom(Names.COMPLETION_STAGE, clazz.name(), indexer.index,
                         assignableCache);
                 boolean hasUni = hasCompletionStage ? false
-                        : Types.isAssignableFrom(Names.UNI, clazz.name(), index, assignableCache);
+                        : Types.isAssignableFrom(Names.UNI, clazz.name(), indexer.index, assignableCache);
                 if (hasCompletionStage || hasUni) {
                     Set<Type> closure = Types.getTypeClosure(clazz, Types.buildResolvedMap(
-                            getParameterizedTypeArguments(), getTypeParameters(), new HashMap<>(), index), index);
+                            getParameterizedTypeArguments(), getTypeParameters(), new HashMap<>(), indexer.index),
+                            indexer.index);
                     // CompletionStage<List<Item>> => List<Item>
                     // Uni<List<String>> => List<String>
                     this.type = extractMatchType(closure, hasCompletionStage ? Names.COMPLETION_STAGE : Names.UNI,
                             FIRST_PARAM_TYPE_EXTRACT_FUN);
-                    this.clazz = index.getClassByName(type.name());
+                    this.clazz = indexer.index.getClassByName(type.name());
                 }
             }
         }


### PR DESCRIPTION
- related to #redhat-developer-demos/quarkus-petclinic/issues/7

In this pr we introduce a stateful `Types.HierarchyIndexer` that (1) skips indexing for processed types and (2) scans interfaces recursively. `AssignableInfo` is now optimized for interfaces/classes (also jandex 3.0 `index.getAllKnownSubinterfaces()` is used instead of a workaround) and if the cached info does not match we try to update the assignable info (because a computing index is used). 