### PR TITLE
Qute generated resolvers - getters should take precedence over fields

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -2542,17 +2542,7 @@ public class QuteProcessor {
             if (interfaceNames != null) {
                 addInterfaces(clazz, config.index(), interfaceNames);
             }
-            // Fields
-            for (FieldInfo field : clazz.fields()) {
-                if (!config.filter().test(field)) {
-                    continue;
-                }
-                if (field.name().equals(name)) {
-                    // Name matches and it's either an enum constant or a non-static field
-                    return field;
-                }
-            }
-            // Methods
+            // Methods; getters should take precedence over fields
             for (MethodInfo method : clazz.methods()) {
                 if (method.returnType().kind() != org.jboss.jandex.Type.Kind.VOID
                         && config.filter().test(method)
@@ -2561,6 +2551,16 @@ public class QuteProcessor {
                     // Skip void, non-public, static and synthetic methods
                     // Method name must match (exact or getter)
                     return method;
+                }
+            }
+            // Fields
+            for (FieldInfo field : clazz.fields()) {
+                if (!config.filter().test(field)) {
+                    continue;
+                }
+                if (field.name().equals(name)) {
+                    // Name matches and it's either an enum constant or a non-static field
+                    return field;
                 }
             }
             DotName superName = clazz.superName();


### PR DESCRIPTION
- this fixes a problem where a Panache entity declares an explicit getter with a return type that differs from the relevant field