### PR TITLE
ArC fixes for spec compatibility, round 3

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.arc.deployment;
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -949,11 +950,13 @@ public class ArcProcessor {
                         injectionPoint.getTargetBean().isPresent()
                                 ? mc.load(injectionPoint.getTargetBean().get().getIdentifier())
                                 : mc.loadNull());
+                boolean isTransient = injectionPoint.isField()
+                        && Modifier.isTransient(injectionPoint.getTarget().asField().flags());
 
                 ResultHandle ret = mc.invokeStaticMethod(instancesMethod, targetBean,
                         injectionPointType, requiredType, requiredQualifiers, mc.getMethodParam(0),
                         injectionPointAnnotations,
-                        javaMember, mc.load(injectionPoint.getPosition()));
+                        javaMember, mc.load(injectionPoint.getPosition()), mc.load(isTransient));
                 mc.returnValue(ret);
             });
             configurator.done();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationStore.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationStore.java
@@ -111,17 +111,23 @@ public final class AnnotationStore {
     }
 
     private Collection<AnnotationInstance> getOriginalAnnotations(AnnotationTarget target) {
+        Collection<AnnotationInstance> annotations;
         switch (target.kind()) {
             case CLASS:
-                return target.asClass().classAnnotations();
+                annotations = target.asClass().classAnnotations();
+                break;
             case METHOD:
                 // Note that the returning collection also contains method params annotations
-                return target.asMethod().annotations();
+                annotations = target.asMethod().annotations();
+                break;
             case FIELD:
-                return target.asField().annotations();
+                annotations = target.asField().annotations();
+                break;
             default:
                 throw new IllegalArgumentException("Unsupported annotation target");
         }
+
+        return Annotations.onlyRuntimeVisible(annotations);
     }
 
     private List<AnnotationsTransformer> initTransformers(Kind kind, Collection<AnnotationsTransformer> transformers) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Annotations.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Annotations.java
@@ -112,6 +112,17 @@ public final class Annotations {
      *
      * @param beanDeployment
      * @param method
+     * @param name
+     * @return whether given method has a parameter that has an annotation with given name
+     */
+    public static boolean hasParameterAnnotation(BeanDeployment beanDeployment, MethodInfo method, DotName name) {
+        return contains(getParameterAnnotations(beanDeployment, method), name);
+    }
+
+    /**
+     *
+     * @param beanDeployment
+     * @param method
      * @return collection of annotations present on all parameters of given method
      */
     public static Set<AnnotationInstance> getParameterAnnotations(BeanDeployment beanDeployment, MethodInfo method) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Annotations.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Annotations.java
@@ -1,8 +1,10 @@
 package io.quarkus.arc.processor;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -171,6 +173,16 @@ public final class Annotations {
             }
         }
         return null;
