### PR TITLE
Upgrade to Hibernate ORM 5.6.15.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -97,7 +97,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>5.6.14.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
+        <hibernate-orm.version>5.6.15.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
         <bytebuddy.version>1.12.18</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>1.1.9.Final</hibernate-reactive.version>
         <hibernate-validator.version>8.0.0.Final</hibernate-validator.version>

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/AbstractLazyBasicTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/AbstractLazyBasicTest.java
@@ -1,12 +1,20 @@
 package io.quarkus.hibernate.orm.lazyloading;
 
 import static io.quarkus.hibernate.orm.TransactionTestUtils.inTransaction;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
 
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.UserTransaction;
 
+import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.junit.jupiter.api.Test;
+
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
 
 public abstract class AbstractLazyBasicTest {
 
@@ -24,11 +32,61 @@ public abstract class AbstractLazyBasicTest {
     }
 
     @Test
+    public void update_all_nullToNull() {
+        initNull();
+        // Updating lazy properties always results in updates, even if the value didn't change,
+        // because we don't know of their previous value.
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
+            delegate.updateAllProperties(em, entityId, null, null, null);
+        }));
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, null, null, null);
+        });
+    }
+
+    @Test
+    public void update_allLazy_nullToNull() {
+        initNull();
+        // Updating lazy properties always results in updates, even if the value didn't change,
+        // because we don't know of their previous value.
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
+            delegate.updateAllLazyProperties(em, entityId, null, null);
+        }));
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, null, null, null);
+        });
+    }
+
+    @Test
+    public void update_oneEager_nullToNull() {
+        initNull();
+        StatementSpy.checkNoUpdate(() -> inTransaction(transaction, () -> {
+            delegate.updateOneEagerProperty(em, entityId, null);
+        }));
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, null, null, null);
+        });
+    }
+
+    @Test
+    public void update_oneLazy_nullToNull() {
+        initNull();
+        // Updating lazy properties always results in updates, even if the value didn't change,
+        // because we don't know of their previous value.
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
+            delegate.updateOneLazyProperty(em, entityId, null);
+        }));
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, null, null, null);
+        });
+    }
+
+    @Test
     public void update_all_nullToNonNull() {
         initNull();
-        inTransaction(transaction, () -> {
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
             delegate.updateAllProperties(em, entityId, "updated1", "updated2", "updated3");
-        });
+        }));
         inTransaction(transaction, () -> {
             delegate.testLazyLoadingAndPersistedValues(em, entityId, "updated1", "updated2", "updated3");
         });
@@ -37,9 +95,9 @@ public abstract class AbstractLazyBasicTest {
     @Test
     public void update_allLazy_nullToNonNull() {
         initNull();
-        inTransaction(transaction, () -> {
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
             delegate.updateAllLazyProperties(em, entityId, "updated1", "updated2");
-        });
+        }));
         inTransaction(transaction, () -> {
             delegate.testLazyLoadingAndPersistedValues(em, entityId, null, "updated1", "updated2");
         });
@@ -48,9 +106,9 @@ public abstract class AbstractLazyBasicTest {
     @Test
     public void update_oneEager_nullToNonNull() {
         initNull();
-        inTransaction(transaction, () -> {
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
             delegate.updateOneEagerProperty(em, entityId, "updated1");
-        });
+        }));
         inTransaction(transaction, () -> {
             delegate.testLazyLoadingAndPersistedValues(em, entityId, "updated1", null, null);
         });
@@ -59,64 +117,112 @@ public abstract class AbstractLazyBasicTest {
     @Test
     public void update_oneLazy_nullToNonNull() {
         initNull();
-        inTransaction(transaction, () -> {
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
             delegate.updateOneLazyProperty(em, entityId, "updated2");
-        });
+        }));
         inTransaction(transaction, () -> {
             delegate.testLazyLoadingAndPersistedValues(em, entityId, null, "updated2", null);
         });
     }
 
     @Test
-    public void update_all_nonNullToNonNull() {
+    public void update_all_nonNullToNonNull_differentValue() {
         initNonNull();
-        inTransaction(transaction, () -> {
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
             delegate.updateAllProperties(em, entityId, "updated1", "updated2", "updated3");
-        });
+        }));
         inTransaction(transaction, () -> {
             delegate.testLazyLoadingAndPersistedValues(em, entityId, "updated1", "updated2", "updated3");
         });
     }
 
     @Test
-    public void update_allLazy_nonNullToNonNull() {
+    public void update_all_nonNullToNonNull_sameValue() {
         initNonNull();
+        // Updating lazy properties always results in updates, even if the value didn't change,
+        // because we don't know of their previous value.
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
+            delegate.updateAllProperties(em, entityId, "initial1", "initial2", "initial3");
+        }));
         inTransaction(transaction, () -> {
-            delegate.updateAllLazyProperties(em, entityId, "updated1", "updated2");
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, "initial1", "initial2", "initial3");
         });
+    }
+
+    @Test
+    public void update_allLazy_nonNullToNonNull_differentValue() {
+        initNonNull();
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
+            delegate.updateAllLazyProperties(em, entityId, "updated1", "updated2");
+        }));
         inTransaction(transaction, () -> {
             delegate.testLazyLoadingAndPersistedValues(em, entityId, "initial1", "updated1", "updated2");
         });
     }
 
     @Test
