### PR TITLE
Change accept header to valid plain text in micrometer documentation

### DIFF
--- a/docs/src/main/asciidoc/micrometer.adoc
+++ b/docs/src/main/asciidoc/micrometer.adoc
@@ -401,7 +401,7 @@ string. For example, setting
 .Exported metrics format
 
 By default, the  metrics are exported using the Prometheus format `application/openmetrics-text`,
-you can revert to the former format by specifying the `Accept` request header to `plain/text` (`curl -H "Accept: plain/text" localhost:8080/q/metrics/`).
+you can revert to the former format by specifying the `Accept` request header to `text/plain` (`curl -H "Accept: text/plain" localhost:8080/q/metrics/`).
 
 == Using MeterFilter to configure metrics
 

--- a/docs/src/main/asciidoc/telemetry-micrometer-tutorial.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer-tutorial.adoc
@@ -90,7 +90,7 @@ NOTE: Metrics appear lazily, you often won't see any data for your endpoint unti
 .Exported metrics format
 
 By default, the  metrics are exported using the Prometheus format `application/openmetrics-text`,
-you can revert to the former format by specifying the `Accept` request header to `plain/text` (`curl -H "Accept: plain/text" localhost:8080/q/metrics/`).
+you can revert to the former format by specifying the `Accept` request header to `text/plain` (`curl -H "Accept: text/plain" localhost:8080/q/metrics/`).
 
 == Inject the MeterRegistry
 


### PR DESCRIPTION
Using `plain/text` returns the following; `406 Micrometer prometheus endpoint does not support plain/text`. The valid value is `text/plain`


Please note the migration guide for 2.16 also contains that phrase.