### PR TITLE
Fail at build time when there are model conflicts in the JAXBContext

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -1353,6 +1353,15 @@ Importing this module will allow HTTP message bodies to be read from XML
 and serialised to XML, for <<resource-types,all the types not already registered with a more specific
 serialisation>>.
 
+The JAXB Resteasy Reactive extension will automatically detect the classes that are used in the resources and require JAXB serialization. Then, it will register these classes into the default `JAXBContext` which is internally used by the JAXB message reader and writer. 
+
+However, in some situations, these classes cause the `JAXBContext` to fail: for example, when you're using the same class name in different java packages. In these cases, the application will fail at build time and print the JAXB exception that caused the issue, so you can properly fix it. Alternatively, you can also exclude the classes that cause the issue by using the property `quarkus.jaxb.exclude-classes`. When excluding classes that are required by any resource, the JAXB resteasy reactive extension will create and cache a custom `JAXBContext` that will include the excluded class, causing a minimal performance degradance. 
+
+[NOTE]
+====
+The property `quarkus.jaxb.exclude-classes` accepts a comma separated list of fully qualified class names, for example: `quarkus.jaxb.exclude-classes=org.acme.one.Model,org.acme.two.Model`. 
+====
+
 ==== Advanced JAXB-specific features
 
 When using the `quarkus-resteasy-reactive-jaxb` extension there are some advanced features that RESTEasy Reactive supports.

--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/utils/JaxbType.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/utils/JaxbType.java
@@ -1,0 +1,68 @@
+package io.quarkus.jaxb.deployment.utils;
+
+import java.util.Locale;
+import java.util.Set;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+public class JaxbType {
+
+    private static final String DEFAULT_JAXB_ANNOTATION_VALUE = "##default";
+
+    private final String modelName;
+    private final Class<?> clazz;
+
+    public JaxbType(Class<?> clazz) {
+        this.modelName = findModelNameFromType(clazz);
+        this.clazz = clazz;
+    }
+
+    public String getModelName() {
+        return modelName;
+    }
+
+    public Class<?> getType() {
+        return clazz;
+    }
+
+    private String findModelNameFromType(Class<?> clazz) {
+        String nameFromAnnotation = DEFAULT_JAXB_ANNOTATION_VALUE;
+        String namespaceFromAnnotation = DEFAULT_JAXB_ANNOTATION_VALUE;
+        XmlType xmlType = clazz.getAnnotation(XmlType.class);
+        if (xmlType != null) {
+            nameFromAnnotation = xmlType.name();
+            namespaceFromAnnotation = xmlType.namespace();
+        } else {
+            XmlRootElement rootElement = clazz.getAnnotation(XmlRootElement.class);
+            if (rootElement != null) {
+                nameFromAnnotation = rootElement.name();
+                namespaceFromAnnotation = rootElement.namespace();
+            }
+        }
+
+        String modelName = nameFromAnnotation;
+        if (DEFAULT_JAXB_ANNOTATION_VALUE.equals(nameFromAnnotation)) {
+            modelName = clazz.getSimpleName().toLowerCase(Locale.ROOT);
+        }
+
+        if (!DEFAULT_JAXB_ANNOTATION_VALUE.equals(namespaceFromAnnotation)) {
+            modelName += "." + namespaceFromAnnotation;
+        }
+
+        return modelName;
+    }
+
+    public static boolean isValidType(Class<?> clazz) {
+        return clazz != null && !clazz.isPrimitive() && !clazz.isArray();
+    }
+
+    public static JaxbType findExistingType(Set<JaxbType> dictionary, JaxbType jaxbType) {
+        for (JaxbType existing : dictionary) {
+            if (existing.modelName.equals(jaxbType.modelName)) {
+                return existing;
+            }
+        }
+        return null;
+    }
+}

--- a/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/one/Model.java
+++ b/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/one/Model.java
@@ -1,0 +1,16 @@
+package io.quarkus.jaxb.deployment.one;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class Model {
+    private String name1;
+
+    public String getName1() {
+        return name1;
+    }
+
+    public void setName1(String name1) {
+        this.name1 = name1;
+    }
+}

--- a/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/two/Model.java
+++ b/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/two/Model.java
@@ -1,0 +1,22 @@
+package io.quarkus.jaxb.deployment.two;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * This class would make the JAXBContext to fail because there is an existing class with same name and model in the
+ * package `one`.
+ * To address this failure, we are excluding this class using the property `quarkus.jaxb.exclude-classes` in the
+ * `application.properties` file.
+ */
+@XmlRootElement
+public class Model {
+    private String name2;
+
+    public String getName2() {
+        return name2;
+    }
+
+    public void setName2(String name2) {
+        this.name2 = name2;
+    }
+}

--- a/extensions/jaxb/deployment/src/test/resources/application.properties
+++ b/extensions/jaxb/deployment/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.jaxb.exclude-classes=io.quarkus.jaxb.deployment.two.Model

