### PR TITLE
UniAsserter - introduce UniAsserterInterceptor

### DIFF
--- a/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
@@ -854,7 +854,46 @@ public class PersonRepository implements PanacheRepositoryBase<Person,Integer> {
 == Testing
 
 Testing reactive Panache entities in a `@QuarkusTest` is slightly more complicated than testing regular Panache entities due to the asynchronous nature of the APIs and the fact that all operations need to run on a Vert.x event loop.
-The usage of `@RunOnVertxContext`, `@TestReactiveTransaction` and `UniAsserter` is described in the xref:hibernate-reactive.adoc#testing[Hibernate Reactive] guide.
+
+The `quarkus-test-vertx` dependency provides the `@io.quarkus.test.vertx.RunOnVertxContext` annotation and the `io.quarkus.test.vertx.UniAsserter` class which are intended precisely for this purpose. 
+The usage is described in the xref:hibernate-reactive.adoc#testing[Hibernate Reactive] guide.
+
+You can also extend the `io.quarkus.test.vertx.UniAsserterInterceptor` to customize the behavior of the injected `UniAsserter`.
+For example, the interceptor can be used to execute the assert methods within a separate database transaction.
+
+.`UniAsserterInterceptor` Example
+[source,java]
+----
+import io.quarkus.test.vertx.UniAsserterInterceptor;
+
+@QuarkusTest
+public class SomeTest {
+
+    static class TransactionalUniAsserterInterceptor extends UniAsserterInterceptor {
+
+        public TransactionUniAsserterInterceptor(UniAsserter asserter) {
+            super(asserter);
+        }
+
+        @Override
+        protected <T> Supplier<Uni<T>> transformUni(Supplier<Uni<T>> uniSupplier) {
+            // Assert/execute methods are invoked within a database transaction
+            return () -> Panache.withTransaction(uniSupplier);
+        }
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testEntity(UniAsserter asserter) {
+        asserter = new TransactionalUniAsserterInterceptor(asserter); <1>
+        asserter.execute(() -> new MyEntity().persist());
+        asserter.assertEquals(() -> MyEntity.count(), 1l);
+        asserter.execute(() -> MyEntity.deleteAll());
+    }
+}
+----
+<1> The `TransactionalUniAsserterInterceptor` wraps the injected `UniAsserter`.
+
 
 == Mocking
 

--- a/test-framework/vertx/src/main/java/io/quarkus/test/vertx/UniAsserterInterceptor.java
+++ b/test-framework/vertx/src/main/java/io/quarkus/test/vertx/UniAsserterInterceptor.java
@@ -1,0 +1,170 @@
+package io.quarkus.test.vertx;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Subclasses can be used to customize the behavior of the injected {@link UniAsserter}.
+ *
+ * Specifically, it can intercept selected methods and perform some additional logic. The {@link #transformUni(Supplier)} method
+ * can be used to transform the provided {@link Uni} supplier for assertion and {@link UniAsserter#execute(Supplier)} methods.
+ * For example, it can be used to perform all assertions within the scope of a database transaction:
+ *
+ * <pre>
+ * &#64;QuarkusTest
+ * public class SomeTest {
+ *
+ *     static class TransactionalUniAsserterInterceptor extends UniAsserterInterceptor {
+ *
+ *         public TransactionUniAsserterInterceptor(UniAsserter asserter){
+ *         super(asserter);
+ *         }
+ *
+ *         &#64;Override
+ *         protected <T> Supplier<Uni<T>> transformUni(Supplier<Uni<T>> uniSupplier) {
+ *             // Assert/execute methods are invoked within a database transaction
+ *             return () -> Panache.withTransaction(uniSupplier);
+ *         }
+ *     }
+ *
+ *     &#64;Test
+ *     &#64;RunOnVertxContext
+ *     public void testEntity(UniAsserter asserter) {
+ *         asserter = new TransactionalUniAsserterInterceptor(asserter);
+ *         asserter.execute(() -> new MyEntity().persist());
+ *         asserter.assertEquals(() -> MyEntity.count(), 1l);
+ *         asserter.execute(() -> MyEntity.deleteAll());
+ *     }
+ * }
+ * </pre>
+ *
+ */
+public abstract class UniAsserterInterceptor implements UniAsserter {
+
+    private final UniAsserter delegate;
+
+    public UniAsserterInterceptor(UniAsserter asserter) {
+        this.delegate = asserter;
+    }
+
+    /**
+     * This method can be used to transform the provided {@link Uni} supplier for assertion methods and
+     * {@link UniAsserter#execute(Supplier)}.
+     *
+     * @param <T>
+     * @param uniSupplier
+     * @return
+     */
+    protected <T> Supplier<Uni<T>> transformUni(Supplier<Uni<T>> uniSupplier) {
+        return uniSupplier;
+    }
+
+    @Override
+    public <T> UniAsserter assertThat(Supplier<Uni<T>> uni, Consumer<T> asserter) {
+        delegate.assertThat(transformUni(uni), asserter);
+        return this;
+    }
+
+    @Override
+    public <T> UniAsserter execute(Supplier<Uni<T>> uni) {
+        delegate.execute(transformUni(uni));
+        return this;
+    }
+
+    @Override
+    public UniAsserter execute(Runnable c) {
+        delegate.execute(c);
+        return this;
+    }
+
+    @Override
+    public <T> UniAsserter assertEquals(Supplier<Uni<T>> uni, T t) {
+        delegate.assertEquals(transformUni(uni), t);
+        return this;
+    }
+
+    @Override
+    public <T> UniAsserter assertNotEquals(Supplier<Uni<T>> uni, T t) {
+        delegate.assertNotEquals(transformUni(uni), t);
+        return this;
+    }
+
+    @Override
+    public <T> UniAsserter assertSame(Supplier<Uni<T>> uni, T t) {
+        delegate.assertSame(transformUni(uni), t);
+        return this;
+    }
+
+    @Override
+    public <T> UniAsserter assertNotSame(Supplier<Uni<T>> uni, T t) {
+        delegate.assertNotSame(transformUni(uni), t);
+        return this;
+    }
+
+    @Override
+    public <T> UniAsserter assertNull(Supplier<Uni<T>> uni) {
+        delegate.assertNull(transformUni(uni));
+        return this;
+    }
+
+    @Override
+    public <T> UniAsserter assertNotNull(Supplier<Uni<T>> uni) {
+        delegate.assertNotNull(transformUni(uni));
+        return this;
+    }
+
+    @Override
+    public <T> UniAsserter surroundWith(Function<Uni<T>, Uni<T>> uni) {
+        delegate.surroundWith(uni);
+        return this;
+    }
+
+    @Override
+    public UniAsserter fail() {
+        delegate.fail();
+        return this;
+    }
+
+    @Override
+    public UniAsserter assertTrue(Supplier<Uni<Boolean>> uni) {
+        delegate.assertTrue(transformUni(uni));
+        return this;
+    }
+
+    @Override
+    public UniAsserter assertFalse(Supplier<Uni<Boolean>> uni) {
+        delegate.assertFalse(transformUni(uni));
+        return this;
+    }
+
+    @Override
+    public <T> UniAsserter assertFailedWith(Supplier<Uni<T>> uni, Consumer<Throwable> c) {
+        delegate.assertFailedWith(transformUni(uni), c);
+        return this;
+    }
+
+    @Override
+    public <T> UniAsserter assertFailedWith(Supplier<Uni<T>> uni, Class<? extends Throwable> c) {
+        delegate.assertFailedWith(transformUni(uni), c);
+        return this;
+    }
+
+    @Override
+    public Object getData(String key) {
+        return delegate.getData(key);
+    }
+
+    @Override
+    public Object putData(String key, Object value) {
+        return delegate.putData(key, value);
+    }
+
+    @Override
+    public void clearData() {
+        delegate.clearData();
+    }
+
+}


### PR DESCRIPTION
A typical implementation use case could be something like:
```java
package org.acme;

import java.util.function.Supplier;
import io.quarkus.hibernate.reactive.panache.Panache;
import io.quarkus.test.vertx.UniAsserter;
import io.smallrye.mutiny.Uni;

public class TransactionalUniAsserterInterceptor extends UniAsserterInterceptor {

    public TransactionUniAsserterInterceptor(UniAsserter asserter) {
        super(asserter);
    }

    @Override
    protected <T> Supplier<Uni<T>> transformUni(Supplier<Uni<T>> uniSupplier) {
        return () -> Panache.withTransaction(uniSupplier);
    }
}
```
which basically "wraps" every assert and execute method with a database transaction.

And the usage looks like:

```java
@RunOnVertxContext
@Test
public void testEntity(UniAsserter asserter) {
        asserter = new TransactionalUniAsserterInterceptor(asserter);
        asserter.execute(() -> new MyEntity().persist());
        asserter.assertEquals(() -> MyEntity.count(), 1l);
        asserter.execute(() -> MyEntity.deleteAll());
    }
```
 