### PR TITLE
Quarkiverse: Install instead of verify

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/build.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn -B clean verify -Dno-format
+        run: mvn -B clean install -Dno-format
 
       - name: Build with Maven (Native)
-        run: mvn -B verify -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip
+        run: mvn -B install -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip


### PR DESCRIPTION
Some extensions require installing the artifact in the local repository in order to have their tests passed
