### PR TITLE
Metrics - check if index contains class before attempting to use it

### DIFF
--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/jandex/JandexBeanInfoAdapter.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/jandex/JandexBeanInfoAdapter.java
@@ -68,7 +68,7 @@ public class JandexBeanInfoAdapter implements BeanInfoAdapter<ClassInfo> {
     private Stream<AnnotationInfo> getMetricAnnotationsThroughStereotype(AnnotationInstance stereotypeInstance,
             IndexView indexView) {
         ClassInfo annotationType = indexView.getClassByName(stereotypeInstance.name());
-        if (annotationType.classAnnotation(DotNames.STEREOTYPE) != null) {
+        if (annotationType != null && annotationType.declaredAnnotation(DotNames.STEREOTYPE) != null) {
             JandexAnnotationInfoAdapter adapter = new JandexAnnotationInfoAdapter(indexView);
             return transformedAnnotations.getAnnotations(annotationType)
                     .stream()


### PR DESCRIPTION
Fixes #30965 

`IndexView` may or may not contain the given class.
Also, `classAnnotation()` is deprecated and was replaced by `declaredAnnotation()`.