### PR TITLE
Don't run quickstart compilation job on PRs that don't target main

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -552,7 +552,8 @@ jobs:
     runs-on: ${{matrix.java.os-name}}
     needs: build-jdk11
     # Skip main in forks
-    if: (github.repository == 'quarkusio/quarkus' && (github.event_name != 'pull_request' || github.base_ref == 'main')) || !endsWith(github.ref, '/main')
+    if: "(github.repository == 'quarkusio/quarkus' && (github.event_name != 'pull_request' || github.base_ref == 'main')) \
+      || (github.repository != 'quarkusio/quarkus' && !endsWith(github.ref, '/main'))"
     timeout-minutes: 90
     strategy:
       fail-fast: false


### PR DESCRIPTION
It seems there was a small mistake in the condition.