+    }
+
+    public static Collection<AnnotationInstance> onlyRuntimeVisible(Collection<AnnotationInstance> annotations) {
+        List<AnnotationInstance> result = new ArrayList<>(annotations.size());
+        for (AnnotationInstance annotation : annotations) {
+            if (annotation.runtimeVisible()) {
+                result.add(annotation);
+            }
+        }
+        return result;
     }
 
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
@@ -55,17 +55,17 @@ public final class BeanConfigurator<T> extends BeanConfiguratorBase<BeanConfigur
 
             String name = this.name;
             if (name == null) {
-                name = Beans.initStereotypeName(stereotypes, implClass);
+                name = Beans.initStereotypeName(stereotypes, implClass, beanDeployment);
             }
 
             Boolean alternative = this.alternative;
             if (alternative == null) {
-                alternative = Beans.initStereotypeAlternative(stereotypes);
+                alternative = Beans.initStereotypeAlternative(stereotypes, beanDeployment);
             }
 
             Integer priority = this.priority;
             if (priority == null) {
-                priority = Beans.initStereotypeAlternativePriority(stereotypes);
+                priority = Beans.initStereotypeAlternativePriority(stereotypes, implClass, beanDeployment);
             }
 
             beanConsumer.accept(new BeanInfo.Builder()

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
@@ -158,9 +158,8 @@ public abstract class BeanConfiguratorBase<THIS extends BeanConfiguratorBase<THI
     }
 
     /**
-     * Unlike for the {@link #name(String)} method a new {@link jakarta.inject.Named} qualifier with the specified value is
-     * added
-     * to the configured bean.
+     * Unlike the {@link #name(String)} method, a new {@link jakarta.inject.Named} qualifier with the specified value
+     * is added to the configured bean.
      *
      * @param name
      * @return self

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -970,7 +970,8 @@ public class BeanDeployment {
                                 beanClass);
                         beanClasses.add(beanClass);
                     }
-                } else if (annotationStore.hasAnnotation(method, DotNames.DISPOSES)) {
+                }
+                if (annotationStore.hasAnnotation(method, DotNames.DISPOSES)) {
                     // Disposers are not inherited
                     disposerMethods.add(method);
                 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -4,6 +4,7 @@ import static io.quarkus.arc.processor.BeanProcessor.initAndSort;
 import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
 
 import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -602,17 +603,18 @@ public class BeanDeployment {
 
     private static Collection<AnnotationInstance> extractAnnotations(AnnotationInstance annotation,
             Map<DotName, ClassInfo> singulars, Map<DotName, ClassInfo> repeatables) {
+        if (!annotation.runtimeVisible()) {
+            return Collections.emptyList();
+        }
         DotName annotationName = annotation.name();
         if (singulars.get(annotationName) != null) {
             return Collections.singleton(annotation);
+        } else if (repeatables.get(annotationName) != null) {
+            // repeatable, we need to extract actual annotations
+            return Annotations.onlyRuntimeVisible(Arrays.asList(annotation.value().asNestedArray()));
         } else {
-            if (repeatables.get(annotationName) != null) {
-                // repeatable, we need to extract actual annotations
-                return new ArrayList<>(Arrays.asList(annotation.value().asNestedArray()));
-            } else {
-                // neither singular nor repeatable, return empty collection
-                return Collections.emptyList();
-            }
+            // neither singular nor repeatable, return empty collection
+            return Collections.emptyList();
         }
     }
 
@@ -695,10 +697,18 @@ public class BeanDeployment {
         }
     }
 
+    private boolean isRuntimeAnnotationType(ClassInfo annotationType) {
+        AnnotationInstance retention = annotationType.declaredAnnotation(Retention.class);
+        return retention != null && "RUNTIME".equals(retention.value().asEnum());
+    }
+
     private Map<DotName, ClassInfo> findQualifiers() {
         Map<DotName, ClassInfo> qualifiers = new HashMap<>();
         for (AnnotationInstance qualifier : beanArchiveImmutableIndex.getAnnotations(DotNames.QUALIFIER)) {
             ClassInfo qualifierClass = qualifier.target().asClass();
+            if (!isRuntimeAnnotationType(qualifierClass)) {
+                continue;
+            }
             if (isExcluded(qualifierClass)) {
                 continue;
             }
@@ -725,6 +735,9 @@ public class BeanDeployment {
         // Note: doesn't use AnnotationStore, this will operate on classes without applying annotation transformers
         for (AnnotationInstance binding : beanArchiveImmutableIndex.getAnnotations(DotNames.INTERCEPTOR_BINDING)) {
             ClassInfo bindingClass = binding.target().asClass();
+            if (!isRuntimeAnnotationType(bindingClass)) {
+                continue;
+            }
             if (isExcluded(bindingClass)) {
                 continue;
             }
@@ -787,6 +800,9 @@ public class BeanDeployment {
         for (DotName stereotypeName : stereotypeNames) {
             ClassInfo stereotypeClass = getClassByName(getBeanArchiveIndex(), stereotypeName);
             if (stereotypeClass != null && !isExcluded(stereotypeClass)) {
+                if (!isRuntimeAnnotationType(stereotypeClass)) {
+                    continue;
+                }
 
                 boolean isAlternative = false;
                 Integer alternativePriority = null;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -1929,14 +1929,17 @@ public class BeanGenerator extends AbstractGenerator {
         ResultHandle annotationsHandle = collectInjectionPointAnnotations(classOutput, beanCreator, bean.getDeployment(),
                 constructor, injectionPoint, annotationLiterals, injectionPointAnnotationsPredicate);
         ResultHandle javaMemberHandle = getJavaMemberHandle(constructor, injectionPoint, reflectionRegistration);
+        boolean isTransient = injectionPoint.isField() && Modifier.isTransient(injectionPoint.getTarget().asField().flags());
 
         return constructor.newInstance(
                 MethodDescriptor.ofConstructor(CurrentInjectionPointProvider.class, InjectableBean.class,
                         Supplier.class, java.lang.reflect.Type.class,
-                        Set.class, Set.class, Member.class, int.class),
+                        Set.class, Set.class, Member.class, int.class, boolean.class),
                 constructor.getThis(), constructor.getMethodParam(paramIdx),
                 Types.getTypeHandle(constructor, injectionPoint.getType(), tccl),
-                requiredQualifiersHandle, annotationsHandle, javaMemberHandle, constructor.load(injectionPoint.getPosition()));
+                requiredQualifiersHandle, annotationsHandle, javaMemberHandle,
+                constructor.load(injectionPoint.getPosition()),
+                constructor.load(isTransient));
     }
 
     private void initializeProxy(BeanInfo bean, String baseName, ClassCreator beanCreator) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -2027,9 +2027,6 @@ public class BeanGenerator extends AbstractGenerator {
                 annotationHandle = constructor
                         .readStaticField(FieldDescriptor.of(InjectLiteral.class, "INSTANCE", InjectLiteral.class));
             } else {
-                if (!annotation.runtimeVisible()) {
-                    continue;
-                }
                 ClassInfo annotationClass = getClassByName(beanDeployment.getBeanArchiveIndex(), annotation.name());
                 if (annotationClass == null) {
                     continue;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolverImpl.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolverImpl.java
@@ -277,13 +277,20 @@ class BeanResolverImpl implements BeanResolver {
         bounds = getUppermostBounds(bounds);
         stricterBounds = getUppermostBounds(stricterBounds);
         for (Type bound : bounds) {
-            for (Type stricterBound : stricterBounds) {
-                if (!beanDeployment.getAssignabilityCheck().isAssignableFrom(bound, stricterBound)) {
-                    return false;
-                }
+            if (!isAssignableFromAtLeastOne(bound, stricterBounds)) {
+                return false;
             }
         }
         return true;
+    }
+
+    boolean isAssignableFromAtLeastOne(Type type1, List<Type> types2) {
+        for (Type type2 : types2) {
+            if (beanDeployment.getAssignabilityCheck().isAssignableFrom(type1, type2)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     boolean lowerBoundsOfWildcardMatch(Type parameter, WildcardType requiredParameter) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -124,7 +124,6 @@ public final class Beans {
                 priority = annotation.value().asInt();
                 continue;
             }
-            // This is not supported ATM but should work once we upgrade to Common Annotations 2.1
             if ((!isAlternative || priority == null) && annotationName.equals(DotNames.PRIORITY)) {
                 priority = annotation.value().asInt();
                 continue;
@@ -240,7 +239,6 @@ public final class Beans {
                 priority = annotation.value().asInt();
                 continue;
             }
-            // This is not supported ATM but should work once we upgrade to Common Annotations 2.1
             if ((!isAlternative || priority == null) && annotation.name().equals(DotNames.PRIORITY)) {
                 priority = annotation.value().asInt();
                 continue;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
@@ -314,13 +314,10 @@ enum BuiltinBean {
 
     private static void generateResourceBytecode(GeneratorContext ctx) {
         ResultHandle annotations = ctx.constructor.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
-        // For a resource field the required qualifiers contain all annotations declared on the field
-        // (hence we need to check if they are runtime-retained and their classes are available)
+        // For a resource field the required qualifiers contain all runtime-retained annotations
+        // declared on the field (hence we need to check if their classes are available)
         if (!ctx.injectionPoint.getRequiredQualifiers().isEmpty()) {
             for (AnnotationInstance annotation : ctx.injectionPoint.getRequiredQualifiers()) {
-                if (!annotation.runtimeVisible()) {
-                    continue;
-                }
                 ClassInfo annotationClass = getClassByName(ctx.beanDeployment.getBeanArchiveIndex(), annotation.name());
                 if (annotationClass == null) {
                     continue;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
@@ -50,6 +50,24 @@ public class Injection {
                         "Multiple @Inject constructors found on " + beanTarget.asClass().name() + ":\n"
                                 + injectConstructors.stream().map(Object::toString).collect(Collectors.joining("\n")));
             }
+            for (AnnotationTarget injectConstructor : injectConstructors) {
+                Set<AnnotationInstance> parameterAnnotations = Annotations.getParameterAnnotations(beanDeployment,
+                        injectConstructor.asMethod());
+                for (AnnotationInstance annotation : parameterAnnotations) {
+                    if (DotNames.DISPOSES.equals(annotation.name())) {
+                        throw new DefinitionException(
+                                "Bean constructor must not have a @Disposes parameter: " + injectConstructor);
+                    }
+                    if (DotNames.OBSERVES.equals(annotation.name())) {
+                        throw new DefinitionException(
+                                "Bean constructor must not have an @Observes parameter: " + injectConstructor);
+                    }
+                    if (DotNames.OBSERVES_ASYNC.equals(annotation.name())) {
+                        throw new DefinitionException(
+                                "Bean constructor must not have an @ObservesAsync parameter: " + injectConstructor);
+                    }
+                }
+            }
 
             Set<MethodInfo> initializerMethods = injections.stream()
                     .filter(it -> it.isMethod() && !it.isConstructor())

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
@@ -76,43 +76,58 @@ public class Injection {
                     .collect(Collectors.toSet());
             for (MethodInfo initializerMethod : initializerMethods) {
                 if (beanDeployment.hasAnnotation(initializerMethod, DotNames.PRODUCES)) {
-                    throw new DefinitionException("Initializer method must not be marked @Produces "
-                            + "(alternatively, producer method must not be marked @Inject): "
+                    throw new DefinitionException("Initializer method must not be annotated @Produces "
+                            + "(alternatively, producer method must not be annotated @Inject): "
                             + beanTarget.asClass() + "." + initializerMethod.name());
                 }
-
-                if (Annotations.contains(Annotations.getParameterAnnotations(beanDeployment, initializerMethod),
-                        DotNames.DISPOSES)) {
-                    throw new DefinitionException("Initializer method must not have a parameter marked @Disposes "
-                            + "(alternatively, disposer method must not be marked @Inject): "
+                if (Annotations.hasParameterAnnotation(beanDeployment, initializerMethod, DotNames.DISPOSES)) {
+                    throw new DefinitionException("Initializer method must not have a @Disposes parameter "
+                            + "(alternatively, disposer method must not be annotated @Inject): "
                             + beanTarget.asClass() + "." + initializerMethod.name());
                 }
-
-                if (Annotations.contains(Annotations.getParameterAnnotations(beanDeployment, initializerMethod),
-                        DotNames.OBSERVES)) {
-                    throw new DefinitionException("Initializer method must not have a parameter marked @Observes "
-                            + "(alternatively, observer method must not be marked @Inject): "
+                if (Annotations.hasParameterAnnotation(beanDeployment, initializerMethod, DotNames.OBSERVES)) {
+                    throw new DefinitionException("Initializer method must not have an @Observes parameter "
+                            + "(alternatively, observer method must not be annotated @Inject): "
                             + beanTarget.asClass() + "." + initializerMethod.name());
                 }
-
-                if (Annotations.contains(Annotations.getParameterAnnotations(beanDeployment, initializerMethod),
-                        DotNames.OBSERVES_ASYNC)) {
-                    throw new DefinitionException("Initializer method must not have a parameter marked @ObservesAsync "
-                            + "(alternatively, async observer method must not be marked @Inject): "
+                if (Annotations.hasParameterAnnotation(beanDeployment, initializerMethod, DotNames.OBSERVES_ASYNC)) {
+                    throw new DefinitionException("Initializer method must not have an @ObservesAsync parameter "
+                            + "(alternatively, async observer method must not be annotated @Inject): "
                             + beanTarget.asClass() + "." + initializerMethod.name());
                 }
             }
 
             return injections;
         } else if (Kind.METHOD.equals(beanTarget.kind())) {
-            if (beanTarget.asMethod().parameterTypes().isEmpty()) {
+            MethodInfo producerMethod = beanTarget.asMethod();
+
+            if (beanDeployment.hasAnnotation(producerMethod, DotNames.INJECT)) {
+                throw new DefinitionException("Producer method must not be annotated @Inject "
+                        + "(alternatively, initializer method must not be annotated @Produces): "
+                        + producerMethod);
+            }
+            if (Annotations.hasParameterAnnotation(beanDeployment, producerMethod, DotNames.DISPOSES)) {
+                throw new DefinitionException("Producer method must not have a @Disposes parameter "
+                        + "(alternatively, disposer method must not be annotated @Produces): "
+                        + producerMethod);
+            }
+            if (Annotations.hasParameterAnnotation(beanDeployment, producerMethod, DotNames.OBSERVES)) {
+                throw new DefinitionException("Producer method must not have an @Observes parameter "
+                        + "(alternatively, observer method must not be annotated @Produces): "
+                        + producerMethod);
+            }
+            if (Annotations.hasParameterAnnotation(beanDeployment, producerMethod, DotNames.OBSERVES_ASYNC)) {
+                throw new DefinitionException("Producer method must not have an @ObservesAsync parameter "
+                        + "(alternatively, async observer method must not be annotated @Produces): "
+                        + producerMethod);
+            }
+
+            if (producerMethod.parameterTypes().isEmpty()) {
                 return Collections.emptyList();
             }
             // All parameters are injection points
-            return Collections.singletonList(
-                    new Injection(beanTarget.asMethod(),
-                            InjectionPointInfo.fromMethod(beanTarget.asMethod(), declaringBean.getImplClazz(),
-                                    beanDeployment, transformer)));
+            return Collections.singletonList(new Injection(producerMethod,
+                    InjectionPointInfo.fromMethod(producerMethod, declaringBean.getImplClazz(), beanDeployment, transformer)));
         }
         throw new IllegalArgumentException("Unsupported annotation target");
     }
@@ -127,11 +142,8 @@ public class Injection {
             AnnotationTarget injectTarget = injectAnnotation.target();
             switch (injectAnnotation.target().kind()) {
                 case FIELD:
-                    injections
-                            .add(new Injection(injectTarget, Collections
-                                    .singletonList(
-                                            InjectionPointInfo.fromField(injectTarget.asField(), beanClass, beanDeployment,
-                                                    transformer))));
+                    injections.add(new Injection(injectTarget, Collections.singletonList(
+                            InjectionPointInfo.fromField(injectTarget.asField(), beanClass, beanDeployment, transformer))));
                     break;
                 case METHOD:
                     injections.add(new Injection(injectTarget,
@@ -170,10 +182,9 @@ public class Injection {
                         && resourceAnnotationInstance.target().asField().annotations().stream()
                                 .noneMatch(a -> DotNames.INJECT.equals(a.name()))) {
                     // Add special injection for a resource field
-                    injections.add(new Injection(resourceAnnotationInstance.target(), Collections
-                            .singletonList(InjectionPointInfo
-                                    .fromResourceField(resourceAnnotationInstance.target().asField(), beanClass,
-                                            beanDeployment, transformer))));
+                    injections.add(new Injection(resourceAnnotationInstance.target(), Collections.singletonList(
+                            InjectionPointInfo.fromResourceField(resourceAnnotationInstance.target().asField(),
+                                    beanClass, beanDeployment, transformer))));
                 }
                 // TODO setter injection
             }
@@ -199,6 +210,34 @@ public class Injection {
 
     static Injection forDisposer(MethodInfo disposerMethod, ClassInfo beanClass, BeanDeployment beanDeployment,
             InjectionPointModifier transformer, BeanInfo declaringBean) {
+        if (beanDeployment.hasAnnotation(disposerMethod, DotNames.INJECT)) {
+            throw new DefinitionException("Disposer method must not be annotated @Inject "
+                    + "(alternatively, initializer method must not have a @Disposes parameter): "
+                    + disposerMethod);
+        }
+        if (beanDeployment.hasAnnotation(disposerMethod, DotNames.PRODUCES)) {
+            throw new DefinitionException("Disposer method must not be annotated @Produces "
+                    + "(alternatively, producer method must not have a @Disposes parameter): "
+                    + disposerMethod);
+        }
+        if (Annotations.hasParameterAnnotation(beanDeployment, disposerMethod, DotNames.OBSERVES)) {
+            throw new DefinitionException("Disposer method must not have an @Observes parameter "
+                    + "(alternatively, observer method must not have a @Disposes parameter): "
+                    + disposerMethod);
+        }
+        if (Annotations.hasParameterAnnotation(beanDeployment, disposerMethod, DotNames.OBSERVES_ASYNC)) {
+            throw new DefinitionException("Disposer method must not have an @ObservesAsync parameter "
+                    + "(alternatively, async observer method must not have a @Disposes parameter): "
+                    + disposerMethod);
+        }
+        if (Annotations.getParameterAnnotations(beanDeployment, disposerMethod)
+                .stream()
+                .filter(it -> DotNames.DISPOSES.equals(it.name()))
+                .count() > 1) {
+            throw new DefinitionException("Disposer method must not have more than 1 @Disposes parameter: "
+                    + disposerMethod);
+        }
+
         return new Injection(disposerMethod, InjectionPointInfo.fromMethod(disposerMethod, beanClass, beanDeployment,
                 annotations -> annotations.stream().anyMatch(a -> a.name().equals(DotNames.DISPOSES)), transformer));
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
@@ -67,7 +67,7 @@ public class InjectionPointInfo {
             InjectionPointModifier transformer) {
         Type type = resolveType(field.type(), beanClass, field.declaringClass(), beanDeployment);
         return new InjectionPointInfo(type,
-                transformer.applyTransformers(type, field, new HashSet<>(field.annotations())),
+                transformer.applyTransformers(type, field, new HashSet<>(Annotations.onlyRuntimeVisible(field.annotations()))),
                 InjectionPointKind.RESOURCE, field, -1, false, false);
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -264,11 +264,11 @@ public final class MethodDescriptors {
 
     public static final MethodDescriptor INSTANCES_LIST_OF = MethodDescriptor
             .ofMethod(Instances.class, "listOf", List.class, InjectableBean.class, Type.class, Type.class,
-                    Set.class, CreationalContextImpl.class, Set.class, Member.class, int.class);
+                    Set.class, CreationalContextImpl.class, Set.class, Member.class, int.class, boolean.class);
 
     public static final MethodDescriptor INSTANCES_LIST_OF_HANDLES = MethodDescriptor
             .ofMethod(Instances.class, "listOfHandles", List.class, InjectableBean.class, Type.class, Type.class,
-                    Set.class, CreationalContextImpl.class, Set.class, Member.class, int.class);
+                    Set.class, CreationalContextImpl.class, Set.class, Member.class, int.class, boolean.class);
 
     public static final MethodDescriptor COMPONENTS_PROVIDER_UNABLE_TO_LOAD_REMOVED_BEAN_TYPE = MethodDescriptor.ofMethod(
             ComponentsProvider.class, "unableToLoadRemovedBeanType",

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -567,6 +567,8 @@ public class ObserverGenerator extends AbstractGenerator {
                                 injectionPointAnnotationsPredicate);
                         ResultHandle javaMemberHandle = BeanGenerator.getJavaMemberHandle(constructor, injectionPoint,
                                 reflectionRegistration);
+                        boolean isTransient = injectionPoint.isField()
+                                && Modifier.isTransient(injectionPoint.getTarget().asField().flags());
 
                         // Wrap the constructor arg in a Supplier so we can pass it to CurrentInjectionPointProvider c'tor.
                         ResultHandle delegateSupplier = constructor.newInstance(
@@ -575,11 +577,12 @@ public class ObserverGenerator extends AbstractGenerator {
                         ResultHandle wrapHandle = constructor.newInstance(
                                 MethodDescriptor.ofConstructor(CurrentInjectionPointProvider.class, InjectableBean.class,
                                         Supplier.class, java.lang.reflect.Type.class,
-                                        Set.class, Set.class, Member.class, int.class),
+                                        Set.class, Set.class, Member.class, int.class, boolean.class),
                                 constructor.loadNull(), delegateSupplier,
                                 Types.getTypeHandle(constructor, injectionPoint.getType()),
                                 requiredQualifiersHandle, annotationsHandle, javaMemberHandle,
-                                constructor.load(injectionPoint.getPosition()));
+                                constructor.load(injectionPoint.getPosition()),
+                                constructor.load(isTransient));
                         ResultHandle wrapSupplierHandle = constructor.newInstance(
                                 MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, wrapHandle);
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
@@ -43,9 +43,10 @@ public class ObserverInfo implements InjectionTargetInfo {
 
     static ObserverInfo create(BeanInfo declaringBean, MethodInfo observerMethod, Injection injection, boolean isAsync,
             List<ObserverTransformer> transformers, BuildContext buildContext, boolean jtaCapabilities) {
-        MethodParameterInfo eventParameter = initEventParam(observerMethod, declaringBean.getDeployment());
+        BeanDeployment beanDeployment = declaringBean.getDeployment();
+        MethodParameterInfo eventParameter = initEventParam(observerMethod, beanDeployment);
         AnnotationInstance priorityAnnotation = find(
-                getParameterAnnotations(declaringBean.getDeployment(), observerMethod, eventParameter.position()),
+                getParameterAnnotations(beanDeployment, observerMethod, eventParameter.position()),
                 DotNames.PRIORITY);
         Integer priority;
         if (priorityAnnotation != null) {
@@ -57,25 +58,35 @@ public class ObserverInfo implements InjectionTargetInfo {
         Type observedType = observerMethod.parameterType(eventParameter.position());
         if (Types.containsTypeVariable(observedType)) {
             Map<String, Type> resolvedTypeVariables = Types
-                    .resolvedTypeVariables(declaringBean.getImplClazz(), declaringBean.getDeployment())
+                    .resolvedTypeVariables(declaringBean.getImplClazz(), beanDeployment)
                     .getOrDefault(observerMethod.declaringClass(), Collections.emptyMap());
             observedType = Types.resolveTypeParam(observedType, resolvedTypeVariables,
-                    declaringBean.getDeployment().getBeanArchiveIndex());
+                    beanDeployment.getBeanArchiveIndex());
         }
 
-        Reception reception = initReception(isAsync, declaringBean.getDeployment(), observerMethod);
+        Reception reception = initReception(isAsync, beanDeployment, observerMethod);
         if (reception == Reception.IF_EXISTS && BuiltinScope.DEPENDENT.is(declaringBean.getScope())) {
             throw new DefinitionException("@Dependent bean must not have a conditional observer method: "
                     + observerMethod);
         }
 
-        return create(null, declaringBean.getDeployment(), declaringBean.getTarget().get().asClass().name(), declaringBean,
+        if (beanDeployment.hasAnnotation(observerMethod, DotNames.INJECT)) {
+            throw new DefinitionException("Observer method must not be annotated @Inject: " + observerMethod);
+        }
+        if (beanDeployment.hasAnnotation(observerMethod, DotNames.PRODUCES)) {
+            throw new DefinitionException("Observer method must not be annotated @Produces: " + observerMethod);
+        }
+        if (Annotations.hasParameterAnnotation(beanDeployment, observerMethod, DotNames.DISPOSES)) {
+            throw new DefinitionException("Observer method must not have a @Disposes parameter: " + observerMethod);
+        }
+
+        return create(null, beanDeployment, declaringBean.getTarget().get().asClass().name(), declaringBean,
                 observerMethod, injection,
                 eventParameter,
                 observedType,
-                initQualifiers(declaringBean.getDeployment(), observerMethod, eventParameter),
+                initQualifiers(beanDeployment, observerMethod, eventParameter),
                 reception,
-                initTransactionPhase(isAsync, declaringBean.getDeployment(), observerMethod), isAsync, priority, transformers,
+                initTransactionPhase(isAsync, beanDeployment, observerMethod), isAsync, priority, transformers,
                 buildContext, jtaCapabilities, null, Collections.emptyMap());
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
@@ -63,12 +63,18 @@ public class ObserverInfo implements InjectionTargetInfo {
                     declaringBean.getDeployment().getBeanArchiveIndex());
         }
 
+        Reception reception = initReception(isAsync, declaringBean.getDeployment(), observerMethod);
+        if (reception == Reception.IF_EXISTS && BuiltinScope.DEPENDENT.is(declaringBean.getScope())) {
+            throw new DefinitionException("@Dependent bean must not have a conditional observer method: "
+                    + observerMethod);
+        }
+
         return create(null, declaringBean.getDeployment(), declaringBean.getTarget().get().asClass().name(), declaringBean,
                 observerMethod, injection,
                 eventParameter,
                 observedType,
                 initQualifiers(declaringBean.getDeployment(), observerMethod, eventParameter),
-                initReception(isAsync, declaringBean.getDeployment(), observerMethod),
+                reception,
                 initTransactionPhase(isAsync, declaringBean.getDeployment(), observerMethod), isAsync, priority, transformers,
                 buildContext, jtaCapabilities, null, Collections.emptyMap());
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/QualifierRegistrar.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/QualifierRegistrar.java
@@ -14,9 +14,9 @@ public interface QualifierRegistrar extends BuildExtension {
 
     /**
      * Returns a map of additional qualifers where the key represents the annotation type and the value is an optional set of
-     * non-binding members. Here, "non-binding" is meant in the sense of {@code jakarta.enterprise.util.Nonbinding}. I.e.
-     * members
-     * named in the set will be ignored when the CDI container is selecting a bean instance for a particular injection point.
+     * non-binding members. Here, "non-binding" is meant in the sense of {@code jakarta.enterprise.util.Nonbinding}.
+     * I.e. members named in the set will be ignored when the CDI container is selecting a bean instance for a particular
+     * injection point.
      */
     Map<DotName, Set<String>> getAdditionalQualifiers();
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/AlternativePriority.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/AlternativePriority.java
@@ -10,10 +10,10 @@ import jakarta.enterprise.inject.Alternative;
 /**
  * If a bean is annotated with this annotation, it is considered an enabled alternative with given priority.
  * Effectively, this is a shortcut for {@code Alternative} plus {@code Priority} annotations.
+ * <p>
+ * This annotation can be used not only on bean classes, but also method and field producers.
  *
- * This annotation can be used not only on bean classes, but also method and field producers (unlike pure {@code Priority}).
- *
- * @deprecated Use {@link Alternative} and {@link io.quarkus.arc.Priority}/{@link jakarta.annotation.Priority} instead
+ * @deprecated Use {@link Alternative} and {@link jakarta.annotation.Priority} instead
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE, ElementType.FIELD })

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InstanceHandle.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InstanceHandle.java
@@ -41,9 +41,8 @@ public interface InstanceHandle<T> extends AutoCloseable, Instance.Handle<T> {
 
     /**
      * Destroy the instance as defined by
-     * {@link jakarta.enterprise.context.spi.Contextual#destroy(Object, jakarta.enterprise.context.spi.CreationalContext)}. If
-     * this
-     * is a CDI contextual instance it is also removed from the underlying context.
+     * {@link jakarta.enterprise.context.spi.Contextual#destroy(Object, jakarta.enterprise.context.spi.CreationalContext)}.
+     * If this is a CDI contextual instance, it is also removed from the underlying context.
      *
      * @see AlterableContext#destroy(jakarta.enterprise.context.spi.Contextual)
      */

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Priority.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Priority.java
@@ -6,10 +6,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This annotation has the same semantics as {@link jakarta.annotation.Priority} except that the {@link Target} meta-annotation
- * is
- * not present. The main motivation is to support method and field declarations, i.e. this annotation can be used for producer
- * methods and fields. Note that this problem is fixed in Common Annotations 2.1.
+ * This annotation has the same semantics as {@link jakarta.annotation.Priority} except that the {@link Target}
+ * meta-annotation is not present. The main motivation is to support method and field declarations, i.e. this annotation
+ * can be used for producer methods and fields. Note that this problem is fixed in Common Annotations 2.1.
  * <p>
  * A priority specified by {@link AlternativePriority} and {@link jakarta.annotation.Priority} takes precedence.
  */

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Priority.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Priority.java
@@ -1,18 +1,25 @@
 package io.quarkus.arc;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
 import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
