### PR TITLE
ArC - reduce allocations for intercepted methods

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -674,6 +674,21 @@ public class BeanDeployment {
         return alternativePriorities != null ? alternativePriorities.compute(target, stereotypes) : null;
     }
 
+    Set<MethodInfo> getObserverAndProducerMethods() {
+        Set<MethodInfo> ret = new HashSet<>();
+        for (ObserverInfo observer : observers) {
+            if (!observer.isSynthetic()) {
+                ret.add(observer.getObserverMethod());
+            }
+        }
+        for (BeanInfo bean : beans) {
+            if (bean.isProducerMethod()) {
+                ret.add(bean.getTarget().get().asMethod());
+            }
+        }
+        return ret;
+    }
+
     private void buildContextPut(String key, Object value) {
         if (buildContext != null) {
             buildContext.putInternal(key, value);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -626,7 +626,7 @@ public class BeanInfo implements InjectionTargetInfo {
         ClassInfo classInfo = target.get().asClass();
         addDecoratedMethods(candidates, classInfo, classInfo, bound,
                 new SubclassSkipPredicate(beanDeployment.getAssignabilityCheck()::isAssignableFrom,
-                        beanDeployment.getBeanArchiveIndex()));
+                        beanDeployment.getBeanArchiveIndex(), beanDeployment.getObserverAndProducerMethods()));
 
         Map<MethodInfo, DecorationInfo> decoratedMethods = new HashMap<>(candidates.size());
         for (Entry<MethodKey, DecorationInfo> entry : candidates.entrySet()) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -163,9 +163,7 @@ public final class MethodDescriptors {
 
     public static final MethodDescriptor INVOCATION_CONTEXTS_PERFORM_AROUND_INVOKE = MethodDescriptor.ofMethod(
             InvocationContexts.class,
-            "performAroundInvoke",
-            Object.class, Object.class, Method.class, Function.class, Object[].class, List.class,
-            Set.class);
+            "performAroundInvoke", Object.class, Object.class, Object[].class, InterceptedMethodMetadata.class);
 
     public static final MethodDescriptor INVOCATION_CONTEXTS_AROUND_CONSTRUCT = MethodDescriptor.ofMethod(
             InvocationContexts.class,
@@ -230,7 +228,7 @@ public final class MethodDescriptors {
 
     public static final MethodDescriptor INTERCEPTED_METHOD_METADATA_CONSTRUCTOR = MethodDescriptor.ofConstructor(
             InterceptedMethodMetadata.class,
-            List.class, Method.class, Set.class);
+            List.class, Method.class, Set.class, Function.class);
 
     public static final MethodDescriptor CREATIONAL_CTX_HAS_DEPENDENT_INSTANCES = MethodDescriptor.ofMethod(
             CreationalContextImpl.class,

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -554,6 +554,9 @@ final class Methods {
                 // Skip bridge methods that have a corresponding "implementation method" on the same class
                 // The algorithm we use to detect these methods is best effort, i.e. there might be use cases where the detection fails
                 return hasImplementation(method);
+            } else if (method.isSynthetic()) {
+                // Skip non-bridge synthetic methods
+                return true;
             }
             if (method.hasAnnotation(DotNames.POST_CONSTRUCT) || method.hasAnnotation(DotNames.PRE_DESTROY)) {
                 // @PreDestroy and @PostConstruct methods declared on the bean are NOT candidates for around invoke interception

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -4,7 +4,6 @@ import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 
-import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -74,12 +73,6 @@ public class SubclassGenerator extends AbstractGenerator {
 
     protected static final String FIELD_NAME_PREDESTROYS = "arc$preDestroys";
     protected static final String FIELD_NAME_CONSTRUCTED = "arc$constructed";
-    protected static final FieldDescriptor FIELD_METADATA_METHOD = FieldDescriptor.of(InterceptedMethodMetadata.class, "method",
-            Method.class);
-    protected static final FieldDescriptor FIELD_METADATA_CHAIN = FieldDescriptor.of(InterceptedMethodMetadata.class, "chain",
-            List.class);
-    protected static final FieldDescriptor FIELD_METADATA_BINDINGS = FieldDescriptor.of(InterceptedMethodMetadata.class,
-            "bindings", Set.class);
 
     private final Predicate<DotName> applicationClassPredicate;
     private final Set<String> existingClasses;
@@ -349,6 +342,7 @@ public class SubclassGenerator extends AbstractGenerator {
             }
 
             MethodDescriptor methodDescriptor = MethodDescriptor.of(method);
+            MethodDescriptor originalMethodDescriptor = MethodDescriptor.of(method);
             InterceptionInfo interception = bean.getInterceptedMethods().get(method);
             DecorationInfo decoration = bean.getDecoratedMethods().get(method);
             MethodDescriptor forwardDescriptor = forwardingMethods.get(methodDescriptor);
@@ -392,10 +386,58 @@ public class SubclassGenerator extends AbstractGenerator {
                             initMetadataMethodFinal.getMethodParam(1), initMetadataMethodFinal.load(bindingKey));
                 });
 
+                DecoratorInfo decorator = decoration != null ? decoration.decorators.get(0) : null;
+                ResultHandle decoratorHandle = null;
+                if (decorator != null) {
+                    decoratorHandle = initMetadataMethod.readInstanceField(FieldDescriptor.of(subclass.getClassName(),
+                            decorator.getIdentifier(), Object.class.getName()), initMetadataMethod.getThis());
+                }
+
+                // Instantiate the forwarding function
+                // Function<InvocationContext, Object> forward = ctx -> super.foo((java.lang.String)ctx.getParameters()[0])
+                FunctionCreator func = initMetadataMethod.createFunction(Function.class);
+                BytecodeCreator funcBytecode = func.getBytecode();
+                ResultHandle ctxHandle = funcBytecode.getMethodParam(0);
+                ResultHandle[] superParamHandles;
+                if (parameters.isEmpty()) {
+                    superParamHandles = new ResultHandle[0];
+                } else {
+                    superParamHandles = new ResultHandle[parameters.size()];
+                    ResultHandle ctxParamsHandle = funcBytecode.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(InvocationContext.class, "getParameters", Object[].class),
+                            ctxHandle);
+                    // autoboxing is handled inside Gizmo
+                    for (int i = 0; i < superParamHandles.length; i++) {
+                        superParamHandles[i] = funcBytecode.readArrayValue(ctxParamsHandle, i);
+                    }
+                }
+                // If a decorator is bound then invoke the method upon the decorator instance instead of the generated forwarding method
+                if (decorator != null) {
+                    AssignableResultHandle funDecoratorInstance = funcBytecode.createVariable(Object.class);
+                    funcBytecode.assign(funDecoratorInstance, decoratorHandle);
+                    String declaringClass = decorator.getBeanClass().toString();
+                    if (decorator.isAbstract()) {
+                        String baseName = DecoratorGenerator.createBaseName(decorator.getTarget().get().asClass());
+                        String targetPackage = DotNames.packageName(decorator.getProviderType().name());
+                        declaringClass = generatedNameFromTarget(targetPackage, baseName,
+                                DecoratorGenerator.ABSTRACT_IMPL_SUFFIX);
+                    }
+                    MethodDescriptor virtualMethodDescriptor = MethodDescriptor.ofMethod(declaringClass,
+                            originalMethodDescriptor.getName(),
+                            originalMethodDescriptor.getReturnType(), originalMethodDescriptor.getParameterTypes());
+                    funcBytecode
+                            .returnValue(funcBytecode.invokeVirtualMethod(virtualMethodDescriptor, funDecoratorInstance,
+                                    superParamHandles));
+                } else {
+                    ResultHandle superResult = funcBytecode.invokeVirtualMethod(forwardDescriptor, initMetadataMethod.getThis(),
+                            superParamHandles);
+                    funcBytecode.returnValue(superResult != null ? superResult : funcBytecode.loadNull());
+                }
+
                 // Now create metadata for the given intercepted method
                 ResultHandle methodMetadataHandle = initMetadataMethod.newInstance(
                         MethodDescriptors.INTERCEPTED_METHOD_METADATA_CONSTRUCTOR,
-                        chainHandle, methodHandle, bindingsHandle);
+                        chainHandle, methodHandle, bindingsHandle, func.getInstance());
 
                 FieldDescriptor metadataField = FieldDescriptor.of(subclass.getClassName(), "arc$" + methodIdx++,
                         InterceptedMethodMetadata.class.getName());
@@ -769,52 +811,6 @@ public class SubclassGenerator extends AbstractGenerator {
             notConstructed.returnValue(notConstructed.invokeVirtualMethod(forwardMethod, notConstructed.getThis(), params));
         }
 
-        ResultHandle decoratorHandle = null;
-        if (decorator != null) {
-            decoratorHandle = interceptedMethod.readInstanceField(FieldDescriptor.of(subclass.getClassName(),
-                    decorator.getIdentifier(), Object.class.getName()), interceptedMethod.getThis());
-        }
-
-        // Forwarding function
-        // Function<InvocationContext, Object> forward = ctx -> super.foo((java.lang.String)ctx.getParameters()[0])
-        FunctionCreator func = interceptedMethod.createFunction(Function.class);
-        BytecodeCreator funcBytecode = func.getBytecode();
-        ResultHandle ctxHandle = funcBytecode.getMethodParam(0);
-        ResultHandle[] superParamHandles;
-        if (parameters.isEmpty()) {
-            superParamHandles = new ResultHandle[0];
-        } else {
-            superParamHandles = new ResultHandle[parameters.size()];
-            ResultHandle ctxParamsHandle = funcBytecode.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(InvocationContext.class, "getParameters", Object[].class),
-                    ctxHandle);
-            // autoboxing is handled inside Gizmo
-            for (int i = 0; i < superParamHandles.length; i++) {
-                superParamHandles[i] = funcBytecode.readArrayValue(ctxParamsHandle, i);
-            }
-        }
-        // If a decorator is bound then invoke the method upon the decorator instance instead of the generated forwarding method
-        if (decorator != null) {
-            AssignableResultHandle funDecoratorInstance = funcBytecode.createVariable(Object.class);
-            funcBytecode.assign(funDecoratorInstance, decoratorHandle);
-            String declaringClass = decorator.getBeanClass().toString();
-            if (decorator.isAbstract()) {
-                String baseName = DecoratorGenerator.createBaseName(decorator.getTarget().get().asClass());
-                String targetPackage = DotNames.packageName(decorator.getProviderType().name());
-                declaringClass = generatedNameFromTarget(targetPackage, baseName, DecoratorGenerator.ABSTRACT_IMPL_SUFFIX);
-            }
-            MethodDescriptor methodDescriptor = MethodDescriptor.ofMethod(
-                    declaringClass, originalMethodDescriptor.getName(),
-                    originalMethodDescriptor.getReturnType(), originalMethodDescriptor.getParameterTypes());
-            funcBytecode
-                    .returnValue(funcBytecode.invokeVirtualMethod(methodDescriptor, funDecoratorInstance, superParamHandles));
-
-        } else {
-            ResultHandle superResult = funcBytecode.invokeVirtualMethod(forwardMethod, interceptedMethod.getThis(),
-                    superParamHandles);
-            funcBytecode.returnValue(superResult != null ? superResult : funcBytecode.loadNull());
-        }
-
         for (Type declaredException : method.exceptions()) {
             interceptedMethod.addException(declaredException.name().toString());
         }
