### PR TITLE
Fix case in path matching in RESTEasy Reactive where templates overshadow static matching

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/PathMatcher.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/PathMatcher.java
@@ -50,6 +50,10 @@ class PathMatcher<T> implements Dumpable {
                 }
             }
         }
+        return defaultMatch(path);
+    }
+
+    PathMatch<T> defaultMatch(String path) {
         return new PathMatch<>("/", path, defaultHandler);
     }
 

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/PathParamOverlapTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/PathParamOverlapTest.java
@@ -1,0 +1,74 @@
+package org.jboss.resteasy.reactive.server.vertx.test.matching;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.function.Supplier;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.RestPath;
+import org.jboss.resteasy.reactive.server.vertx.test.framework.ResteasyReactiveUnitTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class PathParamOverlapTest {
+
+    @RegisterExtension
+    static ResteasyReactiveUnitTest test = new ResteasyReactiveUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(TestResource.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        get("/hello/some/test")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello World!"));
+
+        get("/hello/other/test/new")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello other"));
+
+        get("/hello/some/test/new")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello some"));
+
+        get("/hello/some/test/wrong")
+                .then()
+                .statusCode(404);
+
+        get("/hello/other/test/wrong")
+                .then()
+                .statusCode(404);
+    }
+
+    @Path("/hello")
+    public static class TestResource {
+
+        @GET
+        @Path("/some/test")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String test() {
+            return "Hello World!";
+        }
+
+        @GET
+        @Path("/{id}/test/new")
+        public String second(@RestPath String id) {
+            return "Hello " + id;
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #30667
Fixes: #27154