### PR TITLE
Only register apicurio related classes for reflection when present

### DIFF
--- a/extensions/schema-registry/apicurio/avro/deployment/src/main/java/io/quarkus/apicurio/registry/avro/ApicurioRegistryAvroProcessor.java
+++ b/extensions/schema-registry/apicurio/avro/deployment/src/main/java/io/quarkus/apicurio/registry/avro/ApicurioRegistryAvroProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.apicurio.registry.avro;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -30,11 +31,16 @@ public class ApicurioRegistryAvroProcessor {
                 "io.apicurio.registry.serde.avro.strategy.TopicRecordIdStrategy"));
 
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true,
-                "io.apicurio.registry.serde.DefaultSchemaResolver",
                 "io.apicurio.registry.serde.DefaultIdHandler",
                 "io.apicurio.registry.serde.Legacy4ByteIdHandler",
                 "io.apicurio.registry.serde.fallback.DefaultFallbackArtifactProvider",
                 "io.apicurio.registry.serde.headers.DefaultHeadersHandler"));
+
+        String defaultSchemaResolver = "io.apicurio.registry.serde.DefaultSchemaResolver";
+        if (QuarkusClassLoader.isClassPresentAtRuntime(defaultSchemaResolver)) {
+            // Class not present after 2.2.0.Final
+            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, defaultSchemaResolver));
+        }
     }
 
     @BuildStep

--- a/extensions/schema-registry/confluent/common/deployment/src/main/java/io/quarkus/confluent/registry/common/ConfluentRegistryClientProcessor.java
+++ b/extensions/schema-registry/confluent/common/deployment/src/main/java/io/quarkus/confluent/registry/common/ConfluentRegistryClientProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.confluent.registry.common;
 
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
@@ -19,9 +20,12 @@ public class ConfluentRegistryClientProcessor {
         if (curateOutcomeBuildItem.getApplicationModel().getDependencies().stream().anyMatch(
                 x -> x.getGroupId().equals("io.confluent")
                         && x.getArtifactId().equals("kafka-schema-serializer"))) {
-            reflectiveClass
-                    .produce(new ReflectiveClassBuildItem(true, false, false,
-                            "io.confluent.kafka.serializers.context.NullContextNameStrategy"));
+
+            String nullContextNameStrategy = "io.confluent.kafka.serializers.context.NullContextNameStrategy";
+            if (QuarkusClassLoader.isClassPresentAtRuntime(nullContextNameStrategy)) {
+                // Class not present before v7.0.0
+                reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, nullContextNameStrategy));
+            }
 
             reflectiveClass
                     .produce(new ReflectiveClassBuildItem(true, true, false,


### PR DESCRIPTION
As discussed in https://github.com/quarkusio/quarkus/pull/29886#discussion_r1071074678

> So integration-tests/kafka-avro verifies support for Apicurio Registry 1.x libraries; the tests for Apicurio Registry 2.x libraries is in integration-tests/kafka-avro-apicurio2.
> 
> We use Apicurio Registry 1.2.2 libraries in integration-tests/kafka-avro, because Apicurio Registry 1.3 libraries require some extra support which is a bit hacky (https://github.com/quarkiverse/quarkus-apicurio-registry-client). I believe we want[ed] to drop support for Apicurio Registry 1.x libraries at some point, together with integration-tests/kafka-avro. I'm not sure if that time has come.
> 
> For integration-tests/kafka-avro-apicurio2, I believe we want to use the same version of Apicurio Registry 2.x libraries that we compile against elsewhere.

Prerequisite for #29886