### PR TITLE
Add post-processing to the grpc-stubs project

### DIFF
--- a/extensions/grpc/stubs/pom.xml
+++ b/extensions/grpc/stubs/pom.xml
@@ -19,6 +19,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc-codegen</artifactId>
         </dependency>
         <dependency>
@@ -82,9 +86,11 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}
+                    </protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
+                    </pluginArtifact>
                     <protocPlugins>
                         <protocPlugin>
                             <id>quarkus-grpc-protoc-plugin</id>
@@ -102,6 +108,27 @@
                             <goal>compile</goal>
                             <goal>compile-custom</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>post-process</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <includeProjectDependencies>true</includeProjectDependencies>
+                            <arguments>
+                                <argument>${project.build.directory}/generated-sources/protobuf/grpc-java</argument>
+                            </arguments>
+                            <mainClass>io.quarkus.grpc.deployment.GrpcPostProcessing</mainClass>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/extensions/grpc/stubs/src/main/proto/reflection/v1alpha/reflection.proto
+++ b/extensions/grpc/stubs/src/main/proto/reflection/v1alpha/reflection.proto
@@ -11,7 +11,7 @@ service ServerReflection {
   // The reflection service is structured as a bidirectional stream, ensuring
   // all related requests go to a single server.
   rpc ServerReflectionInfo(stream ServerReflectionRequest)
-  returns (stream ServerReflectionResponse);
+      returns (stream ServerReflectionResponse);
 }
 
 // The message sent by the client when calling ServerReflectionInfo method.


### PR DESCRIPTION
This project contains gRPC definitions (.proto) and generates the stubs and skeletons using the regular gRPC tooling (so not the Quarkus one). Thus, it didn't apply the post-processing steps fixing the @Generated annotation (to avoid `javax`) and removing the "final" modifiers.

This commit calls the post-processor so the generated files using the maven exec plugin.

Fix #31083
