### PR TITLE
Arc - validate Event#select and Event#fire methods for type variables

### DIFF
--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/fire/EventFireTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/fire/EventFireTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.arc.test.event.fire;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class EventFireTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer();
+
+    @Test
+    public <T> void testEventFireThrowsExceptionIfEventTypeHasTypeVariable() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> Arc.container().beanManager().getEvent().select(BarInterface.class).fire(new Foo<T>()),
+                "Event#fire should throw IllegalArgumentException if the payload contains unresolved type variable");
+    }
+
+    public class Foo<T> implements BarInterface {
+
+    }
+
+    public interface BarInterface {
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/select/EventSelectTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/select/EventSelectTest.java
@@ -22,67 +22,56 @@ public class EventSelectTest {
 
     @Test
     public <T> void testEventSelectThrowsExceptionIfEventTypeHasTypeVariable() {
-        try {
-            SecuritySensor sensor = Arc.container().select(SecuritySensor.class).get();
-            sensor.securityEvent.select(new TypeLiteral<SecurityEvent_Illegal<T>>() {
-            });
-            Assertions.fail("Event#select should throw IllegalArgumentException if the event uses type variable");
-        } catch (IllegalArgumentException iae) {
-            // expected
-        }
+        SecuritySensor sensor = Arc.container().select(SecuritySensor.class).get();
+        TypeLiteral<SecurityEvent_Illegal<T>> typeLiteral = new TypeLiteral<SecurityEvent_Illegal<T>>() {
+        };
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> {
+                    sensor.securityEvent.select(typeLiteral);
+                }, "Event#select should throw IllegalArgumentException if the event uses type variable");
+
+        // do the same but with raw type passed into select(Class<U> subtype, Annotation ... qualifiers)
+        Assertions.assertThrows(IllegalArgumentException.class, () -> sensor.securityEvent.select(SecurityEvent_Illegal.class),
+                "Event#select should throw IllegalArgumentException if the event uses type variable");
     }
 
     @Test
     public void testEventSelectThrowsExceptionForDuplicateBindingType() {
-        try {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             SecuritySensor sensor = Arc.container().select(SecuritySensor.class).get();
             sensor.securityEvent.select(new SystemTest.SystemTestLiteral("a") {
             },
                     new SystemTest.SystemTestLiteral("b") {
                     });
-            Assertions.fail("Event#select should throw IllegalArgumentException when there are duplicate bindings specified.");
-        } catch (IllegalArgumentException iae) {
-            // expected
-        }
+        }, "Event#select should throw IllegalArgumentException when there are duplicate bindings specified.");
     }
 
     @Test
     public void testEventSelectWithSubtypeThrowsExceptionForDuplicateBindingType() {
-        try {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             SecuritySensor sensor = Arc.container().select(SecuritySensor.class).get();
             sensor.securityEvent.select(BreakInEvent.class, new SystemTest.SystemTestLiteral("a") {
             },
                     new SystemTest.SystemTestLiteral("b") {
                     });
-            Assertions.fail(
-                    "Event#select should throw IllegalArgumentException when selecting a subtype with duplicate bindings.");
-        } catch (IllegalArgumentException iae) {
-            // expected
-        }
+        }, "Event#select should throw IllegalArgumentException when selecting a subtype with duplicate bindings.");
     }
 
     @Test
     public void testEventSelectThrowsExceptionIfAnnotationIsNotBindingType() {
-        try {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             SecuritySensor sensor = Arc.container().select(SecuritySensor.class).get();
             sensor.securityEvent.select(new AnnotationLiteral<NotABindingType>() {
             });
-            Assertions.fail("Event#select should throw IllegalArgumentException if the annotation is not a binding type.");
-        } catch (IllegalArgumentException iae) {
-            // expected
-        }
+        }, "Event#select should throw IllegalArgumentException if the annotation is not a binding type.");
     }
 
     @Test
     public void testEventSelectWithSubtypeThrowsExceptionIfAnnotationIsNotBindingType() {
-        try {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             SecuritySensor sensor = Arc.container().select(SecuritySensor.class).get();
             sensor.securityEvent.select(BreakInEvent.class, new AnnotationLiteral<NotABindingType>() {
             });
-            Assertions.fail(
-                    "Event#select should throw IllegalArgumentException when selecting a subtype and using annotation that is not a binding type.");
-        } catch (IllegalArgumentException iae) {
-            // expected
-        }
+        }, "Event#select should throw IllegalArgumentException when selecting a subtype and using annotation that is not a binding type.");
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/request/RequestInObserverNotificationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/request/RequestInObserverNotificationTest.java
@@ -14,6 +14,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.util.TypeLiteral;
 import jakarta.inject.Singleton;
 
 import org.junit.jupiter.api.Test;
@@ -32,11 +33,12 @@ public class RequestInObserverNotificationTest {
     @Test
     public void testObserverNotification() {
         ArcContainer container = Arc.container();
-        AtomicReference<String> msg = new AtomicReference<String>();
+        AtomicReference<String> msg = new AtomicReference<>();
         RequestFoo.DESTROYED.set(false);
 
         // Request context should be activated automatically
-        container.beanManager().getEvent().select(AtomicReference.class).fire(msg);
+        container.beanManager().getEvent().select(new TypeLiteral<AtomicReference<String>>() {
+        }).fire(msg);
         String fooId1 = msg.get();
         assertNotNull(fooId1);
         assertTrue(RequestFoo.DESTROYED.get());
@@ -50,7 +52,8 @@ public class RequestInObserverNotificationTest {
             requestContext.activate();
             String fooId2 = container.instance(RequestFoo.class).get().getId();
             assertNotEquals(fooId1, fooId2);
-            container.beanManager().getEvent().select(AtomicReference.class).fire(msg);
+            container.beanManager().getEvent().select(new TypeLiteral<AtomicReference<String>>() {
+            }).fire(msg);
             assertEquals(fooId2, msg.get());
         } finally {
             requestContext.terminate();


### PR DESCRIPTION
This PR aligns event payload validation to that of TCK and Weld.
Related to https://github.com/quarkusio/quarkus/issues/28558

From the specification:
> [(in the desc of `Event#select()` method) ](https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html#event)
> If the specified type contains a type variable, an IllegalArgumentException is thrown.

> The methods fire() and fireAsync() fire an event with the specified qualifiers and notify observers, as defined by Observer notification. If the container is unable to resolve the parameterized type of the event object, it uses the specified type to infer the parameterized type of the event types.

> If the runtime type of the event object contains an unresolvable type variable, an IllegalArgumentException is thrown.

> [An event type may not contain an unresolvable type variable. A wildcard type is not considered an unresolvable type variable.](https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html#event_types_and_qualifier_types)

@mkouba @Ladicek this is a follow up on my Fri Zulip rambling, curious to hear WDYT :)

