### PR TITLE
Use `quarkus.http.ssl-port` instead of `quarkus.https.port`

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -1348,8 +1348,8 @@ public class VertxHttpRecorder {
 
                     }
                     if (clearHttpsProperty) {
-                        String portPropertyName = launchMode == LaunchMode.TEST ? "quarkus.https.test-port"
-                                : "quarkus.https.port";
+                        String portPropertyName = launchMode == LaunchMode.TEST ? "quarkus.http.test-ssl-port"
+                                : "quarkus.http.ssl-port";
                         System.clearProperty(portPropertyName);
                         if (launchMode.isDevOrTest()) {
                             System.clearProperty(propertyWithProfilePrefix(portPropertyName));

--- a/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredURLManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/RestAssuredURLManager.java
@@ -115,7 +115,7 @@ public class RestAssuredURLManager {
             try {
                 oldPort = (Integer) portField.get(null);
                 if (port == null) {
-                    port = useSecureConnection ? getPortFromConfig(DEFAULT_HTTPS_PORT, "quarkus.https.test-port")
+                    port = useSecureConnection ? getPortFromConfig(DEFAULT_HTTPS_PORT, "quarkus.http.test-ssl-port")
                             : getPortFromConfig(DEFAULT_HTTP_PORT, "quarkus.lambda.mock-event-server.test-port",
                                     "quarkus.http.test-port");
                 }

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
@@ -655,7 +655,7 @@ public class QuarkusProdModeTest
                 .map(Integer::parseInt)
                 .orElse(DEFAULT_HTTP_PORT_INT);
 
-        // If http port is 0, then we need to set the port to null in order to use the `quarkus.https.test-port` property
+        // If http port is 0, then we need to set the port to null in order to use the `quarkus.http.test-ssl-port` property
         // which is done in `RestAssuredURLManager.setURL`.
         if (httpPort == 0) {
             httpPort = null;


### PR DESCRIPTION
Also change the port from which the secure connection is established from `quarkus.https.test-port` to `quarkus.http.test-ssl-port`

- Fixes #20228
