### PR TITLE
Return text from /q/metrics when the Accept header contains html

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/handlers/PrometheusHandler.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/export/handlers/PrometheusHandler.java
@@ -52,7 +52,7 @@ public class PrometheusHandler implements Handler<RoutingContext> {
         if (acceptHeader == null) {
             return TextFormat.CONTENT_TYPE_OPENMETRICS_100;
         }
-        if (acceptHeader.startsWith("text/plain")) {
+        if (acceptHeader.contains("text/plain") || acceptHeader.contains("text/html")) {
             return TextFormat.CONTENT_TYPE_004;
         }
         return TextFormat.CONTENT_TYPE_OPENMETRICS_100;


### PR DESCRIPTION
This makes the endpoint more friendly for browsers

See: https://quarkusio.zulipchat.com/#narrow/stream/187030-users

P.S. At some point we might need more sophisticated header negotiation (like JAX-RS does), but we'll see :)