### PR TITLE
<artifactId> uses 'quarkus.platform.artifact-id' property

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -93,7 +93,7 @@ In addition, you can see the `quarkus-maven-plugin` responsible of the packaging
     <dependencies>
         <dependency>
             <groupId>${quarkus.platform.group-id}</groupId>
-            <artifactId>quarkus-bom</artifactId>
+            <artifactId>${quarkus.platform.artifact-id}</artifactId>
             <version>${quarkus.platform.version}</version>
             <type>pom</type>
             <scope>import</scope>


### PR DESCRIPTION
Following https://quarkus.io/guides/getting-started, the user gets a `pom.xml` with `<artifactId>${quarkus.platform.artifact-id}</artifactId>` in the BOM import definition. 