### PR TITLE
Bump Reactive Messaging version to 3.23.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -55,7 +55,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>2.7.0</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>2.30.1</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>3.22.1</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>3.23.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>1.4.1</smallrye-stork.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>

--- a/integration-tests/opentelemetry-reactive-messaging/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
+++ b/integration-tests/opentelemetry-reactive-messaging/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
@@ -163,7 +163,7 @@ public class OpenTelemetryTestCase {
         Assertions.assertEquals("opentelemetry-integration-test", spanData.get("attr_messaging.kafka.consumer_group"));
         Assertions.assertEquals("0", spanData.get("attr_messaging.kafka.partition"));
         Assertions.assertEquals("kafka-consumer-" + channel, spanData.get("attr_messaging.kafka.client_id"));
-        Assertions.assertEquals("0", spanData.get("attr_offset"));
+        Assertions.assertEquals("0", spanData.get("attr_messaging.kafka.message.offset"));
     }
 
     private void verifyCdiCall(Map<String, Object> spanData, Map<String, Object> parentSpanData) {

--- a/jakarta/rewrite.yml
+++ b/jakarta/rewrite.yml
@@ -632,7 +632,7 @@ recipeList:
       newValue: '3.0.0'
   - org.openrewrite.maven.ChangePropertyValue:
       key: smallrye-reactive-messaging.version
-      newValue: '4.1.1'
+      newValue: '4.2.0'
   - org.openrewrite.maven.ChangePropertyValue:
       key: microprofile-rest-client.version
       newValue: '3.0'


### PR DESCRIPTION
- Fixes #22906

https://github.com/smallrye/smallrye-reactive-messaging/releases/tag/3.23.0