### PR TITLE
Make use of @RecordableConstructor in DataSourceSupport

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceSupport.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceSupport.java
@@ -2,17 +2,15 @@ package io.quarkus.agroal.runtime;
 
 import java.util.Map;
 
+import io.quarkus.runtime.annotations.RecordableConstructor;
+
 public class DataSourceSupport {
 
-    // everything needs to be mutable because it's used in a recorder
+    public final boolean disableSslSupport;
+    public final boolean mpMetricsPresent;
+    public final Map<String, Entry> entries;
 
-    public boolean disableSslSupport;
-    public boolean mpMetricsPresent;
-    public Map<String, Entry> entries;
-
-    public DataSourceSupport() {
-    }
-
+    @RecordableConstructor
     public DataSourceSupport(boolean disableSslSupport, boolean mpMetricsPresent, Map<String, Entry> entries) {
         this.disableSslSupport = disableSslSupport;
         this.mpMetricsPresent = mpMetricsPresent;
@@ -20,14 +18,12 @@ public class DataSourceSupport {
     }
 
     public static class Entry {
-        public String dataSourceName;
-        public String resolvedDbKind;
-        public String resolvedDriverClass;
-        public boolean isDefault;
+        public final String dataSourceName;
+        public final String resolvedDbKind;
+        public final String resolvedDriverClass;
+        public final boolean isDefault;
 
-        public Entry() {
-        }
-
+        @RecordableConstructor
         public Entry(String dataSourceName, String resolvedDbKind, String resolvedDriverClass,
                 boolean isDefault) {
             this.dataSourceName = dataSourceName;


### PR DESCRIPTION
This is done in order to make the code more intuitive