### PR TITLE
Add ConfigMappings from a builder class to support full hot reload

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -403,11 +403,6 @@ public final class RunTimeConfigurationGenerator {
                 clinit.invokeStaticMethod(CU_ADD_SOURCE_FACTORY_PROVIDER, buildTimeBuilder,
                         clinit.newInstance(RCSF_NEW, clinit.load(discoveredConfigSourceFactory)));
             }
-            // add mappings
-            for (ConfigClassWithPrefix configMapping : staticConfigMappings) {
-                clinit.invokeStaticMethod(CU_WITH_MAPPING, buildTimeBuilder,
-                        clinit.load(configMapping.getKlass().getName()), clinit.load(configMapping.getPrefix()));
-            }
 
             // additional config builders
             ResultHandle configBuilders = clinit.newInstance(AL_NEW);
@@ -468,11 +463,12 @@ public final class RunTimeConfigurationGenerator {
                     reinit.invokeStaticMethod(CU_ADD_SOURCE_FACTORY_PROVIDER, buildTimeBuilder,
                             reinit.newInstance(RCSF_NEW, reinit.load(discoveredConfigSourceFactory)));
                 }
-                // add mappings
-                for (ConfigClassWithPrefix configMapping : staticConfigMappings) {
-                    reinit.invokeStaticMethod(CU_WITH_MAPPING, buildTimeBuilder,
-                            reinit.load(configMapping.getKlass().getName()), reinit.load(configMapping.getPrefix()));
+                // additional config builders
+                ResultHandle configBuilders = reinit.newInstance(AL_NEW);
+                for (String configBuilder : staticConfigBuilders) {
+                    reinit.invokeVirtualMethod(AL_ADD, configBuilders, reinit.load(configBuilder));
                 }
+                reinit.invokeStaticMethod(CU_CONFIG_BUILDER_LIST, buildTimeBuilder, configBuilders);
 
                 ResultHandle clinitConfig = reinit.checkCast(reinit.invokeVirtualMethod(SRCB_BUILD, buildTimeBuilder),
                         SmallRyeConfig.class);
@@ -554,12 +550,6 @@ public final class RunTimeConfigurationGenerator {
                 for (String discoveredConfigSourceFactory : staticConfigSourceFactories) {
                     readBootstrapConfig.invokeStaticMethod(CU_ADD_SOURCE_FACTORY_PROVIDER, bootstrapBuilder,
                             readBootstrapConfig.newInstance(RCSF_NEW, readBootstrapConfig.load(discoveredConfigSourceFactory)));
-                }
-                // add bootstrap mappings
-                for (ConfigClassWithPrefix configMapping : staticConfigMappings) {
-                    readBootstrapConfig.invokeStaticMethod(CU_WITH_MAPPING, bootstrapBuilder,
-                            readBootstrapConfig.load(configMapping.getKlass().getName()),
-                            readBootstrapConfig.load(configMapping.getPrefix()));
                 }
 
                 // add bootstrap config builders
@@ -647,12 +637,6 @@ public final class RunTimeConfigurationGenerator {
             for (String discoveredConfigSourceFactory : runtimeConfigSourceFactories) {
                 readConfig.invokeStaticMethod(CU_ADD_SOURCE_FACTORY_PROVIDER, runTimeBuilder,
                         readConfig.newInstance(RCSF_NEW, readConfig.load(discoveredConfigSourceFactory)));
-            }
-
-            // add mappings
-            for (ConfigClassWithPrefix configMapping : runtimeConfigMappings) {
-                readConfig.invokeStaticMethod(CU_WITH_MAPPING, runTimeBuilder,
-                        readConfig.load(configMapping.getKlass().getName()), readConfig.load(configMapping.getPrefix()));
             }
 
             // additional config builders

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -88,6 +88,10 @@ public class ConfigGenerationBuildStep {
             SmallRyeConfigBuilder.class, "withSources",
             SmallRyeConfigBuilder.class, ConfigSource[].class);
 
+    private static final MethodDescriptor WITH_MAPPING = MethodDescriptor.ofMethod(
+            SmallRyeConfigBuilder.class, "withMapping",
+            SmallRyeConfigBuilder.class, Class.class, String.class);
+
     @BuildStep
     void staticInitSources(
             BuildProducer<StaticInitConfigSourceProviderBuildItem> staticInitConfigSourceProviderBuildItem,
@@ -217,6 +221,33 @@ public class ConfigGenerationBuildStep {
         }
     }
 
+    @BuildStep
+    void builderMappings(
+            ConfigurationBuildItem configItem,
+            List<ConfigMappingBuildItem> configMappings,
+            BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<StaticInitConfigBuilderBuildItem> staticInitConfigBuilder,
+            BuildProducer<RunTimeConfigBuilderBuildItem> runTimeConfigBuilder) {
+
+        // For Static Init Config
+        Set<ConfigClassWithPrefix> staticMappings = new HashSet<>();
+        staticMappings.addAll(staticSafeConfigMappings(configMappings));
+        staticMappings.addAll(configItem.getReadResult().getBuildTimeRunTimeMappings());
+        String staticInitMappingsConfigBuilder = "io.quarkus.runtime.generated.StaticInitMappingsConfigBuilder";
+        generateMappingsConfigBuilder(generatedClass, reflectiveClass, staticInitMappingsConfigBuilder, staticMappings);
+        staticInitConfigBuilder.produce(new StaticInitConfigBuilderBuildItem(staticInitMappingsConfigBuilder));
+
+        // For RunTime Config
+        Set<ConfigClassWithPrefix> runTimeMappings = new HashSet<>();
+        runTimeMappings.addAll(runtimeConfigMappings(configMappings));
+        runTimeMappings.addAll(configItem.getReadResult().getBuildTimeRunTimeMappings());
+        runTimeMappings.addAll(configItem.getReadResult().getRunTimeMappings());
+        String runTimeMappingsConfigBuilder = "io.quarkus.runtime.generated.RunTimeMappingsConfigBuilder";
+        generateMappingsConfigBuilder(generatedClass, reflectiveClass, runTimeMappingsConfigBuilder, runTimeMappings);
+        runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(runTimeMappingsConfigBuilder));
+    }
+
     /**
      * Generate the Config class that instantiates MP Config and holds all the config objects
      */
@@ -256,6 +287,7 @@ public class ConfigGenerationBuildStep {
         staticConfigSourceFactories.addAll(staticInitConfigSourceFactories.stream()
                 .map(StaticInitConfigSourceFactoryBuildItem::getFactoryClassName).collect(Collectors.toSet()));
 
+        // TODO - duplicated now builderMappings. Still required to filter the unknown properties
         Set<ConfigClassWithPrefix> staticMappings = new HashSet<>();
         staticMappings.addAll(staticSafeConfigMappings(configMappings));
         staticMappings.addAll(configItem.getReadResult().getBuildTimeRunTimeMappings());
@@ -479,6 +511,34 @@ public class ConfigGenerationBuildStep {
             ctor.invokeSpecialMethod(superCtor, ctor.getThis(), ctor.readStaticField(properties),
                     ctor.load(sourceName), ctor.load(sourceOrdinal));
             ctor.returnVoid();
+        }
+
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, className));
+    }
+
+    private static void generateMappingsConfigBuilder(
+            BuildProducer<GeneratedClassBuildItem> generatedClass,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            String className,
+            Set<ConfigClassWithPrefix> mappings) {
+
+        try (ClassCreator classCreator = ClassCreator.builder()
+                .classOutput(new GeneratedClassGizmoAdaptor(generatedClass, true))
+                .className(className)
+                .interfaces(ConfigBuilder.class)
+                .setFinal(true)
+                .build()) {
+
+            MethodCreator method = classCreator.getMethodCreator(CONFIG_BUILDER);
+            ResultHandle configBuilder = method.getMethodParam(0);
+
+            for (ConfigClassWithPrefix mapping : mappings) {
+                method.invokeVirtualMethod(WITH_MAPPING, configBuilder,
+                        method.loadClass(mapping.getKlass()),
+                        method.load(mapping.getPrefix()));
+            }
+
+            method.returnValue(configBuilder);
         }
 
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, className));

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/SecretKeysConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/SecretKeysConfigTest.java
@@ -39,7 +39,7 @@ public class SecretKeysConfigTest {
     }
 
     @ConfigMapping(prefix = "secrets.my")
-    interface MappingSecret {
+    public interface MappingSecret {
         String secret();
     }
 }


### PR DESCRIPTION
- Fixes #29630

The trick here is that the builder classes are on the app classloader, so they are subject to be reloaded. The generated `Config` class is in the Quarkus initial classloader, which we don't reload.