### PR TITLE
Remove default "password" for key stores

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcSslUtils.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcSslUtils.java
@@ -52,7 +52,6 @@ public class GrpcSslUtils {
         final Optional<Path> certFile = sslConfig.certificate;
         final Optional<Path> keyFile = sslConfig.key;
         final Optional<Path> keyStoreFile = sslConfig.keyStore;
-        final String keystorePassword = sslConfig.keyStorePassword;
         final Optional<Path> trustStoreFile = sslConfig.trustStore;
         final Optional<String> trustStorePassword = sslConfig.trustStorePassword;
 
@@ -77,15 +76,19 @@ public class GrpcSslUtils {
             switch (type) {
                 case "pkcs12": {
                     PfxOptions o = new PfxOptions()
-                            .setPassword(keystorePassword)
                             .setValue(Buffer.buffer(data));
+                    if (sslConfig.keyStorePassword.isPresent()) {
+                        o.setPassword(sslConfig.keyStorePassword.get());
+                    }
                     options.setPfxKeyCertOptions(o);
                     break;
                 }
                 case "jks": {
                     JksOptions o = new JksOptions()
-                            .setPassword(keystorePassword)
                             .setValue(Buffer.buffer(data));
+                    if (sslConfig.keyStorePassword.isPresent()) {
+                        o.setPassword(sslConfig.keyStorePassword.get());
+                    }
                     options.setKeyStoreOptions(o);
                     break;
                 }
@@ -97,7 +100,7 @@ public class GrpcSslUtils {
         }
 
         if (trustStoreFile.isPresent()) {
-            if (!trustStorePassword.isPresent()) {
+            if (trustStorePassword.isEmpty()) {
                 throw new IllegalArgumentException("No trust store password provided");
             }
             String type;

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/SslServerConfig.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/SslServerConfig.java
@@ -44,8 +44,8 @@ public class SslServerConfig {
     /**
      * A parameter to specify the password of the key store file. If not given, the default ("password") is used.
      */
-    @ConfigItem(defaultValue = "password")
-    public String keyStorePassword;
+    @ConfigItem
+    public Optional<String> keyStorePassword;
 
     /**
      * An optional trust store which holds the certificate information of the certificates to trust

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-private-key-store.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-private-key-store.properties
@@ -4,4 +4,6 @@ quarkus.oidc.client-id=quarkus-app
 quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.client-id=${quarkus.oidc.client-id}
 quarkus.oidc-client.credentials.jwt.key-store-file=keystore.jks
+quarkus.oidc-client.credentials.jwt.key-store-password=password
 quarkus.oidc-client.credentials.jwt.key-id=keycloak
+quarkus.oidc-client.credentials.jwt.key-password=password

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -257,10 +257,10 @@ public class OidcCommonConfig {
             public Optional<String> keyStoreFile = Optional.empty();
 
             /**
-             * A parameter to specify the password of the key store file. If not given, the default ("password") is used.
+             * A parameter to specify the password of the key store file.
              */
-            @ConfigItem(defaultValue = "password")
-            public String keyStorePassword;
+            @ConfigItem
+            public Optional<String> keyStorePassword;
 
             /**
              * The private key id/alias
@@ -271,8 +271,8 @@ public class OidcCommonConfig {
             /**
              * The private key password
              */
-            @ConfigItem(defaultValue = "password")
-            public String keyPassword;
+            @ConfigItem
+            public Optional<String> keyPassword;
 
             /**
              * JWT audience ('aud') claim value.
@@ -456,8 +456,8 @@ public class OidcCommonConfig {
         /**
          * A parameter to specify the password of the key store file. If not given, the default ("password") is used.
          */
-        @ConfigItem(defaultValue = "password")
-        public String keyStorePassword;
+        @ConfigItem
+        public Optional<String> keyStorePassword;
 
         /**
          * An optional parameter to select a specific key in the key store. When SNI is disabled, if the key store contains

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CertificateConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CertificateConfig.java
@@ -96,7 +96,7 @@ public class CertificateConfig {
 
     /**
      * A parameter to specify the password of the key store file. If not given, and if it can not be retrieved from
-     * {@linkplain CredentialsProvider}, then the default ("password") is used.
+     * {@linkplain CredentialsProvider}.
      *
      * @see {@link #credentialsProvider}
      */


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/29573.

This should be considered as a breaking change for users using "password" as password.
