### PR TITLE
Fix RemoveDeploymentTriggerDecorator order

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ChangeDeploymentTriggerDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ChangeDeploymentTriggerDecorator.java
@@ -11,6 +11,6 @@ public class ChangeDeploymentTriggerDecorator extends ApplyDeploymentTriggerDeco
 
     @Override
     public Class<? extends Decorator>[] after() {
-        return new Class[] { ApplyDeploymentTriggerDecorator.class, RemoveDeploymentTriggerDecorator.class };
+        return new Class[] { ApplyDeploymentTriggerDecorator.class };
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
@@ -322,7 +322,7 @@ public class OpenshiftProcessor {
                 String imageStreamWithTag = name + ":" + i.getTag();
                 result.add(new DecoratorBuildItem(OPENSHIFT, new ApplyContainerImageDecorator(name, imageStreamWithTag)));
                 // remove the default trigger which has a wrong version
-                result.add(new DecoratorBuildItem(OPENSHIFT, new RemoveDeploymentTriggerDecorator()));
+                result.add(new DecoratorBuildItem(OPENSHIFT, new RemoveDeploymentTriggerDecorator(name)));
                 // re-add the trigger with the correct version
                 result.add(new DecoratorBuildItem(OPENSHIFT, new ChangeDeploymentTriggerDecorator(name, imageStreamWithTag)));
             });

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveDeploymentTriggerDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveDeploymentTriggerDecorator.java
@@ -4,11 +4,14 @@ import java.util.Collections;
 
 import io.dekorate.kubernetes.decorator.Decorator;
 import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
-import io.dekorate.openshift.decorator.ApplyDeploymentTriggerDecorator;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.openshift.api.model.DeploymentConfigSpecFluent;
 
 public class RemoveDeploymentTriggerDecorator extends NamedResourceDecorator<DeploymentConfigSpecFluent<?>> {
+
+    public RemoveDeploymentTriggerDecorator(String name) {
+        super(name);
+    }
 
     @Override
     public void andThenVisit(DeploymentConfigSpecFluent<?> deploymentConfigSpec, ObjectMeta objectMeta) {
@@ -16,7 +19,7 @@ public class RemoveDeploymentTriggerDecorator extends NamedResourceDecorator<Dep
     }
 
     @Override
-    public Class<? extends Decorator>[] after() {
-        return new Class[] { ApplyDeploymentTriggerDecorator.class };
+    public Class<? extends Decorator>[] before() {
+        return new Class[] { ChangeDeploymentTriggerDecorator.class };
     }
 }


### PR DESCRIPTION
The decorator RemoveDeploymentTriggerDecorator was not configured to be triggered before ChangeDeploymentTriggerDecorator, so sometimes the image stream tag was wrong.

This change fixes the failure spotted by the test OpenshiftWithDockerAndImageTest where the image stream tag was sometimes 0.1-SNAPSHOT and other times 1.0 when it should be always 1.0.

Relates to the random failures in https://github.com/dekorateio/dekorate/actions/runs/4023231521/jobs/6913879180 and also in the jakarta-rewrite branch