### PR TITLE
Fix wrong artifact ID in Redis docs

### DIFF
--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -39,7 +39,7 @@ In your `pom.xml` file, add:
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
-implementation("io.quarkus:quarkus-redis")
+implementation("io.quarkus:quarkus-redis-client")
 ----
 
 With this dependency, you can then inject Redis clients or _datasource_ (high-level, type-safe API), such as:


### PR DESCRIPTION
In https://quarkus.io/guides/redis-reference#installation, there is a wrong artifact ID in the docs about how to install it with Gradle.

Fixes https://github.com/quarkusio/quarkus/issues/31095 