### PR TITLE
Copied the Vert.x FileCache and FileResolverImpl to override a method allowing us to support the quarkus: URL scheme used by the QuarkusClassLoader

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/AdditionalStaticResourceTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/AdditionalStaticResourceTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.vertx.http;
+
+import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.deployment.spi.AdditionalStaticResourceBuildItem;
+import io.restassured.RestAssured;
+
+public class AdditionalStaticResourceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        String path = "/routes.js";
+
+                        context.produce(new GeneratedResourceBuildItem("META-INF/resources" + path,
+                                "//hello".getBytes(StandardCharsets.UTF_8)));
+                        context.produce(new AdditionalStaticResourceBuildItem(path, false));
+                    }
+                }).produces(GeneratedResourceBuildItem.class)
+                        .produces(AdditionalStaticResourceBuildItem.class)
+                        .build();
+            }
+        };
+    }
+
+    @Test
+    public void testNonApplicationEndpointDirect() {
+        RestAssured.given()
+                .when().get("/routes.js")
+                .then()
+                .statusCode(200)
+                .body(Matchers.is("//hello"));
+    }
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxFileCache.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxFileCache.java
@@ -1,0 +1,224 @@
+package io.quarkus.vertx.core.runtime;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+import java.util.UUID;
+
+import io.vertx.core.VertxException;
+import io.vertx.core.file.impl.FileSystemImpl;
+import io.vertx.core.impl.Utils;
+
+class VertxFileCache {
+
+    static VertxFileCache setupCache(String fileCacheDir) {
+        VertxFileCache cache = new VertxFileCache(setupCacheDir(fileCacheDir));
+        // Add shutdown hook to delete on exit
+        cache.registerShutdownHook();
+        return cache;
+    }
+
+    /**
+     * Prepares the cache directory to be used in the application.
+     */
+    static File setupCacheDir(String fileCacheDir) {
+        // ensure that the argument doesn't end with separator
+        if (fileCacheDir.endsWith(File.separator)) {
+            fileCacheDir = fileCacheDir.substring(0, fileCacheDir.length() - File.separator.length());
+        }
+
+        // the cacheDir will be suffixed a unique id to avoid eavesdropping from other processes/users
+        // also this ensures that if process A deletes cacheDir, it won't affect process B
+        String cacheDirName = fileCacheDir + "-" + UUID.randomUUID();
+        File cacheDir = new File(cacheDirName);
+        // Create the cache directory
+        try {
+            if (Utils.isWindows()) {
+                Files.createDirectories(cacheDir.toPath());
+            } else {
+                // for security reasons, cache directory should not be readable/writable from other users
+                // just like "POSIX mkdtemp(3)", the created directory should have 0700 permission
+                Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwx------");
+                Files.createDirectories(cacheDir.toPath(), PosixFilePermissions.asFileAttribute(perms));
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException(getFolderAccessErrorMessage("create", fileCacheDir), e);
+        }
+        return cacheDir;
+    }
+
+    static String getFolderAccessErrorMessage(String action, String path) {
+        return "Unable to " + action + " folder at path '" + path + "'";
+    }
+
+    private Thread shutdownHook;
+    private File cacheDir;
+
+    public VertxFileCache(File cacheDir) {
+        try {
+            this.cacheDir = cacheDir.getCanonicalFile();
+        } catch (IOException e) {
+            throw new VertxException("Cannot get canonical name of cacheDir", e);
+        }
+    }
+
+    synchronized void registerShutdownHook() {
+        Thread shutdownHook = new Thread(this::runHook);
+        this.shutdownHook = shutdownHook;
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+    }
+
+    private void runHook() {
+        synchronized (this) {
+            // no-op if cache dir has been set to null
+            if (cacheDir == null) {
+                return;
+            }
+        }
+        Thread deleteCacheDirThread = new Thread(() -> {
+            try {
+                deleteCacheDir();
+            } catch (IOException ignore) {
+            }
+        });
+        // start the thread
+        deleteCacheDirThread.start();
+        try {
+            deleteCacheDirThread.join(10 * 1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    String cacheDir() {
+        return getCacheDir().getPath();
+    }
+
+    void close() throws IOException {
+        final Thread hook;
+        synchronized (this) {
+            hook = shutdownHook;
+            // disable the shutdown hook thread
+            shutdownHook = null;
+        }
+        if (hook != null) {
+            // May throw IllegalStateException if called from other shutdown hook so ignore that
+            try {
+                Runtime.getRuntime().removeShutdownHook(hook);
+            } catch (IllegalStateException ignore) {
+                // ignore
+            }
+        }
+        deleteCacheDir();
+    }
+
+    private void deleteCacheDir() throws IOException {
+        final File dir;
+        synchronized (this) {
+            if (cacheDir == null) {
+                return;
+            }
+            // save the state before we force a flip
+            dir = cacheDir;
+            // disable the cache dir
+            cacheDir = null;
+        }
+        // threads will only enter here once, as the resolving flag is flipped above
+        if (dir.exists()) {
+            FileSystemImpl.delete(dir.toPath(), true);
+        }
+    }
+
+    File getFile(String fileName) {
+        return new File(getCacheDir(), fileName);
+    }
+
+    File getCanonicalFile(File file) {
+        try {
+            if (file.isAbsolute()) {
+                return file.getCanonicalFile();
+            } else {
+                return getFile(file.getPath()).getCanonicalFile();
+            }
+        } catch (IOException e) {
+            // if we can't get the canonical form, return null
+            return null;
+        }
+    }
+
+    String relativize(String fileName) {
+        String cachePath = getCacheDir().getPath();
+
+        if (fileName.startsWith(cachePath)) {
+            int cachePathLen = cachePath.length();
+            if (fileName.length() == cachePathLen) {
+                return "";
+            } else {
+                if (fileName.charAt(cachePathLen) == File.separatorChar) {
+                    return fileName.substring(cachePathLen + 1);
+                }
+            }
+        }
+        return null;
+    }
+
+    File cacheFile(String fileName, File resource, boolean overwrite) throws IOException {
+        File cacheFile = new File(getCacheDir(), fileName);
+        fileNameCheck(cacheFile);
+        boolean isDirectory = resource.isDirectory();
+        if (!isDirectory) {
+            cacheFile.getParentFile().mkdirs();
+            if (!overwrite) {
+                try {
+                    Files.copy(resource.toPath(), cacheFile.toPath());
+                } catch (FileAlreadyExistsException ignore) {
+                }
+            } else {
+                Files.copy(resource.toPath(), cacheFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+        } else {
+            cacheFile.mkdirs();
+        }
+        return cacheFile;
+    }
+
+    void cacheFile(String fileName, InputStream is, boolean overwrite) throws IOException {
+        File cacheFile = new File(getCacheDir(), fileName);
+        fileNameCheck(cacheFile);
+        cacheFile.getParentFile().mkdirs();
+        if (!overwrite) {
+            try {
+                Files.copy(is, cacheFile.toPath());
+            } catch (FileAlreadyExistsException ignore) {
+            }
+        } else {
+            Files.copy(is, cacheFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    void cacheDir(String fileName) throws IOException {
+        File file = new File(getCacheDir(), fileName);
+        fileNameCheck(file);
+        file.mkdirs();
+    }
+
+    private void fileNameCheck(File file) throws IOException {
+        if (!file.getCanonicalFile().toPath().startsWith(getCacheDir().toPath())) {
+            throw new VertxException("File is outside of the cacheDir dir: " + file);
+        }
+    }
+
+    private File getCacheDir() {
+        File currentCacheDir = cacheDir;
+        if (currentCacheDir == null) {
+            throw new IllegalStateException("cacheDir has been removed. FileResolver is closing?");
+        }
+        return currentCacheDir;
+    }
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxFileResolver.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxFileResolver.java
@@ -1,0 +1,390 @@
+package io.quarkus.vertx.core.runtime;
+
+import static io.vertx.core.net.impl.URIDecoder.decodeURIComponent;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import io.netty.util.internal.PlatformDependent;
+import io.vertx.core.VertxException;
+import io.vertx.core.file.FileSystemOptions;
+import io.vertx.core.spi.file.FileResolver;
+
+/**
+ * Sometimes the file resources of an application are bundled into jars, or are somewhere on the classpath but not
+ * available on the file system, e.g. in the case of a Vert.x webapp bundled as a fat jar.
+ * <p>
+ * In this case we want the application to access the resource from the classpath as if it was on the file system.
+ * <p>
+ * We can do this by looking for the file on the classpath, and if found, copying it to a temporary cache directory
+ * on disk and serving it from there.
+ * <p>
+ * There is one cache dir per Vert.x instance and they are deleted on Vert.x shutdown.
+ *
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ * @author <a href="https://github.com/rworsnop/">Rob Worsnop</a>
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class VertxFileResolver implements FileResolver {
+
+    public static final String DISABLE_FILE_CACHING_PROP_NAME = "vertx.disableFileCaching";
+    public static final String DISABLE_CP_RESOLVING_PROP_NAME = "vertx.disableFileCPResolving";
+    public static final String CACHE_DIR_BASE_PROP_NAME = "vertx.cacheDirBase";
+    private static final boolean NON_UNIX_FILE_SEP = File.separatorChar != '/';
+    private static final String JAR_URL_SEP = "!/";
+
+    private final File cwd;
+    private final boolean enableCaching;
+    private final boolean enableCPResolving;
+    private final VertxFileCache cache;
+
+    public VertxFileResolver() {
+        this(new FileSystemOptions());
+    }
+
+    public VertxFileResolver(FileSystemOptions fileSystemOptions) {
+        enableCaching = fileSystemOptions.isFileCachingEnabled();
+        enableCPResolving = fileSystemOptions.isClassPathResolvingEnabled();
+
+        if (enableCPResolving) {
+            cache = VertxFileCache.setupCache(fileSystemOptions.getFileCacheDir());
+        } else {
+            cache = null;
+        }
+
+        String cwdOverride = System.getProperty("vertx.cwd");
+        if (cwdOverride != null) {
+            cwd = new File(cwdOverride).getAbsoluteFile();
+        } else {
+            cwd = null;
+        }
+    }
+
+    public String cacheDir() {
+        if (cache != null) {
+            return cache.cacheDir();
+        }
+        return null;
+    }
+
+    VertxFileCache getFileCache() {
+        return this.cache;
+    }
+
+    /**
+     * Close this file resolver, this is a blocking operation.
+     */
+    public void close() throws IOException {
+        if (enableCPResolving) {
+            synchronized (cache) {
+                cache.close();
+            }
+        }
+    }
+
+    public File resolveFile(String fileName) {
+        // First look for file with that name on disk
+        File file = new File(fileName);
+        File resolved;
+        boolean absolute = file.isAbsolute();
+
+        if (cwd != null && !absolute) {
+            resolved = new File(cwd, fileName);
+        } else {
+            resolved = file;
+        }
+        if (this.cache == null) {
+            return resolved;
+        }
+        // We need to synchronized here to avoid 2 different threads to copy the file to the cache directory and so
+        // corrupting the content.
+        if (!resolved.exists()) {
+            synchronized (cache) {
+                // When an absolute file is here, if it falls under the cache directory, then it should be made relative as it
+                // could mean that a previous resolution has been used to resolve a non local file system resource
+                File cacheFile = cache.getCanonicalFile(file);
+                // the file may or may not be in the cache dir after canonicalization
+                if (cacheFile == null) {
+                    // the given file cannot be resolved to the real FS
+                    return file;
+                }
+                // compute the difference of the path
+                String relativize = cache.relativize(cacheFile.getPath());
+                if (relativize != null) {
+                    // file is inside the cache dir, we can continue with the search
+                    if (this.enableCaching && cacheFile.exists()) {
+                        return cacheFile;
+                    }
+                    // as it wasn't found, maybe it hasn't been extracted yet
+                    // adjust the name and absolute references if needed
+                    if (absolute) {
+                        fileName = relativize;
+                        file = new File(relativize);
+                        absolute = false;
+                    }
+                }
+                // https://vertx.io/docs/vertx-core/java/#classpath
+                // if a resource is still absolute, it means it's outside the cache, we don't need to handle it.
+                // otherwise, we need to go over the classpath resources
+                if (!absolute) {
+                    // Look for file on classpath
+                    ClassLoader cl = getClassLoader();
+
+                    //https://github.com/eclipse/vert.x/issues/2126
+                    //Cache all elements in the parent directory if it exists
+                    //this is so that listing the directory after an individual file has
+                    //been read works.
+                    File parentFile = file.getParentFile();
+                    while (parentFile != null) {
+                        String parentFileName = parentFile.getPath();
+                        if (NON_UNIX_FILE_SEP) {
+                            parentFileName = parentFileName.replace(File.separatorChar, '/');
+                        }
+                        URL directoryContents = getValidClassLoaderResource(cl, parentFileName);
+                        if (directoryContents != null) {
+                            unpackUrlResource(directoryContents, parentFileName, cl, true);
+                        }
+                        // https://github.com/eclipse-vertx/vert.x/issues/3654
+                        // go up one level until we reach the top, this way we ensure we extract the whole tree
+                        // not just a branch so directory listing will be correct
+                        parentFile = parentFile.getParentFile();
+                    }
+
+                    if (NON_UNIX_FILE_SEP) {
+                        fileName = fileName.replace(File.separatorChar, '/');
+                    }
+                    URL url = getValidClassLoaderResource(cl, fileName);
+                    if (url != null) {
+                        return unpackUrlResource(url, fileName, cl, false);
+                    }
+                }
+            }
+        }
+        return file;
+    }
+
+    private static boolean isValidWindowsCachePath(char c) {
+        if (c < 32) {
+            return false;
+        }
+        switch (c) {
+            case '"':
+            case '*':
+            case ':':
+            case '<':
+            case '>':
+            case '?':
+            case '|':
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    private static boolean isValidCachePath(String fileName) {
+        if (PlatformDependent.isWindows()) {
+            int len = fileName.length();
+            for (int i = 0; i < len; i++) {
+                char c = fileName.charAt(i);
+                if (!isValidWindowsCachePath(c)) {
+                    return false;
+                }
+                // Space only valid when it's not ending a name
+                if (c == ' ' && (i + 1 == len || fileName.charAt(i + 1) == '/')) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return fileName.indexOf('\u0000') == -1;
+        }
+    }
+
+    /**
+     * Get a class loader resource that can unpack to a valid cache path.
+     * <p>
+     * Some valid entries are avoided purposely when we cannot create the corresponding file in the file cache.
+     */
+    private static URL getValidClassLoaderResource(ClassLoader cl, String fileName) {
+        URL resource = cl.getResource(fileName);
+        if (resource != null && !isValidCachePath(fileName)) {
+            return null;
+        }
+        return resource;
+    }
+
+    private File unpackUrlResource(URL url, String fileName, ClassLoader cl, boolean isDir) {
+        String prot = url.getProtocol();
+        switch (prot) {
+            case "file":
+                return unpackFromFileURL(url, fileName, cl);
+            case "jar":
+                return unpackFromJarURL(url, fileName, cl);
+            case "bundle": // Apache Felix, Knopflerfish
+            case "bundleentry": // Equinox
+            case "bundleresource": // Equinox
+            case "jrt": // java run-time (JEP 220)
+            case "resource": // substratevm (graal native image)
+            case "vfs": // jboss-vfs
+            case "quarkus": // QuarkusClassLoader
+                return unpackFromBundleURL(url, fileName, isDir);
+            default:
+                throw new IllegalStateException("Invalid url protocol: " + prot);
+        }
+    }
+
+    private File unpackFromFileURL(URL url, String fileName, ClassLoader cl) {
+        final File resource = new File(decodeURIComponent(url.getPath(), false));
+        boolean isDirectory = resource.isDirectory();
+        File cacheFile;
+        try {
+            cacheFile = cache.cacheFile(fileName, resource, !enableCaching);
+        } catch (IOException e) {
+            throw new VertxException(getFileAccessErrorMessage("unpack", url.toString()), e);
+        }
+        if (isDirectory) {
+            String[] listing = resource.list();
+            if (listing != null) {
+                for (String file : listing) {
+                    String subResource = fileName + "/" + file;
+                    URL url2 = getValidClassLoaderResource(cl, subResource);
+                    if (url2 == null) {
+                        throw new VertxException("Invalid resource: " + subResource);
+                    }
+                    unpackFromFileURL(url2, subResource, cl);
+                }
+            }
+        }
+        return cacheFile;
+    }
+
+    static String getFileAccessErrorMessage(String action, String path) {
+        return "Unable to " + action + " file at path '" + path + "'";
+    }
+
+    private File unpackFromJarURL(URL url, String fileName, ClassLoader cl) {
+        ZipFile zip = null;
+        try {
+            String path = url.getPath();
+            int idx1 = path.lastIndexOf(".jar!");
+            if (idx1 == -1) {
+                idx1 = path.lastIndexOf(".zip!");
+            }
+            int idx2 = path.lastIndexOf(".jar!", idx1 - 1);
+            if (idx2 == -1) {
+                idx2 = path.lastIndexOf(".zip!", idx1 - 1);
+            }
+            if (idx2 == -1) {
+                File file = new File(decodeURIComponent(path.substring(5, idx1 + 4), false));
+                zip = new ZipFile(file);
+            } else {
+                String s = path.substring(idx2 + 6, idx1 + 4);
+                File file = resolveFile(s);
+                zip = new ZipFile(file);
+            }
+
+            String inJarPath = path.substring(idx1 + 6);
+            StringBuilder prefixBuilder = new StringBuilder();
+            int first = 0;
+            int second;
+            int len = JAR_URL_SEP.length();
+            while ((second = inJarPath.indexOf(JAR_URL_SEP, first)) >= 0) {
+                prefixBuilder.append(inJarPath, first, second).append("/");
+                first = second + len;
+            }
+            String prefix = prefixBuilder.toString();
+            Enumeration<? extends ZipEntry> entries = zip.entries();
+            String prefixCheck = prefix.isEmpty() ? fileName : prefix + fileName;
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                String name = entry.getName();
+                if (name.startsWith(prefixCheck)) {
+                    String p = prefix.isEmpty() ? name : name.substring(prefix.length());
+                    if (name.endsWith("/")) {
+                        // Directory
+                        cache.cacheDir(p);
+                    } else {
+                        try (InputStream is = zip.getInputStream(entry)) {
+                            cache.cacheFile(p, is, !enableCaching);
+                        }
+                    }
+
+                }
+            }
+        } catch (IOException e) {
+            throw new VertxException(getFileAccessErrorMessage("unpack", url.toString()), e);
+        } finally {
+            closeQuietly(zip);
+        }
+
+        return cache.getFile(fileName);
+    }
+
+    private void closeQuietly(Closeable zip) {
+        if (zip != null) {
+            try {
+                zip.close();
+            } catch (IOException e) {
+                // Ignored.
+            }
+        }
+    }
+
+    /**
+     * It is possible to determine if a resource from a bundle is a directory based on whether or not the ClassLoader
+     * returns null for a path (which does not already contain a trailing '/') *and* that path with an added trailing '/'
+     *
+     * @param url the url
+     * @return if the bundle resource represented by the bundle URL is a directory
+     */
+    private boolean isBundleUrlDirectory(URL url) {
+        return url.toExternalForm().endsWith("/") ||
+                getValidClassLoaderResource(getClassLoader(), url.getPath().substring(1) + "/") != null;
+    }
+
+    /**
+     * bundle:// urls are used by OSGi implementations to refer to a file contained in a bundle, or in a fragment. There
+     * is not much we can do to get the file from it, except reading it from the url. This method copies the files by
+     * reading it from the url.
+     *
+     * @param url the url
+     * @param fileName the file name used to cache the content
+     * @return the extracted file
+     */
+    private File unpackFromBundleURL(URL url, String fileName, boolean isDir) {
+        try {
+            if ((getClassLoader() != null && isBundleUrlDirectory(url)) || isDir) {
+                // Directory
+                cache.cacheDir(fileName);
+            } else {
+                try (InputStream is = url.openStream()) {
+                    cache.cacheFile(fileName, is, !enableCaching);
+                }
+            }
+        } catch (IOException e) {
+            throw new VertxException(getFileAccessErrorMessage("unpack", url.toString()), e);
+        }
+        return cache.getFile(fileName);
+    }
+
+    private ClassLoader getClassLoader() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl == null) {
+            cl = getClass().getClassLoader();
+        }
+        // when running on substratevm (graal) the access to class loaders
+        // is very limited and might be only available from compile time
+        // known classes. (Object is always known, so we do a final attempt
+        // to get it here).
+        if (cl == null) {
+            cl = Object.class.getClassLoader();
+        }
+        return cl;
+    }
+}


### PR DESCRIPTION
This isn't ideal, because two Vert.x classes need to be copied. A better version of this fix would be if Vert.x added the `quarkus:` protocol to `FileResolverImpl`, but at least we can test this before making a Vert.x release with that fix.

Now, I'm not sure if we should merge this to solve this now, and fix it when Vert.x makes a release, or wait for the new Vert.x release?

Fixes #28474