+import java.lang.annotation.RetentionPolicy;
 
 /**
- * This annotation has the same semantics as {@link jakarta.annotation.Priority} except that the {@link Target}
- * meta-annotation is not present. The main motivation is to support method and field declarations, i.e. this annotation
- * can be used for producer methods and fields. Note that this problem is fixed in Common Annotations 2.1.
+ * This annotation has the same semantics as {@link jakarta.annotation.Priority}.
+ * <p>
+ * Prior to Common Annotations 2.1, the {@code jakarta.annotation.Priority} annotation
+ * was meta-annotated {@code @Target({TYPE, PARAMETER})} and so was only usable on class
+ * declarations and method parameters. This annotation was introduced to allow annotating
+ * producer methods and fields.
+ * <p>
+ * Since Common Annotations 2.1, the {@code jakarta.annotation.Priority} is no longer
+ * meta-annotated {@code @Target}, so these two annotations are equivalent.
  * <p>
  * A priority specified by {@link AlternativePriority} and {@link jakarta.annotation.Priority} takes precedence.
+ *
+ * @deprecated use {@link jakarta.annotation.Priority}; this annotation will be removed at some time after Quarkus 3.6
  */
-@Retention(RUNTIME)
+@Retention(RetentionPolicy.RUNTIME)
+@Deprecated
 public @interface Priority {
 
     int value();

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Unremovable.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Unremovable.java
@@ -18,8 +18,7 @@ import java.lang.annotation.Target;
  * <li>does not declare an observer,</li>
  * <li>does not declare any producer which is eligible for injection to any injection point,</li>
  * <li>is not directly eligible for injection into any `jakarta.enterprise.inject.Instance` or `jakarta.inject.Provider`
- * injection
- * point</li>
+ * injection point</li>
  * </ul>
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerBean.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerBean.java
@@ -4,11 +4,12 @@ import java.lang.reflect.Type;
 import java.util.Set;
 
 import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.BeanContainer;
 import jakarta.enterprise.inject.spi.BeanManager;
 
 public class BeanManagerBean extends BuiltInBean<BeanManager> {
 
-    private static final Set<Type> BM_TYPES = Set.of(Object.class, BeanManager.class);
+    private static final Set<Type> BM_TYPES = Set.of(Object.class, BeanContainer.class, BeanManager.class);
 
     @Override
     public Set<Type> getTypes() {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
@@ -4,10 +4,10 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import jakarta.el.ELResolver;
 import jakarta.el.ExpressionFactory;
@@ -125,8 +125,8 @@ public class BeanManagerImpl implements BeanManager {
         if (Types.containsTypeVariable(eventType)) {
             throw new IllegalArgumentException("The runtime type of the event object contains a type variable: " + eventType);
         }
-        Set<Annotation> eventQualifiers = Arrays.asList(qualifiers).stream().collect(Collectors.toSet());
-        return ArcContainerImpl.instance().resolveObservers(eventType, eventQualifiers).stream().collect(Collectors.toSet());
+        Set<Annotation> eventQualifiers = new HashSet<>(Arrays.asList(qualifiers));
+        return new LinkedHashSet<>(ArcContainerImpl.instance().resolveObservers(eventType, eventQualifiers));
     }
 
     @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentInjectionPointProvider.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CurrentInjectionPointProvider.java
@@ -34,7 +34,7 @@ import io.quarkus.arc.InjectableReferenceProvider;
 public class CurrentInjectionPointProvider<T> implements InjectableReferenceProvider<T> {
 
     static final InjectionPoint EMPTY = new InjectionPointImpl(Object.class, Object.class, Collections.emptySet(), null, null,
-            null, -1);
+            null, -1, false);
 
     static final Supplier<InjectionPoint> EMPTY_SUPPLIER = new Supplier<InjectionPoint>() {
 
@@ -49,10 +49,11 @@ public class CurrentInjectionPointProvider<T> implements InjectableReferenceProv
     private final InjectionPoint injectionPoint;
 
     public CurrentInjectionPointProvider(InjectableBean<?> bean, Supplier<InjectableReferenceProvider<T>> delegateSupplier,
-            Type requiredType, Set<Annotation> qualifiers, Set<Annotation> annotations, Member javaMember, int position) {
+            Type requiredType, Set<Annotation> qualifiers, Set<Annotation> annotations, Member javaMember, int position,
+            boolean isTransient) {
         this.delegateSupplier = delegateSupplier;
         this.injectionPoint = new InjectionPointImpl(requiredType, requiredType, qualifiers, bean, annotations, javaMember,
-                position);
+                position, isTransient);
     }
 
     @Override
@@ -70,17 +71,16 @@ public class CurrentInjectionPointProvider<T> implements InjectableReferenceProv
     }
 
     public static class InjectionPointImpl implements InjectionPoint {
-
         private final Type requiredType;
         private final Set<Annotation> qualifiers;
         private final InjectableBean<?> bean;
         private final Annotated annotated;
         private final Member member;
+        private final boolean isTransient;
 
         public InjectionPointImpl(Type injectionPointType, Type requiredType, Set<Annotation> qualifiers,
-                InjectableBean<?> bean,
-                Set<Annotation> annotations,
-                Member javaMember, int position) {
+                InjectableBean<?> bean, Set<Annotation> annotations, Member javaMember,
+                int position, boolean isTransient) {
             this.requiredType = requiredType;
             this.qualifiers = qualifiers;
             this.bean = bean;
@@ -93,6 +93,7 @@ public class CurrentInjectionPointProvider<T> implements InjectableReferenceProv
                 this.annotated = null;
             }
             this.member = javaMember;
+            this.isTransient = isTransient;
         }
 
         @Override
@@ -127,7 +128,7 @@ public class CurrentInjectionPointProvider<T> implements InjectableReferenceProv
 
         @Override
         public boolean isTransient() {
-            return false;
+            return isTransient;
         }
 
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceBean.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceBean.java
@@ -32,7 +32,8 @@ public class InstanceBean extends BuiltInBean<Instance<?>> {
         // Obtain current IP to get the required type and qualifiers
         InjectionPoint ip = InjectionPointProvider.get();
         InstanceImpl<Instance<?>> instance = new InstanceImpl<Instance<?>>((InjectableBean<?>) ip.getBean(), ip.getType(),
-                ip.getQualifiers(), (CreationalContextImpl<?>) creationalContext, Collections.EMPTY_SET, ip.getMember(), 0);
+                ip.getQualifiers(), (CreationalContextImpl<?>) creationalContext, Collections.EMPTY_SET, ip.getMember(),
+                0, ip.isTransient());
         CreationalContextImpl.addDependencyToParent((InjectableBean<Instance<?>>) ip.getBean(), instance, creationalContext);
         return instance;
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceProvider.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceProvider.java
@@ -23,15 +23,17 @@ public class InstanceProvider<T> implements InjectableReferenceProvider<Instance
     private final Set<Annotation> annotations;
     private final Member javaMember;
     private final int position;
+    private final boolean isTransient;
 
     public InstanceProvider(Type type, Set<Annotation> qualifiers, InjectableBean<?> targetBean, Set<Annotation> annotations,
-            Member javaMember, int position) {
+            Member javaMember, int position, boolean isTransient) {
         this.requiredType = type;
         this.qualifiers = qualifiers;
         this.targetBean = targetBean;
         this.annotations = annotations;
         this.javaMember = javaMember;
         this.position = position;
+        this.isTransient = isTransient;
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -39,7 +41,7 @@ public class InstanceProvider<T> implements InjectableReferenceProvider<Instance
     public Instance<T> get(CreationalContext<Instance<T>> creationalContext) {
         InstanceImpl<T> instance = new InstanceImpl<T>(targetBean, requiredType, qualifiers,
                 CreationalContextImpl.unwrap(creationalContext),
-                annotations, javaMember, position);
+                annotations, javaMember, position, isTransient);
         CreationalContextImpl.addDependencyToParent(InstanceBean.INSTANCE, instance,
                 (CreationalContext) creationalContext);
         return instance;

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Instances.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Instances.java
@@ -60,7 +60,8 @@ public final class Instances {
     @SuppressWarnings("unchecked")
     public static <T> List<T> listOf(InjectableBean<?> targetBean, Type injectionPointType, Type requiredType,
             Set<Annotation> requiredQualifiers,
-            CreationalContextImpl<?> creationalContext, Set<Annotation> annotations, Member javaMember, int position) {
+            CreationalContextImpl<?> creationalContext, Set<Annotation> annotations, Member javaMember, int position,
+            boolean isTransient) {
         List<InjectableBean<?>> beans = resolveAllBeans(requiredType, requiredQualifiers);
         if (beans.isEmpty()) {
             return Collections.emptyList();
@@ -68,7 +69,7 @@ public final class Instances {
         List<T> list = new ArrayList<>(beans.size());
         InjectionPoint prev = InjectionPointProvider
                 .set(new InjectionPointImpl(injectionPointType, requiredType, requiredQualifiers, targetBean,
-                        annotations, javaMember, position));
+                        annotations, javaMember, position, isTransient));
         try {
             for (InjectableBean<?> bean : beans) {
                 list.add(getBeanInstance((CreationalContextImpl<T>) creationalContext, (InjectableBean<T>) bean));
@@ -81,14 +82,14 @@ public final class Instances {
     }
 
     public static <T> List<InstanceHandle<T>> listOfHandles(InjectableBean<?> targetBean, Type injectionPointType,
-            Type requiredType,
-            Set<Annotation> requiredQualifiers,
-            CreationalContextImpl<?> creationalContext, Set<Annotation> annotations, Member javaMember, int position) {
+            Type requiredType, Set<Annotation> requiredQualifiers,
+            CreationalContextImpl<?> creationalContext, Set<Annotation> annotations, Member javaMember, int position,
+            boolean isTransient) {
         Supplier<InjectionPoint> supplier = new Supplier<InjectionPoint>() {
             @Override
             public InjectionPoint get() {
                 return new InjectionPointImpl(injectionPointType, requiredType, requiredQualifiers, targetBean,
-                        annotations, javaMember, position);
+                        annotations, javaMember, position, isTransient);
             }
         };
         return listOfHandles(supplier, requiredType, requiredQualifiers, creationalContext);

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/MultipleBoundsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/MultipleBoundsTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.arc.test.bean.types;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.util.TypeLiteral;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class MultipleBoundsTest {
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(BazImpl.class, Consumer.class);
+
+    @Test
+    public void multipleBounds() {
+        Consumer<?> consumer = Arc.container().instance(new TypeLiteral<Consumer<?>>() {
+        }).get();
+        assertTrue(consumer.baz instanceof BazImpl<?>);
+    }
+
+    interface Foo {
+    }
+
+    interface Bar {
+    }
+
+    interface Baz<T> {
+    }
+
+    static class FooImpl implements Foo {
+    }
+
+    @Dependent
+    static class BazImpl<T extends Foo & Bar> implements Baz<T> {
+    }
+
+    @Dependent
+    static class Consumer<T extends FooImpl & Bar> {
+        @Inject
+        Baz<T> baz;
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -38,6 +39,7 @@ import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.Annotated;
 import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanContainer;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.inject.spi.InterceptionType;
@@ -76,6 +78,14 @@ public class BeanManagerTest {
                 }
             })
             .build();
+
+    @Test
+    public void testBeanManagerBeanTypes() {
+        BeanManager bm = Arc.container().beanManager();
+
+        assertSame(bm, Arc.container().instance(BeanContainer.class).get());
+        assertSame(bm, Arc.container().instance(BeanManager.class).get());
+    }
 
     @Test
     public void testGetBeans() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/DisposesParamConstructorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/DisposesParamConstructorTest.java
@@ -4,20 +4,20 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.spi.DefinitionException;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.test.ArcTestContainer;
 
-public class MultiInjectConstructorFailureTest {
+public class DisposesParamConstructorTest {
 
     @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
-            .beanClasses(CombineHarvester.class, Head.class)
+            .beanClasses(MyBean.class)
             .shouldFail()
             .build();
 
@@ -26,28 +26,13 @@ public class MultiInjectConstructorFailureTest {
         Throwable error = container.getFailure();
         assertNotNull(error);
         assertTrue(error instanceof DefinitionException);
-        assertTrue(error.getMessage().contains("Multiple @Inject constructors found"));
+        assertTrue(error.getMessage().contains("Bean constructor must not have a @Disposes parameter"));
     }
 
     @Dependent
-    static class Head {
-
-    }
-
-    @Singleton
-    static class CombineHarvester {
-
-        Head head;
-
+    static class MyBean {
         @Inject
-        public CombineHarvester() {
-            this.head = null;
+        public MyBean(@Disposes String ignored) {
         }
-
-        @Inject
-        public CombineHarvester(Head head) {
-            this.head = head;
-        }
-
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/ObservesAsyncParamConstructorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/ObservesAsyncParamConstructorTest.java
@@ -4,20 +4,20 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.ObservesAsync;
 import jakarta.enterprise.inject.spi.DefinitionException;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.test.ArcTestContainer;
 
-public class MultiInjectConstructorFailureTest {
+public class ObservesAsyncParamConstructorTest {
 
     @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
-            .beanClasses(CombineHarvester.class, Head.class)
+            .beanClasses(MyBean.class)
             .shouldFail()
             .build();
 
@@ -26,28 +26,13 @@ public class MultiInjectConstructorFailureTest {
         Throwable error = container.getFailure();
         assertNotNull(error);
         assertTrue(error instanceof DefinitionException);
-        assertTrue(error.getMessage().contains("Multiple @Inject constructors found"));
+        assertTrue(error.getMessage().contains("Bean constructor must not have an @ObservesAsync parameter"));
     }
 
     @Dependent
-    static class Head {
-
-    }
-
-    @Singleton
-    static class CombineHarvester {
-
-        Head head;
-
+    static class MyBean {
         @Inject
-        public CombineHarvester() {
-            this.head = null;
+        public MyBean(@ObservesAsync String ignored) {
         }
-
-        @Inject
-        public CombineHarvester(Head head) {
-            this.head = head;
-        }
-
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/ObservesParamConstructorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/constructornoinject/ObservesParamConstructorTest.java
@@ -4,20 +4,20 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.DefinitionException;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.test.ArcTestContainer;
 
-public class MultiInjectConstructorFailureTest {
+public class ObservesParamConstructorTest {
 
     @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
-            .beanClasses(CombineHarvester.class, Head.class)
+            .beanClasses(MyBean.class)
             .shouldFail()
             .build();
 
@@ -26,28 +26,13 @@ public class MultiInjectConstructorFailureTest {
         Throwable error = container.getFailure();
         assertNotNull(error);
         assertTrue(error instanceof DefinitionException);
-        assertTrue(error.getMessage().contains("Multiple @Inject constructors found"));
+        assertTrue(error.getMessage().contains("Bean constructor must not have an @Observes parameter"));
     }
 
     @Dependent
-    static class Head {
-
-    }
-
-    @Singleton
-    static class CombineHarvester {
-
-        Head head;
-
+    static class MyBean {
         @Inject
-        public CombineHarvester() {
-            this.head = null;
+        public MyBean(@Observes String ignored) {
         }
-
-        @Inject
-        public CombineHarvester(Head head) {
-            this.head = head;
-        }
-
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/metadata/InjectionPointMetadataTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/metadata/InjectionPointMetadataTest.java
@@ -65,6 +65,12 @@ public class InjectionPointMetadataTest {
         assertFalse(annotatedField.isAnnotationPresent(Deprecated.class));
         assertTrue(annotatedField.getAnnotation(Singleton.class) == null);
         assertTrue(annotatedField.getAnnotations(Singleton.class).isEmpty());
+        assertFalse(injectionPoint.isTransient());
+
+        // Transient field
+        InjectionPoint transientInjectionPoint = controller.transientControlled.injectionPoint;
+        assertNotNull(transientInjectionPoint);
+        assertTrue(transientInjectionPoint.isTransient());
 
         // Method
         InjectionPoint methodInjectionPoint = controller.controlledMethod.injectionPoint;
@@ -76,6 +82,7 @@ public class InjectionPointMetadataTest {
         assertEquals(0, methodParam.getPosition());
         assertEquals(Controller.class, methodParam.getDeclaringCallable().getJavaMember().getDeclaringClass());
         assertEquals("setControlled", methodParam.getDeclaringCallable().getJavaMember().getName());
+        assertFalse(methodInjectionPoint.isTransient());
 
         // Constructor
         InjectionPoint ctorInjectionPoint = controller.controlledCtor.injectionPoint;
@@ -91,6 +98,7 @@ public class InjectionPointMetadataTest {
         assertEquals(1, ctorParam.getAnnotations().size());
         assertTrue(ctorParam.getDeclaringCallable() instanceof AnnotatedConstructor);
         assertEquals(Controller.class, ctorParam.getDeclaringCallable().getJavaMember().getDeclaringClass());
+        assertFalse(ctorInjectionPoint.isTransient());
 
         // Instance
         InjectionPoint instanceInjectionPoint = controller.instanceControlled.get().injectionPoint;
@@ -112,6 +120,7 @@ public class InjectionPointMetadataTest {
         assertTrue(annotatedField.getAnnotation(Singleton.class) == null);
         assertTrue(annotatedField.getAnnotations(Singleton.class).isEmpty());
         assertEquals(1, annotatedField.getAnnotations().size());
+        assertFalse(instanceInjectionPoint.isTransient());
     }
 
     @SuppressWarnings({ "unchecked", "serial" })
@@ -136,6 +145,7 @@ public class InjectionPointMetadataTest {
         assertTrue(annotatedParam.isAnnotationPresent(FooAnnotation.class));
         assertTrue(annotatedParam.getAnnotation(Singleton.class) == null);
         assertTrue(annotatedParam.getAnnotations(Singleton.class).isEmpty());
+        assertFalse(injectionPoint.isTransient());
     }
 
     @Singleton
@@ -152,6 +162,9 @@ public class InjectionPointMetadataTest {
 
         @Inject
         Instance<Controlled> instanceControlled;
+
+        @Inject
+        transient Controlled transientControlled;
 
         @Inject
         public Controller(BeanManager beanManager, @Singleton Controlled controlled) {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/ifexists/DependentReceptionIfExistsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/ifexists/DependentReceptionIfExistsTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.arc.test.observers.ifexists;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Reception;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DependentReceptionIfExistsTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(DependentObserver.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void testFailure() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+        assertTrue(error.getMessage().contains("@Dependent bean must not have a conditional observer method"));
+    }
+
+    @Dependent
+    static class DependentObserver {
+        void observeString(@Observes(notifyObserver = Reception.IF_EXISTS) String value) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/illegal/AsyncObserverDisposesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/illegal/AsyncObserverDisposesTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.arc.test.observers.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.ObservesAsync;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class AsyncObserverDisposesTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Observer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Disposer method must not have an @ObservesAsync parameter"));
+    }
+
+    @Dependent
+    static class Observer {
+        void observe(@ObservesAsync String ignored, @Disposes String ignored2) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/illegal/AsyncObserverInjectTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/illegal/AsyncObserverInjectTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.arc.test.observers.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.ObservesAsync;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class AsyncObserverInjectTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Observer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Initializer method must not have an @ObservesAsync parameter"));
+    }
+
+    @Dependent
+    static class Observer {
+        @Inject
+        void observe(@ObservesAsync String ignored) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/illegal/AsyncObserverProducesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/illegal/AsyncObserverProducesTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.arc.test.observers.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.ObservesAsync;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class AsyncObserverProducesTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Observer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Producer method must not have an @ObservesAsync parameter"));
+    }
+
+    @Dependent
+    static class Observer {
+        @Produces
+        String observe(@ObservesAsync String ignored) {
+            return null;
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/illegal/ObserverDisposesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/illegal/ObserverDisposesTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.arc.test.observers.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ObserverDisposesTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Observer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Disposer method must not have an @Observes parameter"));
+    }
+
+    @Dependent
+    static class Observer {
+        void observe(@Observes String ignored, @Disposes String ignored2) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/illegal/ObserverInjectTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/illegal/ObserverInjectTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.arc.test.observers.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ObserverInjectTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Observer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Initializer method must not have an @Observes parameter"));
+    }
+
+    @Dependent
+    static class Observer {
+        @Inject
+        void observe(@Observes String ignored) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/illegal/ObserverProducesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/illegal/ObserverProducesTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.arc.test.observers.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ObserverProducesTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Observer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Producer method must not have an @Observes parameter"));
+    }
+
+    @Dependent
+    static class Observer {
+        @Produces
+        String observe(@Observes String ignored) {
+            return null;
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/illegal/DisposerInjectTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/illegal/DisposerInjectTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.arc.test.producer.disposer.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DisposerInjectTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(ProducerDisposer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Initializer method must not have a @Disposes parameter"));
+    }
+
+    @Dependent
+    static class ProducerDisposer {
+        @Produces
+        @Dependent
+        String produce() {
+            return "";
+        }
+
+        @Inject
+        void dispose(@Disposes String ignored) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/illegal/DisposerProducesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/illegal/DisposerProducesTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.arc.test.producer.disposer.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DisposerProducesTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(ProducerDisposer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Disposer method must not be annotated @Produces"));
+    }
+
+    @Dependent
+    static class ProducerDisposer {
+        @Produces
+        @Dependent
+        String produce() {
+            return "";
+        }
+
+        @Produces
+        void dispose(@Disposes String ignored) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/illegal/DoubleDisposerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/illegal/DoubleDisposerTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.arc.test.producer.disposer.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DoubleDisposerTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(ProducerDisposer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Disposer method must not have more than 1 @Disposes parameter"));
+    }
+
+    @Dependent
+    static class ProducerDisposer {
+        @Produces
+        @Dependent
+        String produceString() {
+            return "";
+        }
+
+        @Produces
+        @Dependent
+        Integer produceInteger() {
+            return 0;
+        }
+
+        void dispose(@Disposes String ignored, @Disposes Integer ignored2) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/NormalScopedArrayProducerFieldTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/NormalScopedArrayProducerFieldTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.arc.test.producer.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DeploymentException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class NormalScopedArrayProducerFieldTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Producer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DeploymentException.class, error);
+        assertTrue(error.getMessage().contains("Producer field for a normal scoped bean must not have an array type"));
+    }
+
+    static class MyPojo {
+    }
+
+    @Dependent
+    static class Producer {
+        @Produces
+        @ApplicationScoped
+        MyPojo[] produce = new MyPojo[0];
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/NormalScopedArrayProducerMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/NormalScopedArrayProducerMethodTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.arc.test.producer.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DeploymentException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class NormalScopedArrayProducerMethodTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Producer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DeploymentException.class, error);
+        assertTrue(error.getMessage().contains("Producer method for a normal scoped bean must not have an array type"));
+    }
+
+    static class MyPojo {
+    }
+
+    @Dependent
+    static class Producer {
+        @Produces
+        @ApplicationScoped
+        MyPojo[] produce() {
+            return new MyPojo[0];
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/NormalScopedPrimitiveProducerFieldTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/NormalScopedPrimitiveProducerFieldTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.arc.test.producer.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DeploymentException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class NormalScopedPrimitiveProducerFieldTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Producer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DeploymentException.class, error);
+        assertTrue(error.getMessage().contains("Producer field for a normal scoped bean must not have a primitive type"));
+    }
+
+    @Dependent
+    static class Producer {
+        @Produces
+        @ApplicationScoped
+        int produce = 0;
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/NormalScopedPrimitiveProducerMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/NormalScopedPrimitiveProducerMethodTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.arc.test.producer.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DeploymentException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class NormalScopedPrimitiveProducerMethodTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Producer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DeploymentException.class, error);
+        assertTrue(error.getMessage().contains("Producer method for a normal scoped bean must not have a primitive type"));
+    }
+
+    static class MyPojo {
+    }
+
+    @Dependent
+    static class Producer {
+        @Produces
+        @ApplicationScoped
+        int produce() {
+            return 0;
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/CyclicStereotypesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/CyclicStereotypesTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.arc.test.stereotypes;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Stereotype;
+import jakarta.inject.Named;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class CyclicStereotypesTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Stereotype1.class, Stereotype2.class, Stereotype3.class,
+            MyBean.class);
+
+    @Test
+    public void test() {
+        InjectableBean<MyBean> bean = Arc.container().instance(MyBean.class).getBean();
+        assertEquals(RequestScoped.class, bean.getScope());
+        assertEquals("myBean", bean.getName());
+        assertTrue(bean.isAlternative());
+        assertEquals(123, bean.getPriority());
+    }
+
+    // stereotype transitivity:
+    // 1 --> 2
+    // 2 --> 3
+    // 3 --> 2
+
+    @Stereotype2
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype1 {
+    }
+
+    @RequestScoped
+    @Named
+    @Stereotype3
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype2 {
+    }
+
+    @Alternative
+    @Priority(123)
+    @Stereotype2
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype3 {
+    }
+
+    @Stereotype1
+    static class MyBean {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/DeeplyTransitiveStereotypesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/DeeplyTransitiveStereotypesTest.java
@@ -1,0 +1,109 @@
+package io.quarkus.arc.test.stereotypes;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Stereotype;
+import jakarta.inject.Named;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DeeplyTransitiveStereotypesTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(
+            Stereotype1.class,
+            Stereotype2.class,
+            Stereotype3.class,
+            Stereotype4.class,
+            Stereotype5.class,
+            Stereotype6.class,
+            Stereotype7.class,
+            MyBean.class);
+
+    @Test
+    public void test() {
+        InjectableBean<MyBean> bean = Arc.container().instance(MyBean.class).getBean();
+        assertEquals(RequestScoped.class, bean.getScope());
+        assertEquals("myBean", bean.getName());
+        assertTrue(bean.isAlternative());
+        assertEquals(123, bean.getPriority());
+    }
+
+    // stereotype transitivity:
+    // 1 --> 2
+    // 2 --> 3
+    // 3 --> 4, 5
+    // 4 --> 6
+    // 5 --> 7
+
+    @Stereotype2
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype1 {
+    }
+
+    @Stereotype3
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype2 {
+    }
+
+    @Stereotype4
+    @Stereotype5
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype3 {
+    }
+
+    @RequestScoped
+    @Stereotype6
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype4 {
+    }
+
+    @Named
+    @Stereotype7
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype5 {
+    }
+
+    @Alternative
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype6 {
+    }
+
+    @Priority(123)
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype7 {
+    }
+
+    @Stereotype1
+    static class MyBean {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/InconsistentPriorityStereotypesOverriddenOnBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/InconsistentPriorityStereotypesOverriddenOnBeanTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.arc.test.stereotypes;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Stereotype;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InconsistentPriorityStereotypesOverriddenOnBeanTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Stereotype1.class, Stereotype2.class, Stereotype3.class,
+            MyBean.class);
+
+    @Test
+    public void test() {
+        InjectableBean<MyBean> bean = Arc.container().instance(MyBean.class).getBean();
+        assertTrue(bean.isAlternative());
+        assertEquals(789, bean.getPriority());
+    }
+
+    // stereotype transitivity:
+    // 1 --> 2, 3
+
+    @Alternative
+    @Stereotype2
+    @Stereotype3
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype1 {
+    }
+
+    @Priority(123)
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype2 {
+    }
+
+    @Priority(456)
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype3 {
+    }
+
+    @Dependent
+    @Stereotype1
+    @Priority(789)
+    static class MyBean {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/InconsistentPriorityStereotypesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/InconsistentPriorityStereotypesTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.arc.test.stereotypes;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Stereotype;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InconsistentPriorityStereotypesTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Stereotype1.class, Stereotype2.class, Stereotype3.class, MyBean.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("inherits multiple different priorities from stereotypes"));
+    }
+
+    // stereotype transitivity:
+    // 1 --> 2, 3
+
+    @Alternative
+    @Stereotype2
+    @Stereotype3
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype1 {
+    }
+
+    @Priority(123)
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype2 {
+    }
+
+    @Priority(456)
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface Stereotype3 {
+    }
+
+    @Dependent
+    @Stereotype1
+    static class MyBean {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/TransitiveStereotypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/TransitiveStereotypeTest.java
@@ -7,6 +7,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -14,16 +15,20 @@ import java.util.Set;
 import java.util.UUID;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Alternative;
 import jakarta.enterprise.inject.Stereotype;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Named;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.test.ArcTestContainer;
 
 public class TransitiveStereotypeTest {
@@ -46,7 +51,7 @@ public class TransitiveStereotypeTest {
 
             Set<Bean<?>> metadata = bm.getBeans(MyBean.class);
             assertEquals(1, metadata.size());
-            assertEquals(RequestScoped.class, metadata.iterator().next().getScope());
+            assertMetadata((InjectableBean<?>) metadata.iterator().next());
 
             container.requestContext().deactivate();
         }
@@ -60,13 +65,23 @@ public class TransitiveStereotypeTest {
 
             Set<Bean<?>> metadata = bm.getBeans(MyBean.class);
             assertEquals(1, metadata.size());
-            assertEquals(RequestScoped.class, metadata.iterator().next().getScope());
+            assertMetadata((InjectableBean<?>) metadata.iterator().next());
 
             container.requestContext().deactivate();
         }
     }
 
+    private void assertMetadata(InjectableBean<?> bean) {
+        assertEquals(RequestScoped.class, bean.getScope());
+        assertEquals("myBean", bean.getName());
+        assertTrue(bean.isAlternative());
+        assertEquals(123, bean.getPriority());
+    }
+
     @RequestScoped
+    @Named
+    @Alternative
+    @Priority(123)
     @Stereotype
     @Target({ TYPE, METHOD, FIELD })
     @Retention(RUNTIME)


### PR DESCRIPTION
Related to #28558

- fix some bad formatting caused by the move to `jakarta`
- add `BeanContainer` to the set of bean types of the `BeanManager` built-in bean
- implement `InjectionPoint.isTransient()` properly
- fix resolution of beans with parameterized types with type parameters with multiple bounds
- validate that producers of normal-scoped beans do not have primitive or array type
- ignore class-retained annotations everywhere
  - I already attempted to fix issues caused by class-retained annotations once, but the CDI TCK contains tests with some pretty wild class-retained annotations, so this commit addresses that holistically
- fix `BeanManagerImpl.resolveObserverMethods()` to return an ordered set per specification
- validate that bean constructors have no `@Disposes`, `@Observes` or `@ObservesAsync` parameters
- validate that `@Dependent` beans don't have conditional observer methods
- unify and fix handling of transitive stereotypes
- validate that producer/disposer methods don't have `@Observes[Async]` parameters
- deprecate the `io.quarkus.arc.Priority` annotation
  - `jakarta.annotation.Priority` can now be put anywhere, so `io.quarkus.arc.Priority` is not needed anymore