### PR TITLE
MongoDB with Panache fix multitenancy documentation

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -1314,8 +1314,8 @@ import io.quarkus.mongodb.panache.common.MongoEntity;
 public class Person extends PanacheMongoEntityBase {
     @BsonId
     public Long id;
-    public String firstName;
-    public String lastName;
+    public String firstname;
+    public String lastname;
 }
 ----
 
@@ -1394,13 +1394,11 @@ public class PanacheMongoMultiTenancyTest {
         person1.id = 1L;
         person1.firstname = "Pedro";
         person1.lastname = "Pereira";
-        person1.status = Status.ALIVE;
 
         Person person2 = new Person();
         person2.id = 2L;
         person2.firstname = "Tibé";
         person2.lastname = "Venâncio";
-        person2.status = Status.ALIVE;
 
         String endpoint = "/persons";
 


### PR DESCRIPTION
Removing `person1.status = Status.ALIVE;` and `person2.status = Status.ALIVE;`. Because for this example the Person class does not have a status attribute.

Transform Person attributes  `firstName` and  `lastName` to lowercase 

@loicmathieu @gsmet 