### PR TITLE
Improve JDBC driver error message in Agroal processor

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.enterprise.inject.Default;
 import javax.inject.Singleton;
@@ -344,14 +345,13 @@ class AgroalProcessor {
             }
         }
 
-        throw new ConfigurationException("Unable to find a JDBC driver corresponding to the database kind '"
-                + dbKind + "' for the "
-                + (DataSourceUtil.isDefault(dataSourceName) ? "default datasource"
-                        : "datasource '" + dataSourceName + "'")
-                + ". Either provide a suitable JDBC driver extension, define the driver manually, or disable the JDBC datasource by adding "
-                + (DataSourceUtil.isDefault(dataSourceName) ? "'quarkus.datasource.jdbc=false'"
-                        : "'quarkus.datasource." + dataSourceName + ".jdbc=false'")
-                + " to your configuration if you don't need it.");
+        throw new ConfigurationException(String.format(
+                "Unable to find a JDBC driver corresponding to the database kind '%s' for the %s (available: '%s'). "
+                        + "Check if it's a typo, otherwise provide a suitable JDBC driver extension, define the driver manually, or disable the JDBC datasource by adding %s to your configuration if you don't need it.",
+                dbKind, DataSourceUtil.isDefault(dataSourceName) ? "default datasource" : "datasource '" + dataSourceName + "'",
+                jdbcDriverBuildItems.stream().map(JdbcDriverBuildItem::getDbKind).collect(Collectors.joining("','")),
+                DataSourceUtil.isDefault(dataSourceName) ? "'quarkus.datasource.jdbc=false'"
+                        : "'quarkus.datasource." + dataSourceName + ".jdbc=false'"));
     }
 
     @BuildStep

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -347,11 +347,11 @@ class AgroalProcessor {
 
         throw new ConfigurationException(String.format(
                 "Unable to find a JDBC driver corresponding to the database kind '%s' for the %s (available: '%s'). "
-                        + "Check if it's a typo, otherwise provide a suitable JDBC driver extension, define the driver manually, or disable the JDBC datasource by adding %s to your configuration if you don't need it.",
+                        + "Check if it's a typo, otherwise provide a suitable JDBC driver extension, define the driver manually,"
+                        + " or disable the JDBC datasource by adding '%s=false' to your configuration if you don't need it.",
                 dbKind, DataSourceUtil.isDefault(dataSourceName) ? "default datasource" : "datasource '" + dataSourceName + "'",
                 jdbcDriverBuildItems.stream().map(JdbcDriverBuildItem::getDbKind).collect(Collectors.joining("','")),
-                DataSourceUtil.isDefault(dataSourceName) ? "'quarkus.datasource.jdbc=false'"
-                        : "'quarkus.datasource." + dataSourceName + ".jdbc=false'"));
+                DataSourceUtil.dataSourcePropertyKey(dataSourceName, "jdbc")));
     }
 
     @BuildStep

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -138,16 +138,10 @@ public class DataSources {
 
         DataSourceSupport.Entry matchingSupportEntry = dataSourceSupport.entries.get(dataSourceName);
         if (!dataSourceJdbcRuntimeConfig.url.isPresent()) {
-            String errorMessage;
-            // we don't have any URL configuration so using a standard message
-            if (DataSourceUtil.isDefault(dataSourceName)) {
-                errorMessage = "quarkus.datasource.jdbc.url has not been defined";
-            } else {
-                errorMessage = "quarkus.datasource." + dataSourceName + ".jdbc.url has not been defined";
-            }
             //this is not an error situation, because we want to allow the situation where a JDBC extension
             //is installed but has not been configured
-            return new UnconfiguredDataSource(errorMessage);
+            return new UnconfiguredDataSource(
+                    DataSourceUtil.dataSourcePropertyKey(dataSourceName, "jdbc.url") + " has not been defined");
         }
 
         // we first make sure that all available JDBC drivers are loaded in the current TCCL

--- a/extensions/datasource/common/src/main/java/io/quarkus/datasource/common/runtime/DataSourceUtil.java
+++ b/extensions/datasource/common/src/main/java/io/quarkus/datasource/common/runtime/DataSourceUtil.java
@@ -15,6 +15,14 @@ public final class DataSourceUtil {
         return dataSourceNames.contains(DEFAULT_DATASOURCE_NAME);
     }
 
+    public static String dataSourcePropertyKey(String datasourceName, String radical) {
+        if (datasourceName == null || DataSourceUtil.isDefault(datasourceName)) {
+            return "quarkus.datasource." + radical;
+        } else {
+            return "quarkus.datasource.\"" + datasourceName + "\"." + radical;
+        }
+    }
+
     public static List<String> dataSourcePropertyKeys(String datasourceName, String radical) {
         if (datasourceName == null || DataSourceUtil.isDefault(datasourceName)) {
             return List.of("quarkus.datasource." + radical);


### PR DESCRIPTION
This improves the error message when the DB Kind is not found.

```
Unable to find a JDBC driver corresponding to the database kind 'postgres' for the default datasource (available: 'postgresql'). Check if it's a typo, otherwise provide a suitable JDBC driver extension, define the
driver manually, or disable the JDBC datasource by adding 'quarkus.datasource.jdbc=false' to your configuration if you don't need it.
```

Based on feedback from https://github.com/quarkusio/quarkus/issues/30701#issuecomment-1410757424
