### PR TITLE
Update `enforcer-maven-plugin` from `3.0.0-M3` to `3.2.1`

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -28,7 +28,7 @@
         <scala-plugin.version>${scala-maven-plugin.version}</scala-plugin.version>
 
         <!-- version.* properties are defined in jboss-parent and are overridden/updated here: -->
-        <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>
+        <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
         <version.exec.plugin>3.0.0</version.exec.plugin>
         <failsafe-plugin.version>${version.surefire.plugin}</failsafe-plugin.version>
@@ -500,12 +500,6 @@
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-enforcer-rules</artifactId>
                             <version>${project.version}</version>
-                        </dependency>
-                        <!-- This dependency can be removed when MENFORCER-422 is available -->
-                        <dependency>
-                            <groupId>com.github.gastaldi</groupId>
-                            <artifactId>enforcer-rules</artifactId>
-                            <version>0.0.1</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -54,6 +54,7 @@
         <version.jpa>3.0.0</version.jpa>
         <version.mutiny>2.1.0</version.mutiny>
 
+        <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     </properties>
@@ -198,12 +199,6 @@
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-enforcer-rules</artifactId>
                             <version>${project.version}</version>
-                        </dependency>
-                        <!-- This dependency can be removed when MENFORCER-422 is available -->
-                        <dependency>
-                            <groupId>com.github.gastaldi</groupId>
-                            <artifactId>enforcer-rules</artifactId>
-                            <version>0.0.1</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -38,6 +38,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
+        <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <jandex.version>3.0.5</jandex.version>
@@ -109,12 +110,6 @@
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-enforcer-rules</artifactId>
                             <version>${project.version}</version>
-                        </dependency>
-                        <!-- This dependency can be removed when MENFORCER-422 is available -->
-                        <dependency>
-                            <groupId>com.github.gastaldi</groupId>
-                            <artifactId>enforcer-rules</artifactId>
-                            <version>0.0.1</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -35,6 +35,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
 
+        <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
+        <!-- Keeping 3.0.0.M3 because 3.2.1 requires class changes -->
         <enforcer-api.version>3.0.0-M3</enforcer-api.version>
         <maven-invoker-plugin.version>3.2.2</maven-invoker-plugin.version>
         <maven-core.version>3.8.7</maven-core.version>

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -37,6 +37,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
+        <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <jackson-bom.version>2.14.2</jackson-bom.version>
@@ -80,12 +81,6 @@
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-enforcer-rules</artifactId>
                             <version>${project.version}</version>
-                        </dependency>
-                        <!-- This dependency can be removed when MENFORCER-422 is available -->
-                        <dependency>
-                            <groupId>com.github.gastaldi</groupId>
-                            <artifactId>enforcer-rules</artifactId>
-                            <version>0.0.1</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/independent-projects/ide-config/pom.xml
+++ b/independent-projects/ide-config/pom.xml
@@ -39,6 +39,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
+        <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
     </properties>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -45,6 +45,7 @@
         <version.jandex>3.0.5</version.jandex>
         <version.gizmo>1.6.0.Final</version.gizmo>
         <version.jboss-logging>3.5.0.Final</version.jboss-logging>
+        <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
         <version.smallrye-mutiny>2.1.0</version.smallrye-mutiny>
@@ -121,12 +122,6 @@
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-enforcer-rules</artifactId>
                             <version>${project.version}</version>
-                        </dependency>
-                        <!-- This dependency can be removed when MENFORCER-422 is available -->
-                        <dependency>
-                            <groupId>com.github.gastaldi</groupId>
-                            <artifactId>enforcer-rules</artifactId>
-                            <version>0.0.1</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -57,6 +57,7 @@
         <gizmo.version>1.6.0.Final</gizmo.version>
         <jakarta.persistence-api.version>3.0.0</jakarta.persistence-api.version>
 
+        <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <mutiny.version>2.1.0</mutiny.version>
@@ -405,12 +406,6 @@
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-enforcer-rules</artifactId>
                             <version>${project.version}</version>
-                        </dependency>
-                        <!-- This dependency can be removed when MENFORCER-422 is available -->
-                        <dependency>
-                            <groupId>com.github.gastaldi</groupId>
-                            <artifactId>enforcer-rules</artifactId>
-                            <version>0.0.1</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/independent-projects/revapi/pom.xml
+++ b/independent-projects/revapi/pom.xml
@@ -28,6 +28,7 @@
     </scm>
 
     <properties>
+        <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -60,6 +60,7 @@
         <jboss-logging.version>3.5.0.Final</jboss-logging.version>
         <maven-core.version>3.8.7</maven-core.version>
         <mockito.version>5.1.1</mockito.version>
+        <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <quarkus.version>999-SNAPSHOT</quarkus.version>
@@ -252,12 +253,6 @@
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-enforcer-rules</artifactId>
                         <version>${project.version}</version>
-                    </dependency>
-                    <!-- This dependency can be removed when MENFORCER-422 is available -->
-                    <dependency>
-                        <groupId>com.github.gastaldi</groupId>
-                        <artifactId>enforcer-rules</artifactId>
-                        <version>0.0.1</version>
                     </dependency>
                 </dependencies>
                 <executions>


### PR DESCRIPTION
This updates the plugin used in the build but not the dependency on the `enforcer-api` in the custom rules created in `independent-projects/enforcer-rules` to avoid breaking other projects  