### PR TITLE
Fixed header of 2 doc topics

### DIFF
--- a/docs/src/main/asciidoc/security-architecture-concept.adoc
+++ b/docs/src/main/asciidoc/security-architecture-concept.adoc
@@ -7,6 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Quarkus Security architecture
 include::_attributes.adoc[]
 :categories: security
+
 The Quarkus Security architecture provides several built-in authentication mechanisms. The `HttpAuthenticationMechanism` interface is the main entry mechanism for securing HTTP applications in Quarkus. Quarkus Security is also highly customizable.
 
 == Core components of Quarkus Security

--- a/docs/src/main/asciidoc/security-identity-providers-concept.adoc
+++ b/docs/src/main/asciidoc/security-identity-providers-concept.adoc
@@ -7,6 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Identity providers
 include::_attributes.adoc[]
 :categories: security
+
 In the Quarkus Security framework, identity providers play a key role in authentication and authorization, providing services for storing and verifying user identities.
 The JPA `IdentityProvider` creates a `SecurityIdentity` instance used during user authentication to verify and authorize access requests, making your Quarkus application secure.
 [[identity-providers]]


### PR DESCRIPTION
This PR fixes the missing a line between header and introduction in 2 topics, which is causing an issue with the site build refresh.