### PR TITLE
Set SameSite Strict only on OIDC session cookie

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -603,7 +603,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
     public static class Authentication {
 
         /**
-         * SameSite attribute values for the session, state and post logout cookies.
+         * SameSite attribute values for the session cookie.
          */
         public enum CookieSameSite {
             STRICT,
@@ -767,7 +767,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public Optional<String> cookieDomain = Optional.empty();
 
         /**
-         * SameSite attribute for the session, state and post logout cookies.
+         * SameSite attribute for the session cookie.
          */
         @ConfigItem(defaultValue = "strict")
         public CookieSameSite cookieSameSite = CookieSameSite.STRICT;

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -799,7 +799,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                     public Void apply(String cookieValue) {
                                         String sessionCookie = createCookie(context, configContext.oidcConfig,
                                                 getSessionCookieName(configContext.oidcConfig),
-                                                cookieValue, sessionMaxAge).getValue();
+                                                cookieValue, sessionMaxAge, true).getValue();
                                         if (sessionCookie.length() >= MAX_COOKIE_VALUE_LENGTH) {
                                             LOG.warnf(
                                                     "Session cookie length for the tenant %s is equal or greater than %d bytes."
@@ -914,6 +914,11 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
     static ServerCookie createCookie(RoutingContext context, OidcTenantConfig oidcConfig,
             String name, String value, long maxAge) {
+        return createCookie(context, oidcConfig, name, value, maxAge, false);
+    }
+
+    static ServerCookie createCookie(RoutingContext context, OidcTenantConfig oidcConfig,
+            String name, String value, long maxAge, boolean sessionCookie) {
         ServerCookie cookie = new CookieImpl(name, value);
         cookie.setHttpOnly(true);
         cookie.setSecure(oidcConfig.authentication.cookieForceSecure || context.request().isSSL());
@@ -924,7 +929,9 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         if (auth.cookieDomain.isPresent()) {
             cookie.setDomain(auth.getCookieDomain().get());
         }
-        cookie.setSameSite(CookieSameSite.valueOf(auth.cookieSameSite.name()));
+        if (sessionCookie) {
+            cookie.setSameSite(CookieSameSite.valueOf(auth.cookieSameSite.name()));
+        }
         context.response().addCookie(cookie);
         return cookie;
     }

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -55,9 +55,9 @@ public class CodeFlowTest {
                     .loadWebResponse(new WebRequest(URI.create("http://localhost:8081/index.html").toURL()));
             verifyLocationHeader(webClient, webResponse.getResponseHeaderValue("location"), null, "web-app", false);
 
-            String stateCookieString = webResponse.getResponseHeaderValue("Set-Cookie");
-            assertTrue(stateCookieString.startsWith("q_auth_Default_test="));
-            assertTrue(stateCookieString.contains("SameSite=Strict"));
+            Cookie stateCookie = getStateCookie(webClient, null);
+            assertNotNull(stateCookie);
+            assertNull(stateCookie.getSameSite());
 
             webClient.getCookieManager().clearCookies();
 
@@ -95,6 +95,7 @@ public class CodeFlowTest {
 
             Cookie sessionCookie = getSessionCookie(webClient, null);
             assertNotNull(sessionCookie);
+            assertEquals("strict", sessionCookie.getSameSite());
 
             webClient.getCookieManager().clearCookies();
         }
@@ -176,10 +177,6 @@ public class CodeFlowTest {
             verifyLocationHeader(webClient, keycloakUrl, "tenant-https_test", "xforwarded%2Ftenant-https",
                     true);
 
-            String stateCookieString = webResponse.getResponseHeaderValue("Set-Cookie");
-            assertTrue(stateCookieString.startsWith("q_auth_tenant-https_test="));
-            assertTrue(stateCookieString.contains("SameSite=Lax"));
-
             HtmlPage page = webClient.getPage(keycloakUrl);
 
             assertEquals("Sign in to quarkus", page.getTitleText());
@@ -195,6 +192,7 @@ public class CodeFlowTest {
             String endpointLocation = webResponse.getResponseHeaderValue("location");
 
             Cookie stateCookie = getStateCookie(webClient, "tenant-https_test");
+            assertNull(stateCookie.getSameSite());
             verifyCodeVerifier(stateCookie, keycloakUrl);
 
             assertTrue(endpointLocation.startsWith("https"));
@@ -222,6 +220,7 @@ public class CodeFlowTest {
             assertEquals("tenant-https:reauthenticated", page.getBody().asNormalizedText());
             Cookie sessionCookie = getSessionCookie(webClient, "tenant-https_test");
             assertNotNull(sessionCookie);
+            assertEquals("lax", sessionCookie.getSameSite());
             webClient.getCookieManager().clearCookies();
         }
     }


### PR DESCRIPTION
Fixes #30625.

OIDC session cookie (represents the current user authentication) but also state cookie (which is used to coordinate the code flow with Keycloak where a returned `state` query parameter is matched against it) and the logout cookie (helper cookie for the Quarkus app to verify the post logout is correct) were all set to have `SameSite=Strict` attribute as part of the hardening effort for various cookies.

Unfortunately it has caused the immediate side-effects when using the browser with providers incl Keycloak (see #30625, I confirmed it) which can only be fixed by configuring that `SameSite=Lax` is used. 

I missed it as HtmlUnit was not enforcing the SameStrict policy correctly for the cross-site redirects and DevServices for Keycloak is not affected as it has its own SPA. 

It has to be reverted at least on `main`/`2.16` branches. Looks like some providers are not affected (ex GitHub) but in general, expecting users having to configure `samesite=lax` to fix the problem is not a good evolution of quarkus-oidc.
FYI, the session cookie will remain `samesite=strict` but also can be configured to be `samesite=lax`.

Updated the tests to verify it is now the case: 1) no `SameSite` attribute for state/logout cookies - which means it is the Lax default value 2) session cookie is same site strict by default, lax if requested in the config.
