### PR TITLE
Remove deprecated Fernflower configuration

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -235,13 +235,6 @@ public class PackageConfig {
     public boolean includeDependencyList;
 
     /**
-     * Fernflower Decompiler configuration
-     */
-    @ConfigItem
-    @Deprecated(forRemoval = true)
-    public FernflowerConfig fernflower;
-
-    /**
      * Quiltflower Decompiler configuration
      */
     @ConfigItem
@@ -288,30 +281,6 @@ public class PackageConfig {
 
     public String getRunnerSuffix() {
         return addRunnerSuffix ? runnerSuffix : "";
-    }
-
-    @ConfigGroup
-    @Deprecated(forRemoval = true)
-    public static class FernflowerConfig {
-
-        /**
-         * An advanced option that will decompile generated and transformed bytecode into the 'decompiled' directory.
-         * This is only taken into account when fast-jar is used.
-         */
-        @ConfigItem(defaultValue = "false")
-        public boolean enabled;
-
-        /**
-         * The git hash to use to download the fernflower tool from https://jitpack.io/com/github/fesh0r/fernflower/
-         */
-        @ConfigItem(defaultValue = "dbf407a655")
-        public String hash;
-
-        /**
-         * The directory into which to save the fernflower tool if it doesn't exist
-         */
-        @ConfigItem(defaultValue = "${user.home}/.quarkus")
-        public String jarDirectory;
     }
 
     @ConfigGroup

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -601,19 +601,11 @@ public class JarResultBuildStep {
         Path decompiledOutputDir = null;
         boolean wasDecompiledSuccessfully = true;
         Decompiler decompiler = null;
-        if (packageConfig.fernflower.enabled || packageConfig.quiltflower.enabled) {
+        if (packageConfig.quiltflower.enabled) {
             decompiledOutputDir = buildDir.getParent().resolve("decompiled");
             FileUtil.deleteDirectory(decompiledOutputDir);
             Files.createDirectory(decompiledOutputDir);
-            if (packageConfig.fernflower.enabled) {
-                decompiler = new Decompiler.FernflowerDecompiler();
-                Path jarDirectory = Paths.get(packageConfig.fernflower.jarDirectory);
-                if (!Files.exists(jarDirectory)) {
-                    Files.createDirectory(jarDirectory);
-                }
-                decompiler.init(new Decompiler.Context(packageConfig.fernflower.hash, jarDirectory, decompiledOutputDir));
-                decompiler.downloadIfNecessary();
-            } else if (packageConfig.quiltflower.enabled) {
+            if (packageConfig.quiltflower.enabled) {
                 decompiler = new Decompiler.QuiltflowerDecompiler();
                 Path jarDirectory = Paths.get(packageConfig.quiltflower.jarDirectory);
                 if (!Files.exists(jarDirectory)) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -509,6 +509,7 @@ public class JarResultBuildStep {
                 });
     }
 
+    @SuppressWarnings("deprecation")
     private JarBuildItem buildLegacyThinJar(CurateOutcomeBuildItem curateOutcomeBuildItem,
             OutputTargetBuildItem outputTargetBuildItem,
             TransformedClassesBuildItem transformedClasses,
@@ -541,6 +542,7 @@ public class JarResultBuildStep {
                 suffixToClassifier(packageConfig.getRunnerSuffix()));
     }
 
+    @SuppressWarnings("deprecation")
     private JarBuildItem buildThinJar(CurateOutcomeBuildItem curateOutcomeBuildItem,
             OutputTargetBuildItem outputTargetBuildItem,
             TransformedClassesBuildItem transformedClasses,
@@ -644,7 +646,7 @@ public class JarResultBuildStep {
                 }
             }
             if (decompiler != null) {
-                wasDecompiledSuccessfully &= decompiler.decompile(transformedZip);
+                wasDecompiledSuccessfully = decompiler.decompile(transformedZip);
             }
         }
         //now generated classes and resources
@@ -745,7 +747,7 @@ public class JarResultBuildStep {
             //to memory, split them, discard comments, sort them, then write them to disk
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             outputTargetBuildItem.getBuildSystemProperties().store(out, null);
-            List<String> lines = Arrays.stream(new String(out.toByteArray(), StandardCharsets.UTF_8).split("\n"))
+            List<String> lines = Arrays.stream(out.toString(StandardCharsets.UTF_8).split("\n"))
                     .filter(s -> !s.startsWith("#")).sorted().collect(Collectors.toList());
             Path buildSystemProps = quarkus.resolve(BUILD_SYSTEM_PROPERTIES);
             try (OutputStream fileOutput = Files.newOutputStream(buildSystemProps)) {

--- a/integration-tests/hibernate-orm-panache/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-panache/src/main/resources/application.properties
@@ -7,4 +7,4 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.statistics=true
 quarkus.hibernate-orm.metrics.enabled=true
 
-quarkus.package.fernflower.enabled=true
+quarkus.package.quiltflower.enabled=true

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/resources/application.properties
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/resources/application.properties
@@ -28,4 +28,4 @@ mp.messaging.incoming.countries-t2-in.topic=countries-t2
 mp.messaging.incoming.countries-t2-in.auto.offset.reset=earliest
 mp.messaging.incoming.countries-t2-in.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
-quarkus.package.fernflower.enabled=true
+quarkus.package.quiltflower.enabled=true


### PR DESCRIPTION
We have Quiltflower support since [2.10](https://quarkus.io/blog/quarkus-2-10-0-final-released/#quiltflower-decompiler-support), so it's a good time to remove the old Fernflower support