### PR TITLE
Upgrade microprofile-openapi-tck to 3.1

### DIFF
--- a/tcks/microprofile-openapi/pom.xml
+++ b/tcks/microprofile-openapi/pom.xml
@@ -14,7 +14,7 @@
     <name>Quarkus - TCK - MicroProfile OpenAPI</name>
 
     <properties>
-        <microprofile-openapi-tck.version>3.0</microprofile-openapi-tck.version>
+        <microprofile-openapi-tck.version>3.1</microprofile-openapi-tck.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Related to #31084

@MikeEdgar I tried to upgrade the OpenAPI TCK in main as I thought it would be an easy one but there are 2 test failures.

Could you have a look?

```
[ERROR]   AirlinesAppTest>Arquillian.run:138->testOperationUserResource:285 1 expectation failed.
JSON path paths.'/user/special'.post.requestBody.content.'application/json'.schema doesn't match.
Expected: is null
  Actual: <{$ref=#/components/schemas/User}>

[ERROR]   AirlinesAppTest>Arquillian.run:138->testOperationUserResource:285 1 expectation failed.
JSON path paths.'/user/special'.post.requestBody.content.'application/json'.schema doesn't match.
Expected: is null
  Actual: <{$ref=#/components/schemas/User}>
```