### PR TITLE
Interpolate ClientHeaderParam in REST client reactive

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/MicroProfileRestClientEnricher.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/MicroProfileRestClientEnricher.java
@@ -217,9 +217,9 @@ class MicroProfileRestClientEnricher implements JaxrsClientReactiveEnricher {
             boolean required = annotation.valueWithDefault(index, "required").asBoolean();
             ResultHandle valuesList = creator.newInstance(MethodDescriptor.ofConstructor(ArrayList.class));
             for (String value : values) {
-                if (value.startsWith("${") && value.endsWith("}")) {
+                if (value.contains("${")) {
                     ResultHandle queryValueFromConfig = creator.invokeStaticMethod(
-                            MethodDescriptor.ofMethod(ConfigUtils.class, "getConfigValue", String.class, String.class,
+                            MethodDescriptor.ofMethod(ConfigUtils.class, "interpolate", String.class, String.class,
                                     boolean.class),
                             creator.load(value), creator.load(required));
                     creator.ifNotNull(queryValueFromConfig)
@@ -501,9 +501,9 @@ class MicroProfileRestClientEnricher implements JaxrsClientReactiveEnricher {
             boolean required = annotation.valueWithDefault(index, "required").asBoolean();
             ResultHandle headerList = fillHeaders.newInstance(MethodDescriptor.ofConstructor(ArrayList.class));
             for (String value : values) {
-                if (value.startsWith("${") && value.endsWith("}")) {
+                if (value.contains("${")) {
                     ResultHandle headerValueFromConfig = fillHeaders.invokeStaticMethod(
-                            MethodDescriptor.ofMethod(ConfigUtils.class, "getConfigValue", String.class, String.class,
+                            MethodDescriptor.ofMethod(ConfigUtils.class, "interpolate", String.class, String.class,
                                     boolean.class),
                             fillHeaders.load(value), fillHeaders.load(required));
                     fillHeaders.ifNotNull(headerValueFromConfig)

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/headers/ClientHeaderParamFromPropertyTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/headers/ClientHeaderParamFromPropertyTest.java
@@ -57,6 +57,14 @@ public class ClientHeaderParamFromPropertyTest {
         assertThat(client.missingNonRequiredProperty()).isEqualTo(HEADER_VALUE);
     }
 
+    @Test
+    void shouldSupportAdditionalTextOnHeaderProperty() {
+        Client client = RestClientBuilder.newBuilder().baseUri(baseUri)
+                .build(Client.class);
+
+        assertThat(client.supportAdditionalText()).isEqualTo("Bearer " + HEADER_VALUE + " Token");
+    }
+
     @Path("/")
     @ApplicationScoped
     public static class Resource {
@@ -64,6 +72,13 @@ public class ClientHeaderParamFromPropertyTest {
         public String returnHeaderValue(@HeaderParam("my-header") String header) {
             return header;
         }
+
+        @GET
+        @Path("/additional-text")
+        public String returnAdditionalText(@HeaderParam("additional-text") String header) {
+            return header;
+        }
+
     }
 
     @ClientHeaderParam(name = "my-header", value = "${my.property-value}")
@@ -78,5 +93,11 @@ public class ClientHeaderParamFromPropertyTest {
         @GET
         @ClientHeaderParam(name = "some-other-header", value = "${non-existent-property}", required = false)
         String missingNonRequiredProperty();
+
+        @GET
+        @ClientHeaderParam(name = "additional-text", value = "Bearer ${my.property-value} Token")
+        @Path("/additional-text")
+        String supportAdditionalText();
+
     }
 }

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ConfigUtils.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ConfigUtils.java
@@ -1,6 +1,6 @@
 package io.quarkus.rest.client.reactive.runtime;
 
-import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
@@ -9,20 +9,51 @@ public class ConfigUtils {
 
     private static final Logger log = Logger.getLogger(ConfigUtils.class);
 
+    static final String PREFIX = "${";
+    static final String SUFFIX = "}";
+
+    /**
+     * Interpolates the given expression. The expression is expected to be in the form of ${config.property.name}.
+     *
+     * @param expression the expression to interpolate
+     * @param required whether the expression is required to be present in the configuration
+     * @return null if the resulting expression is empty, otherwise the interpolated expression
+     */
+    public static String interpolate(String expression, boolean required) {
+        StringBuilder sb = new StringBuilder(expression);
+        int idx;
+        while ((idx = sb.lastIndexOf(PREFIX)) > -1) {
+            int endIdx = sb.indexOf(SUFFIX, idx);
+            if (endIdx < 0) {
+                throw new IllegalArgumentException("Invalid expression: " + expression);
+            }
+            String configValue = getConfigValue(sb.substring(idx, endIdx + 1), required);
+            // If no value is found, we return null directly
+            if (configValue == null) {
+                return null;
+            }
+            sb.replace(idx, endIdx + 1, configValue);
+        }
+        if (sb.length() == 0) {
+            return null;
+        }
+        return sb.toString();
+    }
+
     public static String getConfigValue(String configProperty, boolean required) {
         String propertyName = stripPrefixAndSuffix(configProperty);
         try {
-            return ConfigProvider.getConfig().getValue(propertyName, String.class);
-        } catch (NoSuchElementException e) {
-            String message = "Failed to find value for config property " + configProperty +
-                    " in application configuration. Please provide the value for the property, e.g. by adding " +
-                    propertyName + "=<desired-value> to your application.properties";
-            if (required) {
-                throw new IllegalArgumentException(message, e);
-            } else {
+            Optional<String> optionalValue = ConfigProvider.getConfig().getOptionalValue(propertyName, String.class);
+            if (optionalValue.isEmpty()) {
+                String message = String.format("Failed to find value for config property %s in application configuration. "
+                        + "Please provide the value for the property, e.g. by adding %s=<desired-value> to your application.properties",
+                        configProperty, propertyName);
+                if (required) {
+                    throw new IllegalArgumentException(message);
+                }
                 log.warn(message);
-                return null;
             }
+            return optionalValue.orElse(null);
         } catch (IllegalArgumentException e) {
             String message = "Failed to convert value for property " + configProperty + " to String";
             if (required) {


### PR DESCRIPTION
- Add interpolation functionality for expressions of the form `${config.property.name}`
- Add a test for supporting additional text on the header property
- Fixes #30631