### PR TITLE
Improve linking in security topics and some style edits

### DIFF
--- a/docs/src/main/asciidoc/doc-concept.adoc
+++ b/docs/src/main/asciidoc/doc-concept.adoc
@@ -17,7 +17,7 @@ Each content type resolves a different user need, fulfills a different purpose, 
 
 We chose to align Quarkus docs with the Diátaxis documentation framework{fn-diataxis}, which defines a core content structure that addresses the different needs users have when consulting docs. 
 
-image::diataxis-framework.png[The content types in the Diátaxis documentation framework{fn-diataxis},width=70%, align=center]
+image::diataxis-framework.png[The content types in the Diátaxis documentation framework{fn-diataxis},width=40%, align=left]
 
 *Image credit: https://diataxis.fr/*
 

--- a/docs/src/main/asciidoc/security-architecture-concept.adoc
+++ b/docs/src/main/asciidoc/security-architecture-concept.adoc
@@ -29,12 +29,14 @@ To learn more about security authentication in Quarkus and the supported mechani
 
 == Proactive authentication
 
-Proactive authentication is enabled in Quarkus by default. The request is always authenticated if an incoming request has a credential, even if the target page does not require authentication
+Proactive authentication is enabled in Quarkus by default. 
+The request is always authenticated if an incoming request has a credential, even if the target page does not require authentication
 For more information, see xref:security-proactive-authentication-concept.adoc[Proactive authentication].
 
 == Quarkus Security customization
 
-Quarkus Security is also highly customizable. You can customize the following core security components of Quarkus:
+Quarkus Security is also highly customizable. 
+You can customize the following core security components of Quarkus:
 
 * `HttpAuthenticationMechanism`
 * `IdentityProvider`
@@ -44,4 +46,7 @@ For more information about customizing Quarkus Security, including reactive secu
 
 == References
 
+* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
+* xref:security-identity-providers-concept.adoc[Identity providers]
 * xref:security-authorize-web-endpoints-reference.adoc[Authorization of web endpoints]

--- a/docs/src/main/asciidoc/security-authentication-mechanisms-concept.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms-concept.adoc
@@ -3,36 +3,47 @@
 include::_attributes.adoc[]
 :categories: security,web
 
-The Quarkus Security framework supports multiple authentication mechanisms, which you can use to secure your applications.
-Some supported authentication mechanisms are built into Quarkus, and some require you to add an extension.
+The Quarkus Security framework supports multiple authentication mechanisms, which you can use to secure your applications. 
 You can also combine authentication mechanisms.
 
+[TIP]
+====
 Before you choose an authentication mechanism for securing your Quarkus applications, review the information provided.
+====
+
+== Overview of supported authentication mechanisms
+
+Some supported authentication mechanisms are built into Quarkus, and some require you to add an extension, all of which are detailed in the following sections on this page:
+
+* <<Built-in authentication mechanisms>>
+* <<Other supported authentication mechanisms>>
+
+The following table maps specific authentication requirements to a supported mechanism that you can use in Quarkus:
 
 .Authentication requirements and mechanisms
+[width=80%]
 [source, adoc]
 |===
-^|Authentication requirement ^| Authentication mechanism
+|Authentication requirement | Authentication mechanism
 
-^|Username and password ^|xref:security-basic-authentication-concept.adoc[Basic], xref:security-authentication-mechanisms-concept.adoc#form-auth[Form]
+|Username and password |xref:security-basic-authentication-concept.adoc[Basic], xref:security-authentication-mechanisms-concept.adoc#form-auth[Form]
 
-^|Bearer access token  ^a| xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer], xref:security-jwt.adoc[JWT], xref:security-oauth2.adoc[OAuth2]
+|Bearer access token  a| xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer], xref:security-jwt.adoc[JWT], xref:security-oauth2.adoc[OAuth2]
 
-^|Single sign-on (SSO) ^|xref:security-oidc-code-flow-authentication-concept.adoc[OIDC Code Flow], xref:security-authentication-mechanisms-concept.adoc#form-auth[Form]
+|Single sign-on (SSO) |xref:security-oidc-code-flow-authentication-concept.adoc[OIDC Code Flow], xref:security-authentication-mechanisms-concept.adoc#form-auth[Form]
 
-^|Client certificate  ^|xref:security-authentication-mechanisms-concept.adoc#mutual-tls[Mutual TLS (MTLS)]
+|Client certificate  |xref:security-authentication-mechanisms-concept.adoc#mutual-tls[Mutual TLS (MTLS)]
 
