### PR TITLE
Remove leftover "host" property in K8s/OpenShift/Knative

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
@@ -91,13 +91,6 @@ public class KnativeConfig implements PlatformConfiguration {
     Optional<String> serviceAccount;
 
     /**
-     * The host under which the application is going to be exposed
-     *
-     */
-    @ConfigItem
-    Optional<String> host;
-
-    /**
      * The application ports
      */
     @ConfigItem
@@ -293,10 +286,6 @@ public class KnativeConfig implements PlatformConfiguration {
 
     public Optional<String> getServiceAccount() {
         return serviceAccount;
-    }
-
-    public Optional<String> getHost() {
-        return host;
     }
 
     @Override

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -116,15 +116,6 @@ public class KubernetesConfig implements PlatformConfiguration {
     Optional<String> serviceAccount;
 
     /**
-     * The host under which the application is going to be exposed
-     *
-     * @deprecated Use the {@code quarkus.kubernetes.ingress.host} instead
-     */
-    @ConfigItem
-    @Deprecated
-    Optional<String> host;
-
-    /**
      * The application ports
      */
     @ConfigItem
@@ -437,10 +428,6 @@ public class KubernetesConfig implements PlatformConfiguration {
 
     public Optional<String> getServiceAccount() {
         return serviceAccount;
-    }
-
-    public Optional<String> getHost() {
-        return host;
     }
 
     @Override

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -147,15 +147,6 @@ public class OpenshiftConfig implements PlatformConfiguration {
     Optional<String> serviceAccount;
 
     /**
-     * The host under which the application is going to be exposed
-     *
-     * @deprecated Use the {@code quarkus.openshift.route.host} instead
-     */
-    @ConfigItem
-    @Deprecated
-    Optional<String> host;
-
-    /**
      * The application ports
      */
     @ConfigItem
@@ -391,10 +382,6 @@ public class OpenshiftConfig implements PlatformConfiguration {
 
     public Optional<String> getServiceAccount() {
         return serviceAccount;
-    }
-
-    public Optional<String> getHost() {
-        return host;
     }
 
     @Override

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
@@ -36,8 +36,6 @@ public interface PlatformConfiguration extends EnvVarHolder {
 
     Optional<String> getServiceAccount();
 
-    Optional<String> getHost();
-
     Optional<String> getContainerName();
 
     Map<String, PortConfig> getPorts();


### PR DESCRIPTION
This property was marked as deprecated a while ago and its support was removed in https://github.com/quarkusio/quarkus/pull/30977