### PR TITLE
Fix typo in snapstart enable config

### DIFF
--- a/docs/src/main/asciidoc/amazon-snapstart.adoc
+++ b/docs/src/main/asciidoc/amazon-snapstart.adoc
@@ -22,7 +22,7 @@ However, you can enable/disable it explicitly using:
 
 [source, properties]
 ----
-quarkus.snapstart.enabled=true|false
+quarkus.snapstart.enable=true|false
 ----
 
 IMPORTANT: It does not enable/disable SnapStart for your function, only the Quarkus optimizations.


### PR DESCRIPTION
The documentation spells the enable configuration parameter incorrectly which results in this warning from quarkus:

`[WARNING] [io.quarkus.config] Unrecognized configuration key "quarkus.snapstart.enabled" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo`