### PR TITLE
Use quotes for the path to find maven basedir in mvnw

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/maven-wrapper/base/mvnw.tpl.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/maven-wrapper/base/mvnw.tpl.qute
@@ -164,7 +164,7 @@ concat_lines() {
   fi
 }
 
-BASE_DIR=$(find_maven_basedir "$(dirname $0)")
+BASE_DIR=$(find_maven_basedir "$(dirname "$0")")
 if [ -z "$BASE_DIR" ]; then
   exit 1;
 fi


### PR DESCRIPTION
Use quotes for the path to find maven basedir in mvnw

Fixes https://github.com/quarkusio/quarkus/issues/30642

Sync with the latest wrapper upstream changes https://github.com/apache/maven-wrapper/blob/master/maven-wrapper-distribution/src/resources/mvnw#L173

CC @jorsol


Old info (see comments for the details):
`pwd` was used before https://github.com/quarkusio/quarkus/pull/30108 changes

https://github.com/apache/maven-wrapper/commit/e87947e893bbf8aba1827cf1fae10b422655c9b7 changed the line in upstream, imho cosmetic and [MWRAPPER-56](https://issues.apache.org/jira/browse/MWRAPPER-56) unrelated change that caused regression in behavior on Quarkus CLI side

