### PR TITLE
QDOCS-85: enhancements to OIDC code flow tutorial and concept topics

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-concept.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-concept.adoc
@@ -37,8 +37,9 @@ The following tokens are issued:
 
 See also the xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties] reference guide.
 
-For information about protecting your applications using Bearer Token authorization, see xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication].
+To learn about how you can protect web applications by using the OIDC authorization code flow mechanism, see xref:security-oidc-code-flow-authentication-tutorial.adoc[Protect a web application by using OIDC authorization code flow]
 
+If you want to protect your applications by using Bearer Token authentication, see xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication].
 For information about how to support multiple tenants, see xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect Multi-Tenancy].
 
 == Using the authorization code flow mechanism

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -1,5 +1,5 @@
 [id="security-oidc-code-flow-authentication-tutorial"]
-= Protect a web application by using OIDC authorization code flow mechanism
+= Protect a web application by using OIDC authorization code flow
 include::_attributes.adoc[]
 :categories: security,web
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -174,7 +174,7 @@ Select a realm, enter the client id and secret, a relative service endpoint path
 [[develop-web-app-applications]]
 === Developing OpenID Connect Web App Applications
 
-If you develop a xref:security-oidc-web-authentication-concept.adoc[Quarkus OIDC web-app application], then you should set `quarkus.oidc.application-type=web-app` in `application.properties` before starting the application.
+If you develop a xref:security-oidc-code-flow-authentication-concept.adoc[Quarkus OIDC web-app application], then you should set `quarkus.oidc.application-type=web-app` in `application.properties` before starting the application.
 
 You will see a screen like this one:
 
@@ -212,7 +212,7 @@ It will ensure that if you access the application from the browser in dev mode, 
 You can run the tests against a Keycloak container started in a test mode in a xref:continuous-testing.adoc[Continuous Testing] mode.
 
 It is also recommended to run the integration tests against Keycloak using `Dev Services for Keycloak`.
-For more information, see xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-keycloak-devservices[Testing OpenID onnect Service Applications with Dev Services] and xref:security-oidc-web-authentication-concept.adoc#integration-testing-keycloak-devservices[Testing OpenID Connect WebApp Applications with Dev Services].
+For more information, see xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-keycloak-devservices[Testing OpenID onnect Service Applications with Dev Services] and xref:security-oidc-code-flow-authentication-concept.adoc#integration-testing-keycloak-devservices[Testing OpenID Connect WebApp Applications with Dev Services].
 
 [[keycloak-initialization]]
 === Keycloak Initialization
@@ -312,7 +312,7 @@ If you work with other providers then a Dev UI experience described in the <<key
 The current access token is used by default to test the service with `Swagger UI` or `GrapghQL UI`. If the provider (other than Keycloak) returns a binary access token then it will be used with `Swagger UI` or `GrapghQL UI` only if this provider has a token introspection endpoint otherwise an `IdToken` which is always in a JWT format will be passed to `Swagger UI` or `GrapghQL UI`. In such cases you can verify with the manual Dev UI test that `401` will always be returned for the current binary access token. Also note that using `IdToken` as a fallback with either of these UIs is only possible with the authorization code flow.
 ====
 
-Some providers such as `Auth0` do not support a standard RP initiated logout so the provider specific logout properties will have to be configured for a logout option be visible. For more information, see xref:security-oidc-web-authentication-concept.adoc#user-initiated-logout[OpenID Connect User-Initiated Logout].
+Some providers such as `Auth0` do not support a standard RP initiated logout so the provider specific logout properties will have to be configured for a logout option be visible. For more information, see xref:security-oidc-code-flow-authentication-concept.adoc#user-initiated-logout[OpenID Connect User-Initiated Logout].
 
 Similarly, if you'd like to use a `password` or `client_credentials` grant for Dev UI to acquire the tokens then you may have to configure some extra provider specific properties, for example:
 
@@ -409,5 +409,5 @@ This document refers to the `http://localhost:8080/q/dev` Dev UI URL in several 
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * https://openid.net/connect/[OpenID Connect]
 * xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
