### PR TITLE
Allow multiple OIDC code flows in the same browser

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -773,6 +773,20 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public CookieSameSite cookieSameSite = CookieSameSite.LAX;
 
         /**
+         * If a state cookie is present then a `state` query parameter must also be present and both the state
+         * cookie name suffix and state cookie value have to match the value of the `state` query parameter when
+         * the redirect path matches the current path.
+         * However, if multiple authentications are attempted from the same browser, for example, from the different
+         * browser tabs, then the currently available state cookie may represent the authentication flow
+         * initiated from another tab and not related to the current request.
+         * Disable this property if you would like to avoid supporting multiple authorization code flows running in the same
+         * browser.
+         *
+         */
+        @ConfigItem(defaultValue = "true")
+        public boolean allowMultipleCodeFlows = true;
+
+        /**
          * If this property is set to 'true' then an OIDC UserInfo endpoint will be called.
          */
         @ConfigItem(defaultValueDocumentation = "false")
@@ -1020,6 +1034,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setCookieSameSite(CookieSameSite cookieSameSite) {
             this.cookieSameSite = cookieSameSite;
+        }
+
+        public boolean isAllowMultipleCodeFlows() {
+            return allowMultipleCodeFlows;
+        }
+
+        public void setAllowMultipleCodeFlows(boolean allowMultipleCodeFlows) {
+            this.allowMultipleCodeFlows = allowMultipleCodeFlows;
         }
     }
 

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.keycloak;
 
+import java.util.List;
+
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -37,7 +39,9 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
     @Override
     public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
         if (context.request().path().contains("callback-before-wrong-redirect")) {
-            if (context.getCookie("q_auth_tenant-before-wrong-redirect") != null) {
+            List<String> stateParam = context.queryParam("state");
+            if (stateParam.size() == 1 &&
+                    context.getCookie("q_auth_tenant-before-wrong-redirect_" + stateParam.get(0)) != null) {
                 // trigger the code to access token exchange failure due to a redirect uri mismatch
                 config.authentication.setRedirectPath("wrong-path");
             }
@@ -45,4 +49,5 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
         }
         return Uni.createFrom().nullItem();
     }
+
 }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -266,6 +266,12 @@ public class ProtectedResource {
     @GET
     @Path("refresh/tenant-listener")
     public String getRefreshTokenTenantListener() {
+        throw new InternalServerErrorException("This method must not be invoked");
+    }
+
+    @GET
+    @Path("refresh/tenant-listener/callback")
+    public String getRefreshTokenTenantListenerCallback() {
         return getRefreshToken();
     }
 

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -24,6 +24,7 @@ quarkus.oidc.tenant-listener.credentials.secret=secret
 # Redirect parameters are dropped by redirecting the authenticated user but this final redirect loses the login event message
 # on Vertx context; so disabling it for the test endpoint to confirm the login event has been accepted
 quarkus.oidc.tenant-listener.authentication.remove-redirect-parameters=false
+quarkus.oidc.tenant-listener.authentication.redirect-path=/web-app/refresh/tenant-listener/callback
 quarkus.oidc.tenant-listener.application-type=web-app
 
 # Tenant which does not need to restore a request path after redirect, client_secret_post method

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -632,7 +632,13 @@ public class BearerTokenAuthorizationTest {
     }
 
     private Cookie getStateCookie(WebClient webClient, String tenantId) {
-        return webClient.getCookieManager().getCookie("q_auth" + (tenantId == null ? "" : "_" + tenantId));
+        String cookieSuffix = "q_auth" + (tenantId == null ? "" : "_" + tenantId) + "_";
+        for (Cookie c : webClient.getCookieManager().getCookies()) {
+            if (c.getName().startsWith(cookieSuffix) && c.getName().length() > cookieSuffix.length()) {
+                return c;
+            }
+        }
+        return null;
     }
 
     private Cookie getSessionCookie(WebClient webClient, String tenantId) {


### PR DESCRIPTION
Fixes #27348.

Right now, when Quarkus OIDC is processing a redirect from Keycloak/other providers, will fail with 401 if it detects a state cookie but no matching `state` query is found in the request URI, even if the current request path does not match the actual redirect path - which is not a problem in a typical single tab browser authentication flow.

However looks like a lot of users want to support a multi-tab authentication or there could be some tests doing parallel authentication flows. For example, with a multi-tab authentication, the user accesses Quarkus, is redirected to Keycloak, but does not complete the authentication in that tab for whatever reasons, then opens another tab, and accesses Quarkus again which detects a state cookie from another pending authentication from the 1st tab but finds no state query parameter and fails with 401.

This PR updates `CodeAuthenticationMechanism` to use unique state cookie names as recommended in #27348, will fail  the request if it finds a session cookie but no matching state query parameter only if the current request path matches the redirect path (i.e if it is a redirect from Keycloak) which makes it closer to the way the OAuth2 spec is in fact recommens checking the state cookie or if the user has chosen not to support multiple authorization code flows from the same browser.

If `CodeAuthenticationMechanism`  does not fail with `401` then it does not mean it will let the request through, the only difference now is that it will issue a new challenge, thus making it possible to authenticate from multiple tabs.

I've verified it with the browser and added a test confirming the same with the following sequence:
- access the test endpoint, be redirected to Keycloak, prepare to submit name and password
- now use the same `WebClient` to access Quarkus again, complete the authentication flow, get the data from Quarkus
- now complete the original authentication - `You are already logged in` message is returned from Keycloak

All in all, it is a fairly straightforward update, but I won't ask to backport to avoid any side effects at all.