--- a/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbConfig.java
+++ b/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbConfig.java
@@ -1,0 +1,17 @@
+package io.quarkus.jaxb.runtime;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED, name = "jaxb")
+public class JaxbConfig {
+    /**
+     * Exclude classes to automatically be bound to the default JAXB context.
+     */
+    @ConfigItem
+    public Optional<List<String>> excludeClasses;
+}

--- a/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextConfigRecorder.java
+++ b/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextConfigRecorder.java
@@ -1,6 +1,7 @@
 package io.quarkus.jaxb.runtime;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -8,13 +9,17 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class JaxbContextConfigRecorder {
-    private volatile static Set<String> classesToBeBound = new HashSet<>();
+    private volatile static Set<Class<?>> classesToBeBound = new HashSet<>();
 
-    public void addClassesToBeBound(Collection<String> additionalClassesToBeBound) {
-        this.classesToBeBound.addAll(additionalClassesToBeBound);
+    public void addClassesToBeBound(Collection<Class<?>> classes) {
+        this.classesToBeBound.addAll(classes);
     }
 
-    public static String[] getClassesToBeBound() {
-        return classesToBeBound.toArray(new String[0]);
+    public static Set<Class<?>> getClassesToBeBound() {
+        return Collections.unmodifiableSet(classesToBeBound);
+    }
+
+    public static boolean isClassBound(Class<?> clazz) {
+        return classesToBeBound.contains(clazz.getName());
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/one/Model.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/one/Model.java
@@ -1,0 +1,22 @@
+package io.quarkus.resteasy.reactive.jaxb.deployment.test.one;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * This class would make the JAXBContext to fail because there is an existing class with same name and model in the
+ * package `one`.
+ * To address this failure, we are excluding the model classes using the property `quarkus.jaxb.exclude-classes` in the
+ * `application.properties` file.
+ */
+@XmlRootElement
+public class Model {
+    private String name1;
+
+    public String getName1() {
+        return name1;
+    }
+
+    public void setName1(String name1) {
+        this.name1 = name1;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/two/Model.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/two/Model.java
@@ -1,0 +1,22 @@
+package io.quarkus.resteasy.reactive.jaxb.deployment.test.two;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * This class would make the JAXBContext to fail because there is an existing class with same name and model in the
+ * package `one`.
+ * To address this failure, we are excluding the model classes using the property `quarkus.jaxb.exclude-classes` in the
+ * `application.properties` file.
+ */
+@XmlRootElement
+public class Model {
+    private String name2;
+
+    public String getName2() {
+        return name2;
+    }
+
+    public void setName2(String name2) {
+        this.name2 = name2;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/resources/exclude-model-from-jaxb.properties
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/resources/exclude-model-from-jaxb.properties
@@ -1,0 +1,1 @@
+quarkus.jaxb.exclude-classes=io.quarkus.resteasy.reactive.jaxb.deployment.test.one.Model,io.quarkus.resteasy.reactive.jaxb.deployment.test.two.Model

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/runtime/src/main/java/io/quarkus/resteasy/reactive/jaxb/runtime/JAXBContextContextResolver.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/runtime/src/main/java/io/quarkus/resteasy/reactive/jaxb/runtime/JAXBContextContextResolver.java
@@ -1,0 +1,33 @@
+package io.quarkus.resteasy.reactive.jaxb.runtime;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.xml.bind.JAXBContext;
+
+import io.quarkus.jaxb.runtime.JaxbContextCustomizer;
+import io.quarkus.jaxb.runtime.JaxbContextProducer;
+
+public class JAXBContextContextResolver implements ContextResolver<JAXBContext> {
+
+    private ConcurrentHashMap<Class<?>, JAXBContext> cache = new ConcurrentHashMap<>();
+
+    @Inject
+    Instance<JaxbContextCustomizer> customizers;
+
+    @Inject
+    JaxbContextProducer jaxbContextProducer;
+
+    @Override
+    public JAXBContext getContext(Class<?> clazz) {
+        JAXBContext jaxbContext = cache.get(clazz);
+        if (jaxbContext == null) {
+            jaxbContext = jaxbContextProducer.createJAXBContext(customizers, clazz);
+            cache.put(clazz, jaxbContext);
+        }
+
+        return jaxbContext;
+    }
+}

--- a/integration-tests/rest-client-reactive-multipart/src/main/java/io/quarkus/it/rest/client/multipart/Data.java
+++ b/integration-tests/rest-client-reactive-multipart/src/main/java/io/quarkus/it/rest/client/multipart/Data.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.rest.client.multipart;
+
+import jakarta.ws.rs.FormParam;
+
+import org.jboss.resteasy.reactive.PartType;
+
+public class Data {
+    @FormParam("text")
+    @PartType("text/plain")
+    private String text;
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+}

--- a/integration-tests/rest-client-reactive-multipart/src/main/java/io/quarkus/it/rest/client/multipart/FileResponse.java
+++ b/integration-tests/rest-client-reactive-multipart/src/main/java/io/quarkus/it/rest/client/multipart/FileResponse.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.rest.client.multipart;
+
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/file")
+public class FileResponse {
+    @POST
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello(@BeanParam Data data) {
+        return data.getText();
+    }
+}

--- a/integration-tests/rest-client-reactive-multipart/src/main/resources/larger-than-default-form-attribute.txt
+++ b/integration-tests/rest-client-reactive-multipart/src/main/resources/larger-than-default-form-attribute.txt
@@ -1,0 +1,3753 @@
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi
+%%
+Type: language
+Subtag: an
+Description: Aragonese
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ar
+Description: Arabic
+Added: 2005-10-16
+Suppress-Script: Arab
+Scope: macrolanguage
+%%
+Type: language
+Subtag: as
+Description: Assamese
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: av
+Description: Avaric
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ay
+Description: Aymara
+Added: 2005-10-16
+Suppress-Script: Latn
+Scope: macrolanguage
+%%
+Type: language
+Subtag: az
+Description: Azerbaijani
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: ba
+Description: Bashkir
+Added: 2005-10-16
+%%
+Type: language
+Subtag: be
+Description: Belarusian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bg
+Description: Bulgarian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: bh
+Description: Bihari languages
+Added: 2005-10-16
+Scope: collection
+%%
+Type: language
+Subtag: bi
+Description: Bislama
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bm
+Description: Bambara
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bn
+Description: Bengali
+Description: Bangla
+Added: 2005-10-16
+Suppress-Script: Beng
+%%
+Type: language
+Subtag: bo
+Description: Tibetan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: br
+Description: Breton
+Added: 2005-10-16
+%%
+Type: language
+Subtag: bs
+Description: Bosnian
+Added: 2005-10-16
+Suppress-Script: Latn
+Macrolanguage: sh
+%%
+Type: language
+Subtag: ca
+Description: Catalan
+Description: Valencian
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ce
+Description:
+%%
+Type: language
+Subtag: ce
+Description:
+File-Date: 2018-04-23
+%%
+Type: language
+Subtag: aa
+Description: Afar
+Added: 2005-10-16
+%%
+Type: language
+Subtag: ab
+Description: Abkhazian
+Added: 2005-10-16
+Suppress-Script: Cyrl
+%%
+Type: language
+Subtag: ae
+Description: Avestan
+Added: 2005-10-16
+%%
+Type: language
+Subtag: af
+Description: Afrikaans
+Added: 2005-10-16
+Suppress-Script: Latn
+%%
+Type: language
+Subtag: ak
+Description: Akan
+Added: 2005-10-16
+Scope: macrolanguage
+%%
+Type: language
+Subtag: am
+Description: Amharic
+Added: 2005-10-16
+Suppress-Script: Ethi

--- a/integration-tests/rest-client-reactive-multipart/src/test/java/io/quarkus/it/rest/client/multipart/LargerThanDefaultFormAttributeMultipartFormInputTest.java
+++ b/integration-tests/rest-client-reactive-multipart/src/test/java/io/quarkus/it/rest/client/multipart/LargerThanDefaultFormAttributeMultipartFormInputTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.it.rest.client.multipart;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.vertx.core.http.HttpServerOptions;
+
+@Disabled
+@QuarkusTest
+public class LargerThanDefaultFormAttributeMultipartFormInputTest {
+    private final File FILE = new File("./src/main/resources/larger-than-default-form-attribute.txt");
+
+    @Test
+    public void test() throws IOException {
+        String fileContents = new String(Files.readAllBytes(FILE.toPath()), StandardCharsets.UTF_8);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 10; ++i) {
+            sb.append(fileContents);
+        }
+        fileContents = sb.toString();
+
+        Assertions.assertTrue(fileContents.length() > HttpServerOptions.DEFAULT_MAX_FORM_ATTRIBUTE_SIZE);
+        given()
+                .multiPart("text", fileContents)
+                .accept("text/plain")
+                .when()
+                .post("/file")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.TEXT)
+                .body(equalTo(fileContents));
+    }
+
+}


### PR DESCRIPTION
When having these two classes:

```java
package io.quarkus.resteasy.reactive.jaxb.deployment.test.one;

import jakarta.xml.bind.annotation.XmlRootElement;

@XmlRootElement
public class Model {
    private String name;
    // ...
}
```

And:
```java
package io.quarkus.resteasy.reactive.jaxb.deployment.test.two;

import jakarta.xml.bind.annotation.XmlRootElement;

@XmlRootElement
public class Model {
    private String name;
    // ...
}
```

If users use the `quarkus-jaxb` extension and they inject the JAXBContext, for example:

```java
@Inject
JAXBContext context;
```

This will fail at runtime because JAXB sees the Model classes as one because of the name. 

These changes address this issue by failing at build time, so users can properly address it by fixing the JAXB model. 

Moreover, users can now exclude any of these classes by using the new property `quarkus.jaxb.exclude-classes`, for example:

```
quarkus.jaxb.exclude-classes=io.quarkus.jaxb.deployment.two.Model
```

Plus, in resteasy reactive, if users exclude a class that is required to serialize/deserialize using JAXB, it will not cause any harm because internally it will recreate a cached JAXBContext including the excluded cache.

Fix https://github.com/quarkusio/quarkus/issues/31032