### PR TITLE
Use CDI when accessing UserTransaction/TransactionManager in QuarkusTransaction

### DIFF
--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/QuarkusTransaction.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/QuarkusTransaction.java
@@ -9,8 +9,6 @@ import jakarta.transaction.Transactional;
 
 import com.arjuna.ats.jta.UserTransaction;
 
-import io.quarkus.arc.Arc;
-
 /**
  * A simplified transaction interface. While broadly covering the same use cases as {@link jakarta.transaction.UserTransaction},
  * this class is designed to be easier to use. The main features it offers over {@code UserTransaction} are:
@@ -52,8 +50,7 @@ public interface QuarkusTransaction {
      * @param options Options that apply to the new transaction
      */
     static void begin(BeginOptions options) {
-        RequestScopedTransaction tx = Arc.container().instance(RequestScopedTransaction.class).get();
-        tx.begin(options);
+        QuarkusTransactionImpl.begin(options);
     }
 
     /**

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/QuarkusTransactionImpl.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/QuarkusTransactionImpl.java
@@ -218,6 +218,11 @@ class QuarkusTransactionImpl {
         }
     }
 
+    static void begin(BeginOptions options) {
+        RequestScopedTransaction tx = Arc.container().instance(RequestScopedTransaction.class).get();
+        tx.begin(options);
+    }
+
     static void rollback() {
         try {
             getUserTransaction().rollback();
@@ -244,15 +249,14 @@ class QuarkusTransactionImpl {
 
     private static jakarta.transaction.UserTransaction getUserTransaction() {
         if (cachedUserTransaction == null) {
-            return cachedUserTransaction = com.arjuna.ats.jta.UserTransaction.userTransaction();
+            return cachedUserTransaction = Arc.container().instance(UserTransaction.class).get();
         }
         return cachedUserTransaction;
     }
 
     private static TransactionManager getTransactionManager() {
         if (cachedTransactionManager == null) {
-            return cachedTransactionManager = com.arjuna.ats.jta.TransactionManager
-                    .transactionManager();
+            return cachedTransactionManager = Arc.container().instance(TransactionManager.class).get();
         }
         return cachedTransactionManager;
     }

--- a/integration-tests/narayana-jta/pom.xml
+++ b/integration-tests/narayana-jta/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>

--- a/integration-tests/narayana-jta/src/main/java/io/quarkus/narayana/jta/TransactionBeanWithEvents.java
+++ b/integration-tests/narayana-jta/src/main/java/io/quarkus/narayana/jta/TransactionBeanWithEvents.java
@@ -66,6 +66,18 @@ public class TransactionBeanWithEvents {
         log.debug("Running transactional bean method");
 
         try {
+            listenToCommitRollback();
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot get transaction to register synchronization on bean call", e);
+        }
+
+        if (!isCommit) {
+            throw new RuntimeException("Rollback here!");
+        }
+    }
+
+    void listenToCommitRollback() {
+        try {
             tm.getTransaction().registerSynchronization(new Synchronization() {
                 @Override
                 public void beforeCompletion() {
@@ -84,10 +96,6 @@ public class TransactionBeanWithEvents {
             });
         } catch (Exception e) {
             throw new IllegalStateException("Cannot get transaction to register synchronization on bean call", e);
-        }
-
-        if (!isCommit) {
-            throw new RuntimeException("Rollback here!");
         }
     }
 

--- a/integration-tests/narayana-jta/src/test/java/io/quarkus/narayana/jta/TransactionScopeQuarkusTransactionRunnerTest.java
+++ b/integration-tests/narayana-jta/src/test/java/io/quarkus/narayana/jta/TransactionScopeQuarkusTransactionRunnerTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.narayana.jta;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.enterprise.context.ContextNotActiveException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class TransactionScopeQuarkusTransactionRunnerTest {
+
+    @Inject
+    TransactionScopedBean beanTransactional;
+
+    @Inject
+    TransactionBeanWithEvents beanEvents;
+
+    @Test
+    void transactionScopedInTransaction() {
+        TransactionScopedBean.resetCounters();
+
+        QuarkusTransaction.requiringNew().run(() -> {
+            beanTransactional.setValue(42);
+            assertEquals(1, TransactionScopedBean.getInitializedCount(), "Expected @PostConstruct to be invoked");
+            assertEquals(42, beanTransactional.getValue(), "Transaction scope did not save the value");
+
+            QuarkusTransaction.suspendingExisting().run(() -> {
+                assertThrows(ContextNotActiveException.class, () -> {
+                    beanTransactional.getValue();
+                }, "Not expecting to have available TransactionScoped bean outside of the transaction");
+
+                QuarkusTransaction.requiringNew().run(() -> {
+                    beanTransactional.setValue(1);
+                    assertEquals(2, TransactionScopedBean.getInitializedCount(), "Expected @PostConstruct to be invoked");
+                    assertEquals(1, beanTransactional.getValue(), "Transaction scope did not save the value");
+                });
+                assertEquals(1, TransactionScopedBean.getPreDestroyCount(), "Expected @PreDestroy to be invoked");
+
+                assertThrows(ContextNotActiveException.class, () -> {
+                    beanTransactional.getValue();
+                }, "Not expecting to have available TransactionScoped bean outside of the transaction");
+            });
+
+            assertEquals(42, beanTransactional.getValue(), "Transaction scope did not resumed correctly");
+        });
+        assertEquals(2, TransactionScopedBean.getPreDestroyCount(), "Expected @PreDestroy to be invoked");
+    }
+
+    @Test
+    void scopeEventsAreEmitted() {
+        TransactionBeanWithEvents.cleanCounts();
+
+        QuarkusTransaction.requiringNew().run(() -> {
+            beanEvents.listenToCommitRollback();
+        });
+
+        assertEquals(1, TransactionBeanWithEvents.getInitialized(), "Expected @Initialized to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getBeforeDestroyed(), "Expected @BeforeDestroyed to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getDestroyed(), "Expected @Destroyed to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getCommited(), "Expected commit to be called once");
+        assertEquals(0, TransactionBeanWithEvents.getRolledBack(), "Expected no rollback");
+        TransactionBeanWithEvents.cleanCounts();
+
+        assertThatThrownBy(() -> QuarkusTransaction.requiringNew().run(() -> {
+            beanEvents.listenToCommitRollback();
+            throw new RuntimeException();
+        }))
+                // expect runtime exception to rollback the call
+                .isInstanceOf(RuntimeException.class);
+
+        assertEquals(1, TransactionBeanWithEvents.getInitialized(), "Expected @Initialized to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getBeforeDestroyed(), "Expected @BeforeDestroyed to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getDestroyed(), "Expected @Destroyed to be observed");
+        assertEquals(0, TransactionBeanWithEvents.getCommited(), "Expected no commit");
+        assertEquals(1, TransactionBeanWithEvents.getRolledBack(), "Expected rollback to be called once");
+        TransactionBeanWithEvents.cleanCounts();
+    }
+
+}

--- a/integration-tests/narayana-jta/src/test/java/io/quarkus/narayana/jta/TransactionScopeTransactionalTest.java
+++ b/integration-tests/narayana-jta/src/test/java/io/quarkus/narayana/jta/TransactionScopeTransactionalTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.narayana.jta;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class TransactionScopeTransactionalTest {
+    @Inject
+    TransactionBeanWithEvents beanEvents;
+
+    @Test
+    void scopeEventsAreEmitted() {
+        TransactionBeanWithEvents.cleanCounts();
+
+        beanEvents.doInTransaction(true);
+
+        assertEquals(1, TransactionBeanWithEvents.getInitialized(), "Expected @Initialized to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getBeforeDestroyed(), "Expected @BeforeDestroyed to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getDestroyed(), "Expected @Destroyed to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getCommited(), "Expected commit to be called once");
+        assertEquals(0, TransactionBeanWithEvents.getRolledBack(), "Expected no rollback");
+        TransactionBeanWithEvents.cleanCounts();
+
+        assertThatThrownBy(() -> beanEvents.doInTransaction(false))
+                // expect runtime exception to rollback the call
+                .isInstanceOf(RuntimeException.class);
+
+        assertEquals(1, TransactionBeanWithEvents.getInitialized(), "Expected @Initialized to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getBeforeDestroyed(), "Expected @BeforeDestroyed to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getDestroyed(), "Expected @Destroyed to be observed");
+        assertEquals(0, TransactionBeanWithEvents.getCommited(), "Expected no commit");
+        assertEquals(1, TransactionBeanWithEvents.getRolledBack(), "Expected rollback to be called once");
+        TransactionBeanWithEvents.cleanCounts();
+    }
+
+}

--- a/integration-tests/narayana-jta/src/test/java/io/quarkus/narayana/jta/TransactionScopeUserTransactionTest.java
+++ b/integration-tests/narayana-jta/src/test/java/io/quarkus/narayana/jta/TransactionScopeUserTransactionTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.narayana.jta;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.enterprise.context.ContextNotActiveException;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.UserTransaction;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class TransactionScopeUserTransactionTest {
+    @Inject
+    UserTransaction tx;
+
+    @Inject
+    TransactionManager tm;
+
+    @Inject
+    TransactionScopedBean beanTransactional;
+
+    @Inject
+    TransactionBeanWithEvents beanEvents;
+
+    @Test
+    void transactionScopedInTransaction() throws Exception {
+        TransactionScopedBean.resetCounters();
+
+        tx.begin();
+        beanTransactional.setValue(42);
+        assertEquals(1, TransactionScopedBean.getInitializedCount(), "Expected @PostConstruct to be invoked");
+        assertEquals(42, beanTransactional.getValue(), "Transaction scope did not save the value");
+        Transaction suspendedTransaction = tm.suspend();
+
+        assertThrows(ContextNotActiveException.class, () -> {
+            beanTransactional.getValue();
+        }, "Not expecting to have available TransactionScoped bean outside of the transaction");
+
+        tx.begin();
+        beanTransactional.setValue(1);
+        assertEquals(2, TransactionScopedBean.getInitializedCount(), "Expected @PostConstruct to be invoked");
+        assertEquals(1, beanTransactional.getValue(), "Transaction scope did not save the value");
+        tx.commit();
+        assertEquals(1, TransactionScopedBean.getPreDestroyCount(), "Expected @PreDestroy to be invoked");
+
+        assertThrows(ContextNotActiveException.class, () -> {
+            beanTransactional.getValue();
+        }, "Not expecting to have available TransactionScoped bean outside of the transaction");
+
+        tm.resume(suspendedTransaction);
+        assertEquals(42, beanTransactional.getValue(), "Transaction scope did not resumed correctly");
+        tx.rollback();
+        assertEquals(2, TransactionScopedBean.getPreDestroyCount(), "Expected @PreDestroy to be invoked");
+    }
+
+    @Test
+    void scopeEventsAreEmitted() throws Exception {
+        TransactionBeanWithEvents.cleanCounts();
+
+        tx.begin();
+        beanEvents.listenToCommitRollback();
+        tx.commit();
+
+        assertEquals(1, TransactionBeanWithEvents.getInitialized(), "Expected @Initialized to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getBeforeDestroyed(), "Expected @BeforeDestroyed to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getDestroyed(), "Expected @Destroyed to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getCommited(), "Expected commit to be called once");
+        assertEquals(0, TransactionBeanWithEvents.getRolledBack(), "Expected no rollback");
+        TransactionBeanWithEvents.cleanCounts();
+
+        tx.begin();
+        beanEvents.listenToCommitRollback();
+        tx.rollback();
+
+        assertEquals(1, TransactionBeanWithEvents.getInitialized(), "Expected @Initialized to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getBeforeDestroyed(), "Expected @BeforeDestroyed to be observed");
+        assertEquals(1, TransactionBeanWithEvents.getDestroyed(), "Expected @Destroyed to be observed");
+        assertEquals(0, TransactionBeanWithEvents.getCommited(), "Expected no commit");
+        assertEquals(1, TransactionBeanWithEvents.getRolledBack(), "Expected rollback to be called once");
+        TransactionBeanWithEvents.cleanCounts();
+    }
+
+}


### PR DESCRIPTION
So that CDI scopes are handled correctly.

Fixes #28709