### PR TITLE
Instruct GraalVM / Mandrel >= 23.0.0 to keep more accurate debug information

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -25,6 +25,7 @@ public final class GraalVM {
         static final Version VERSION_21_3_0 = new Version("GraalVM 21.3.0", "21.3.0", Distribution.ORACLE);
         public static final Version VERSION_22_3_0 = new Version("GraalVM 22.3.0", "22.3.0", Distribution.ORACLE);
         public static final Version VERSION_22_2_0 = new Version("GraalVM 22.2.0", "22.2.0", Distribution.ORACLE);
+        public static final Version VERSION_23_0_0 = new Version("GraalVM 23.0.0", "23.0.0", Distribution.ORACLE);
 
         public static final Version MINIMUM = VERSION_22_2_0;
         public static final Version CURRENT = VERSION_22_3_0;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -702,6 +702,18 @@ public class NativeImageBuildStep {
                     nativeImageArgs.add("-H:-ParseOnce");
                 }
 
+                if (nativeConfig.debug.enabled && graalVMVersion.compareTo(GraalVM.Version.VERSION_23_0_0) >= 0) {
+                    /*
+                     * Instruct GraalVM / Mandrel to keep more accurate information about source locations when generating
+                     * debug info for debugging and monitoring tools. This parameter may break compatibility with Truffle.
+                     * Affected users should explicitly pass {@code -H:-TrackNodeSourcePosition} through
+                     * {@code quarkus.native.additional-build-args} to override it.
+                     *
+                     * See https://github.com/quarkusio/quarkus/issues/30772 for more details.
+                     */
+                    nativeImageArgs.add("-H:+TrackNodeSourcePosition");
+                }
+
                 /**
                  * This makes sure the Kerberos integration module is made available in case any library
                  * refers to it (e.g. the PostgreSQL JDBC requires it, seems plausible that many others will as well):


### PR DESCRIPTION
Instruct GraalVM / Mandrel to keep more accurate debug information about source locations when generating debug info for debugging and monitoring tools. This parameter may break compatibility with Truffle.  Affected users should explicitly pass `-H:-TrackNodeSourcePosition` through `quarkus.native.additional-build-args` to override it.

Closes: #30772

cc @jerboaa 