### PR TITLE
Support file and byte array attachments in `MailTemplateInstance`

### DIFF
--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
@@ -56,6 +56,12 @@ public interface MailTemplate {
 
         MailTemplateInstance addInlineAttachment(String name, File file, String contentType, String contentId);
 
+        MailTemplateInstance addInlineAttachment(String name, byte[] data, String contentType, String contentId);
+
+        MailTemplateInstance addAttachment(String name, File file, String contentType);
+
+        MailTemplateInstance addAttachment(String name, byte[] data, String contentType);
+
         /**
          *
          * @param key

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateInstanceImpl.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/runtime/MailTemplateInstanceImpl.java
@@ -88,6 +88,24 @@ class MailTemplateInstanceImpl implements MailTemplate.MailTemplateInstance {
     }
 
     @Override
+    public MailTemplateInstance addInlineAttachment(String name, byte[] data, String contentType, String contentId) {
+        this.mail.addInlineAttachment(name, data, contentType, contentId);
+        return this;
+    }
+
+    @Override
+    public MailTemplateInstance addAttachment(String name, File file, String contentType) {
+        this.mail.addAttachment(name, file, contentType);
+        return this;
+    }
+
+    @Override
+    public MailTemplateInstance addAttachment(String name, byte[] data, String contentType) {
+        this.mail.addAttachment(name, data, contentType);
+        return this;
+    }
+
+    @Override
     public MailTemplateInstance data(String key, Object value) {
         this.templateInstance.data(key, value);
         return this;


### PR DESCRIPTION
Included missing `add*Attachment` methods 

- Fixes #30805