### PR TITLE
Arc - validate Event raw type injection points and throw DefinitionException when found

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
@@ -134,6 +134,13 @@ public class InjectionPointInfo {
         this.position = position;
         this.isTransientReference = isTransientReference;
         this.isDelegate = isDelegate;
+
+        // validation - Event injection point can never be a raw type
+        if (DotNames.EVENT.equals(requiredType.name()) && requiredType.kind() == Type.Kind.CLASS) {
+            throw new DefinitionException(
+                    "Event injection point can never be raw type - please specify the type parameter. Injection point: "
+                            + target);
+        }
     }
 
     void resolve(BeanInfo bean) {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/injection/invalid/ConstructorEventRawTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/injection/invalid/ConstructorEventRawTypeTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.arc.test.event.injection.invalid;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ConstructorEventRawTypeTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(InvalidBean.class).shouldFail()
+            .build();
+
+    @Test
+    public void testExceptionIsThrown() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @Dependent
+    public static class InvalidBean {
+
+        // raw event type
+        public InvalidBean(Event event) {
+        }
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/injection/invalid/DisposerMethodEventRawTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/injection/invalid/DisposerMethodEventRawTypeTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.arc.test.event.injection.invalid;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DisposerMethodEventRawTypeTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(DisposerMethodInjectionBean.class).shouldFail()
+            .build();
+
+    @Test
+    public void testExceptionIsThrown() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @Dependent
+    public static class DisposerMethodInjectionBean {
+
+        @Produces
+        public Foo produceFoo() {
+            return new Foo();
+        }
+
+        // rawtype Event
+        public void disposeFoo(@Disposes Foo foo, Event event) {
+        }
+
+    }
+
+    static class Foo {
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/injection/invalid/EventRawTypeInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/injection/invalid/EventRawTypeInjectionTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.arc.test.event.injection.invalid;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class EventRawTypeInjectionTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(WrongBean.class).shouldFail()
+            .build();
+
+    @Test
+    public void testExceptionIsThrown() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @Singleton
+    @Unremovable
+    static class WrongBean {
+
+        @Inject
+        Event rawEvent;
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/injection/invalid/InitMethodEventRawTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/injection/invalid/InitMethodEventRawTypeTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.arc.test.event.injection.invalid;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InitMethodEventRawTypeTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(InvalidBean.class).shouldFail()
+            .build();
+
+    @Test
+    public void testExceptionIsThrown() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @Dependent
+    public static class InvalidBean {
+
+        // raw event type
+        @Inject
+        public void initMethod(Event event) {
+        }
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/injection/invalid/ObserverMethodEventRawType.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/injection/invalid/ObserverMethodEventRawType.java
@@ -1,0 +1,37 @@
+package io.quarkus.arc.test.event.injection.invalid;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ObserverMethodEventRawType {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(InvalidBean.class).shouldFail()
+            .build();
+
+    @Test
+    public void testExceptionIsThrown() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @Dependent
+    public static class InvalidBean {
+
+        // raw event type
+        public void observe(@Observes String something, Event event) {
+        }
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/injection/invalid/ProducerMethodEventRawTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/injection/invalid/ProducerMethodEventRawTypeTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.arc.test.event.injection.invalid;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ProducerMethodEventRawTypeTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(ProducerMethodInjectionBean.class).shouldFail()
+            .build();
+
+    @Test
+    public void testExceptionIsThrown() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @Dependent
+    public static class ProducerMethodInjectionBean {
+
+        @Produces
+        public Foo produceFoo(Event event) { // rawtype event injection point
+            return new Foo();
+        }
+    }
+
+    static class Foo {
+
+    }
+}


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/issues/28558

According to CDI spec, injecting a raw type of `Event` leads to a `DefinitionException` which we so far didn't check.
Tests mirror those in TCKs and should capture the scenarios in which this can potentially occur.