### PR TITLE
Gradle ITs: fix passing system properties

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
@@ -104,7 +104,7 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
     }
 
     private static String toPropertyArg(String name, String value) {
-        return new StringBuilder().append("-D=").append(name).append("=").append(value).toString();
+        return new StringBuilder().append("-D").append(name).append("=").append(value).toString();
     }
 
     private void printCommandOutput(File projectDir, List<String> command, BuildResult commandResult, int exitCode) {


### PR DESCRIPTION
Currently passes something like `-D=maven.repo.local=/home...` to the spawned Gradle test runners, the `=` is wrong here.