### PR TITLE
Bump Dekorate to 3.4.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -161,7 +161,7 @@
         <kotlin.version>1.8.10</kotlin.version>
         <kotlin.coroutine.version>1.6.4</kotlin.coroutine.version>
         <kotlin-serialization.version>1.4.1</kotlin-serialization.version>
-        <dekorate.version>3.3.1</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
+        <dekorate.version>3.4.0</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>
         <jboss-logmanager.version>1.1.1</jboss-logmanager.version>

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddSelectorToDeploymentDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddSelectorToDeploymentDecorator.java
@@ -2,6 +2,7 @@
 package io.quarkus.kubernetes.deployment;
 
 import io.dekorate.kubernetes.decorator.AddToMatchingLabelsDecorator;
+import io.dekorate.kubernetes.decorator.AddToSelectorDecorator;
 import io.dekorate.kubernetes.decorator.Decorator;
 import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
 import io.dekorate.kubernetes.decorator.ResourceProvidingDecorator;
@@ -29,6 +30,6 @@ public class AddSelectorToDeploymentDecorator extends NamedResourceDecorator<Dep
 
     @Override
     public Class<? extends Decorator>[] before() {
-        return new Class[] { AddToMatchingLabelsDecorator.class };
+        return new Class[] { AddToMatchingLabelsDecorator.class, AddToSelectorDecorator.class };
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
@@ -322,7 +322,7 @@ public class OpenshiftProcessor {
                 String imageStreamWithTag = name + ":" + i.getTag();
                 result.add(new DecoratorBuildItem(OPENSHIFT, new ApplyContainerImageDecorator(name, imageStreamWithTag)));
                 // remove the default trigger which has a wrong version
-                result.add(new DecoratorBuildItem(OPENSHIFT, new RemoveDeploymentTriggerDecorator()));
+                result.add(new DecoratorBuildItem(OPENSHIFT, new RemoveDeploymentTriggerDecorator(name)));
                 // re-add the trigger with the correct version
                 result.add(new DecoratorBuildItem(OPENSHIFT, new ChangeDeploymentTriggerDecorator(name, imageStreamWithTag)));
             });

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveDeploymentTriggerDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveDeploymentTriggerDecorator.java
@@ -10,6 +10,10 @@ import io.fabric8.openshift.api.model.DeploymentConfigSpecFluent;
 
 public class RemoveDeploymentTriggerDecorator extends NamedResourceDecorator<DeploymentConfigSpecFluent<?>> {
 
+    public RemoveDeploymentTriggerDecorator(String name) {
+        super(name);
+    }
+
     @Override
     public void andThenVisit(DeploymentConfigSpecFluent<?> deploymentConfigSpec, ObjectMeta objectMeta) {
         deploymentConfigSpec.withTriggers(Collections.emptyList());
@@ -18,5 +22,10 @@ public class RemoveDeploymentTriggerDecorator extends NamedResourceDecorator<Dep
     @Override
     public Class<? extends Decorator>[] after() {
         return new Class[] { ApplyDeploymentTriggerDecorator.class };
+    }
+
+    @Override
+    public Class<? extends Decorator>[] before() {
+        return new Class[] { ChangeDeploymentTriggerDecorator.class };
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveOptionalFromConfigMapEnvSourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveOptionalFromConfigMapEnvSourceDecorator.java
@@ -1,6 +1,10 @@
 package io.quarkus.kubernetes.deployment;
 
+import io.dekorate.knative.decorator.AddConfigMapVolumeToRevisionDecorator;
+import io.dekorate.knative.decorator.AddSecretVolumeToRevisionDecorator;
+import io.dekorate.kubernetes.decorator.AddConfigMapVolumeDecorator;
 import io.dekorate.kubernetes.decorator.AddEnvVarDecorator;
+import io.dekorate.kubernetes.decorator.AddSecretVolumeDecorator;
 import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
 import io.dekorate.kubernetes.decorator.Decorator;
 import io.fabric8.kubernetes.api.model.ConfigMapEnvSourceFluent;
@@ -14,6 +18,8 @@ public class RemoveOptionalFromConfigMapEnvSourceDecorator extends ApplicationCo
 
     @Override
     public Class<? extends Decorator>[] after() {
-        return new Class[] { AddEnvVarDecorator.class, ApplicationContainerDecorator.class };
+        return new Class[] { AddEnvVarDecorator.class,
+                AddSecretVolumeDecorator.class, AddSecretVolumeToRevisionDecorator.class,
+                AddConfigMapVolumeToRevisionDecorator.class, AddConfigMapVolumeDecorator.class };
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveOptionalFromConfigMapKeySelectorDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveOptionalFromConfigMapKeySelectorDecorator.java
@@ -1,6 +1,10 @@
 package io.quarkus.kubernetes.deployment;
 
+import io.dekorate.knative.decorator.AddConfigMapVolumeToRevisionDecorator;
+import io.dekorate.knative.decorator.AddSecretVolumeToRevisionDecorator;
+import io.dekorate.kubernetes.decorator.AddConfigMapVolumeDecorator;
 import io.dekorate.kubernetes.decorator.AddEnvVarDecorator;
+import io.dekorate.kubernetes.decorator.AddSecretVolumeDecorator;
 import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
 import io.dekorate.kubernetes.decorator.Decorator;
 import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorFluent;
@@ -14,6 +18,8 @@ public class RemoveOptionalFromConfigMapKeySelectorDecorator extends Application
 
     @Override
     public Class<? extends Decorator>[] after() {
-        return new Class[] { AddEnvVarDecorator.class, ApplicationContainerDecorator.class };
+        return new Class[] { AddEnvVarDecorator.class,
+                AddSecretVolumeDecorator.class, AddSecretVolumeToRevisionDecorator.class,
+                AddConfigMapVolumeToRevisionDecorator.class, AddConfigMapVolumeDecorator.class };
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveOptionalFromSecretEnvSourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveOptionalFromSecretEnvSourceDecorator.java
@@ -1,7 +1,11 @@
 
 package io.quarkus.kubernetes.deployment;
 
+import io.dekorate.knative.decorator.AddConfigMapVolumeToRevisionDecorator;
+import io.dekorate.knative.decorator.AddSecretVolumeToRevisionDecorator;
+import io.dekorate.kubernetes.decorator.AddConfigMapVolumeDecorator;
 import io.dekorate.kubernetes.decorator.AddEnvVarDecorator;
+import io.dekorate.kubernetes.decorator.AddSecretVolumeDecorator;
 import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
 import io.dekorate.kubernetes.decorator.Decorator;
 import io.fabric8.kubernetes.api.model.SecretEnvSourceFluent;
@@ -15,7 +19,9 @@ public class RemoveOptionalFromSecretEnvSourceDecorator extends ApplicationConta
 
     @Override
     public Class<? extends Decorator>[] after() {
-        return new Class[] { AddEnvVarDecorator.class, ApplicationContainerDecorator.class };
+        return new Class[] { AddEnvVarDecorator.class,
+                AddSecretVolumeDecorator.class, AddSecretVolumeToRevisionDecorator.class,
+                AddConfigMapVolumeToRevisionDecorator.class, AddConfigMapVolumeDecorator.class };
     }
 
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveOptionalFromSecretKeySelectorDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveOptionalFromSecretKeySelectorDecorator.java
@@ -1,7 +1,11 @@
 
 package io.quarkus.kubernetes.deployment;
 
+import io.dekorate.knative.decorator.AddConfigMapVolumeToRevisionDecorator;
+import io.dekorate.knative.decorator.AddSecretVolumeToRevisionDecorator;
+import io.dekorate.kubernetes.decorator.AddConfigMapVolumeDecorator;
 import io.dekorate.kubernetes.decorator.AddEnvVarDecorator;
+import io.dekorate.kubernetes.decorator.AddSecretVolumeDecorator;
 import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
 import io.dekorate.kubernetes.decorator.Decorator;
 import io.fabric8.kubernetes.api.model.SecretKeySelectorFluent;
@@ -15,6 +19,8 @@ public class RemoveOptionalFromSecretKeySelectorDecorator extends ApplicationCon
 
     @Override
     public Class<? extends Decorator>[] after() {
-        return new Class[] { AddEnvVarDecorator.class, ApplicationContainerDecorator.class };
+        return new Class[] { AddEnvVarDecorator.class,
+                AddSecretVolumeDecorator.class, AddSecretVolumeToRevisionDecorator.class,
+                AddConfigMapVolumeToRevisionDecorator.class, AddConfigMapVolumeDecorator.class };
     }
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithDockerAndImageTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithDockerAndImageTest.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -37,7 +36,6 @@ public class OpenshiftWithDockerAndImageTest {
     private ProdModeTestResults prodModeTestResults;
 
     @Test
-    @Disabled("This is failing always in the Jakarta branch and needs fixing")
     public void assertGeneratedResources() throws IOException {
         Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
 


### PR DESCRIPTION
Changes: https://github.com/dekorateio/dekorate/releases/tag/3.4.0

This version includes a detecion cycle logic to spot issues when applying decorators. 

Actually, we have detected a couple of issues with the decorators:
- RemoveDeploymentTriggerDecorator:

```
[error]: Build step io.quarkus.kubernetes.deployment.KubernetesProcessor#build threw an exception: java.lang.RuntimeException: Cycle detected when ordering decorators: 
- io.quarkus.kubernetes.deployment.ChangeDeploymentTriggerDecorator
- io.quarkus.kubernetes.deployment.RemoveDeploymentTriggerDecorator
```

- RemoveOptionalFromConfigMapEnvSource, ...

```
[error]: Build step io.quarkus.kubernetes.deployment.KubernetesProcessor#build threw an exception: java.lang.RuntimeException: Cycle detected when ordering decorators: 
- io.quarkus.kubernetes.deployment.RemoveOptionalFromSecretEnvSourceDecorator
- io.quarkus.kubernetes.deployment.RemoveOptionalFromSecretKeySelectorDecorator
- io.quarkus.kubernetes.deployment.RemoveOptionalFromConfigMapEnvSourceDecorator
- io.quarkus.kubernetes.deployment.RemoveOptionalFromConfigMapKeySelectorDecorator
```