### PR TITLE
Introduce convertScopes to `@InjectSpy`

### DIFF
--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/CapitalizerService.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/CapitalizerService.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.mockbean;
 
-import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Singleton;
 
-@ApplicationScoped
+@Singleton
 public class CapitalizerService {
 
     public String capitalize(String input) {

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/WithSpiesTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/WithSpiesTest.java
@@ -15,7 +15,7 @@ import io.quarkus.test.junit.mockito.InjectSpy;
 @QuarkusTest
 class WithSpiesTest {
 
-    @InjectSpy
+    @InjectSpy(convertScopes = true)
     CapitalizerService capitalizerService;
 
     @InjectSpy

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/InjectMock.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/InjectMock.java
@@ -15,7 +15,7 @@ public @interface InjectMock {
 
     /**
      * If true, then Quarkus will change the scope of the target {@code Singleton} bean to {@code ApplicationScoped}
-     * to make the mockable.
+     * to make it mockable.
      * This is an advanced setting and should only be used if you don't rely on the differences between {@code Singleton}
      * and {@code ApplicationScoped} beans (for example it is invalid to read fields of {@code ApplicationScoped} beans
      * as a proxy stands in place of the actual implementation)

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/InjectSpy.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/InjectSpy.java
@@ -23,4 +23,12 @@ public @interface InjectSpy {
      * @see org.mockito.AdditionalAnswers#delegatesTo(Object)
      */
     boolean delegate() default false;
+
+    /**
+     * If true, then Quarkus will change the scope of the target {@code Singleton} bean to {@code ApplicationScoped}.
+     * This is an advanced setting and should only be used if you don't rely on the differences between {@code Singleton}
+     * and {@code ApplicationScoped} beans (for example it is invalid to read fields of {@code ApplicationScoped} beans
+     * as a proxy stands in place of the actual implementation)
+     */
+    boolean convertScopes() default false;
 }

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SingletonToApplicationScopedTestBuildChainCustomizerProducer.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SingletonToApplicationScopedTestBuildChainCustomizerProducer.java
@@ -35,7 +35,7 @@ public class SingletonToApplicationScopedTestBuildChainCustomizerProducer implem
 
     @Override
     public Consumer<BuildChainBuilder> produce(Index testClassesIndex) {
-        return new Consumer<BuildChainBuilder>() {
+        return new Consumer<>() {
 
             @Override
             public void accept(BuildChainBuilder buildChainBuilder) {

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SingletonToApplicationScopedTestBuildChainCustomizerProducer.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SingletonToApplicationScopedTestBuildChainCustomizerProducer.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.junit.mockito.internal;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -25,10 +26,12 @@ import io.quarkus.builder.BuildContext;
 import io.quarkus.builder.BuildStep;
 import io.quarkus.test.junit.buildchain.TestBuildChainCustomizerProducer;
 import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.junit.mockito.InjectSpy;
 
 public class SingletonToApplicationScopedTestBuildChainCustomizerProducer implements TestBuildChainCustomizerProducer {
 
     private static final DotName INJECT_MOCK = DotName.createSimple(InjectMock.class.getName());
+    private static final DotName INJECT_SPY = DotName.createSimple(InjectSpy.class.getName());
 
     @Override
     public Consumer<BuildChainBuilder> produce(Index testClassesIndex) {
@@ -40,7 +43,9 @@ public class SingletonToApplicationScopedTestBuildChainCustomizerProducer implem
                     @Override
                     public void execute(BuildContext context) {
                         Set<DotName> mockTypes = new HashSet<>();
-                        List<AnnotationInstance> instances = testClassesIndex.getAnnotations(INJECT_MOCK);
+                        List<AnnotationInstance> instances = new ArrayList<>();
+                        instances.addAll(testClassesIndex.getAnnotations(INJECT_MOCK));
+                        instances.addAll(testClassesIndex.getAnnotations(INJECT_SPY));
                         for (AnnotationInstance instance : instances) {
                             if (instance.target().kind() != AnnotationTarget.Kind.FIELD) {
                                 continue;


### PR DESCRIPTION
The same way we support `convertScopes` on `@InjectMock` we can support it on `@InjectSpy` as well.

Closes: #30608