### PR TITLE
Increase timeout of Data6 group of native tests

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -38,7 +38,7 @@
         },
         {
             "category": "Data6",
-            "timeout": 65,
+            "timeout": 70,
             "test-modules": "elasticsearch-rest-client, elasticsearch-rest-high-level-client, hibernate-search-orm-elasticsearch, hibernate-search-orm-elasticsearch-tenancy, hibernate-search-orm-opensearch, hibernate-search-orm-elasticsearch-coordination-outbox-polling, hibernate-reactive-panache, hibernate-reactive-panache-kotlin",
             "os-name": "ubuntu-latest"
         },


### PR DESCRIPTION
Doing this in response to a timeout seen in #30807