### PR TITLE
Allow same origin CORS requests without 3rd party origins being configured

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSameOriginWithoutOriginConfigTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSameOriginWithoutOriginConfigTestCase.java
@@ -1,0 +1,36 @@
+package io.quarkus.vertx.http.cors;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class CORSSameOriginWithoutOriginConfigTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BeanRegisteringRoute.class)
+                    .addAsResource("conf/cors-same-origin-only.properties", "application.properties"));
+
+    @Test
+    void corsSameOriginRequest() {
+        String origin = "http://localhost:8081";
+        given().header("Origin", origin)
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin);
+    }
+
+    @Test
+    void corsInvalidSameOriginRequest() {
+        String origin = "http://externalhost:8081";
+        given().header("Origin", origin)
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/resources/conf/cors-same-origin-only.properties
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/cors-same-origin-only.properties
@@ -1,0 +1,1 @@
+quarkus.http.cors=true

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
@@ -187,10 +187,13 @@ public class CORSFilter implements Handler<RoutingContext> {
 
             boolean allowsOrigin = wildcardOrigin;
             if (!allowsOrigin) {
-                allowsOrigin = !corsConfig.origins.isEmpty()
-                        && (corsConfig.origins.get().contains(origin)
-                                || isOriginAllowedByRegex(allowedOriginsRegex, origin)
-                                || isSameOrigin(request, origin));
+                if (!corsConfig.origins.isEmpty()) {
+                    allowsOrigin = corsConfig.origins.get().contains(origin)
+                            || isOriginAllowedByRegex(allowedOriginsRegex, origin)
+                            || isSameOrigin(request, origin);
+                } else {
+                    allowsOrigin = isSameOrigin(request, origin);
+                }
             }
 
             if (allowsOrigin) {


### PR DESCRIPTION
Fixes #30698.

Earlier, when `CORSFilter` was enabling wildcard `*` Origins out of the box, the same origin requests were allowed by simply configuring `quarkus.http.cors=true`, but there was a hidden cost related to `*`.

Now that the `*` is not enabled by default, the same origin requests are only allowed if the `quarkus.http.cors.origins` is configured. More specifically, the same origin requests are allowed without having to configure them only if `quarkus.http.cors.origins`  contains 3rd party origins. 

If it is just a single-origin case as i #30698 then one needs to configure a wildcard or same origin URLs - but it should not be necessary if we allow now the auto same origin checks with the configured non-matching origins.

For example, right now, if we have
```
quarkus.http.cors=true
quarkus.http.cors.origins=github.com
```

then the same origin request to `http://localhost:8081` will be allowed.

But if we only have 

```
quarkus.http.cors=true
```

then the same origin request to `http://localhost:8081` will not be allowed, which I believe should be fixed.

