### PR TITLE
Backport to 2.16: Upgrade to Hibernate ORM 5.6.15.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -91,7 +91,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>5.6.14.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
+        <hibernate-orm.version>5.6.15.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
         <bytebuddy.version>1.12.18</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>1.1.9.Final</hibernate-reactive.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/LazyBasicDefaultGroupTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/LazyBasicDefaultGroupTest.java
@@ -25,7 +25,9 @@ public class LazyBasicDefaultGroupTest extends AbstractLazyBasicTest {
                     .addClass(MyEntity.class)
                     .addClass(AccessDelegate.class)
                     .addClass(AccessDelegateImpl.class))
-            .withConfigurationResource("application.properties");
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.hibernate-orm.unsupported-properties.\"hibernate.session_factory.statement_inspector\"",
+                    StatementSpy.class.getName());
 
     public LazyBasicDefaultGroupTest() {
         super(new AccessDelegateImpl());

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/LazyBasicMultiNonDefaultGroupTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/LazyBasicMultiNonDefaultGroupTest.java
@@ -26,7 +26,9 @@ public class LazyBasicMultiNonDefaultGroupTest extends AbstractLazyBasicTest {
                     .addClass(MyEntity.class)
                     .addClass(AccessDelegate.class)
                     .addClass(AccessDelegateImpl.class))
-            .withConfigurationResource("application.properties");
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.hibernate-orm.unsupported-properties.\"hibernate.session_factory.statement_inspector\"",
+                    StatementSpy.class.getName());
 
     public LazyBasicMultiNonDefaultGroupTest() {
         super(new AccessDelegateImpl());

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/LazyBasicNonDefaultGroupTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/LazyBasicNonDefaultGroupTest.java
@@ -26,7 +26,9 @@ public class LazyBasicNonDefaultGroupTest extends AbstractLazyBasicTest {
                     .addClass(MyEntity.class)
                     .addClass(AccessDelegate.class)
                     .addClass(AccessDelegateImpl.class))
-            .withConfigurationResource("application.properties");
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.hibernate-orm.unsupported-properties.\"hibernate.session_factory.statement_inspector\"",
+                    StatementSpy.class.getName());
 
     public LazyBasicNonDefaultGroupTest() {
         super(new AccessDelegateImpl());


### PR DESCRIPTION
Backport of #30946 to branch 2.16.

The tests are slightly different because in 2.16 we can't use features introduced by #30640 (which was merged into 3.0 only).

Release notes for ORM 5.6.15.Final: https://in.relation.to/2023/02/06/hibernate-orm-5615-final/