-^|WebAuthn ^|xref:security-webauthn-concept.adoc[WebAuthn]
+|WebAuthn |xref:security-webauthn-concept.adoc[WebAuthn]
 
-^|Kerberos ticket    ^|link:https://quarkiverse.github.io/quarkiverse-docs/quarkus-kerberos/dev/index.html[Kerberos]
+|Kerberos ticket    |link:https://quarkiverse.github.io/quarkiverse-docs/quarkus-kerberos/dev/index.html[Kerberos]
 |===
 
-* See also the <<table>> table featured later in this section.
+See also the <<table>> table featured later in this section.
 
+== Built-in authentication mechanisms
 
-== Built-in authentication support
-
-Quarkus Security provides the following built-in authentication mechanisms:
+Quarkus Security provides the following built-in authentication support:
 
 * xref:security-basic-authentication-concept.adoc[Basic authentication]
 * <<form-auth>>
@@ -40,7 +51,12 @@ Quarkus Security provides the following built-in authentication mechanisms:
 
 === Basic authentication
 
-You can secure your Quarkus application endpoints with the built-in HTTP Basic authentication mechanism. For more information, see xref:security-basic-authentication-concept.adoc[Basic authentication].
+You can secure your Quarkus application endpoints with the built-in HTTP Basic authentication mechanism. 
+For more information, see the following documentation:
+* xref:security-basic-authentication-concept.adoc[Basic authentication]
+* xref:security-identity-providers-concept.adoc[Identity providers]
+* xref:security-basic-authentication-howto.adoc[Enable Basic authentication]
+* xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and JPA]
 
 [[form-auth]]
 === Form-based authentication
@@ -330,3 +346,11 @@ Ensure that the value of the `auth-mechanism` property matches the authenticatio
 
 Proactive authentication is enabled in Quarkus by default. This means that if an incoming request has a credential then that request will always be authenticated, even if the target page does not require authentication.
 For more information, see xref:security-proactive-authentication-concept.adoc[Proactive authentication].
+
+== References
+
+* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-architecture-concept.adoc[Quarkus Security architecture] 
+* xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
+* xref:security-identity-providers-concept.adoc[Identity providers]
+* xref:security-authorize-web-endpoints-reference.adoc[Authorization of web endpoints]

--- a/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
+++ b/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
@@ -389,3 +389,7 @@ It is possible to use multiple expressions in the role definition.
 == References
 
 * xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-architecture-concept.adoc[Quarkus Security architecture] 
+* xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
+* xref:security-basic-authentication-concept.adoc[Basic authentication]
+* xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and JPA]

--- a/docs/src/main/asciidoc/security-basic-authentication-concept.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-concept.adoc
@@ -31,6 +31,7 @@ The following table outlines some limitations of using HTTP Basic authentication
 
 
 .Limitations of HTTP Basic authentication
+[width=80%]
 [cols="35%,65%"]
 |===
 |Limitation |Description
@@ -41,7 +42,7 @@ The risk of exposing credentials as plain text increases if a load balancer term
 Also, in multi-hop deployments, the credentials can be exposed if HTTPS is used between the client and the first Quarkus endpoint only, and the credentials are propagated to the next Quarkus endpoint over HTTP.
 
 |Credentials are sent with each request
-|In Basic authentication, a username and password need to be sent with each request, which increases the risk of credentials being exposed.
+|In Basic authentication, a username and password must be sent with each request, which increases the risk of credentials being exposed.
 
 |Application complexity increases
 |The Quarkus application must validate that usernames, passwords, and roles are managed securely.
@@ -55,10 +56,17 @@ Depending on the use case, other authentication mechanisms that delegate usernam
 For more information about how you can secure your Quarkus applications by using Basic authentication, see the following resources:
 
 * xref:security-basic-authentication-howto.adoc[Enable Basic authentication]
-* xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication]
+* xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and JPA]
+
+== Role-based access control
+
+{project-name} also includes built-in security to allow for role-based access control (RBAC) based on the common security annotations @RolesAllowed, @DenyAll, @PermitAll on REST endpoints and CDI beans. 
+For more information, see xref:security-authorize-web-endpoints-reference.adoc[Authorization of web endpoints].
 
 == References
 
 * xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-architecture-concept.adoc[Quarkus Security architecture] 
 * xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
-
+* xref:security-identity-providers-concept.adoc[Identity providers]
+* xref:security-authorize-web-endpoints-reference.adoc[Authorization of web endpoints]

