### PR TITLE
Remove Stalebot from the list of GitHub applications

### DIFF
--- a/.github/ISSUE_TEMPLATE/extension_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/extension_proposal.yml
@@ -55,13 +55,6 @@ body:
       value: |
         - 
 
-  - type: checkboxes
-    attributes:
-      label: GitHub Applications?
-      description: Do you need any of these GitHub applications enabled in your repository?
-      options:
-        - label: "[Stale](https://github.com/marketplace/stale) - Automatically close stale Issues and Pull Requests that tend to accumulate during a project"
-
   - type: textarea
     attributes:
       label: Additional context


### PR DESCRIPTION
Removing Stalebot from the list of GitHub Applications enabled in Quarkiverse