### PR TITLE
[2.13.x] - Update 2.13 to use the new container images

### DIFF
--- a/.github/workflows/native-cron-build.yml.disabled
+++ b/.github/workflows/native-cron-build.yml.disabled
@@ -20,7 +20,7 @@ jobs:
         run: sudo systemctl stop mysql
 
       - name: Pull docker image
-        run: docker pull quay.io/quarkus/ubi-quarkus-native-image:20.2.0-java${{ matrix.java }}
+        run: docker pull quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3-java${{ matrix.java }}
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
@@ -55,7 +55,7 @@ jobs:
         run: ./mvnw -B install -DskipTests -DskipITs -Dformat.skip
 
       - name: Run integration tests in native
-        run: ./mvnw -B --settings .github/mvn-settings.xml verify -f integration-tests/pom.xml --fail-at-end -Dno-format -Dtest-containers -Dstart-containers -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:20.2.0-java${{ matrix.java }} -pl '!io.quarkus:quarkus-integration-test-google-cloud-functions-http,!io.quarkus:quarkus-integration-test-google-cloud-functions,!io.quarkus:quarkus-integration-test-funqy-google-cloud-functions'
+        run: ./mvnw -B --settings .github/mvn-settings.xml verify -f integration-tests/pom.xml --fail-at-end -Dno-format -Dtest-containers -Dstart-containers -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:20.2.0-java${{ matrix.java }} -pl '!io.quarkus:quarkus-integration-test-google-cloud-functions-http,!io.quarkus:quarkus-integration-test-google-cloud-functions,!io.quarkus:quarkus-integration-test-funqy-google-cloud-functions'
 
       - name: Report
         if: always()

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -16,8 +16,8 @@ import io.quarkus.runtime.util.ContainerRuntimeUtil;
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public class NativeConfig {
 
-    public static final String DEFAULT_GRAALVM_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-native-image:22.3-java17";
-    public static final String DEFAULT_MANDREL_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17";
+    public static final String DEFAULT_GRAALVM_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3-java17";
+    public static final String DEFAULT_MANDREL_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17";
 
     /**
      * Comma-separated, additional arguments to pass to the build process.
@@ -211,7 +211,7 @@ public class NativeConfig {
 
     /**
      * The docker image to use to do the image build. It can be one of `graalvm`, `mandrel`, or the full image path, e.g.
-     * {@code quay.io/quarkus/ubi-quarkus-mandrel:21.3-java17}.
+     * {@code quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17}.
      */
     @ConfigItem(defaultValue = "${platform.quarkus.native.builder-image}")
     public String builderImage;

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/NativeConfigTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/NativeConfigTest.java
@@ -8,18 +8,21 @@ class NativeConfigTest {
 
     @Test
     public void testBuilderImageProperlyDetected() {
-        assertThat(createConfig("graalvm").getEffectiveBuilderImage()).contains("ubi-quarkus-native-image")
+        assertThat(createConfig("graalvm").getEffectiveBuilderImage()).contains("ubi-quarkus-graalvmce-builder-image")
                 .contains("java17");
-        assertThat(createConfig("GraalVM").getEffectiveBuilderImage()).contains("ubi-quarkus-native-image")
+        assertThat(createConfig("GraalVM").getEffectiveBuilderImage()).contains("ubi-quarkus-graalvmce-builder-image")
                 .contains("java17");
-        assertThat(createConfig("GraalVM").getEffectiveBuilderImage()).contains("ubi-quarkus-native-image")
+        assertThat(createConfig("GraalVM").getEffectiveBuilderImage()).contains("ubi-quarkus-graalvmce-builder-image")
                 .contains("java17");
-        assertThat(createConfig("GRAALVM").getEffectiveBuilderImage()).contains("ubi-quarkus-native-image")
+        assertThat(createConfig("GRAALVM").getEffectiveBuilderImage()).contains("ubi-quarkus-graalvmce-builder-image")
                 .contains("java17");
 
-        assertThat(createConfig("mandrel").getEffectiveBuilderImage()).contains("ubi-quarkus-mandrel").contains("java17");
-        assertThat(createConfig("Mandrel").getEffectiveBuilderImage()).contains("ubi-quarkus-mandrel").contains("java17");
-        assertThat(createConfig("MANDREL").getEffectiveBuilderImage()).contains("ubi-quarkus-mandrel").contains("java17");
+        assertThat(createConfig("mandrel").getEffectiveBuilderImage()).contains("ubi-quarkus-mandrel-builder-image")
+                .contains("java17");
+        assertThat(createConfig("Mandrel").getEffectiveBuilderImage()).contains("ubi-quarkus-mandrel-builder-image")
+                .contains("java17");
+        assertThat(createConfig("MANDREL").getEffectiveBuilderImage()).contains("ubi-quarkus-mandrel-builder-image")
+                .contains("java17");
 
         assertThat(createConfig("aRandomString").getEffectiveBuilderImage()).isEqualTo("aRandomString");
     }

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
@@ -28,7 +28,7 @@ class NativeImageBuildContainerRunnerTest {
         command = localRunner.buildCommand("docker", Collections.emptyList(), Collections.emptyList());
         found = false;
         for (String part : command) {
-            if (part.contains("ubi-quarkus-native-image")) {
+            if (part.contains("ubi-quarkus-graalvmce-builder-image")) {
                 found = true;
             }
         }
@@ -39,7 +39,7 @@ class NativeImageBuildContainerRunnerTest {
         command = localRunner.buildCommand("docker", Collections.emptyList(), Collections.emptyList());
         found = false;
         for (String part : command) {
-            if (part.contains("ubi-quarkus-mandrel")) {
+            if (part.contains("ubi-quarkus-mandrel-builder-image")) {
                 found = true;
             }
         }

--- a/docs/src/main/asciidoc/amazon-lambda.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda.adoc
@@ -577,7 +577,7 @@ To extract the required ssl, you must start up a Docker container in the backgro
 First, let's start the GraalVM container, noting the container id output.
 [source,bash,subs=attributes+]
 ----
-docker run -it -d --entrypoint bash quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}
+docker run -it -d --entrypoint bash quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor}
 
 # This will output a container id, like 6304eea6179522aff69acb38eca90bedfd4b970a5475aa37ccda3585bc2abdde
 # Note this value as we will need it for the commands below

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -400,7 +400,7 @@ The reason for this is that the local build driver invoked through `-Dquarkus.na
 ====
 Building with Mandrel requires a custom builder image parameter to be passed additionally:
 
-:build-additional-parameters: -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:{mandrel-flavor}
+:build-additional-parameters: -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}
 include::{includes}/devtools/build-native-container-parameters.adoc[]
 :!build-additional-parameters:
 
@@ -408,7 +408,7 @@ Please note that the above command points to a floating tag.
 It is highly recommended to use the floating tag,
 so that your builder image remains up-to-date and secure.
 If you absolutely must, you may hard-code to a specific tag
-(see https://quay.io/repository/quarkus/ubi-quarkus-mandrel?tab=tags[here] for available tags),
+(see https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags[here] for available tags),
 but be aware that you won't get security updates that way and it's unsupported.
 ====
 
@@ -455,7 +455,7 @@ The project generation has provided a `Dockerfile.native-micro` in the `src/main
 
 [source,dockerfile]
 ----
-FROM quay.io/quarkus/quarkus-micro-image:1.0
+FROM quay.io/quarkus/quarkus-micro-image:2.0
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work
@@ -529,7 +529,7 @@ Sample Dockerfile for building with Maven:
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor} AS build
+FROM quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build
 COPY --chown=quarkus:quarkus mvnw /code/mvnw
 COPY --chown=quarkus:quarkus .mvn /code/.mvn
 COPY --chown=quarkus:quarkus pom.xml /code/
@@ -540,7 +540,7 @@ COPY src /code/src
 RUN ./mvnw package -Pnative
 
 ## Stage 2 : create the docker final image
-FROM quay.io/quarkus/quarkus-micro-image:1.0
+FROM quay.io/quarkus/quarkus-micro-image:2.0
 WORKDIR /work/
 COPY --from=build /code/target/*-runner /work/application
 
@@ -567,7 +567,7 @@ Sample Dockerfile for building with Gradle:
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor} AS build
+FROM quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build
 USER root
 RUN microdnf install findutils
 COPY --chown=quarkus:quarkus gradlew /code/gradlew
@@ -581,7 +581,7 @@ COPY src /code/src
 RUN ./gradlew build -Dquarkus.package.type=native
 
 ## Stage 2 : create the docker final image
-FROM quay.io/quarkus/quarkus-micro-image:1.0
+FROM quay.io/quarkus/quarkus-micro-image:2.0
 WORKDIR /work/
 COPY --from=build /code/build/*-runner /work/application
 RUN chmod 775 /work
@@ -617,7 +617,7 @@ Please see xref:native-and-ssl.adoc#working-with-containers[our Using SSL With N
 
 [NOTE,subs=attributes+]
 ====
-To use Mandrel instead of GraalVM CE, update the `FROM` clause to: `FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor} AS build`.
+To use Mandrel instead of GraalVM CE, update the `FROM` clause to: `FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image-builder-image:{mandrel-flavor} AS build`.
 ====
 
 [NOTE]
@@ -637,7 +637,7 @@ You only need to copy your application, and you are done:
 
 [source, dockerfile]
 ----
-FROM quay.io/quarkus/quarkus-distroless-image:1.0
+FROM quay.io/quarkus/quarkus-distroless-image:2.0
 COPY target/*-runner /application
 
 EXPOSE 8080
@@ -646,7 +646,7 @@ USER nonroot
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
 ----
 
-Quarkus provides the `quay.io/quarkus/quarkus-distroless-image:1.0` image.
+Quarkus provides the `quay.io/quarkus/quarkus-distroless-image:2.0` image.
 It contains the required packages to run a native executable and is only **9Mb**.
 Just add your application on top of this image, and you will get a tiny container image.
 
@@ -663,7 +663,7 @@ Sample multistage Dockerfile for building an image from `scratch`:
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor} AS build
+FROM quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build
 USER root
 RUN microdnf install make gcc
 COPY --chown=quarkus:quarkus mvnw /code/mvnw
@@ -747,13 +747,13 @@ docker run \
   --v $(pwd):/work <1>
   -w /work <2>
   --entrypoint bin/sh \
-  quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor} \ <3>
+  quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor} \ <3>
   -c "native-image $(cat native-image.args) -J-Xmx4g" <4>
 ----
 
 <1> Mount the host's directory `target/native-image` to the container's `/work`. Thus, the generated binary will also be written to this directory.
 <2> Switch the working directory to `/work`, which we have mounted in <1>.
-<3> Use the `quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}` docker image introduced in <<#multistage-docker,Using a multi-stage Docker build>> to build the native image.
+<3> Use the `quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor}` docker image introduced in <<#multistage-docker,Using a multi-stage Docker build>> to build the native image.
 <4> Call `native-image` with the content of file `native-image.args` as arguments. We also supply an additional argument to limit the process's maximum memory to 4 Gigabytes (this may vary depending on the project being built and the machine building it).
 
 [WARNING]

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -404,13 +404,13 @@ Configuring the `quarkusBuild` task can be done as following:
 quarkusBuild {
     nativeArgs {
         containerBuild = true <1>
-        builderImage = "quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}" <2>
+        builderImage = "quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor}" <2>
     }
 }
 ----
 
 <1> Set `quarkus.native.container-build` property to `true`
-<2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}`
+<2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor}`
 ****
 
 [role="secondary asciidoc-tabs-sync-kotlin"]
@@ -421,13 +421,13 @@ quarkusBuild {
 tasks.quarkusBuild {
     nativeArgs {
         "container-build" to true <1>
-        "builder-image" to "quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}" <2>
+        "builder-image" to "quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor}" <2>
     }
 }
 ----
 
 <1> Set `quarkus.native.container-build` property to `true`
-<2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}`
+<2> Set `quarkus.native.builder-image` property to `quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor}`
 ****
 
 [WARNING]
@@ -450,12 +450,12 @@ Note that in this case the build itself runs in a Docker container too, so you d
 
 [TIP]
 ====
-By default, the native executable will be generated using the `quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}` Docker image.
+By default, the native executable will be generated using the `quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor}` Docker image.
 
 If you want to build a native executable with a different Docker image (for instance to use a different GraalVM version),
 use the `-Dquarkus.native.builder-image=<image name>` build argument.
 
-The list of the available Docker images can be found on https://quay.io/repository/quarkus/ubi-quarkus-native-image?tab=tags[quay.io].
+The list of the available Docker images can be found on https://quay.io/repository/quarkus/ubi-quarkus-graalvmce-builder-image?tab=tags[quay.io].
 Be aware that a given Quarkus version might not be compatible with all the images available.
 ====
 

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -431,12 +431,12 @@ Note that in this case the build itself runs in a Docker container too, so you d
 
 [TIP]
 ====
-By default, the native executable will be generated using the `quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}` Docker image.
+By default, the native executable will be generated using the `quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor}` Docker image.
 
 If you want to build a native executable with a different Docker image (for instance to use a different GraalVM version),
 use the `-Dquarkus.native.builder-image=<image name>` build argument.
 
-The list of the available Docker images can be found on https://quay.io/repository/quarkus/ubi-quarkus-native-image?tab=tags[quay.io].
+The list of the available Docker images can be found on https://quay.io/repository/quarkus/ubi-quarkus-graalvmce-builder-image?tab=tags[quay.io].
 Be aware that a given Quarkus version might not be compatible with all the images available.
 ====
 

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -67,7 +67,7 @@ So, go ahead and add the following options to that file:
 [source,properties,subs=attributes+]
 ----
 quarkus.native.container-build=true
-quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:{mandrel-flavor}
+quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor}
 quarkus.container-image.build=true
 quarkus.container-image.group=test
 ----
@@ -494,7 +494,7 @@ These are called expert options and you can learn more about them by running:
 
 [source,bash,subs=attributes+]
 ----
-docker run quay.io/quarkus/ubi-quarkus-mandrel:{mandrel-flavor} --expert-options-all
+docker run quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor} --expert-options-all
 ----
 
 [WARNING]
@@ -1610,7 +1610,7 @@ E.g.
 [source,bash,subs=attributes+]
 ----
 ./mvnw package -DskipTests -Dnative -Dquarkus.native.container-build=true \
-    -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:{mandrel-flavor} \
+    -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor} \
     -Dquarkus.native.enable-vm-inspection=true
 ----
 

--- a/docs/src/main/asciidoc/platform.adoc
+++ b/docs/src/main/asciidoc/platform.adoc
@@ -128,7 +128,7 @@ A platform properties file for the example above would contain:
 
 [source,text,subs=attributes+]
 ----
-platform.quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}
+platform.quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor}
 ----
 
 There is also a Maven plugin goal that validates the platform properties content and its artifact coordinates and also checks whether the platform properties artifact is present in the platform's BOM. Here is a sample plugin configuration:

--- a/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
+++ b/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
@@ -8,7 +8,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::_attributes.adoc[]
 
 To ease the containerization of native executables, Quarkus provides a base image providing the requirements to run these executables.
-The `quarkus-micro-image:1.0` image is:
+The `quarkus-micro-image:2.0` image is:
 
 * small (based on `ubi8-micro`)
 * designed for containers
@@ -21,7 +21,7 @@ In your `Dockerfile`, just use:
 
 [source, dockerfile]
 ----
-FROM quay.io/quarkus/quarkus-micro-image:1.0
+FROM quay.io/quarkus/quarkus-micro-image:2.0
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work
@@ -42,7 +42,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as BUILD
 RUN microdnf install freetype
 
 # Second stage - copy the dependencies
-FROM quay.io/quarkus/quarkus-micro-image:1.0
+FROM quay.io/quarkus/quarkus-micro-image:2.0
 COPY --from=BUILD \
    /lib64/libfreetype.so.6 \
    /lib64/libbz2.so.1 \
@@ -65,7 +65,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as BUILD
 RUN microdnf install freetype fontconfig
 
 # Second stage - copy the dependencies
-FROM quay.io/quarkus/quarkus-micro-image:1.0
+FROM quay.io/quarkus/quarkus-micro-image:2.0
 COPY --from=BUILD \
    /lib64/libfreetype.so.6 \
    /lib64/libgcc_s.so.1 \

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
@@ -29,7 +29,7 @@ public class JibConfig {
      * "registry.access.redhat.com/ubi8/ubi-minimal" which is a bigger base image, but provide more built-in utilities
      * such as the microdnf package manager.
      */
-    @ConfigItem(defaultValue = "quay.io/quarkus/quarkus-micro-image:1.0")
+    @ConfigItem(defaultValue = "quay.io/quarkus/quarkus-micro-image:2.0")
     public String baseNativeImage;
 
     /**

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftBaseNativeImage.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftBaseNativeImage.java
@@ -8,7 +8,7 @@ import io.quarkus.container.image.deployment.util.ImageUtil;
 public enum OpenshiftBaseNativeImage {
 
     //We only compare `repositories` so registries and tags are stripped
-    QUARKUS("quarkus/ubi-quarkus-native-binary-s2i:latest", "/home/quarkus/", "application", "QUARKUS_HOME", "QUARKUS_OPTS");
+    QUARKUS("quarkus/ubi-quarkus-native-binary-s2i:2.0", "/home/quarkus/", "application", "QUARKUS_HOME", "QUARKUS_OPTS");
 
     private final String image;
     private final String nativeBinaryDirectory;

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftConfig.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftConfig.java
@@ -15,7 +15,7 @@ public class OpenshiftConfig {
 
     public static final String DEFAULT_BASE_JVM_JDK11_IMAGE = "registry.access.redhat.com/ubi8/openjdk-11:1.15";
     public static final String DEFAULT_BASE_JVM_JDK17_IMAGE = "registry.access.redhat.com/ubi8/openjdk-17:1.15";
-    public static final String DEFAULT_BASE_NATIVE_IMAGE = "quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0";
+    public static final String DEFAULT_BASE_NATIVE_IMAGE = "quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0";
     public static final String DEFAULT_NATIVE_TARGET_FILENAME = "application";
 
     public static final String DEFAULT_JVM_DOCKERFILE = "src/main/docker/Dockerfile.jvm";

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/S2iBaseNativeImage.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/S2iBaseNativeImage.java
@@ -8,7 +8,7 @@ import io.quarkus.container.image.deployment.util.ImageUtil;
 public enum S2iBaseNativeImage {
 
     //We only compare `repositories` so registries and tags are stripped
-    QUARKUS("quarkus/ubi-quarkus-native-binary-s2i:latest", "application", "QUARKUS_HOME", "QUARKUS_OPTS");
+    QUARKUS("quarkus/ubi-quarkus-native-binary-s2i:2.0", "application", "QUARKUS_HOME", "QUARKUS_OPTS");
 
     private final String image;
     private final String fixedNativeBinaryName;

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/S2iConfig.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/S2iConfig.java
@@ -14,7 +14,7 @@ public class S2iConfig {
 
     public static final String DEFAULT_BASE_JVM_JDK11_IMAGE = "registry.access.redhat.com/ubi8/openjdk-11:1.15";
     public static final String DEFAULT_BASE_JVM_JDK17_IMAGE = "registry.access.redhat.com/ubi8/openjdk-17:1.15";
-    public static final String DEFAULT_BASE_NATIVE_IMAGE = "quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0";
+    public static final String DEFAULT_BASE_NATIVE_IMAGE = "quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0";
     public static final String DEFAULT_NATIVE_TARGET_FILENAME = "application";
 
     public static final String DEFAULT_JVM_DOCKERFILE = "src/main/docker/Dockerfile.jvm";

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iBaseNativeImage.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iBaseNativeImage.java
@@ -8,7 +8,7 @@ import io.quarkus.container.image.deployment.util.ImageUtil;
 public enum S2iBaseNativeImage {
 
     //We only compare `repositories` so registries and tags are stripped
-    QUARKUS("quarkus/ubi-quarkus-native-binary-s2i:latest", "application", "QUARKUS_HOME", "QUARKUS_OPTS");
+    QUARKUS("quarkus/ubi-quarkus-native-binary-s2i:2.0", "application", "QUARKUS_HOME", "QUARKUS_OPTS");
 
     private final String image;
     private final String fixedNativeBinaryName;

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iConfig.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iConfig.java
@@ -15,7 +15,7 @@ public class S2iConfig {
 
     public static final String DEFAULT_BASE_JVM_JDK11_IMAGE = "registry.access.redhat.com/ubi8/openjdk-11:1.14";
     public static final String DEFAULT_BASE_JVM_JDK17_IMAGE = "registry.access.redhat.com/ubi8/openjdk-17:1.14";
-    public static final String DEFAULT_BASE_NATIVE_IMAGE = "quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0";
+    public static final String DEFAULT_BASE_NATIVE_IMAGE = "quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0";
     public static final String DEFAULT_NATIVE_TARGET_FILENAME = "application";
 
     public static String getDefaultJvmImage(CompiledJavaVersionBuildItem.JavaVersion version) {

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iConfig.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iConfig.java
@@ -13,8 +13,8 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public class S2iConfig {
 
-    public static final String DEFAULT_BASE_JVM_JDK11_IMAGE = "registry.access.redhat.com/ubi8/openjdk-11:1.14";
-    public static final String DEFAULT_BASE_JVM_JDK17_IMAGE = "registry.access.redhat.com/ubi8/openjdk-17:1.14";
+    public static final String DEFAULT_BASE_JVM_JDK11_IMAGE = "registry.access.redhat.com/ubi8/openjdk-11:1.15";
+    public static final String DEFAULT_BASE_JVM_JDK17_IMAGE = "registry.access.redhat.com/ubi8/openjdk-17:1.15";
     public static final String DEFAULT_BASE_NATIVE_IMAGE = "quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0";
     public static final String DEFAULT_NATIVE_TARGET_FILENAME = "application";
 

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/codestart.yml
@@ -7,4 +7,4 @@ language:
         native:
           from: registry.access.redhat.com/ubi8/ubi-minimal:8.6
         native-micro:
-          from: quay.io/quarkus/quarkus-micro-image:1.0
+          from: quay.io/quarkus/quarkus-micro-image:2.0

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
@@ -310,7 +310,7 @@ class QuarkusCodestartGenerationTest {
                 .satisfies(checkNotContains("ENTRYPOINT"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native-micro")).exists()
                 .satisfies(checkContains("./mvnw package -Pnative"))
-                .satisfies(checkContains("quay.io/quarkus/quarkus-micro-image:1.0"))
+                .satisfies(checkContains("quay.io/quarkus/quarkus-micro-image:2.0"))
                 .satisfies(checkContains("CMD [\"./application\", \"-Dquarkus.http.host=0.0.0.0\"]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native")).exists()
                 .satisfies(checkContains("./mvnw package -Pnative"))
@@ -334,7 +334,7 @@ class QuarkusCodestartGenerationTest {
                 .satisfies(checkContains("ENTRYPOINT [ \"/deployments/run-java.sh\" ]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native-micro")).exists()
                 .satisfies(checkContains("./gradlew build -Dquarkus.package.type=native"))
-                .satisfies(checkContains("quay.io/quarkus/quarkus-micro-image:1.0"))
+                .satisfies(checkContains("quay.io/quarkus/quarkus-micro-image:2.0"))
                 .satisfies(checkContains("CMD [\"./application\", \"-Dquarkus.http.host=0.0.0.0\"]"));
         assertThat(projectDir.resolve("src/main/docker/Dockerfile.native")).exists()
                 .satisfies(checkContains("./gradlew build -Dquarkus.package.type=native"))


### PR DESCRIPTION
Update the Quarkus images to multi-archs variants

- the builder images are now: quarkusubi-quarkus-graalvmce-builder-image and quarkusubi-quarkus-mandrel-builder-image. Both at multi-archs (AMD64 and ARM64).
- the s2i images are now: quarkusubi-quarkus-native-binary-s2i:2.0 and quarkusubi-quarkus-graalvmce-s2i
- the base images are now: quarkusquarkus-micro-image:2.0 and quarkusquarkus-distroless-image:2.0