-* xref:security-oidc-web-authentication-concept.adoc[Web authentication using OIDC authorization code flow]
+* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:security-overview-concept.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -14,7 +14,7 @@ When serving multiple customers from the same application (e.g.: SaaS), each cus
 
 Please read the xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication] guide if you need to authorize a tenant using Bearer Token Authorization.
 
-If you need to authenticate and authorize a tenant using OpenID Connect Authorization Code Flow, read the xref:security-oidc-web-authentication-concept.adoc[Web authentication using OIDC authorization code flow] guide.
+If you need to authenticate and authorize a tenant using OpenID Connect Authorization Code Flow, read the xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications] guide.
 
 Also see the xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties] reference guide.
 

--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -9,9 +9,9 @@ include::_attributes.adoc[]
 
 == Introduction
 
-If you use xref:security-oidc-web-authentication-concept.adoc[OpenID Connect Authorization Code Flow] to protect Quarkus endpoints, then you need to configure Quarkus to tell it how to connect to OpenID Connect providers, how to authenticate to such providers, which scopes to use, etc.
+If you use xref:security-oidc-code-flow-authentication-concept.adoc[OpenID Connect Authorization Code Flow] to protect Quarkus endpoints, then you need to configure Quarkus to tell it how to connect to OpenID Connect providers, how to authenticate to such providers, which scopes to use, and so on.
 
-Sometimes you need to use the configuration to work around the fact that some providers do not implement OpenID Connect completely or when they are in fact xref:security-oidc-web-authentication-concept.adoc#oauth2[OAuth2 providers only].
+Sometimes you need to use the configuration to work around the fact that some providers do not implement OpenID Connect completely or when they are in fact xref:security-oidc-code-flow-authentication-concept.adoc#oauth2[OAuth2 providers only].
 
 The configuration of such providers can become complex, very technical and difficult to understand.
 
@@ -364,5 +364,5 @@ quarkus.oidc.credentials.secret=<Client Secret>
 
 == References
 
-* xref:security-oidc-web-authentication-concept.adoc[Web authentication using OIDC authorization code flow]
+* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:security-overview-concept.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-testing.adoc
+++ b/docs/src/main/asciidoc/security-testing.adoc
@@ -89,7 +89,7 @@ This will run the test with an identity with the given username and roles. Note 
 disable authorization while also providing an identity to run the test under, which can be useful if the endpoint expects an
 identity to be present.
 
-See xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-security-annotation[OpenID Connect Bearer Token Integration testing], xref:security-oidc-web-authentication-concept.adoc#integration-testing-security-annotation[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-security-annotation[SmallRye JWT Integration testing] for more details about testing the endpoint code which depends on the injected `JsonWebToken`.
+See xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-security-annotation[OpenID Connect Bearer Token Integration testing], xref:security-oidc-code-flow-authentication-concept.adoc#integration-testing-security-annotation[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-security-annotation[SmallRye JWT Integration testing] for more details about testing the endpoint code which depends on the injected `JsonWebToken`.
 
 [WARNING]
 ====
@@ -122,7 +122,7 @@ for example by setting `quarkus.http.auth.basic=true` or `%test.quarkus.http.aut
 == Use Wiremock for Integration Testing
 
 You can also use Wiremock to mock the authorization OAuth2 and OIDC services:
-See xref:security-oauth2.adoc#integration-testing[OAuth2 Integration testing], xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-wiremock[OpenID Connect Bearer Token Integration testing], xref:security-oidc-web-authentication-concept.adoc#integration-testing-wiremock[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-wiremock[SmallRye JWT Integration testing] for more details.
+See xref:security-oauth2.adoc#integration-testing[OAuth2 Integration testing], xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-wiremock[OpenID Connect Bearer Token Integration testing], xref:security-oidc-code-flow-authentication-concept.adoc#integration-testing-wiremock[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-wiremock[SmallRye JWT Integration testing] for more details.
 
 == References
 


### PR DESCRIPTION
The following updates were completed in this PR:

- Corrections to links to point to newly-created security-oidc-code-flow-authentication-concept and security-oidc-code-flow-authentication-tutorial topics (created following recomposition of security-openid-connect-web-authentication.adoc into the Diataxis framework)
- Improved cross-linking between tutorial and concept topics
- Minor style edits to topic titles

Closes https://issues.redhat.com/browse/QDOCS-123