-    public void update_oneEager_nonNullToNonNull() {
+    public void update_allLazy_nonNullToNonNull_sameValue() {
         initNonNull();
+        // Updating lazy properties always results in updates, even if the value didn't change,
+        // because we don't know of their previous value.
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
+            delegate.updateAllLazyProperties(em, entityId, "initial2", "initial3");
+        }));
         inTransaction(transaction, () -> {
-            delegate.updateOneEagerProperty(em, entityId, "updated1");
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, "initial1", "initial2", "initial3");
         });
+    }
+
+    @Test
+    public void update_oneEager_nonNullToNonNull_differentValue() {
+        initNonNull();
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
+            delegate.updateOneEagerProperty(em, entityId, "updated1");
+        }));
         inTransaction(transaction, () -> {
             delegate.testLazyLoadingAndPersistedValues(em, entityId, "updated1", "initial2", "initial3");
         });
     }
 
     @Test
-    public void update_oneLazy_nonNullToNonNull() {
+    public void update_oneEager_nonNullToNonNull_sameValue() {
         initNonNull();
+        StatementSpy.checkNoUpdate(() -> inTransaction(transaction, () -> {
+            delegate.updateOneEagerProperty(em, entityId, "initial1");
+        }));
         inTransaction(transaction, () -> {
-            delegate.updateOneLazyProperty(em, entityId, "updated2");
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, "initial1", "initial2", "initial3");
         });
+    }
+
+    @Test
+    public void update_oneLazy_nonNullToNonNull_differentValue() {
+        initNonNull();
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
+            delegate.updateOneLazyProperty(em, entityId, "updated2");
+        }));
         inTransaction(transaction, () -> {
             delegate.testLazyLoadingAndPersistedValues(em, entityId, "initial1", "updated2", "initial3");
         });
     }
 
     @Test
+    public void update_oneLazy_nonNullToNonNull_sameValue() {
+        initNonNull();
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
+            delegate.updateOneLazyProperty(em, entityId, "initial2");
+        }));
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, "initial1", "initial2", "initial3");
+        });
+    }
+
+    @Test
     public void update_all_nonNullToNull() {
         initNonNull();
-        inTransaction(transaction, () -> {
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
             delegate.updateAllProperties(em, entityId, null, null, null);
-        });
+        }));
         inTransaction(transaction, () -> {
             delegate.testLazyLoadingAndPersistedValues(em, entityId, null, null, null);
         });
@@ -125,9 +231,9 @@ public abstract class AbstractLazyBasicTest {
     @Test
     public void update_allLazy_nonNullToNull() {
         initNonNull();
-        inTransaction(transaction, () -> {
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
             delegate.updateAllLazyProperties(em, entityId, null, null);
-        });
+        }));
         inTransaction(transaction, () -> {
             delegate.testLazyLoadingAndPersistedValues(em, entityId, "initial1", null, null);
         });
@@ -136,9 +242,9 @@ public abstract class AbstractLazyBasicTest {
     @Test
     public void update_oneEager_nonNullToNull() {
         initNonNull();
-        inTransaction(transaction, () -> {
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
             delegate.updateOneEagerProperty(em, entityId, null);
-        });
+        }));
         inTransaction(transaction, () -> {
             delegate.testLazyLoadingAndPersistedValues(em, entityId, null, "initial2", "initial3");
         });
@@ -147,9 +253,9 @@ public abstract class AbstractLazyBasicTest {
     @Test
     public void update_oneLazy_nonNullToNull() {
         initNonNull();
-        inTransaction(transaction, () -> {
+        StatementSpy.checkAtLeastOneUpdate(() -> inTransaction(transaction, () -> {
             delegate.updateOneLazyProperty(em, entityId, null);
-        });
+        }));
         inTransaction(transaction, () -> {
             delegate.testLazyLoadingAndPersistedValues(em, entityId, "initial1", null, "initial3");
         });
@@ -196,5 +302,42 @@ public abstract class AbstractLazyBasicTest {
                 String expectedEagerProperty1,
                 String expectedLazyProperty1,
                 String expectedLazyProperty2);
+    }
+
+    @PersistenceUnitExtension
+    public static class StatementSpy implements StatementInspector {
+        private static final ThreadLocal<List<String>> statements = new ThreadLocal<>();
+
+        public static void checkAtLeastOneUpdate(Runnable runnable) {
+            check(runnable, list -> assertThat(list)
+                    .isNotEmpty() // Something is wrong if we didn't even load an entity
+                    .anySatisfy(sql -> assertThat(sql).containsIgnoringCase("update")));
+        }
+
+        public static void checkNoUpdate(Runnable runnable) {
+            check(runnable, list -> assertThat(list)
+                    .isNotEmpty() // Something is wrong if we didn't even load an entity
+                    .allSatisfy(sql -> assertThat(sql).doesNotContainIgnoringCase("update")));
+        }
+
+        public static void check(Runnable runnable, Consumer<List<String>> assertion) {
+            List<String> list = new ArrayList<>();
+            if (statements.get() != null) {
+                throw new IllegalStateException("Cannot nest checkNoUpdate()");
+            }
+            statements.set(list);
+            runnable.run();
+            statements.remove();
+            assertion.accept(list);
+        }
+
+        @Override
+        public String inspect(String sql) {
+            List<String> list = statements.get();
+            if (list != null) {
+                list.add(sql);
+            }
+            return sql;
+        }
     }
 }


### PR DESCRIPTION
Fixes #30234

Release notes for ORM 5.6.15.Final: https://in.relation.to/2023/02/06/hibernate-orm-5615-final/

Note this patch should apply cleanly to 2.16, at least for the Java part, as it does not rely on JPA classes directly.