### PR TITLE
Use MapProperty instead of Map

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -256,8 +256,9 @@ public abstract class QuarkusBuild extends QuarkusTask {
                 }
             });
         }
-        if (extension().getQuarkusBuildProperties().containsKey(propName)) {
-            return extension().getQuarkusBuildProperties().get(propName);
+        Map<String, String> quarkusBuildProperties = extension().getQuarkusBuildProperties().get();
+        if (quarkusBuildProperties.containsKey(propName)) {
+            return quarkusBuildProperties.get(propName);
         } else if (applicationProperties.contains(propName)) {
             return applicationProperties.getProperty(propName);
         } else if (getQuarkusBuildEnvProperties().containsKey(propName)) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
@@ -34,8 +34,9 @@ public abstract class QuarkusTask extends DefaultTask {
                 realProperties.setProperty(key, (String) value);
             }
         }
-        if (!extension().getQuarkusBuildProperties().isEmpty()) {
-            extension().getQuarkusBuildProperties().entrySet().stream().filter(entry -> entry.getKey().startsWith("quarkus."))
+        Map<String, String> quarkusBuildProperties = extension().getQuarkusBuildProperties().get();
+        if (!quarkusBuildProperties.isEmpty()) {
+            quarkusBuildProperties.entrySet().stream().filter(entry -> entry.getKey().startsWith("quarkus."))
                     .forEach(entry -> {
                         realProperties.put(entry.getKey(), entry.getValue());
                     });


### PR DESCRIPTION
Changes the type of quarkusBuildProperties from Map to MapProperty. This
allows build authors to specify values which may only become available
later in the build by passed into the build using providers.

Follow up to #29971
