### PR TITLE
ArC: detect unsupported Inject annotations

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/observer/ObserverTransformerTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/observer/ObserverTransformerTest.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
 import jakarta.inject.Qualifier;
 import jakarta.inject.Singleton;
 
@@ -25,8 +26,6 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
-import com.google.inject.Inject;
 
 import io.quarkus.arc.deployment.ObserverTransformerBuildItem;
 import io.quarkus.arc.processor.ObserverTransformer;

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/wrongannotations/BeanWithIncorrectInject.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/wrongannotations/BeanWithIncorrectInject.java
@@ -1,0 +1,21 @@
+package io.quarkus.arc.test.wrongannotations;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+
+import com.google.inject.Inject;
+
+public class BeanWithIncorrectInject {
+
+    @Inject
+    BeanManager bm1;
+
+    @javax.inject.Inject
+    BeanManager bm2;
+
+    @com.oracle.svm.core.annotate.Inject
+    BeanManager bm3;
+
+    @org.gradle.internal.impldep.javax.inject.Inject
+    BeanManager bm4;
+
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/wrongannotations/WrongInjectTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/wrongannotations/WrongInjectTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.arc.test.wrongannotations;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.inject.Inject;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WrongInjectTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BeanWithIncorrectInject.class))
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                assertTrue(rootCause.getMessage().contains(
+                        "@com.google.inject.Inject declared on io.quarkus.arc.test.wrongannotations.BeanWithIncorrectInject.bm1, use @jakarta.inject.Inject instead"),
+                        t.toString());
+                assertTrue(rootCause.getMessage().contains(
+                        "@javax.inject.Inject declared on io.quarkus.arc.test.wrongannotations.BeanWithIncorrectInject.bm2, use @jakarta.inject.Inject instead"),
+                        t.toString());
+                assertTrue(rootCause.getMessage().contains(
+                        "@com.oracle.svm.core.annotate.Inject declared on io.quarkus.arc.test.wrongannotations.BeanWithIncorrectInject.bm3, use @jakarta.inject.Inject instead"),
+                        t.toString());
+                assertTrue(rootCause.getMessage().contains(
+                        "@org.gradle.internal.impldep.javax.inject.Inject declared on io.quarkus.arc.test.wrongannotations.BeanWithIncorrectInject.bm4, use @jakarta.inject.Inject instead"),
+                        t.toString());
+                assertTrue(rootCause.getMessage().contains(
+                        "@javax.inject.Inject declared on io.quarkus.arc.test.wrongannotations.WrongInjectTest.beanManager, use @jakarta.inject.Inject instead"),
+                        t.toString());
+            });
+
+    @Inject
+    BeanManager beanManager;
+
+    @Test
+    public void testValidationFailed() {
+        // This method should not be invoked
+        fail();
+    }
+
+}


### PR DESCRIPTION
- including javax.inject.Inject, com.google.inject.Inject, com.oracle.svm.core.annotate.Inject and
org.gradle.internal.impldep.javax.inject.Inject