@@ -857,10 +853,7 @@ public class SubclassGenerator extends AbstractGenerator {
         // InvocationContexts.performAroundInvoke(...)
         ResultHandle methodMetadataHandle = tryCatch.readInstanceField(metadataField, tryCatch.getThis());
         ResultHandle ret = tryCatch.invokeStaticMethod(MethodDescriptors.INVOCATION_CONTEXTS_PERFORM_AROUND_INVOKE,
-                tryCatch.getThis(),
-                tryCatch.readInstanceField(FIELD_METADATA_METHOD, methodMetadataHandle), func.getInstance(), paramsHandle,
-                tryCatch.readInstanceField(FIELD_METADATA_CHAIN, methodMetadataHandle),
-                tryCatch.readInstanceField(FIELD_METADATA_BINDINGS, methodMetadataHandle));
+                tryCatch.getThis(), paramsHandle, methodMetadataHandle);
         tryCatch.returnValue(ret);
     }
 

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/SubclassSkipPredicateTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/SubclassSkipPredicateTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -24,7 +25,8 @@ public class SubclassSkipPredicateTest {
     public void testPredicate() throws IOException {
         IndexView index = Basics.index(Base.class, Submarine.class, Long.class, Number.class);
         AssignabilityCheck assignabilityCheck = new AssignabilityCheck(index, null);
-        SubclassSkipPredicate predicate = new SubclassSkipPredicate(assignabilityCheck::isAssignableFrom, null);
+        SubclassSkipPredicate predicate = new SubclassSkipPredicate(assignabilityCheck::isAssignableFrom, null,
+                Collections.emptySet());
 
         ClassInfo submarineClass = index.getClassByName(DotName.createSimple(Submarine.class.getName()));
         predicate.startProcessing(submarineClass, submarineClass);

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundConstructInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundConstructInvocationContext.java
@@ -11,16 +11,34 @@ import java.util.function.Supplier;
  */
 class AroundConstructInvocationContext extends LifecycleCallbackInvocationContext {
 
+    private final Constructor<?> constructor;
     private final Supplier<Object> aroundConstructForward;
 
     AroundConstructInvocationContext(Constructor<?> constructor, Object[] parameters, Set<Annotation> interceptorBindings,
             List<InterceptorInvocation> chain, Supplier<Object> aroundConstructForward) {
-        super(null, constructor, parameters, interceptorBindings, chain);
+        super(null, parameters, interceptorBindings, chain);
         this.aroundConstructForward = aroundConstructForward;
+        this.constructor = constructor;
     }
 
     protected void interceptorChainCompleted() throws Exception {
         target = aroundConstructForward.get();
+    }
+
+    @Override
+    public Constructor<?> getConstructor() {
+        return constructor;
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public void setParameters(Object[] params) {
+        validateParameters(constructor, params);
+        this.parameters = params;
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundInvokeInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundInvokeInvocationContext.java
@@ -1,57 +1,77 @@
 package io.quarkus.arc.impl;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 
-import jakarta.interceptor.InvocationContext;
+import io.quarkus.arc.ArcInvocationContext;
 
 /**
- * Special type of InvocationContext for AroundInvoke interceptors.
+ * An {@link javax.interceptor.InvocationContext} for {@link javax.interceptor.AroundInvoke} interceptors.
  * <p>
- * A new instance of {@link AroundInvokeInvocationContext} is created for each interceptor in the chain. This does not comply
- * with the spec but allows for "asynchronous continuation" of an interceptor chain execution. In other words, it is possible to
- * "cut off" the chain (interceptors executed before dispatch return immediately) and execute all remaining interceptors
- * asynchronously, possibly on a different thread.
+ * A new instance is created for the first interceptor in the chain. Furthermore, subsequent interceptors receive a new instance
+ * of {@link NextAroundInvokeInvocationContext}. This does not comply with the spec but allows for "asynchronous continuation"
+ * of an interceptor chain execution. In other words, it is possible to "cut off" the chain (interceptors executed before
+ * dispatch return immediately) and execute all remaining interceptors asynchronously, possibly on a different thread.
  * <p>
  * Note that context data and method parameters are mutable and are not guarded/synchronized. We expect them to be modified
  * before or after dispatch. If modified before and after dispatch an unpredictable behavior may occur.
+ * <p>
+ * Note that {@link #getParameters()} only reflects modifications of the current interceptor. If an interceptor with higher
+ * priority in the same chain calls {@link #setParameters(Object[])} then the changes are not reflected.
+ *
  */
 class AroundInvokeInvocationContext extends AbstractInvocationContext {
 
-    private final int position;
-    private final Function<InvocationContext, Object> aroundInvokeForward;
+    private final InterceptedMethodMetadata metadata;
 
-    AroundInvokeInvocationContext(Object target, Method method, Object[] parameters,
-            ContextDataMap contextData, Set<Annotation> interceptorBindings, int position,
-            List<InterceptorInvocation> chain, Function<InvocationContext, Object> aroundInvokeForward) {
-        super(target, method, null, parameters, contextData, interceptorBindings, chain);
-        this.position = position;
-        this.aroundInvokeForward = aroundInvokeForward;
+    AroundInvokeInvocationContext(Object target, Object[] args, InterceptedMethodMetadata metadata) {
+        super(target, args, new ContextDataMap(metadata.bindings));
+        this.metadata = metadata;
     }
 
-    static Object perform(Object target, Method method,
-            Function<InvocationContext, Object> aroundInvokeForward, Object[] parameters,
-            List<InterceptorInvocation> chain,
-            Set<Annotation> interceptorBindings) throws Exception {
+    static Object perform(Object target, Object[] args, InterceptedMethodMetadata metadata) throws Exception {
+        return metadata.chain.get(0).invoke(new AroundInvokeInvocationContext(target, args, metadata));
+    }
 
-        return chain.get(0).invoke(new AroundInvokeInvocationContext(target, method,
-                parameters, null, interceptorBindings, 1, chain, aroundInvokeForward));
+    @Override
+    public Set<Annotation> getInterceptorBindings() {
+        return metadata.bindings;
+    }
+
+    public Method getMethod() {
+        return metadata.method;
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public void setParameters(Object[] params) {
+        validateParameters(metadata.method, params);
+        this.parameters = params;
     }
 
     @Override
     public Object proceed() throws Exception {
+        return proceed(1);
+    }
+
+    private Object proceed(int currentPosition) throws Exception {
         try {
-            if (position < chain.size()) {
+            if (currentPosition < metadata.chain.size()) {
                 // Invoke the next interceptor in the chain
-                return chain.get(position).invoke(new AroundInvokeInvocationContext(target, method,
-                        parameters, contextData, interceptorBindings, position + 1, chain, aroundInvokeForward));
+                return metadata.chain.get(currentPosition)
+                        .invoke(new NextAroundInvokeInvocationContext(currentPosition + 1, parameters));
             } else {
                 // Invoke the target method
-                return aroundInvokeForward.apply(this);
+                return metadata.aroundInvokeForward.apply(this);
             }
         } catch (InvocationTargetException e) {
             Throwable cause = e.getCause();
@@ -63,6 +83,74 @@ class AroundInvokeInvocationContext extends AbstractInvocationContext {
             }
             throw new RuntimeException(cause);
         }
+    }
+
+    class NextAroundInvokeInvocationContext implements ArcInvocationContext {
+
+        private final int position;
+        protected Object[] parameters;
+
+        public NextAroundInvokeInvocationContext(int position, Object[] parameters) {
+            this.position = position;
+            this.parameters = parameters;
+        }
+
+        @Override
+        public Object proceed() throws Exception {
+            return AroundInvokeInvocationContext.this.proceed(position);
+        }
+
+        @Override
+        public Object getTarget() {
+            return AroundInvokeInvocationContext.this.getTarget();
+        }
+
+        @Override
+        public Object getTimer() {
+            return AroundInvokeInvocationContext.this.getTimer();
+        }
+
+        @Override
+        public Method getMethod() {
+            return AroundInvokeInvocationContext.this.getMethod();
+        }
+
+        @Override
+        public Constructor<?> getConstructor() {
+            return AroundInvokeInvocationContext.this.getConstructor();
+        }
+
+        @Override
+        public Object[] getParameters() {
+            return parameters;
+        }
+
+        @Override
+        public void setParameters(Object[] params) {
+            validateParameters(metadata.method, params);
+            this.parameters = params;
+        }
+
+        @Override
+        public Map<String, Object> getContextData() {
+            return AroundInvokeInvocationContext.this.getContextData();
+        }
+
+        @Override
+        public Set<Annotation> getInterceptorBindings() {
+            return AroundInvokeInvocationContext.this.getInterceptorBindings();
+        }
+
+        @Override
+        public <T extends Annotation> T findIterceptorBinding(Class<T> annotationType) {
+            return AroundInvokeInvocationContext.this.findIterceptorBinding(annotationType);
+        }
+
+        @Override
+        public <T extends Annotation> List<T> findIterceptorBindings(Class<T> annotationType) {
+            return AroundInvokeInvocationContext.this.findIterceptorBindings(annotationType);
+        }
+
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedMethodMetadata.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedMethodMetadata.java
@@ -4,17 +4,26 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 
+import jakarta.interceptor.InvocationContext;
+
+/**
+ * Immutable metadata for a specific intercepted method.
+ */
 public class InterceptedMethodMetadata {
 
     public final List<InterceptorInvocation> chain;
     public final Method method;
     public final Set<Annotation> bindings;
+    public final Function<InvocationContext, Object> aroundInvokeForward;
 
-    public InterceptedMethodMetadata(List<InterceptorInvocation> chain, Method method, Set<Annotation> bindings) {
+    public InterceptedMethodMetadata(List<InterceptorInvocation> chain, Method method, Set<Annotation> bindings,
+            Function<InvocationContext, Object> aroundInvokeForward) {
         this.chain = chain;
         this.method = method;
         this.bindings = bindings;
+        this.aroundInvokeForward = aroundInvokeForward;
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedStaticMethods.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedStaticMethods.java
@@ -2,44 +2,28 @@ package io.quarkus.arc.impl;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.Function;
-
-import jakarta.interceptor.InvocationContext;
 
 public final class InterceptedStaticMethods {
 
-    private static final ConcurrentMap<String, InterceptedStaticMethod> METHODS = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<String, InterceptedMethodMetadata> METADATA = new ConcurrentHashMap<>();
 
     private InterceptedStaticMethods() {
     }
 
-    public static void register(String key, InterceptedStaticMethod method) {
-        METHODS.putIfAbsent(key, method);
+    public static void register(String key, InterceptedMethodMetadata metadata) {
+        METADATA.putIfAbsent(key, metadata);
     }
 
     public static Object aroundInvoke(String key, Object[] args) throws Exception {
-        InterceptedStaticMethod method = METHODS.get(key);
-        if (method == null) {
+        InterceptedMethodMetadata metadata = METADATA.get(key);
+        if (metadata == null) {
             throw new IllegalArgumentException("Intercepted method metadata not found for key: " + key);
         }
-        return InvocationContexts.performAroundInvoke(null, method.metadata.method, method.forward, args, method.metadata.chain,
-                method.metadata.bindings);
-    }
-
-    public static final class InterceptedStaticMethod {
-
-        final Function<InvocationContext, Object> forward;
-        final InterceptedMethodMetadata metadata;
-
-        public InterceptedStaticMethod(Function<InvocationContext, Object> forward, InterceptedMethodMetadata metadata) {
-            this.forward = forward;
-            this.metadata = metadata;
-        }
-
+        return InvocationContexts.performAroundInvoke(null, args, metadata);
     }
 
     static void clear() {
-        METHODS.clear();
+        METADATA.clear();
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InvocationContexts.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InvocationContexts.java
@@ -2,10 +2,8 @@ package io.quarkus.arc.impl;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import jakarta.interceptor.InvocationContext;
@@ -18,19 +16,14 @@ public final class InvocationContexts {
     /**
      *
      * @param target
-     * @param method
-     * @param aroundInvokeForward
      * @param args
-     * @param chain
-     * @param interceptorBindings
+     * @param metadata
      * @return the return value
      * @throws Exception
      */
-    public static Object performAroundInvoke(Object target, Method method,
-            Function<InvocationContext, Object> aroundInvokeForward, Object[] args,
-            List<InterceptorInvocation> chain,
-            Set<Annotation> interceptorBindings) throws Exception {
-        return AroundInvokeInvocationContext.perform(target, method, aroundInvokeForward, args, chain, interceptorBindings);
+    public static Object performAroundInvoke(Object target, Object[] args, InterceptedMethodMetadata metadata)
+            throws Exception {
+        return AroundInvokeInvocationContext.perform(target, args, metadata);
     }
 
     /**
@@ -42,7 +35,7 @@ public final class InvocationContexts {
      */
     public static InvocationContext postConstruct(Object target, List<InterceptorInvocation> chain,
             Set<Annotation> interceptorBindings) {
-        return new LifecycleCallbackInvocationContext(target, null, null, interceptorBindings, chain);
+        return new LifecycleCallbackInvocationContext(target, null, interceptorBindings, chain);
     }
 
     /**
@@ -54,7 +47,7 @@ public final class InvocationContexts {
      */
     public static InvocationContext preDestroy(Object target, List<InterceptorInvocation> chain,
             Set<Annotation> interceptorBindings) {
-        return new LifecycleCallbackInvocationContext(target, null, null, interceptorBindings, chain);
+        return new LifecycleCallbackInvocationContext(target, null, interceptorBindings, chain);
     }
 
     /**

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/parameters/FirstParamInterceptor.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/parameters/FirstParamInterceptor.java
@@ -1,0 +1,26 @@
+package io.quarkus.arc.test.interceptors.parameters;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Simple
+@Priority(1)
+@Interceptor
+public class FirstParamInterceptor {
+
+    @AroundInvoke
+    Object interceptParameters(InvocationContext ctx) throws Exception {
+        Object[] params = ctx.getParameters();
+        if (params.length == 1 && params[0] != null) {
+            if (params[0] instanceof CharSequence) {
+                params[0] = params[0].getClass().getSimpleName();
+            } else if (params[0] instanceof Number) {
+                params[0] = 123456;
+            }
+            ctx.setParameters(params);
+        }
+        return ctx.proceed();
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/parameters/ParamInterceptorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/parameters/ParamInterceptorTest.java
@@ -15,7 +15,8 @@ import io.quarkus.arc.test.ArcTestContainer;
 public class ParamInterceptorTest {
 
     @RegisterExtension
-    public ArcTestContainer container = new ArcTestContainer(SimpleBean.class, Simple.class, ParamInterceptor.class);
+    public ArcTestContainer container = new ArcTestContainer(SimpleBean.class, Simple.class, FirstParamInterceptor.class,
+            SecondParamInterceptor.class, ThirdParamInterceptor.class);
 
     @Test
     public void testInterception() {
@@ -40,13 +41,13 @@ public class ParamInterceptorTest {
         });
 
         simpleBean.setPrimitiveIntVal(0);
-        assertEquals("123456", simpleBean.getVal());
+        assertEquals("123458", simpleBean.getVal());
 
         simpleBean.setIntVal(1);
-        assertEquals("123456", simpleBean.getVal());
+        assertEquals("123458", simpleBean.getVal());
 
         simpleBean.setNumberVal(2L);
-        assertEquals("123456", simpleBean.getVal());
+        assertEquals("123458", simpleBean.getVal());
 
         handle.destroy();
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/parameters/SecondParamInterceptor.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/parameters/SecondParamInterceptor.java
@@ -6,19 +6,16 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 
 @Simple
-@Priority(1)
+@Priority(2)
 @Interceptor
-public class ParamInterceptor {
+public class SecondParamInterceptor {
 
     @AroundInvoke
     Object interceptParameters(InvocationContext ctx) throws Exception {
-
         Object[] params = ctx.getParameters();
         if (params.length == 1 && params[0] != null) {
-            if (params[0] instanceof CharSequence) {
-                params[0] = params[0].getClass().getSimpleName();
-            } else if (params[0] instanceof Number) {
-                params[0] = 123456;
+            if (params[0] instanceof Number) {
+                params[0] = ((Number) params[0]).intValue() + 1;
             }
             ctx.setParameters(params);
         }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/parameters/ThirdParamInterceptor.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/parameters/ThirdParamInterceptor.java
@@ -1,0 +1,24 @@
+package io.quarkus.arc.test.interceptors.parameters;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Simple
+@Priority(2)
+@Interceptor
+public class ThirdParamInterceptor {
+
+    @AroundInvoke
+    Object interceptParameters(InvocationContext ctx) throws Exception {
+        Object[] params = ctx.getParameters();
+        if (params.length == 1 && params[0] != null) {
+            if (params[0] instanceof Number) {
+                params[0] = ((Number) params[0]).intValue() + 1;
+            }
+            ctx.setParameters(params);
+        }
+        return ctx.proceed();
+    }
+}


### PR DESCRIPTION
- forwarding lambdas are stateless and thus may become part of immutable InterceptedMethodMetadata
- note that metadata are shared accross all invocations of an intercepted method

[InterceptorBenchmark](https://github.com/mkouba/arc-benchmarks) shows ~ 14% lower allocation rate (using JMH GC profiler) and ~ 4% better throughput.