### PR TITLE
Bump htmlunit version to 2.70.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,7 @@ updates:
       # RX Java 2
       - dependency-name: io.reactivex.rxjava2:rxjava
       # Test dependencies
+      - dependency-name: net.sourceforge.htmlunit:htmlunit
       - dependency-name: io.rest-assured:*
       - dependency-name: org.junit:junit-bom
       - dependency-name: org.junit.jupiter:*

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -38,7 +38,7 @@
         <jandex-gradle-plugin.version>1.0.0</jandex-gradle-plugin.version>
 
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
-        <htmlunit.version>2.40.0</htmlunit.version>
+        <htmlunit.version>2.70.0</htmlunit.version>
         <javaparser-core.version>3.24.2</javaparser-core.version>
         <jdeparser.version>2.0.3.Final</jdeparser.version>
         <subethasmtp.version>5.2.8</subethasmtp.version>

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeDefaultTenantTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeDefaultTenantTestCase.java
@@ -59,7 +59,7 @@ public class CodeFlowDevModeDefaultTenantTestCase {
 
             page = loginForm.getInputByName("login").click();
 
-            assertEquals("alice", page.getBody().asText());
+            assertEquals("alice", page.getBody().asNormalizedText());
 
             webClient.getCookieManager().clearCookies();
         }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
