### PR TITLE
Remove tika configuration from the bot

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -567,13 +567,6 @@ triage:
       directories:
         - extensions/vertx
         - integration-tests/vertx
-    - id: tika
-      labels: [area/tika]
-      title: tika
-      notify: [sberyozkin]
-      directories:
-        - extensions/tika/
-        - integration-tests/tika/
     - id: testing
       title: "quarkusintegrationtest"
       labels: [area/testing]


### PR DESCRIPTION
This extension has long been moved to the Quarkiverse