### PR TITLE
Make OIDC session cookie same site lax by default

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -769,8 +769,8 @@ public class OidcTenantConfig extends OidcCommonConfig {
         /**
          * SameSite attribute for the session cookie.
          */
-        @ConfigItem(defaultValue = "strict")
-        public CookieSameSite cookieSameSite = CookieSameSite.STRICT;
+        @ConfigItem(defaultValue = "lax")
+        public CookieSameSite cookieSameSite = CookieSameSite.LAX;
 
         /**
          * If this property is set to 'true' then an OIDC UserInfo endpoint will be called.

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -107,7 +107,7 @@ quarkus.oidc.tenant-https.authentication.cookie-suffix=test
 quarkus.oidc.tenant-https.authentication.error-path=/tenant-https/error
 quarkus.oidc.tenant-https.authentication.pkce-required=true
 quarkus.oidc.tenant-https.authentication.pkce-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
-quarkus.oidc.tenant-https.authentication.cookie-same-site=lax
+quarkus.oidc.tenant-https.authentication.cookie-same-site=strict
 
 quarkus.oidc.tenant-javascript.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-javascript.client-id=quarkus-app

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -95,7 +95,7 @@ public class CodeFlowTest {
 
             Cookie sessionCookie = getSessionCookie(webClient, null);
             assertNotNull(sessionCookie);
-            assertEquals("strict", sessionCookie.getSameSite());
+            assertEquals("lax", sessionCookie.getSameSite());
 
             webClient.getCookieManager().clearCookies();
         }
@@ -220,7 +220,7 @@ public class CodeFlowTest {
             assertEquals("tenant-https:reauthenticated", page.getBody().asNormalizedText());
             Cookie sessionCookie = getSessionCookie(webClient, "tenant-https_test");
             assertNotNull(sessionCookie);
-            assertEquals("lax", sessionCookie.getSameSite());
+            assertEquals("strict", sessionCookie.getSameSite());
             webClient.getCookieManager().clearCookies();
         }
     }


### PR DESCRIPTION
Fixes #30797 

Unfortunately having a same site strict attribute for all of the OIDC session cookies has proven to be non-viable OOB since any application doing a few extra redirects will start failing.

We'll retain though an option to restrict strictly the session cookie to the same path, which will work for simple applications doing no redirects beyond the default OIDC redirects (ex, only one redirect from Keycloak to the Quarkus path which was used to initiate the authentication) and then it is just GET or POST without any other not same root but same site redirects.

Updated tests: Now samesite is lax by defaut for the session cookie (`CodeFlowTest#testCodeFlowNoConsent`) but if required it can become strict (`CodeFlowTest#testCodeFlowForceHttpsRedirectUriAndPkce` - its config requires `strict`)