### PR TITLE
Fixed return type typo in smallrye graphQL guide

### DIFF
--- a/docs/src/main/asciidoc/smallrye-graphql.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql.adoc
@@ -667,7 +667,7 @@ Add the following to our `FilmResource` class:
 ----
     @Query
     @Description("Get all characters from a galaxy far far away")
-    public List<Characters> characters() {
+    public List<Character> characters() {
         return service.getAllCharacters();
     }
 ----


### PR DESCRIPTION
cc @jmartisk