### PR TITLE
Create "native" category for docs

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -5,7 +5,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Building a Native Executable
 include::_attributes.adoc[]
-:categories: getting-started
+:categories: getting-started, native
 :summary: Build native executables with GraalVM or Mandrel.
 
 This guide covers:

--- a/docs/src/main/asciidoc/doc-reference.adoc
+++ b/docs/src/main/asciidoc/doc-reference.adoc
@@ -329,6 +329,7 @@ Quarkus documentation is grouped into the following categories.
 | integration | Support for integration extensions (Camel)
 | messaging | Integrations with messaging systems like Kafka, AMQP, or RabbitMQ.
 | miscellaneous | Miscellaneous
+| native | Everything related to native executables
 | observability | Extensions and integrations for runtime and application observability
 | reactive | Extensions that support reactive technologies and techniques
 | security | Security

--- a/docs/src/main/asciidoc/native-and-ssl.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl.adoc
@@ -5,7 +5,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using SSL With Native Executables
 include::_attributes.adoc[]
-:categories: core
+:categories: core, native, security
 :summary: In this guide, we will discuss how you can get your native images to support SSL, as native images don't support it out of the box.
 :devtools-no-gradle:
 

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -6,6 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Native Reference Guide
 
 include::_attributes.adoc[]
+:categories: native
 
 This guide is a companion to the
 xref:building-native-image.adoc[Building a Native Executable],

--- a/docs/src/main/asciidoc/writing-native-applications-tips.adoc
+++ b/docs/src/main/asciidoc/writing-native-applications-tips.adoc
@@ -5,7 +5,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Tips for writing native applications
 include::_attributes.adoc[]
-:categories: core, writing-extensions
+:categories: core, writing-extensions, native
 :summary: This guide is a collection of tips to help you solve the problems you encounter when compiling applications to native executable.
 
 This guide contains various tips and tricks for getting around problems that might arise when attempting to run Java applications as native executables.

--- a/docs/src/main/java/io/quarkus/docs/generation/YamlMetadataGenerator.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/YamlMetadataGenerator.java
@@ -265,6 +265,7 @@ public class YamlMetadataGenerator {
         integration("integration", "Integration"),
         messaging("messaging", "Messaging"),
         miscellaneous("miscellaneous", "Miscellaneous"),
+        native_docs("native", "Native"),
         observability("observability", "Observability"),
         reactive("reactive", "Reactive"),
         security("security", "Security"),


### PR DESCRIPTION
This makes it easier to filter all the guides, tutorials, references, etc. that are related to native mode.