@@ -51,7 +51,7 @@ public class CodeFlowDevModeTestCase {
 
             // Default tenant is disabled and client secret is wrong
             HtmlPage page = webClient.getPage("http://localhost:8080/unprotected");
-            assertEquals("unprotected", page.getBody().asText());
+            assertEquals("unprotected", page.getBody().asNormalizedText());
 
             try {
                 webClient.getPage("http://localhost:8080/protected");
@@ -95,7 +95,7 @@ public class CodeFlowDevModeTestCase {
 
             page = loginForm.getInputByName("login").click();
 
-            assertEquals("alice", page.getBody().asText());
+            assertEquals("alice", page.getBody().asNormalizedText());
 
             assertEquals("custom", page.getWebClient().getCookieManager().getCookie("q_session").getValue().split("\\|")[3]);
 
@@ -122,7 +122,7 @@ public class CodeFlowDevModeTestCase {
 
             page = loginForm.getInputByName("login").click();
 
-            assertEquals("tenant-config-resolver:alice", page.getBody().asText());
+            assertEquals("tenant-config-resolver:alice", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/SecurityDisabledTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/SecurityDisabledTestCase.java
@@ -30,7 +30,7 @@ public class SecurityDisabledTestCase {
         try (final WebClient webClient = createWebClient()) {
 
             HtmlPage page = webClient.getPage("http://localhost:8081/unprotected");
-            assertEquals("unprotected", page.getBody().asText());
+            assertEquals("unprotected", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -86,12 +86,12 @@ public class CodeFlowTest {
 
             assertEquals(
                     client.getAuthServerUrl(),
-                    page.asText());
+                    page.asNormalizedText());
 
             page = webClient.getPage("http://localhost:8081/web-app/configMetadataScopes");
 
-            assertTrue(page.asText().contains("openid"));
-            assertTrue(page.asText().contains("profile"));
+            assertTrue(page.asNormalizedText().contains("openid"));
+            assertTrue(page.asNormalizedText().contains("profile"));
 
             Cookie sessionCookie = getSessionCookie(webClient, null);
             assertNotNull(sessionCookie);
@@ -157,7 +157,7 @@ public class CodeFlowTest {
 
             HtmlPage page = webClient.getPage(URI.create(endpointErrorLocation).toURL());
             assertEquals("code: b, error: invalid_scope, error_description: Invalid scopes: unknown",
-                    page.getBody().asText());
+                    page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -219,7 +219,7 @@ public class CodeFlowTest {
             assertNull(endpointLocationWithoutQueryUri.getRawQuery());
 
             page = webClient.getPage(endpointLocationWithoutQueryUri.toURL());
-            assertEquals("tenant-https:reauthenticated", page.getBody().asText());
+            assertEquals("tenant-https:reauthenticated", page.getBody().asNormalizedText());
             Cookie sessionCookie = getSessionCookie(webClient, "tenant-https_test");
             assertNotNull(sessionCookie);
             webClient.getCookieManager().clearCookies();
@@ -279,7 +279,7 @@ public class CodeFlowTest {
             JsonObject idToken = OidcUtils.decodeJwtContent(sessionCookie.getValue().split("\\|")[0]);
             String expiresAt = idToken.getInteger("exp").toString();
             page = webClient.getPage(endpointLocationWithoutQueryUri.toURL());
-            String response = page.getBody().asText();
+            String response = page.getBody().asNormalizedText();
             assertTrue(
                     response.startsWith("tenant-https:reauthenticated?code=b&expiresAt=" + expiresAt + "&expiresInDuration="));
             Integer duration = Integer.valueOf(response.substring(response.length() - 1));
@@ -430,11 +430,11 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
             page = loginForm.getInputByName("login").click();
-            assertEquals("Tenant Logout, refreshed: false", page.asText());
+            assertEquals("Tenant Logout, refreshed: false", page.asNormalizedText());
             assertNotNull(getSessionCookie(webClient, "tenant-logout"));
 
             page = webClient.getPage("http://localhost:8081/tenant-logout/logout");
-            assertTrue(page.asText().contains("You were logged out"));
+            assertTrue(page.asNormalizedText().contains("You were logged out"));
             assertNull(getSessionCookie(webClient, "tenant-logout"));
 
             page = webClient.getPage("http://localhost:8081/tenant-logout");
@@ -452,7 +452,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
             page = loginForm.getInputByName("login").click();
-            assertEquals("Tenant Refresh, refreshed: false", page.asText());
+            assertEquals("Tenant Refresh, refreshed: false", page.asNormalizedText());
 
             Cookie sessionCookie = getSessionCookie(webClient, "tenant-refresh");
             assertNotNull(sessionCookie);
@@ -479,7 +479,7 @@ public class CodeFlowTest {
 
             // local session refreshed and still valid
             page = webClient.getPage("http://localhost:8081/tenant-refresh");
-            assertEquals("Tenant Refresh, refreshed: false", page.asText());
+            assertEquals("Tenant Refresh, refreshed: false", page.asNormalizedText());
             assertNotNull(getSessionCookie(webClient, "tenant-refresh"));
 
             //wait now so that we reach the refresh timeout
@@ -526,7 +526,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
             page = loginForm.getInputByName("login").click();
-            assertEquals("Tenant AutoRefresh, refreshed: false", page.asText());
+            assertEquals("Tenant AutoRefresh, refreshed: false", page.asNormalizedText());
 
             Cookie sessionCookie = getSessionCookie(webClient, "tenant-autorefresh");
             assertNotNull(sessionCookie);
@@ -535,7 +535,7 @@ public class CodeFlowTest {
             // Auto-refresh-interval is 30 secs so every call auto-refreshes the token
             // Right now the original ID token is still valid but will be auto-refreshed
             page = webClient.getPage("http://localhost:8081/tenant-autorefresh");
-            assertEquals("Tenant AutoRefresh, refreshed: true", page.asText());
+            assertEquals("Tenant AutoRefresh, refreshed: true", page.asNormalizedText());
             sessionCookie = getSessionCookie(webClient, "tenant-autorefresh");
             assertNotNull(sessionCookie);
             String nextIdToken = getIdToken(sessionCookie);
@@ -564,7 +564,7 @@ public class CodeFlowTest {
 
             page = webClient.getPage("http://localhost:8081/web-app");
 
-            assertEquals("alice", page.getBody().asText());
+            assertEquals("alice", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -585,7 +585,7 @@ public class CodeFlowTest {
 
             page = loginForm.getInputByName("login").click();
 
-            assertEquals("callback:alice", page.getBody().asText());
+            assertEquals("callback:alice", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -621,7 +621,7 @@ public class CodeFlowTest {
             assertNull(endpointLocationUri2.getRawQuery());
 
             page = webClient.getPage(endpointLocationUri2.toString());
-            assertEquals("callback-jwt:alice", page.getBody().asText());
+            assertEquals("callback-jwt:alice", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -667,11 +667,11 @@ public class CodeFlowTest {
 
             page = loginForm.getInputByName("login").click();
 
-            assertEquals("web-app2:alice", page.getBody().asText());
+            assertEquals("web-app2:alice", page.getBody().asNormalizedText());
 
             page = webClient.getPage("http://localhost:8081/web-app2/name");
 
-            assertEquals("web-app2:alice", page.getBody().asText());
+            assertEquals("web-app2:alice", page.getBody().asNormalizedText());
 
             assertNull(getStateCookie(webClient, "tenant-2"));
             Cookie sessionCookie = getSessionCookie(webClient, "tenant-2");
@@ -735,7 +735,7 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
             try {
                 page = loginForm.getInputByName("login").click();
-                fail("401 status error is expected: " + page.getBody().asText());
+                fail("401 status error is expected: " + page.getBody().asNormalizedText());
             } catch (FailingHttpStatusCodeException ex) {
                 assertEquals(401, ex.getStatusCode());
                 assertEquals("http://localhost:8081/web-app/callback-before-wrong-redirect",
@@ -764,7 +764,7 @@ public class CodeFlowTest {
 
             page = webClient.getPage("http://localhost:8081/web-app/access");
 
-            assertEquals("AT injected", page.getBody().asText());
+            assertEquals("AT injected", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -788,7 +788,7 @@ public class CodeFlowTest {
 
             page = webClient.getPage("http://localhost:8081/web-app/refresh");
 
-            assertEquals("RT injected", page.getBody().asText());
+            assertEquals("RT injected", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -808,7 +808,7 @@ public class CodeFlowTest {
 
             page = loginForm.getInputByName("login").click();
 
-            assertEquals("RT injected", page.getBody().asText());
+            assertEquals("RT injected", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -827,12 +827,12 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             page = loginForm.getInputByName("login").click();
-            assertEquals("tenant-idtoken-only:alice", page.getBody().asText());
+            assertEquals("tenant-idtoken-only:alice", page.getBody().asNormalizedText());
 
             page = webClient.getPage("http://localhost:8081/web-app/access/tenant-idtoken-only");
-            assertEquals("tenant-idtoken-only:no access", page.getBody().asText());
+            assertEquals("tenant-idtoken-only:no access", page.getBody().asNormalizedText());
             page = webClient.getPage("http://localhost:8081/web-app/refresh/tenant-idtoken-only");
-            assertEquals("tenant-idtoken-only:no refresh", page.getBody().asText());
+            assertEquals("tenant-idtoken-only:no refresh", page.getBody().asNormalizedText());
 
             Cookie idTokenCookie = getSessionCookie(page.getWebClient(), "tenant-idtoken-only");
             checkSingleTokenCookie(idTokenCookie, "ID");
@@ -858,12 +858,12 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             page = loginForm.getInputByName("login").click();
-            assertEquals("tenant-id-refresh-token:alice", page.getBody().asText());
+            assertEquals("tenant-id-refresh-token:alice", page.getBody().asNormalizedText());
 
             page = webClient.getPage("http://localhost:8081/web-app/access/tenant-id-refresh-token");
-            assertEquals("tenant-id-refresh-token:no access", page.getBody().asText());
+            assertEquals("tenant-id-refresh-token:no access", page.getBody().asNormalizedText());
             page = webClient.getPage("http://localhost:8081/web-app/refresh/tenant-id-refresh-token");
-            assertEquals("tenant-id-refresh-token:RT injected", page.getBody().asText());
+            assertEquals("tenant-id-refresh-token:RT injected", page.getBody().asNormalizedText());
 
             Cookie idTokenCookie = getSessionCookie(page.getWebClient(), "tenant-id-refresh-token");
             String[] parts = idTokenCookie.getValue().split("\\|");
@@ -894,12 +894,12 @@ public class CodeFlowTest {
 
             page = loginForm.getInputByName("login").click();
             assertEquals("tenant-split-tokens:alice, id token has 5 parts, access token has 5 parts, refresh token has 5 parts",
-                    page.getBody().asText());
+                    page.getBody().asNormalizedText());
 
             page = webClient.getPage("http://localhost:8081/web-app/access/tenant-split-tokens");
-            assertEquals("tenant-split-tokens:AT injected", page.getBody().asText());
+            assertEquals("tenant-split-tokens:AT injected", page.getBody().asNormalizedText());
             page = webClient.getPage("http://localhost:8081/web-app/refresh/tenant-split-tokens");
-            assertEquals("tenant-split-tokens:RT injected", page.getBody().asText());
+            assertEquals("tenant-split-tokens:RT injected", page.getBody().asNormalizedText());
 
             Cookie idTokenCookie = getSessionCookie(page.getWebClient(), "tenant-split-tokens");
             checkSingleTokenCookie(idTokenCookie, "ID", true);
@@ -949,12 +949,12 @@ public class CodeFlowTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
 
             page = loginForm.getInputByName("login").click();
-            assertEquals("tenant-split-id-refresh-token:alice", page.getBody().asText());
+            assertEquals("tenant-split-id-refresh-token:alice", page.getBody().asNormalizedText());
 
             page = webClient.getPage("http://localhost:8081/web-app/access/tenant-split-id-refresh-token");
-            assertEquals("tenant-split-id-refresh-token:no access", page.getBody().asText());
+            assertEquals("tenant-split-id-refresh-token:no access", page.getBody().asNormalizedText());
             page = webClient.getPage("http://localhost:8081/web-app/refresh/tenant-split-id-refresh-token");
-            assertEquals("tenant-split-id-refresh-token:RT injected", page.getBody().asText());
+            assertEquals("tenant-split-id-refresh-token:RT injected", page.getBody().asNormalizedText());
 
             Cookie idTokenCookie = getSessionCookie(page.getWebClient(), "tenant-split-id-refresh-token");
             checkSingleTokenCookie(idTokenCookie, "ID");
@@ -1026,7 +1026,8 @@ public class CodeFlowTest {
 
             page = loginForm.getInputByName("login").click();
 
-            assertEquals("RT injected(event:OIDC_LOGIN,tenantId:tenant-listener,blockingApi:true)", page.getBody().asText());
+            assertEquals("RT injected(event:OIDC_LOGIN,tenantId:tenant-listener,blockingApi:true)",
+                    page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -1046,7 +1047,7 @@ public class CodeFlowTest {
 
             page = loginForm.getInputByName("login").click();
 
-            assertEquals("RT injected:aValue", page.getBody().asText());
+            assertEquals("RT injected:aValue", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -1129,7 +1130,7 @@ public class CodeFlowTest {
 
             page = loginForm.getInputByName("login").click();
 
-            assertEquals("alice", page.getBody().asText());
+            assertEquals("alice", page.getBody().asNormalizedText());
         }
     }
 

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -56,19 +56,19 @@ public class BearerTokenAuthorizationTest {
             // First call after a redirect, tenant-id is initially calculated from the state `q_auth` cookie.
             // 'reauthenticated' flag is set is because, in fact, it is actually a 2nd call due to
             // quarkus-oidc doing a final redirect after completing a code flow to drop the redirect OIDC parameters
-            assertEquals("tenant-web-app:alice:reauthenticated", page.getBody().asText());
+            assertEquals("tenant-web-app:alice:reauthenticated", page.getBody().asNormalizedText());
             assertNotNull(getSessionCookie(webClient, "tenant-web-app"));
             assertNull(getStateCookie(webClient, "tenant-web-app"));
 
             // Second call after a redirect, tenant-id is calculated from the state `q_session` cookie
             page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app/api/user/webapp");
-            assertEquals("tenant-web-app:alice:reauthenticated", page.getBody().asText());
+            assertEquals("tenant-web-app:alice:reauthenticated", page.getBody().asNormalizedText());
             assertNotNull(getSessionCookie(webClient, "tenant-web-app"));
             assertNull(getStateCookie(webClient, "tenant-web-app"));
 
             // Local logout
             page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app/api/user/webapp?logout=true");
-            assertEquals("tenant-web-app:alice:reauthenticated:logout", page.getBody().asText());
+            assertEquals("tenant-web-app:alice:reauthenticated:logout", page.getBody().asNormalizedText());
             assertNull(getSessionCookie(webClient, "tenant-web-app"));
             assertNull(getStateCookie(webClient, "tenant-web-app"));
 
@@ -98,7 +98,7 @@ public class BearerTokenAuthorizationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
             page = loginForm.getInputByName("login").click();
-            assertEquals("tenant-web-app2:alice", page.getBody().asText());
+            assertEquals("tenant-web-app2:alice", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -114,7 +114,7 @@ public class BearerTokenAuthorizationTest {
             page = loginForm.getInputByName("login").click();
 
             assertEquals("userName: alice, idToken: true, accessToken: true, refreshToken: true",
-                    page.getBody().asText());
+                    page.getBody().asNormalizedText());
 
             Cookie sessionCookie = getSessionCookie(page.getWebClient(), "tenant-web-app-refresh");
             assertNotNull(sessionCookie);
@@ -181,7 +181,7 @@ public class BearerTokenAuthorizationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
             page = loginForm.getInputByName("login").click();
-            assertEquals("alice:web-app", page.getBody().asText());
+            assertEquals("alice:web-app", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -205,7 +205,7 @@ public class BearerTokenAuthorizationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
             page = loginForm.getInputByName("login").click();
-            assertEquals("alice:web-app", page.getBody().asText());
+            assertEquals("alice:web-app", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
         RestAssured.given().auth().oauth2(getAccessToken("alice", "hybrid"))
@@ -228,10 +228,10 @@ public class BearerTokenAuthorizationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
             page = loginForm.getInputByName("login").click();
-            assertEquals("tenant-web-app-no-discovery:alice", page.getBody().asText());
+            assertEquals("tenant-web-app-no-discovery:alice", page.getBody().asNormalizedText());
 
             page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app-no-discovery/api/user/webapp-no-discovery");
-            assertEquals("tenant-web-app-no-discovery:alice", page.getBody().asText());
+            assertEquals("tenant-web-app-no-discovery:alice", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -247,7 +247,7 @@ public class BearerTokenAuthorizationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
             page = loginForm.getInputByName("login").click();
-            assertEquals("tenant-web-app:alice:reauthenticated", page.getBody().asText());
+            assertEquals("tenant-web-app:alice:reauthenticated", page.getBody().asNormalizedText());
             // tenant-web-app2
             page = webClient.getPage("http://localhost:8081/tenant/tenant-web-app2/api/user/webapp2");
             assertNull(getStateCookieSavedPath(webClient, "tenant-web-app2"));
@@ -256,7 +256,7 @@ public class BearerTokenAuthorizationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
             page = loginForm.getInputByName("login").click();
-            assertEquals("tenant-web-app2:alice", page.getBody().asText());
+            assertEquals("tenant-web-app2:alice", page.getBody().asNormalizedText());
 
             webClient.getCookieManager().clearCookies();
         }
@@ -568,7 +568,7 @@ public class BearerTokenAuthorizationTest {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
             page = loginForm.getInputByName("login").click();
-            assertEquals("tenant-web-app-dynamic:alice", page.getBody().asText());
+            assertEquals("tenant-web-app-dynamic:alice", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -69,11 +69,11 @@ public class CodeFlowAuthorizationTest {
 
             page = form.getInputByValue("login").click();
 
-            assertEquals("alice, cache size: 0", page.getBody().asText());
+            assertEquals("alice, cache size: 0", page.getBody().asNormalizedText());
             assertNotNull(getSessionCookie(webClient, "code-flow"));
 
             page = webClient.getPage("http://localhost:8081/code-flow/logout");
-            assertEquals("Welcome, clientId: quarkus-web-app", page.getBody().asText());
+            assertEquals("Welcome, clientId: quarkus-web-app", page.getBody().asNormalizedText());
             assertNull(getSessionCookie(webClient, "code-flow"));
             // Clear the post logout cookie
             webClient.getCookieManager().clearCookies();
@@ -97,7 +97,7 @@ public class CodeFlowAuthorizationTest {
 
             page = form.getInputByValue("login").click();
 
-            assertEquals("user: alice", page.getBody().asText());
+            assertEquals("user: alice", page.getBody().asNormalizedText());
             Cookie sessionCookie = getSessionCookie(webClient, tenant);
             assertNotNull(sessionCookie);
             // default session cookie format: "idtoken|accesstoken|refreshtoken"
@@ -105,7 +105,7 @@ public class CodeFlowAuthorizationTest {
 
             // repeat the call with the session cookie containing the encrypted id token
             page = webClient.getPage("http://localhost:8081/code-flow-encrypted-id-token/" + tenant);
-            assertEquals("user: alice", page.getBody().asText());
+            assertEquals("user: alice", page.getBody().asNormalizedText());
 
             webClient.getCookieManager().clearCookies();
         }
@@ -124,12 +124,12 @@ public class CodeFlowAuthorizationTest {
 
             page = form.getInputByValue("login").click();
 
-            assertEquals("alice", page.getBody().asText());
+            assertEquals("alice", page.getBody().asNormalizedText());
 
             assertNotNull(getSessionCookie(webClient, "code-flow-form-post"));
 
             page = webClient.getPage("http://localhost:8081/code-flow-form-post");
-            assertEquals("alice", page.getBody().asText());
+            assertEquals("alice", page.getBody().asNormalizedText());
 
             // Session is still active
             assertNotNull(getSessionCookie(webClient, "code-flow-form-post"));
@@ -166,12 +166,12 @@ public class CodeFlowAuthorizationTest {
 
             page = form.getInputByValue("login").click();
 
-            assertEquals("alice", page.getBody().asText());
+            assertEquals("alice", page.getBody().asNormalizedText());
 
             assertNotNull(getSessionCookie(webClient, "code-flow-form-post"));
 
             page = webClient.getPage("http://localhost:8081/code-flow-form-post");
-            assertEquals("alice", page.getBody().asText());
+            assertEquals("alice", page.getBody().asNormalizedText());
 
             // Session is still active
             Cookie sessionCookie = getSessionCookie(webClient, "code-flow-form-post");
@@ -225,7 +225,7 @@ public class CodeFlowAuthorizationTest {
 
             page = form.getInputByValue("login").click();
 
-            assertEquals("alice:alice:alice, cache size: 1", page.getBody().asText());
+            assertEquals("alice:alice:alice, cache size: 1", page.getBody().asNormalizedText());
 
             Cookie sessionCookie = getSessionCookie(webClient, tenantId);
             assertNotNull(sessionCookie);
@@ -250,7 +250,7 @@ public class CodeFlowAuthorizationTest {
 
             page = form.getInputByValue("login").click();
 
-            assertEquals("alice:alice:alice, cache size: 0", page.getBody().asText());
+            assertEquals("alice:alice:alice, cache size: 0", page.getBody().asNormalizedText());
 
             Cookie sessionCookie = getSessionCookie(webClient, "code-flow-user-info-github-cached-in-idtoken");
             assertNotNull(sessionCookie);
@@ -260,7 +260,7 @@ public class CodeFlowAuthorizationTest {
             // refresh
             Thread.sleep(3000);
             page = webClient.getPage("http://localhost:8081/code-flow-user-info-github-cached-in-idtoken");
-            assertEquals("alice:alice:bob, cache size: 0", page.getBody().asText());
+            assertEquals("alice:alice:bob, cache size: 0", page.getBody().asNormalizedText());
 
             webClient.getCookieManager().clearCookies();
         }

--- a/integration-tests/smallrye-jwt-oidc-webapp/src/test/java/io/quarkus/it/keycloak/SmallRyeJwtOidcWebAppTest.java
+++ b/integration-tests/smallrye-jwt-oidc-webapp/src/test/java/io/quarkus/it/keycloak/SmallRyeJwtOidcWebAppTest.java
@@ -75,7 +75,7 @@ public class SmallRyeJwtOidcWebAppTest {
 
             page = loginForm.getInputByName("login").click();
 
-            assertEquals("alice", page.getBody().asText());
+            assertEquals("alice", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
         }
     }


### PR DESCRIPTION
An overdue version bump but also a preparation for fixing #30625, as HtmlUnit `Cookie` on the main branch has no way of checking the same site value, while checking manually with all the redirects is tricky 