--- a/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
@@ -3,7 +3,7 @@
 include::_attributes.adoc[]
 :categories: security
 
-Enable Basic authentication for your Quarkus project and allow users to authenticate with a username and password.
+Enable xref:security-basic-authentication-concept.adoc[Basic authentication] for your Quarkus project and allow users to authenticate with a username and password.
 
 == Prerequisites
 
@@ -48,3 +48,4 @@ To walk through how to configure Basic authentication together with JPA for stor
 * xref:security-overview-concept.adoc[Quarkus Security overview]
 * xref:security-identity-providers.adoc[Identity Providers]
 * xref:security-testing.adoc#configuring-user-information[Configuring User Information in application.properties]
+* xref:security-basic-authentication-concept.adoc[Basic authentication] 

--- a/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
@@ -594,6 +594,9 @@ Use the following information to learn how you can securely use `OpenID Connect`
 == References
 
 * xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-architecture-concept.adoc[Quarkus Security architecture] 
+* xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
+* xref:security-identity-providers-concept.adoc[Identity providers]
 * xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
 * xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:hibernate-orm-panache.adoc[Simplified Hibernate ORM with Panache]

--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -621,3 +621,6 @@ xref:context-propagation.adoc[Context Propagation Guide].
 == References
 
 * xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-architecture-concept.adoc[Quarkus Security architecture] 
+* xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
+* xref:security-identity-providers-concept.adoc[Identity providers]

--- a/docs/src/main/asciidoc/security-overview-concept.adoc
+++ b/docs/src/main/asciidoc/security-overview-concept.adoc
@@ -23,7 +23,7 @@ Quarkus Security also supports the following features:
 * <<Cross-origin resource sharing>>
 * <<Cross-site Request Forgery (CSRF) prevention>>
 * <<SameSite cookies>>
-* <<Secret engines>>
+* <<Secrets engines>>
 * <<Secure serialization>>
 * <<Secure auto-generated resources by REST Data with Panache>>
 * xref:security-vulnerability-detection-concept.adoc[Security vulnerability detection and National Vulnerability Database (NVD) registration]

--- a/docs/src/main/asciidoc/security-overview-concept.adoc
+++ b/docs/src/main/asciidoc/security-overview-concept.adoc
@@ -12,7 +12,7 @@ Before you start building security into your Quarkus applications, learn about t
 The Quarkus Security framework provides built-in security mechanisms for Basic, form-based, and mutual TLS (mTLS) authentication.
 You can also integrate Quarkus with several well-known security xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[authentication mechanisms] and protocols.
 
-{project-name} also includes built-in security to allow for role-based Access control (RBAC) based on the common security annotations @RolesAllowed, @DenyAll, @PermitAll on REST endpoints and CDI beans. 
+{project-name} also includes built-in security to allow for role-based access control (RBAC) based on the common security annotations @RolesAllowed, @DenyAll, @PermitAll on REST endpoints and CDI beans. 
 For more information, see xref:security-authorize-web-endpoints-reference.adoc[Authorization of web endpoints].
 
 Quarkus Security also supports the following features:
@@ -80,3 +80,10 @@ For more information, see xref:rest-data-panache.adoc#securing-endpoints[Securin
 
 Most of the Quarkus tags are reported in the US link:https://nvd.nist.gov[National Vulnerability Database (NVD)]. 
 For information about security vulnerabilities, see xref:security-vulnerability-detection-concept.adoc[Security vulnerability detection and reporting in Quarkus].
+
+
+== References
+
+* xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and JPA]
+* xref:security-oidc-code-flow-authentication-tutorial.adoc[Protect a web application by using OIDC authorization code flow]
+* xref:security-protect-service-application-using-oidc-bearer-authentication-tutorial.adoc[Protect a service application by using OIDC bearer authentication]

--- a/docs/src/main/asciidoc/security-proactive-authentication-concept.adoc
+++ b/docs/src/main/asciidoc/security-proactive-authentication-concept.adoc
@@ -152,5 +152,6 @@ public class AuthenticationFailedExceptionHandler {
 == References
 
 * xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-architecture-concept.adoc[Quarkus Security architecture] 
 * xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
-
+* xref:security-identity-providers-concept.adoc[Identity providers]


### PR DESCRIPTION
This PR enhances some of the recently restructured security topics to:

- [x] Add links to the Security overview page and other key security topics.
- [x] Style and quality edits (fixed broken section anchor, whitespace before table, table style, one sentence per line)

REF: [QDOCS-126](https://issues.redhat.com/browse/QDOCS-126)