### PR TITLE
CI - Remove deprecated set-output calls

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+          echo "date=$(/bin/date -u "+%Y-%m")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Maven Repository
         id: cache-maven
@@ -152,7 +152,7 @@ jobs:
             GIB_ARGS+=" -Dgib.referenceBranch=refs/remotes/quarkusio/main -Dgib.fetchReferenceBranch -Dgib.disableIfBranchMatches='main|\d+\.\d+|.*backport.*'"
           fi
           echo "GIB_ARGS: $GIB_ARGS"
-          echo "::set-output name=gib_args::${GIB_ARGS}"
+          echo "gib_args=${GIB_ARGS}" >> $GITHUB_OUTPUT
       - name: Get GIB impacted modules
         id: get-gib-impacted
         # mvnw just for creating gib-impacted.log ("validate" should not waste much time if not incremental at all, e.g. on main)
@@ -165,7 +165,7 @@ jobs:
             GIB_IMPACTED=''
           fi
           echo "GIB_IMPACTED: ${GIB_IMPACTED}"
-          echo "::set-output name=impacted_modules::${GIB_IMPACTED//$'\n'/'%0A'}"
+          echo "impacted_modules=${GIB_IMPACTED//$'\n'/'%0A'}" >> $GITHUB_OUTPUT
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
@@ -212,13 +212,13 @@ jobs:
           echo "GIB_IMPACTED_MODULES: ${GIB_IMPACTED_MODULES}"
           json=$(.github/filter-native-tests-json.sh "${GIB_IMPACTED_MODULES}" | tr -d '\n')
           echo "${json}"
-          echo "::set-output name=matrix::${json}"
+          echo "matrix=${json}" >> $GITHUB_OUTPUT
       - name: Calculate matrix from matrix-jvm-tests.json
         id: calc-jvm-matrix
         run: |
           json=$(.github/filter-jvm-tests-json.sh)
           echo "${json}"
-          echo "::set-output name=matrix::${json}"
+          echo "matrix=${json}" >> $GITHUB_OUTPUT
       - name: Calculate run flags
         id: calc-run-flags
         run: |
@@ -233,11 +233,11 @@ jobs:
             if ! echo -n "${GIB_IMPACTED_MODULES}" | grep -q 'tcks/.*'; then run_tcks=false; fi
           fi
           echo "run_jvm=${run_jvm}, run_devtools=${run_devtools}, run_gradle=${run_gradle}, run_maven=${run_maven}, run_tcks=${run_tcks}"
-          echo "::set-output name=run_jvm::${run_jvm}"
-          echo "::set-output name=run_devtools::${run_devtools}"
-          echo "::set-output name=run_gradle::${run_gradle}"
-          echo "::set-output name=run_maven::${run_maven}"
-          echo "::set-output name=run_tcks::${run_tcks}"
+          echo "run_jvm=${run_jvm}" >> $GITHUB_OUTPUT
+          echo "run_devtools=${run_devtools}" >> $GITHUB_OUTPUT
+          echo "run_gradle=${run_gradle}" >> $GITHUB_OUTPUT
+          echo "run_maven=${run_maven}" >> $GITHUB_OUTPUT
+          echo "run_tcks=${run_tcks}" >> $GITHUB_OUTPUT
 
   jvm-tests:
     name: JVM Tests - JDK ${{matrix.java.name}}

--- a/.github/workflows/ci-fork-mvn-cache.yml
+++ b/.github/workflows/ci-fork-mvn-cache.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+          echo "date=$(/bin/date -u "+%Y-%m")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Maven Repository
         id: cache-maven

--- a/.github/workflows/ci-istio.yml
+++ b/.github/workflows/ci-istio.yml
@@ -71,7 +71,7 @@ jobs:
           password: ${{ secrets.QUAY_QUARKUSCI_PASSWORD }}
       - name: Get kubeconfig
         id: kubeconfig
-        run: a="$(cat ~/.kube/config)"; a="${a//'%'/'%25'}"; a="${a//$'\n'/'%0A'}"; a="${a//$'\r'/'%0D'}"; echo "::set-output name=config::$a"
+        run: a="$(cat ~/.kube/config)"; a="${a//'%'/'%25'}"; a="${a//$'\n'/'%0A'}"; a="${a//$'\r'/'%0D'}"; echo "config=$a" >> $GITHUB_OUTPUT
       - name: Install Istio
         uses: huang195/actions-install-istio@v1.0.0
         with:

--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+          echo "date=$(/bin/date -u "+%Y-%m")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Maven Repository
         id: cache-maven

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+          echo "date=$(/bin/date -u "+%Y-%m")" >> $GITHUB_OUTPUT
       - name: Cache Maven Repository
         id: cache-maven
         uses: actions/cache@v3

--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+          echo "date=$(/bin/date -u "+%Y-%m")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Maven Repository
         id: cache-maven

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+          echo "date=$(/bin/date -u "+%Y-%m")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache SonarCloud packages
         uses: actions/cache@v3

--- a/.github/workflows/sonarcloud.yml.disabled
+++ b/.github/workflows/sonarcloud.yml.disabled
@@ -21,7 +21,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+          echo "date=$(/bin/date -u "+%Y-%m")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache SonarCloud packages
         uses: actions/cache@v2


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/