### PR TITLE
Remove explicit mock-maker-inline configs

### DIFF
--- a/extensions/grpc/runtime/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/extensions/grpc/runtime/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/extensions/mongodb-client/runtime/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/extensions/mongodb-client/runtime/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/extensions/example-extension/deployment/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/extensions/example-extension/deployment/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/test-framework/junit5-internal/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/test-framework/junit5-internal/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline


### PR DESCRIPTION
It's the default now in Mockito 5.