### PR TITLE
Fix missing preamble on doc index page

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-bearer-authentication-concept.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-authentication-concept.adoc
@@ -7,7 +7,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = OIDC Bearer authentication
 include::_attributes.adoc[]
 :categories: security,web
-
 :summary: To secure HTTP access to JAX-RS endpoints in your application, you can use Bearer authentication provided by the Quarkus OpenID Connect (OIDC) extension.
 
 == Overview of the Bearer authentication mechanism in Quarkus


### PR DESCRIPTION
Remove bad line space, which breaks the header section. 