### PR TITLE
Add link to 'how to write a guide' docs in create-extension template

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/runtime/src/main/resources/META-INF/quarkus-extension.tpl.qute.yaml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/runtime/src/main/resources/META-INF/quarkus-extension.tpl.qute.yaml
@@ -3,7 +3,7 @@ name: {extension.name}
 metadata:
 #  keywords:
 #    - {extension.id}
-#  guide: {extension.guide ?: '...'}
+#  guide: {extension.guide ?: '...'} # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
 #  categories:
 #    - "miscellaneous"
 #  status: "preview"

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateCoreExtension/extensions_my-ext_runtime_src_main_resources_META-INF_quarkus-extension.yaml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateCoreExtension/extensions_my-ext_runtime_src_main_resources_META-INF_quarkus-extension.yaml
@@ -3,7 +3,7 @@ name: My Ext
 metadata:
 #  keywords:
 #    - my-ext
-#  guide: ...
+#  guide: ... # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
 #  categories:
 #    - "miscellaneous"
 #  status: "preview"

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateCoreExtensionFromExtensionsDir/extensions_my-ext_runtime_src_main_resources_META-INF_quarkus-extension.yaml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateCoreExtensionFromExtensionsDir/extensions_my-ext_runtime_src_main_resources_META-INF_quarkus-extension.yaml
@@ -3,7 +3,7 @@ name: My Ext
 metadata:
 #  keywords:
 #    - my-ext
-#  guide: ...
+#  guide: ... # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
 #  categories:
 #    - "miscellaneous"
 #  status: "preview"


### PR DESCRIPTION
We're seeing a lot of extensions being published with dead linkes in the 'guides' section. See, for example, discussion in https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Automating.20updating.20quarkiverse.20antora.20playbook/near/326074249 and #31148 as a recent example. 

One thing we suggested doing was commenting out the `guide` entry in newly created extensions, but it's actually already commented out. To try and encourage people to ensure the guide exists before un-commenting the line, we can add some links to documentation about documentation. This would be generally handy anyway.