### PR TITLE
Add RSS section to memory management in native ref guide

### DIFF
--- a/docs/src/main/asciidoc/images/malloc-bytes.svg
+++ b/docs/src/main/asciidoc/images/malloc-bytes.svg
@@ -1,0 +1,4269 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" width="1200" height="2134" onload="init(evt)" viewBox="0 0 1200 2134" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<!-- Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples. -->
+<!-- NOTES:  -->
+<defs>
+	<linearGradient id="background" y1="0" y2="1" x1="0" x2="0" >
+		<stop stop-color="#eef2ee" offset="5%" />
+		<stop stop-color="#e0ffe0" offset="95%" />
+	</linearGradient>
+</defs>
+<style type="text/css">
+	text { font-family:Verdana; font-size:12px; fill:rgb(0,0,0); }
+	#search, #ignorecase { opacity:0.1; cursor:pointer; }
+	#search:hover, #search.show, #ignorecase:hover, #ignorecase.show { opacity:1; }
+	#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+	#title { text-anchor:middle; font-size:17px}
+	#unzoom { cursor:pointer; }
+	#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+	.hide { display:none; }
+	.parent { opacity:0.5; }
+</style>
+<script type="text/ecmascript">
+<![CDATA[
+	"use strict";
+	var details, searchbtn, unzoombtn, matchedtxt, svg, searching, currentSearchTerm, ignorecase, ignorecaseBtn;
+	function init(evt) {
+		details = document.getElementById("details").firstChild;
+		searchbtn = document.getElementById("search");
+		ignorecaseBtn = document.getElementById("ignorecase");
+		unzoombtn = document.getElementById("unzoom");
+		matchedtxt = document.getElementById("matched");
+		svg = document.getElementsByTagName("svg")[0];
+		searching = 0;
+		currentSearchTerm = null;
+
+		// use GET parameters to restore a flamegraphs state.
+		var params = get_params();
+		if (params.x && params.y)
+			zoom(find_group(document.querySelector('[x="' + params.x + '"][y="' + params.y + '"]')));
+                if (params.s) search(params.s);
+	}
+
+	// event listeners
+	window.addEventListener("click", function(e) {
+		var target = find_group(e.target);
+		if (target) {
+			if (target.nodeName == "a") {
+				if (e.ctrlKey === false) return;
+				e.preventDefault();
+			}
+			if (target.classList.contains("parent")) unzoom(true);
+			zoom(target);
+			if (!document.querySelector('.parent')) {
+				// we have basically done a clearzoom so clear the url
+				var params = get_params();
+				if (params.x) delete params.x;
+				if (params.y) delete params.y;
+				history.replaceState(null, null, parse_params(params));
+				unzoombtn.classList.add("hide");
+				return;
+			}
+
+			// set parameters for zoom state
+			var el = target.querySelector("rect");
+			if (el && el.attributes && el.attributes.y && el.attributes._orig_x) {
+				var params = get_params()
+				params.x = el.attributes._orig_x.value;
+				params.y = el.attributes.y.value;
+				history.replaceState(null, null, parse_params(params));
+			}
+		}
+		else if (e.target.id == "unzoom") clearzoom();
+		else if (e.target.id == "search") search_prompt();
+		else if (e.target.id == "ignorecase") toggle_ignorecase();
+	}, false)
+
+	// mouse-over for info
+	// show
+	window.addEventListener("mouseover", function(e) {
+		var target = find_group(e.target);
+		if (target) details.nodeValue = "Function: " + g_to_text(target);
+	}, false)
+
+	// clear
+	window.addEventListener("mouseout", function(e) {
+		var target = find_group(e.target);
+		if (target) details.nodeValue = ' ';
+	}, false)
+
+	// ctrl-F for search
+	// ctrl-I to toggle case-sensitive search
+	window.addEventListener("keydown",function (e) {
+		if (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)) {
+			e.preventDefault();
+			search_prompt();
+		}
+		else if (e.ctrlKey && e.keyCode === 73) {
+			e.preventDefault();
+			toggle_ignorecase();
+		}
+	}, false)
+
+	// functions
+	function get_params() {
+		var params = {};
+		var paramsarr = window.location.search.substr(1).split('&');
+		for (var i = 0; i < paramsarr.length; ++i) {
+			var tmp = paramsarr[i].split("=");
+			if (!tmp[0] || !tmp[1]) continue;
+			params[tmp[0]]  = decodeURIComponent(tmp[1]);
+		}
+		return params;
+	}
+	function parse_params(params) {
+		var uri = "?";
+		for (var key in params) {
+			uri += key + '=' + encodeURIComponent(params[key]) + '&';
+		}
+		if (uri.slice(-1) == "&")
+			uri = uri.substring(0, uri.length - 1);
+		if (uri == '?')
+			uri = window.location.href.split('?')[0];
+		return uri;
+	}
+	function find_child(node, selector) {
+		var children = node.querySelectorAll(selector);
+		if (children.length) return children[0];
+	}
+	function find_group(node) {
+		var parent = node.parentElement;
+		if (!parent) return;
+		if (parent.id == "frames") return node;
+		return find_group(parent);
+	}
+	function orig_save(e, attr, val) {
+		if (e.attributes["_orig_" + attr] != undefined) return;
+		if (e.attributes[attr] == undefined) return;
+		if (val == undefined) val = e.attributes[attr].value;
+		e.setAttribute("_orig_" + attr, val);
+	}
+	function orig_load(e, attr) {
+		if (e.attributes["_orig_"+attr] == undefined) return;
+		e.attributes[attr].value = e.attributes["_orig_" + attr].value;
+		e.removeAttribute("_orig_"+attr);
+	}
+	function g_to_text(e) {
+		var text = find_child(e, "title").firstChild.nodeValue;
+		return (text)
+	}
+	function g_to_func(e) {
+		var func = g_to_text(e);
+		// if there's any manipulation we want to do to the function
+		// name before it's searched, do it here before returning.
+		return (func);
+	}
+	function update_text(e) {
+		var r = find_child(e, "rect");
+		var t = find_child(e, "text");
+		var w = parseFloat(r.attributes.width.value) -3;
+		var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
+		t.attributes.x.value = parseFloat(r.attributes.x.value) + 3;
+
+		// Smaller than this size won't fit anything
+		if (w < 2 * 12 * 0.59) {
+			t.textContent = "";
+			return;
+		}
+
+		t.textContent = txt;
+		var sl = t.getSubStringLength(0, txt.length);
+		// check if only whitespace or if we can fit the entire string into width w
+		if (/^ *$/.test(txt) || sl < w)
+			return;
+
+		// this isn't perfect, but gives a good starting point
+		// and avoids calling getSubStringLength too often
+		var start = Math.floor((w/sl) * txt.length);
+		for (var x = start; x > 0; x = x-2) {
+			if (t.getSubStringLength(0, x + 2) <= w) {
+				t.textContent = txt.substring(0, x) + "..";
+				return;
+			}
+		}
+		t.textContent = "";
+	}
+
+	// zoom
+	function zoom_reset(e) {
+		if (e.attributes != undefined) {
+			orig_load(e, "x");
+			orig_load(e, "width");
+		}
+		if (e.childNodes == undefined) return;
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
+			zoom_reset(c[i]);
+		}
+	}
+	function zoom_child(e, x, ratio) {
+		if (e.attributes != undefined) {
+			if (e.attributes.x != undefined) {
+				orig_save(e, "x");
+				e.attributes.x.value = (parseFloat(e.attributes.x.value) - x - 10) * ratio + 10;
+				if (e.tagName == "text")
+					e.attributes.x.value = find_child(e.parentNode, "rect[x]").attributes.x.value + 3;
+			}
+			if (e.attributes.width != undefined) {
+				orig_save(e, "width");
+				e.attributes.width.value = parseFloat(e.attributes.width.value) * ratio;
+			}
+		}
+
+		if (e.childNodes == undefined) return;
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
+			zoom_child(c[i], x - 10, ratio);
+		}
+	}
+	function zoom_parent(e) {
+		if (e.attributes) {
+			if (e.attributes.x != undefined) {
+				orig_save(e, "x");
+				e.attributes.x.value = 10;
+			}
+			if (e.attributes.width != undefined) {
+				orig_save(e, "width");
+				e.attributes.width.value = parseInt(svg.width.baseVal.value) - (10 * 2);
+			}
+		}
+		if (e.childNodes == undefined) return;
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
+			zoom_parent(c[i]);
+		}
+	}
+	function zoom(node) {
+		var attr = find_child(node, "rect").attributes;
+		var width = parseFloat(attr.width.value);
+		var xmin = parseFloat(attr.x.value);
+		var xmax = parseFloat(xmin + width);
+		var ymin = parseFloat(attr.y.value);
+		var ratio = (svg.width.baseVal.value - 2 * 10) / width;
+
+		// XXX: Workaround for JavaScript float issues (fix me)
+		var fudge = 0.0001;
+
+		unzoombtn.classList.remove("hide");
+
+		var el = document.getElementById("frames").children;
+		for (var i = 0; i < el.length; i++) {
+			var e = el[i];
+			var a = find_child(e, "rect").attributes;
+			var ex = parseFloat(a.x.value);
+			var ew = parseFloat(a.width.value);
+			var upstack;
+			// Is it an ancestor
+			if (0 == 0) {
+				upstack = parseFloat(a.y.value) > ymin;
+			} else {
+				upstack = parseFloat(a.y.value) < ymin;
+			}
+			if (upstack) {
+				// Direct ancestor
+				if (ex <= xmin && (ex+ew+fudge) >= xmax) {
+					e.classList.add("parent");
+					zoom_parent(e);
+					update_text(e);
+				}
+				// not in current path
+				else
+					e.classList.add("hide");
+			}
+			// Children maybe
+			else {
+				// no common path
+				if (ex < xmin || ex + fudge >= xmax) {
+					e.classList.add("hide");
+				}
+				else {
+					zoom_child(e, xmin, ratio);
+					update_text(e);
+				}
+			}
+		}
+		search();
+	}
+	function unzoom(dont_update_text) {
+		unzoombtn.classList.add("hide");
+		var el = document.getElementById("frames").children;
+		for(var i = 0; i < el.length; i++) {
+			el[i].classList.remove("parent");
+			el[i].classList.remove("hide");
+			zoom_reset(el[i]);
+			if(!dont_update_text) update_text(el[i]);
+		}
+		search();
+	}
+	function clearzoom() {
+		unzoom();
+
+		// remove zoom state
+		var params = get_params();
+		if (params.x) delete params.x;
+		if (params.y) delete params.y;
+		history.replaceState(null, null, parse_params(params));
+	}
+
+	// search
+	function toggle_ignorecase() {
+		ignorecase = !ignorecase;
+		if (ignorecase) {
+			ignorecaseBtn.classList.add("show");
+		} else {
+			ignorecaseBtn.classList.remove("show");
+		}
+		reset_search();
+		search();
+	}
+	function reset_search() {
+		var el = document.querySelectorAll("#frames rect");
+		for (var i = 0; i < el.length; i++) {
+			orig_load(el[i], "fill")
+		}
+		var params = get_params();
+		delete params.s;
+		history.replaceState(null, null, parse_params(params));
+	}
+	function search_prompt() {
+		if (!searching) {
+			var term = prompt("Enter a search term (regexp " +
+			    "allowed, eg: ^ext4_)"
+			    + (ignorecase ? ", ignoring case" : "")
+			    + "\nPress Ctrl-i to toggle case sensitivity", "");
+			if (term != null) search(term);
+		} else {
+			reset_search();
+			searching = 0;
+			currentSearchTerm = null;
+			searchbtn.classList.remove("show");
+			searchbtn.firstChild.nodeValue = "Search"
+			matchedtxt.classList.add("hide");
+			matchedtxt.firstChild.nodeValue = ""
+		}
+	}
+	function search(term) {
+		if (term) currentSearchTerm = term;
+
+		var re = new RegExp(currentSearchTerm, ignorecase ? 'i' : '');
+		var el = document.getElementById("frames").children;
+		var matches = new Object();
+		var maxwidth = 0;
+		for (var i = 0; i < el.length; i++) {
+			var e = el[i];
+			var func = g_to_func(e);
+			var rect = find_child(e, "rect");
+			if (func == null || rect == null)
+				continue;
+
+			// Save max width. Only works as we have a root frame
+			var w = parseFloat(rect.attributes.width.value);
+			if (w > maxwidth)
+				maxwidth = w;
+
+			if (func.match(re)) {
+				// highlight
+				var x = parseFloat(rect.attributes.x.value);
+				orig_save(rect, "fill");
+				rect.attributes.fill.value = "rgb(230,0,230)";
+
+				// remember matches
+				if (matches[x] == undefined) {
+					matches[x] = w;
+				} else {
+					if (w > matches[x]) {
+						// overwrite with parent
+						matches[x] = w;
+					}
+				}
+				searching = 1;
+			}
+		}
+		if (!searching)
+			return;
+		var params = get_params();
+		params.s = currentSearchTerm;
+		history.replaceState(null, null, parse_params(params));
+
+		searchbtn.classList.add("show");
+		searchbtn.firstChild.nodeValue = "Reset Search";
+
+		// calculate percent matched, excluding vertical overlap
+		var count = 0;
+		var lastx = -1;
+		var lastw = 0;
+		var keys = Array();
+		for (k in matches) {
+			if (matches.hasOwnProperty(k))
+				keys.push(k);
+		}
+		// sort the matched frames by their x location
+		// ascending, then width descending
+		keys.sort(function(a, b){
+			return a - b;
+		});
+		// Step through frames saving only the biggest bottom-up frames
+		// thanks to the sort order. This relies on the tree property
+		// where children are always smaller than their parents.
+		var fudge = 0.0001;	// JavaScript floating point
+		for (var k in keys) {
+			var x = parseFloat(keys[k]);
+			var w = matches[keys[k]];
+			if (x >= lastx + lastw - fudge) {
+				count += w;
+				lastx = x;
+				lastw = w;
+			}
+		}
+		// display matched percent
+		matchedtxt.classList.remove("hide");
+		var pct = 100 * count / maxwidth;
+		if (pct != 100) pct = pct.toFixed(1)
+		matchedtxt.firstChild.nodeValue = "Matched: " + pct + "%";
+	}
+]]>
+</script>
+<rect x="0.0" y="0" width="1200.0" height="2134.0" fill="url(#background)"  />
+<text id="title" x="600.00" y="24" >malloc bytes Flame Graph</text>
+<text id="details" x="10.00" y="2117" > </text>
+<text id="unzoom" x="10.00" y="24" class="hide">Reset Zoom</text>
+<text id="search" x="1090.00" y="24" >Search</text>
+<text id="ignorecase" x="1174.00" y="24" >ic</text>
+<text id="matched" x="1090.00" y="2117" > </text>
+<g id="frames">
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="1189.6" y="2037" width="0.2" height="15.0" fill="rgb(0,234,145)" rx="2" ry="2" />
+<text  x="1192.60" y="2047.5" ></text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (88 bytes, 0.02%)</title><rect x="19.3" y="1877" width="0.2" height="15.0" fill="rgb(0,210,196)" rx="2" ry="2" />
+<text  x="22.33" y="1887.5" ></text>
+</g>
+<g >
+<title>DefaultChannelId_processHandlePid_9e5f1f52c4046428c73e5a21c855aeba641ce4d2 (944 bytes, 0.18%)</title><rect x="15.1" y="1893" width="2.1" height="15.0" fill="rgb(0,192,19)" rx="2" ry="2" />
+<text  x="18.09" y="1903.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="517" width="0.3" height="15.0" fill="rgb(0,231,127)" rx="2" ry="2" />
+<text  x="13.20" y="527.5" ></text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (88 bytes, 0.02%)</title><rect x="18.5" y="1957" width="0.2" height="15.0" fill="rgb(0,224,191)" rx="2" ry="2" />
+<text  x="21.54" y="1967.5" ></text>
+</g>
+<g >
+<title>[unknown] (712 bytes, 0.14%)</title><rect x="19.5" y="2053" width="1.6" height="15.0" fill="rgb(0,220,88)" rx="2" ry="2" />
+<text  x="22.53" y="2063.5" ></text>
+</g>
+<g >
+<title>AccessController_executePrivileged_d07f5fea2e10c57d20fe35f694351835c33861ed (45 bytes, 0.01%)</title><rect x="65.5" y="1653" width="0.1" height="15.0" fill="rgb(0,228,78)" rx="2" ry="2" />
+<text  x="68.53" y="1663.5" ></text>
+</g>
+<g >
+<title>CgroupV1Subsystem_initSubSystem_a04243dc8d2e2953fe1807decc2f03e9c02ca462 (125 bytes, 0.02%)</title><rect x="63.3" y="1717" width="0.3" height="15.0" fill="rgb(0,214,90)" rx="2" ry="2" />
+<text  x="66.29" y="1727.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (88 bytes, 0.02%)</title><rect x="18.5" y="1765" width="0.2" height="15.0" fill="rgb(0,218,52)" rx="2" ry="2" />
+<text  x="21.54" y="1775.5" ></text>
+</g>
+<g >
+<title>malloc (45 bytes, 0.01%)</title><rect x="30.4" y="1637" width="0.1" height="15.0" fill="rgb(0,196,104)" rx="2" ry="2" />
+<text  x="33.35" y="1647.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (88 bytes, 0.02%)</title><rect x="17.9" y="1701" width="0.2" height="15.0" fill="rgb(0,196,95)" rx="2" ry="2" />
+<text  x="20.94" y="1711.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1013" width="0.3" height="15.0" fill="rgb(0,206,3)" rx="2" ry="2" />
+<text  x="13.20" y="1023.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (88 bytes, 0.02%)</title><rect x="1189.4" y="1733" width="0.2" height="15.0" fill="rgb(0,210,129)" rx="2" ry="2" />
+<text  x="1192.40" y="1743.5" ></text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (88 bytes, 0.02%)</title><rect x="1189.4" y="1957" width="0.2" height="15.0" fill="rgb(0,237,187)" rx="2" ry="2" />
+<text  x="1192.40" y="1967.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (944 bytes, 0.18%)</title><rect x="15.1" y="2021" width="2.1" height="15.0" fill="rgb(0,215,87)" rx="2" ry="2" />
+<text  x="18.09" y="2031.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (88 bytes, 0.02%)</title><rect x="18.7" y="1685" width="0.2" height="15.0" fill="rgb(0,225,118)" rx="2" ry="2" />
+<text  x="21.73" y="1695.5" ></text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (88 bytes, 0.02%)</title><rect x="1189.6" y="1957" width="0.2" height="15.0" fill="rgb(0,190,132)" rx="2" ry="2" />
+<text  x="1192.60" y="1967.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="1189.8" y="2037" width="0.2" height="15.0" fill="rgb(0,222,36)" rx="2" ry="2" />
+<text  x="1192.80" y="2047.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (88 bytes, 0.02%)</title><rect x="19.3" y="1797" width="0.2" height="15.0" fill="rgb(0,239,173)" rx="2" ry="2" />
+<text  x="22.33" y="1807.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_prepareStart_ba0fc6a9cffeebf7551afea9217d6f5eb9aadeb6 (512 bytes, 0.10%)</title><rect x="64.2" y="1605" width="1.1" height="15.0" fill="rgb(0,198,137)" rx="2" ry="2" />
+<text  x="67.18" y="1615.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="17.9" y="2005" width="0.2" height="15.0" fill="rgb(0,217,197)" rx="2" ry="2" />
+<text  x="20.94" y="2015.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (88 bytes, 0.02%)</title><rect x="17.9" y="1765" width="0.2" height="15.0" fill="rgb(0,236,23)" rx="2" ry="2" />
+<text  x="20.94" y="1775.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1045" width="0.3" height="15.0" fill="rgb(0,203,75)" rx="2" ry="2" />
+<text  x="13.20" y="1055.5" ></text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (88 bytes, 0.02%)</title><rect x="1189.4" y="1877" width="0.2" height="15.0" fill="rgb(0,202,193)" rx="2" ry="2" />
+<text  x="1192.40" y="1887.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1637" width="0.3" height="15.0" fill="rgb(0,196,144)" rx="2" ry="2" />
+<text  x="13.20" y="1647.5" ></text>
+</g>
+<g >
+<title>Formatters$7_renderRaw_824a95cfa271ea6fbe5197dbfda5079fe4151a87 (14,320 bytes, 2.74%)</title><rect x="30.7" y="1653" width="32.3" height="15.0" fill="rgb(0,191,21)" rx="2" ry="2" />
+<text  x="33.67" y="1663.5" >Fo..</text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (88 bytes, 0.02%)</title><rect x="1189.8" y="1829" width="0.2" height="15.0" fill="rgb(0,206,112)" rx="2" ry="2" />
+<text  x="1192.80" y="1839.5" ></text>
+</g>
+<g >
+<title>malloc (45 bytes, 0.01%)</title><rect x="980.6" y="1573" width="0.1" height="15.0" fill="rgb(0,217,133)" rx="2" ry="2" />
+<text  x="983.65" y="1583.5" ></text>
+</g>
+<g >
+<title>Thread_start0_1ac299bac29d78e193ed792d1de667f50cd6b267 (512 bytes, 0.10%)</title><rect x="64.2" y="1653" width="1.1" height="15.0" fill="rgb(0,227,85)" rx="2" ry="2" />
+<text  x="67.18" y="1663.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="133" width="0.3" height="15.0" fill="rgb(0,211,133)" rx="2" ry="2" />
+<text  x="13.20" y="143.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_openSelector_a98c4c1fde2d2766fa4075be761910d1644ea8f3 (405,504 bytes, 77.52%)</title><rect x="65.9" y="1733" width="914.7" height="15.0" fill="rgb(0,218,41)" rx="2" ry="2" />
+<text  x="68.85" y="1743.5" >NioEventLoop_openSelector_a98c4c1fde2d2766fa4075be761910d1644ea8f3</text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (88 bytes, 0.02%)</title><rect x="18.3" y="1781" width="0.2" height="15.0" fill="rgb(0,220,24)" rx="2" ry="2" />
+<text  x="21.34" y="1791.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_a248ca38f52050b4cd112d073aa11463562bd8f6 (88 bytes, 0.02%)</title><rect x="1189.4" y="1621" width="0.2" height="15.0" fill="rgb(0,198,164)" rx="2" ry="2" />
+<text  x="1192.40" y="1631.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (88 bytes, 0.02%)</title><rect x="18.7" y="1733" width="0.2" height="15.0" fill="rgb(0,226,6)" rx="2" ry="2" />
+<text  x="21.73" y="1743.5" ></text>
+</g>
+<g >
+<title>ApplicationImpl_doStart_4f75ecc76b43645d5297b6092848747808c532c7 (424,074 bytes, 81.07%)</title><rect x="24.4" y="1941" width="956.6" height="15.0" fill="rgb(0,214,1)" rx="2" ry="2" />
+<text  x="27.40" y="1951.5" >ApplicationImpl_doStart_4f75ecc76b43645d5297b6092848747808c532c7</text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (88 bytes, 0.02%)</title><rect x="18.9" y="1957" width="0.2" height="15.0" fill="rgb(0,237,192)" rx="2" ry="2" />
+<text  x="21.93" y="1967.5" ></text>
+</g>
+<g >
+<title>malloc (472 bytes, 0.09%)</title><rect x="21.1" y="1925" width="1.1" height="15.0" fill="rgb(0,214,136)" rx="2" ry="2" />
+<text  x="24.13" y="1935.5" ></text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (88 bytes, 0.02%)</title><rect x="19.3" y="1893" width="0.2" height="15.0" fill="rgb(0,222,149)" rx="2" ry="2" />
+<text  x="22.33" y="1903.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="85" width="0.3" height="15.0" fill="rgb(0,197,87)" rx="2" ry="2" />
+<text  x="13.20" y="95.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="677" width="0.3" height="15.0" fill="rgb(0,196,13)" rx="2" ry="2" />
+<text  x="13.20" y="687.5" ></text>
+</g>
+<g >
+<title>VertxBuilder_initFileResolver_5126ad051ba63842daa7b7d7df7bce703802e84b (74 bytes, 0.01%)</title><rect x="65.3" y="1829" width="0.2" height="15.0" fill="rgb(0,210,63)" rx="2" ry="2" />
+<text  x="68.33" y="1839.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="2005" width="0.3" height="15.0" fill="rgb(0,224,73)" rx="2" ry="2" />
+<text  x="13.20" y="2015.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_64cb8fa504ff8d8ed6468c31dd67915d26710d8b (88 bytes, 0.02%)</title><rect x="18.5" y="1637" width="0.2" height="15.0" fill="rgb(0,192,134)" rx="2" ry="2" />
+<text  x="21.54" y="1647.5" ></text>
+</g>
+<g >
+<title>Containers_activeProcessorCount_69a70d68269b86774873269a89490f0e7a966343 (266 bytes, 0.05%)</title><rect x="63.0" y="1861" width="0.6" height="15.0" fill="rgb(0,238,12)" rx="2" ry="2" />
+<text  x="65.98" y="1871.5" ></text>
+</g>
+<g >
+<title>malloc (120 bytes, 0.02%)</title><rect x="10.2" y="37" width="0.3" height="15.0" fill="rgb(0,229,37)" rx="2" ry="2" />
+<text  x="13.20" y="47.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="837" width="0.3" height="15.0" fill="rgb(0,215,123)" rx="2" ry="2" />
+<text  x="13.20" y="847.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_c26cfb3083610a614cb5843727b1293a2e050fbe (77 bytes, 0.01%)</title><rect x="63.6" y="1669" width="0.2" height="15.0" fill="rgb(0,201,19)" rx="2" ry="2" />
+<text  x="66.58" y="1679.5" ></text>
+</g>
+<g >
+<title>CEntryPointSnippets_attachUnattachedThread_6f4750d3dbddf08d3924adea7f570a198fb4673c (944 bytes, 0.18%)</title><rect x="21.1" y="1973" width="2.2" height="15.0" fill="rgb(0,193,149)" rx="2" ry="2" />
+<text  x="24.13" y="1983.5" ></text>
+</g>
+<g >
+<title>TimeZone_setDefaultZone_719cf571a5f894fb67632ec84b255527dfb877eb (472 bytes, 0.09%)</title><rect x="29.2" y="1813" width="1.1" height="15.0" fill="rgb(0,218,26)" rx="2" ry="2" />
+<text  x="32.22" y="1823.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_monitorEnter_ed99d0c1674a21db0860911fdb11b326aefec12b (88 bytes, 0.02%)</title><rect x="19.3" y="1669" width="0.2" height="15.0" fill="rgb(0,209,184)" rx="2" ry="2" />
+<text  x="22.33" y="1679.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_lock_62993eeba5aa50f4c636524077187e4fcd926085 (88 bytes, 0.02%)</title><rect x="18.1" y="1653" width="0.2" height="15.0" fill="rgb(0,239,134)" rx="2" ry="2" />
+<text  x="21.14" y="1663.5" ></text>
+</g>
+<g >
+<title>ClassInitializationInfo_invokeClassInitializer_aa7b9b942c88d6732e408e8eb614c29c67e71338 (87 bytes, 0.02%)</title><rect x="29.0" y="1861" width="0.2" height="15.0" fill="rgb(0,224,82)" rx="2" ry="2" />
+<text  x="32.02" y="1871.5" ></text>
+</g>
+<g >
+<title>ContainerInfo_getCpuPeriod_cf44affb3f3627d2fef69139ba5dda25a961193a (45 bytes, 0.01%)</title><rect x="980.6" y="1781" width="0.1" height="15.0" fill="rgb(0,190,134)" rx="2" ry="2" />
+<text  x="983.65" y="1791.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="17.2" y="2021" width="0.2" height="15.0" fill="rgb(0,215,136)" rx="2" ry="2" />
+<text  x="20.22" y="2031.5" ></text>
+</g>
+<g >
+<title>UnixFileSystem_canonicalize0_9b179a3d935be1cd24e6743c1818f8126231c1e2 (74 bytes, 0.01%)</title><rect x="65.3" y="1733" width="0.2" height="15.0" fill="rgb(0,223,192)" rx="2" ry="2" />
+<text  x="68.33" y="1743.5" ></text>
+</g>
+<g >
+<title>SimpleDateFormat_constructor_8877a0cef187263b0d206d9a01e1563055a24388 (14,320 bytes, 2.74%)</title><rect x="30.7" y="1573" width="32.3" height="15.0" fill="rgb(0,222,183)" rx="2" ry="2" />
+<text  x="33.67" y="1583.5" >Si..</text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (88 bytes, 0.02%)</title><rect x="18.3" y="1893" width="0.2" height="15.0" fill="rgb(0,217,139)" rx="2" ry="2" />
+<text  x="21.34" y="1903.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (88 bytes, 0.02%)</title><rect x="19.3" y="1765" width="0.2" height="15.0" fill="rgb(0,217,41)" rx="2" ry="2" />
+<text  x="22.33" y="1775.5" ></text>
+</g>
+<g >
+<title>BundleContentSubstitutedLocalizationSupport_getBundleContentOf_ca03ba632254ad07027aec1c08388a0baf678b4f (7,160 bytes, 1.37%)</title><rect x="46.8" y="1461" width="16.2" height="15.0" fill="rgb(0,205,27)" rx="2" ry="2" />
+<text  x="49.82" y="1471.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="17.9" y="1989" width="0.2" height="15.0" fill="rgb(0,222,186)" rx="2" ry="2" />
+<text  x="20.94" y="1999.5" ></text>
+</g>
+<g >
+<title>ThreadExecutorMap$1_execute_58ae9c4125806c97f7c19c4897bf737056b796fb (512 bytes, 0.10%)</title><rect x="64.2" y="1701" width="1.1" height="15.0" fill="rgb(0,204,46)" rx="2" ry="2" />
+<text  x="67.18" y="1711.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (88 bytes, 0.02%)</title><rect x="1189.6" y="1813" width="0.2" height="15.0" fill="rgb(0,230,208)" rx="2" ry="2" />
+<text  x="1192.60" y="1823.5" ></text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (88 bytes, 0.02%)</title><rect x="18.1" y="1877" width="0.2" height="15.0" fill="rgb(0,190,160)" rx="2" ry="2" />
+<text  x="21.14" y="1887.5" ></text>
+</g>
+<g >
+<title>ClassInitializationInfo_initialize_fc2a388d0cb0b18ea354b79ca3bc111ec6e55467 (944 bytes, 0.18%)</title><rect x="15.1" y="1957" width="2.1" height="15.0" fill="rgb(0,228,41)" rx="2" ry="2" />
+<text  x="18.09" y="1967.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (88 bytes, 0.02%)</title><rect x="18.1" y="1861" width="0.2" height="15.0" fill="rgb(0,192,182)" rx="2" ry="2" />
+<text  x="21.14" y="1871.5" ></text>
+</g>
+<g >
+<title>Provider$Service_newInstanceOf_d6c5e6317e19c4616ca374bed85add86e37febc6 (87 bytes, 0.02%)</title><rect x="29.0" y="1765" width="0.2" height="15.0" fill="rgb(0,205,58)" rx="2" ry="2" />
+<text  x="32.02" y="1775.5" ></text>
+</g>
+<g >
+<title>Runtime_loadLibrary0_3934a65fa759b24cc118fe2881141717d148e91b (472 bytes, 0.09%)</title><rect x="23.3" y="1957" width="1.0" height="15.0" fill="rgb(0,214,12)" rx="2" ry="2" />
+<text  x="26.26" y="1967.5" ></text>
+</g>
+<g >
+<title>CgroupV1Subsystem_getMemoryLimit_2f64f2e29b84961d0d2c4847c33c59cb70da73db (164 bytes, 0.03%)</title><rect x="63.6" y="1781" width="0.3" height="15.0" fill="rgb(0,225,103)" rx="2" ry="2" />
+<text  x="66.58" y="1791.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (88 bytes, 0.02%)</title><rect x="17.7" y="1797" width="0.2" height="15.0" fill="rgb(0,217,205)" rx="2" ry="2" />
+<text  x="20.74" y="1807.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (88 bytes, 0.02%)</title><rect x="18.9" y="1861" width="0.2" height="15.0" fill="rgb(0,205,181)" rx="2" ry="2" />
+<text  x="21.93" y="1871.5" ></text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (88 bytes, 0.02%)</title><rect x="17.7" y="1957" width="0.2" height="15.0" fill="rgb(0,194,109)" rx="2" ry="2" />
+<text  x="20.74" y="1967.5" ></text>
+</g>
+<g >
+<title>AccessController_doPrivileged_de67c881e9b98da6843ef32b423a3d8bdbb4a36a (45 bytes, 0.01%)</title><rect x="980.6" y="1701" width="0.1" height="15.0" fill="rgb(0,214,155)" rx="2" ry="2" />
+<text  x="983.65" y="1711.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (88 bytes, 0.02%)</title><rect x="19.1" y="1909" width="0.2" height="15.0" fill="rgb(0,193,158)" rx="2" ry="2" />
+<text  x="22.13" y="1919.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_lock_62993eeba5aa50f4c636524077187e4fcd926085 (88 bytes, 0.02%)</title><rect x="17.7" y="1653" width="0.2" height="15.0" fill="rgb(0,237,205)" rx="2" ry="2" />
+<text  x="20.74" y="1663.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_lock_62993eeba5aa50f4c636524077187e4fcd926085 (88 bytes, 0.02%)</title><rect x="18.7" y="1653" width="0.2" height="15.0" fill="rgb(0,202,89)" rx="2" ry="2" />
+<text  x="21.73" y="1663.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (88 bytes, 0.02%)</title><rect x="18.9" y="1909" width="0.2" height="15.0" fill="rgb(0,229,123)" rx="2" ry="2" />
+<text  x="21.93" y="1919.5" ></text>
+</g>
+<g >
+<title>VertxCoreRecorder_calculateEventLoopThreads_ab0f3aaab2929a0c355ef20a2c7ec3337201213a (444 bytes, 0.08%)</title><rect x="63.0" y="1909" width="1.0" height="15.0" fill="rgb(0,200,1)" rx="2" ry="2" />
+<text  x="65.98" y="1919.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (88 bytes, 0.02%)</title><rect x="19.1" y="1717" width="0.2" height="15.0" fill="rgb(0,217,60)" rx="2" ry="2" />
+<text  x="22.13" y="1727.5" ></text>
+</g>
+<g >
+<title>FileInputStream_open0_8b1b5fc3043b8ae0dd0d8b68b3a5a224719f9dca (45 bytes, 0.01%)</title><rect x="63.0" y="1669" width="0.1" height="15.0" fill="rgb(0,206,173)" rx="2" ry="2" />
+<text  x="65.98" y="1679.5" ></text>
+</g>
+<g >
+<title>ntloop-thread-2 (88 bytes, 0.02%)</title><rect x="17.9" y="2069" width="0.2" height="15.0" fill="rgb(0,194,91)" rx="2" ry="2" />
+<text  x="20.94" y="2079.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="18.1" y="2005" width="0.2" height="15.0" fill="rgb(0,213,8)" rx="2" ry="2" />
+<text  x="21.14" y="2015.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="1189.8" y="1509" width="0.2" height="15.0" fill="rgb(0,197,56)" rx="2" ry="2" />
+<text  x="1192.80" y="1519.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (88 bytes, 0.02%)</title><rect x="1189.6" y="1749" width="0.2" height="15.0" fill="rgb(0,230,142)" rx="2" ry="2" />
+<text  x="1192.60" y="1759.5" ></text>
+</g>
+<g >
+<title>PhysicalMemory_doInitialize_b2730a761790fc32d4dd55a0d291b0c22e40ab39 (178 bytes, 0.03%)</title><rect x="63.6" y="1845" width="0.4" height="15.0" fill="rgb(0,209,3)" rx="2" ry="2" />
+<text  x="66.58" y="1855.5" ></text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="19.1" y="1605" width="0.2" height="15.0" fill="rgb(0,198,3)" rx="2" ry="2" />
+<text  x="22.13" y="1615.5" ></text>
+</g>
+<g >
+<title>GZIPInputStream_constructor_c96ccb0372fe76fd9d98b28266a378cd9152d4c3 (7,160 bytes, 1.37%)</title><rect x="46.8" y="1413" width="16.2" height="15.0" fill="rgb(0,211,32)" rx="2" ry="2" />
+<text  x="49.82" y="1423.5" ></text>
+</g>
+<g >
+<title>PosixNativeLibrarySupport_initializeBuiltinLibraries_5ed9203f884545e34ccff2735cc59e80270b4276 (472 bytes, 0.09%)</title><rect x="23.3" y="1989" width="1.0" height="15.0" fill="rgb(0,204,47)" rx="2" ry="2" />
+<text  x="26.26" y="1999.5" ></text>
+</g>
+<g >
+<title>GzipBundleCompression_decompressBundle_814832a1dbe1a42068e9da5f2556515af88d72d7 (7,160 bytes, 1.37%)</title><rect x="46.8" y="1429" width="16.2" height="15.0" fill="rgb(0,213,194)" rx="2" ry="2" />
+<text  x="49.82" y="1439.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_readAllLinesPrivileged_935f757c989c01771a71134b8c379bc859fc1402 (77 bytes, 0.01%)</title><rect x="63.6" y="1749" width="0.2" height="15.0" fill="rgb(0,209,27)" rx="2" ry="2" />
+<text  x="66.58" y="1759.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (88 bytes, 0.02%)</title><rect x="19.3" y="1733" width="0.2" height="15.0" fill="rgb(0,191,188)" rx="2" ry="2" />
+<text  x="22.33" y="1743.5" ></text>
+</g>
+<g >
+<title>CgroupUtil$$Lambda$017b0cd0360754c055090b7d9521ad624f6920d8_run_5c088bd044b8b175a48676ce16a00fd18da382a5 (86 bytes, 0.02%)</title><rect x="63.4" y="1621" width="0.2" height="15.0" fill="rgb(0,235,157)" rx="2" ry="2" />
+<text  x="66.38" y="1631.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (88 bytes, 0.02%)</title><rect x="19.3" y="1749" width="0.2" height="15.0" fill="rgb(0,199,208)" rx="2" ry="2" />
+<text  x="22.33" y="1759.5" ></text>
+</g>
+<g >
+<title>ApplicationLifecycleManager_run_d5cb017ad26675ebbd7be504099501fde301d161 (424,090 bytes, 81.07%)</title><rect x="24.4" y="1973" width="956.6" height="15.0" fill="rgb(0,193,74)" rx="2" ry="2" />
+<text  x="27.37" y="1983.5" >ApplicationLifecycleManager_run_d5cb017ad26675ebbd7be504099501fde301d161</text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="18.3" y="2021" width="0.2" height="15.0" fill="rgb(0,228,22)" rx="2" ry="2" />
+<text  x="21.34" y="2031.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1285" width="0.3" height="15.0" fill="rgb(0,197,69)" rx="2" ry="2" />
+<text  x="13.20" y="1295.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (88 bytes, 0.02%)</title><rect x="17.9" y="1813" width="0.2" height="15.0" fill="rgb(0,210,155)" rx="2" ry="2" />
+<text  x="20.94" y="1823.5" ></text>
+</g>
+<g >
+<title>NativePRNG_&lt;clinit&gt;_7b71c0784f8d2b83daeb8d1e226a95b607564702 (87 bytes, 0.02%)</title><rect x="29.0" y="1701" width="0.2" height="15.0" fill="rgb(0,213,51)" rx="2" ry="2" />
+<text  x="32.02" y="1711.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (88 bytes, 0.02%)</title><rect x="1189.6" y="1701" width="0.2" height="15.0" fill="rgb(0,233,160)" rx="2" ry="2" />
+<text  x="1192.60" y="1711.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (88 bytes, 0.02%)</title><rect x="19.1" y="1813" width="0.2" height="15.0" fill="rgb(0,200,150)" rx="2" ry="2" />
+<text  x="22.13" y="1823.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1797" width="0.3" height="15.0" fill="rgb(0,211,122)" rx="2" ry="2" />
+<text  x="13.20" y="1807.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_execute0_b415979b772d95542b736dc7462790490c971673 (512 bytes, 0.10%)</title><rect x="64.2" y="1765" width="1.1" height="15.0" fill="rgb(0,203,137)" rx="2" ry="2" />
+<text  x="67.18" y="1775.5" ></text>
+</g>
+<g >
+<title>ClassInitializationInfo_initialize_fc2a388d0cb0b18ea354b79ca3bc111ec6e55467 (87 bytes, 0.02%)</title><rect x="29.0" y="1733" width="0.2" height="15.0" fill="rgb(0,203,161)" rx="2" ry="2" />
+<text  x="32.02" y="1743.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (88 bytes, 0.02%)</title><rect x="1189.8" y="1861" width="0.2" height="15.0" fill="rgb(0,198,50)" rx="2" ry="2" />
+<text  x="1192.80" y="1871.5" ></text>
+</g>
+<g >
+<title>ResourceBundle_containsKey_54b542817807d492c96f36e6ee9bd047392ec125 (7,160 bytes, 1.37%)</title><rect x="30.7" y="1509" width="16.1" height="15.0" fill="rgb(0,196,115)" rx="2" ry="2" />
+<text  x="33.67" y="1519.5" ></text>
+</g>
+<g >
+<title>FileInputStream_open0_8b1b5fc3043b8ae0dd0d8b68b3a5a224719f9dca (45 bytes, 0.01%)</title><rect x="980.6" y="1605" width="0.1" height="15.0" fill="rgb(0,192,91)" rx="2" ry="2" />
+<text  x="983.65" y="1615.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (88 bytes, 0.02%)</title><rect x="1189.6" y="1829" width="0.2" height="15.0" fill="rgb(0,228,64)" rx="2" ry="2" />
+<text  x="1192.60" y="1839.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (88 bytes, 0.02%)</title><rect x="18.1" y="1797" width="0.2" height="15.0" fill="rgb(0,219,121)" rx="2" ry="2" />
+<text  x="21.14" y="1807.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="17.7" y="2053" width="0.2" height="15.0" fill="rgb(0,212,5)" rx="2" ry="2" />
+<text  x="20.74" y="2063.5" ></text>
+</g>
+<g >
+<title>CEntryPointSnippets_createIsolate_bb00f99aac090dc55c4d720184b7788129da5b4b (944 bytes, 0.18%)</title><rect x="21.1" y="2005" width="2.2" height="15.0" fill="rgb(0,200,36)" rx="2" ry="2" />
+<text  x="24.13" y="2015.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (88 bytes, 0.02%)</title><rect x="18.9" y="1797" width="0.2" height="15.0" fill="rgb(0,215,14)" rx="2" ry="2" />
+<text  x="21.93" y="1807.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="1189.2" y="1525" width="0.2" height="15.0" fill="rgb(0,206,92)" rx="2" ry="2" />
+<text  x="1192.21" y="1535.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (88 bytes, 0.02%)</title><rect x="18.1" y="1941" width="0.2" height="15.0" fill="rgb(0,214,119)" rx="2" ry="2" />
+<text  x="21.14" y="1951.5" ></text>
+</g>
+<g >
+<title>Inflater_init_a4cd52a872c5e0e850f4481152c720bd7b39637f (7,160 bytes, 1.37%)</title><rect x="30.7" y="1397" width="16.1" height="15.0" fill="rgb(0,206,59)" rx="2" ry="2" />
+<text  x="33.67" y="1407.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="1189.6" y="2021" width="0.2" height="15.0" fill="rgb(0,197,192)" rx="2" ry="2" />
+<text  x="1192.60" y="2031.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1077" width="0.3" height="15.0" fill="rgb(0,211,3)" rx="2" ry="2" />
+<text  x="13.20" y="1087.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="485" width="0.3" height="15.0" fill="rgb(0,213,39)" rx="2" ry="2" />
+<text  x="13.20" y="495.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="1189.8" y="2021" width="0.2" height="15.0" fill="rgb(0,209,116)" rx="2" ry="2" />
+<text  x="1192.80" y="2031.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder_startServer_6339da8207b53cc10107689907ed08d77bc8d9af (600 bytes, 0.11%)</title><rect x="64.0" y="1909" width="1.3" height="15.0" fill="rgb(0,233,178)" rx="2" ry="2" />
+<text  x="66.98" y="1919.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (88 bytes, 0.02%)</title><rect x="1189.4" y="1909" width="0.2" height="15.0" fill="rgb(0,210,50)" rx="2" ry="2" />
+<text  x="1192.40" y="1919.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="181" width="0.3" height="15.0" fill="rgb(0,219,125)" rx="2" ry="2" />
+<text  x="13.20" y="191.5" ></text>
+</g>
+<g >
+<title>WriterHandler_doPublish_d36f3fe3661009300151d79e6db671da9ccbc459 (14,320 bytes, 2.74%)</title><rect x="30.7" y="1749" width="32.3" height="15.0" fill="rgb(0,209,120)" rx="2" ry="2" />
+<text  x="33.67" y="1759.5" >Wr..</text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_64cb8fa504ff8d8ed6468c31dd67915d26710d8b (88 bytes, 0.02%)</title><rect x="19.1" y="1637" width="0.2" height="15.0" fill="rgb(0,200,134)" rx="2" ry="2" />
+<text  x="22.13" y="1647.5" ></text>
+</g>
+<g >
+<title>CgroupV1Subsystem_getCpuPeriod_af2665b8ccf1535123ef8d345b5b9b8505005dfa (45 bytes, 0.01%)</title><rect x="980.6" y="1749" width="0.1" height="15.0" fill="rgb(0,202,113)" rx="2" ry="2" />
+<text  x="983.65" y="1759.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (88 bytes, 0.02%)</title><rect x="18.3" y="1765" width="0.2" height="15.0" fill="rgb(0,211,152)" rx="2" ry="2" />
+<text  x="21.34" y="1775.5" ></text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (88 bytes, 0.02%)</title><rect x="17.7" y="1893" width="0.2" height="15.0" fill="rgb(0,222,182)" rx="2" ry="2" />
+<text  x="20.74" y="1903.5" ></text>
+</g>
+<g >
+<title>CompressedBundle_getContent_e202d21fa4041ac423203615eace2d3fdd988d5c (7,160 bytes, 1.37%)</title><rect x="46.8" y="1445" width="16.2" height="15.0" fill="rgb(0,238,47)" rx="2" ry="2" />
+<text  x="49.82" y="1455.5" ></text>
+</g>
+<g >
+<title>CgroupV1Subsystem_getCpuPeriod_af2665b8ccf1535123ef8d345b5b9b8505005dfa (45 bytes, 0.01%)</title><rect x="30.4" y="1813" width="0.1" height="15.0" fill="rgb(0,211,87)" rx="2" ry="2" />
+<text  x="33.35" y="1823.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="18.3" y="2005" width="0.2" height="15.0" fill="rgb(0,219,7)" rx="2" ry="2" />
+<text  x="21.34" y="2015.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="1189.6" y="1973" width="0.2" height="15.0" fill="rgb(0,220,107)" rx="2" ry="2" />
+<text  x="1192.60" y="1983.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer$JavaMonitorConditionObject_await_7622305ec5751c313d2e3891c69459bf83c7766d (88 bytes, 0.02%)</title><rect x="10.0" y="1925" width="0.2" height="15.0" fill="rgb(0,225,74)" rx="2" ry="2" />
+<text  x="13.00" y="1935.5" ></text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="1189.4" y="1605" width="0.2" height="15.0" fill="rgb(0,227,125)" rx="2" ry="2" />
+<text  x="1192.40" y="1615.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (88 bytes, 0.02%)</title><rect x="18.9" y="1685" width="0.2" height="15.0" fill="rgb(0,201,53)" rx="2" ry="2" />
+<text  x="21.93" y="1695.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="18.5" y="1525" width="0.2" height="15.0" fill="rgb(0,224,24)" rx="2" ry="2" />
+<text  x="21.54" y="1535.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (88 bytes, 0.02%)</title><rect x="17.9" y="1797" width="0.2" height="15.0" fill="rgb(0,215,197)" rx="2" ry="2" />
+<text  x="20.94" y="1807.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="1189.8" y="1989" width="0.2" height="15.0" fill="rgb(0,204,151)" rx="2" ry="2" />
+<text  x="1192.80" y="1999.5" ></text>
+</g>
+<g >
+<title>malloc (77 bytes, 0.01%)</title><rect x="63.6" y="1605" width="0.2" height="15.0" fill="rgb(0,198,133)" rx="2" ry="2" />
+<text  x="66.58" y="1615.5" ></text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (88 bytes, 0.02%)</title><rect x="1189.2" y="1877" width="0.2" height="15.0" fill="rgb(0,208,24)" rx="2" ry="2" />
+<text  x="1192.21" y="1887.5" ></text>
+</g>
+<g >
+<title>EPollSelectorImpl_constructor_e766728b6679c7c5e8eabbee0cfd0f70e475eb9e (405,504 bytes, 77.52%)</title><rect x="65.9" y="1717" width="914.7" height="15.0" fill="rgb(0,218,0)" rx="2" ry="2" />
+<text  x="68.85" y="1727.5" >EPollSelectorImpl_constructor_e766728b6679c7c5e8eabbee0cfd0f70e475eb9e</text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (88 bytes, 0.02%)</title><rect x="1189.6" y="1909" width="0.2" height="15.0" fill="rgb(0,220,199)" rx="2" ry="2" />
+<text  x="1192.60" y="1919.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="18.3" y="1589" width="0.2" height="15.0" fill="rgb(0,239,171)" rx="2" ry="2" />
+<text  x="21.34" y="1599.5" ></text>
+</g>
+<g >
+<title>TimerThread_run_525d3e24a1ac03d71e8c79a2e41a78e8142fce3e (88 bytes, 0.02%)</title><rect x="10.0" y="1989" width="0.2" height="15.0" fill="rgb(0,214,175)" rx="2" ry="2" />
+<text  x="13.00" y="1999.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="373" width="0.3" height="15.0" fill="rgb(0,222,80)" rx="2" ry="2" />
+<text  x="13.20" y="383.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_lock_62993eeba5aa50f4c636524077187e4fcd926085 (88 bytes, 0.02%)</title><rect x="19.3" y="1653" width="0.2" height="15.0" fill="rgb(0,231,76)" rx="2" ry="2" />
+<text  x="22.33" y="1663.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="18.7" y="1989" width="0.2" height="15.0" fill="rgb(0,226,4)" rx="2" ry="2" />
+<text  x="21.73" y="1999.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_execute_de764a165551e0f5ba19bdc2e390bc981738693c (512 bytes, 0.10%)</title><rect x="64.2" y="1781" width="1.1" height="15.0" fill="rgb(0,214,45)" rx="2" ry="2" />
+<text  x="67.18" y="1791.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1717" width="0.3" height="15.0" fill="rgb(0,217,111)" rx="2" ry="2" />
+<text  x="13.20" y="1727.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1813" width="0.3" height="15.0" fill="rgb(0,209,95)" rx="2" ry="2" />
+<text  x="13.20" y="1823.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_lock_62993eeba5aa50f4c636524077187e4fcd926085 (88 bytes, 0.02%)</title><rect x="1189.4" y="1653" width="0.2" height="15.0" fill="rgb(0,190,69)" rx="2" ry="2" />
+<text  x="1192.40" y="1663.5" ></text>
+</g>
+<g >
+<title>AccessController_doPrivileged_de67c881e9b98da6843ef32b423a3d8bdbb4a36a (45 bytes, 0.01%)</title><rect x="30.4" y="1765" width="0.1" height="15.0" fill="rgb(0,213,27)" rx="2" ry="2" />
+<text  x="33.35" y="1775.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1845" width="0.3" height="15.0" fill="rgb(0,198,157)" rx="2" ry="2" />
+<text  x="13.20" y="1855.5" ></text>
+</g>
+<g >
+<title>fileOpen (87 bytes, 0.02%)</title><rect x="63.8" y="1621" width="0.1" height="15.0" fill="rgb(0,219,110)" rx="2" ry="2" />
+<text  x="66.75" y="1631.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (88 bytes, 0.02%)</title><rect x="1189.2" y="1861" width="0.2" height="15.0" fill="rgb(0,234,33)" rx="2" ry="2" />
+<text  x="1192.21" y="1871.5" ></text>
+</g>
+<g >
+<title>CEntryPointSnippets_attachThread_79968be9e283fa24b8007dd7d4944f94cacc3a11 (944 bytes, 0.18%)</title><rect x="21.1" y="1989" width="2.2" height="15.0" fill="rgb(0,230,153)" rx="2" ry="2" />
+<text  x="24.13" y="1999.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_lock_62993eeba5aa50f4c636524077187e4fcd926085 (88 bytes, 0.02%)</title><rect x="18.3" y="1653" width="0.2" height="15.0" fill="rgb(0,230,190)" rx="2" ry="2" />
+<text  x="21.34" y="1663.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="17.2" y="1829" width="0.2" height="15.0" fill="rgb(0,210,41)" rx="2" ry="2" />
+<text  x="20.22" y="1839.5" ></text>
+</g>
+<g >
+<title>EnhancedQueueExecutor$PoolThreadNode_park_fd84a7455e9afdd1efde5271630f3118dc8af70d (88 bytes, 0.02%)</title><rect x="17.2" y="1925" width="0.2" height="15.0" fill="rgb(0,201,62)" rx="2" ry="2" />
+<text  x="20.22" y="1935.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (944 bytes, 0.18%)</title><rect x="15.1" y="2037" width="2.1" height="15.0" fill="rgb(0,234,124)" rx="2" ry="2" />
+<text  x="18.09" y="2047.5" ></text>
+</g>
+<g >
+<title>Unsafe_park_8e78b5f196bf0524b1490ff9abb68dc337e02cca (88 bytes, 0.02%)</title><rect x="17.2" y="1893" width="0.2" height="15.0" fill="rgb(0,221,149)" rx="2" ry="2" />
+<text  x="20.22" y="1903.5" ></text>
+</g>
+<g >
+<title>malloc (405,504 bytes, 77.52%)</title><rect x="65.9" y="1669" width="914.7" height="15.0" fill="rgb(0,191,76)" rx="2" ry="2" />
+<text  x="68.85" y="1679.5" >malloc</text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="597" width="0.3" height="15.0" fill="rgb(0,230,16)" rx="2" ry="2" />
+<text  x="13.20" y="607.5" ></text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (88 bytes, 0.02%)</title><rect x="19.1" y="1877" width="0.2" height="15.0" fill="rgb(0,205,81)" rx="2" ry="2" />
+<text  x="22.13" y="1887.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (88 bytes, 0.02%)</title><rect x="19.1" y="1749" width="0.2" height="15.0" fill="rgb(0,222,146)" rx="2" ry="2" />
+<text  x="22.13" y="1759.5" ></text>
+</g>
+<g >
+<title>VertxImpl_deployVerticle_33b83779921c079bb60d1a486edef78d6c79b809 (512 bytes, 0.10%)</title><rect x="64.2" y="1877" width="1.1" height="15.0" fill="rgb(0,233,152)" rx="2" ry="2" />
+<text  x="67.18" y="1887.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_execute_a3188f61dd7d4e513f9f9b00b04676cbaba90786 (512 bytes, 0.10%)</title><rect x="64.2" y="1749" width="1.1" height="15.0" fill="rgb(0,208,60)" rx="2" ry="2" />
+<text  x="67.18" y="1759.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (88 bytes, 0.02%)</title><rect x="19.1" y="1685" width="0.2" height="15.0" fill="rgb(0,211,79)" rx="2" ry="2" />
+<text  x="22.13" y="1695.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="1189.6" y="2005" width="0.2" height="15.0" fill="rgb(0,238,150)" rx="2" ry="2" />
+<text  x="1192.60" y="2015.5" ></text>
+</g>
+<g >
+<title>NativeLibrarySupport_loadLibrary0_b3b4b6f515dbc542b72b0c760c091e3257c24d03 (472 bytes, 0.09%)</title><rect x="23.3" y="1925" width="1.0" height="15.0" fill="rgb(0,219,168)" rx="2" ry="2" />
+<text  x="26.26" y="1935.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (88 bytes, 0.02%)</title><rect x="19.3" y="1813" width="0.2" height="15.0" fill="rgb(0,239,168)" rx="2" ry="2" />
+<text  x="22.33" y="1823.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="10.0" y="2021" width="0.2" height="15.0" fill="rgb(0,213,141)" rx="2" ry="2" />
+<text  x="13.00" y="2031.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="1189.4" y="2053" width="0.2" height="15.0" fill="rgb(0,234,140)" rx="2" ry="2" />
+<text  x="1192.40" y="2063.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="2037" width="0.3" height="15.0" fill="rgb(0,214,149)" rx="2" ry="2" />
+<text  x="13.20" y="2047.5" ></text>
+</g>
+<g >
+<title>ResourceBundle_getObject_4da88f3a21bdc4052050d92a1129bc13299456ec (7,160 bytes, 1.37%)</title><rect x="46.8" y="1509" width="16.2" height="15.0" fill="rgb(0,190,186)" rx="2" ry="2" />
+<text  x="49.82" y="1519.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="18.5" y="2005" width="0.2" height="15.0" fill="rgb(0,210,106)" rx="2" ry="2" />
+<text  x="21.54" y="2015.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (88 bytes, 0.02%)</title><rect x="1189.8" y="1781" width="0.2" height="15.0" fill="rgb(0,200,51)" rx="2" ry="2" />
+<text  x="1192.80" y="1791.5" ></text>
+</g>
+<g >
+<title>Java_java_io_UnixFileSystem_canonicalize0 (74 bytes, 0.01%)</title><rect x="65.3" y="1717" width="0.2" height="15.0" fill="rgb(0,239,183)" rx="2" ry="2" />
+<text  x="68.33" y="1727.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (88 bytes, 0.02%)</title><rect x="18.1" y="1765" width="0.2" height="15.0" fill="rgb(0,206,67)" rx="2" ry="2" />
+<text  x="21.14" y="1775.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_a248ca38f52050b4cd112d073aa11463562bd8f6 (88 bytes, 0.02%)</title><rect x="1189.8" y="1621" width="0.2" height="15.0" fill="rgb(0,216,113)" rx="2" ry="2" />
+<text  x="1192.80" y="1631.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="19.1" y="2021" width="0.2" height="15.0" fill="rgb(0,224,42)" rx="2" ry="2" />
+<text  x="22.13" y="2031.5" ></text>
+</g>
+<g >
+<title>ColorPatternFormatter_constructor_17e219c171fecc37b72f97fcfdbcc41acdb77139 (472 bytes, 0.09%)</title><rect x="29.2" y="1877" width="1.1" height="15.0" fill="rgb(0,203,78)" rx="2" ry="2" />
+<text  x="32.22" y="1887.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (944 bytes, 0.18%)</title><rect x="15.1" y="1989" width="2.1" height="15.0" fill="rgb(0,193,156)" rx="2" ry="2" />
+<text  x="18.09" y="1999.5" ></text>
+</g>
+<g >
+<title>CgroupUtil$$Lambda$017b0cd0360754c055090b7d9521ad624f6920d8_run_5c088bd044b8b175a48676ce16a00fd18da382a5 (45 bytes, 0.01%)</title><rect x="980.6" y="1669" width="0.1" height="15.0" fill="rgb(0,201,147)" rx="2" ry="2" />
+<text  x="983.65" y="1679.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="17.7" y="1973" width="0.2" height="15.0" fill="rgb(0,199,48)" rx="2" ry="2" />
+<text  x="20.74" y="1983.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="917" width="0.3" height="15.0" fill="rgb(0,236,192)" rx="2" ry="2" />
+<text  x="13.20" y="927.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="19.1" y="1525" width="0.2" height="15.0" fill="rgb(0,190,173)" rx="2" ry="2" />
+<text  x="22.13" y="1535.5" ></text>
+</g>
+<g >
+<title>DateFormatSymbols_initializeData_107cedab671f757aaa47b69e62491c78266709ff (14,320 bytes, 2.74%)</title><rect x="30.7" y="1525" width="32.3" height="15.0" fill="rgb(0,217,152)" rx="2" ry="2" />
+<text  x="33.67" y="1535.5" >Da..</text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="18.5" y="1605" width="0.2" height="15.0" fill="rgb(0,218,74)" rx="2" ry="2" />
+<text  x="21.54" y="1615.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="1189.8" y="1525" width="0.2" height="15.0" fill="rgb(0,234,47)" rx="2" ry="2" />
+<text  x="1192.80" y="1535.5" ></text>
+</g>
+<g >
+<title>AccessController_doPrivileged_de67c881e9b98da6843ef32b423a3d8bdbb4a36a (86 bytes, 0.02%)</title><rect x="63.4" y="1653" width="0.2" height="15.0" fill="rgb(0,198,51)" rx="2" ry="2" />
+<text  x="66.38" y="1663.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="18.7" y="1541" width="0.2" height="15.0" fill="rgb(0,191,28)" rx="2" ry="2" />
+<text  x="21.73" y="1551.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (88 bytes, 0.02%)</title><rect x="18.1" y="1845" width="0.2" height="15.0" fill="rgb(0,207,62)" rx="2" ry="2" />
+<text  x="21.14" y="1855.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_a248ca38f52050b4cd112d073aa11463562bd8f6 (88 bytes, 0.02%)</title><rect x="17.9" y="1621" width="0.2" height="15.0" fill="rgb(0,211,126)" rx="2" ry="2" />
+<text  x="20.94" y="1631.5" ></text>
+</g>
+<g >
+<title>NativePRNG$RandomIO_constructor_0fc8ee30149f294916e05a477a8530e657119cc5 (50 bytes, 0.01%)</title><rect x="29.1" y="1621" width="0.1" height="15.0" fill="rgb(0,233,196)" rx="2" ry="2" />
+<text  x="32.10" y="1631.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="757" width="0.3" height="15.0" fill="rgb(0,196,123)" rx="2" ry="2" />
+<text  x="13.20" y="767.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="693" width="0.3" height="15.0" fill="rgb(0,218,20)" rx="2" ry="2" />
+<text  x="13.20" y="703.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="421" width="0.3" height="15.0" fill="rgb(0,222,177)" rx="2" ry="2" />
+<text  x="13.20" y="431.5" ></text>
+</g>
+<g >
+<title>LoggingSetupRecorder_configureConsoleHandler_d3eab2815a5b640baa45abf32202b696ba30b145 (472 bytes, 0.09%)</title><rect x="29.2" y="1893" width="1.1" height="15.0" fill="rgb(0,234,193)" rx="2" ry="2" />
+<text  x="32.22" y="1903.5" ></text>
+</g>
+<g >
+<title>PhysicalMemory_size_22977868d3d370162f640afbf90078a73a12859a (178 bytes, 0.03%)</title><rect x="63.6" y="1861" width="0.4" height="15.0" fill="rgb(0,191,60)" rx="2" ry="2" />
+<text  x="66.58" y="1871.5" ></text>
+</g>
+<g >
+<title>Formatters$7$1_initialValue_3694a699ee3761251cc77f179807c025eb121da1 (14,320 bytes, 2.74%)</title><rect x="30.7" y="1589" width="32.3" height="15.0" fill="rgb(0,211,104)" rx="2" ry="2" />
+<text  x="33.67" y="1599.5" >Fo..</text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="1189.6" y="1509" width="0.2" height="15.0" fill="rgb(0,193,21)" rx="2" ry="2" />
+<text  x="1192.60" y="1519.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="19.1" y="2053" width="0.2" height="15.0" fill="rgb(0,192,135)" rx="2" ry="2" />
+<text  x="22.13" y="2063.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="64.0" y="1717" width="0.2" height="15.0" fill="rgb(0,205,11)" rx="2" ry="2" />
+<text  x="66.98" y="1727.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_a248ca38f52050b4cd112d073aa11463562bd8f6 (88 bytes, 0.02%)</title><rect x="18.9" y="1621" width="0.2" height="15.0" fill="rgb(0,227,73)" rx="2" ry="2" />
+<text  x="21.93" y="1631.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_ce21dbdb026180d7d228acb3f01bb9c084323937 (88 bytes, 0.02%)</title><rect x="17.2" y="1877" width="0.2" height="15.0" fill="rgb(0,203,106)" rx="2" ry="2" />
+<text  x="20.22" y="1887.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="853" width="0.3" height="15.0" fill="rgb(0,234,68)" rx="2" ry="2" />
+<text  x="13.20" y="863.5" ></text>
+</g>
+<g >
+<title>Logger_logRaw_0039e62f7976993e0c1689009844197b4c504120 (14,320 bytes, 2.74%)</title><rect x="30.7" y="1877" width="32.3" height="15.0" fill="rgb(0,197,136)" rx="2" ry="2" />
+<text  x="33.67" y="1887.5" >Lo..</text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="293" width="0.3" height="15.0" fill="rgb(0,237,180)" rx="2" ry="2" />
+<text  x="13.20" y="303.5" ></text>
+</g>
+<g >
+<title>all (523,085 bytes, 100%)</title><rect x="10.0" y="2085" width="1180.0" height="15.0" fill="rgb(0,219,48)" rx="2" ry="2" />
+<text  x="13.00" y="2095.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="18.3" y="1541" width="0.2" height="15.0" fill="rgb(0,214,33)" rx="2" ry="2" />
+<text  x="21.34" y="1551.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (88 bytes, 0.02%)</title><rect x="1189.4" y="1701" width="0.2" height="15.0" fill="rgb(0,205,195)" rx="2" ry="2" />
+<text  x="1192.40" y="1711.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1381" width="0.3" height="15.0" fill="rgb(0,239,64)" rx="2" ry="2" />
+<text  x="13.20" y="1391.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="885" width="0.3" height="15.0" fill="rgb(0,233,94)" rx="2" ry="2" />
+<text  x="13.20" y="895.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (88 bytes, 0.02%)</title><rect x="17.7" y="1861" width="0.2" height="15.0" fill="rgb(0,227,72)" rx="2" ry="2" />
+<text  x="20.74" y="1871.5" ></text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (88 bytes, 0.02%)</title><rect x="18.5" y="1893" width="0.2" height="15.0" fill="rgb(0,196,21)" rx="2" ry="2" />
+<text  x="21.54" y="1903.5" ></text>
+</g>
+<g >
+<title>Unsafe_park_8e78b5f196bf0524b1490ff9abb68dc337e02cca (88 bytes, 0.02%)</title><rect x="10.0" y="1893" width="0.2" height="15.0" fill="rgb(0,225,72)" rx="2" ry="2" />
+<text  x="13.00" y="1903.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (88 bytes, 0.02%)</title><rect x="19.3" y="1829" width="0.2" height="15.0" fill="rgb(0,233,190)" rx="2" ry="2" />
+<text  x="22.33" y="1839.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="18.1" y="1573" width="0.2" height="15.0" fill="rgb(0,204,48)" rx="2" ry="2" />
+<text  x="21.14" y="1583.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (88 bytes, 0.02%)</title><rect x="18.7" y="1941" width="0.2" height="15.0" fill="rgb(0,210,174)" rx="2" ry="2" />
+<text  x="21.73" y="1951.5" ></text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (88 bytes, 0.02%)</title><rect x="18.7" y="1877" width="0.2" height="15.0" fill="rgb(0,220,207)" rx="2" ry="2" />
+<text  x="21.73" y="1887.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="725" width="0.3" height="15.0" fill="rgb(0,238,182)" rx="2" ry="2" />
+<text  x="13.20" y="735.5" ></text>
+</g>
+<g >
+<title>CgroupV1Subsystem_getCpuPeriod_af2665b8ccf1535123ef8d345b5b9b8505005dfa (45 bytes, 0.01%)</title><rect x="63.0" y="1813" width="0.1" height="15.0" fill="rgb(0,237,60)" rx="2" ry="2" />
+<text  x="65.98" y="1823.5" ></text>
+</g>
+<g >
+<title>AccessController_doPrivileged_de67c881e9b98da6843ef32b423a3d8bdbb4a36a (45 bytes, 0.01%)</title><rect x="63.0" y="1765" width="0.1" height="15.0" fill="rgb(0,210,190)" rx="2" ry="2" />
+<text  x="65.98" y="1775.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="533" width="0.3" height="15.0" fill="rgb(0,231,100)" rx="2" ry="2" />
+<text  x="13.20" y="543.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="1189.8" y="2005" width="0.2" height="15.0" fill="rgb(0,198,121)" rx="2" ry="2" />
+<text  x="1192.80" y="2015.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="1189.2" y="2053" width="0.2" height="15.0" fill="rgb(0,235,157)" rx="2" ry="2" />
+<text  x="1192.21" y="2063.5" ></text>
+</g>
+<g >
+<title>LoggerNode_publish_22c63d42072bb2e82dedc9c5c7b57dfced38af9e (14,320 bytes, 2.74%)</title><rect x="30.7" y="1829" width="32.3" height="15.0" fill="rgb(0,227,25)" rx="2" ry="2" />
+<text  x="33.67" y="1839.5" >Lo..</text>
+</g>
+<g >
+<title>JavaMonitor_monitorEnter_ed99d0c1674a21db0860911fdb11b326aefec12b (88 bytes, 0.02%)</title><rect x="17.9" y="1669" width="0.2" height="15.0" fill="rgb(0,209,168)" rx="2" ry="2" />
+<text  x="20.94" y="1679.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1605" width="0.3" height="15.0" fill="rgb(0,221,80)" rx="2" ry="2" />
+<text  x="13.20" y="1615.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="245" width="0.3" height="15.0" fill="rgb(0,199,195)" rx="2" ry="2" />
+<text  x="13.20" y="255.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (88 bytes, 0.02%)</title><rect x="18.5" y="1685" width="0.2" height="15.0" fill="rgb(0,201,166)" rx="2" ry="2" />
+<text  x="21.54" y="1695.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_64cb8fa504ff8d8ed6468c31dd67915d26710d8b (88 bytes, 0.02%)</title><rect x="18.3" y="1637" width="0.2" height="15.0" fill="rgb(0,198,119)" rx="2" ry="2" />
+<text  x="21.34" y="1647.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (88 bytes, 0.02%)</title><rect x="17.7" y="1829" width="0.2" height="15.0" fill="rgb(0,201,132)" rx="2" ry="2" />
+<text  x="20.74" y="1839.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="997" width="0.3" height="15.0" fill="rgb(0,227,153)" rx="2" ry="2" />
+<text  x="13.20" y="1007.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1685" width="0.3" height="15.0" fill="rgb(0,233,143)" rx="2" ry="2" />
+<text  x="13.20" y="1695.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="18.9" y="2005" width="0.2" height="15.0" fill="rgb(0,238,150)" rx="2" ry="2" />
+<text  x="21.93" y="2015.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (88 bytes, 0.02%)</title><rect x="19.1" y="1925" width="0.2" height="15.0" fill="rgb(0,235,10)" rx="2" ry="2" />
+<text  x="22.13" y="1935.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1877" width="0.3" height="15.0" fill="rgb(0,190,166)" rx="2" ry="2" />
+<text  x="13.20" y="1887.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1653" width="0.3" height="15.0" fill="rgb(0,201,8)" rx="2" ry="2" />
+<text  x="13.20" y="1663.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (88 bytes, 0.02%)</title><rect x="19.3" y="1925" width="0.2" height="15.0" fill="rgb(0,238,43)" rx="2" ry="2" />
+<text  x="22.33" y="1935.5" ></text>
+</g>
+<g >
+<title>LoggerNode_publish_22c63d42072bb2e82dedc9c5c7b57dfced38af9e (14,320 bytes, 2.74%)</title><rect x="30.7" y="1861" width="32.3" height="15.0" fill="rgb(0,235,52)" rx="2" ry="2" />
+<text  x="33.67" y="1871.5" >Lo..</text>
+</g>
+<g >
+<title>ReflectionAccessorHolder_75ce93443a36c6518e1c0b8aafcb545baaa247d4_1e524d7aea3e39d0cbc142b782ff54e0dcda9900 (139 bytes, 0.03%)</title><rect x="63.3" y="1813" width="0.3" height="15.0" fill="rgb(0,201,63)" rx="2" ry="2" />
+<text  x="66.26" y="1823.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_doWait_a4ccf2ab26598d78fd60e68c33ba4c28c8272ce9 (88 bytes, 0.02%)</title><rect x="10.0" y="1941" width="0.2" height="15.0" fill="rgb(0,191,194)" rx="2" ry="2" />
+<text  x="13.00" y="1951.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="17.7" y="1509" width="0.2" height="15.0" fill="rgb(0,232,111)" rx="2" ry="2" />
+<text  x="20.74" y="1519.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="1189.2" y="1973" width="0.2" height="15.0" fill="rgb(0,219,140)" rx="2" ry="2" />
+<text  x="1192.21" y="1983.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (88 bytes, 0.02%)</title><rect x="1189.2" y="1701" width="0.2" height="15.0" fill="rgb(0,199,100)" rx="2" ry="2" />
+<text  x="1192.21" y="1711.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="469" width="0.3" height="15.0" fill="rgb(0,214,114)" rx="2" ry="2" />
+<text  x="13.20" y="479.5" ></text>
+</g>
+<g >
+<title>UnixNativeDispatcher_copyToNativeBuffer_e3b51b20f662f377ae411b6c066cbf57bd8aa61b (2,048 bytes, 0.39%)</title><rect x="24.4" y="1845" width="4.6" height="15.0" fill="rgb(0,196,106)" rx="2" ry="2" />
+<text  x="27.40" y="1855.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (88 bytes, 0.02%)</title><rect x="18.7" y="1797" width="0.2" height="15.0" fill="rgb(0,220,79)" rx="2" ry="2" />
+<text  x="21.73" y="1807.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="1189.4" y="1509" width="0.2" height="15.0" fill="rgb(0,200,136)" rx="2" ry="2" />
+<text  x="1192.40" y="1519.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="565" width="0.3" height="15.0" fill="rgb(0,217,62)" rx="2" ry="2" />
+<text  x="13.20" y="575.5" ></text>
+</g>
+<g >
+<title>malloc (87 bytes, 0.02%)</title><rect x="63.8" y="1605" width="0.1" height="15.0" fill="rgb(0,229,168)" rx="2" ry="2" />
+<text  x="66.75" y="1615.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_a248ca38f52050b4cd112d073aa11463562bd8f6 (88 bytes, 0.02%)</title><rect x="1189.6" y="1621" width="0.2" height="15.0" fill="rgb(0,231,59)" rx="2" ry="2" />
+<text  x="1192.60" y="1631.5" ></text>
+</g>
+<g >
+<title>Java_java_lang_ProcessHandleImpl_isAlive0 (472 bytes, 0.09%)</title><rect x="16.2" y="1765" width="1.0" height="15.0" fill="rgb(0,196,139)" rx="2" ry="2" />
+<text  x="19.15" y="1775.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_ce21dbdb026180d7d228acb3f01bb9c084323937 (88 bytes, 0.02%)</title><rect x="10.0" y="1877" width="0.2" height="15.0" fill="rgb(0,197,151)" rx="2" ry="2" />
+<text  x="13.00" y="1887.5" ></text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (88 bytes, 0.02%)</title><rect x="18.9" y="1877" width="0.2" height="15.0" fill="rgb(0,192,132)" rx="2" ry="2" />
+<text  x="21.93" y="1887.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="805" width="0.3" height="15.0" fill="rgb(0,212,164)" rx="2" ry="2" />
+<text  x="13.20" y="815.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="17.2" y="1861" width="0.2" height="15.0" fill="rgb(0,233,201)" rx="2" ry="2" />
+<text  x="20.22" y="1871.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="1189.4" y="1573" width="0.2" height="15.0" fill="rgb(0,237,124)" rx="2" ry="2" />
+<text  x="1192.40" y="1583.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="1189.2" y="2005" width="0.2" height="15.0" fill="rgb(0,233,24)" rx="2" ry="2" />
+<text  x="1192.21" y="2015.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (88 bytes, 0.02%)</title><rect x="18.9" y="1701" width="0.2" height="15.0" fill="rgb(0,228,87)" rx="2" ry="2" />
+<text  x="21.93" y="1711.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_c26cfb3083610a614cb5843727b1293a2e050fbe (87 bytes, 0.02%)</title><rect x="63.8" y="1669" width="0.1" height="15.0" fill="rgb(0,191,119)" rx="2" ry="2" />
+<text  x="66.75" y="1679.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (88 bytes, 0.02%)</title><rect x="18.3" y="1941" width="0.2" height="15.0" fill="rgb(0,224,118)" rx="2" ry="2" />
+<text  x="21.34" y="1951.5" ></text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (88 bytes, 0.02%)</title><rect x="18.1" y="1957" width="0.2" height="15.0" fill="rgb(0,232,2)" rx="2" ry="2" />
+<text  x="21.14" y="1967.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="965" width="0.3" height="15.0" fill="rgb(0,221,92)" rx="2" ry="2" />
+<text  x="13.20" y="975.5" ></text>
+</g>
+<g >
+<title>ReflectionAccessorHolder_75ce93443a36c6518e1c0b8aafcb545baaa247d4_1e524d7aea3e39d0cbc142b782ff54e0dcda9900 (944 bytes, 0.18%)</title><rect x="15.1" y="1861" width="2.1" height="15.0" fill="rgb(0,209,64)" rx="2" ry="2" />
+<text  x="18.09" y="1871.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="18.5" y="2021" width="0.2" height="15.0" fill="rgb(0,190,140)" rx="2" ry="2" />
+<text  x="21.54" y="2031.5" ></text>
+</g>
+<g >
+<title>Unsafe_allocateMemory_6ab8a5ef1159e68fb35483ee78388b05c345ae44 (2,048 bytes, 0.39%)</title><rect x="24.4" y="1813" width="4.6" height="15.0" fill="rgb(0,211,114)" rx="2" ry="2" />
+<text  x="27.40" y="1823.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder_doServerStart_176ad7801dd4e14e35e4577a958f043326c0d595 (600 bytes, 0.11%)</title><rect x="64.0" y="1893" width="1.3" height="15.0" fill="rgb(0,227,149)" rx="2" ry="2" />
+<text  x="66.98" y="1903.5" ></text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (88 bytes, 0.02%)</title><rect x="19.1" y="1957" width="0.2" height="15.0" fill="rgb(0,192,33)" rx="2" ry="2" />
+<text  x="22.13" y="1967.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (88 bytes, 0.02%)</title><rect x="17.9" y="1925" width="0.2" height="15.0" fill="rgb(0,227,93)" rx="2" ry="2" />
+<text  x="20.94" y="1935.5" ></text>
+</g>
+<g >
+<title>Inflater_constructor_cac54a3763eea18d04793fac0dc074735040f8c2 (7,160 bytes, 1.37%)</title><rect x="30.7" y="1413" width="16.1" height="15.0" fill="rgb(0,236,10)" rx="2" ry="2" />
+<text  x="33.67" y="1423.5" ></text>
+</g>
+<g >
+<title>Provider$Service_newInstance_71b3f290a96671576fcbfdd2316b814b30de17f9 (87 bytes, 0.02%)</title><rect x="29.0" y="1797" width="0.2" height="15.0" fill="rgb(0,205,154)" rx="2" ry="2" />
+<text  x="32.02" y="1807.5" ></text>
+</g>
+<g >
+<title>MultithreadEventExecutorGroup_constructor_7ff0062598de99aac4b3b44439aa0eba0a2843f1 (405,504 bytes, 77.52%)</title><rect x="65.9" y="1781" width="914.7" height="15.0" fill="rgb(0,238,85)" rx="2" ry="2" />
+<text  x="68.85" y="1791.5" >MultithreadEventExecutorGroup_constructor_7ff0062598de99aac4b3b44439aa0eba0a2843f1</text>
+</g>
+<g >
+<title>FileInputStream_open0_8b1b5fc3043b8ae0dd0d8b68b3a5a224719f9dca (87 bytes, 0.02%)</title><rect x="63.8" y="1637" width="0.1" height="15.0" fill="rgb(0,221,117)" rx="2" ry="2" />
+<text  x="66.75" y="1647.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (88 bytes, 0.02%)</title><rect x="1189.8" y="1845" width="0.2" height="15.0" fill="rgb(0,194,101)" rx="2" ry="2" />
+<text  x="1192.80" y="1855.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_monitorEnter_ed99d0c1674a21db0860911fdb11b326aefec12b (88 bytes, 0.02%)</title><rect x="18.7" y="1669" width="0.2" height="15.0" fill="rgb(0,215,37)" rx="2" ry="2" />
+<text  x="21.73" y="1679.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_c26cfb3083610a614cb5843727b1293a2e050fbe (45 bytes, 0.01%)</title><rect x="980.6" y="1637" width="0.1" height="15.0" fill="rgb(0,212,74)" rx="2" ry="2" />
+<text  x="983.65" y="1647.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="17.9" y="1525" width="0.2" height="15.0" fill="rgb(0,193,64)" rx="2" ry="2" />
+<text  x="20.94" y="1535.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (88 bytes, 0.02%)</title><rect x="1189.6" y="1797" width="0.2" height="15.0" fill="rgb(0,207,207)" rx="2" ry="2" />
+<text  x="1192.60" y="1807.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (88 bytes, 0.02%)</title><rect x="19.1" y="1941" width="0.2" height="15.0" fill="rgb(0,209,8)" rx="2" ry="2" />
+<text  x="22.13" y="1951.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="645" width="0.3" height="15.0" fill="rgb(0,238,122)" rx="2" ry="2" />
+<text  x="13.20" y="655.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="19.1" y="1557" width="0.2" height="15.0" fill="rgb(0,230,182)" rx="2" ry="2" />
+<text  x="22.13" y="1567.5" ></text>
+</g>
+<g >
+<title>ntloop-thread-8 (88 bytes, 0.02%)</title><rect x="19.1" y="2069" width="0.2" height="15.0" fill="rgb(0,216,95)" rx="2" ry="2" />
+<text  x="22.13" y="2079.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="1189.4" y="1589" width="0.2" height="15.0" fill="rgb(0,220,81)" rx="2" ry="2" />
+<text  x="1192.40" y="1599.5" ></text>
+</g>
+<g >
+<title>ResourceBundle_getObject_4da88f3a21bdc4052050d92a1129bc13299456ec (7,160 bytes, 1.37%)</title><rect x="46.8" y="1493" width="16.2" height="15.0" fill="rgb(0,239,91)" rx="2" ry="2" />
+<text  x="49.82" y="1503.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="64.0" y="1733" width="0.2" height="15.0" fill="rgb(0,207,91)" rx="2" ry="2" />
+<text  x="66.98" y="1743.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (88 bytes, 0.02%)</title><rect x="1189.8" y="1941" width="0.2" height="15.0" fill="rgb(0,198,65)" rx="2" ry="2" />
+<text  x="1192.80" y="1951.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (88 bytes, 0.02%)</title><rect x="18.3" y="1749" width="0.2" height="15.0" fill="rgb(0,238,97)" rx="2" ry="2" />
+<text  x="21.34" y="1759.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_monitorEnter_ed99d0c1674a21db0860911fdb11b326aefec12b (88 bytes, 0.02%)</title><rect x="17.7" y="1669" width="0.2" height="15.0" fill="rgb(0,226,23)" rx="2" ry="2" />
+<text  x="20.74" y="1679.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1493" width="0.3" height="15.0" fill="rgb(0,236,8)" rx="2" ry="2" />
+<text  x="13.20" y="1503.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (88 bytes, 0.02%)</title><rect x="18.7" y="1925" width="0.2" height="15.0" fill="rgb(0,216,200)" rx="2" ry="2" />
+<text  x="21.73" y="1935.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="19.1" y="1541" width="0.2" height="15.0" fill="rgb(0,237,61)" rx="2" ry="2" />
+<text  x="22.13" y="1551.5" ></text>
+</g>
+<g >
+<title>malloc (92,275 bytes, 17.64%)</title><rect x="981.0" y="2053" width="208.2" height="15.0" fill="rgb(0,210,176)" rx="2" ry="2" />
+<text  x="984.05" y="2063.5" >malloc</text>
+</g>
+<g >
+<title>AccessController_executePrivileged_d07f5fea2e10c57d20fe35f694351835c33861ed (87 bytes, 0.02%)</title><rect x="63.8" y="1717" width="0.1" height="15.0" fill="rgb(0,221,120)" rx="2" ry="2" />
+<text  x="66.75" y="1727.5" ></text>
+</g>
+<g >
+<title>Thread-1 (3,112 bytes, 0.59%)</title><rect x="10.2" y="2069" width="7.0" height="15.0" fill="rgb(0,192,31)" rx="2" ry="2" />
+<text  x="13.20" y="2079.5" ></text>
+</g>
+<g >
+<title>malloc (7,160 bytes, 1.37%)</title><rect x="46.8" y="1365" width="16.2" height="15.0" fill="rgb(0,193,160)" rx="2" ry="2" />
+<text  x="49.82" y="1375.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_64cb8fa504ff8d8ed6468c31dd67915d26710d8b (88 bytes, 0.02%)</title><rect x="1189.2" y="1637" width="0.2" height="15.0" fill="rgb(0,197,9)" rx="2" ry="2" />
+<text  x="1192.21" y="1647.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_64cb8fa504ff8d8ed6468c31dd67915d26710d8b (88 bytes, 0.02%)</title><rect x="19.3" y="1637" width="0.2" height="15.0" fill="rgb(0,225,83)" rx="2" ry="2" />
+<text  x="22.33" y="1647.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1429" width="0.3" height="15.0" fill="rgb(0,201,199)" rx="2" ry="2" />
+<text  x="13.20" y="1439.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="19.1" y="1573" width="0.2" height="15.0" fill="rgb(0,217,115)" rx="2" ry="2" />
+<text  x="22.13" y="1583.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1765" width="0.3" height="15.0" fill="rgb(0,196,180)" rx="2" ry="2" />
+<text  x="13.20" y="1775.5" ></text>
+</g>
+<g >
+<title>CompletableFuture_waitingGet_5e021f5c77dc8d7ebdbd18918aaf72de0c4b7b81 (88 bytes, 0.02%)</title><rect x="64.0" y="1861" width="0.2" height="15.0" fill="rgb(0,239,23)" rx="2" ry="2" />
+<text  x="66.98" y="1871.5" ></text>
+</g>
+<g >
+<title>malloc (472 bytes, 0.09%)</title><rect x="15.1" y="1765" width="1.1" height="15.0" fill="rgb(0,227,188)" rx="2" ry="2" />
+<text  x="18.09" y="1775.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_lambda$readStringValue$0_bf9c455fb8e17fdb73fd283b71cbbb23b2dde357 (45 bytes, 0.01%)</title><rect x="65.5" y="1621" width="0.1" height="15.0" fill="rgb(0,224,62)" rx="2" ry="2" />
+<text  x="68.53" y="1631.5" ></text>
+</g>
+<g >
+<title>LockSupport_parkNanos_2b761ef0a67536a89c27ff8847e5178d8c83366f (88 bytes, 0.02%)</title><rect x="10.0" y="1909" width="0.2" height="15.0" fill="rgb(0,220,54)" rx="2" ry="2" />
+<text  x="13.00" y="1919.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (88 bytes, 0.02%)</title><rect x="19.1" y="1701" width="0.2" height="15.0" fill="rgb(0,205,38)" rx="2" ry="2" />
+<text  x="22.13" y="1711.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="64.0" y="1701" width="0.2" height="15.0" fill="rgb(0,214,105)" rx="2" ry="2" />
+<text  x="66.98" y="1711.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1525" width="0.3" height="15.0" fill="rgb(0,219,105)" rx="2" ry="2" />
+<text  x="13.20" y="1535.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (88 bytes, 0.02%)</title><rect x="1189.4" y="1861" width="0.2" height="15.0" fill="rgb(0,199,114)" rx="2" ry="2" />
+<text  x="1192.40" y="1871.5" ></text>
+</g>
+<g >
+<title>AccessController_executePrivileged_d07f5fea2e10c57d20fe35f694351835c33861ed (45 bytes, 0.01%)</title><rect x="30.4" y="1749" width="0.1" height="15.0" fill="rgb(0,194,16)" rx="2" ry="2" />
+<text  x="33.35" y="1759.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="18.7" y="2005" width="0.2" height="15.0" fill="rgb(0,191,146)" rx="2" ry="2" />
+<text  x="21.73" y="2015.5" ></text>
+</g>
+<g >
+<title>NativeLibrarySupport_addLibrary_ee97d6289c5f5a32f122eb095930df8285abfdd0 (472 bytes, 0.09%)</title><rect x="23.3" y="1909" width="1.0" height="15.0" fill="rgb(0,239,30)" rx="2" ry="2" />
+<text  x="26.26" y="1919.5" ></text>
+</g>
+<g >
+<title>VertxCoreRecorder_calculateDefaultIOThreads_69a33cc12318e241ce6e6592859193fec600c60f (444 bytes, 0.08%)</title><rect x="63.0" y="1893" width="1.0" height="15.0" fill="rgb(0,221,9)" rx="2" ry="2" />
+<text  x="65.98" y="1903.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="17.2" y="1845" width="0.2" height="15.0" fill="rgb(0,208,71)" rx="2" ry="2" />
+<text  x="20.22" y="1855.5" ></text>
+</g>
+<g >
+<title>JNI_OnLoad_net (472 bytes, 0.09%)</title><rect x="23.3" y="1861" width="1.0" height="15.0" fill="rgb(0,208,90)" rx="2" ry="2" />
+<text  x="26.26" y="1871.5" ></text>
+</g>
+<g >
+<title>Containers_activeProcessorCount_69a70d68269b86774873269a89490f0e7a966343 (141 bytes, 0.03%)</title><rect x="980.6" y="1797" width="0.4" height="15.0" fill="rgb(0,194,198)" rx="2" ry="2" />
+<text  x="983.65" y="1807.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_a248ca38f52050b4cd112d073aa11463562bd8f6 (88 bytes, 0.02%)</title><rect x="18.1" y="1621" width="0.2" height="15.0" fill="rgb(0,230,58)" rx="2" ry="2" />
+<text  x="21.14" y="1631.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (88 bytes, 0.02%)</title><rect x="18.7" y="1717" width="0.2" height="15.0" fill="rgb(0,209,29)" rx="2" ry="2" />
+<text  x="21.73" y="1727.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1957" width="0.3" height="15.0" fill="rgb(0,235,50)" rx="2" ry="2" />
+<text  x="13.20" y="1967.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1157" width="0.3" height="15.0" fill="rgb(0,208,99)" rx="2" ry="2" />
+<text  x="13.20" y="1167.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (88 bytes, 0.02%)</title><rect x="18.9" y="1749" width="0.2" height="15.0" fill="rgb(0,214,183)" rx="2" ry="2" />
+<text  x="21.93" y="1759.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (88 bytes, 0.02%)</title><rect x="17.9" y="1941" width="0.2" height="15.0" fill="rgb(0,205,143)" rx="2" ry="2" />
+<text  x="20.94" y="1951.5" ></text>
+</g>
+<g >
+<title>CompletableFuture$Signaller_block_5761c373b2df8e8870006ef1cd19ef1f8c7e701a (88 bytes, 0.02%)</title><rect x="64.0" y="1813" width="0.2" height="15.0" fill="rgb(0,222,43)" rx="2" ry="2" />
+<text  x="66.98" y="1823.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (88 bytes, 0.02%)</title><rect x="17.9" y="1717" width="0.2" height="15.0" fill="rgb(0,211,56)" rx="2" ry="2" />
+<text  x="20.94" y="1727.5" ></text>
+</g>
+<g >
+<title>ProcessHandleImpl_initNative_f1d23a512e6881ad00c1e3a814f0e1a58d6bf46e (472 bytes, 0.09%)</title><rect x="15.1" y="1781" width="1.1" height="15.0" fill="rgb(0,227,138)" rx="2" ry="2" />
+<text  x="18.09" y="1791.5" ></text>
+</g>
+<g >
+<title>ntloop-thread-0 (144 bytes, 0.03%)</title><rect x="17.4" y="2069" width="0.3" height="15.0" fill="rgb(0,225,24)" rx="2" ry="2" />
+<text  x="20.42" y="2079.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="10.0" y="1845" width="0.2" height="15.0" fill="rgb(0,199,11)" rx="2" ry="2" />
+<text  x="13.00" y="1855.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="1189.4" y="2037" width="0.2" height="15.0" fill="rgb(0,190,44)" rx="2" ry="2" />
+<text  x="1192.40" y="2047.5" ></text>
+</g>
+<g >
+<title>JavaMainWrapper_runCore0_030cf55ee73b0e1076836b52cdbbde2ffc0c5232 (424,090 bytes, 81.07%)</title><rect x="24.4" y="2005" width="956.6" height="15.0" fill="rgb(0,207,66)" rx="2" ry="2" />
+<text  x="27.37" y="2015.5" >JavaMainWrapper_runCore0_030cf55ee73b0e1076836b52cdbbde2ffc0c5232</text>
+</g>
+<g >
+<title>VertxCoreRecorder_calculateDefaultIOThreads_69a33cc12318e241ce6e6592859193fec600c60f (141 bytes, 0.03%)</title><rect x="980.6" y="1829" width="0.4" height="15.0" fill="rgb(0,212,2)" rx="2" ry="2" />
+<text  x="983.65" y="1839.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1925" width="0.3" height="15.0" fill="rgb(0,225,181)" rx="2" ry="2" />
+<text  x="13.20" y="1935.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1973" width="0.3" height="15.0" fill="rgb(0,199,62)" rx="2" ry="2" />
+<text  x="13.20" y="1983.5" ></text>
+</g>
+<g >
+<title>VertxImpl_deployVerticle_f73d81e521a5b5f93ee1eb1091c90587f9918d15 (512 bytes, 0.10%)</title><rect x="64.2" y="1861" width="1.1" height="15.0" fill="rgb(0,202,95)" rx="2" ry="2" />
+<text  x="67.18" y="1871.5" ></text>
+</g>
+<g >
+<title>ConfigUtils_configBuilder_70515b2e01c7966f5bb28ea4f331f6f28cb05924 (2,135 bytes, 0.41%)</title><rect x="24.4" y="1909" width="4.8" height="15.0" fill="rgb(0,227,113)" rx="2" ry="2" />
+<text  x="27.40" y="1919.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="17.2" y="2005" width="0.2" height="15.0" fill="rgb(0,210,83)" rx="2" ry="2" />
+<text  x="20.22" y="2015.5" ></text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (88 bytes, 0.02%)</title><rect x="18.9" y="1893" width="0.2" height="15.0" fill="rgb(0,214,17)" rx="2" ry="2" />
+<text  x="21.93" y="1903.5" ></text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="1189.6" y="1605" width="0.2" height="15.0" fill="rgb(0,239,198)" rx="2" ry="2" />
+<text  x="1192.60" y="1615.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_readStringValue_cbc732074f2c96921b9ad69310afd25a7e2ad29d (45 bytes, 0.01%)</title><rect x="30.4" y="1781" width="0.1" height="15.0" fill="rgb(0,209,19)" rx="2" ry="2" />
+<text  x="33.35" y="1791.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="10.0" y="1797" width="0.2" height="15.0" fill="rgb(0,231,8)" rx="2" ry="2" />
+<text  x="13.00" y="1807.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1557" width="0.3" height="15.0" fill="rgb(0,227,111)" rx="2" ry="2" />
+<text  x="13.20" y="1567.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_monitorEnter_ed99d0c1674a21db0860911fdb11b326aefec12b (88 bytes, 0.02%)</title><rect x="1189.6" y="1669" width="0.2" height="15.0" fill="rgb(0,209,27)" rx="2" ry="2" />
+<text  x="1192.60" y="1679.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="1189.6" y="1541" width="0.2" height="15.0" fill="rgb(0,217,101)" rx="2" ry="2" />
+<text  x="1192.60" y="1551.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="19.1" y="1989" width="0.2" height="15.0" fill="rgb(0,233,172)" rx="2" ry="2" />
+<text  x="22.13" y="1999.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_aac741e2ef07c171301eb35c0deea3293fe4d747 (45 bytes, 0.01%)</title><rect x="63.0" y="1685" width="0.1" height="15.0" fill="rgb(0,204,3)" rx="2" ry="2" />
+<text  x="65.98" y="1695.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_64cb8fa504ff8d8ed6468c31dd67915d26710d8b (88 bytes, 0.02%)</title><rect x="17.9" y="1637" width="0.2" height="15.0" fill="rgb(0,206,40)" rx="2" ry="2" />
+<text  x="20.94" y="1647.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="19.3" y="2037" width="0.2" height="15.0" fill="rgb(0,205,162)" rx="2" ry="2" />
+<text  x="22.33" y="2047.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_readStringValue_cbc732074f2c96921b9ad69310afd25a7e2ad29d (45 bytes, 0.01%)</title><rect x="63.0" y="1781" width="0.1" height="15.0" fill="rgb(0,203,42)" rx="2" ry="2" />
+<text  x="65.98" y="1791.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (88 bytes, 0.02%)</title><rect x="17.9" y="1749" width="0.2" height="15.0" fill="rgb(0,209,69)" rx="2" ry="2" />
+<text  x="20.94" y="1759.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1941" width="0.3" height="15.0" fill="rgb(0,203,42)" rx="2" ry="2" />
+<text  x="13.20" y="1951.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="18.1" y="1509" width="0.2" height="15.0" fill="rgb(0,226,82)" rx="2" ry="2" />
+<text  x="21.14" y="1519.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="69" width="0.3" height="15.0" fill="rgb(0,227,104)" rx="2" ry="2" />
+<text  x="13.20" y="79.5" ></text>
+</g>
+<g >
+<title>QuarkusExecutorFactory_internalCreateExecutor_e71f8b24fdeea218877bc5fc9b2eb1bd3237ca96 (141 bytes, 0.03%)</title><rect x="65.5" y="1797" width="0.4" height="15.0" fill="rgb(0,197,156)" rx="2" ry="2" />
+<text  x="68.53" y="1807.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="18.3" y="1989" width="0.2" height="15.0" fill="rgb(0,233,150)" rx="2" ry="2" />
+<text  x="21.34" y="1999.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (88 bytes, 0.02%)</title><rect x="17.7" y="1717" width="0.2" height="15.0" fill="rgb(0,209,47)" rx="2" ry="2" />
+<text  x="20.74" y="1727.5" ></text>
+</g>
+<g >
+<title>ThreadPoolSetup$createExecutor2117483448_deploy_0_fa294124ad9806fc01fbc260ae9ba91775cccce8 (157 bytes, 0.03%)</title><rect x="30.3" y="1925" width="0.4" height="15.0" fill="rgb(0,205,117)" rx="2" ry="2" />
+<text  x="33.32" y="1935.5" ></text>
+</g>
+<g >
+<title>ProcessHandle_current_af4b5bbdac538ce7b18765f748fd3d275d8f7347 (944 bytes, 0.18%)</title><rect x="15.1" y="1845" width="2.1" height="15.0" fill="rgb(0,224,166)" rx="2" ry="2" />
+<text  x="18.09" y="1855.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="1189.8" y="1573" width="0.2" height="15.0" fill="rgb(0,198,60)" rx="2" ry="2" />
+<text  x="1192.80" y="1583.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (944 bytes, 0.18%)</title><rect x="15.1" y="2005" width="2.1" height="15.0" fill="rgb(0,194,149)" rx="2" ry="2" />
+<text  x="18.09" y="2015.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_a248ca38f52050b4cd112d073aa11463562bd8f6 (88 bytes, 0.02%)</title><rect x="19.1" y="1621" width="0.2" height="15.0" fill="rgb(0,196,138)" rx="2" ry="2" />
+<text  x="22.13" y="1631.5" ></text>
+</g>
+<g >
+<title>FileInputStream_open0_8b1b5fc3043b8ae0dd0d8b68b3a5a224719f9dca (45 bytes, 0.01%)</title><rect x="30.4" y="1669" width="0.1" height="15.0" fill="rgb(0,215,93)" rx="2" ry="2" />
+<text  x="33.35" y="1679.5" ></text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="19.3" y="1605" width="0.2" height="15.0" fill="rgb(0,214,106)" rx="2" ry="2" />
+<text  x="22.33" y="1615.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="2053" width="0.3" height="15.0" fill="rgb(0,209,42)" rx="2" ry="2" />
+<text  x="13.20" y="2063.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="17.9" y="1589" width="0.2" height="15.0" fill="rgb(0,221,55)" rx="2" ry="2" />
+<text  x="20.94" y="1599.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (88 bytes, 0.02%)</title><rect x="1189.6" y="1781" width="0.2" height="15.0" fill="rgb(0,232,167)" rx="2" ry="2" />
+<text  x="1192.60" y="1791.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (88 bytes, 0.02%)</title><rect x="1189.4" y="1813" width="0.2" height="15.0" fill="rgb(0,210,200)" rx="2" ry="2" />
+<text  x="1192.40" y="1823.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_lock_62993eeba5aa50f4c636524077187e4fcd926085 (88 bytes, 0.02%)</title><rect x="1189.8" y="1653" width="0.2" height="15.0" fill="rgb(0,237,13)" rx="2" ry="2" />
+<text  x="1192.80" y="1663.5" ></text>
+</g>
+<g >
+<title>Formatters$JustifyingFormatStep_render_d94fcacf85253953d5f8889ed1ac473c1821719b (14,320 bytes, 2.74%)</title><rect x="30.7" y="1669" width="32.3" height="15.0" fill="rgb(0,208,142)" rx="2" ry="2" />
+<text  x="33.67" y="1679.5" >Fo..</text>
+</g>
+<g >
+<title>LoggingResourceProcessor$setupLoggingRuntimeInit217128813_deploy_0_c10eb082ad1a10e59bf5cbe02b0dd3f2483f6249 (472 bytes, 0.09%)</title><rect x="29.2" y="1925" width="1.1" height="15.0" fill="rgb(0,225,191)" rx="2" ry="2" />
+<text  x="32.22" y="1935.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (88 bytes, 0.02%)</title><rect x="18.3" y="1733" width="0.2" height="15.0" fill="rgb(0,233,77)" rx="2" ry="2" />
+<text  x="21.34" y="1743.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="64.0" y="1781" width="0.2" height="15.0" fill="rgb(0,206,72)" rx="2" ry="2" />
+<text  x="66.98" y="1791.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1301" width="0.3" height="15.0" fill="rgb(0,238,42)" rx="2" ry="2" />
+<text  x="13.20" y="1311.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_a248ca38f52050b4cd112d073aa11463562bd8f6 (88 bytes, 0.02%)</title><rect x="18.3" y="1621" width="0.2" height="15.0" fill="rgb(0,233,189)" rx="2" ry="2" />
+<text  x="21.34" y="1631.5" ></text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="18.1" y="1605" width="0.2" height="15.0" fill="rgb(0,230,185)" rx="2" ry="2" />
+<text  x="21.14" y="1615.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (88 bytes, 0.02%)</title><rect x="19.1" y="1781" width="0.2" height="15.0" fill="rgb(0,198,61)" rx="2" ry="2" />
+<text  x="22.13" y="1791.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="1189.6" y="1525" width="0.2" height="15.0" fill="rgb(0,211,154)" rx="2" ry="2" />
+<text  x="1192.60" y="1535.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_doDeploy_5f37e6b58ee4495a21f1669cabb458f94e8ab8eb (512 bytes, 0.10%)</title><rect x="64.2" y="1829" width="1.1" height="15.0" fill="rgb(0,197,165)" rx="2" ry="2" />
+<text  x="67.18" y="1839.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (88 bytes, 0.02%)</title><rect x="1189.2" y="1845" width="0.2" height="15.0" fill="rgb(0,196,150)" rx="2" ry="2" />
+<text  x="1192.21" y="1855.5" ></text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (88 bytes, 0.02%)</title><rect x="1189.4" y="1893" width="0.2" height="15.0" fill="rgb(0,214,168)" rx="2" ry="2" />
+<text  x="1192.40" y="1903.5" ></text>
+</g>
+<g >
+<title>MultistepFormatter_format_6309f8edbfe0401a455d3d5513b3c861363dcecf (14,320 bytes, 2.74%)</title><rect x="30.7" y="1701" width="32.3" height="15.0" fill="rgb(0,214,192)" rx="2" ry="2" />
+<text  x="33.67" y="1711.5" >Mu..</text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (88 bytes, 0.02%)</title><rect x="18.3" y="1909" width="0.2" height="15.0" fill="rgb(0,207,110)" rx="2" ry="2" />
+<text  x="21.34" y="1919.5" ></text>
+</g>
+<g >
+<title>JNILibraryInitializer_initialize_c0e364aa41bf0fb0839cfb1ac5604dbaad7ebd53 (472 bytes, 0.09%)</title><rect x="23.3" y="1893" width="1.0" height="15.0" fill="rgb(0,205,170)" rx="2" ry="2" />
+<text  x="26.26" y="1903.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1989" width="0.3" height="15.0" fill="rgb(0,227,7)" rx="2" ry="2" />
+<text  x="13.20" y="1999.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (88 bytes, 0.02%)</title><rect x="17.7" y="1685" width="0.2" height="15.0" fill="rgb(0,213,78)" rx="2" ry="2" />
+<text  x="20.74" y="1695.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (88 bytes, 0.02%)</title><rect x="1189.4" y="1765" width="0.2" height="15.0" fill="rgb(0,202,195)" rx="2" ry="2" />
+<text  x="1192.40" y="1775.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_64cb8fa504ff8d8ed6468c31dd67915d26710d8b (88 bytes, 0.02%)</title><rect x="1189.6" y="1637" width="0.2" height="15.0" fill="rgb(0,219,151)" rx="2" ry="2" />
+<text  x="1192.60" y="1647.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_monitorEnter_ed99d0c1674a21db0860911fdb11b326aefec12b (88 bytes, 0.02%)</title><rect x="18.1" y="1669" width="0.2" height="15.0" fill="rgb(0,191,21)" rx="2" ry="2" />
+<text  x="21.14" y="1679.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_c26cfb3083610a614cb5843727b1293a2e050fbe (45 bytes, 0.01%)</title><rect x="65.5" y="1605" width="0.1" height="15.0" fill="rgb(0,207,25)" rx="2" ry="2" />
+<text  x="68.53" y="1615.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_aac741e2ef07c171301eb35c0deea3293fe4d747 (86 bytes, 0.02%)</title><rect x="63.4" y="1573" width="0.2" height="15.0" fill="rgb(0,196,171)" rx="2" ry="2" />
+<text  x="66.38" y="1583.5" ></text>
+</g>
+<g >
+<title>Unsafe_allocateMemory_6ab8a5ef1159e68fb35483ee78388b05c345ae44 (405,504 bytes, 77.52%)</title><rect x="65.9" y="1701" width="914.7" height="15.0" fill="rgb(0,235,146)" rx="2" ry="2" />
+<text  x="68.85" y="1711.5" >Unsafe_allocateMemory_6ab8a5ef1159e68fb35483ee78388b05c345ae44</text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (88 bytes, 0.02%)</title><rect x="1189.4" y="1749" width="0.2" height="15.0" fill="rgb(0,223,100)" rx="2" ry="2" />
+<text  x="1192.40" y="1759.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="18.7" y="1557" width="0.2" height="15.0" fill="rgb(0,236,188)" rx="2" ry="2" />
+<text  x="21.73" y="1567.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="64.0" y="1749" width="0.2" height="15.0" fill="rgb(0,211,190)" rx="2" ry="2" />
+<text  x="66.98" y="1759.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (88 bytes, 0.02%)</title><rect x="17.7" y="1765" width="0.2" height="15.0" fill="rgb(0,224,184)" rx="2" ry="2" />
+<text  x="20.74" y="1775.5" ></text>
+</g>
+<g >
+<title>AccessController_executePrivileged_d07f5fea2e10c57d20fe35f694351835c33861ed (45 bytes, 0.01%)</title><rect x="63.0" y="1749" width="0.1" height="15.0" fill="rgb(0,202,192)" rx="2" ry="2" />
+<text  x="65.98" y="1759.5" ></text>
+</g>
+<g >
+<title>LinuxStackOverflowSupport_lookupStackEnd_0ef95534f2cee5243dd34b08f2012060accd5752 (472 bytes, 0.09%)</title><rect x="21.1" y="1941" width="1.1" height="15.0" fill="rgb(0,236,140)" rx="2" ry="2" />
+<text  x="24.13" y="1951.5" ></text>
+</g>
+<g >
+<title>SubstrateMethodAccessor_invoke_1646d4f7bf658eabd638416736a8d30c8afb8530 (944 bytes, 0.18%)</title><rect x="15.1" y="1877" width="2.1" height="15.0" fill="rgb(0,226,85)" rx="2" ry="2" />
+<text  x="18.09" y="1887.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="18.9" y="2021" width="0.2" height="15.0" fill="rgb(0,197,66)" rx="2" ry="2" />
+<text  x="21.93" y="2031.5" ></text>
+</g>
+<g >
+<title>CgroupSubsystemController_getLongValue_5b80cabcf39909fd5a58e534d3495da67fa37757 (45 bytes, 0.01%)</title><rect x="63.0" y="1797" width="0.1" height="15.0" fill="rgb(0,195,154)" rx="2" ry="2" />
+<text  x="65.98" y="1807.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (88 bytes, 0.02%)</title><rect x="18.1" y="1685" width="0.2" height="15.0" fill="rgb(0,201,28)" rx="2" ry="2" />
+<text  x="21.14" y="1695.5" ></text>
+</g>
+<g >
+<title>AccessController_executePrivileged_d07f5fea2e10c57d20fe35f694351835c33861ed (86 bytes, 0.02%)</title><rect x="63.4" y="1637" width="0.2" height="15.0" fill="rgb(0,210,59)" rx="2" ry="2" />
+<text  x="66.38" y="1647.5" ></text>
+</g>
+<g >
+<title>Runtime_availableProcessors_8c88a5035e0f76404bd388d31bc8ea17e15f987b (266 bytes, 0.05%)</title><rect x="63.0" y="1877" width="0.6" height="15.0" fill="rgb(0,204,159)" rx="2" ry="2" />
+<text  x="65.98" y="1887.5" ></text>
+</g>
+<g >
+<title>ContainerInfo_getMemoryLimit_f76588ca4e6a9b384c85d3e08a84eec8e9ea6a4b (164 bytes, 0.03%)</title><rect x="63.6" y="1813" width="0.3" height="15.0" fill="rgb(0,236,71)" rx="2" ry="2" />
+<text  x="66.58" y="1823.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (88 bytes, 0.02%)</title><rect x="18.3" y="1701" width="0.2" height="15.0" fill="rgb(0,218,188)" rx="2" ry="2" />
+<text  x="21.34" y="1711.5" ></text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (88 bytes, 0.02%)</title><rect x="18.7" y="1893" width="0.2" height="15.0" fill="rgb(0,225,39)" rx="2" ry="2" />
+<text  x="21.73" y="1903.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="1189.4" y="2005" width="0.2" height="15.0" fill="rgb(0,217,21)" rx="2" ry="2" />
+<text  x="1192.40" y="2015.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="19.3" y="1573" width="0.2" height="15.0" fill="rgb(0,212,165)" rx="2" ry="2" />
+<text  x="22.33" y="1583.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1173" width="0.3" height="15.0" fill="rgb(0,230,163)" rx="2" ry="2" />
+<text  x="13.20" y="1183.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="17.9" y="1557" width="0.2" height="15.0" fill="rgb(0,194,202)" rx="2" ry="2" />
+<text  x="20.94" y="1567.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="197" width="0.3" height="15.0" fill="rgb(0,231,108)" rx="2" ry="2" />
+<text  x="13.20" y="207.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (88 bytes, 0.02%)</title><rect x="18.3" y="1813" width="0.2" height="15.0" fill="rgb(0,203,120)" rx="2" ry="2" />
+<text  x="21.34" y="1823.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (88 bytes, 0.02%)</title><rect x="18.7" y="1701" width="0.2" height="15.0" fill="rgb(0,198,11)" rx="2" ry="2" />
+<text  x="21.73" y="1711.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_monitorEnter_ed99d0c1674a21db0860911fdb11b326aefec12b (88 bytes, 0.02%)</title><rect x="1189.2" y="1669" width="0.2" height="15.0" fill="rgb(0,231,169)" rx="2" ry="2" />
+<text  x="1192.21" y="1679.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (88 bytes, 0.02%)</title><rect x="17.9" y="1909" width="0.2" height="15.0" fill="rgb(0,238,98)" rx="2" ry="2" />
+<text  x="20.94" y="1919.5" ></text>
+</g>
+<g >
+<title>ntloop-thread-6 (88 bytes, 0.02%)</title><rect x="18.7" y="2069" width="0.2" height="15.0" fill="rgb(0,194,2)" rx="2" ry="2" />
+<text  x="21.73" y="2079.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="1189.4" y="1557" width="0.2" height="15.0" fill="rgb(0,219,94)" rx="2" ry="2" />
+<text  x="1192.40" y="1567.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_lambda$readStringValue$0_bf9c455fb8e17fdb73fd283b71cbbb23b2dde357 (86 bytes, 0.02%)</title><rect x="63.4" y="1605" width="0.2" height="15.0" fill="rgb(0,229,140)" rx="2" ry="2" />
+<text  x="66.38" y="1615.5" ></text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (88 bytes, 0.02%)</title><rect x="18.5" y="1877" width="0.2" height="15.0" fill="rgb(0,220,15)" rx="2" ry="2" />
+<text  x="21.54" y="1887.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="229" width="0.3" height="15.0" fill="rgb(0,233,54)" rx="2" ry="2" />
+<text  x="13.20" y="239.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="17.2" y="2037" width="0.2" height="15.0" fill="rgb(0,223,99)" rx="2" ry="2" />
+<text  x="20.22" y="2047.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_monitorEnter_ed99d0c1674a21db0860911fdb11b326aefec12b (88 bytes, 0.02%)</title><rect x="18.5" y="1669" width="0.2" height="15.0" fill="rgb(0,216,148)" rx="2" ry="2" />
+<text  x="21.54" y="1679.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_aac741e2ef07c171301eb35c0deea3293fe4d747 (87 bytes, 0.02%)</title><rect x="63.8" y="1653" width="0.1" height="15.0" fill="rgb(0,235,46)" rx="2" ry="2" />
+<text  x="66.75" y="1663.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (88 bytes, 0.02%)</title><rect x="18.5" y="1941" width="0.2" height="15.0" fill="rgb(0,209,81)" rx="2" ry="2" />
+<text  x="21.54" y="1951.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="18.7" y="1525" width="0.2" height="15.0" fill="rgb(0,211,92)" rx="2" ry="2" />
+<text  x="21.73" y="1535.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1205" width="0.3" height="15.0" fill="rgb(0,192,11)" rx="2" ry="2" />
+<text  x="13.20" y="1215.5" ></text>
+</g>
+<g >
+<title>VertxHttpProcessor$preinitializeRouter1141331088_deploy_0_eb454017235d0c767bf7a14871e6f0a7102409c7 (405,930 bytes, 77.60%)</title><rect x="65.3" y="1925" width="915.7" height="15.0" fill="rgb(0,235,93)" rx="2" ry="2" />
+<text  x="68.33" y="1935.5" >VertxHttpProcessor$preinitializeRouter1141331088_deploy_0_eb454017235d0c767bf7a14871e6f0a7102409c7</text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="17.7" y="1605" width="0.2" height="15.0" fill="rgb(0,200,81)" rx="2" ry="2" />
+<text  x="20.74" y="1615.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="18.5" y="1557" width="0.2" height="15.0" fill="rgb(0,228,76)" rx="2" ry="2" />
+<text  x="21.54" y="1567.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="18.5" y="1509" width="0.2" height="15.0" fill="rgb(0,212,181)" rx="2" ry="2" />
+<text  x="21.54" y="1519.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="18.3" y="1557" width="0.2" height="15.0" fill="rgb(0,221,150)" rx="2" ry="2" />
+<text  x="21.34" y="1567.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="17.7" y="1989" width="0.2" height="15.0" fill="rgb(0,239,2)" rx="2" ry="2" />
+<text  x="20.74" y="1999.5" ></text>
+</g>
+<g >
+<title>VertxBuilder_vertx_86c4d260a7bb5352a6d3d8245b7e64b0114eb27a (405,661 bytes, 77.55%)</title><rect x="65.5" y="1845" width="915.1" height="15.0" fill="rgb(0,227,30)" rx="2" ry="2" />
+<text  x="68.50" y="1855.5" >VertxBuilder_vertx_86c4d260a7bb5352a6d3d8245b7e64b0114eb27a</text>
+</g>
+<g >
+<title>ExecutorRecorder_setupRunTime_b5bcde4f2439ea116b5b32743f0bc2f8634e7aab (157 bytes, 0.03%)</title><rect x="30.3" y="1909" width="0.4" height="15.0" fill="rgb(0,201,164)" rx="2" ry="2" />
+<text  x="33.32" y="1919.5" ></text>
+</g>
+<g >
+<title>findJavaTZ_md (472 bytes, 0.09%)</title><rect x="29.2" y="1797" width="1.1" height="15.0" fill="rgb(0,218,110)" rx="2" ry="2" />
+<text  x="32.22" y="1807.5" ></text>
+</g>
+<g >
+<title>VertxCoreRecorder_convertToVertxOptions_5df5c7f4ecb26b4882053676b03b274cb80d3af5 (195 bytes, 0.04%)</title><rect x="980.6" y="1845" width="0.4" height="15.0" fill="rgb(0,231,129)" rx="2" ry="2" />
+<text  x="983.61" y="1855.5" ></text>
+</g>
+<g >
+<title>NativePRNG$1_run_0743137d09c21590ab03a7a771560aaf4331d759 (87 bytes, 0.02%)</title><rect x="29.0" y="1637" width="0.2" height="15.0" fill="rgb(0,228,32)" rx="2" ry="2" />
+<text  x="32.02" y="1647.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (88 bytes, 0.02%)</title><rect x="18.1" y="1749" width="0.2" height="15.0" fill="rgb(0,233,81)" rx="2" ry="2" />
+<text  x="21.14" y="1759.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1125" width="0.3" height="15.0" fill="rgb(0,202,109)" rx="2" ry="2" />
+<text  x="13.20" y="1135.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (88 bytes, 0.02%)</title><rect x="17.9" y="1845" width="0.2" height="15.0" fill="rgb(0,216,175)" rx="2" ry="2" />
+<text  x="20.94" y="1855.5" ></text>
+</g>
+<g >
+<title>ContainerInfo_getCpuPeriod_cf44affb3f3627d2fef69139ba5dda25a961193a (45 bytes, 0.01%)</title><rect x="30.4" y="1845" width="0.1" height="15.0" fill="rgb(0,237,64)" rx="2" ry="2" />
+<text  x="33.35" y="1855.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (88 bytes, 0.02%)</title><rect x="18.7" y="1909" width="0.2" height="15.0" fill="rgb(0,214,43)" rx="2" ry="2" />
+<text  x="21.73" y="1919.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_lock_62993eeba5aa50f4c636524077187e4fcd926085 (88 bytes, 0.02%)</title><rect x="1189.2" y="1653" width="0.2" height="15.0" fill="rgb(0,214,35)" rx="2" ry="2" />
+<text  x="1192.21" y="1663.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1477" width="0.3" height="15.0" fill="rgb(0,217,162)" rx="2" ry="2" />
+<text  x="13.20" y="1487.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_lambda$readStringValue$0_bf9c455fb8e17fdb73fd283b71cbbb23b2dde357 (45 bytes, 0.01%)</title><rect x="980.6" y="1653" width="0.1" height="15.0" fill="rgb(0,221,132)" rx="2" ry="2" />
+<text  x="983.65" y="1663.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="437" width="0.3" height="15.0" fill="rgb(0,220,133)" rx="2" ry="2" />
+<text  x="13.20" y="447.5" ></text>
+</g>
+<g >
+<title>ExtFormatter_format_ba0a8dcfebb0497fdc53b8bd84f218e703194cab (14,320 bytes, 2.74%)</title><rect x="30.7" y="1733" width="32.3" height="15.0" fill="rgb(0,236,208)" rx="2" ry="2" />
+<text  x="33.67" y="1743.5" >Ex..</text>
+</g>
+<g >
+<title>BundleContentSubstitutedLocalizationSupport_getBundleContentOf_ca03ba632254ad07027aec1c08388a0baf678b4f (7,160 bytes, 1.37%)</title><rect x="30.7" y="1477" width="16.1" height="15.0" fill="rgb(0,196,163)" rx="2" ry="2" />
+<text  x="33.67" y="1487.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (88 bytes, 0.02%)</title><rect x="18.7" y="1765" width="0.2" height="15.0" fill="rgb(0,197,75)" rx="2" ry="2" />
+<text  x="21.73" y="1775.5" ></text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (88 bytes, 0.02%)</title><rect x="19.1" y="1893" width="0.2" height="15.0" fill="rgb(0,225,3)" rx="2" ry="2" />
+<text  x="22.13" y="1903.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_lock_62993eeba5aa50f4c636524077187e4fcd926085 (88 bytes, 0.02%)</title><rect x="1189.6" y="1653" width="0.2" height="15.0" fill="rgb(0,223,149)" rx="2" ry="2" />
+<text  x="1192.60" y="1663.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_startThread_c59a1324122e39ffe7ab2f6ba4a58cb7f800282f (512 bytes, 0.10%)</title><rect x="64.2" y="1733" width="1.1" height="15.0" fill="rgb(0,198,180)" rx="2" ry="2" />
+<text  x="67.18" y="1743.5" ></text>
+</g>
+<g >
+<title>CgroupUtil$$Lambda$017b0cd0360754c055090b7d9521ad624f6920d8_run_5c088bd044b8b175a48676ce16a00fd18da382a5 (87 bytes, 0.02%)</title><rect x="63.8" y="1701" width="0.1" height="15.0" fill="rgb(0,200,123)" rx="2" ry="2" />
+<text  x="66.75" y="1711.5" ></text>
+</g>
+<g >
+<title>ExtHandler_publishToNestedHandlers_6bb2a8dc889e254bc0e9fac9b66e1c23f91e58d9 (14,320 bytes, 2.74%)</title><rect x="30.7" y="1781" width="32.3" height="15.0" fill="rgb(0,239,56)" rx="2" ry="2" />
+<text  x="33.67" y="1791.5" >Ex..</text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="17.9" y="2021" width="0.2" height="15.0" fill="rgb(0,216,17)" rx="2" ry="2" />
+<text  x="20.94" y="2031.5" ></text>
+</g>
+<g >
+<title>ntloop-thread-5 (88 bytes, 0.02%)</title><rect x="18.5" y="2069" width="0.2" height="15.0" fill="rgb(0,231,0)" rx="2" ry="2" />
+<text  x="21.54" y="2079.5" ></text>
+</g>
+<g >
+<title>Formatters$7$1_initialValue_c9f0e7cd3f6f825bd6791128fa0c0ab93655e38c (14,320 bytes, 2.74%)</title><rect x="30.7" y="1605" width="32.3" height="15.0" fill="rgb(0,194,96)" rx="2" ry="2" />
+<text  x="33.67" y="1615.5" >Fo..</text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1237" width="0.3" height="15.0" fill="rgb(0,193,126)" rx="2" ry="2" />
+<text  x="13.20" y="1247.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="1189.2" y="1589" width="0.2" height="15.0" fill="rgb(0,214,81)" rx="2" ry="2" />
+<text  x="1192.21" y="1599.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1349" width="0.3" height="15.0" fill="rgb(0,223,12)" rx="2" ry="2" />
+<text  x="13.20" y="1359.5" ></text>
+</g>
+<g >
+<title>fileOpen (86 bytes, 0.02%)</title><rect x="63.4" y="1541" width="0.2" height="15.0" fill="rgb(0,197,194)" rx="2" ry="2" />
+<text  x="66.38" y="1551.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (88 bytes, 0.02%)</title><rect x="19.1" y="1797" width="0.2" height="15.0" fill="rgb(0,237,17)" rx="2" ry="2" />
+<text  x="22.13" y="1807.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_a248ca38f52050b4cd112d073aa11463562bd8f6 (88 bytes, 0.02%)</title><rect x="19.3" y="1621" width="0.2" height="15.0" fill="rgb(0,204,208)" rx="2" ry="2" />
+<text  x="22.33" y="1631.5" ></text>
+</g>
+<g >
+<title>Constructor_newInstanceWithCaller_7990cd71760b72a496cfbe05ccee4199a26b322d (87 bytes, 0.02%)</title><rect x="29.0" y="1749" width="0.2" height="15.0" fill="rgb(0,195,151)" rx="2" ry="2" />
+<text  x="32.02" y="1759.5" ></text>
+</g>
+<g >
+<title>CgroupMetrics_getCpuPeriod_d00a6b36b95f65f253fcb3fc6ab60391532f5023 (45 bytes, 0.01%)</title><rect x="980.6" y="1765" width="0.1" height="15.0" fill="rgb(0,205,48)" rx="2" ry="2" />
+<text  x="983.65" y="1775.5" ></text>
+</g>
+<g >
+<title>Runtime_availableProcessors_8c88a5035e0f76404bd388d31bc8ea17e15f987b (141 bytes, 0.03%)</title><rect x="65.5" y="1781" width="0.4" height="15.0" fill="rgb(0,210,84)" rx="2" ry="2" />
+<text  x="68.53" y="1791.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (88 bytes, 0.02%)</title><rect x="1189.8" y="1749" width="0.2" height="15.0" fill="rgb(0,213,12)" rx="2" ry="2" />
+<text  x="1192.80" y="1759.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (88 bytes, 0.02%)</title><rect x="18.7" y="1749" width="0.2" height="15.0" fill="rgb(0,203,86)" rx="2" ry="2" />
+<text  x="21.73" y="1759.5" ></text>
+</g>
+<g >
+<title>Transport_eventLoopGroup_ee4a3052dc2152541ce73463072570ddd5994765 (405,504 bytes, 77.52%)</title><rect x="65.9" y="1813" width="914.7" height="15.0" fill="rgb(0,212,0)" rx="2" ry="2" />
+<text  x="68.85" y="1823.5" >Transport_eventLoopGroup_ee4a3052dc2152541ce73463072570ddd5994765</text>
+</g>
+<g >
+<title>AccessController_doPrivileged_de67c881e9b98da6843ef32b423a3d8bdbb4a36a (45 bytes, 0.01%)</title><rect x="65.5" y="1669" width="0.1" height="15.0" fill="rgb(0,220,64)" rx="2" ry="2" />
+<text  x="68.53" y="1679.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_64cb8fa504ff8d8ed6468c31dd67915d26710d8b (88 bytes, 0.02%)</title><rect x="1189.4" y="1637" width="0.2" height="15.0" fill="rgb(0,211,167)" rx="2" ry="2" />
+<text  x="1192.40" y="1647.5" ></text>
+</g>
+<g >
+<title>ntloop-thread-3 (88 bytes, 0.02%)</title><rect x="18.1" y="2069" width="0.2" height="15.0" fill="rgb(0,237,20)" rx="2" ry="2" />
+<text  x="21.14" y="2079.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (88 bytes, 0.02%)</title><rect x="17.7" y="1701" width="0.2" height="15.0" fill="rgb(0,232,120)" rx="2" ry="2" />
+<text  x="20.74" y="1711.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="19.1" y="1509" width="0.2" height="15.0" fill="rgb(0,213,195)" rx="2" ry="2" />
+<text  x="22.13" y="1519.5" ></text>
+</g>
+<g >
+<title>ProcessHandleImpl_&lt;clinit&gt;_2dac20ae5357b5a5d0629297171e36b2f2ee0617 (944 bytes, 0.18%)</title><rect x="15.1" y="1797" width="2.1" height="15.0" fill="rgb(0,238,143)" rx="2" ry="2" />
+<text  x="18.09" y="1807.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="17.9" y="1973" width="0.2" height="15.0" fill="rgb(0,227,62)" rx="2" ry="2" />
+<text  x="20.94" y="1983.5" ></text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (88 bytes, 0.02%)</title><rect x="1189.8" y="1957" width="0.2" height="15.0" fill="rgb(0,206,79)" rx="2" ry="2" />
+<text  x="1192.80" y="1967.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (88 bytes, 0.02%)</title><rect x="19.3" y="1781" width="0.2" height="15.0" fill="rgb(0,215,60)" rx="2" ry="2" />
+<text  x="22.33" y="1791.5" ></text>
+</g>
+<g >
+<title>UUID_randomUUID_86d04b1d7dbfadf544c1611884a34f3b0b67cc05 (87 bytes, 0.02%)</title><rect x="29.0" y="1893" width="0.2" height="15.0" fill="rgb(0,232,56)" rx="2" ry="2" />
+<text  x="32.02" y="1903.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="18.7" y="2037" width="0.2" height="15.0" fill="rgb(0,232,158)" rx="2" ry="2" />
+<text  x="21.73" y="2047.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (88 bytes, 0.02%)</title><rect x="18.7" y="1829" width="0.2" height="15.0" fill="rgb(0,208,149)" rx="2" ry="2" />
+<text  x="21.73" y="1839.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (88 bytes, 0.02%)</title><rect x="18.5" y="1829" width="0.2" height="15.0" fill="rgb(0,219,108)" rx="2" ry="2" />
+<text  x="21.54" y="1839.5" ></text>
+</g>
+<g >
+<title>ThreadLocal_get_89205c86d6fa365525945ac732abfddef7dd46f7 (14,320 bytes, 2.74%)</title><rect x="30.7" y="1637" width="32.3" height="15.0" fill="rgb(0,195,130)" rx="2" ry="2" />
+<text  x="33.67" y="1647.5" >Th..</text>
+</g>
+<g >
+<title>CgroupSubsystemController_getLongValue_5b80cabcf39909fd5a58e534d3495da67fa37757 (45 bytes, 0.01%)</title><rect x="980.6" y="1733" width="0.1" height="15.0" fill="rgb(0,192,112)" rx="2" ry="2" />
+<text  x="983.65" y="1743.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_monitorEnter_ed99d0c1674a21db0860911fdb11b326aefec12b (88 bytes, 0.02%)</title><rect x="18.3" y="1669" width="0.2" height="15.0" fill="rgb(0,209,25)" rx="2" ry="2" />
+<text  x="21.34" y="1679.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (88 bytes, 0.02%)</title><rect x="18.3" y="1829" width="0.2" height="15.0" fill="rgb(0,226,64)" rx="2" ry="2" />
+<text  x="21.34" y="1839.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="18.9" y="2053" width="0.2" height="15.0" fill="rgb(0,209,55)" rx="2" ry="2" />
+<text  x="21.93" y="2063.5" ></text>
+</g>
+<g >
+<title>CgroupMetrics_getMemoryLimit_ab7440bfe4986fcf364eba899cfa2aafda723937 (164 bytes, 0.03%)</title><rect x="63.6" y="1797" width="0.3" height="15.0" fill="rgb(0,232,16)" rx="2" ry="2" />
+<text  x="66.58" y="1807.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (88 bytes, 0.02%)</title><rect x="1189.2" y="1765" width="0.2" height="15.0" fill="rgb(0,215,3)" rx="2" ry="2" />
+<text  x="1192.21" y="1775.5" ></text>
+</g>
+<g >
+<title>AccessController_doPrivileged_de67c881e9b98da6843ef32b423a3d8bdbb4a36a (77 bytes, 0.01%)</title><rect x="63.6" y="1733" width="0.2" height="15.0" fill="rgb(0,191,63)" rx="2" ry="2" />
+<text  x="66.58" y="1743.5" ></text>
+</g>
+<g >
+<title>CgroupUtil$$Lambda$017b0cd0360754c055090b7d9521ad624f6920d8_run_5c088bd044b8b175a48676ce16a00fd18da382a5 (45 bytes, 0.01%)</title><rect x="63.0" y="1733" width="0.1" height="15.0" fill="rgb(0,223,108)" rx="2" ry="2" />
+<text  x="65.98" y="1743.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1413" width="0.3" height="15.0" fill="rgb(0,218,177)" rx="2" ry="2" />
+<text  x="13.20" y="1423.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="18.3" y="2053" width="0.2" height="15.0" fill="rgb(0,233,94)" rx="2" ry="2" />
+<text  x="21.34" y="2063.5" ></text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (88 bytes, 0.02%)</title><rect x="1189.6" y="1877" width="0.2" height="15.0" fill="rgb(0,236,96)" rx="2" ry="2" />
+<text  x="1192.60" y="1887.5" ></text>
+</g>
+<g >
+<title>FileInputStream_open0_8b1b5fc3043b8ae0dd0d8b68b3a5a224719f9dca (77 bytes, 0.01%)</title><rect x="63.6" y="1637" width="0.2" height="15.0" fill="rgb(0,237,177)" rx="2" ry="2" />
+<text  x="66.58" y="1647.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="17.7" y="2037" width="0.2" height="15.0" fill="rgb(0,217,182)" rx="2" ry="2" />
+<text  x="20.74" y="2047.5" ></text>
+</g>
+<g >
+<title>ContainerInfo_getCpuPeriod_cf44affb3f3627d2fef69139ba5dda25a961193a (45 bytes, 0.01%)</title><rect x="63.0" y="1845" width="0.1" height="15.0" fill="rgb(0,221,37)" rx="2" ry="2" />
+<text  x="65.98" y="1855.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (88 bytes, 0.02%)</title><rect x="18.9" y="1829" width="0.2" height="15.0" fill="rgb(0,230,46)" rx="2" ry="2" />
+<text  x="21.93" y="1839.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (88 bytes, 0.02%)</title><rect x="18.7" y="1861" width="0.2" height="15.0" fill="rgb(0,195,191)" rx="2" ry="2" />
+<text  x="21.73" y="1871.5" ></text>
+</g>
+<g >
+<title>AccessController_executePrivileged_d07f5fea2e10c57d20fe35f694351835c33861ed (45 bytes, 0.01%)</title><rect x="980.6" y="1685" width="0.1" height="15.0" fill="rgb(0,230,93)" rx="2" ry="2" />
+<text  x="983.65" y="1695.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (88 bytes, 0.02%)</title><rect x="18.5" y="1717" width="0.2" height="15.0" fill="rgb(0,217,115)" rx="2" ry="2" />
+<text  x="21.54" y="1727.5" ></text>
+</g>
+<g >
+<title>malloc (472 bytes, 0.09%)</title><rect x="22.2" y="1941" width="1.1" height="15.0" fill="rgb(0,223,48)" rx="2" ry="2" />
+<text  x="25.20" y="1951.5" ></text>
+</g>
+<g >
+<title>CgroupUtil$$Lambda$017b0cd0360754c055090b7d9521ad624f6920d8_run_5c088bd044b8b175a48676ce16a00fd18da382a5 (45 bytes, 0.01%)</title><rect x="30.4" y="1733" width="0.1" height="15.0" fill="rgb(0,212,30)" rx="2" ry="2" />
+<text  x="33.35" y="1743.5" ></text>
+</g>
+<g >
+<title>QuarkusDelayedHandler_doPublish_27f211cd8b0bcbb35d0a9c07a965098ef480c751 (14,320 bytes, 2.74%)</title><rect x="30.7" y="1797" width="32.3" height="15.0" fill="rgb(0,210,199)" rx="2" ry="2" />
+<text  x="33.67" y="1807.5" >Qu..</text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="18.7" y="2021" width="0.2" height="15.0" fill="rgb(0,203,200)" rx="2" ry="2" />
+<text  x="21.73" y="2031.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="53" width="0.3" height="15.0" fill="rgb(0,213,25)" rx="2" ry="2" />
+<text  x="13.20" y="63.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_64cb8fa504ff8d8ed6468c31dd67915d26710d8b (88 bytes, 0.02%)</title><rect x="1189.8" y="1637" width="0.2" height="15.0" fill="rgb(0,193,4)" rx="2" ry="2" />
+<text  x="1192.80" y="1647.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (88 bytes, 0.02%)</title><rect x="19.3" y="1685" width="0.2" height="15.0" fill="rgb(0,190,0)" rx="2" ry="2" />
+<text  x="22.33" y="1695.5" ></text>
+</g>
+<g >
+<title>LockSupport_parkNanos_2b761ef0a67536a89c27ff8847e5178d8c83366f (88 bytes, 0.02%)</title><rect x="17.2" y="1909" width="0.2" height="15.0" fill="rgb(0,213,86)" rx="2" ry="2" />
+<text  x="20.22" y="1919.5" ></text>
+</g>
+<g >
+<title>malloc (128 bytes, 0.02%)</title><rect x="17.4" y="2053" width="0.3" height="15.0" fill="rgb(0,231,132)" rx="2" ry="2" />
+<text  x="20.42" y="2063.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (88 bytes, 0.02%)</title><rect x="18.5" y="1925" width="0.2" height="15.0" fill="rgb(0,205,83)" rx="2" ry="2" />
+<text  x="21.54" y="1935.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="18.1" y="2037" width="0.2" height="15.0" fill="rgb(0,232,63)" rx="2" ry="2" />
+<text  x="21.14" y="2047.5" ></text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="18.7" y="1605" width="0.2" height="15.0" fill="rgb(0,222,160)" rx="2" ry="2" />
+<text  x="21.73" y="1615.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (88 bytes, 0.02%)</title><rect x="18.3" y="1717" width="0.2" height="15.0" fill="rgb(0,199,82)" rx="2" ry="2" />
+<text  x="21.34" y="1727.5" ></text>
+</g>
+<g >
+<title>CgroupSubsystemController_getLongValue_5b80cabcf39909fd5a58e534d3495da67fa37757 (45 bytes, 0.01%)</title><rect x="65.5" y="1701" width="0.1" height="15.0" fill="rgb(0,227,65)" rx="2" ry="2" />
+<text  x="68.53" y="1711.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (88 bytes, 0.02%)</title><rect x="17.9" y="1829" width="0.2" height="15.0" fill="rgb(0,196,127)" rx="2" ry="2" />
+<text  x="20.94" y="1839.5" ></text>
+</g>
+<g >
+<title>PatternFormatter_setPattern_8f17060cfaa21a3878aa98408e4cd24cf05031ba (472 bytes, 0.09%)</title><rect x="29.2" y="1861" width="1.1" height="15.0" fill="rgb(0,197,122)" rx="2" ry="2" />
+<text  x="32.22" y="1871.5" ></text>
+</g>
+<g >
+<title>ClassInitializationInfo_initialize_fc2a388d0cb0b18ea354b79ca3bc111ec6e55467 (944 bytes, 0.18%)</title><rect x="15.1" y="1829" width="2.1" height="15.0" fill="rgb(0,219,58)" rx="2" ry="2" />
+<text  x="18.09" y="1839.5" ></text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (88 bytes, 0.02%)</title><rect x="18.7" y="1957" width="0.2" height="15.0" fill="rgb(0,209,47)" rx="2" ry="2" />
+<text  x="21.73" y="1967.5" ></text>
+</g>
+<g >
+<title>SecureRandom_getDefaultPRNG_9a62220866806cba795a0c5951e18c4557304ce5 (87 bytes, 0.02%)</title><rect x="29.0" y="1813" width="0.2" height="15.0" fill="rgb(0,211,134)" rx="2" ry="2" />
+<text  x="32.02" y="1823.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (88 bytes, 0.02%)</title><rect x="18.1" y="1925" width="0.2" height="15.0" fill="rgb(0,199,95)" rx="2" ry="2" />
+<text  x="21.14" y="1935.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder_initializeRouter_c0e44ca8f166b805ce796ed6560e6c30b5da1274 (405,930 bytes, 77.60%)</title><rect x="65.3" y="1909" width="915.7" height="15.0" fill="rgb(0,190,157)" rx="2" ry="2" />
+<text  x="68.33" y="1919.5" >VertxHttpRecorder_initializeRouter_c0e44ca8f166b805ce796ed6560e6c30b5da1274</text>
+</g>
+<g >
+<title>Containers_activeProcessorCount_69a70d68269b86774873269a89490f0e7a966343 (141 bytes, 0.03%)</title><rect x="65.5" y="1765" width="0.4" height="15.0" fill="rgb(0,199,56)" rx="2" ry="2" />
+<text  x="68.53" y="1775.5" ></text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="17.9" y="1605" width="0.2" height="15.0" fill="rgb(0,191,58)" rx="2" ry="2" />
+<text  x="20.94" y="1615.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_lambda$readStringValue$0_bf9c455fb8e17fdb73fd283b71cbbb23b2dde357 (45 bytes, 0.01%)</title><rect x="30.4" y="1717" width="0.1" height="15.0" fill="rgb(0,233,9)" rx="2" ry="2" />
+<text  x="33.35" y="1727.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (88 bytes, 0.02%)</title><rect x="1189.8" y="1701" width="0.2" height="15.0" fill="rgb(0,234,11)" rx="2" ry="2" />
+<text  x="1192.80" y="1711.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_aac741e2ef07c171301eb35c0deea3293fe4d747 (45 bytes, 0.01%)</title><rect x="65.5" y="1589" width="0.1" height="15.0" fill="rgb(0,210,54)" rx="2" ry="2" />
+<text  x="68.53" y="1599.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="18.3" y="1573" width="0.2" height="15.0" fill="rgb(0,212,146)" rx="2" ry="2" />
+<text  x="21.34" y="1583.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (88 bytes, 0.02%)</title><rect x="19.1" y="1861" width="0.2" height="15.0" fill="rgb(0,234,120)" rx="2" ry="2" />
+<text  x="22.13" y="1871.5" ></text>
+</g>
+<g >
+<title>malloc (7,160 bytes, 1.37%)</title><rect x="30.7" y="1381" width="16.1" height="15.0" fill="rgb(0,208,5)" rx="2" ry="2" />
+<text  x="33.67" y="1391.5" ></text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (88 bytes, 0.02%)</title><rect x="1189.2" y="1957" width="0.2" height="15.0" fill="rgb(0,196,194)" rx="2" ry="2" />
+<text  x="1192.21" y="1967.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (88 bytes, 0.02%)</title><rect x="1189.6" y="1941" width="0.2" height="15.0" fill="rgb(0,226,92)" rx="2" ry="2" />
+<text  x="1192.60" y="1951.5" ></text>
+</g>
+<g >
+<title>Application_start_f0300884f5c38b6448504f5177e19dff60a47b71 (424,074 bytes, 81.07%)</title><rect x="24.4" y="1957" width="956.6" height="15.0" fill="rgb(0,237,135)" rx="2" ry="2" />
+<text  x="27.40" y="1967.5" >Application_start_f0300884f5c38b6448504f5177e19dff60a47b71</text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (88 bytes, 0.02%)</title><rect x="18.3" y="1877" width="0.2" height="15.0" fill="rgb(0,234,91)" rx="2" ry="2" />
+<text  x="21.34" y="1887.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_monitorEnter_ed99d0c1674a21db0860911fdb11b326aefec12b (88 bytes, 0.02%)</title><rect x="18.9" y="1669" width="0.2" height="15.0" fill="rgb(0,227,106)" rx="2" ry="2" />
+<text  x="21.93" y="1679.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="1189.2" y="1989" width="0.2" height="15.0" fill="rgb(0,207,116)" rx="2" ry="2" />
+<text  x="1192.21" y="1999.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="18.3" y="2037" width="0.2" height="15.0" fill="rgb(0,213,193)" rx="2" ry="2" />
+<text  x="21.34" y="2047.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (88 bytes, 0.02%)</title><rect x="1189.6" y="1845" width="0.2" height="15.0" fill="rgb(0,203,207)" rx="2" ry="2" />
+<text  x="1192.60" y="1855.5" ></text>
+</g>
+<g >
+<title>NativeLibrarySupport_loadLibraryRelative_074e1259a339aa844bac29c4b8212b7b0ec4ab9e (472 bytes, 0.09%)</title><rect x="23.3" y="1941" width="1.0" height="15.0" fill="rgb(0,225,199)" rx="2" ry="2" />
+<text  x="26.26" y="1951.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1269" width="0.3" height="15.0" fill="rgb(0,208,21)" rx="2" ry="2" />
+<text  x="13.20" y="1279.5" ></text>
+</g>
+<g >
+<title>malloc (472 bytes, 0.09%)</title><rect x="29.2" y="1781" width="1.1" height="15.0" fill="rgb(0,202,200)" rx="2" ry="2" />
+<text  x="32.22" y="1791.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (88 bytes, 0.02%)</title><rect x="1189.6" y="1685" width="0.2" height="15.0" fill="rgb(0,192,143)" rx="2" ry="2" />
+<text  x="1192.60" y="1695.5" ></text>
+</g>
+<g >
+<title>ListResourceBundle_handleKeySet_fb44948facbbd6452e82b5e0fd6b338f078abab5 (7,160 bytes, 1.37%)</title><rect x="30.7" y="1493" width="16.1" height="15.0" fill="rgb(0,232,157)" rx="2" ry="2" />
+<text  x="33.67" y="1503.5" ></text>
+</g>
+<g >
+<title>FileInputStream_open0_8b1b5fc3043b8ae0dd0d8b68b3a5a224719f9dca (86 bytes, 0.02%)</title><rect x="63.4" y="1557" width="0.2" height="15.0" fill="rgb(0,235,166)" rx="2" ry="2" />
+<text  x="66.38" y="1567.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="10.0" y="2037" width="0.2" height="15.0" fill="rgb(0,216,45)" rx="2" ry="2" />
+<text  x="13.00" y="2047.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (88 bytes, 0.02%)</title><rect x="17.9" y="1685" width="0.2" height="15.0" fill="rgb(0,209,86)" rx="2" ry="2" />
+<text  x="20.94" y="1695.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="18.9" y="1973" width="0.2" height="15.0" fill="rgb(0,190,196)" rx="2" ry="2" />
+<text  x="21.93" y="1983.5" ></text>
+</g>
+<g >
+<title>NativePRNG$1_run_a372c05362181dcdf073b8e3cf30f445c2c20224 (87 bytes, 0.02%)</title><rect x="29.0" y="1653" width="0.2" height="15.0" fill="rgb(0,229,164)" rx="2" ry="2" />
+<text  x="32.02" y="1663.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="341" width="0.3" height="15.0" fill="rgb(0,214,188)" rx="2" ry="2" />
+<text  x="13.20" y="351.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (88 bytes, 0.02%)</title><rect x="19.1" y="1845" width="0.2" height="15.0" fill="rgb(0,192,116)" rx="2" ry="2" />
+<text  x="22.13" y="1855.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="325" width="0.3" height="15.0" fill="rgb(0,232,203)" rx="2" ry="2" />
+<text  x="13.20" y="335.5" ></text>
+</g>
+<g >
+<title>StackOverflowCheckImpl_initialize_b671a6e5270db0afaef21a804ae8be00b6266c25 (944 bytes, 0.18%)</title><rect x="21.1" y="1957" width="2.2" height="15.0" fill="rgb(0,225,197)" rx="2" ry="2" />
+<text  x="24.13" y="1967.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="101" width="0.3" height="15.0" fill="rgb(0,194,81)" rx="2" ry="2" />
+<text  x="13.20" y="111.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (88 bytes, 0.02%)</title><rect x="1189.8" y="1813" width="0.2" height="15.0" fill="rgb(0,229,139)" rx="2" ry="2" />
+<text  x="1192.80" y="1823.5" ></text>
+</g>
+<g >
+<title>UUID$Holder_&lt;clinit&gt;_553614be727eefa517d214bfafa9b5df584019e0 (87 bytes, 0.02%)</title><rect x="29.0" y="1845" width="0.2" height="15.0" fill="rgb(0,237,151)" rx="2" ry="2" />
+<text  x="32.02" y="1855.5" ></text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (88 bytes, 0.02%)</title><rect x="18.3" y="1957" width="0.2" height="15.0" fill="rgb(0,206,1)" rx="2" ry="2" />
+<text  x="21.34" y="1967.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (88 bytes, 0.02%)</title><rect x="18.9" y="1765" width="0.2" height="15.0" fill="rgb(0,195,25)" rx="2" ry="2" />
+<text  x="21.93" y="1775.5" ></text>
+</g>
+<g >
+<title>UnixNativeDispatcher_stat_66fa36559a40ee8c017477fce4906f1ddc631840 (2,048 bytes, 0.39%)</title><rect x="24.4" y="1861" width="4.6" height="15.0" fill="rgb(0,228,67)" rx="2" ry="2" />
+<text  x="27.40" y="1871.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="19.3" y="2053" width="0.2" height="15.0" fill="rgb(0,227,129)" rx="2" ry="2" />
+<text  x="22.33" y="2063.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (88 bytes, 0.02%)</title><rect x="1189.4" y="1845" width="0.2" height="15.0" fill="rgb(0,233,127)" rx="2" ry="2" />
+<text  x="1192.40" y="1855.5" ></text>
+</g>
+<g >
+<title>FileCache_setupCache_14655269c074c9b2dbfdc13a1df1ef5743473dd3 (74 bytes, 0.01%)</title><rect x="65.3" y="1797" width="0.2" height="15.0" fill="rgb(0,208,61)" rx="2" ry="2" />
+<text  x="68.33" y="1807.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="19.3" y="1989" width="0.2" height="15.0" fill="rgb(0,229,55)" rx="2" ry="2" />
+<text  x="22.33" y="1999.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1509" width="0.3" height="15.0" fill="rgb(0,214,157)" rx="2" ry="2" />
+<text  x="13.20" y="1519.5" ></text>
+</g>
+<g >
+<title>DotEnvConfigSourceProvider_constructor_0e9fda87d7ea44361be6e78ec89fb587c17251d3 (2,048 bytes, 0.39%)</title><rect x="24.4" y="1893" width="4.6" height="15.0" fill="rgb(0,196,187)" rx="2" ry="2" />
+<text  x="27.40" y="1903.5" ></text>
+</g>
+<g >
+<title>EnhancedQueueExecutor$ThreadBody_run_b983f53757480f1b7db07a8d314bfbf5799f4b5f (88 bytes, 0.02%)</title><rect x="17.2" y="1941" width="0.2" height="15.0" fill="rgb(0,205,144)" rx="2" ry="2" />
+<text  x="20.22" y="1951.5" ></text>
+</g>
+<g >
+<title>NettyRecorder$1_run_93c818dc1ee0dfd53b6309724eec3c4ddaaa36a1 (944 bytes, 0.18%)</title><rect x="15.1" y="1973" width="2.1" height="15.0" fill="rgb(0,190,9)" rx="2" ry="2" />
+<text  x="18.09" y="1983.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="18.3" y="1509" width="0.2" height="15.0" fill="rgb(0,218,187)" rx="2" ry="2" />
+<text  x="21.34" y="1519.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (88 bytes, 0.02%)</title><rect x="1189.8" y="1717" width="0.2" height="15.0" fill="rgb(0,212,132)" rx="2" ry="2" />
+<text  x="1192.80" y="1727.5" ></text>
+</g>
+<g >
+<title>CgroupSubsystemController_getLongValue_5b80cabcf39909fd5a58e534d3495da67fa37757 (87 bytes, 0.02%)</title><rect x="63.8" y="1765" width="0.1" height="15.0" fill="rgb(0,209,89)" rx="2" ry="2" />
+<text  x="66.75" y="1775.5" ></text>
+</g>
+<g >
+<title>CgroupSubsystemFactory_create_b7c21728cc857d7d9ec59213070ae47c75419af7 (139 bytes, 0.03%)</title><rect x="63.3" y="1781" width="0.3" height="15.0" fill="rgb(0,232,171)" rx="2" ry="2" />
+<text  x="66.26" y="1791.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (88 bytes, 0.02%)</title><rect x="1189.2" y="1909" width="0.2" height="15.0" fill="rgb(0,231,125)" rx="2" ry="2" />
+<text  x="1192.21" y="1919.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (88 bytes, 0.02%)</title><rect x="1189.4" y="1717" width="0.2" height="15.0" fill="rgb(0,198,135)" rx="2" ry="2" />
+<text  x="1192.40" y="1727.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="18.5" y="1573" width="0.2" height="15.0" fill="rgb(0,236,107)" rx="2" ry="2" />
+<text  x="21.54" y="1583.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (88 bytes, 0.02%)</title><rect x="19.1" y="1765" width="0.2" height="15.0" fill="rgb(0,192,63)" rx="2" ry="2" />
+<text  x="22.13" y="1775.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="18.7" y="1509" width="0.2" height="15.0" fill="rgb(0,211,114)" rx="2" ry="2" />
+<text  x="21.73" y="1519.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="19.3" y="1541" width="0.2" height="15.0" fill="rgb(0,211,38)" rx="2" ry="2" />
+<text  x="22.33" y="1551.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_monitorEnter_ed99d0c1674a21db0860911fdb11b326aefec12b (88 bytes, 0.02%)</title><rect x="1189.4" y="1669" width="0.2" height="15.0" fill="rgb(0,229,160)" rx="2" ry="2" />
+<text  x="1192.40" y="1679.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="18.1" y="1525" width="0.2" height="15.0" fill="rgb(0,224,187)" rx="2" ry="2" />
+<text  x="21.14" y="1535.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1317" width="0.3" height="15.0" fill="rgb(0,213,123)" rx="2" ry="2" />
+<text  x="13.20" y="1327.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (88 bytes, 0.02%)</title><rect x="1189.2" y="1941" width="0.2" height="15.0" fill="rgb(0,232,177)" rx="2" ry="2" />
+<text  x="1192.21" y="1951.5" ></text>
+</g>
+<g >
+<title>VertxBuilder_init_b401802142ff7797952f998daedc530f99fc1979 (74 bytes, 0.01%)</title><rect x="65.3" y="1845" width="0.2" height="15.0" fill="rgb(0,225,175)" rx="2" ry="2" />
+<text  x="68.33" y="1855.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="1189.2" y="1541" width="0.2" height="15.0" fill="rgb(0,196,157)" rx="2" ry="2" />
+<text  x="1192.21" y="1551.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (88 bytes, 0.02%)</title><rect x="18.9" y="1717" width="0.2" height="15.0" fill="rgb(0,231,196)" rx="2" ry="2" />
+<text  x="21.93" y="1727.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1061" width="0.3" height="15.0" fill="rgb(0,197,188)" rx="2" ry="2" />
+<text  x="13.20" y="1071.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1141" width="0.3" height="15.0" fill="rgb(0,204,164)" rx="2" ry="2" />
+<text  x="13.20" y="1151.5" ></text>
+</g>
+<g >
+<title>malloc (512 bytes, 0.10%)</title><rect x="64.2" y="1573" width="1.1" height="15.0" fill="rgb(0,208,54)" rx="2" ry="2" />
+<text  x="67.18" y="1583.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (88 bytes, 0.02%)</title><rect x="1189.4" y="1797" width="0.2" height="15.0" fill="rgb(0,234,32)" rx="2" ry="2" />
+<text  x="1192.40" y="1807.5" ></text>
+</g>
+<g >
+<title>FileResolverImpl_constructor_d160e21dbc6c6024cccf062b56559e13aa6c76ac (74 bytes, 0.01%)</title><rect x="65.3" y="1813" width="0.2" height="15.0" fill="rgb(0,199,31)" rx="2" ry="2" />
+<text  x="68.33" y="1823.5" ></text>
+</g>
+<g >
+<title>malloc (45 bytes, 0.01%)</title><rect x="63.0" y="1637" width="0.1" height="15.0" fill="rgb(0,233,184)" rx="2" ry="2" />
+<text  x="65.98" y="1647.5" ></text>
+</g>
+<g >
+<title>CgroupUtil$$Lambda$37daef4d527668b89facc004c17817855b05f31f_run_02a50fe2088b0ce7eaa17bbf8d7e46f9d9bd7fb6 (77 bytes, 0.01%)</title><rect x="63.6" y="1701" width="0.2" height="15.0" fill="rgb(0,192,153)" rx="2" ry="2" />
+<text  x="66.58" y="1711.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_lock_62993eeba5aa50f4c636524077187e4fcd926085 (88 bytes, 0.02%)</title><rect x="18.5" y="1653" width="0.2" height="15.0" fill="rgb(0,233,16)" rx="2" ry="2" />
+<text  x="21.54" y="1663.5" ></text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (88 bytes, 0.02%)</title><rect x="18.1" y="1893" width="0.2" height="15.0" fill="rgb(0,214,62)" rx="2" ry="2" />
+<text  x="21.14" y="1903.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1573" width="0.3" height="15.0" fill="rgb(0,193,89)" rx="2" ry="2" />
+<text  x="13.20" y="1583.5" ></text>
+</g>
+<g >
+<title>GZIPInputStream_constructor_c96ccb0372fe76fd9d98b28266a378cd9152d4c3 (7,160 bytes, 1.37%)</title><rect x="30.7" y="1429" width="16.1" height="15.0" fill="rgb(0,210,202)" rx="2" ry="2" />
+<text  x="33.67" y="1439.5" ></text>
+</g>
+<g >
+<title>JavaMainWrapper_doRun_befa12b002bb2c4ede2c3e72011cc12e1c7fe82a (425,522 bytes, 81.35%)</title><rect x="21.1" y="2021" width="959.9" height="15.0" fill="rgb(0,213,53)" rx="2" ry="2" />
+<text  x="24.13" y="2031.5" >JavaMainWrapper_doRun_befa12b002bb2c4ede2c3e72011cc12e1c7fe82a</text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (88 bytes, 0.02%)</title><rect x="1189.6" y="1925" width="0.2" height="15.0" fill="rgb(0,228,118)" rx="2" ry="2" />
+<text  x="1192.60" y="1935.5" ></text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (88 bytes, 0.02%)</title><rect x="1189.6" y="1893" width="0.2" height="15.0" fill="rgb(0,224,10)" rx="2" ry="2" />
+<text  x="1192.60" y="1903.5" ></text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (88 bytes, 0.02%)</title><rect x="1189.8" y="1877" width="0.2" height="15.0" fill="rgb(0,198,144)" rx="2" ry="2" />
+<text  x="1192.80" y="1887.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (88 bytes, 0.02%)</title><rect x="18.1" y="1829" width="0.2" height="15.0" fill="rgb(0,232,49)" rx="2" ry="2" />
+<text  x="21.14" y="1839.5" ></text>
+</g>
+<g >
+<title>ExtHandler_publish_c1b3417c05c10f8f0e39ee90f8558fe70d91f16f (14,320 bytes, 2.74%)</title><rect x="30.7" y="1765" width="32.3" height="15.0" fill="rgb(0,197,80)" rx="2" ry="2" />
+<text  x="33.67" y="1775.5" >Ex..</text>
+</g>
+<g >
+<title>ThreadLocal_setInitialValue_9baeab7e63aa0c03efb4e22b369dc49e63923d5a (14,320 bytes, 2.74%)</title><rect x="30.7" y="1621" width="32.3" height="15.0" fill="rgb(0,232,209)" rx="2" ry="2" />
+<text  x="33.67" y="1631.5" >Th..</text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="149" width="0.3" height="15.0" fill="rgb(0,227,132)" rx="2" ry="2" />
+<text  x="13.20" y="159.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (88 bytes, 0.02%)</title><rect x="18.1" y="1781" width="0.2" height="15.0" fill="rgb(0,195,83)" rx="2" ry="2" />
+<text  x="21.14" y="1791.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (88 bytes, 0.02%)</title><rect x="1189.4" y="1941" width="0.2" height="15.0" fill="rgb(0,210,135)" rx="2" ry="2" />
+<text  x="1192.40" y="1951.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="18.5" y="1973" width="0.2" height="15.0" fill="rgb(0,211,17)" rx="2" ry="2" />
+<text  x="21.54" y="1983.5" ></text>
+</g>
+<g >
+<title>tloop-thread-10 (88 bytes, 0.02%)</title><rect x="1189.2" y="2069" width="0.2" height="15.0" fill="rgb(0,203,139)" rx="2" ry="2" />
+<text  x="1192.21" y="2079.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_monitorEnter_ed99d0c1674a21db0860911fdb11b326aefec12b (88 bytes, 0.02%)</title><rect x="1189.8" y="1669" width="0.2" height="15.0" fill="rgb(0,234,79)" rx="2" ry="2" />
+<text  x="1192.80" y="1679.5" ></text>
+</g>
+<g >
+<title>ntloop-thread-7 (88 bytes, 0.02%)</title><rect x="18.9" y="2069" width="0.2" height="15.0" fill="rgb(0,221,145)" rx="2" ry="2" />
+<text  x="21.93" y="2079.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (88 bytes, 0.02%)</title><rect x="19.3" y="1717" width="0.2" height="15.0" fill="rgb(0,222,165)" rx="2" ry="2" />
+<text  x="22.33" y="1727.5" ></text>
+</g>
+<g >
+<title>CgroupMetrics_getCpuPeriod_d00a6b36b95f65f253fcb3fc6ab60391532f5023 (45 bytes, 0.01%)</title><rect x="65.5" y="1733" width="0.1" height="15.0" fill="rgb(0,194,69)" rx="2" ry="2" />
+<text  x="68.53" y="1743.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_aac741e2ef07c171301eb35c0deea3293fe4d747 (45 bytes, 0.01%)</title><rect x="980.6" y="1621" width="0.1" height="15.0" fill="rgb(0,196,49)" rx="2" ry="2" />
+<text  x="983.65" y="1631.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_readStringValue_cbc732074f2c96921b9ad69310afd25a7e2ad29d (45 bytes, 0.01%)</title><rect x="980.6" y="1717" width="0.1" height="15.0" fill="rgb(0,219,179)" rx="2" ry="2" />
+<text  x="983.65" y="1727.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (88 bytes, 0.02%)</title><rect x="19.1" y="1829" width="0.2" height="15.0" fill="rgb(0,236,172)" rx="2" ry="2" />
+<text  x="22.13" y="1839.5" ></text>
+</g>
+<g >
+<title>Timing_printStartupTime_e30891fdacdd75955bce2c2f89be34d5e3f90c23 (14,320 bytes, 2.74%)</title><rect x="30.7" y="1925" width="32.3" height="15.0" fill="rgb(0,234,125)" rx="2" ry="2" />
+<text  x="33.67" y="1935.5" >Ti..</text>
+</g>
+<g >
+<title>FileCache_constructor_f40bb27e8610400ea95f3ba9fd3ed852bd80d944 (74 bytes, 0.01%)</title><rect x="65.3" y="1781" width="0.2" height="15.0" fill="rgb(0,215,61)" rx="2" ry="2" />
+<text  x="68.33" y="1791.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (88 bytes, 0.02%)</title><rect x="18.7" y="1813" width="0.2" height="15.0" fill="rgb(0,231,85)" rx="2" ry="2" />
+<text  x="21.73" y="1823.5" ></text>
+</g>
+<g >
+<title>FormatStringParser_getSteps_d810e1b2d21e3484f4f85ca36e2fa831f94c7016 (472 bytes, 0.09%)</title><rect x="29.2" y="1845" width="1.1" height="15.0" fill="rgb(0,222,113)" rx="2" ry="2" />
+<text  x="32.22" y="1855.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_readStringValue_cbc732074f2c96921b9ad69310afd25a7e2ad29d (87 bytes, 0.02%)</title><rect x="63.8" y="1749" width="0.1" height="15.0" fill="rgb(0,234,13)" rx="2" ry="2" />
+<text  x="66.75" y="1759.5" ></text>
+</g>
+<g >
+<title>Runtime_maxMemory_db08cee07a760dcea3c208cfc4791b462d9eb917 (178 bytes, 0.03%)</title><rect x="63.6" y="1877" width="0.4" height="15.0" fill="rgb(0,225,136)" rx="2" ry="2" />
+<text  x="66.58" y="1887.5" ></text>
+</g>
+<g >
+<title>CgroupSubsystemController_getLongValue_5b80cabcf39909fd5a58e534d3495da67fa37757 (86 bytes, 0.02%)</title><rect x="63.4" y="1685" width="0.2" height="15.0" fill="rgb(0,216,7)" rx="2" ry="2" />
+<text  x="66.38" y="1695.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (88 bytes, 0.02%)</title><rect x="18.7" y="1845" width="0.2" height="15.0" fill="rgb(0,201,122)" rx="2" ry="2" />
+<text  x="21.73" y="1855.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="261" width="0.3" height="15.0" fill="rgb(0,218,180)" rx="2" ry="2" />
+<text  x="13.20" y="271.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="581" width="0.3" height="15.0" fill="rgb(0,230,136)" rx="2" ry="2" />
+<text  x="13.20" y="591.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="18.9" y="1557" width="0.2" height="15.0" fill="rgb(0,211,167)" rx="2" ry="2" />
+<text  x="21.93" y="1567.5" ></text>
+</g>
+<g >
+<title>Containers_activeProcessorCount_69a70d68269b86774873269a89490f0e7a966343 (141 bytes, 0.03%)</title><rect x="30.4" y="1861" width="0.3" height="15.0" fill="rgb(0,198,33)" rx="2" ry="2" />
+<text  x="33.35" y="1871.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="1189.8" y="1973" width="0.2" height="15.0" fill="rgb(0,206,208)" rx="2" ry="2" />
+<text  x="1192.80" y="1983.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (88 bytes, 0.02%)</title><rect x="1189.4" y="1781" width="0.2" height="15.0" fill="rgb(0,212,80)" rx="2" ry="2" />
+<text  x="1192.40" y="1791.5" ></text>
+</g>
+<g >
+<title>DefaultChannelId_&lt;clinit&gt;_a4d633f218fafc8a843d66859aea64266c369080 (944 bytes, 0.18%)</title><rect x="15.1" y="1925" width="2.1" height="15.0" fill="rgb(0,220,47)" rx="2" ry="2" />
+<text  x="18.09" y="1935.5" ></text>
+</g>
+<g >
+<title>Quarkus_run_7b200c41008a3c5f18cd42d608d602b518bc6c94 (424,090 bytes, 81.07%)</title><rect x="24.4" y="1989" width="956.6" height="15.0" fill="rgb(0,233,140)" rx="2" ry="2" />
+<text  x="27.37" y="1999.5" >Quarkus_run_7b200c41008a3c5f18cd42d608d602b518bc6c94</text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="1189.4" y="1973" width="0.2" height="15.0" fill="rgb(0,215,113)" rx="2" ry="2" />
+<text  x="1192.40" y="1983.5" ></text>
+</g>
+<g >
+<title>ClassInitializationInfo_invokeClassInitializer_aa7b9b942c88d6732e408e8eb614c29c67e71338 (125 bytes, 0.02%)</title><rect x="63.3" y="1749" width="0.3" height="15.0" fill="rgb(0,231,89)" rx="2" ry="2" />
+<text  x="66.29" y="1759.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1701" width="0.3" height="15.0" fill="rgb(0,233,19)" rx="2" ry="2" />
+<text  x="13.20" y="1711.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="19.3" y="1525" width="0.2" height="15.0" fill="rgb(0,201,54)" rx="2" ry="2" />
+<text  x="22.33" y="1535.5" ></text>
+</g>
+<g >
+<title>Inflater_constructor_cac54a3763eea18d04793fac0dc074735040f8c2 (7,160 bytes, 1.37%)</title><rect x="46.8" y="1397" width="16.2" height="15.0" fill="rgb(0,192,28)" rx="2" ry="2" />
+<text  x="49.82" y="1407.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="17.9" y="2053" width="0.2" height="15.0" fill="rgb(0,218,152)" rx="2" ry="2" />
+<text  x="20.94" y="2063.5" ></text>
+</g>
+<g >
+<title>malloc (2,048 bytes, 0.39%)</title><rect x="24.4" y="1781" width="4.6" height="15.0" fill="rgb(0,209,58)" rx="2" ry="2" />
+<text  x="27.40" y="1791.5" ></text>
+</g>
+<g >
+<title>AccessController_doPrivileged_de67c881e9b98da6843ef32b423a3d8bdbb4a36a (87 bytes, 0.02%)</title><rect x="63.8" y="1733" width="0.1" height="15.0" fill="rgb(0,223,182)" rx="2" ry="2" />
+<text  x="66.75" y="1743.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="453" width="0.3" height="15.0" fill="rgb(0,222,178)" rx="2" ry="2" />
+<text  x="13.20" y="463.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (88 bytes, 0.02%)</title><rect x="17.7" y="1813" width="0.2" height="15.0" fill="rgb(0,194,46)" rx="2" ry="2" />
+<text  x="20.74" y="1823.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="17.7" y="2005" width="0.2" height="15.0" fill="rgb(0,218,205)" rx="2" ry="2" />
+<text  x="20.74" y="2015.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="17.9" y="2037" width="0.2" height="15.0" fill="rgb(0,203,160)" rx="2" ry="2" />
+<text  x="20.94" y="2047.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (88 bytes, 0.02%)</title><rect x="1189.2" y="1797" width="0.2" height="15.0" fill="rgb(0,225,42)" rx="2" ry="2" />
+<text  x="1192.21" y="1807.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1589" width="0.3" height="15.0" fill="rgb(0,217,174)" rx="2" ry="2" />
+<text  x="13.20" y="1599.5" ></text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="64.0" y="1797" width="0.2" height="15.0" fill="rgb(0,212,64)" rx="2" ry="2" />
+<text  x="66.98" y="1807.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="901" width="0.3" height="15.0" fill="rgb(0,210,130)" rx="2" ry="2" />
+<text  x="13.20" y="911.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_aac741e2ef07c171301eb35c0deea3293fe4d747 (77 bytes, 0.01%)</title><rect x="63.6" y="1653" width="0.2" height="15.0" fill="rgb(0,221,206)" rx="2" ry="2" />
+<text  x="66.58" y="1663.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="19.1" y="2005" width="0.2" height="15.0" fill="rgb(0,233,3)" rx="2" ry="2" />
+<text  x="22.13" y="2015.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1365" width="0.3" height="15.0" fill="rgb(0,190,22)" rx="2" ry="2" />
+<text  x="13.20" y="1375.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (88 bytes, 0.02%)</title><rect x="19.3" y="1941" width="0.2" height="15.0" fill="rgb(0,208,45)" rx="2" ry="2" />
+<text  x="22.33" y="1951.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="405" width="0.3" height="15.0" fill="rgb(0,233,169)" rx="2" ry="2" />
+<text  x="13.20" y="415.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="18.7" y="1973" width="0.2" height="15.0" fill="rgb(0,235,49)" rx="2" ry="2" />
+<text  x="21.73" y="1983.5" ></text>
+</g>
+<g >
+<title>FileInputStream_open0_8b1b5fc3043b8ae0dd0d8b68b3a5a224719f9dca (45 bytes, 0.01%)</title><rect x="65.5" y="1573" width="0.1" height="15.0" fill="rgb(0,208,165)" rx="2" ry="2" />
+<text  x="68.53" y="1583.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="741" width="0.3" height="15.0" fill="rgb(0,212,14)" rx="2" ry="2" />
+<text  x="13.20" y="751.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="17.7" y="1541" width="0.2" height="15.0" fill="rgb(0,227,100)" rx="2" ry="2" />
+<text  x="20.74" y="1551.5" ></text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (88 bytes, 0.02%)</title><rect x="19.3" y="1957" width="0.2" height="15.0" fill="rgb(0,210,105)" rx="2" ry="2" />
+<text  x="22.33" y="1967.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="17.7" y="1573" width="0.2" height="15.0" fill="rgb(0,238,151)" rx="2" ry="2" />
+<text  x="20.74" y="1583.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="18.9" y="1573" width="0.2" height="15.0" fill="rgb(0,213,18)" rx="2" ry="2" />
+<text  x="21.93" y="1583.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (88 bytes, 0.02%)</title><rect x="1189.2" y="1813" width="0.2" height="15.0" fill="rgb(0,235,49)" rx="2" ry="2" />
+<text  x="1192.21" y="1823.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="309" width="0.3" height="15.0" fill="rgb(0,231,188)" rx="2" ry="2" />
+<text  x="13.20" y="319.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="18.9" y="1509" width="0.2" height="15.0" fill="rgb(0,193,30)" rx="2" ry="2" />
+<text  x="21.93" y="1519.5" ></text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="1189.2" y="1605" width="0.2" height="15.0" fill="rgb(0,218,42)" rx="2" ry="2" />
+<text  x="1192.21" y="1615.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_64cb8fa504ff8d8ed6468c31dd67915d26710d8b (88 bytes, 0.02%)</title><rect x="17.7" y="1637" width="0.2" height="15.0" fill="rgb(0,222,31)" rx="2" ry="2" />
+<text  x="20.74" y="1647.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (88 bytes, 0.02%)</title><rect x="1189.2" y="1781" width="0.2" height="15.0" fill="rgb(0,231,183)" rx="2" ry="2" />
+<text  x="1192.21" y="1791.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1333" width="0.3" height="15.0" fill="rgb(0,212,196)" rx="2" ry="2" />
+<text  x="13.20" y="1343.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (88 bytes, 0.02%)</title><rect x="1189.6" y="1861" width="0.2" height="15.0" fill="rgb(0,194,35)" rx="2" ry="2" />
+<text  x="1192.60" y="1871.5" ></text>
+</g>
+<g >
+<title>CgroupMetrics_getCpuPeriod_d00a6b36b95f65f253fcb3fc6ab60391532f5023 (45 bytes, 0.01%)</title><rect x="30.4" y="1829" width="0.1" height="15.0" fill="rgb(0,196,80)" rx="2" ry="2" />
+<text  x="33.35" y="1839.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (88 bytes, 0.02%)</title><rect x="1189.8" y="1925" width="0.2" height="15.0" fill="rgb(0,193,186)" rx="2" ry="2" />
+<text  x="1192.80" y="1935.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="19.1" y="2037" width="0.2" height="15.0" fill="rgb(0,201,153)" rx="2" ry="2" />
+<text  x="22.13" y="2047.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="19.3" y="2005" width="0.2" height="15.0" fill="rgb(0,215,201)" rx="2" ry="2" />
+<text  x="22.33" y="2015.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_a248ca38f52050b4cd112d073aa11463562bd8f6 (88 bytes, 0.02%)</title><rect x="1189.2" y="1621" width="0.2" height="15.0" fill="rgb(0,215,51)" rx="2" ry="2" />
+<text  x="1192.21" y="1631.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (88 bytes, 0.02%)</title><rect x="17.9" y="1733" width="0.2" height="15.0" fill="rgb(0,234,85)" rx="2" ry="2" />
+<text  x="20.94" y="1743.5" ></text>
+</g>
+<g >
+<title>VertxCoreRecorder_initialize_aaf29a27cdf86a993cbc54b4e9974703a6d03613 (405,930 bytes, 77.60%)</title><rect x="65.3" y="1861" width="915.7" height="15.0" fill="rgb(0,233,82)" rx="2" ry="2" />
+<text  x="68.33" y="1871.5" >VertxCoreRecorder_initialize_aaf29a27cdf86a993cbc54b4e9974703a6d03613</text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="213" width="0.3" height="15.0" fill="rgb(0,237,184)" rx="2" ry="2" />
+<text  x="13.20" y="223.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_c26cfb3083610a614cb5843727b1293a2e050fbe (45 bytes, 0.01%)</title><rect x="30.4" y="1701" width="0.1" height="15.0" fill="rgb(0,219,80)" rx="2" ry="2" />
+<text  x="33.35" y="1711.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="19.1" y="1589" width="0.2" height="15.0" fill="rgb(0,214,19)" rx="2" ry="2" />
+<text  x="22.13" y="1599.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (88 bytes, 0.02%)</title><rect x="19.3" y="1909" width="0.2" height="15.0" fill="rgb(0,193,164)" rx="2" ry="2" />
+<text  x="22.33" y="1919.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1189" width="0.3" height="15.0" fill="rgb(0,207,87)" rx="2" ry="2" />
+<text  x="13.20" y="1199.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (88 bytes, 0.02%)</title><rect x="18.5" y="1701" width="0.2" height="15.0" fill="rgb(0,229,101)" rx="2" ry="2" />
+<text  x="21.54" y="1711.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1397" width="0.3" height="15.0" fill="rgb(0,204,76)" rx="2" ry="2" />
+<text  x="13.20" y="1407.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="18.5" y="2037" width="0.2" height="15.0" fill="rgb(0,220,13)" rx="2" ry="2" />
+<text  x="21.54" y="2047.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (88 bytes, 0.02%)</title><rect x="1189.8" y="1909" width="0.2" height="15.0" fill="rgb(0,217,53)" rx="2" ry="2" />
+<text  x="1192.80" y="1919.5" ></text>
+</g>
+<g >
+<title>CgroupUtil$$Lambda$017b0cd0360754c055090b7d9521ad624f6920d8_run_5c088bd044b8b175a48676ce16a00fd18da382a5 (45 bytes, 0.01%)</title><rect x="65.5" y="1637" width="0.1" height="15.0" fill="rgb(0,233,169)" rx="2" ry="2" />
+<text  x="68.53" y="1647.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="19.3" y="1557" width="0.2" height="15.0" fill="rgb(0,230,4)" rx="2" ry="2" />
+<text  x="22.33" y="1567.5" ></text>
+</g>
+<g >
+<title>ClassInitializationInfo_invokeClassInitializer_aa7b9b942c88d6732e408e8eb614c29c67e71338 (944 bytes, 0.18%)</title><rect x="15.1" y="1941" width="2.1" height="15.0" fill="rgb(0,207,59)" rx="2" ry="2" />
+<text  x="18.09" y="1951.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_deployVerticle_d1ec6d742094e9caf9549168fd6eb610e7882f7c (512 bytes, 0.10%)</title><rect x="64.2" y="1845" width="1.1" height="15.0" fill="rgb(0,201,8)" rx="2" ry="2" />
+<text  x="67.18" y="1855.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="19.3" y="2021" width="0.2" height="15.0" fill="rgb(0,216,7)" rx="2" ry="2" />
+<text  x="22.33" y="2031.5" ></text>
+</g>
+<g >
+<title>UnixUriUtils_toUri_b31694158b0cc5b0b7fa053b7090aaf73698f54b (2,048 bytes, 0.39%)</title><rect x="24.4" y="1877" width="4.6" height="15.0" fill="rgb(0,220,202)" rx="2" ry="2" />
+<text  x="27.40" y="1887.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="18.9" y="1989" width="0.2" height="15.0" fill="rgb(0,218,79)" rx="2" ry="2" />
+<text  x="21.93" y="1999.5" ></text>
+</g>
+<g >
+<title>ProcessHandleImpl_isAlive0_f9bb1b2509685ef765f7fa7c53ad6f5cd15a3da7 (472 bytes, 0.09%)</title><rect x="16.2" y="1781" width="1.0" height="15.0" fill="rgb(0,211,96)" rx="2" ry="2" />
+<text  x="19.15" y="1791.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="18.1" y="2053" width="0.2" height="15.0" fill="rgb(0,207,32)" rx="2" ry="2" />
+<text  x="21.14" y="2063.5" ></text>
+</g>
+<g >
+<title>malloc (2,048 bytes, 0.39%)</title><rect x="10.5" y="2053" width="4.6" height="15.0" fill="rgb(0,226,113)" rx="2" ry="2" />
+<text  x="13.47" y="2063.5" ></text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (88 bytes, 0.02%)</title><rect x="17.7" y="1877" width="0.2" height="15.0" fill="rgb(0,195,163)" rx="2" ry="2" />
+<text  x="20.74" y="1887.5" ></text>
+</g>
+<g >
+<title>ClassInitializationInfo_initialize_fc2a388d0cb0b18ea354b79ca3bc111ec6e55467 (87 bytes, 0.02%)</title><rect x="29.0" y="1877" width="0.2" height="15.0" fill="rgb(0,216,80)" rx="2" ry="2" />
+<text  x="32.02" y="1887.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="17.9" y="1573" width="0.2" height="15.0" fill="rgb(0,198,126)" rx="2" ry="2" />
+<text  x="20.94" y="1583.5" ></text>
+</g>
+<g >
+<title>malloc (86 bytes, 0.02%)</title><rect x="63.4" y="1525" width="0.2" height="15.0" fill="rgb(0,215,46)" rx="2" ry="2" />
+<text  x="66.38" y="1535.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_monitorEnter_ed99d0c1674a21db0860911fdb11b326aefec12b (88 bytes, 0.02%)</title><rect x="19.1" y="1669" width="0.2" height="15.0" fill="rgb(0,193,86)" rx="2" ry="2" />
+<text  x="22.13" y="1679.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="17.7" y="1589" width="0.2" height="15.0" fill="rgb(0,208,135)" rx="2" ry="2" />
+<text  x="20.74" y="1599.5" ></text>
+</g>
+<g >
+<title>ExtHandler_publish_c1b3417c05c10f8f0e39ee90f8558fe70d91f16f (14,320 bytes, 2.74%)</title><rect x="30.7" y="1813" width="32.3" height="15.0" fill="rgb(0,229,158)" rx="2" ry="2" />
+<text  x="33.67" y="1823.5" >Ex..</text>
+</g>
+<g >
+<title>TimeZone_getDefault_cff20669ea32daef266c7d0643b7fe56dbc83d79 (472 bytes, 0.09%)</title><rect x="29.2" y="1829" width="1.1" height="15.0" fill="rgb(0,211,175)" rx="2" ry="2" />
+<text  x="32.22" y="1839.5" ></text>
+</g>
+<g >
+<title>malloc (45 bytes, 0.01%)</title><rect x="65.5" y="1541" width="0.1" height="15.0" fill="rgb(0,223,31)" rx="2" ry="2" />
+<text  x="68.53" y="1551.5" ></text>
+</g>
+<g >
+<title>Runtime_availableProcessors_8c88a5035e0f76404bd388d31bc8ea17e15f987b (141 bytes, 0.03%)</title><rect x="980.6" y="1813" width="0.4" height="15.0" fill="rgb(0,217,120)" rx="2" ry="2" />
+<text  x="983.65" y="1823.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_lambda$readAllLinesPrivileged$1_d791271ddf5eb4521c23f28f21fe11c683060ff4 (77 bytes, 0.01%)</title><rect x="63.6" y="1685" width="0.2" height="15.0" fill="rgb(0,236,13)" rx="2" ry="2" />
+<text  x="66.58" y="1695.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (88 bytes, 0.02%)</title><rect x="17.7" y="1909" width="0.2" height="15.0" fill="rgb(0,224,17)" rx="2" ry="2" />
+<text  x="20.74" y="1919.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_lock_62993eeba5aa50f4c636524077187e4fcd926085 (88 bytes, 0.02%)</title><rect x="18.9" y="1653" width="0.2" height="15.0" fill="rgb(0,208,167)" rx="2" ry="2" />
+<text  x="21.93" y="1663.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="1189.6" y="1989" width="0.2" height="15.0" fill="rgb(0,238,59)" rx="2" ry="2" />
+<text  x="1192.60" y="1999.5" ></text>
+</g>
+<g >
+<title>CgroupV1Subsystem_setSubSystemControllerPath_b7e0b96e675fd9b21c89e0aebf296b9767110ec4 (86 bytes, 0.02%)</title><rect x="63.4" y="1701" width="0.2" height="15.0" fill="rgb(0,208,156)" rx="2" ry="2" />
+<text  x="66.38" y="1711.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_lock_62993eeba5aa50f4c636524077187e4fcd926085 (88 bytes, 0.02%)</title><rect x="19.1" y="1653" width="0.2" height="15.0" fill="rgb(0,210,84)" rx="2" ry="2" />
+<text  x="22.13" y="1663.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="18.3" y="1973" width="0.2" height="15.0" fill="rgb(0,234,131)" rx="2" ry="2" />
+<text  x="21.34" y="1983.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="10.0" y="2053" width="0.2" height="15.0" fill="rgb(0,199,157)" rx="2" ry="2" />
+<text  x="13.00" y="2063.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1253" width="0.3" height="15.0" fill="rgb(0,218,6)" rx="2" ry="2" />
+<text  x="13.20" y="1263.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="1189.8" y="1589" width="0.2" height="15.0" fill="rgb(0,217,33)" rx="2" ry="2" />
+<text  x="1192.80" y="1599.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1861" width="0.3" height="15.0" fill="rgb(0,204,186)" rx="2" ry="2" />
+<text  x="13.20" y="1871.5" ></text>
+</g>
+<g >
+<title>Thread_start_d043f016dd75eb113f895de55f2e129bad1ee51a (512 bytes, 0.10%)</title><rect x="64.2" y="1669" width="1.1" height="15.0" fill="rgb(0,234,63)" rx="2" ry="2" />
+<text  x="67.18" y="1679.5" ></text>
+</g>
+<g >
+<title>Inflater_init_a4cd52a872c5e0e850f4481152c720bd7b39637f (7,160 bytes, 1.37%)</title><rect x="46.8" y="1381" width="16.2" height="15.0" fill="rgb(0,214,79)" rx="2" ry="2" />
+<text  x="49.82" y="1391.5" ></text>
+</g>
+<g >
+<title>Config_readConfig_a68a1a88a9311bdfd87db5b1080709177ec73023 (2,135 bytes, 0.41%)</title><rect x="24.4" y="1925" width="4.8" height="15.0" fill="rgb(0,220,195)" rx="2" ry="2" />
+<text  x="27.40" y="1935.5" ></text>
+</g>
+<g >
+<title>CompletableFuture_get_d44e7c3335cf0dd8ff84643159440a459da07e4f (88 bytes, 0.02%)</title><rect x="64.0" y="1877" width="0.2" height="15.0" fill="rgb(0,202,198)" rx="2" ry="2" />
+<text  x="66.98" y="1887.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="1189.6" y="2053" width="0.2" height="15.0" fill="rgb(0,234,120)" rx="2" ry="2" />
+<text  x="1192.60" y="2063.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1461" width="0.3" height="15.0" fill="rgb(0,227,30)" rx="2" ry="2" />
+<text  x="13.20" y="1471.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="18.1" y="1973" width="0.2" height="15.0" fill="rgb(0,199,171)" rx="2" ry="2" />
+<text  x="21.14" y="1983.5" ></text>
+</g>
+<g >
+<title>LoggingSetupRecorder_initializeLogging_b2eca277561602d1bb347acfd5b2845aceebbb17 (472 bytes, 0.09%)</title><rect x="29.2" y="1909" width="1.1" height="15.0" fill="rgb(0,222,29)" rx="2" ry="2" />
+<text  x="32.22" y="1919.5" ></text>
+</g>
+<g >
+<title>JavaMonitor_lock_62993eeba5aa50f4c636524077187e4fcd926085 (88 bytes, 0.02%)</title><rect x="17.9" y="1653" width="0.2" height="15.0" fill="rgb(0,209,183)" rx="2" ry="2" />
+<text  x="20.94" y="1663.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (88 bytes, 0.02%)</title><rect x="17.9" y="1781" width="0.2" height="15.0" fill="rgb(0,225,56)" rx="2" ry="2" />
+<text  x="20.94" y="1791.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (88 bytes, 0.02%)</title><rect x="10.0" y="2005" width="0.2" height="15.0" fill="rgb(0,228,21)" rx="2" ry="2" />
+<text  x="13.00" y="2015.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (88 bytes, 0.02%)</title><rect x="18.3" y="1845" width="0.2" height="15.0" fill="rgb(0,233,52)" rx="2" ry="2" />
+<text  x="21.34" y="1855.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="165" width="0.3" height="15.0" fill="rgb(0,195,196)" rx="2" ry="2" />
+<text  x="13.20" y="175.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (88 bytes, 0.02%)</title><rect x="18.9" y="1813" width="0.2" height="15.0" fill="rgb(0,232,118)" rx="2" ry="2" />
+<text  x="21.93" y="1823.5" ></text>
+</g>
+<g >
+<title>fileOpen (77 bytes, 0.01%)</title><rect x="63.6" y="1621" width="0.2" height="15.0" fill="rgb(0,211,132)" rx="2" ry="2" />
+<text  x="66.58" y="1631.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="18.9" y="1541" width="0.2" height="15.0" fill="rgb(0,218,0)" rx="2" ry="2" />
+<text  x="21.93" y="1551.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="17.2" y="2053" width="0.2" height="15.0" fill="rgb(0,215,203)" rx="2" ry="2" />
+<text  x="20.22" y="2063.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="1189.4" y="2021" width="0.2" height="15.0" fill="rgb(0,208,142)" rx="2" ry="2" />
+<text  x="1192.40" y="2031.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="1189.6" y="1589" width="0.2" height="15.0" fill="rgb(0,220,48)" rx="2" ry="2" />
+<text  x="1192.60" y="1599.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="18.5" y="1989" width="0.2" height="15.0" fill="rgb(0,230,39)" rx="2" ry="2" />
+<text  x="21.54" y="1999.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_c26cfb3083610a614cb5843727b1293a2e050fbe (86 bytes, 0.02%)</title><rect x="63.4" y="1589" width="0.2" height="15.0" fill="rgb(0,207,53)" rx="2" ry="2" />
+<text  x="66.38" y="1599.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_a248ca38f52050b4cd112d073aa11463562bd8f6 (88 bytes, 0.02%)</title><rect x="17.7" y="1621" width="0.2" height="15.0" fill="rgb(0,209,129)" rx="2" ry="2" />
+<text  x="20.74" y="1631.5" ></text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (88 bytes, 0.02%)</title><rect x="17.9" y="1893" width="0.2" height="15.0" fill="rgb(0,196,127)" rx="2" ry="2" />
+<text  x="20.94" y="1903.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (88 bytes, 0.02%)</title><rect x="19.3" y="1701" width="0.2" height="15.0" fill="rgb(0,209,84)" rx="2" ry="2" />
+<text  x="22.33" y="1711.5" ></text>
+</g>
+<g >
+<title>File_getCanonicalFile_9e1378aa18d1107a252c479457851057eea2728c (74 bytes, 0.01%)</title><rect x="65.3" y="1765" width="0.2" height="15.0" fill="rgb(0,194,125)" rx="2" ry="2" />
+<text  x="68.33" y="1775.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (88 bytes, 0.02%)</title><rect x="1189.8" y="1733" width="0.2" height="15.0" fill="rgb(0,195,74)" rx="2" ry="2" />
+<text  x="1192.80" y="1743.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="661" width="0.3" height="15.0" fill="rgb(0,219,89)" rx="2" ry="2" />
+<text  x="13.20" y="671.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (88 bytes, 0.02%)</title><rect x="17.9" y="1861" width="0.2" height="15.0" fill="rgb(0,192,8)" rx="2" ry="2" />
+<text  x="20.94" y="1871.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="17.2" y="1989" width="0.2" height="15.0" fill="rgb(0,211,179)" rx="2" ry="2" />
+<text  x="20.22" y="1999.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1909" width="0.3" height="15.0" fill="rgb(0,195,32)" rx="2" ry="2" />
+<text  x="13.20" y="1919.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (88 bytes, 0.02%)</title><rect x="17.7" y="1925" width="0.2" height="15.0" fill="rgb(0,226,97)" rx="2" ry="2" />
+<text  x="20.74" y="1935.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="821" width="0.3" height="15.0" fill="rgb(0,196,161)" rx="2" ry="2" />
+<text  x="13.20" y="831.5" ></text>
+</g>
+<g >
+<title>malloc (74 bytes, 0.01%)</title><rect x="65.3" y="1701" width="0.2" height="15.0" fill="rgb(0,196,25)" rx="2" ry="2" />
+<text  x="68.33" y="1711.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="18.7" y="1573" width="0.2" height="15.0" fill="rgb(0,233,162)" rx="2" ry="2" />
+<text  x="21.73" y="1583.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (88 bytes, 0.02%)</title><rect x="18.1" y="1909" width="0.2" height="15.0" fill="rgb(0,217,86)" rx="2" ry="2" />
+<text  x="21.14" y="1919.5" ></text>
+</g>
+<g >
+<title>CgroupSubsystemController_getLongValue_5b80cabcf39909fd5a58e534d3495da67fa37757 (45 bytes, 0.01%)</title><rect x="30.4" y="1797" width="0.1" height="15.0" fill="rgb(0,203,203)" rx="2" ry="2" />
+<text  x="33.35" y="1807.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="18.3" y="1525" width="0.2" height="15.0" fill="rgb(0,215,84)" rx="2" ry="2" />
+<text  x="21.34" y="1535.5" ></text>
+</g>
+<g >
+<title>ThreadLocalResettingRunnable_run_a77177d7e1c6cfa12b9833a791708fb5e8bb116c (88 bytes, 0.02%)</title><rect x="17.2" y="1957" width="0.2" height="15.0" fill="rgb(0,199,106)" rx="2" ry="2" />
+<text  x="20.22" y="1967.5" ></text>
+</g>
+<g >
+<title>tloop-thread-11 (88 bytes, 0.02%)</title><rect x="1189.4" y="2069" width="0.2" height="15.0" fill="rgb(0,193,47)" rx="2" ry="2" />
+<text  x="1192.40" y="2079.5" ></text>
+</g>
+<g >
+<title>ContainerInfo_getCpuPeriod_cf44affb3f3627d2fef69139ba5dda25a961193a (45 bytes, 0.01%)</title><rect x="65.5" y="1749" width="0.1" height="15.0" fill="rgb(0,218,138)" rx="2" ry="2" />
+<text  x="68.53" y="1759.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="10.0" y="1813" width="0.2" height="15.0" fill="rgb(0,206,193)" rx="2" ry="2" />
+<text  x="13.00" y="1823.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="64.0" y="1765" width="0.2" height="15.0" fill="rgb(0,239,208)" rx="2" ry="2" />
+<text  x="66.98" y="1775.5" ></text>
+</g>
+<g >
+<title>CgroupMetrics_getCpuPeriod_d00a6b36b95f65f253fcb3fc6ab60391532f5023 (45 bytes, 0.01%)</title><rect x="63.0" y="1829" width="0.1" height="15.0" fill="rgb(0,225,187)" rx="2" ry="2" />
+<text  x="65.98" y="1839.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (88 bytes, 0.02%)</title><rect x="17.7" y="1733" width="0.2" height="15.0" fill="rgb(0,197,6)" rx="2" ry="2" />
+<text  x="20.74" y="1743.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="18.5" y="2053" width="0.2" height="15.0" fill="rgb(0,195,144)" rx="2" ry="2" />
+<text  x="21.54" y="2063.5" ></text>
+</g>
+<g >
+<title>CEntryPointSnippets_initializeIsolate_30d4137bea42ce60ee1e88f09a09cc0d089fe0c8 (488 bytes, 0.09%)</title><rect x="23.3" y="2005" width="1.1" height="15.0" fill="rgb(0,197,120)" rx="2" ry="2" />
+<text  x="26.26" y="2015.5" ></text>
+</g>
+<g >
+<title>fileOpen (45 bytes, 0.01%)</title><rect x="63.0" y="1653" width="0.1" height="15.0" fill="rgb(0,200,32)" rx="2" ry="2" />
+<text  x="65.98" y="1663.5" ></text>
+</g>
+<g >
+<title>ClassInitializationInfo_initialize_fc2a388d0cb0b18ea354b79ca3bc111ec6e55467 (125 bytes, 0.02%)</title><rect x="63.3" y="1765" width="0.3" height="15.0" fill="rgb(0,201,98)" rx="2" ry="2" />
+<text  x="66.29" y="1775.5" ></text>
+</g>
+<g >
+<title>JBossLogManagerLogger_doLogf_a6c731911aaeaaa6b8b49ca85174d16283f1728e (14,320 bytes, 2.74%)</title><rect x="30.7" y="1909" width="32.3" height="15.0" fill="rgb(0,195,108)" rx="2" ry="2" />
+<text  x="33.67" y="1919.5" >JB..</text>
+</g>
+<g >
+<title>main (425,522 bytes, 81.35%)</title><rect x="21.1" y="2037" width="959.9" height="15.0" fill="rgb(0,191,136)" rx="2" ry="2" />
+<text  x="24.13" y="2047.5" >main</text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="501" width="0.3" height="15.0" fill="rgb(0,219,53)" rx="2" ry="2" />
+<text  x="13.20" y="511.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="1189.4" y="1525" width="0.2" height="15.0" fill="rgb(0,201,144)" rx="2" ry="2" />
+<text  x="1192.40" y="1535.5" ></text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="1189.8" y="1605" width="0.2" height="15.0" fill="rgb(0,219,128)" rx="2" ry="2" />
+<text  x="1192.80" y="1615.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (88 bytes, 0.02%)</title><rect x="18.9" y="1941" width="0.2" height="15.0" fill="rgb(0,230,164)" rx="2" ry="2" />
+<text  x="21.93" y="1951.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (88 bytes, 0.02%)</title><rect x="18.3" y="1925" width="0.2" height="15.0" fill="rgb(0,192,101)" rx="2" ry="2" />
+<text  x="21.34" y="1935.5" ></text>
+</g>
+<g >
+<title>AccessController_executePrivileged_1ba2fbbcef76cf84d7325876e891df7921a9234e (87 bytes, 0.02%)</title><rect x="29.0" y="1669" width="0.2" height="15.0" fill="rgb(0,237,35)" rx="2" ry="2" />
+<text  x="32.02" y="1679.5" ></text>
+</g>
+<g >
+<title>DateFormatSymbols_getProviderInstance_7a17802d9699bb2ef893d8654f4e77ff733da109 (14,320 bytes, 2.74%)</title><rect x="30.7" y="1557" width="32.3" height="15.0" fill="rgb(0,212,15)" rx="2" ry="2" />
+<text  x="33.67" y="1567.5" >Da..</text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_64cb8fa504ff8d8ed6468c31dd67915d26710d8b (88 bytes, 0.02%)</title><rect x="18.1" y="1637" width="0.2" height="15.0" fill="rgb(0,235,179)" rx="2" ry="2" />
+<text  x="21.14" y="1647.5" ></text>
+</g>
+<g >
+<title>JNI_OnLoad_dynamic_net (472 bytes, 0.09%)</title><rect x="23.3" y="1845" width="1.0" height="15.0" fill="rgb(0,190,175)" rx="2" ry="2" />
+<text  x="26.26" y="1855.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_doStartThread_46a8d24327e945849187371c711ef791886d3c7d (512 bytes, 0.10%)</title><rect x="64.2" y="1717" width="1.1" height="15.0" fill="rgb(0,193,53)" rx="2" ry="2" />
+<text  x="67.18" y="1727.5" ></text>
+</g>
+<g >
+<title>ClassInitializationInfo_invokeClassInitializer_aa7b9b942c88d6732e408e8eb614c29c67e71338 (944 bytes, 0.18%)</title><rect x="15.1" y="1813" width="2.1" height="15.0" fill="rgb(0,200,179)" rx="2" ry="2" />
+<text  x="18.09" y="1823.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (88 bytes, 0.02%)</title><rect x="1189.8" y="1797" width="0.2" height="15.0" fill="rgb(0,222,59)" rx="2" ry="2" />
+<text  x="1192.80" y="1807.5" ></text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (88 bytes, 0.02%)</title><rect x="17.9" y="1877" width="0.2" height="15.0" fill="rgb(0,215,10)" rx="2" ry="2" />
+<text  x="20.94" y="1887.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1621" width="0.3" height="15.0" fill="rgb(0,237,193)" rx="2" ry="2" />
+<text  x="13.20" y="1631.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_lambda$readStringValue$0_bf9c455fb8e17fdb73fd283b71cbbb23b2dde357 (87 bytes, 0.02%)</title><rect x="63.8" y="1685" width="0.1" height="15.0" fill="rgb(0,224,106)" rx="2" ry="2" />
+<text  x="66.75" y="1695.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="17.9" y="1541" width="0.2" height="15.0" fill="rgb(0,208,22)" rx="2" ry="2" />
+<text  x="20.94" y="1551.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="1189.2" y="2021" width="0.2" height="15.0" fill="rgb(0,207,154)" rx="2" ry="2" />
+<text  x="1192.21" y="2031.5" ></text>
+</g>
+<g >
+<title>VertxCoreProcessor$eventLoopCount1012482323_deploy_0_242414b060989c430190e177fe4f23d8d0e19aa4 (444 bytes, 0.08%)</title><rect x="63.0" y="1925" width="1.0" height="15.0" fill="rgb(0,201,64)" rx="2" ry="2" />
+<text  x="65.98" y="1935.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="17.9" y="1509" width="0.2" height="15.0" fill="rgb(0,190,97)" rx="2" ry="2" />
+<text  x="20.94" y="1519.5" ></text>
+</g>
+<g >
+<title>CgroupV1Subsystem_&lt;clinit&gt;_13078f89869f28dfac300c7c4ad6b8c681db9967 (125 bytes, 0.02%)</title><rect x="63.3" y="1733" width="0.3" height="15.0" fill="rgb(0,194,167)" rx="2" ry="2" />
+<text  x="66.29" y="1743.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="2021" width="0.3" height="15.0" fill="rgb(0,192,200)" rx="2" ry="2" />
+<text  x="13.20" y="2031.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="17.7" y="1525" width="0.2" height="15.0" fill="rgb(0,217,71)" rx="2" ry="2" />
+<text  x="20.74" y="1535.5" ></text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (88 bytes, 0.02%)</title><rect x="17.9" y="1957" width="0.2" height="15.0" fill="rgb(0,234,56)" rx="2" ry="2" />
+<text  x="20.94" y="1967.5" ></text>
+</g>
+<g >
+<title>EventLoopContext_runOnContext_6503de9ae7377948e3e16be4ae8faae0418f6d4d (512 bytes, 0.10%)</title><rect x="64.2" y="1797" width="1.1" height="15.0" fill="rgb(0,223,83)" rx="2" ry="2" />
+<text  x="67.18" y="1807.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="1189.8" y="1541" width="0.2" height="15.0" fill="rgb(0,199,32)" rx="2" ry="2" />
+<text  x="1192.80" y="1551.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_c26cfb3083610a614cb5843727b1293a2e050fbe (45 bytes, 0.01%)</title><rect x="63.0" y="1701" width="0.1" height="15.0" fill="rgb(0,218,78)" rx="2" ry="2" />
+<text  x="65.98" y="1711.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (425,522 bytes, 81.35%)</title><rect x="21.1" y="2053" width="959.9" height="15.0" fill="rgb(0,238,53)" rx="2" ry="2" />
+<text  x="24.13" y="2063.5" >__libc_start_call_main</text>
+</g>
+<g >
+<title>NioEventLoop_constructor_028fef7272962462688d7328ac11db5a2121187e (405,504 bytes, 77.52%)</title><rect x="65.9" y="1749" width="914.7" height="15.0" fill="rgb(0,206,53)" rx="2" ry="2" />
+<text  x="68.85" y="1759.5" >NioEventLoop_constructor_028fef7272962462688d7328ac11db5a2121187e</text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1541" width="0.3" height="15.0" fill="rgb(0,230,153)" rx="2" ry="2" />
+<text  x="13.20" y="1551.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="18.5" y="1589" width="0.2" height="15.0" fill="rgb(0,232,73)" rx="2" ry="2" />
+<text  x="21.54" y="1599.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_readStringValue_cbc732074f2c96921b9ad69310afd25a7e2ad29d (45 bytes, 0.01%)</title><rect x="65.5" y="1685" width="0.1" height="15.0" fill="rgb(0,213,64)" rx="2" ry="2" />
+<text  x="68.53" y="1695.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="949" width="0.3" height="15.0" fill="rgb(0,197,206)" rx="2" ry="2" />
+<text  x="13.20" y="959.5" ></text>
+</g>
+<g >
+<title>AccessController_executePrivileged_d07f5fea2e10c57d20fe35f694351835c33861ed (77 bytes, 0.01%)</title><rect x="63.6" y="1717" width="0.2" height="15.0" fill="rgb(0,195,143)" rx="2" ry="2" />
+<text  x="66.58" y="1727.5" ></text>
+</g>
+<g >
+<title>BannerFormatter_format_360cc812bf2abb143d4bff716256cd9efd7baf49 (14,320 bytes, 2.74%)</title><rect x="30.7" y="1717" width="32.3" height="15.0" fill="rgb(0,226,206)" rx="2" ry="2" />
+<text  x="33.67" y="1727.5" >Ba..</text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (88 bytes, 0.02%)</title><rect x="18.5" y="1733" width="0.2" height="15.0" fill="rgb(0,221,3)" rx="2" ry="2" />
+<text  x="21.54" y="1743.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="789" width="0.3" height="15.0" fill="rgb(0,223,42)" rx="2" ry="2" />
+<text  x="13.20" y="799.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1093" width="0.3" height="15.0" fill="rgb(0,229,42)" rx="2" ry="2" />
+<text  x="13.20" y="1103.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (88 bytes, 0.02%)</title><rect x="18.7" y="1781" width="0.2" height="15.0" fill="rgb(0,218,56)" rx="2" ry="2" />
+<text  x="21.73" y="1791.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (88 bytes, 0.02%)</title><rect x="1189.2" y="1717" width="0.2" height="15.0" fill="rgb(0,206,199)" rx="2" ry="2" />
+<text  x="1192.21" y="1727.5" ></text>
+</g>
+<g >
+<title>ClassInitializationInfo_invokeClassInitializer_aa7b9b942c88d6732e408e8eb614c29c67e71338 (87 bytes, 0.02%)</title><rect x="29.0" y="1717" width="0.2" height="15.0" fill="rgb(0,230,99)" rx="2" ry="2" />
+<text  x="32.02" y="1727.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1781" width="0.3" height="15.0" fill="rgb(0,235,152)" rx="2" ry="2" />
+<text  x="13.20" y="1791.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (88 bytes, 0.02%)</title><rect x="18.3" y="1861" width="0.2" height="15.0" fill="rgb(0,219,20)" rx="2" ry="2" />
+<text  x="21.34" y="1871.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (88 bytes, 0.02%)</title><rect x="1189.2" y="1749" width="0.2" height="15.0" fill="rgb(0,196,75)" rx="2" ry="2" />
+<text  x="1192.21" y="1759.5" ></text>
+</g>
+<g >
+<title>DateFormatSymbolsProviderImpl_getInstance_fd5ef844c5f7083d1f50c77e7c6995a381833aaf (14,320 bytes, 2.74%)</title><rect x="30.7" y="1541" width="32.3" height="15.0" fill="rgb(0,237,140)" rx="2" ry="2" />
+<text  x="33.67" y="1551.5" >Da..</text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="117" width="0.3" height="15.0" fill="rgb(0,204,56)" rx="2" ry="2" />
+<text  x="13.20" y="127.5" ></text>
+</g>
+<g >
+<title>FileInputStream_constructor_aac741e2ef07c171301eb35c0deea3293fe4d747 (45 bytes, 0.01%)</title><rect x="30.4" y="1685" width="0.1" height="15.0" fill="rgb(0,216,1)" rx="2" ry="2" />
+<text  x="33.35" y="1695.5" ></text>
+</g>
+<g >
+<title>Provider$Service_newInstanceUtil_5d6f5ee37fa9a9ce7d164d7490af76f94fd2b66a (87 bytes, 0.02%)</title><rect x="29.0" y="1781" width="0.2" height="15.0" fill="rgb(0,201,175)" rx="2" ry="2" />
+<text  x="32.02" y="1791.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_a248ca38f52050b4cd112d073aa11463562bd8f6 (88 bytes, 0.02%)</title><rect x="18.7" y="1621" width="0.2" height="15.0" fill="rgb(0,233,179)" rx="2" ry="2" />
+<text  x="21.73" y="1631.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_startThread_c9fcf45ff5a76e482d445c8024217e659f57f894 (512 bytes, 0.10%)</title><rect x="64.2" y="1637" width="1.1" height="15.0" fill="rgb(0,203,58)" rx="2" ry="2" />
+<text  x="67.18" y="1647.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="17.7" y="1557" width="0.2" height="15.0" fill="rgb(0,214,28)" rx="2" ry="2" />
+<text  x="20.74" y="1567.5" ></text>
+</g>
+<g >
+<title>VertxHttpProcessor$openSocket1866188241_deploy_0_faffc3fcdbd04fafef01aa06b85b3a2efa86e425 (600 bytes, 0.11%)</title><rect x="64.0" y="1925" width="1.3" height="15.0" fill="rgb(0,195,37)" rx="2" ry="2" />
+<text  x="66.98" y="1935.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (88 bytes, 0.02%)</title><rect x="18.3" y="1685" width="0.2" height="15.0" fill="rgb(0,207,2)" rx="2" ry="2" />
+<text  x="21.34" y="1695.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (88 bytes, 0.02%)</title><rect x="19.1" y="1733" width="0.2" height="15.0" fill="rgb(0,203,59)" rx="2" ry="2" />
+<text  x="22.13" y="1743.5" ></text>
+</g>
+<g >
+<title>VertxCoreRecorder$VertxSupplier_get_52c96bc8af0bec88a61cfaffe07b92f472ca12ac (405,930 bytes, 77.60%)</title><rect x="65.3" y="1893" width="915.7" height="15.0" fill="rgb(0,226,131)" rx="2" ry="2" />
+<text  x="68.33" y="1903.5" >VertxCoreRecorder$VertxSupplier_get_52c96bc8af0bec88a61cfaffe07b92f472ca12ac</text>
+</g>
+<g >
+<title>File_getCanonicalPath_2599b21b2d224b954be77a59d41f1e7805fe1d2e (74 bytes, 0.01%)</title><rect x="65.3" y="1749" width="0.2" height="15.0" fill="rgb(0,228,138)" rx="2" ry="2" />
+<text  x="68.33" y="1759.5" ></text>
+</g>
+<g >
+<title>VertxImpl_constructor_80d00396d68392bbd263011f0698431a464c816c (405,661 bytes, 77.55%)</title><rect x="65.5" y="1829" width="915.1" height="15.0" fill="rgb(0,201,71)" rx="2" ry="2" />
+<text  x="68.50" y="1839.5" >VertxImpl_constructor_80d00396d68392bbd263011f0698431a464c816c</text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (88 bytes, 0.02%)</title><rect x="1189.2" y="1925" width="0.2" height="15.0" fill="rgb(0,200,175)" rx="2" ry="2" />
+<text  x="1192.21" y="1935.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="18.9" y="1525" width="0.2" height="15.0" fill="rgb(0,214,206)" rx="2" ry="2" />
+<text  x="21.93" y="1535.5" ></text>
+</g>
+<g >
+<title>Metrics_systemMetrics_e306d1f6dd971ec02d4b6f58381706f5f7e73160 (139 bytes, 0.03%)</title><rect x="63.3" y="1845" width="0.3" height="15.0" fill="rgb(0,195,184)" rx="2" ry="2" />
+<text  x="66.26" y="1855.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="1189.6" y="1557" width="0.2" height="15.0" fill="rgb(0,227,165)" rx="2" ry="2" />
+<text  x="1192.60" y="1567.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (88 bytes, 0.02%)</title><rect x="17.7" y="1941" width="0.2" height="15.0" fill="rgb(0,213,56)" rx="2" ry="2" />
+<text  x="20.74" y="1951.5" ></text>
+</g>
+<g >
+<title>CgroupMetrics_getInstance_8d6e26d7f3f57187a7ce0dd2ce8a777c842a4fab (139 bytes, 0.03%)</title><rect x="63.3" y="1797" width="0.3" height="15.0" fill="rgb(0,207,26)" rx="2" ry="2" />
+<text  x="66.26" y="1807.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="10.0" y="1829" width="0.2" height="15.0" fill="rgb(0,228,184)" rx="2" ry="2" />
+<text  x="13.00" y="1839.5" ></text>
+</g>
+<g >
+<title>DefaultChannelId_defaultProcessId_779f0198976365a04cb9462622d4e4513adc5ce5 (944 bytes, 0.18%)</title><rect x="15.1" y="1909" width="2.1" height="15.0" fill="rgb(0,239,181)" rx="2" ry="2" />
+<text  x="18.09" y="1919.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1029" width="0.3" height="15.0" fill="rgb(0,202,169)" rx="2" ry="2" />
+<text  x="13.20" y="1039.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="1189.2" y="1509" width="0.2" height="15.0" fill="rgb(0,224,55)" rx="2" ry="2" />
+<text  x="1192.21" y="1519.5" ></text>
+</g>
+<g >
+<title>tloop-thread-12 (88 bytes, 0.02%)</title><rect x="1189.6" y="2069" width="0.2" height="15.0" fill="rgb(0,193,180)" rx="2" ry="2" />
+<text  x="1192.60" y="2079.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="629" width="0.3" height="15.0" fill="rgb(0,234,129)" rx="2" ry="2" />
+<text  x="13.20" y="639.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (88 bytes, 0.02%)</title><rect x="1189.6" y="1733" width="0.2" height="15.0" fill="rgb(0,224,122)" rx="2" ry="2" />
+<text  x="1192.60" y="1743.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="1189.6" y="1573" width="0.2" height="15.0" fill="rgb(0,195,17)" rx="2" ry="2" />
+<text  x="1192.60" y="1583.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (88 bytes, 0.02%)</title><rect x="18.5" y="1861" width="0.2" height="15.0" fill="rgb(0,212,107)" rx="2" ry="2" />
+<text  x="21.54" y="1871.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (88 bytes, 0.02%)</title><rect x="1189.8" y="1685" width="0.2" height="15.0" fill="rgb(0,206,35)" rx="2" ry="2" />
+<text  x="1192.80" y="1695.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="18.1" y="1541" width="0.2" height="15.0" fill="rgb(0,192,38)" rx="2" ry="2" />
+<text  x="21.14" y="1551.5" ></text>
+</g>
+<g >
+<title>Containers_memoryLimitInBytes_98031c4a1c1fa8070fd7ebd29819a4cafbbe93dd (178 bytes, 0.03%)</title><rect x="63.6" y="1829" width="0.4" height="15.0" fill="rgb(0,193,132)" rx="2" ry="2" />
+<text  x="66.58" y="1839.5" ></text>
+</g>
+<g >
+<title>CgroupSubsystemController_getLongValueMatchingLine_9bd92ea05ded6032ceb3761a6d345765e773f43e (77 bytes, 0.01%)</title><rect x="63.6" y="1765" width="0.2" height="15.0" fill="rgb(0,235,191)" rx="2" ry="2" />
+<text  x="66.58" y="1775.5" ></text>
+</g>
+<g >
+<title>Logger_log_202eb98e1c81a0e79e30d5112a402ad27bcc85b3 (14,320 bytes, 2.74%)</title><rect x="30.7" y="1893" width="32.3" height="15.0" fill="rgb(0,234,72)" rx="2" ry="2" />
+<text  x="33.67" y="1903.5" >Lo..</text>
+</g>
+<g >
+<title>NativePRNG_initIO_a1eb987787d4582c7b5714bb84680cab76004799 (87 bytes, 0.02%)</title><rect x="29.0" y="1685" width="0.2" height="15.0" fill="rgb(0,232,155)" rx="2" ry="2" />
+<text  x="32.02" y="1695.5" ></text>
+</g>
+<g >
+<title>VertxCoreRecorder$VertxSupplier_get_933aa744d9166b784d03d36421df70bdd55027d1 (405,930 bytes, 77.60%)</title><rect x="65.3" y="1877" width="915.7" height="15.0" fill="rgb(0,194,191)" rx="2" ry="2" />
+<text  x="68.33" y="1887.5" >VertxCoreRecorder$VertxSupplier_get_933aa744d9166b784d03d36421df70bdd55027d1</text>
+</g>
+<g >
+<title>fileOpen (45 bytes, 0.01%)</title><rect x="980.6" y="1589" width="0.1" height="15.0" fill="rgb(0,194,134)" rx="2" ry="2" />
+<text  x="983.65" y="1599.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (88 bytes, 0.02%)</title><rect x="1189.4" y="1829" width="0.2" height="15.0" fill="rgb(0,197,66)" rx="2" ry="2" />
+<text  x="1192.40" y="1839.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1749" width="0.3" height="15.0" fill="rgb(0,233,81)" rx="2" ry="2" />
+<text  x="13.20" y="1759.5" ></text>
+</g>
+<g >
+<title>quarkus-project (518,509 bytes, 99.13%)</title><rect x="19.5" y="2069" width="1169.7" height="15.0" fill="rgb(0,237,14)" rx="2" ry="2" />
+<text  x="22.53" y="2079.5" >quarkus-project</text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="1189.8" y="2053" width="0.2" height="15.0" fill="rgb(0,201,207)" rx="2" ry="2" />
+<text  x="1192.80" y="2063.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="19.3" y="1973" width="0.2" height="15.0" fill="rgb(0,197,160)" rx="2" ry="2" />
+<text  x="22.33" y="1983.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1445" width="0.3" height="15.0" fill="rgb(0,235,29)" rx="2" ry="2" />
+<text  x="13.20" y="1455.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="18.9" y="2037" width="0.2" height="15.0" fill="rgb(0,197,128)" rx="2" ry="2" />
+<text  x="21.93" y="2047.5" ></text>
+</g>
+<g >
+<title>fileOpen (45 bytes, 0.01%)</title><rect x="30.4" y="1653" width="0.1" height="15.0" fill="rgb(0,212,82)" rx="2" ry="2" />
+<text  x="33.35" y="1663.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="17.2" y="1973" width="0.2" height="15.0" fill="rgb(0,206,111)" rx="2" ry="2" />
+<text  x="20.22" y="1983.5" ></text>
+</g>
+<g >
+<title>ForkJoinPool_unmanagedBlock_c019b6dfc96cc903bc146d36320638bf3cc6060e (88 bytes, 0.02%)</title><rect x="64.0" y="1829" width="0.2" height="15.0" fill="rgb(0,230,67)" rx="2" ry="2" />
+<text  x="66.98" y="1839.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="549" width="0.3" height="15.0" fill="rgb(0,216,87)" rx="2" ry="2" />
+<text  x="13.20" y="559.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="773" width="0.3" height="15.0" fill="rgb(0,230,191)" rx="2" ry="2" />
+<text  x="13.20" y="783.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (88 bytes, 0.02%)</title><rect x="1189.4" y="1685" width="0.2" height="15.0" fill="rgb(0,235,58)" rx="2" ry="2" />
+<text  x="1192.40" y="1695.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_lambda$readStringValue$0_bf9c455fb8e17fdb73fd283b71cbbb23b2dde357 (45 bytes, 0.01%)</title><rect x="63.0" y="1717" width="0.1" height="15.0" fill="rgb(0,228,67)" rx="2" ry="2" />
+<text  x="65.98" y="1727.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1109" width="0.3" height="15.0" fill="rgb(0,227,115)" rx="2" ry="2" />
+<text  x="13.20" y="1119.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (88 bytes, 0.02%)</title><rect x="18.9" y="1845" width="0.2" height="15.0" fill="rgb(0,196,200)" rx="2" ry="2" />
+<text  x="21.93" y="1855.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="277" width="0.3" height="15.0" fill="rgb(0,198,34)" rx="2" ry="2" />
+<text  x="13.20" y="287.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="17.2" y="1797" width="0.2" height="15.0" fill="rgb(0,235,125)" rx="2" ry="2" />
+<text  x="20.22" y="1807.5" ></text>
+</g>
+<g >
+<title>tloop-thread-14 (88 bytes, 0.02%)</title><rect x="1189.8" y="2069" width="0.2" height="15.0" fill="rgb(0,198,133)" rx="2" ry="2" />
+<text  x="1192.80" y="2079.5" ></text>
+</g>
+<g >
+<title>malloc (712 bytes, 0.14%)</title><rect x="19.5" y="2037" width="1.6" height="15.0" fill="rgb(0,219,158)" rx="2" ry="2" />
+<text  x="22.53" y="2047.5" ></text>
+</g>
+<g >
+<title>TimerThread_mainLoop_440c56e7d7107c43e6a907512a16d41b2ebdb5cd (88 bytes, 0.02%)</title><rect x="10.0" y="1973" width="0.2" height="15.0" fill="rgb(0,211,0)" rx="2" ry="2" />
+<text  x="13.00" y="1983.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_a248ca38f52050b4cd112d073aa11463562bd8f6 (88 bytes, 0.02%)</title><rect x="18.5" y="1621" width="0.2" height="15.0" fill="rgb(0,230,20)" rx="2" ry="2" />
+<text  x="21.54" y="1631.5" ></text>
+</g>
+<g >
+<title>-thread-checker (88 bytes, 0.02%)</title><rect x="10.0" y="2069" width="0.2" height="15.0" fill="rgb(0,198,58)" rx="2" ry="2" />
+<text  x="13.00" y="2079.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="933" width="0.3" height="15.0" fill="rgb(0,229,70)" rx="2" ry="2" />
+<text  x="13.20" y="943.5" ></text>
+</g>
+<g >
+<title>SubstrateMethodAccessor_invoke_1646d4f7bf658eabd638416736a8d30c8afb8530 (139 bytes, 0.03%)</title><rect x="63.3" y="1829" width="0.3" height="15.0" fill="rgb(0,213,93)" rx="2" ry="2" />
+<text  x="66.26" y="1839.5" ></text>
+</g>
+<g >
+<title>ecutor-thread-0 (88 bytes, 0.02%)</title><rect x="17.2" y="2069" width="0.2" height="15.0" fill="rgb(0,225,109)" rx="2" ry="2" />
+<text  x="20.22" y="2079.5" ></text>
+</g>
+<g >
+<title>JNILibraryInitializer_callOnLoadFunction_5e1ad3b27c0293083aa0f544d93105f071f4f604 (472 bytes, 0.09%)</title><rect x="23.3" y="1877" width="1.0" height="15.0" fill="rgb(0,211,43)" rx="2" ry="2" />
+<text  x="26.26" y="1887.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1669" width="0.3" height="15.0" fill="rgb(0,208,178)" rx="2" ry="2" />
+<text  x="13.20" y="1679.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (2,048 bytes, 0.39%)</title><rect x="24.4" y="1797" width="4.6" height="15.0" fill="rgb(0,205,148)" rx="2" ry="2" />
+<text  x="27.40" y="1807.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (88 bytes, 0.02%)</title><rect x="18.5" y="1909" width="0.2" height="15.0" fill="rgb(0,227,77)" rx="2" ry="2" />
+<text  x="21.54" y="1919.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_doDeploy_54ca0c22b25be869b149ec6f9e6a540331a23219 (512 bytes, 0.10%)</title><rect x="64.2" y="1813" width="1.1" height="15.0" fill="rgb(0,230,108)" rx="2" ry="2" />
+<text  x="67.18" y="1823.5" ></text>
+</g>
+<g >
+<title>MonitorSupport_wait_b0c5e448fe0dfd1ad5d1daf2e4fb2c75873ec83e (88 bytes, 0.02%)</title><rect x="10.0" y="1957" width="0.2" height="15.0" fill="rgb(0,236,156)" rx="2" ry="2" />
+<text  x="13.00" y="1967.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="1189.2" y="1573" width="0.2" height="15.0" fill="rgb(0,238,133)" rx="2" ry="2" />
+<text  x="1192.21" y="1583.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (88 bytes, 0.02%)</title><rect x="1189.2" y="1829" width="0.2" height="15.0" fill="rgb(0,202,49)" rx="2" ry="2" />
+<text  x="1192.21" y="1839.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (88 bytes, 0.02%)</title><rect x="18.3" y="1797" width="0.2" height="15.0" fill="rgb(0,221,175)" rx="2" ry="2" />
+<text  x="21.34" y="1807.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="1189.8" y="1557" width="0.2" height="15.0" fill="rgb(0,207,140)" rx="2" ry="2" />
+<text  x="1192.80" y="1567.5" ></text>
+</g>
+<g >
+<title>ntloop-thread-9 (88 bytes, 0.02%)</title><rect x="19.3" y="2069" width="0.2" height="15.0" fill="rgb(0,206,6)" rx="2" ry="2" />
+<text  x="22.33" y="2079.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (88 bytes, 0.02%)</title><rect x="1189.2" y="1685" width="0.2" height="15.0" fill="rgb(0,224,200)" rx="2" ry="2" />
+<text  x="1192.21" y="1695.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="19.3" y="1589" width="0.2" height="15.0" fill="rgb(0,233,89)" rx="2" ry="2" />
+<text  x="22.33" y="1599.5" ></text>
+</g>
+<g >
+<title>NioEventLoopGroup_newChild_9efbfe1f828b1c5d178f1583c0e1374692b641f4 (405,504 bytes, 77.52%)</title><rect x="65.9" y="1765" width="914.7" height="15.0" fill="rgb(0,212,150)" rx="2" ry="2" />
+<text  x="68.85" y="1775.5" >NioEventLoopGroup_newChild_9efbfe1f828b1c5d178f1583c0e1374692b641f4</text>
+</g>
+<g >
+<title>ForkJoinPool_managedBlock_20b77ea9f31a7be42e4736c0c44aa6cf804552f0 (88 bytes, 0.02%)</title><rect x="64.0" y="1845" width="0.2" height="15.0" fill="rgb(0,226,199)" rx="2" ry="2" />
+<text  x="66.98" y="1855.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="613" width="0.3" height="15.0" fill="rgb(0,215,112)" rx="2" ry="2" />
+<text  x="13.20" y="623.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (88 bytes, 0.02%)</title><rect x="18.5" y="1813" width="0.2" height="15.0" fill="rgb(0,195,154)" rx="2" ry="2" />
+<text  x="21.54" y="1823.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="709" width="0.3" height="15.0" fill="rgb(0,197,81)" rx="2" ry="2" />
+<text  x="13.20" y="719.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (88 bytes, 0.02%)</title><rect x="18.5" y="1781" width="0.2" height="15.0" fill="rgb(0,222,82)" rx="2" ry="2" />
+<text  x="21.54" y="1791.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (512 bytes, 0.10%)</title><rect x="64.2" y="1589" width="1.1" height="15.0" fill="rgb(0,210,182)" rx="2" ry="2" />
+<text  x="67.18" y="1599.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (88 bytes, 0.02%)</title><rect x="19.3" y="1861" width="0.2" height="15.0" fill="rgb(0,214,140)" rx="2" ry="2" />
+<text  x="22.33" y="1871.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (88 bytes, 0.02%)</title><rect x="18.9" y="1733" width="0.2" height="15.0" fill="rgb(0,199,93)" rx="2" ry="2" />
+<text  x="21.93" y="1743.5" ></text>
+</g>
+<g >
+<title>ColorPatternFormatter$ColorStep_render_76a2c0d8a878f2c2e984090993d68fb2c8fe67b3 (14,320 bytes, 2.74%)</title><rect x="30.7" y="1685" width="32.3" height="15.0" fill="rgb(0,225,106)" rx="2" ry="2" />
+<text  x="33.67" y="1695.5" >Co..</text>
+</g>
+<g >
+<title>NativeBuffer_constructor_60ef9b54132e614de9281bcff829c0e9834858ea (2,048 bytes, 0.39%)</title><rect x="24.4" y="1829" width="4.6" height="15.0" fill="rgb(0,235,133)" rx="2" ry="2" />
+<text  x="27.40" y="1839.5" ></text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="18.3" y="1605" width="0.2" height="15.0" fill="rgb(0,201,40)" rx="2" ry="2" />
+<text  x="21.34" y="1615.5" ></text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_64cb8fa504ff8d8ed6468c31dd67915d26710d8b (88 bytes, 0.02%)</title><rect x="18.9" y="1637" width="0.2" height="15.0" fill="rgb(0,235,63)" rx="2" ry="2" />
+<text  x="21.93" y="1647.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="1189.2" y="1557" width="0.2" height="15.0" fill="rgb(0,230,179)" rx="2" ry="2" />
+<text  x="1192.21" y="1567.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (88 bytes, 0.02%)</title><rect x="18.1" y="1813" width="0.2" height="15.0" fill="rgb(0,197,137)" rx="2" ry="2" />
+<text  x="21.14" y="1823.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (88 bytes, 0.02%)</title><rect x="17.2" y="1813" width="0.2" height="15.0" fill="rgb(0,210,77)" rx="2" ry="2" />
+<text  x="20.22" y="1823.5" ></text>
+</g>
+<g >
+<title>ParkEvent_acquire_9729a9607fcfe87b3019379ae7f6c9fc9bc57b31 (88 bytes, 0.02%)</title><rect x="18.1" y="1557" width="0.2" height="15.0" fill="rgb(0,192,45)" rx="2" ry="2" />
+<text  x="21.14" y="1567.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (88 bytes, 0.02%)</title><rect x="18.1" y="1733" width="0.2" height="15.0" fill="rgb(0,202,60)" rx="2" ry="2" />
+<text  x="21.14" y="1743.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="18.1" y="2021" width="0.2" height="15.0" fill="rgb(0,205,136)" rx="2" ry="2" />
+<text  x="21.14" y="2031.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="869" width="0.3" height="15.0" fill="rgb(0,224,121)" rx="2" ry="2" />
+<text  x="13.20" y="879.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="1189.4" y="1989" width="0.2" height="15.0" fill="rgb(0,200,0)" rx="2" ry="2" />
+<text  x="1192.40" y="1999.5" ></text>
+</g>
+<g >
+<title>SecureRandom_constructor_1889264a78142788341f8cc941d340cf7ff466b4 (87 bytes, 0.02%)</title><rect x="29.0" y="1829" width="0.2" height="15.0" fill="rgb(0,237,30)" rx="2" ry="2" />
+<text  x="32.02" y="1839.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1733" width="0.3" height="15.0" fill="rgb(0,201,57)" rx="2" ry="2" />
+<text  x="13.20" y="1743.5" ></text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (88 bytes, 0.02%)</title><rect x="1189.8" y="1893" width="0.2" height="15.0" fill="rgb(0,227,177)" rx="2" ry="2" />
+<text  x="1192.80" y="1903.5" ></text>
+</g>
+<g >
+<title>CgroupUtil_readStringValue_cbc732074f2c96921b9ad69310afd25a7e2ad29d (86 bytes, 0.02%)</title><rect x="63.4" y="1669" width="0.2" height="15.0" fill="rgb(0,199,106)" rx="2" ry="2" />
+<text  x="66.38" y="1679.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (88 bytes, 0.02%)</title><rect x="1189.6" y="1717" width="0.2" height="15.0" fill="rgb(0,203,174)" rx="2" ry="2" />
+<text  x="1192.60" y="1727.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (88 bytes, 0.02%)</title><rect x="18.1" y="1717" width="0.2" height="15.0" fill="rgb(0,231,50)" rx="2" ry="2" />
+<text  x="21.14" y="1727.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (88 bytes, 0.02%)</title><rect x="18.1" y="1701" width="0.2" height="15.0" fill="rgb(0,202,158)" rx="2" ry="2" />
+<text  x="21.14" y="1711.5" ></text>
+</g>
+<g >
+<title>ExecutorRecorder_createExecutor_0c71cf4975020f560acf13e353c2f0f347cfe22f (141 bytes, 0.03%)</title><rect x="30.4" y="1893" width="0.3" height="15.0" fill="rgb(0,223,180)" rx="2" ry="2" />
+<text  x="33.35" y="1903.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (88 bytes, 0.02%)</title><rect x="17.7" y="1781" width="0.2" height="15.0" fill="rgb(0,193,184)" rx="2" ry="2" />
+<text  x="20.74" y="1791.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="18.5" y="1541" width="0.2" height="15.0" fill="rgb(0,221,162)" rx="2" ry="2" />
+<text  x="21.54" y="1551.5" ></text>
+</g>
+<g >
+<title>ntloop-thread-1 (88 bytes, 0.02%)</title><rect x="17.7" y="2069" width="0.2" height="15.0" fill="rgb(0,191,193)" rx="2" ry="2" />
+<text  x="20.74" y="2079.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (88 bytes, 0.02%)</title><rect x="1189.2" y="1733" width="0.2" height="15.0" fill="rgb(0,222,142)" rx="2" ry="2" />
+<text  x="1192.21" y="1743.5" ></text>
+</g>
+<g >
+<title>Runtime_availableProcessors_8c88a5035e0f76404bd388d31bc8ea17e15f987b (141 bytes, 0.03%)</title><rect x="30.4" y="1877" width="0.3" height="15.0" fill="rgb(0,237,36)" rx="2" ry="2" />
+<text  x="33.35" y="1887.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="18.9" y="1589" width="0.2" height="15.0" fill="rgb(0,234,0)" rx="2" ry="2" />
+<text  x="21.93" y="1599.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_doStartThread_eeda64be06080ce00e7e09ba0a2049b2025a920d (512 bytes, 0.10%)</title><rect x="64.2" y="1621" width="1.1" height="15.0" fill="rgb(0,201,188)" rx="2" ry="2" />
+<text  x="67.18" y="1631.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (88 bytes, 0.02%)</title><rect x="1189.4" y="1925" width="0.2" height="15.0" fill="rgb(0,211,55)" rx="2" ry="2" />
+<text  x="1192.40" y="1935.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1893" width="0.3" height="15.0" fill="rgb(0,193,184)" rx="2" ry="2" />
+<text  x="13.20" y="1903.5" ></text>
+</g>
+<g >
+<title>fileOpen (45 bytes, 0.01%)</title><rect x="65.5" y="1557" width="0.1" height="15.0" fill="rgb(0,192,143)" rx="2" ry="2" />
+<text  x="68.53" y="1567.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="18.7" y="1589" width="0.2" height="15.0" fill="rgb(0,202,2)" rx="2" ry="2" />
+<text  x="21.73" y="1599.5" ></text>
+</g>
+<g >
+<title>FileInputStreamPool_getInputStream_fdeea35b7850075f47690eb49f939717aa724d83 (50 bytes, 0.01%)</title><rect x="29.1" y="1605" width="0.1" height="15.0" fill="rgb(0,225,53)" rx="2" ry="2" />
+<text  x="32.10" y="1615.5" ></text>
+</g>
+<g >
+<title>malloc (472 bytes, 0.09%)</title><rect x="23.3" y="1829" width="1.0" height="15.0" fill="rgb(0,224,27)" rx="2" ry="2" />
+<text  x="26.26" y="1839.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1221" width="0.3" height="15.0" fill="rgb(0,201,82)" rx="2" ry="2" />
+<text  x="13.20" y="1231.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="981" width="0.3" height="15.0" fill="rgb(0,207,172)" rx="2" ry="2" />
+<text  x="13.20" y="991.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (88 bytes, 0.02%)</title><rect x="17.7" y="1845" width="0.2" height="15.0" fill="rgb(0,238,170)" rx="2" ry="2" />
+<text  x="20.74" y="1855.5" ></text>
+</g>
+<g >
+<title>QuarkusExecutorFactory_createExecutor_c95ec5f1dfb3051ebd97a0aa6aa028cfbf84f215 (141 bytes, 0.03%)</title><rect x="65.5" y="1813" width="0.4" height="15.0" fill="rgb(0,212,37)" rx="2" ry="2" />
+<text  x="68.53" y="1823.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (88 bytes, 0.02%)</title><rect x="19.3" y="1845" width="0.2" height="15.0" fill="rgb(0,231,73)" rx="2" ry="2" />
+<text  x="22.33" y="1855.5" ></text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (88 bytes, 0.02%)</title><rect x="1189.2" y="1893" width="0.2" height="15.0" fill="rgb(0,218,89)" rx="2" ry="2" />
+<text  x="1192.21" y="1903.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (88 bytes, 0.02%)</title><rect x="18.5" y="1797" width="0.2" height="15.0" fill="rgb(0,238,65)" rx="2" ry="2" />
+<text  x="21.54" y="1807.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (88 bytes, 0.02%)</title><rect x="18.5" y="1749" width="0.2" height="15.0" fill="rgb(0,222,156)" rx="2" ry="2" />
+<text  x="21.54" y="1759.5" ></text>
+</g>
+<g >
+<title>PosixNativeLibrarySupport_loadNetLibrary_dcbc1b4cd48bf3b5ce2ecb65a60592e1c14387e2 (472 bytes, 0.09%)</title><rect x="23.3" y="1973" width="1.0" height="15.0" fill="rgb(0,238,29)" rx="2" ry="2" />
+<text  x="26.26" y="1983.5" ></text>
+</g>
+<g >
+<title>CompressedBundle_getContent_e202d21fa4041ac423203615eace2d3fdd988d5c (7,160 bytes, 1.37%)</title><rect x="30.7" y="1461" width="16.1" height="15.0" fill="rgb(0,221,91)" rx="2" ry="2" />
+<text  x="33.67" y="1471.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (88 bytes, 0.02%)</title><rect x="18.9" y="1925" width="0.2" height="15.0" fill="rgb(0,190,171)" rx="2" ry="2" />
+<text  x="21.93" y="1935.5" ></text>
+</g>
+<g >
+<title>ThreadData_initializeParkEvent_0972d8b3cf8f9c5f1f67a764784b23f815d853d5 (88 bytes, 0.02%)</title><rect x="10.0" y="1861" width="0.2" height="15.0" fill="rgb(0,221,59)" rx="2" ry="2" />
+<text  x="13.00" y="1871.5" ></text>
+</g>
+<g >
+<title>start_thread (88 bytes, 0.02%)</title><rect x="18.7" y="2053" width="0.2" height="15.0" fill="rgb(0,238,206)" rx="2" ry="2" />
+<text  x="21.73" y="2063.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (88 bytes, 0.02%)</title><rect x="1189.6" y="1765" width="0.2" height="15.0" fill="rgb(0,220,33)" rx="2" ry="2" />
+<text  x="1192.60" y="1775.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="357" width="0.3" height="15.0" fill="rgb(0,217,124)" rx="2" ry="2" />
+<text  x="13.20" y="367.5" ></text>
+</g>
+<g >
+<title>malloc (88 bytes, 0.02%)</title><rect x="19.3" y="1509" width="0.2" height="15.0" fill="rgb(0,236,70)" rx="2" ry="2" />
+<text  x="22.33" y="1519.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="389" width="0.3" height="15.0" fill="rgb(0,236,111)" rx="2" ry="2" />
+<text  x="13.20" y="399.5" ></text>
+</g>
+<g >
+<title>UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda (405,504 bytes, 77.52%)</title><rect x="65.9" y="1685" width="914.7" height="15.0" fill="rgb(0,222,123)" rx="2" ry="2" />
+<text  x="68.85" y="1695.5" >UnmanagedMemory_malloc_e771cd5a636f1d1ddaa55ba896a102f328c04fda</text>
+</g>
+<g >
+<title>MultithreadEventExecutorGroup_constructor_8065881a5eaca808323d46dcb6b44d43723c3c29 (405,504 bytes, 77.52%)</title><rect x="65.9" y="1797" width="914.7" height="15.0" fill="rgb(0,214,80)" rx="2" ry="2" />
+<text  x="68.85" y="1807.5" >MultithreadEventExecutorGroup_constructor_8065881a5eaca808323d46dcb6b44d43723c3c29</text>
+</g>
+<g >
+<title>CgroupV1Subsystem_getCpuPeriod_af2665b8ccf1535123ef8d345b5b9b8505005dfa (45 bytes, 0.01%)</title><rect x="65.5" y="1717" width="0.1" height="15.0" fill="rgb(0,212,133)" rx="2" ry="2" />
+<text  x="68.53" y="1727.5" ></text>
+</g>
+<g >
+<title>start_thread (944 bytes, 0.18%)</title><rect x="15.1" y="2053" width="2.1" height="15.0" fill="rgb(0,218,8)" rx="2" ry="2" />
+<text  x="18.09" y="2063.5" ></text>
+</g>
+<g >
+<title>ListResourceBundle_handleGetObject_cc9f55a74c558f90e035dd4df45e047498d00cad (7,160 bytes, 1.37%)</title><rect x="46.8" y="1477" width="16.2" height="15.0" fill="rgb(0,192,36)" rx="2" ry="2" />
+<text  x="49.82" y="1487.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (88 bytes, 0.02%)</title><rect x="17.7" y="1749" width="0.2" height="15.0" fill="rgb(0,205,189)" rx="2" ry="2" />
+<text  x="20.74" y="1759.5" ></text>
+</g>
+<g >
+<title>[unknown] (120 bytes, 0.02%)</title><rect x="10.2" y="1829" width="0.3" height="15.0" fill="rgb(0,233,23)" rx="2" ry="2" />
+<text  x="13.20" y="1839.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_parkCurrentPlatformOrCarrierThread_d58e6f5ca506e3093029fdc729cefb8205b0624d (88 bytes, 0.02%)</title><rect x="18.1" y="1589" width="0.2" height="15.0" fill="rgb(0,231,49)" rx="2" ry="2" />
+<text  x="21.14" y="1599.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (88 bytes, 0.02%)</title><rect x="17.7" y="2021" width="0.2" height="15.0" fill="rgb(0,216,75)" rx="2" ry="2" />
+<text  x="20.74" y="2031.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (88 bytes, 0.02%)</title><rect x="1189.2" y="2037" width="0.2" height="15.0" fill="rgb(0,227,157)" rx="2" ry="2" />
+<text  x="1192.21" y="2047.5" ></text>
+</g>
+<g >
+<title>GzipBundleCompression_decompressBundle_814832a1dbe1a42068e9da5f2556515af88d72d7 (7,160 bytes, 1.37%)</title><rect x="30.7" y="1445" width="16.1" height="15.0" fill="rgb(0,215,78)" rx="2" ry="2" />
+<text  x="33.67" y="1455.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (88 bytes, 0.02%)</title><rect x="1189.8" y="1765" width="0.2" height="15.0" fill="rgb(0,233,170)" rx="2" ry="2" />
+<text  x="1192.80" y="1775.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (88 bytes, 0.02%)</title><rect x="19.1" y="1973" width="0.2" height="15.0" fill="rgb(0,200,97)" rx="2" ry="2" />
+<text  x="22.13" y="1983.5" ></text>
+</g>
+<g >
+<title>LockSupport_park_ad3b0439cc81f3747a99376fb5cad89af288f997 (88 bytes, 0.02%)</title><rect x="18.9" y="1605" width="0.2" height="15.0" fill="rgb(0,218,91)" rx="2" ry="2" />
+<text  x="21.93" y="1615.5" ></text>
+</g>
+<g >
+<title>malloc (472 bytes, 0.09%)</title><rect x="16.2" y="1749" width="1.0" height="15.0" fill="rgb(0,218,209)" rx="2" ry="2" />
+<text  x="19.15" y="1759.5" ></text>
+</g>
+<g >
+<title>LoggerNode_publish_22c63d42072bb2e82dedc9c5c7b57dfced38af9e (14,320 bytes, 2.74%)</title><rect x="30.7" y="1845" width="32.3" height="15.0" fill="rgb(0,229,51)" rx="2" ry="2" />
+<text  x="33.67" y="1855.5" >Lo..</text>
+</g>
+<g >
+<title>JavaMonitorQueuedSynchronizer_acquire_64cb8fa504ff8d8ed6468c31dd67915d26710d8b (88 bytes, 0.02%)</title><rect x="18.7" y="1637" width="0.2" height="15.0" fill="rgb(0,190,208)" rx="2" ry="2" />
+<text  x="21.73" y="1647.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (88 bytes, 0.02%)</title><rect x="18.1" y="1989" width="0.2" height="15.0" fill="rgb(0,201,115)" rx="2" ry="2" />
+<text  x="21.14" y="1999.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (88 bytes, 0.02%)</title><rect x="18.5" y="1845" width="0.2" height="15.0" fill="rgb(0,224,150)" rx="2" ry="2" />
+<text  x="21.54" y="1855.5" ></text>
+</g>
+<g >
+<title>ntloop-thread-4 (88 bytes, 0.02%)</title><rect x="18.3" y="2069" width="0.2" height="15.0" fill="rgb(0,230,148)" rx="2" ry="2" />
+<text  x="21.34" y="2079.5" ></text>
+</g>
+<g >
+<title>ThreadPerTaskExecutor_execute_4cbf4a43ed81f9a6fe047e89340efab737a9fbb7 (512 bytes, 0.10%)</title><rect x="64.2" y="1685" width="1.1" height="15.0" fill="rgb(0,209,52)" rx="2" ry="2" />
+<text  x="67.18" y="1695.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (88 bytes, 0.02%)</title><rect x="18.9" y="1781" width="0.2" height="15.0" fill="rgb(0,227,196)" rx="2" ry="2" />
+<text  x="21.93" y="1791.5" ></text>
+</g>
+<g >
+<title>PosixParkEvent_constructor_029944ed232cd248e5758953197d9fca968913a7 (88 bytes, 0.02%)</title><rect x="1189.4" y="1541" width="0.2" height="15.0" fill="rgb(0,200,142)" rx="2" ry="2" />
+<text  x="1192.40" y="1551.5" ></text>
+</g>
+</g>
+</svg>

--- a/docs/src/main/asciidoc/images/mmap-munmap.svg
+++ b/docs/src/main/asciidoc/images/mmap-munmap.svg
@@ -1,0 +1,1301 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" width="1200" height="758" onload="init(evt)" viewBox="0 0 1200 758" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<!-- Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples. -->
+<!-- NOTES:  -->
+<defs>
+	<linearGradient id="background" y1="0" y2="1" x1="0" x2="0" >
+		<stop stop-color="#eef2ee" offset="5%" />
+		<stop stop-color="#e0ffe0" offset="95%" />
+	</linearGradient>
+</defs>
+<style type="text/css">
+	text { font-family:Verdana; font-size:12px; fill:rgb(0,0,0); }
+	#search, #ignorecase { opacity:0.1; cursor:pointer; }
+	#search:hover, #search.show, #ignorecase:hover, #ignorecase.show { opacity:1; }
+	#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+	#title { text-anchor:middle; font-size:17px}
+	#unzoom { cursor:pointer; }
+	#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+	.hide { display:none; }
+	.parent { opacity:0.5; }
+</style>
+<script type="text/ecmascript">
+<![CDATA[
+	"use strict";
+	var details, searchbtn, unzoombtn, matchedtxt, svg, searching, currentSearchTerm, ignorecase, ignorecaseBtn;
+	function init(evt) {
+		details = document.getElementById("details").firstChild;
+		searchbtn = document.getElementById("search");
+		ignorecaseBtn = document.getElementById("ignorecase");
+		unzoombtn = document.getElementById("unzoom");
+		matchedtxt = document.getElementById("matched");
+		svg = document.getElementsByTagName("svg")[0];
+		searching = 0;
+		currentSearchTerm = null;
+
+		// use GET parameters to restore a flamegraphs state.
+		var params = get_params();
+		if (params.x && params.y)
+			zoom(find_group(document.querySelector('[x="' + params.x + '"][y="' + params.y + '"]')));
+                if (params.s) search(params.s);
+	}
+
+	// event listeners
+	window.addEventListener("click", function(e) {
+		var target = find_group(e.target);
+		if (target) {
+			if (target.nodeName == "a") {
+				if (e.ctrlKey === false) return;
+				e.preventDefault();
+			}
+			if (target.classList.contains("parent")) unzoom(true);
+			zoom(target);
+			if (!document.querySelector('.parent')) {
+				// we have basically done a clearzoom so clear the url
+				var params = get_params();
+				if (params.x) delete params.x;
+				if (params.y) delete params.y;
+				history.replaceState(null, null, parse_params(params));
+				unzoombtn.classList.add("hide");
+				return;
+			}
+
+			// set parameters for zoom state
+			var el = target.querySelector("rect");
+			if (el && el.attributes && el.attributes.y && el.attributes._orig_x) {
+				var params = get_params()
+				params.x = el.attributes._orig_x.value;
+				params.y = el.attributes.y.value;
+				history.replaceState(null, null, parse_params(params));
+			}
+		}
+		else if (e.target.id == "unzoom") clearzoom();
+		else if (e.target.id == "search") search_prompt();
+		else if (e.target.id == "ignorecase") toggle_ignorecase();
+	}, false)
+
+	// mouse-over for info
+	// show
+	window.addEventListener("mouseover", function(e) {
+		var target = find_group(e.target);
+		if (target) details.nodeValue = "Function: " + g_to_text(target);
+	}, false)
+
+	// clear
+	window.addEventListener("mouseout", function(e) {
+		var target = find_group(e.target);
+		if (target) details.nodeValue = ' ';
+	}, false)
+
+	// ctrl-F for search
+	// ctrl-I to toggle case-sensitive search
+	window.addEventListener("keydown",function (e) {
+		if (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)) {
+			e.preventDefault();
+			search_prompt();
+		}
+		else if (e.ctrlKey && e.keyCode === 73) {
+			e.preventDefault();
+			toggle_ignorecase();
+		}
+	}, false)
+
+	// functions
+	function get_params() {
+		var params = {};
+		var paramsarr = window.location.search.substr(1).split('&');
+		for (var i = 0; i < paramsarr.length; ++i) {
+			var tmp = paramsarr[i].split("=");
+			if (!tmp[0] || !tmp[1]) continue;
+			params[tmp[0]]  = decodeURIComponent(tmp[1]);
+		}
+		return params;
+	}
+	function parse_params(params) {
+		var uri = "?";
+		for (var key in params) {
+			uri += key + '=' + encodeURIComponent(params[key]) + '&';
+		}
+		if (uri.slice(-1) == "&")
+			uri = uri.substring(0, uri.length - 1);
+		if (uri == '?')
+			uri = window.location.href.split('?')[0];
+		return uri;
+	}
+	function find_child(node, selector) {
+		var children = node.querySelectorAll(selector);
+		if (children.length) return children[0];
+	}
+	function find_group(node) {
+		var parent = node.parentElement;
+		if (!parent) return;
+		if (parent.id == "frames") return node;
+		return find_group(parent);
+	}
+	function orig_save(e, attr, val) {
+		if (e.attributes["_orig_" + attr] != undefined) return;
+		if (e.attributes[attr] == undefined) return;
+		if (val == undefined) val = e.attributes[attr].value;
+		e.setAttribute("_orig_" + attr, val);
+	}
+	function orig_load(e, attr) {
+		if (e.attributes["_orig_"+attr] == undefined) return;
+		e.attributes[attr].value = e.attributes["_orig_" + attr].value;
+		e.removeAttribute("_orig_"+attr);
+	}
+	function g_to_text(e) {
+		var text = find_child(e, "title").firstChild.nodeValue;
+		return (text)
+	}
+	function g_to_func(e) {
+		var func = g_to_text(e);
+		// if there's any manipulation we want to do to the function
+		// name before it's searched, do it here before returning.
+		return (func);
+	}
+	function update_text(e) {
+		var r = find_child(e, "rect");
+		var t = find_child(e, "text");
+		var w = parseFloat(r.attributes.width.value) -3;
+		var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
+		t.attributes.x.value = parseFloat(r.attributes.x.value) + 3;
+
+		// Smaller than this size won't fit anything
+		if (w < 2 * 12 * 0.59) {
+			t.textContent = "";
+			return;
+		}
+
+		t.textContent = txt;
+		var sl = t.getSubStringLength(0, txt.length);
+		// check if only whitespace or if we can fit the entire string into width w
+		if (/^ *$/.test(txt) || sl < w)
+			return;
+
+		// this isn't perfect, but gives a good starting point
+		// and avoids calling getSubStringLength too often
+		var start = Math.floor((w/sl) * txt.length);
+		for (var x = start; x > 0; x = x-2) {
+			if (t.getSubStringLength(0, x + 2) <= w) {
+				t.textContent = txt.substring(0, x) + "..";
+				return;
+			}
+		}
+		t.textContent = "";
+	}
+
+	// zoom
+	function zoom_reset(e) {
+		if (e.attributes != undefined) {
+			orig_load(e, "x");
+			orig_load(e, "width");
+		}
+		if (e.childNodes == undefined) return;
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
+			zoom_reset(c[i]);
+		}
+	}
+	function zoom_child(e, x, ratio) {
+		if (e.attributes != undefined) {
+			if (e.attributes.x != undefined) {
+				orig_save(e, "x");
+				e.attributes.x.value = (parseFloat(e.attributes.x.value) - x - 10) * ratio + 10;
+				if (e.tagName == "text")
+					e.attributes.x.value = find_child(e.parentNode, "rect[x]").attributes.x.value + 3;
+			}
+			if (e.attributes.width != undefined) {
+				orig_save(e, "width");
+				e.attributes.width.value = parseFloat(e.attributes.width.value) * ratio;
+			}
+		}
+
+		if (e.childNodes == undefined) return;
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
+			zoom_child(c[i], x - 10, ratio);
+		}
+	}
+	function zoom_parent(e) {
+		if (e.attributes) {
+			if (e.attributes.x != undefined) {
+				orig_save(e, "x");
+				e.attributes.x.value = 10;
+			}
+			if (e.attributes.width != undefined) {
+				orig_save(e, "width");
+				e.attributes.width.value = parseInt(svg.width.baseVal.value) - (10 * 2);
+			}
+		}
+		if (e.childNodes == undefined) return;
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
+			zoom_parent(c[i]);
+		}
+	}
+	function zoom(node) {
+		var attr = find_child(node, "rect").attributes;
+		var width = parseFloat(attr.width.value);
+		var xmin = parseFloat(attr.x.value);
+		var xmax = parseFloat(xmin + width);
+		var ymin = parseFloat(attr.y.value);
+		var ratio = (svg.width.baseVal.value - 2 * 10) / width;
+
+		// XXX: Workaround for JavaScript float issues (fix me)
+		var fudge = 0.0001;
+
+		unzoombtn.classList.remove("hide");
+
+		var el = document.getElementById("frames").children;
+		for (var i = 0; i < el.length; i++) {
+			var e = el[i];
+			var a = find_child(e, "rect").attributes;
+			var ex = parseFloat(a.x.value);
+			var ew = parseFloat(a.width.value);
+			var upstack;
+			// Is it an ancestor
+			if (0 == 0) {
+				upstack = parseFloat(a.y.value) > ymin;
+			} else {
+				upstack = parseFloat(a.y.value) < ymin;
+			}
+			if (upstack) {
+				// Direct ancestor
+				if (ex <= xmin && (ex+ew+fudge) >= xmax) {
+					e.classList.add("parent");
+					zoom_parent(e);
+					update_text(e);
+				}
+				// not in current path
+				else
+					e.classList.add("hide");
+			}
+			// Children maybe
+			else {
+				// no common path
+				if (ex < xmin || ex + fudge >= xmax) {
+					e.classList.add("hide");
+				}
+				else {
+					zoom_child(e, xmin, ratio);
+					update_text(e);
+				}
+			}
+		}
+		search();
+	}
+	function unzoom(dont_update_text) {
+		unzoombtn.classList.add("hide");
+		var el = document.getElementById("frames").children;
+		for(var i = 0; i < el.length; i++) {
+			el[i].classList.remove("parent");
+			el[i].classList.remove("hide");
+			zoom_reset(el[i]);
+			if(!dont_update_text) update_text(el[i]);
+		}
+		search();
+	}
+	function clearzoom() {
+		unzoom();
+
+		// remove zoom state
+		var params = get_params();
+		if (params.x) delete params.x;
+		if (params.y) delete params.y;
+		history.replaceState(null, null, parse_params(params));
+	}
+
+	// search
+	function toggle_ignorecase() {
+		ignorecase = !ignorecase;
+		if (ignorecase) {
+			ignorecaseBtn.classList.add("show");
+		} else {
+			ignorecaseBtn.classList.remove("show");
+		}
+		reset_search();
+		search();
+	}
+	function reset_search() {
+		var el = document.querySelectorAll("#frames rect");
+		for (var i = 0; i < el.length; i++) {
+			orig_load(el[i], "fill")
+		}
+		var params = get_params();
+		delete params.s;
+		history.replaceState(null, null, parse_params(params));
+	}
+	function search_prompt() {
+		if (!searching) {
+			var term = prompt("Enter a search term (regexp " +
+			    "allowed, eg: ^ext4_)"
+			    + (ignorecase ? ", ignoring case" : "")
+			    + "\nPress Ctrl-i to toggle case sensitivity", "");
+			if (term != null) search(term);
+		} else {
+			reset_search();
+			searching = 0;
+			currentSearchTerm = null;
+			searchbtn.classList.remove("show");
+			searchbtn.firstChild.nodeValue = "Search"
+			matchedtxt.classList.add("hide");
+			matchedtxt.firstChild.nodeValue = ""
+		}
+	}
+	function search(term) {
+		if (term) currentSearchTerm = term;
+
+		var re = new RegExp(currentSearchTerm, ignorecase ? 'i' : '');
+		var el = document.getElementById("frames").children;
+		var matches = new Object();
+		var maxwidth = 0;
+		for (var i = 0; i < el.length; i++) {
+			var e = el[i];
+			var func = g_to_func(e);
+			var rect = find_child(e, "rect");
+			if (func == null || rect == null)
+				continue;
+
+			// Save max width. Only works as we have a root frame
+			var w = parseFloat(rect.attributes.width.value);
+			if (w > maxwidth)
+				maxwidth = w;
+
+			if (func.match(re)) {
+				// highlight
+				var x = parseFloat(rect.attributes.x.value);
+				orig_save(rect, "fill");
+				rect.attributes.fill.value = "rgb(230,0,230)";
+
+				// remember matches
+				if (matches[x] == undefined) {
+					matches[x] = w;
+				} else {
+					if (w > matches[x]) {
+						// overwrite with parent
+						matches[x] = w;
+					}
+				}
+				searching = 1;
+			}
+		}
+		if (!searching)
+			return;
+		var params = get_params();
+		params.s = currentSearchTerm;
+		history.replaceState(null, null, parse_params(params));
+
+		searchbtn.classList.add("show");
+		searchbtn.firstChild.nodeValue = "Reset Search";
+
+		// calculate percent matched, excluding vertical overlap
+		var count = 0;
+		var lastx = -1;
+		var lastw = 0;
+		var keys = Array();
+		for (k in matches) {
+			if (matches.hasOwnProperty(k))
+				keys.push(k);
+		}
+		// sort the matched frames by their x location
+		// ascending, then width descending
+		keys.sort(function(a, b){
+			return a - b;
+		});
+		// Step through frames saving only the biggest bottom-up frames
+		// thanks to the sort order. This relies on the tree property
+		// where children are always smaller than their parents.
+		var fudge = 0.0001;	// JavaScript floating point
+		for (var k in keys) {
+			var x = parseFloat(keys[k]);
+			var w = matches[keys[k]];
+			if (x >= lastx + lastw - fudge) {
+				count += w;
+				lastx = x;
+				lastw = w;
+			}
+		}
+		// display matched percent
+		matchedtxt.classList.remove("hide");
+		var pct = 100 * count / maxwidth;
+		if (pct != 100) pct = pct.toFixed(1)
+		matchedtxt.firstChild.nodeValue = "Matched: " + pct + "%";
+	}
+]]>
+</script>
+<rect x="0.0" y="0" width="1200.0" height="758.0" fill="url(#background)"  />
+<text id="title" x="600.00" y="24" >mmap/munmap Flame Graph</text>
+<text id="details" x="10.00" y="741" > </text>
+<text id="unzoom" x="10.00" y="24" class="hide">Reset Zoom</text>
+<text id="search" x="1090.00" y="24" >Search</text>
+<text id="ignorecase" x="1174.00" y="24" >ic</text>
+<text id="matched" x="1090.00" y="741" > </text>
+<g id="frames">
+<g >
+<title>VertxBuilder_initFileResolver_5126ad051ba63842daa7b7d7df7bce703802e84b (1 calls, 0.28%)</title><rect x="618.2" y="469" width="3.3" height="15.0" fill="rgb(0,237,98)" rx="2" ry="2" />
+<text  x="621.18" y="479.5" ></text>
+</g>
+<g >
+<title>AbstractCommittedMemoryProvider_allocate_918a0ef631252cb78d29dd03c08dbccf83223158 (3 calls, 0.84%)</title><rect x="621.5" y="293" width="9.9" height="15.0" fill="rgb(0,194,59)" rx="2" ry="2" />
+<text  x="624.48" y="303.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_beforeThreadRun_625dbc2d8f29de4059347a312d70fca27d8844ba (136 calls, 38.10%)</title><rect x="730.6" y="629" width="449.5" height="15.0" fill="rgb(0,226,81)" rx="2" ry="2" />
+<text  x="733.56" y="639.5" >PosixPlatformThreads_beforeThreadRun_625dbc2d8f29de4059347a31..</text>
+</g>
+<g >
+<title>main (21 calls, 5.88%)</title><rect x="562.0" y="677" width="69.4" height="15.0" fill="rgb(0,234,33)" rx="2" ry="2" />
+<text  x="564.99" y="687.5" >main</text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewArray_14bf8d109c130a0ddaaade0f47cdc765ff19c6ba (3 calls, 0.84%)</title><rect x="621.5" y="357" width="9.9" height="15.0" fill="rgb(0,198,120)" rx="2" ry="2" />
+<text  x="624.48" y="367.5" ></text>
+</g>
+<g >
+<title>PoolArena_constructor_8bbf1984e9528514d8d24057d1c2ec7e94230fa2 (3 calls, 0.84%)</title><rect x="1180.1" y="165" width="9.9" height="15.0" fill="rgb(0,207,83)" rx="2" ry="2" />
+<text  x="1183.08" y="175.5" ></text>
+</g>
+<g >
+<title>AbstractCommittedMemoryProvider_allocate_918a0ef631252cb78d29dd03c08dbccf83223158 (4 calls, 1.12%)</title><rect x="1166.9" y="549" width="13.2" height="15.0" fill="rgb(0,220,3)" rx="2" ry="2" />
+<text  x="1169.86" y="559.5" ></text>
+</g>
+<g >
+<title>UnixNativeDispatcher_mkdir_1e7a7a7ef34f4cd0ab81782923cab6800199f7bc (1 calls, 0.28%)</title><rect x="618.2" y="341" width="3.3" height="15.0" fill="rgb(0,197,188)" rx="2" ry="2" />
+<text  x="621.18" y="351.5" ></text>
+</g>
+<g >
+<title>__GI___mmap (2 calls, 0.56%)</title><rect x="621.5" y="277" width="6.6" height="15.0" fill="rgb(0,224,36)" rx="2" ry="2" />
+<text  x="624.48" y="287.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_71dd1359e6111b4e76afcd8d96300ce614d59f0a (3 calls, 0.84%)</title><rect x="1180.1" y="405" width="9.9" height="15.0" fill="rgb(0,220,111)" rx="2" ry="2" />
+<text  x="1183.08" y="415.5" ></text>
+</g>
+<g >
+<title>Files_createAndCheckIsDirectory_81661efbd4d2fa5a1ba3fdea34723e491026d2bf (1 calls, 0.28%)</title><rect x="618.2" y="389" width="3.3" height="15.0" fill="rgb(0,214,96)" rx="2" ry="2" />
+<text  x="621.18" y="399.5" ></text>
+</g>
+<g >
+<title>KeyMap_find_77bfa563bc84c3bcf95d4902f01d509fa85842dc (3 calls, 0.84%)</title><rect x="598.3" y="245" width="10.0" height="15.0" fill="rgb(0,239,160)" rx="2" ry="2" />
+<text  x="601.35" y="255.5" ></text>
+</g>
+<g >
+<title>MultithreadEventExecutorGroup_constructor_8065881a5eaca808323d46dcb6b44d43723c3c29 (3 calls, 0.84%)</title><rect x="621.5" y="437" width="9.9" height="15.0" fill="rgb(0,200,127)" rx="2" ry="2" />
+<text  x="624.48" y="447.5" ></text>
+</g>
+<g >
+<title>SmallRyeConfigSources_getValue_c683de82362e3215d4c2d292eb27ed717a72cad1 (3 calls, 0.84%)</title><rect x="598.3" y="341" width="10.0" height="15.0" fill="rgb(0,207,185)" rx="2" ry="2" />
+<text  x="601.35" y="351.5" ></text>
+</g>
+<g >
+<title>SmallRyeConfigBuilder_build_8de7683a14a0464633c26718ebe18a05f3b806b8 (3 calls, 0.84%)</title><rect x="608.3" y="549" width="9.9" height="15.0" fill="rgb(0,197,94)" rx="2" ry="2" />
+<text  x="611.26" y="559.5" ></text>
+</g>
+<g >
+<title>SmallRyeConfigSources_getValue_c683de82362e3215d4c2d292eb27ed717a72cad1 (3 calls, 0.84%)</title><rect x="588.4" y="341" width="9.9" height="15.0" fill="rgb(0,217,1)" rx="2" ry="2" />
+<text  x="591.43" y="351.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewArrayLikeObject_bde29bdbdc821b2d66501dbb6111cdc60a0cf9a7 (3 calls, 0.84%)</title><rect x="621.5" y="341" width="9.9" height="15.0" fill="rgb(0,229,40)" rx="2" ry="2" />
+<text  x="624.48" y="351.5" ></text>
+</g>
+<g >
+<title>FutureImpl_addListener_4bc8037810e73a435dd07c1ec0be76321827b7c2 (3 calls, 0.84%)</title><rect x="1180.1" y="309" width="9.9" height="15.0" fill="rgb(0,195,200)" rx="2" ry="2" />
+<text  x="1183.08" y="319.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_bind_66c77c9d67d14d6a33203baee3b3c0eff560aa37 (3 calls, 0.84%)</title><rect x="1180.1" y="373" width="9.9" height="15.0" fill="rgb(0,227,102)" rx="2" ry="2" />
+<text  x="1183.08" y="383.5" ></text>
+</g>
+<g >
+<title>NioEventLoopGroup_newChild_9efbfe1f828b1c5d178f1583c0e1374692b641f4 (3 calls, 0.84%)</title><rect x="621.5" y="405" width="9.9" height="15.0" fill="rgb(0,207,13)" rx="2" ry="2" />
+<text  x="624.48" y="415.5" ></text>
+</g>
+<g >
+<title>ConfigGenerationBuildStep$checkForBuildTimeConfigChange1532146938_deploy_814ae0d81af460230d1403afb8b2a3bcb423923c (3 calls, 0.84%)</title><rect x="588.4" y="565" width="9.9" height="15.0" fill="rgb(0,208,43)" rx="2" ry="2" />
+<text  x="591.43" y="575.5" ></text>
+</g>
+<g >
+<title>__munmap (2 calls, 0.56%)</title><rect x="571.9" y="597" width="6.6" height="15.0" fill="rgb(0,195,161)" rx="2" ry="2" />
+<text  x="574.90" y="607.5" ></text>
+</g>
+<g >
+<title>SecretKeys$$Lambda$c4842093039e75da922a5c2a9306e3ac35ba91b5_get_652d10df16c54528b7605fbafb89c57fb11d0d75 (3 calls, 0.84%)</title><rect x="608.3" y="501" width="9.9" height="15.0" fill="rgb(0,204,62)" rx="2" ry="2" />
+<text  x="611.26" y="511.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb66146990c0e171fce0e59d (139 calls, 38.94%)</title><rect x="730.6" y="661" width="459.4" height="15.0" fill="rgb(0,202,52)" rx="2" ry="2" />
+<text  x="733.56" y="671.5" >PosixPlatformThreads_pthreadStartRoutine_52b0f4d576e98783eb661..</text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewArrayLikeObject0_9482f79e6149c3288885e0150a43b3e3f3fbb7aa (132 calls, 36.97%)</title><rect x="730.6" y="517" width="436.3" height="15.0" fill="rgb(0,238,28)" rx="2" ry="2" />
+<text  x="733.56" y="527.5" >ThreadLocalAllocation_slowPathNewArrayLikeObject0_9482f79e6..</text>
+</g>
+<g >
+<title>Config_initGroup$io$quarkus$vertx$http$runtime$HttpConfiguration_96d0475789c066c0346fee172bb251d464d5a408 (3 calls, 0.84%)</title><rect x="598.3" y="549" width="10.0" height="15.0" fill="rgb(0,210,143)" rx="2" ry="2" />
+<text  x="601.35" y="559.5" ></text>
+</g>
+<g >
+<title>ProfileConfigSourceInterceptor_getProfileValue_4b45309e0a1ab1f119fa918ab18ac8332949a106 (3 calls, 0.84%)</title><rect x="588.4" y="421" width="9.9" height="15.0" fill="rgb(0,196,141)" rx="2" ry="2" />
+<text  x="591.43" y="431.5" ></text>
+</g>
+<g >
+<title>HeapChunkProvider_produceAlignedChunk_8214fff9e22061bbd4db5fe049c9b41ab0d75e2a (3 calls, 0.84%)</title><rect x="621.5" y="309" width="9.9" height="15.0" fill="rgb(0,198,133)" rx="2" ry="2" />
+<text  x="624.48" y="319.5" ></text>
+</g>
+<g >
+<title>FileCache_setupCacheDir_b62e228f2a1b4a273859d5e4e42daac8c53de951 (1 calls, 0.28%)</title><rect x="618.2" y="421" width="3.3" height="15.0" fill="rgb(0,231,21)" rx="2" ry="2" />
+<text  x="621.18" y="431.5" ></text>
+</g>
+<g >
+<title>__GI___mmap (1 calls, 0.28%)</title><rect x="1170.2" y="533" width="3.3" height="15.0" fill="rgb(0,237,100)" rx="2" ry="2" />
+<text  x="1173.17" y="543.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewInstance_1ecc2a4758346549b4d5779d3ae68d61340736a4 (3 calls, 0.84%)</title><rect x="598.3" y="181" width="10.0" height="15.0" fill="rgb(0,232,128)" rx="2" ry="2" />
+<text  x="601.35" y="191.5" ></text>
+</g>
+<g >
+<title>EventLoopContext$$Lambda$4a3e2850fe71a800d5c041cf8c0187bc4f73f307_run_cfda83ea70aa595c06f55299c48277de05b8170c (3 calls, 0.84%)</title><rect x="1180.1" y="517" width="9.9" height="15.0" fill="rgb(0,192,187)" rx="2" ry="2" />
+<text  x="1183.08" y="527.5" ></text>
+</g>
+<g >
+<title>__GI___mmap (2 calls, 0.56%)</title><rect x="1180.1" y="85" width="6.6" height="15.0" fill="rgb(0,197,139)" rx="2" ry="2" />
+<text  x="1183.08" y="95.5" ></text>
+</g>
+<g >
+<title>SmallRyeConfig_getConfigValue_8d86ddc1578d21549243d3667c0063e0133f9cfc (3 calls, 0.84%)</title><rect x="588.4" y="517" width="9.9" height="15.0" fill="rgb(0,218,42)" rx="2" ry="2" />
+<text  x="591.43" y="527.5" ></text>
+</g>
+<g >
+<title>HashMap_putVal_a317b593f5b45ff42b9d347eb7a723ace4668094 (3 calls, 0.84%)</title><rect x="608.3" y="133" width="9.9" height="15.0" fill="rgb(0,202,27)" rx="2" ry="2" />
+<text  x="611.26" y="143.5" ></text>
+</g>
+<g >
+<title>AbstractEventExecutor_safeExecute_ec5db7766d492a39c23b93fb07becc79ac720932 (3 calls, 0.84%)</title><rect x="1180.1" y="533" width="9.9" height="15.0" fill="rgb(0,190,35)" rx="2" ry="2" />
+<text  x="1183.08" y="543.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewInstanceWithoutAllocating_cb30e26c12ff20c032edd4d7b692136d8122fa75 (3 calls, 0.84%)</title><rect x="598.3" y="165" width="10.0" height="15.0" fill="rgb(0,229,206)" rx="2" ry="2" />
+<text  x="601.35" y="175.5" ></text>
+</g>
+<g >
+<title>ConfigGenerationBuildStep$checkForBuildTimeConfigChange1532146938_deploy_5_fea3440b9151ae12a488d5e8b8517daa03c376ee (3 calls, 0.84%)</title><rect x="588.4" y="549" width="9.9" height="15.0" fill="rgb(0,236,115)" rx="2" ry="2" />
+<text  x="591.43" y="559.5" ></text>
+</g>
+<g >
+<title>CEntryPointSnippets_createIsolate_bb00f99aac090dc55c4d720184b7788129da5b4b (5 calls, 1.40%)</title><rect x="562.0" y="645" width="16.5" height="15.0" fill="rgb(0,226,95)" rx="2" ry="2" />
+<text  x="564.99" y="655.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_openSelector_a98c4c1fde2d2766fa4075be761910d1644ea8f3 (3 calls, 0.84%)</title><rect x="621.5" y="373" width="9.9" height="15.0" fill="rgb(0,193,0)" rx="2" ry="2" />
+<text  x="624.48" y="383.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewInstance_1ecc2a4758346549b4d5779d3ae68d61340736a4 (3 calls, 0.84%)</title><rect x="588.4" y="277" width="9.9" height="15.0" fill="rgb(0,198,40)" rx="2" ry="2" />
+<text  x="591.43" y="287.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewInstanceWithoutAllocating_cb30e26c12ff20c032edd4d7b692136d8122fa75 (4 calls, 1.12%)</title><rect x="1166.9" y="581" width="13.2" height="15.0" fill="rgb(0,221,117)" rx="2" ry="2" />
+<text  x="1169.86" y="591.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_run_890c192beeafdbf2947bae1da834ddaa3eefa065 (3 calls, 0.84%)</title><rect x="1180.1" y="565" width="9.9" height="15.0" fill="rgb(0,209,56)" rx="2" ry="2" />
+<text  x="1183.08" y="575.5" ></text>
+</g>
+<g >
+<title>[unknown] (16 calls, 4.48%)</title><rect x="10.0" y="693" width="52.9" height="15.0" fill="rgb(0,220,7)" rx="2" ry="2" />
+<text  x="13.00" y="703.5" >[unkn..</text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_setupTcpHttpServer_4c14de13bfd8cdd1807ec0aa33b91c684bca1d43 (3 calls, 0.84%)</title><rect x="1180.1" y="437" width="9.9" height="15.0" fill="rgb(0,230,127)" rx="2" ry="2" />
+<text  x="1183.08" y="447.5" ></text>
+</g>
+<g >
+<title>__GI_mprotect (1 calls, 0.28%)</title><rect x="568.6" y="597" width="3.3" height="15.0" fill="rgb(0,237,156)" rx="2" ry="2" />
+<text  x="571.60" y="607.5" ></text>
+</g>
+<g >
+<title>SmallRyeConfig_getIndexedPropertiesIndexes_12531f43c170fc9983a993c3f1ea5e9d94b99163 (3 calls, 0.84%)</title><rect x="608.3" y="309" width="9.9" height="15.0" fill="rgb(0,190,142)" rx="2" ry="2" />
+<text  x="611.26" y="319.5" ></text>
+</g>
+<g >
+<title>AbstractMappingConfigSourceInterceptor_iterateNames_50b0798cb191224bc5227c7d0ebbc9a169f568a9 (3 calls, 0.84%)</title><rect x="608.3" y="245" width="9.9" height="15.0" fill="rgb(0,190,119)" rx="2" ry="2" />
+<text  x="611.26" y="255.5" ></text>
+</g>
+<g >
+<title>SecretKeysConfigSourceInterceptor_getValue_1184f5122352f2b0feb14cd2df23e0ead560cd53 (3 calls, 0.84%)</title><rect x="588.4" y="357" width="9.9" height="15.0" fill="rgb(0,210,174)" rx="2" ry="2" />
+<text  x="591.43" y="367.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder_initializeRouter_c0e44ca8f166b805ce796ed6560e6c30b5da1274 (4 calls, 1.12%)</title><rect x="618.2" y="549" width="13.2" height="15.0" fill="rgb(0,218,125)" rx="2" ry="2" />
+<text  x="621.18" y="559.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewInstance_1ecc2a4758346549b4d5779d3ae68d61340736a4 (4 calls, 1.12%)</title><rect x="1166.9" y="597" width="13.2" height="15.0" fill="rgb(0,231,89)" rx="2" ry="2" />
+<text  x="1169.86" y="607.5" ></text>
+</g>
+<g >
+<title>__madvise (1 calls, 0.28%)</title><rect x="10.0" y="677" width="3.3" height="15.0" fill="rgb(0,212,78)" rx="2" ry="2" />
+<text  x="13.00" y="687.5" ></text>
+</g>
+<g >
+<title>__munmap (27 calls, 7.56%)</title><rect x="631.4" y="693" width="89.2" height="15.0" fill="rgb(0,217,133)" rx="2" ry="2" />
+<text  x="634.40" y="703.5" >__munmap</text>
+</g>
+<g >
+<title>Isolates_create_6a023903d7461797f97dbbd5bfd1599cb8eee331 (5 calls, 1.40%)</title><rect x="562.0" y="629" width="16.5" height="15.0" fill="rgb(0,217,53)" rx="2" ry="2" />
+<text  x="564.99" y="639.5" ></text>
+</g>
+<g >
+<title>PropertyNamesConfigSourceInterceptor_iterateNames_ab7cd65b33134afcff39876704d2ac6caa82ff6a (3 calls, 0.84%)</title><rect x="608.3" y="261" width="9.9" height="15.0" fill="rgb(0,233,172)" rx="2" ry="2" />
+<text  x="611.26" y="271.5" ></text>
+</g>
+<g >
+<title>AbstractMappingConfigSourceInterceptor_iterateNames_50b0798cb191224bc5227c7d0ebbc9a169f568a9 (3 calls, 0.84%)</title><rect x="608.3" y="165" width="9.9" height="15.0" fill="rgb(0,208,198)" rx="2" ry="2" />
+<text  x="611.26" y="175.5" ></text>
+</g>
+<g >
+<title>ExpressionConfigSourceInterceptor_getValue_563933897d47fd84b3c2fc72001e673c1cc0c547 (3 calls, 0.84%)</title><rect x="598.3" y="453" width="10.0" height="15.0" fill="rgb(0,193,26)" rx="2" ry="2" />
+<text  x="601.35" y="463.5" ></text>
+</g>
+<g >
+<title>VertxHttpRecorder$WebDeploymentVerticle_start_eee26621e958aa4ab93215bffee79f9c9522e286 (3 calls, 0.84%)</title><rect x="1180.1" y="453" width="9.9" height="15.0" fill="rgb(0,235,197)" rx="2" ry="2" />
+<text  x="1183.08" y="463.5" ></text>
+</g>
+<g >
+<title>SecretKeys_doUnlocked_02c262834547d564493b15176335460b2155afbe (3 calls, 0.84%)</title><rect x="608.3" y="517" width="9.9" height="15.0" fill="rgb(0,197,202)" rx="2" ry="2" />
+<text  x="611.26" y="527.5" ></text>
+</g>
+<g >
+<title>ConfigMappingContext_constructGroup_1cadaa42fa7df1266cbc66060ddad43f1e5d0b4b (3 calls, 0.84%)</title><rect x="608.3" y="453" width="9.9" height="15.0" fill="rgb(0,191,51)" rx="2" ry="2" />
+<text  x="611.26" y="463.5" ></text>
+</g>
+<g >
+<title>RelocateConfigSourceInterceptor_getValue_50c035a42df6b98cdced39f216d477221493c2cb (3 calls, 0.84%)</title><rect x="598.3" y="373" width="10.0" height="15.0" fill="rgb(0,202,186)" rx="2" ry="2" />
+<text  x="601.35" y="383.5" ></text>
+</g>
+<g >
+<title>UnixFileSystemProvider_createDirectory_b0781ecc429df3df4cdcbfafd9e223be24bb2b8d (1 calls, 0.28%)</title><rect x="618.2" y="357" width="3.3" height="15.0" fill="rgb(0,204,119)" rx="2" ry="2" />
+<text  x="621.18" y="367.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewInstanceWithoutAllocating_cb30e26c12ff20c032edd4d7b692136d8122fa75 (3 calls, 0.84%)</title><rect x="588.4" y="261" width="9.9" height="15.0" fill="rgb(0,239,177)" rx="2" ry="2" />
+<text  x="591.43" y="271.5" ></text>
+</g>
+<g >
+<title>ExpressionConfigSourceInterceptor_getValue_88007ff8463db20d2a117bfbea146ce16259df0d (3 calls, 0.84%)</title><rect x="588.4" y="469" width="9.9" height="15.0" fill="rgb(0,225,141)" rx="2" ry="2" />
+<text  x="591.43" y="479.5" ></text>
+</g>
+<g >
+<title>__GI_mprotect (75 calls, 21.01%)</title><rect x="314.1" y="693" width="247.9" height="15.0" fill="rgb(0,213,10)" rx="2" ry="2" />
+<text  x="317.09" y="703.5" >__GI_mprotect</text>
+</g>
+<g >
+<title>HttpServerImpl_listen_72bb58c9dd4df80336e163761f4218489305bf4d (3 calls, 0.84%)</title><rect x="1180.1" y="389" width="9.9" height="15.0" fill="rgb(0,211,119)" rx="2" ry="2" />
+<text  x="1183.08" y="399.5" ></text>
+</g>
+<g >
+<title>NioEventLoop_constructor_028fef7272962462688d7328ac11db5a2121187e (3 calls, 0.84%)</title><rect x="621.5" y="389" width="9.9" height="15.0" fill="rgb(0,214,100)" rx="2" ry="2" />
+<text  x="624.48" y="399.5" ></text>
+</g>
+<g >
+<title>Constructor_newInstanceWithCaller_7990cd71760b72a496cfbe05ccee4199a26b322d (3 calls, 0.84%)</title><rect x="608.3" y="421" width="9.9" height="15.0" fill="rgb(0,210,98)" rx="2" ry="2" />
+<text  x="611.26" y="431.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewArrayLikeObject0_9482f79e6149c3288885e0150a43b3e3f3fbb7aa (3 calls, 0.84%)</title><rect x="621.5" y="325" width="9.9" height="15.0" fill="rgb(0,194,156)" rx="2" ry="2" />
+<text  x="624.48" y="335.5" ></text>
+</g>
+<g >
+<title>RelocateConfigSourceInterceptor_getValue_50c035a42df6b98cdced39f216d477221493c2cb (3 calls, 0.84%)</title><rect x="598.3" y="389" width="10.0" height="15.0" fill="rgb(0,197,101)" rx="2" ry="2" />
+<text  x="601.35" y="399.5" ></text>
+</g>
+<g >
+<title>StringLatin1_newString_737b8b7723fc21def120d47219c87491aa1f9ab3 (3 calls, 0.84%)</title><rect x="598.3" y="197" width="10.0" height="15.0" fill="rgb(0,215,74)" rx="2" ry="2" />
+<text  x="601.35" y="207.5" ></text>
+</g>
+<g >
+<title>ConfigRecorder_handleConfigChange_5951d450315945767a9b5c8c794b4362c96ad5b8 (3 calls, 0.84%)</title><rect x="588.4" y="533" width="9.9" height="15.0" fill="rgb(0,237,41)" rx="2" ry="2" />
+<text  x="591.43" y="543.5" ></text>
+</g>
+<g >
+<title>IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d96cbc1a188a6051c29be1299afe681d67942e_92184801f7fd30d3f12b7ed07a5b388f27b8f61c (139 calls, 38.94%)</title><rect x="730.6" y="677" width="459.4" height="15.0" fill="rgb(0,219,149)" rx="2" ry="2" />
+<text  x="733.56" y="687.5" >IsolateEnterStub_PosixPlatformThreads_pthreadStartRoutine_38d9..</text>
+</g>
+<g >
+<title>ClassInitializationInfo_invokeClassInitializer_aa7b9b942c88d6732e408e8eb614c29c67e71338 (3 calls, 0.84%)</title><rect x="1180.1" y="213" width="9.9" height="15.0" fill="rgb(0,207,103)" rx="2" ry="2" />
+<text  x="1183.08" y="223.5" ></text>
+</g>
+<g >
+<title>HeapChunkProvider_produceAlignedChunk_8214fff9e22061bbd4db5fe049c9b41ab0d75e2a (3 calls, 0.84%)</title><rect x="588.4" y="245" width="9.9" height="15.0" fill="rgb(0,202,114)" rx="2" ry="2" />
+<text  x="591.43" y="255.5" ></text>
+</g>
+<g >
+<title>AbstractCommittedMemoryProvider_allocate_918a0ef631252cb78d29dd03c08dbccf83223158 (3 calls, 0.84%)</title><rect x="608.3" y="53" width="9.9" height="15.0" fill="rgb(0,234,163)" rx="2" ry="2" />
+<text  x="611.26" y="63.5" ></text>
+</g>
+<g >
+<title>FutureBase_emitSuccess_55cfcf56c6b5c5b0c39988886242a4bb039479e0 (3 calls, 0.84%)</title><rect x="1180.1" y="293" width="9.9" height="15.0" fill="rgb(0,221,137)" rx="2" ry="2" />
+<text  x="1183.08" y="303.5" ></text>
+</g>
+<g >
+<title>Files_createDirectories_faf3d43fb52cea94e1550ec1bf0ca361e8e35d1c (1 calls, 0.28%)</title><rect x="618.2" y="405" width="3.3" height="15.0" fill="rgb(0,204,106)" rx="2" ry="2" />
+<text  x="621.18" y="415.5" ></text>
+</g>
+<g >
+<title>VertxCoreRecorder_initialize_aaf29a27cdf86a993cbc54b4e9974703a6d03613 (4 calls, 1.12%)</title><rect x="618.2" y="501" width="13.2" height="15.0" fill="rgb(0,237,205)" rx="2" ry="2" />
+<text  x="621.18" y="511.5" ></text>
+</g>
+<g >
+<title>AbstractCommittedMemoryProvider_allocate_918a0ef631252cb78d29dd03c08dbccf83223158 (3 calls, 0.84%)</title><rect x="598.3" y="133" width="10.0" height="15.0" fill="rgb(0,209,139)" rx="2" ry="2" />
+<text  x="601.35" y="143.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewInstance_1ecc2a4758346549b4d5779d3ae68d61340736a4 (3 calls, 0.84%)</title><rect x="1180.1" y="149" width="9.9" height="15.0" fill="rgb(0,231,96)" rx="2" ry="2" />
+<text  x="1183.08" y="159.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewArrayLikeObject_bde29bdbdc821b2d66501dbb6111cdc60a0cf9a7 (132 calls, 36.97%)</title><rect x="730.6" y="533" width="436.3" height="15.0" fill="rgb(0,213,84)" rx="2" ry="2" />
+<text  x="733.56" y="543.5" >ThreadLocalAllocation_slowPathNewArrayLikeObject_bde29bdbdc..</text>
+</g>
+<g >
+<title>RelocateConfigSourceInterceptor_getValue_50c035a42df6b98cdced39f216d477221493c2cb (3 calls, 0.84%)</title><rect x="588.4" y="389" width="9.9" height="15.0" fill="rgb(0,230,184)" rx="2" ry="2" />
+<text  x="591.43" y="399.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor_runAllTasks_27862f6cb6cf6e5477dcb74075a95b294ffafca3 (3 calls, 0.84%)</title><rect x="1180.1" y="549" width="9.9" height="15.0" fill="rgb(0,218,186)" rx="2" ry="2" />
+<text  x="1183.08" y="559.5" ></text>
+</g>
+<g >
+<title>StringLatin1_newString_737b8b7723fc21def120d47219c87491aa1f9ab3 (132 calls, 36.97%)</title><rect x="730.6" y="581" width="436.3" height="15.0" fill="rgb(0,215,63)" rx="2" ry="2" />
+<text  x="733.56" y="591.5" >StringLatin1_newString_737b8b7723fc21def120d47219c87491aa1f..</text>
+</g>
+<g >
+<title>SmallRyeConfig$ConfigSources$PropertyNames_get_5485406d1916240c3ef6f1b883b41b302f245212 (3 calls, 0.84%)</title><rect x="608.3" y="277" width="9.9" height="15.0" fill="rgb(0,223,7)" rx="2" ry="2" />
+<text  x="611.26" y="287.5" ></text>
+</g>
+<g >
+<title>KeyMap_findRootValue_f55e492e81fa59260539cebfa004d31b057317a9 (3 calls, 0.84%)</title><rect x="598.3" y="261" width="10.0" height="15.0" fill="rgb(0,228,93)" rx="2" ry="2" />
+<text  x="601.35" y="271.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_lambda$listen$2_fff13204af89bb30487011af1e773a9ba4947997 (3 calls, 0.84%)</title><rect x="1180.1" y="245" width="9.9" height="15.0" fill="rgb(0,212,86)" rx="2" ry="2" />
+<text  x="1183.08" y="255.5" ></text>
+</g>
+<g >
+<title>HeapChunkProvider_produceAlignedChunk_8214fff9e22061bbd4db5fe049c9b41ab0d75e2a (4 calls, 1.12%)</title><rect x="1166.9" y="565" width="13.2" height="15.0" fill="rgb(0,190,126)" rx="2" ry="2" />
+<text  x="1169.86" y="575.5" ></text>
+</g>
+<g >
+<title>PropertyNamesConfigSourceInterceptor_getValue_d99be0b2e4266ece5d90f1f41fb0b29593c87bad (3 calls, 0.84%)</title><rect x="598.3" y="501" width="10.0" height="15.0" fill="rgb(0,204,3)" rx="2" ry="2" />
+<text  x="601.35" y="511.5" ></text>
+</g>
+<g >
+<title>VertxBuilder_vertx_86c4d260a7bb5352a6d3d8245b7e64b0114eb27a (3 calls, 0.84%)</title><rect x="621.5" y="485" width="9.9" height="15.0" fill="rgb(0,190,83)" rx="2" ry="2" />
+<text  x="624.48" y="495.5" ></text>
+</g>
+<g >
+<title>PooledByteBufAllocator_&lt;clinit&gt;_1e6d8f7d023bf0895747a542839c1da650733dfd (3 calls, 0.84%)</title><rect x="1180.1" y="197" width="9.9" height="15.0" fill="rgb(0,216,127)" rx="2" ry="2" />
+<text  x="1183.08" y="207.5" ></text>
+</g>
+<g >
+<title>__GI___mmap (2 calls, 0.56%)</title><rect x="598.3" y="117" width="6.7" height="15.0" fill="rgb(0,236,95)" rx="2" ry="2" />
+<text  x="601.35" y="127.5" ></text>
+</g>
+<g >
+<title>ExpressionConfigSourceInterceptor_getValue_88007ff8463db20d2a117bfbea146ce16259df0d (3 calls, 0.84%)</title><rect x="598.3" y="469" width="10.0" height="15.0" fill="rgb(0,227,108)" rx="2" ry="2" />
+<text  x="601.35" y="479.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewInstanceWithoutAllocating_cb30e26c12ff20c032edd4d7b692136d8122fa75 (3 calls, 0.84%)</title><rect x="608.3" y="85" width="9.9" height="15.0" fill="rgb(0,239,180)" rx="2" ry="2" />
+<text  x="611.26" y="95.5" ></text>
+</g>
+<g >
+<title>ConfigValueConfigSourceWrapper_getConfigValue_09608a4de7dcb70ca60951dc60776caaab137eac (3 calls, 0.84%)</title><rect x="598.3" y="325" width="10.0" height="15.0" fill="rgb(0,209,207)" rx="2" ry="2" />
+<text  x="601.35" y="335.5" ></text>
+</g>
+<g >
+<title>UnixNativeDispatcher_mkdir0_d414e03c6e68bf88408d46278aadb5f290fbd17d (1 calls, 0.28%)</title><rect x="618.2" y="325" width="3.3" height="15.0" fill="rgb(0,198,96)" rx="2" ry="2" />
+<text  x="621.18" y="335.5" ></text>
+</g>
+<g >
+<title>__GI___mmap (2 calls, 0.56%)</title><rect x="562.0" y="597" width="6.6" height="15.0" fill="rgb(0,192,84)" rx="2" ry="2" />
+<text  x="564.99" y="607.5" ></text>
+</g>
+<g >
+<title>SmallRyeConfig_getOptionalValues_ae2978c1a0b5ac04aa3255c1e9b7029f0321fea2 (3 calls, 0.84%)</title><rect x="608.3" y="357" width="9.9" height="15.0" fill="rgb(0,206,35)" rx="2" ry="2" />
+<text  x="611.26" y="367.5" ></text>
+</g>
+<g >
+<title>SmallRyeConfig_getPropertyNames_730a96424a293ec1b03929fc6c28230c67f7ef48 (3 calls, 0.84%)</title><rect x="608.3" y="293" width="9.9" height="15.0" fill="rgb(0,224,178)" rx="2" ry="2" />
+<text  x="611.26" y="303.5" ></text>
+</g>
+<g >
+<title>ConfigValueConfigSourceWrapper_getConfigValue_09608a4de7dcb70ca60951dc60776caaab137eac (3 calls, 0.84%)</title><rect x="588.4" y="325" width="9.9" height="15.0" fill="rgb(0,239,150)" rx="2" ry="2" />
+<text  x="591.43" y="335.5" ></text>
+</g>
+<g >
+<title>ProfileConfigSourceInterceptor_getProfileValue_4b45309e0a1ab1f119fa918ab18ac8332949a106 (3 calls, 0.84%)</title><rect x="598.3" y="421" width="10.0" height="15.0" fill="rgb(0,192,50)" rx="2" ry="2" />
+<text  x="601.35" y="431.5" ></text>
+</g>
+<g >
+<title>_dl_sysdep_start (5 calls, 1.40%)</title><rect x="46.4" y="677" width="16.5" height="15.0" fill="rgb(0,196,115)" rx="2" ry="2" />
+<text  x="49.36" y="687.5" ></text>
+</g>
+<g >
+<title>TCPServerBase$$Lambda$9ed511ad64a69a8d77133074c72d59835d95316e_handle_a9a83ae404e7aa567b22304648833b08775436ae (3 calls, 0.84%)</title><rect x="1180.1" y="261" width="9.9" height="15.0" fill="rgb(0,223,111)" rx="2" ry="2" />
+<text  x="1183.08" y="271.5" ></text>
+</g>
+<g >
+<title>ExpressionConfigSourceInterceptor_getValue_563933897d47fd84b3c2fc72001e673c1cc0c547 (3 calls, 0.84%)</title><rect x="588.4" y="453" width="9.9" height="15.0" fill="rgb(0,238,128)" rx="2" ry="2" />
+<text  x="591.43" y="463.5" ></text>
+</g>
+<g >
+<title>StringBuilder_toString_fff5cf8f9838ca54b87be4fc46d795a7c0e01bd4 (3 calls, 0.84%)</title><rect x="598.3" y="213" width="10.0" height="15.0" fill="rgb(0,191,105)" rx="2" ry="2" />
+<text  x="601.35" y="223.5" ></text>
+</g>
+<g >
+<title>SmallRyeConfig_getIndexedProperties_a9d754c67bb4e4c56eb8e164acc3d392229ed49b (3 calls, 0.84%)</title><rect x="608.3" y="325" width="9.9" height="15.0" fill="rgb(0,205,146)" rx="2" ry="2" />
+<text  x="611.26" y="335.5" ></text>
+</g>
+<g >
+<title>ConfigMappingProvider_mapConfiguration_294991459bba7effcf9a3b5da53f81dc2826a56c (3 calls, 0.84%)</title><rect x="608.3" y="533" width="9.9" height="15.0" fill="rgb(0,205,141)" rx="2" ry="2" />
+<text  x="611.26" y="543.5" ></text>
+</g>
+<g >
+<title>NameIterator_getNextSegment_8cc5f31df88d30d5785134d7b4ebaf7ea862f699 (3 calls, 0.84%)</title><rect x="598.3" y="229" width="10.0" height="15.0" fill="rgb(0,221,39)" rx="2" ry="2" />
+<text  x="601.35" y="239.5" ></text>
+</g>
+<g >
+<title>dl_main (4 calls, 1.12%)</title><rect x="49.7" y="661" width="13.2" height="15.0" fill="rgb(0,226,101)" rx="2" ry="2" />
+<text  x="52.66" y="671.5" ></text>
+</g>
+<g >
+<title>HeapChunkProvider_produceAlignedChunk_8214fff9e22061bbd4db5fe049c9b41ab0d75e2a (3 calls, 0.84%)</title><rect x="1180.1" y="117" width="9.9" height="15.0" fill="rgb(0,213,125)" rx="2" ry="2" />
+<text  x="1183.08" y="127.5" ></text>
+</g>
+<g >
+<title>KeyMap_findRootValue_4348ed9ff28c4ecb3bba4f5fff255576bddeadee (3 calls, 0.84%)</title><rect x="598.3" y="277" width="10.0" height="15.0" fill="rgb(0,199,115)" rx="2" ry="2" />
+<text  x="601.35" y="287.5" ></text>
+</g>
+<g >
+<title>FallbackConfigSourceInterceptor_getValue_72258817427828e12e02ce243a835f8f485a162e (3 calls, 0.84%)</title><rect x="588.4" y="485" width="9.9" height="15.0" fill="rgb(0,235,15)" rx="2" ry="2" />
+<text  x="591.43" y="495.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewInstance_1ecc2a4758346549b4d5779d3ae68d61340736a4 (3 calls, 0.84%)</title><rect x="608.3" y="101" width="9.9" height="15.0" fill="rgb(0,229,2)" rx="2" ry="2" />
+<text  x="611.26" y="111.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_getOrCreateMonitorFromObject_eb8b5d9d3fd42d442f927de69bb1be1fe3bccb7e (3 calls, 0.84%)</title><rect x="578.5" y="565" width="9.9" height="15.0" fill="rgb(0,197,96)" rx="2" ry="2" />
+<text  x="581.52" y="575.5" ></text>
+</g>
+<g >
+<title>Arrays_copyOfRange_289badfd980998aad0ada38eb3a926841af70498 (132 calls, 36.97%)</title><rect x="730.6" y="565" width="436.3" height="15.0" fill="rgb(0,235,152)" rx="2" ry="2" />
+<text  x="733.56" y="575.5" >Arrays_copyOfRange_289badfd980998aad0ada38eb3a926841af70498</text>
+</g>
+<g >
+<title>FutureImpl_onComplete_6910ae6710f9bd8aad3c67ff8e7ccefcb1eefa5d (3 calls, 0.84%)</title><rect x="1180.1" y="341" width="9.9" height="15.0" fill="rgb(0,214,170)" rx="2" ry="2" />
+<text  x="1183.08" y="351.5" ></text>
+</g>
+<g >
+<title>ContextInternal_dispatch_956f42b94541754ae21f0403cde535312ba0ccdf (3 calls, 0.84%)</title><rect x="1180.1" y="501" width="9.9" height="15.0" fill="rgb(0,216,30)" rx="2" ry="2" />
+<text  x="1183.08" y="511.5" ></text>
+</g>
+<g >
+<title>VertxCoreRecorder$VertxSupplier_get_52c96bc8af0bec88a61cfaffe07b92f472ca12ac (4 calls, 1.12%)</title><rect x="618.2" y="533" width="13.2" height="15.0" fill="rgb(0,192,37)" rx="2" ry="2" />
+<text  x="621.18" y="543.5" ></text>
+</g>
+<g >
+<title>ClassInitializationInfo_initialize_fc2a388d0cb0b18ea354b79ca3bc111ec6e55467 (3 calls, 0.84%)</title><rect x="1180.1" y="229" width="9.9" height="15.0" fill="rgb(0,194,114)" rx="2" ry="2" />
+<text  x="1183.08" y="239.5" ></text>
+</g>
+<g >
+<title>__GI___mmap (76 calls, 21.29%)</title><rect x="62.9" y="693" width="251.2" height="15.0" fill="rgb(0,236,133)" rx="2" ry="2" />
+<text  x="65.89" y="703.5" >__GI___mmap</text>
+</g>
+<g >
+<title>SmallRyeConfig_getValue_a16f787491eb4416549c0049336d17fca3ca0136 (3 calls, 0.84%)</title><rect x="598.3" y="533" width="10.0" height="15.0" fill="rgb(0,229,159)" rx="2" ry="2" />
+<text  x="601.35" y="543.5" ></text>
+</g>
+<g >
+<title>DeploymentManager$$Lambda$55ccb11f81ec7506c2af3f7713ac302282463b97_handle_b8d125042118b12813074c63d184060e9f913b55 (3 calls, 0.84%)</title><rect x="1180.1" y="485" width="9.9" height="15.0" fill="rgb(0,230,13)" rx="2" ry="2" />
+<text  x="1183.08" y="495.5" ></text>
+</g>
+<g >
+<title>Quarkus_run_7b200c41008a3c5f18cd42d608d602b518bc6c94 (13 calls, 3.64%)</title><rect x="588.4" y="629" width="43.0" height="15.0" fill="rgb(0,219,135)" rx="2" ry="2" />
+<text  x="591.43" y="639.5" >Quar..</text>
+</g>
+<g >
+<title>HashMap_newNode_69629eeece52599241f7d930d59ec6c80269ccd0 (3 calls, 0.84%)</title><rect x="608.3" y="117" width="9.9" height="15.0" fill="rgb(0,205,53)" rx="2" ry="2" />
+<text  x="611.26" y="127.5" ></text>
+</g>
+<g >
+<title>ProfileConfigSourceInterceptor_iterateNames_f8539fa624e814ff84aef39674c445cfbca2e26a (3 calls, 0.84%)</title><rect x="608.3" y="213" width="9.9" height="15.0" fill="rgb(0,213,93)" rx="2" ry="2" />
+<text  x="611.26" y="223.5" ></text>
+</g>
+<g >
+<title>ProfileConfigSourceInterceptor_getValue_e2ac71ac64266bd94f4c5091c0183f4a72e2ad33 (3 calls, 0.84%)</title><rect x="588.4" y="437" width="9.9" height="15.0" fill="rgb(0,210,78)" rx="2" ry="2" />
+<text  x="591.43" y="447.5" ></text>
+</g>
+<g >
+<title>RelocateConfigSourceInterceptor_getValue_50c035a42df6b98cdced39f216d477221493c2cb (3 calls, 0.84%)</title><rect x="588.4" y="373" width="9.9" height="15.0" fill="rgb(0,202,198)" rx="2" ry="2" />
+<text  x="591.43" y="383.5" ></text>
+</g>
+<g >
+<title>_dl_map_object (10 calls, 2.80%)</title><rect x="13.3" y="677" width="33.1" height="15.0" fill="rgb(0,218,17)" rx="2" ry="2" />
+<text  x="16.31" y="687.5" >_d..</text>
+</g>
+<g >
+<title>__GI___mmap (74 calls, 20.73%)</title><rect x="730.6" y="469" width="244.6" height="15.0" fill="rgb(0,216,166)" rx="2" ry="2" />
+<text  x="733.56" y="479.5" >__GI___mmap</text>
+</g>
+<g >
+<title>ConfigMappingProvider_mapConfiguration_0cd3ea125633fed235da4abf5a52ee1c831e6c88 (3 calls, 0.84%)</title><rect x="608.3" y="485" width="9.9" height="15.0" fill="rgb(0,238,139)" rx="2" ry="2" />
+<text  x="611.26" y="495.5" ></text>
+</g>
+<g >
+<title>__munmap (2 calls, 0.56%)</title><rect x="1173.5" y="533" width="6.6" height="15.0" fill="rgb(0,226,158)" rx="2" ry="2" />
+<text  x="1176.47" y="543.5" ></text>
+</g>
+<g >
+<title>FileCache_setupCache_14655269c074c9b2dbfdc13a1df1ef5743473dd3 (1 calls, 0.28%)</title><rect x="618.2" y="437" width="3.3" height="15.0" fill="rgb(0,231,106)" rx="2" ry="2" />
+<text  x="621.18" y="447.5" ></text>
+</g>
+<g >
+<title>__GI___mmap (2 calls, 0.56%)</title><rect x="588.4" y="213" width="6.6" height="15.0" fill="rgb(0,193,167)" rx="2" ry="2" />
+<text  x="591.43" y="223.5" ></text>
+</g>
+<g >
+<title>ConfigMappingContext_constructRoot_e2502f7db2602b2a5ba65349b32c53c15e9ece41 (3 calls, 0.84%)</title><rect x="608.3" y="469" width="9.9" height="15.0" fill="rgb(0,213,5)" rx="2" ry="2" />
+<text  x="611.26" y="479.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewInstanceWithoutAllocating_cb30e26c12ff20c032edd4d7b692136d8122fa75 (3 calls, 0.84%)</title><rect x="578.5" y="533" width="9.9" height="15.0" fill="rgb(0,206,196)" rx="2" ry="2" />
+<text  x="581.52" y="543.5" ></text>
+</g>
+<g >
+<title>ApplicationImpl_doStart_4f75ecc76b43645d5297b6092848747808c532c7 (13 calls, 3.64%)</title><rect x="588.4" y="581" width="43.0" height="15.0" fill="rgb(0,223,165)" rx="2" ry="2" />
+<text  x="591.43" y="591.5" >Appl..</text>
+</g>
+<g >
+<title>JaxRsSecurityConfig273591402Impl_constructor_0df2535e252ba7a39085195d69f70b261aed0562 (3 calls, 0.84%)</title><rect x="608.3" y="373" width="9.9" height="15.0" fill="rgb(0,220,170)" rx="2" ry="2" />
+<text  x="611.26" y="383.5" ></text>
+</g>
+<g >
+<title>String_substring_c83e66efbd7d8e3b7e280667e83636fafaa06780 (132 calls, 36.97%)</title><rect x="730.6" y="597" width="436.3" height="15.0" fill="rgb(0,229,171)" rx="2" ry="2" />
+<text  x="733.56" y="607.5" >String_substring_c83e66efbd7d8e3b7e280667e83636fafaa06780</text>
+</g>
+<g >
+<title>RelocateConfigSourceInterceptor_getValue_50c035a42df6b98cdced39f216d477221493c2cb (3 calls, 0.84%)</title><rect x="588.4" y="405" width="9.9" height="15.0" fill="rgb(0,208,48)" rx="2" ry="2" />
+<text  x="591.43" y="415.5" ></text>
+</g>
+<g >
+<title>__munmap (1 calls, 0.28%)</title><rect x="614.9" y="37" width="3.3" height="15.0" fill="rgb(0,228,167)" rx="2" ry="2" />
+<text  x="617.87" y="47.5" ></text>
+</g>
+<g >
+<title>SecretKeysConfigSourceInterceptor_getValue_1184f5122352f2b0feb14cd2df23e0ead560cd53 (3 calls, 0.84%)</title><rect x="598.3" y="357" width="10.0" height="15.0" fill="rgb(0,211,137)" rx="2" ry="2" />
+<text  x="601.35" y="367.5" ></text>
+</g>
+<g >
+<title>VertxImpl_constructor_80d00396d68392bbd263011f0698431a464c816c (3 calls, 0.84%)</title><rect x="621.5" y="469" width="9.9" height="15.0" fill="rgb(0,211,196)" rx="2" ry="2" />
+<text  x="624.48" y="479.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewInstance_1ecc2a4758346549b4d5779d3ae68d61340736a4 (3 calls, 0.84%)</title><rect x="578.5" y="549" width="9.9" height="15.0" fill="rgb(0,196,74)" rx="2" ry="2" />
+<text  x="581.52" y="559.5" ></text>
+</g>
+<g >
+<title>Config_readConfig_a68a1a88a9311bdfd87db5b1080709177ec73023 (6 calls, 1.68%)</title><rect x="598.3" y="565" width="19.9" height="15.0" fill="rgb(0,239,30)" rx="2" ry="2" />
+<text  x="601.35" y="575.5" ></text>
+</g>
+<g >
+<title>__munmap (1 calls, 0.28%)</title><rect x="628.1" y="277" width="3.3" height="15.0" fill="rgb(0,211,110)" rx="2" ry="2" />
+<text  x="631.10" y="287.5" ></text>
+</g>
+<g >
+<title>HeapChunkProvider_produceAlignedChunk_8214fff9e22061bbd4db5fe049c9b41ab0d75e2a (3 calls, 0.84%)</title><rect x="608.3" y="69" width="9.9" height="15.0" fill="rgb(0,195,19)" rx="2" ry="2" />
+<text  x="611.26" y="79.5" ></text>
+</g>
+<g >
+<title>HttpServerImpl_listen_185ed8b18670dd3cc9dbf45f218d7d19378543f3 (3 calls, 0.84%)</title><rect x="1180.1" y="421" width="9.9" height="15.0" fill="rgb(0,197,120)" rx="2" ry="2" />
+<text  x="1183.08" y="431.5" ></text>
+</g>
+<g >
+<title>__munmap (1 calls, 0.28%)</title><rect x="585.1" y="485" width="3.3" height="15.0" fill="rgb(0,190,52)" rx="2" ry="2" />
+<text  x="588.13" y="495.5" ></text>
+</g>
+<g >
+<title>__munmap (1 calls, 0.28%)</title><rect x="605.0" y="117" width="3.3" height="15.0" fill="rgb(0,212,151)" rx="2" ry="2" />
+<text  x="607.96" y="127.5" ></text>
+</g>
+<g >
+<title>DisableableConfigSource_getValue_dd5a8f83e536a33a29fad8b80f41d623e9a627fd (3 calls, 0.84%)</title><rect x="598.3" y="309" width="10.0" height="15.0" fill="rgb(0,211,45)" rx="2" ry="2" />
+<text  x="601.35" y="319.5" ></text>
+</g>
+<g >
+<title>VertxBuilder_init_b401802142ff7797952f998daedc530f99fc1979 (1 calls, 0.28%)</title><rect x="618.2" y="485" width="3.3" height="15.0" fill="rgb(0,207,167)" rx="2" ry="2" />
+<text  x="621.18" y="495.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_getOrCreateMonitor_68798058b9a9ed7f5d62a593d86db1159ed3afa8 (3 calls, 0.84%)</title><rect x="578.5" y="581" width="9.9" height="15.0" fill="rgb(0,206,125)" rx="2" ry="2" />
+<text  x="581.52" y="591.5" ></text>
+</g>
+<g >
+<title>ProfileConfigSourceInterceptor_getValue_e2ac71ac64266bd94f4c5091c0183f4a72e2ad33 (3 calls, 0.84%)</title><rect x="598.3" y="437" width="10.0" height="15.0" fill="rgb(0,223,74)" rx="2" ry="2" />
+<text  x="601.35" y="447.5" ></text>
+</g>
+<g >
+<title>KeyMap_findRootValue_4348ed9ff28c4ecb3bba4f5fff255576bddeadee (3 calls, 0.84%)</title><rect x="588.4" y="293" width="9.9" height="15.0" fill="rgb(0,191,34)" rx="2" ry="2" />
+<text  x="591.43" y="303.5" ></text>
+</g>
+<g >
+<title>PromiseImpl_addListener_bad00c05a09868de1c4bb35541f59764f7768b88 (3 calls, 0.84%)</title><rect x="1180.1" y="325" width="9.9" height="15.0" fill="rgb(0,202,113)" rx="2" ry="2" />
+<text  x="1183.08" y="335.5" ></text>
+</g>
+<g >
+<title>all (357 calls, 100%)</title><rect x="10.0" y="709" width="1180.0" height="15.0" fill="rgb(0,233,123)" rx="2" ry="2" />
+<text  x="13.00" y="719.5" ></text>
+</g>
+<g >
+<title>PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a767bbe2792953 (139 calls, 38.94%)</title><rect x="730.6" y="645" width="459.4" height="15.0" fill="rgb(0,197,193)" rx="2" ry="2" />
+<text  x="733.56" y="655.5" >PlatformThreads_threadStartRoutine_10f43c6170891dc932ada21565a..</text>
+</g>
+<g >
+<title>ConfigSourceInterceptor_iterateNames_5b63a23e397992673a07819cc27fffd2458a8a90 (3 calls, 0.84%)</title><rect x="608.3" y="229" width="9.9" height="15.0" fill="rgb(0,231,101)" rx="2" ry="2" />
+<text  x="611.26" y="239.5" ></text>
+</g>
+<g >
+<title>HeapChunkProvider_produceAlignedChunk_8214fff9e22061bbd4db5fe049c9b41ab0d75e2a (3 calls, 0.84%)</title><rect x="578.5" y="517" width="9.9" height="15.0" fill="rgb(0,206,37)" rx="2" ry="2" />
+<text  x="581.52" y="527.5" ></text>
+</g>
+<g >
+<title>Application_start_f0300884f5c38b6448504f5177e19dff60a47b71 (13 calls, 3.64%)</title><rect x="588.4" y="597" width="43.0" height="15.0" fill="rgb(0,212,63)" rx="2" ry="2" />
+<text  x="591.43" y="607.5" >Appl..</text>
+</g>
+<g >
+<title>__GI___mmap (2 calls, 0.56%)</title><rect x="578.5" y="485" width="6.6" height="15.0" fill="rgb(0,211,197)" rx="2" ry="2" />
+<text  x="581.52" y="495.5" ></text>
+</g>
+<g >
+<title>Thread_start_d043f016dd75eb113f895de55f2e129bad1ee51a (3 calls, 0.84%)</title><rect x="578.5" y="629" width="9.9" height="15.0" fill="rgb(0,221,76)" rx="2" ry="2" />
+<text  x="581.52" y="639.5" ></text>
+</g>
+<g >
+<title>AbstractCommittedMemoryProvider_allocate_918a0ef631252cb78d29dd03c08dbccf83223158 (132 calls, 36.97%)</title><rect x="730.6" y="485" width="436.3" height="15.0" fill="rgb(0,198,26)" rx="2" ry="2" />
+<text  x="733.56" y="495.5" >AbstractCommittedMemoryProvider_allocate_918a0ef631252cb78d..</text>
+</g>
+<g >
+<title>Files_createDirectory_b1fb5c8cf54dd2762581b9f6358ec69ea7ff48b1 (1 calls, 0.28%)</title><rect x="618.2" y="373" width="3.3" height="15.0" fill="rgb(0,204,73)" rx="2" ry="2" />
+<text  x="621.18" y="383.5" ></text>
+</g>
+<g >
+<title>__GI_munmap (1 calls, 0.28%)</title><rect x="46.4" y="661" width="3.3" height="15.0" fill="rgb(0,221,55)" rx="2" ry="2" />
+<text  x="49.36" y="671.5" ></text>
+</g>
+<g >
+<title>ConfigMappingLoader_configMappingObject_76e5756678d1387dee802f0e056dd05c8b1ab174 (3 calls, 0.84%)</title><rect x="608.3" y="437" width="9.9" height="15.0" fill="rgb(0,234,6)" rx="2" ry="2" />
+<text  x="611.26" y="447.5" ></text>
+</g>
+<g >
+<title>__munmap (1 calls, 0.28%)</title><rect x="1186.7" y="85" width="3.3" height="15.0" fill="rgb(0,227,166)" rx="2" ry="2" />
+<text  x="1189.69" y="95.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (21 calls, 5.88%)</title><rect x="562.0" y="693" width="69.4" height="15.0" fill="rgb(0,203,56)" rx="2" ry="2" />
+<text  x="564.99" y="703.5" >__libc_..</text>
+</g>
+<g >
+<title>ReflectionAccessorHolder_6256dc01c62b83584a91b273ee44253b3b9604aa_bf8df2d0d29dfaf972778a55a7fbe38b4f750068 (3 calls, 0.84%)</title><rect x="608.3" y="405" width="9.9" height="15.0" fill="rgb(0,200,191)" rx="2" ry="2" />
+<text  x="611.26" y="415.5" ></text>
+</g>
+<g >
+<title>HashMap_put_984cd2450422ab28c8fd057c8fadb18b9b383f84 (3 calls, 0.84%)</title><rect x="608.3" y="149" width="9.9" height="15.0" fill="rgb(0,232,181)" rx="2" ry="2" />
+<text  x="611.26" y="159.5" ></text>
+</g>
+<g >
+<title>mmap (3 calls, 0.84%)</title><rect x="720.6" y="693" width="10.0" height="15.0" fill="rgb(0,222,53)" rx="2" ry="2" />
+<text  x="723.64" y="703.5" ></text>
+</g>
+<g >
+<title>HeapChunkProvider_produceAlignedChunk_8214fff9e22061bbd4db5fe049c9b41ab0d75e2a (132 calls, 36.97%)</title><rect x="730.6" y="501" width="436.3" height="15.0" fill="rgb(0,213,103)" rx="2" ry="2" />
+<text  x="733.56" y="511.5" >HeapChunkProvider_produceAlignedChunk_8214fff9e22061bbd4db5..</text>
+</g>
+<g >
+<title>JavaMainWrapper_doRun_befa12b002bb2c4ede2c3e72011cc12e1c7fe82a (21 calls, 5.88%)</title><rect x="562.0" y="661" width="69.4" height="15.0" fill="rgb(0,224,186)" rx="2" ry="2" />
+<text  x="564.99" y="671.5" >JavaMai..</text>
+</g>
+<g >
+<title>inuxImageHeapProvider_initialize_510ae54f9ab8dc090d945c5725154e9693a448d7 (5 calls, 1.40%)</title><rect x="562.0" y="613" width="16.5" height="15.0" fill="rgb(0,220,170)" rx="2" ry="2" />
+<text  x="564.99" y="623.5" ></text>
+</g>
+<g >
+<title>VertxCoreRecorder$VertxSupplier_get_933aa744d9166b784d03d36421df70bdd55027d1 (4 calls, 1.12%)</title><rect x="618.2" y="517" width="13.2" height="15.0" fill="rgb(0,223,139)" rx="2" ry="2" />
+<text  x="621.18" y="527.5" ></text>
+</g>
+<g >
+<title>RelocateConfigSourceInterceptor_getValue_50c035a42df6b98cdced39f216d477221493c2cb (3 calls, 0.84%)</title><rect x="598.3" y="405" width="10.0" height="15.0" fill="rgb(0,215,118)" rx="2" ry="2" />
+<text  x="601.35" y="415.5" ></text>
+</g>
+<g >
+<title>__munmap (1 calls, 0.28%)</title><rect x="595.0" y="213" width="3.3" height="15.0" fill="rgb(0,219,156)" rx="2" ry="2" />
+<text  x="598.04" y="223.5" ></text>
+</g>
+<g >
+<title>SingleThreadEventExecutor$4_run_55ca2f6230c9e9c71b0a140297234caeb45faec4 (3 calls, 0.84%)</title><rect x="1180.1" y="581" width="9.9" height="15.0" fill="rgb(0,208,175)" rx="2" ry="2" />
+<text  x="1183.08" y="591.5" ></text>
+</g>
+<g >
+<title>JavaMainWrapper_runCore0_030cf55ee73b0e1076836b52cdbbde2ffc0c5232 (13 calls, 3.64%)</title><rect x="588.4" y="645" width="43.0" height="15.0" fill="rgb(0,212,173)" rx="2" ry="2" />
+<text  x="591.43" y="655.5" >Java..</text>
+</g>
+<g >
+<title>PropertyNamesConfigSourceInterceptor_getValue_d99be0b2e4266ece5d90f1f41fb0b29593c87bad (3 calls, 0.84%)</title><rect x="588.4" y="501" width="9.9" height="15.0" fill="rgb(0,209,172)" rx="2" ry="2" />
+<text  x="591.43" y="511.5" ></text>
+</g>
+<g >
+<title>__GI_mprotect (4 calls, 1.12%)</title><rect x="49.7" y="645" width="13.2" height="15.0" fill="rgb(0,207,116)" rx="2" ry="2" />
+<text  x="52.66" y="655.5" ></text>
+</g>
+<g >
+<title>SmallRyeConfig_getConfigValue_8d86ddc1578d21549243d3667c0063e0133f9cfc (3 calls, 0.84%)</title><rect x="598.3" y="517" width="10.0" height="15.0" fill="rgb(0,208,118)" rx="2" ry="2" />
+<text  x="601.35" y="527.5" ></text>
+</g>
+<g >
+<title>AbstractCommittedMemoryProvider_allocate_918a0ef631252cb78d29dd03c08dbccf83223158 (3 calls, 0.84%)</title><rect x="588.4" y="229" width="9.9" height="15.0" fill="rgb(0,221,80)" rx="2" ry="2" />
+<text  x="591.43" y="239.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewInstanceWithoutAllocating_cb30e26c12ff20c032edd4d7b692136d8122fa75 (3 calls, 0.84%)</title><rect x="1180.1" y="133" width="9.9" height="15.0" fill="rgb(0,199,68)" rx="2" ry="2" />
+<text  x="1183.08" y="143.5" ></text>
+</g>
+<g >
+<title>AbstractMappingConfigSourceInterceptor_iterateNames_50b0798cb191224bc5227c7d0ebbc9a169f568a9 (3 calls, 0.84%)</title><rect x="608.3" y="181" width="9.9" height="15.0" fill="rgb(0,202,106)" rx="2" ry="2" />
+<text  x="611.26" y="191.5" ></text>
+</g>
+<g >
+<title>TCPServerBase_listen_d08a3266674118921442d3aa2715f5853a65d159 (3 calls, 0.84%)</title><rect x="1180.1" y="357" width="9.9" height="15.0" fill="rgb(0,228,56)" rx="2" ry="2" />
+<text  x="1183.08" y="367.5" ></text>
+</g>
+<g >
+<title>__GI___mmap (2 calls, 0.56%)</title><rect x="608.3" y="37" width="6.6" height="15.0" fill="rgb(0,234,129)" rx="2" ry="2" />
+<text  x="611.26" y="47.5" ></text>
+</g>
+<g >
+<title>AbstractCommittedMemoryProvider_allocate_918a0ef631252cb78d29dd03c08dbccf83223158 (3 calls, 0.84%)</title><rect x="1180.1" y="101" width="9.9" height="15.0" fill="rgb(0,206,121)" rx="2" ry="2" />
+<text  x="1183.08" y="111.5" ></text>
+</g>
+<g >
+<title>ThreadLocalAllocation_slowPathNewArray_14bf8d109c130a0ddaaade0f47cdc765ff19c6ba (132 calls, 36.97%)</title><rect x="730.6" y="549" width="436.3" height="15.0" fill="rgb(0,234,36)" rx="2" ry="2" />
+<text  x="733.56" y="559.5" >ThreadLocalAllocation_slowPathNewArray_14bf8d109c130a0ddaaa..</text>
+</g>
+<g >
+<title>PooledByteBufAllocator_constructor_fe6e8f4d19a6c7f347960676322b49494f13d288 (3 calls, 0.84%)</title><rect x="1180.1" y="181" width="9.9" height="15.0" fill="rgb(0,216,199)" rx="2" ry="2" />
+<text  x="1183.08" y="191.5" ></text>
+</g>
+<g >
+<title>DefaultsConfigSource_getValue_2c35a1835dc46ec608999766aa57680c372e6336 (3 calls, 0.84%)</title><rect x="598.3" y="293" width="10.0" height="15.0" fill="rgb(0,220,41)" rx="2" ry="2" />
+<text  x="601.35" y="303.5" ></text>
+</g>
+<g >
+<title>Thread_run_857ee078f8137062fcf27275732adf5c4870652a (3 calls, 0.84%)</title><rect x="1180.1" y="629" width="9.9" height="15.0" fill="rgb(0,196,115)" rx="2" ry="2" />
+<text  x="1183.08" y="639.5" ></text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_slowPathMonitorEnter_e2610e5fc63d7e5bc9ffcb61611428ac43f22ac8 (3 calls, 0.84%)</title><rect x="578.5" y="613" width="9.9" height="15.0" fill="rgb(0,215,2)" rx="2" ry="2" />
+<text  x="581.52" y="623.5" ></text>
+</g>
+<g >
+<title>VertxHttpProcessor$preinitializeRouter1141331088_deploy_0_eb454017235d0c767bf7a14871e6f0a7102409c7 (4 calls, 1.12%)</title><rect x="618.2" y="565" width="13.2" height="15.0" fill="rgb(0,195,208)" rx="2" ry="2" />
+<text  x="621.18" y="575.5" ></text>
+</g>
+<g >
+<title>__munmap (58 calls, 16.25%)</title><rect x="975.2" y="469" width="191.7" height="15.0" fill="rgb(0,236,40)" rx="2" ry="2" />
+<text  x="978.15" y="479.5" >__munmap</text>
+</g>
+<g >
+<title>FallbackConfigSourceInterceptor_getValue_72258817427828e12e02ce243a835f8f485a162e (3 calls, 0.84%)</title><rect x="598.3" y="485" width="10.0" height="15.0" fill="rgb(0,232,82)" rx="2" ry="2" />
+<text  x="601.35" y="495.5" ></text>
+</g>
+<g >
+<title>AbstractCommittedMemoryProvider_allocate_918a0ef631252cb78d29dd03c08dbccf83223158 (3 calls, 0.84%)</title><rect x="578.5" y="501" width="9.9" height="15.0" fill="rgb(0,195,25)" rx="2" ry="2" />
+<text  x="581.52" y="511.5" ></text>
+</g>
+<g >
+<title>SmallRyeConfig_getIndexedOptionalValues_cbdf38fc345f76c94455be90cb6735a1a756baa2 (3 calls, 0.84%)</title><rect x="608.3" y="341" width="9.9" height="15.0" fill="rgb(0,190,29)" rx="2" ry="2" />
+<text  x="611.26" y="351.5" ></text>
+</g>
+<g >
+<title>mmap (10 calls, 2.80%)</title><rect x="13.3" y="661" width="33.1" height="15.0" fill="rgb(0,215,21)" rx="2" ry="2" />
+<text  x="16.31" y="671.5" >mmap</text>
+</g>
+<g >
+<title>MultiThreadedMonitorSupport_monitorEnter_363f659f4868cc5cda0e2f97a84504c1b541a8a4 (3 calls, 0.84%)</title><rect x="578.5" y="597" width="9.9" height="15.0" fill="rgb(0,224,53)" rx="2" ry="2" />
+<text  x="581.52" y="607.5" ></text>
+</g>
+<g >
+<title>CEntryPointSnippets_initializeIsolate_30d4137bea42ce60ee1e88f09a09cc0d089fe0c8 (3 calls, 0.84%)</title><rect x="578.5" y="645" width="9.9" height="15.0" fill="rgb(0,213,5)" rx="2" ry="2" />
+<text  x="581.52" y="655.5" ></text>
+</g>
+<g >
+<title>FutureImpl$3_onSuccess_91f01e9dafdfb1042b65fbdbf5df068fcd9c243b (3 calls, 0.84%)</title><rect x="1180.1" y="277" width="9.9" height="15.0" fill="rgb(0,231,171)" rx="2" ry="2" />
+<text  x="1183.08" y="287.5" ></text>
+</g>
+<g >
+<title>mkdir (1 calls, 0.28%)</title><rect x="618.2" y="309" width="3.3" height="15.0" fill="rgb(0,196,109)" rx="2" ry="2" />
+<text  x="621.18" y="319.5" ></text>
+</g>
+<g >
+<title>Transport_eventLoopGroup_ee4a3052dc2152541ce73463072570ddd5994765 (3 calls, 0.84%)</title><rect x="621.5" y="453" width="9.9" height="15.0" fill="rgb(0,229,60)" rx="2" ry="2" />
+<text  x="624.48" y="463.5" ></text>
+</g>
+<g >
+<title>start_thread (139 calls, 38.94%)</title><rect x="730.6" y="693" width="459.4" height="15.0" fill="rgb(0,206,115)" rx="2" ry="2" />
+<text  x="733.56" y="703.5" >start_thread</text>
+</g>
+<g >
+<title>ThreadExecutorMap$2_run_2b5e655e3cf03c9d20e895e720c63196ee62187d (3 calls, 0.84%)</title><rect x="1180.1" y="597" width="9.9" height="15.0" fill="rgb(0,223,126)" rx="2" ry="2" />
+<text  x="1183.08" y="607.5" ></text>
+</g>
+<g >
+<title>FastThreadLocalRunnable_run_9c72fc59d8dca3ed4c2dca7c625b2ae94e3d3388 (3 calls, 0.84%)</title><rect x="1180.1" y="613" width="9.9" height="15.0" fill="rgb(0,210,3)" rx="2" ry="2" />
+<text  x="1183.08" y="623.5" ></text>
+</g>
+<g >
+<title>DefaultsConfigSource_getValue_2c35a1835dc46ec608999766aa57680c372e6336 (3 calls, 0.84%)</title><rect x="588.4" y="309" width="9.9" height="15.0" fill="rgb(0,190,55)" rx="2" ry="2" />
+<text  x="591.43" y="319.5" ></text>
+</g>
+<g >
+<title>AbstractMappingConfigSourceInterceptor_iterateNames_50b0798cb191224bc5227c7d0ebbc9a169f568a9 (3 calls, 0.84%)</title><rect x="608.3" y="197" width="9.9" height="15.0" fill="rgb(0,219,12)" rx="2" ry="2" />
+<text  x="611.26" y="207.5" ></text>
+</g>
+<g >
+<title>HeapChunkProvider_produceAlignedChunk_8214fff9e22061bbd4db5fe049c9b41ab0d75e2a (3 calls, 0.84%)</title><rect x="598.3" y="149" width="10.0" height="15.0" fill="rgb(0,195,126)" rx="2" ry="2" />
+<text  x="601.35" y="159.5" ></text>
+</g>
+<g >
+<title>DeploymentManager_lambda$doDeploy$5_41aafaf9f05b584f980dea2270ed9b50d3994588 (3 calls, 0.84%)</title><rect x="1180.1" y="469" width="9.9" height="15.0" fill="rgb(0,222,59)" rx="2" ry="2" />
+<text  x="1183.08" y="479.5" ></text>
+</g>
+<g >
+<title>MultithreadEventExecutorGroup_constructor_7ff0062598de99aac4b3b44439aa0eba0a2843f1 (3 calls, 0.84%)</title><rect x="621.5" y="421" width="9.9" height="15.0" fill="rgb(0,209,145)" rx="2" ry="2" />
+<text  x="624.48" y="431.5" ></text>
+</g>
+<g >
+<title>PosixPlatformThreads_setNativeName_e3d6a51d7eb4851a9193a711a6469a8b3462db9c (136 calls, 38.10%)</title><rect x="730.6" y="613" width="449.5" height="15.0" fill="rgb(0,193,93)" rx="2" ry="2" />
+<text  x="733.56" y="623.5" >PosixPlatformThreads_setNativeName_e3d6a51d7eb4851a9193a711a6..</text>
+</g>
+<g >
+<title>ApplicationLifecycleManager_run_d5cb017ad26675ebbd7be504099501fde301d161 (13 calls, 3.64%)</title><rect x="588.4" y="613" width="43.0" height="15.0" fill="rgb(0,194,100)" rx="2" ry="2" />
+<text  x="591.43" y="623.5" >Appl..</text>
+</g>
+<g >
+<title>FactoryMethodHolder_JaxRsSecurityConfig273591402Impl_constructor_ff75bab6f72c71aa4a9e391d9d99d64a4668643b_1e3beab63da26126c1e55f310422226126e11283 (3 calls, 0.84%)</title><rect x="608.3" y="389" width="9.9" height="15.0" fill="rgb(0,221,154)" rx="2" ry="2" />
+<text  x="611.26" y="399.5" ></text>
+</g>
+<g >
+<title>FileResolverImpl_constructor_d160e21dbc6c6024cccf062b56559e13aa6c76ac (1 calls, 0.28%)</title><rect x="618.2" y="453" width="3.3" height="15.0" fill="rgb(0,198,178)" rx="2" ry="2" />
+<text  x="621.18" y="463.5" ></text>
+</g>
+</g>
+</svg>

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -153,6 +153,257 @@ $ quarkus-project-0.1-SNAPSHOT-runner -XX:PrintFlags=
   -XX:±VerboseGC                               Print more information about the heap before and after each collection. Default: - (disabled).
 ----
 
+[[rss]]
+=== Resident Set Size (RSS)
+
+As described in the
+xref:performance-measure.adoc[Measuring Performance guide],
+the footprint of Quarkus applications is measured using the resident set size (RSS).
+This is also applicable to native applications,
+but the runtime engine that manages the footprint is GraalVM rather than the JVM.
+
+The reporting techniques specified in the
+xref:performance-measure.adoc[Measuring Performance guide]
+are applicable to native applications too,
+but what causes the RSS to be higher or lower is specific to how GraalVM works.
+
+When the RSS is higher in one version of the application versus another,
+the following checks should be carried out first:
+
+* Check the <<native-reports,native build time reports>>
+and see if there are big discrepancies in the number of used packages, used classes or used methods.
+A bigger universe will result in bigger memory footprint.
+* Check the size of the binary for differences.
+Using `readelf` you can observe the size of different sections and compare them.
+The `.text` section where code lives,
+and the `.svm_heap` section where heap produced at build time lives,
+are particularly interesting.
+* Generate <<heap-dumps,heap dumps>> and inspect them with tools such as VisualVM or Eclipse MAT.
+
+Often profiling, instrumenting or tracing applications is the best way to figure out how things work.
+In the case of RSS and native applications,
+the techniques that Brendan Gregg explains in the
+https://www.brendangregg.com/FlameGraphs/memoryflamegraphs.html["Memory Leak (and Growth) Flame Graphs"] guide are particularly useful.
+This section uses the bcc/eBPF method since this is available in the Linux kernel in use for the tests.
+
+To see these in action, these techniques will be applied to the startup of Quarkus native executables.
+To capture all system calls that happen on startup,
+generate native executables with debug info,
+symbols and preserve the frame pointer:
+
+[source,bash]
+----
+$ ./mvnw package -DskipTests -Dnative \
+    -Dquarkus.native.debug.enabled \
+    -Dquarkus.native.additional-build-args=-H:-DeleteLocalSymbols,-H:+PreserveFramePointer
+----
+
+As a first step, let's measure how much RSS a native executables takes on startup:
+
+[source,bash]
+----
+$ ps -o pid,rss,command -p $(pidof quarkus-project-1.0.0-SNAPSHOT-runner)
+    PID   RSS COMMAND
+   6441 37176 ./target/quarkus-project-1.0.0-SNAPSHOT-runner
+----
+
+The aim of this execercise is to capture all the relevant information from the very first instruction.
+One way to achieve this is by running the native executable with `gdb` and instructing it to stop at the very first instruction.
+Once stopped, fire up the bcc/eBPF tracer and then request `gdb` complete the startup.
+So, let's start by running the native executable via `gdb`:
+
+[source,bash]
+----
+$ gdb ./target/quarkus-project-1.0.0-SNAPSHOT-runner
+...
+Reading symbols from ./target/quarkus-project-1.0.0-SNAPSHOT-runner...
+Reading symbols from <...>/quarkus-project/target/quarkus-project-1.0.0-SNAPSHOT-runner.debug...
+----
+
+`starti` is a `gdb` command that sets a temporary breakpoint at the very first instruction of the program's execution.
+This command is well suited for this scenario:
+
+[source,bash]
+----
+(gdb) starti
+Starting program: <...>/quarkus-project/target/quarkus-project-1.0.0-SNAPSHOT-runner
+Program stopped.
+0x00007ffff7fe4790 in _start () from /lib64/ld-linux-x86-64.so.2
+----
+
+Next invoke bcc/eBPF `stackcount` to trace a particular system call that is relevant for RSS and capture stack traces.
+`mmap` and `munmap` are interesting because of how GraalVM allocates heap.
+The very first time a thread allocates something,
+it will request a heap chunk that it will use exclusively until it has run out of space in that chunk,
+in which case it will request another heap chunk.
+So by tracing these system calls,
+the code paths that end up requesting new heap chunks will be recorded.
+
+[source,bash]
+----
+$ sudo /usr/share/bcc/tools/stackcount -P -p $(pidof quarkus-project-1.0.0-SNAPSHOT-runner) -U "t:syscalls:sys_enter_m*"
+Tracing 36 functions for "t:syscalls:sys_enter_m*"... Hit Ctrl-C to end.
+----
+
+Then go back to the `gdb` shell and instruct it to continue the startup procedure after hitting the first instruction:
+
+[source,bash]
+----
+(gdb) continue
+Continuing.
+[Thread debugging using libthread_db enabled]
+Using host libthread_db library "/lib64/libthread_db.so.1".
+[New Thread 0x7ffff65ff6c0 (LWP 7049)]
+...
+[Thread 0x7ffff4dff6c0 (LWP 7051) exited]
+...
+__  ____  __  _____   ___  __ ____  ______
+ --/ __ \/ / / / _ | / _ \/ //_/ / / / __/
+ -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \
+--\___\_\____/_/ |_/_/|_/_/|_|\____/___/
+2023-02-06 10:22:46,607 INFO  [io.quarkus] (main) quarkus-project 1.0.0-SNAPSHOT native (powered by Quarkus 2.16.1.Final) started in 0.020s. Listening on: http://0.0.0.0:8080
+2023-02-06 10:22:46,608 INFO  [io.quarkus] (main) Profile prod activated.
+2023-02-06 10:22:46,608 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy-reactive, smallrye-context-propagation, vertx]
+----
+
+Once the startup has complete,
+press `Ctrl-C` on the `stackcount` shell and the stack traces should appear:
+
+[source,bash]
+----
+$ sudo /usr/share/bcc/tools/stackcount -P -p $(pidof quarkus-project-1.0.0-SNAPSHOT-runner) -U "t:syscalls:sys_enter_m*"
+Tracing 36 functions for "t:syscalls:sys_enter_m*"... Hit Ctrl-C to end.
+^C
+  __GI___mmap
+  AbstractCommittedMemoryProvider_allocate_918a0ef631252cb78d29dd03c08dbccf83223158
+  HeapChunkProvider_produceAlignedChunk_8214fff9e22061bbd4db5fe049c9b41ab0d75e2a
+  ThreadLocalAllocation_slowPathNewInstanceWithoutAllocating_cb30e26c12ff20c032edd4d7b692136d8122fa75
+  ThreadLocalAllocation_slowPathNewInstance_1ecc2a4758346549b4d5779d3ae68d61340736a4
+  StringLatin1_newString_737b8b7723fc21def120d47219c87491aa1f9ab3
+  StringBuilder_toString_fff5cf8f9838ca54b87be4fc46d795a7c0e01bd4
+  NameIterator_getNextSegment_8cc5f31df88d30d5785134d7b4ebaf7ea862f699
+  KeyMap_find_77bfa563bc84c3bcf95d4902f01d509fa85842dc
+  KeyMap_findRootValue_f55e492e81fa59260539cebfa004d31b057317a9
+  KeyMap_findRootValue_4348ed9ff28c4ecb3bba4f5fff255576bddeadee
+  DefaultsConfigSource_getValue_2c35a1835dc46ec608999766aa57680c372e6336
+  DisableableConfigSource_getValue_dd5a8f83e536a33a29fad8b80f41d623e9a627fd
+  ConfigValueConfigSourceWrapper_getConfigValue_09608a4de7dcb70ca60951dc60776caaab137eac
+  SmallRyeConfigSources_getValue_c683de82362e3215d4c2d292eb27ed717a72cad1
+  SecretKeysConfigSourceInterceptor_getValue_1184f5122352f2b0feb14cd2df23e0ead560cd53
+  RelocateConfigSourceInterceptor_getValue_50c035a42df6b98cdced39f216d477221493c2cb
+  RelocateConfigSourceInterceptor_getValue_50c035a42df6b98cdced39f216d477221493c2cb
+  RelocateConfigSourceInterceptor_getValue_50c035a42df6b98cdced39f216d477221493c2cb
+  ProfileConfigSourceInterceptor_getProfileValue_4b45309e0a1ab1f119fa918ab18ac8332949a106
+  ProfileConfigSourceInterceptor_getValue_e2ac71ac64266bd94f4c5091c0183f4a72e2ad33
+  ExpressionConfigSourceInterceptor_getValue_563933897d47fd84b3c2fc72001e673c1cc0c547
+  ExpressionConfigSourceInterceptor_getValue_88007ff8463db20d2a117bfbea146ce16259df0d
+  FallbackConfigSourceInterceptor_getValue_72258817427828e12e02ce243a835f8f485a162e
+  PropertyNamesConfigSourceInterceptor_getValue_d99be0b2e4266ece5d90f1f41fb0b29593c87bad
+  SmallRyeConfig_getConfigValue_8d86ddc1578d21549243d3667c0063e0133f9cfc
+  SmallRyeConfig_getValue_a16f787491eb4416549c0049336d17fca3ca0136
+  Config_initGroup$io$quarkus$vertx$http$runtime$HttpConfiguration_96d0475789c066c0346fee172bb251d464d5a408
+  Config_readConfig_a68a1a88a9311bdfd87db5b1080709177ec73023
+  ApplicationImpl_doStart_4f75ecc76b43645d5297b6092848747808c532c7
+  Application_start_f0300884f5c38b6448504f5177e19dff60a47b71
+  ApplicationLifecycleManager_run_d5cb017ad26675ebbd7be504099501fde301d161
+  Quarkus_run_7b200c41008a3c5f18cd42d608d602b518bc6c94
+  JavaMainWrapper_runCore0_030cf55ee73b0e1076836b52cdbbde2ffc0c5232
+  JavaMainWrapper_doRun_befa12b002bb2c4ede2c3e72011cc12e1c7fe82a
+  main
+  __libc_start_call_main
+    1
+...
+----
+
+[TIP]
+====
+Because bcc/eBPF captures all system calls that match the desired pattern,
+some math can be applied to calculate the number of calls made and see if that matches the expectations.
+====
+
+Combining the previous step with
+https://github.com/brendangregg/FlameGraph[flamegraph] generation provides optimal visualization:
+
+[source,bash]
+----
+$ sudo /usr/share/bcc/tools/stackcount -P -p $(pidof quarkus-project-1.0.0-SNAPSHOT-runner) -U "t:syscalls:sys_enter_m*" > mmap-munmap.stacks
+$ export FG_HOME=...
+$ ${FG_HOME}/stackcollapse.pl mmap-munmap.stacks | ${FG_HOME}/flamegraph.pl --color=mem --title="mmap/munmap Flame Graph" --countname="calls" > mmap-munmap.svg
+----
+
+The resulting flamegraph has a couple of interesting areas:
+
+image::mmap-munmap.svg[mmap/munmap flamegraph]
+
+The biggest area in our environment is the one on the right hand side under `start_thread`.
+There are several things of interest to notice there:
+
+* A lot of threads are starting up by default in this system.
+  That's normal because the environment has 32 cores,
+  and the default Vert.x/Netty behaviour is to create as many threads as cores.
+  There are other threads aside from those.
+* All threads, upon first allocation, use the thread local chunk allocation logic to get an aligned heap chunk.
+  The very first allocation for the majority of the threads involves taking the thread name and trimming it so that it can fall within the 15 character limit enforced by kernels.
+* There are both `mmap` and `munmap` calls.
+  To rationale for these calls is embedded within the GraalVM source code,
+  but to summarise:
+  ** There are 2 `mmap` calls for each allocated chunk,
+      one to reserve and one to commit.
+  ** When calculating the size to reserve,
+     the requested size to allocate can be rounded up to the page size.
+     The maintain alignment some of the reserved memory might be unreserved.
+     That is where the `munmap` calls are coming from.
+* The default size of aligned heap chunks is 1MB.
+  Hence, knowing the amount of `mmap` calls can give us an estimate of the amount of memory allocated heap chunks take.
+
+The other area of interest is the one under `__libc_start_call_main`.
+Here the stack traces on the `main` thread that trigger new heap chunks can be observerd.
+It's important to understand that these stack traces do not necessarily point to hotspots,
+but they indicate paths that in this particular run trigger new heap chunk allocations.
+So, the stack traces can vary slightly from one run to another.
+Nevertheless, these stack traces can be still be useful when comparing multiple Quarkus versions,
+and see if there has been any significant changes in the shape and code executed.
+
+[NOTE]
+====
+The stack traces might lack method calls that you would normally expect to see.
+This can happen due to methods being inlined,
+which is a typical optimization in any compiled code.
+====
+
+Other patterns of interest for bcc/eBPF tracing are:
+
+* `"c:*alloc" for malloc/calloc/realloc system calls, and `"c:free"`.
+  These are also present in Quarkus native executable startup,
+  when setting Java NIO selector (e.g. epoll) or loading cgroup files.
+* `"t:exceptions:page_fault_*"` for tracking page faults.
+
+Finally, bcc/eBPF can be extended with custom scripts to track different metrics.
+For example, https://raw.githubusercontent.com/galderz/BPF-tools/topic.1202.fix-mallocstacks/old/2017-12-23/mallocstacks.py[this sample bcc tracing script]
+counts the number of bytes allocated via `malloc`,
+as opposed to the number of calls.
+Repeat the process above but instead of using bcc's `stackcount` command,
+get the script linked and execute:
+
+[source,bash]
+----
+$ sudo mallocstacks.py -p $(pidof quarkus-project-1.0.0-SNAPSHOT-runner) -f > malloc-bytes.stacks
+----
+
+The stacks generated by this script are already collapsed,
+so the flamegraph can be generated just like this:
+
+[source,bash]
+----
+$ cat malloc-bytes.stacks | ${FG_HOME}/flamegraph.pl --color=mem --title="malloc bytes Flame Graph" --countname="bytes" > malloc-bytes.svg
+----
+
+The flamegraph that reports allocated malloc bytes looks like this:
+
+image::malloc-bytes.svg[malloc bytes flamegraph]
+
+This shows that the biggest contributor to memory requested via `malloc` is NIO/epoll.
+
 [[inspecting-and-debugging]]
 == Inspecting and Debugging Native Executables
 This debugging guide provides further details on debugging issues in Quarkus native executables that might arise during development or production.
@@ -1643,6 +1894,7 @@ com.oracle.svm.core.VM=GraalVM 22.0.0.2-Final Java 11 Mandrel Distribution
 
 See <<gc-logging,Native Memory Management GC Logging section>> for details.
 
+[[heap-dumps]]
 === Can I get a heap dump of a native executable? e.g. if it runs out of memory
 
 Starting with GraalVM 22.2.0 it is possible to create heap dumps upon request,

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -345,7 +345,7 @@ There are several things of interest to notice there:
 * All threads, upon first allocation, use the thread local chunk allocation logic to get an aligned heap chunk.
   The very first allocation for the majority of the threads involves taking the thread name and trimming it so that it can fall within the 15 character limit enforced by kernels.
 * There are both `mmap` and `munmap` calls.
-  To rationale for these calls is embedded within the GraalVM source code,
+  The rationale for these calls is embedded within the GraalVM source code,
   but to summarise:
   ** There are 2 `mmap` calls for each allocated chunk,
       one to reserve and one to commit.


### PR DESCRIPTION
Distilling steps and techniques used in [this native startup RSS regression](https://issues.redhat.com/browse/QUARKUS-2456).