### PR TITLE
2.13.x: Upgrade RESTEasy to 4.7.9.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -19,7 +19,7 @@
         <bouncycastle.tls.fips.version>1.0.12.3</bouncycastle.tls.fips.version>
         <findbugs.version>3.0.2</findbugs.version>
         <jandex.version>2.4.3.Final</jandex.version>
-        <resteasy.version>4.7.7.Final</resteasy.version>
+        <resteasy.version>4.7.8.Final</resteasy.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-jdbc.version>0.2.4</opentracing-jdbc.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -19,7 +19,7 @@
         <bouncycastle.tls.fips.version>1.0.12.3</bouncycastle.tls.fips.version>
         <findbugs.version>3.0.2</findbugs.version>
         <jandex.version>2.4.3.Final</jandex.version>
-        <resteasy.version>4.7.8.Final</resteasy.version>
+        <resteasy.version>4.7.9.Final</resteasy.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-jdbc.version>0.2.4</opentracing-jdbc.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>


### PR DESCRIPTION
Upgrade to include the latest fixes in RESTEasy