### PR TITLE
Remove duplicate notification of SseBroadcaster's onErrorListeners

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseBroadcasterImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseBroadcasterImpl.java
@@ -127,11 +127,4 @@ public class SseBroadcasterImpl implements SseBroadcaster {
             listener.accept(sseEventSink);
         }
     }
-
-    synchronized void fireException(SseEventSinkImpl sseEventSink, Throwable t) {
-        for (BiConsumer<SseEventSink, Throwable> listener : onErrorListeners) {
-            listener.accept(sseEventSink, t);
-        }
-    }
-
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseEventSinkImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseEventSinkImpl.java
@@ -32,15 +32,7 @@ public class SseEventSinkImpl implements SseEventSink {
         if (isClosed())
             throw new IllegalStateException("Already closed");
         // NOTE: we can't cast event to OutboundSseEventImpl because the TCK sends us its own subclass
-        CompletionStage<?> ret = SseUtil.send(context, event, Collections.emptyList());
-        if (broadcaster != null) {
-            return ret.whenComplete((value, x) -> {
-                if (x != null) {
-                    broadcaster.fireException(this, x);
-                }
-            });
-        }
-        return ret;
+        return SseUtil.send(context, event, Collections.emptyList());
     }
 
     @Override


### PR DESCRIPTION
Follow-up to #30686

onErrorListeners of SseBroadcasterImpl are being notified by SseEventSinkImpl#send(). After #30686, they are also being notified by SseBroadcasterImpl#broadcast().

SseBroadcasterImpl is the more reasonable place for the notification (to avoid being overlooked), so remove the duplicate notification in SseEventSinkImpl.