### PR TITLE
Adjust source language absent in documentation code blocks

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -603,7 +603,7 @@ spec:
 
 CPU & Memory limits and requests can be applied to a `Container` (more info in https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes documentation]) using the following configuration:
 
-[source]
+[source,properties]
 ----
 quarkus.kubernetes.resources.requests.memory=64Mi
 quarkus.kubernetes.resources.requests.cpu=250m
@@ -629,7 +629,7 @@ containers:
 
 Kubernetes exposes applications using https://kubernetes.io/docs/concepts/services-networking/ingress[Ingress resources]. To generate the Ingress resource, just apply the following configuration:
 
-[source]
+[source,properties]
 ----
 quarkus.kubernetes.ingress.expose=true
 ----
@@ -767,7 +767,7 @@ spec:
 
 To secure the incoming connections, Kubernetes allows enabling https://kubernetes.io/docs/concepts/services-networking/ingress/#tls[TLS] within the Ingress resource by specifying a Secret that contains a TLS private key and certificate. You can generate a secured Ingress resource by simply adding the "tls.secret-name" properties:
 
-[source]
+[source,properties]
 ----
 quarkus.kubernetes.ingress.expose=true
 quarkus.kubernetes.ingress.target-port=https

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -153,7 +153,7 @@ tests while having the application running in parallel.
 .Changing the test port
 ====
 You can configure the ports used by tests by configuring `quarkus.http.test-port` for HTTP and `quarkus.http.test-ssl-port` for HTTPS in your `application.properties`:
-[source]
+[source,properties]
 ----
 quarkus.http.test-port=8083
 quarkus.http.test-ssl-port=8446
@@ -169,7 +169,7 @@ so no additional configuration should be required.
 When using REST Assured in your test, the connection and response timeouts are set to 30 seconds.
 You can override this setting with the `quarkus.http.test-timeout` property:
 
-[source]
+[source,properties]
 ----
 quarkus.http.test-timeout=10s
 ----

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -425,7 +425,7 @@ Supported forwarding address headers are:
 
 One can easily add a https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite[SameSite] cookie property to any of the cookies set by a Quarkus endpoint by listing a cookie name and a `SameSite` attribute, for example:
 
-[source]
+[source,properties]
 ----
 quarkus.http.same-site-cookie.jwt.value=Lax
 quarkus.http.same-site-cookie.session.value=Strict

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -442,7 +442,7 @@ public class TopologyProducer {
 The Kafka Streams extension is configured via the Quarkus configuration file `application.properties`.
 Create the file `aggregator/src/main/resources/application.properties` with the following contents:
 
-[source]
+[source,properties]
 ----
 quarkus.kafka-streams.bootstrap-servers=localhost:9092
 quarkus.kafka-streams.application-server=${hostname}:8080

--- a/docs/src/main/asciidoc/podman.adoc
+++ b/docs/src/main/asciidoc/podman.adoc
@@ -123,14 +123,14 @@ For a detailed explanation, see this https://quarkus.io/blog/quarkus-devservices
 
 Edit `~/.testcontainers.properties` and add the following line
 
-[source,bash]
+[source,properties]
 ----
 ryuk.container.privileged=true
 ----
 
 Alternatively, you can disable ryuk:
 
-[source]
+[source,bash]
 ----
 export TESTCONTAINERS_RYUK_DISABLED=true #not recommended - see above!
 ----

--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -446,7 +446,7 @@ You can register `plugins`, `job-listeners` and `trigger-listeners` through Quar
 
 The example below registers the plugin `org.quartz.plugins.history.LoggingJobHistoryPlugin` named as `jobHistory` with the property `jobSuccessMessage` defined as `Job [{1}.{0}] execution complete and reports: {8}`
 
-[source,conf]
+[source,properties]
 ----
 quarkus.quartz.plugins.jobHistory.class=org.quartz.plugins.history.LoggingJobHistoryPlugin
 quarkus.quartz.plugins.jobHistory.properties.jobSuccessMessage=Job [{1}.{0}] execution complete and reports: {8}

--- a/docs/src/main/asciidoc/spring-cache.adoc
+++ b/docs/src/main/asciidoc/spring-cache.adoc
@@ -170,7 +170,7 @@ include::{includes}/devtools/dev.adoc[]
 Then, call `http://localhost:8080/weather?city=Raleigh` from a browser.
 After six long seconds, the application will answer something like this:
 
-[source]
+[source,json]
 ----
 {"dailyForecasts":["MONDAY will be cloudy in Raleigh","TUESDAY will be chilly in Raleigh","WEDNESDAY will be rainy in Raleigh"],"executionTimeInMs":6001}
 ----


### PR DESCRIPTION
I've noticed that some code blocks are without or with the wrong source language. The proposed changes adjust the identified code blocks with an appropriate language.