### PR TITLE
TIP quarkus-systemd-notify when deploy to systemd

### DIFF
--- a/docs/src/main/asciidoc/container-image.adoc
+++ b/docs/src/main/asciidoc/container-image.adoc
@@ -209,6 +209,13 @@ For example, if both `container-image-docker` and `container-image-s2i` are pres
 quarkus.container-image.builder=docker
 ----
 
+== Integrating with `systemd-notify`
+
+If you are building a container image in order to deploy your Quarkus application as a Linux service with Podman and Systemd, you might want to consider including the https://quarkiverse.github.io/quarkiverse-docs/quarkus-systemd-notify/dev/index.html[Quarkus Systemd Notify Extension] as part of your application, with:
+
+:add-extension-extensions: io.quarkiverse.systemd.notify:quarkus-systemd-notify
+include::{includes}/devtools/extension-add.adoc[]
+
 == Customizing
 
 The following properties can be used to customize the container image build process.


### PR DESCRIPTION
I've been following a tutorial to deploy container image based application as a service on Linux using Podman and Systemd.

I am a Java developer, not much of a sysadmin. The tutorial was easy to follow and everything seemed to be working as expected, _except_ when configuring a systemd service the Quarkus app was started again as normal (I could interact with the app) but the systemd status was always dangling to "Starting" / initialising, despite the log from the Quarkus app showed it was fully started for long.

I've then been following a "rabbit hole" only to figure out:

1. avoid launching with `podman run --sdnotify=container ...` unless I know _for certain_ the container image do support the NOTIFY_SOCKET, which is not always so trivial to figure out. I've learned from:
https://github.com/containers/podman/issues/15029#issuecomment-1192244755
2. I later noticed analogous topic for Quarkus was discussed in this thread:
https://github.com/quarkusio/quarkus/issues/29107#issuecomment-1340864656

This was a great learning opportunity, but at the same time if only I had this TIP inside of the quarkus guide (this PR) I guess it would have saved me quite some time 😅 , so I hope this addendum is merged in the hope of being a very relevant suggestion to the next one reading after me :)

Thanks!