### PR TITLE
ArC fixes for spec compatibility, round 2

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -846,6 +846,7 @@ public class BeanGenerator extends AbstractGenerator {
             // Invoke the disposer method
             // declaringProvider.get(new CreationalContextImpl<>()).dispose()
             MethodInfo disposerMethod = bean.getDisposer().getDisposerMethod();
+            boolean isStatic = Modifier.isStatic(disposerMethod.flags());
 
             ResultHandle declaringProviderSupplierHandle = destroy.readInstanceField(
                     FieldDescriptor.of(beanCreator.getClassName(), FIELD_NAME_DECLARING_PROVIDER_SUPPLIER,
@@ -855,15 +856,21 @@ public class BeanGenerator extends AbstractGenerator {
                     MethodDescriptors.SUPPLIER_GET, declaringProviderSupplierHandle);
             ResultHandle ctxHandle = destroy.newInstance(
                     MethodDescriptor.ofConstructor(CreationalContextImpl.class, Contextual.class), destroy.loadNull());
-            ResultHandle declaringProviderInstanceHandle = destroy.invokeInterfaceMethod(
-                    MethodDescriptors.INJECTABLE_REF_PROVIDER_GET, declaringProviderHandle,
-                    ctxHandle);
-
-            if (bean.getDeclaringBean().getScope().isNormal()) {
-                // We need to unwrap the client proxy
+            ResultHandle declaringProviderInstanceHandle;
+            if (isStatic) {
+                // for static disposers, we don't need to resolve this handle
+                // the `null` will only be used for reflective invocation in case the disposer is private, which is OK
+                declaringProviderInstanceHandle = destroy.loadNull();
+            } else {
                 declaringProviderInstanceHandle = destroy.invokeInterfaceMethod(
-                        MethodDescriptors.CLIENT_PROXY_GET_CONTEXTUAL_INSTANCE,
-                        declaringProviderInstanceHandle);
+                        MethodDescriptors.INJECTABLE_REF_PROVIDER_GET, declaringProviderHandle,
+                        ctxHandle);
+                if (bean.getDeclaringBean().getScope().isNormal()) {
+                    // We need to unwrap the client proxy
+                    declaringProviderInstanceHandle = destroy.invokeInterfaceMethod(
+                            MethodDescriptors.CLIENT_PROXY_GET_CONTEXTUAL_INSTANCE,
+                            declaringProviderInstanceHandle);
+                }
             }
 
             ResultHandle[] referenceHandles = new ResultHandle[disposerMethod.parametersCount()];
@@ -904,6 +911,8 @@ public class BeanGenerator extends AbstractGenerator {
                 destroy.invokeStaticMethod(MethodDescriptors.REFLECTIONS_INVOKE_METHOD,
                         destroy.loadClass(disposerMethod.declaringClass().name().toString()),
                         destroy.load(disposerMethod.name()), paramTypesArray, declaringProviderInstanceHandle, argsArray);
+            } else if (isStatic) {
+                destroy.invokeStaticMethod(MethodDescriptor.of(disposerMethod), referenceHandles);
             } else {
                 destroy.invokeVirtualMethod(MethodDescriptor.of(disposerMethod), declaringProviderInstanceHandle,
                         referenceHandles);
@@ -912,8 +921,8 @@ public class BeanGenerator extends AbstractGenerator {
             // Destroy @Dependent instances injected into method parameters of a disposer method
             destroy.invokeInterfaceMethod(MethodDescriptors.CREATIONAL_CTX_RELEASE, ctxHandle);
 
-            // If the declaring bean is @Dependent we must destroy the instance afterwards
-            if (BuiltinScope.DEPENDENT.is(bean.getDisposer().getDeclaringBean().getScope())) {
+            // If the declaring bean is @Dependent and the disposer is not static, we must destroy the instance afterwards
+            if (BuiltinScope.DEPENDENT.is(bean.getDisposer().getDeclaringBean().getScope()) && !isStatic) {
                 destroy.invokeInterfaceMethod(MethodDescriptors.INJECTABLE_BEAN_DESTROY, declaringProviderHandle,
                         declaringProviderInstanceHandle, ctxHandle);
             }
@@ -927,7 +936,7 @@ public class BeanGenerator extends AbstractGenerator {
 
         // Bridge method needed
         MethodCreator bridgeDestroy = beanCreator.getMethodCreator("destroy", void.class, Object.class, CreationalContext.class)
-                .setModifiers(ACC_PUBLIC);
+                .setModifiers(ACC_PUBLIC | ACC_BRIDGE);
         bridgeDestroy.returnValue(bridgeDestroy.invokeVirtualMethod(destroy.getMethodDescriptor(), bridgeDestroy.getThis(),
                 bridgeDestroy.getMethodParam(0),
                 bridgeDestroy.getMethodParam(1)));
@@ -1241,6 +1250,8 @@ public class BeanGenerator extends AbstractGenerator {
         AssignableResultHandle instanceHandle;
 
         MethodInfo producerMethod = bean.getTarget().get().asMethod();
+        boolean isStatic = Modifier.isStatic(producerMethod.flags());
+
         instanceHandle = create.createVariable(DescriptorUtils.extToInt(providerType.className()));
         // instance = declaringProviderSupplier.get().get(new CreationalContextImpl<>()).produce()
         ResultHandle ctxHandle = create.newInstance(
@@ -1252,8 +1263,9 @@ public class BeanGenerator extends AbstractGenerator {
                 create.getThis());
         ResultHandle declaringProviderHandle = create.invokeInterfaceMethod(
                 MethodDescriptors.SUPPLIER_GET, declaringProviderSupplierHandle);
-        if (Modifier.isStatic(producerMethod.flags())) {
-            // for static producers, we don't need to resolve this this handle
+        if (isStatic) {
+            // for static producers, we don't need to resolve this handle
+            // the `null` will only be used for reflective invocation in case the producer is private, which is OK
             declaringProviderInstanceHandle = create.loadNull();
         } else {
             declaringProviderInstanceHandle = create.invokeInterfaceMethod(
@@ -1309,7 +1321,7 @@ public class BeanGenerator extends AbstractGenerator {
                     argsArray));
         } else {
             ResultHandle invokeMethodHandle;
-            if (Modifier.isStatic(producerMethod.flags())) {
+            if (isStatic) {
                 invokeMethodHandle = create.invokeStaticMethod(MethodDescriptor.of(producerMethod),
                         referenceHandles);
             } else {
@@ -1326,8 +1338,8 @@ public class BeanGenerator extends AbstractGenerator {
                             bean.getTarget().get().asMethod().name() + "()");
         }
 
-        // If the declaring bean is @Dependent we must destroy the instance afterwards
-        if (BuiltinScope.DEPENDENT.is(bean.getDeclaringBean().getScope())) {
+        // If the declaring bean is @Dependent and the producer is not static, we must destroy the instance afterwards
+        if (BuiltinScope.DEPENDENT.is(bean.getDeclaringBean().getScope()) && !isStatic) {
             create.invokeInterfaceMethod(MethodDescriptors.INJECTABLE_BEAN_DESTROY, declaringProviderHandle,
                     declaringProviderInstanceHandle, ctxHandle);
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -172,7 +172,7 @@ public final class Beans {
 
         if (isAlternative) {
             if (priority == null) {
-                priority = declaringBean.getAlternativePriority();
+                priority = declaringBean.getPriority();
             }
             priority = initAlternativePriority(producerMethod, priority, stereotypes, beanDeployment);
             if (priority == null) {
@@ -287,7 +287,7 @@ public final class Beans {
 
         if (isAlternative) {
             if (priority == null) {
-                priority = declaringBean.getAlternativePriority();
+                priority = declaringBean.getPriority();
             }
             priority = initAlternativePriority(producerField, priority, stereotypes, beanDeployment);
             // after all attempts, priority is still null

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -69,18 +70,13 @@ public class TypesTest {
             }
         }
         ClassInfo producerClass = index.getClassByName(producerName);
-        final String producersName = "produce";
-        assertThrows(DefinitionException.class,
-                () -> Types.getProducerMethodTypeClosure(producerClass.method(producersName), dummyDeployment));
-        assertThrows(DefinitionException.class,
-                () -> Types.getProducerFieldTypeClosure(producerClass.field(producersName), dummyDeployment));
-
-        // now assert the same with nested wildcard
-        final String nestedWildCardProducersName = "produceNested";
-        assertThrows(DefinitionException.class,
-                () -> Types.getProducerMethodTypeClosure(producerClass.method(nestedWildCardProducersName), dummyDeployment));
-        assertThrows(DefinitionException.class,
-                () -> Types.getProducerFieldTypeClosure(producerClass.field(nestedWildCardProducersName), dummyDeployment));
+        for (String name : Arrays.asList("produce", "produceNested", "produceTypeVar",
+                "produceArray", "produceNestedArray", "produceTypeVarArray")) {
+            assertThrows(DefinitionException.class,
+                    () -> Types.getProducerMethodTypeClosure(producerClass.method(name), dummyDeployment));
+            assertThrows(DefinitionException.class,
+                    () -> Types.getProducerFieldTypeClosure(producerClass.field(name), dummyDeployment));
+        }
 
         // now assert following ones do NOT throw, the wildcard in the hierarchy is just ignored
         final String wildcardInTypeHierarchy = "eagleProducer";
@@ -140,9 +136,33 @@ public class TypesTest {
             return null;
         }
 
+        public T produceTypeVar() {
+            return null;
+        }
+
+        public List<? extends Number>[][] produceArray() {
+            return null;
+        }
+
+        public List<Set<? extends Number>>[][] produceNestedArray() {
+            return null;
+        }
+
+        public T[][] produceTypeVarArray() {
+            return null;
+        }
+
         List<? extends Number> produce;
 
         List<Set<? extends Number>> produceNested;
+
+        public T produceTypeVar;
+
+        List<? extends Number>[] produceArray;
+
+        List<Set<? extends Number>>[] produceNestedArray;
+
+        public T[] produceTypeVarArray;
 
         // following producer should NOT throw an exception because the return types doesn't contain wildcard
         // but the hierarchy of the return type actually contains one

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Reflections.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Reflections.java
@@ -21,6 +21,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
+import javax.enterprise.inject.CreationException;
+
 /**
  * Neither the class nor its methods are considered a public API and should only be used internally.
  */
@@ -129,7 +131,17 @@ public final class Reflections {
             }
             try {
                 return constructor.newInstance(args);
-            } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            } catch (InvocationTargetException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+                if (cause instanceof Error) {
+                    throw (Error) cause;
+                }
+                // this method is only used to instantiate beans, so throwing `CreationException` is fine
+                throw new CreationException(cause);
+            } catch (InstantiationException | IllegalAccessException | IllegalArgumentException e) {
                 throw new RuntimeException("Cannot invoke constructor: " + clazz.getName(), e);
             }
         }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/alternatives/priority/AlternativeProducerPriorityOnClassTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/alternatives/priority/AlternativeProducerPriorityOnClassTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.arc.test.alternatives.priority;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.MyQualifier;
+
+public class AlternativeProducerPriorityOnClassTest {
+    @RegisterExtension
+    ArcTestContainer testContainer = new ArcTestContainer(Producer.class, Consumer.class);
+
+    @Test
+    public void testAlternativePriorityResolution() {
+        Consumer bean = Arc.container().instance(Consumer.class).get();
+        assertNotNull(bean.foo);
+        assertNotNull(bean.bar);
+    }
+
+    static class Foo {
+    }
+
+    @MyQualifier
+    static class Bar {
+    }
+
+    @Dependent
+    @Priority(1000)
+    static class Producer {
+        @Produces
+        @Alternative
+        Foo produceFoo = new Foo();
+
+        @Produces
+        @Alternative
+        @MyQualifier
+        Bar produceBar() {
+            return new Bar();
+        }
+    }
+
+    @Dependent
+    static class Consumer {
+        @Inject
+        Foo foo;
+
+        @Inject
+        @MyQualifier
+        Bar bar;
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/create/BeanCreateErrorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/create/BeanCreateErrorTest.java
@@ -1,0 +1,86 @@
+package io.quarkus.arc.test.bean.create;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.CreationException;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class BeanCreateErrorTest {
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(CheckedExceptionBean.class, CheckedExceptionProducerBean.class,
+            UncheckedExceptionBean.class, UncheckedExceptionProducerBean.class);
+
+    @Test
+    public void checkedExceptionWrapped() {
+        // Test that the checked exception is wrapped
+
+        CreationException exception = assertThrows(CreationException.class, () -> {
+            Arc.container().instance(CheckedExceptionBean.class);
+        });
+        assertEquals("foo", exception.getCause().getMessage());
+
+        exception = assertThrows(CreationException.class, () -> {
+            Arc.container().instance(BigInteger.class);
+        });
+        assertEquals("bar", exception.getCause().getMessage());
+    }
+
+    @Test
+    public void uncheckedExceptionNotWrapped() {
+        // Test that the unchecked exception is _not_ wrapped
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            Arc.container().instance(UncheckedExceptionBean.class);
+        });
+
+        assertThrows(IllegalStateException.class, () -> {
+            Arc.container().instance(BigDecimal.class);
+        });
+    }
+
+    @Dependent
+    static class CheckedExceptionBean {
+        @Inject
+        public CheckedExceptionBean() throws Exception {
+            throw new Exception("foo");
+        }
+    }
+
+    @Dependent
+    static class CheckedExceptionProducerBean {
+        @Produces
+        @Dependent
+        BigInteger produce() throws Exception {
+            throw new Exception("bar");
+        }
+    }
+
+    @Dependent
+    static class UncheckedExceptionBean {
+        @Inject
+        public UncheckedExceptionBean() {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Dependent
+    static class UncheckedExceptionProducerBean {
+        @Produces
+        @Dependent
+        BigDecimal produce() {
+            throw new IllegalStateException();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/ArrayBeanTypesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/ArrayBeanTypesTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.arc.test.bean.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.util.TypeLiteral;
+import javax.inject.Named;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ArrayBeanTypesTest {
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(Producer.class);
+
+    @Test
+    public <T> void test() {
+        InjectableBean<Object> intArray = Arc.container().instance("intArray").getBean();
+        assertBeanTypes(intArray, Object.class, int[][].class);
+
+        InjectableBean<Object> stringArray = Arc.container().instance("stringArray").getBean();
+        assertBeanTypes(stringArray, Object.class, String[].class);
+
+        InjectableBean<Object> listArray = Arc.container().instance("listArray").getBean();
+        assertBeanTypes(listArray, Object.class, new TypeLiteral<List<String>[]>() {
+        }.getType());
+    }
+
+    private void assertBeanTypes(Bean<?> bean, Type... expectedTypes) {
+        Set<Type> types = bean.getTypes();
+
+        assertEquals(expectedTypes.length, types.size());
+        for (Type expectedType : expectedTypes) {
+            assertTrue(types.contains(expectedType));
+        }
+    }
+
+    @Dependent
+    static class Producer<T extends Number> {
+        @Produces
+        @Dependent
+        @Named("intArray")
+        int[][] intArray() {
+            return new int[0][0];
+        }
+
+        @Produces
+        @Dependent
+        @Named("stringArray")
+        String[] stringArray() {
+            return new String[0];
+        }
+
+        @Produces
+        @Dependent
+        @Named("listArray")
+        List<String>[] listArray() {
+            return (List<String>[]) new List<?>[0];
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/StaticDisposerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/StaticDisposerTest.java
@@ -1,0 +1,112 @@
+package io.quarkus.arc.test.producer.disposer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Disposes;
+import javax.enterprise.inject.Produces;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class StaticDisposerTest {
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(Producers.class, Dependency.class);
+
+    @Test
+    public void testProducersDisposers() {
+        assertState(0, 0, false, false, 0, 0);
+
+        InstanceHandle<BigInteger> intHandle = Arc.container().instance(BigInteger.class);
+        assertEquals(1, intHandle.get().intValue()); // instance producer
+        assertState(1, 1, false, false, 1, 0);
+        intHandle.destroy(); // static disposer
+        assertState(1, 1, false, true, 2, 2);
+
+        InstanceHandle<BigDecimal> decHandle = Arc.container().instance(BigDecimal.class);
+        assertEquals(2, decHandle.get().intValue()); // static producer
+        assertState(1, 1, false, true, 3, 2);
+        decHandle.destroy(); // instance disposer
+        assertState(2, 2, true, true, 4, 4);
+    }
+
+    private void assertState(int expectedInstancesCreated, int expectedInstancesDestroyed,
+            boolean expectedInstanceDisposerCalled, boolean expectedStaticDisposerCalled,
+            int expectedDependencyCreated, int expectedDependencyDestroyed) {
+        assertEquals(expectedInstancesCreated, Producers.instancesCreated);
+        assertEquals(expectedInstancesDestroyed, Producers.instancesDestroyed);
+        assertEquals(expectedInstanceDisposerCalled, Producers.instanceDisposerCalled);
+        assertEquals(expectedStaticDisposerCalled, Producers.staticDisposerCalled);
+        assertEquals(expectedDependencyCreated, Dependency.created);
+        assertEquals(expectedDependencyDestroyed, Dependency.destroyed);
+    }
+
+    @Dependent
+    static class Producers {
+        static int instancesCreated = 0;
+        static int instancesDestroyed = 0;
+
+        static boolean instanceDisposerCalled = false;
+        static boolean staticDisposerCalled = false;
+
+        @PostConstruct
+        void created() {
+            instancesCreated++;
+        }
+
+        @PreDestroy
+        void destroy() {
+            instancesDestroyed++;
+        }
+
+        @Produces
+        @Dependent
+        BigInteger instanceProducer(Dependency ignored) {
+            return new BigInteger("1");
+        }
+
+        @Produces
+        @Dependent
+        static BigDecimal staticProducer(Dependency ignored) {
+            return new BigDecimal("2.0");
+        }
+
+        void instanceDisposer(@Disposes BigDecimal disposed, Dependency ignored) {
+            assertFalse(instanceDisposerCalled);
+            assertEquals(2, disposed.intValue());
+            instanceDisposerCalled = true;
+        }
+
+        static void staticDisposer(@Disposes BigInteger disposed, Dependency ignored) {
+            assertFalse(staticDisposerCalled);
+            assertEquals(1, disposed.intValue());
+            staticDisposerCalled = true;
+        }
+    }
+
+    @Dependent
+    static class Dependency {
+        static int created = 0;
+        static int destroyed = 0;
+
+        @PostConstruct
+        void created() {
+            created++;
+        }
+
+        @PreDestroy
+        void destroyed() {
+            destroyed++;
+        }
+    }
+}


### PR DESCRIPTION
Related to #28558

- fix obtaining priority of a producer-based alternative from class-level `@Priority`
  - producers take priority from the declaring class
- fix generating `Bean.create()` to wrap checked exceptions in `CreationException`
  - the path of least resistance: what was up to now generated as `create()` is now called `doCreate()` and `create()` just wraps that into `try`/`catch`
- add support for static disposer methods
  - also fixes a NPE in case of static producer method declared on a `@Dependent` bean
- improve runtime representation of array bean types
  - we always used `GenericArrayType` to represent array bean types at runtime, which is unexpected for people, and also for at least one TCK test that expects a `java.lang.Class` representation of `String[]`
- add validation for array-typed producers