### PR TITLE
Provide useful hint when json processing extensions missing from REST Client

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -47,6 +47,7 @@ import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.client.spi.MissingMessageBodyReaderErrorMessageContextualizer;
 import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -71,6 +72,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.util.AsmUtil;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.MethodCreator;
@@ -125,6 +127,12 @@ class RestClientReactiveProcessor {
     @BuildStep
     ExtensionSslNativeSupportBuildItem activateSslNativeSupport() {
         return new ExtensionSslNativeSupportBuildItem(Feature.REST_CLIENT_REACTIVE);
+    }
+
+    @BuildStep
+    ServiceProviderBuildItem nativeSpiSupport() {
+        return ServiceProviderBuildItem
+                .allProvidersFromClassPath(MissingMessageBodyReaderErrorMessageContextualizer.class.getName());
     }
 
     @BuildStep

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/spi/JsonMissingMessageBodyReaderErrorMessageContextualizer.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/spi/JsonMissingMessageBodyReaderErrorMessageContextualizer.java
@@ -1,0 +1,16 @@
+package io.quarkus.rest.client.reactive.runtime.spi;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.client.spi.MissingMessageBodyReaderErrorMessageContextualizer;
+
+public class JsonMissingMessageBodyReaderErrorMessageContextualizer implements
+        MissingMessageBodyReaderErrorMessageContextualizer {
+    @Override
+    public String provideContextMessage(Input input) {
+        if ((input.mediaType() != null) && input.mediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)) {
+            return "Consider adding one the 'quarkus-rest-client-reactive-jackson' or 'quarkus-rest-client-reactive-jsonb' extensions";
+        }
+        return null;
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/spi/XmlMissingMessageBodyReaderErrorMessageContextualizer.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/spi/XmlMissingMessageBodyReaderErrorMessageContextualizer.java
@@ -1,0 +1,16 @@
+package io.quarkus.rest.client.reactive.runtime.spi;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.client.spi.MissingMessageBodyReaderErrorMessageContextualizer;
+
+public class XmlMissingMessageBodyReaderErrorMessageContextualizer implements
+        MissingMessageBodyReaderErrorMessageContextualizer {
+    @Override
+    public String provideContextMessage(Input input) {
+        if ((input.mediaType() != null) && input.mediaType().isCompatible(MediaType.APPLICATION_XML_TYPE)) {
+            return "Consider adding the 'quarkus-rest-client-reactive-jaxb' extension";
+        }
+        return null;
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/resources/META-INF/services/org.jboss.resteasy.reactive.client.spi.MissingMessageBodyReaderErrorMessageContextualizer
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/resources/META-INF/services/org.jboss.resteasy.reactive.client.spi.MissingMessageBodyReaderErrorMessageContextualizer
@@ -1,0 +1,2 @@
+io.quarkus.rest.client.reactive.runtime.spi.JsonMissingMessageBodyReaderErrorMessageContextualizer
+io.quarkus.rest.client.reactive.runtime.spi.XmlMissingMessageBodyReaderErrorMessageContextualizer

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientReaderInterceptorContextImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientReaderInterceptorContextImpl.java
@@ -28,7 +28,6 @@ public class ClientReaderInterceptorContextImpl extends AbstractClientIntercepto
     final ConfigurationImpl configuration;
     final Serialisers serialisers;
     InputStream inputStream;
-    boolean done = false;
     private int index = 0;
     private final ReaderInterceptor[] interceptors;
     private final MultivaluedMap<String, String> headers = new CaseInsensitiveMap<>();

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/spi/MissingMessageBodyReaderErrorMessageContextualizer.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/spi/MissingMessageBodyReaderErrorMessageContextualizer.java
@@ -1,0 +1,27 @@
+package org.jboss.resteasy.reactive.client.spi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.core.MediaType;
+
+public interface MissingMessageBodyReaderErrorMessageContextualizer {
+
+    /**
+     * Takes the same input as {@link javax.ws.rs.ext.MessageBodyReader#isReadable(Class, Type, Annotation[], MediaType)}
+     * and returns a {@code String} that contextualizes the error message.
+     * The result can be null if this class is not able to provide any useful context information.
+     */
+    String provideContextMessage(Input input);
+
+    interface Input {
+
+        Class<?> type();
+
+        Type genericType();
+
+        Annotation[] annotations();
+
+        MediaType mediaType();
+    }
+}


### PR DESCRIPTION
Relates to: #30465

The error message from #30465 now looks like:

```
Response could not be mapped to type class a.b.c.SomeClass. Hints: Consider adding one the 'quarkus-rest-client-reactive-jackson' or 'quarkus-rest-client-reactive-jsonb' extensions
```