### PR TITLE
Test-only: little cleanup of some Gradle ITs

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/LaunchUtils.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/LaunchUtils.java
@@ -30,7 +30,9 @@ public class LaunchUtils {
         if (env != null) {
             processBuilder.environment().putAll(env);
         }
-        return processBuilder.start();
+        Process process = processBuilder.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(process::destroyForcibly));
+        return process;
     }
 
     public static void dumpFileContentOnFailure(final Callable<Void> operation, final File logFile,

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/LegacyJarFormatWorksTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/LegacyJarFormatWorksTest.java
@@ -7,7 +7,6 @@ import static org.awaitility.Awaitility.await;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
@@ -17,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.devmode.util.DevModeTestUtils;
 
 public class LegacyJarFormatWorksTest extends QuarkusGradleWrapperTestBase {
-    private static Future<?> jarRun;
 
     @Test
     public void testLegacyJarFormatWorks() throws Exception {
@@ -45,22 +43,9 @@ public class LegacyJarFormatWorksTest extends QuarkusGradleWrapperTestBase {
 
             String logs = FileUtils.readFileToString(output, "UTF-8");
 
-            assertThatOutputWorksCorrectly(logs);
-
-            // test that the application name and version are properly set
-            assertThat(DevModeTestUtils.getHttpResponse("/hello", () -> {
-                return jarRun == null ? null : jarRun.isDone() ? "jar run mode has terminated" : null;
-            }).equals("hello"));
+            assertThat(logs).contains("INFO").contains("cdi, resteasy");
         } finally {
             process.destroy();
         }
     }
-
-    private void assertThatOutputWorksCorrectly(String logs) {
-        assertThat(logs.isEmpty()).isFalse();
-        String infoLogLevel = "INFO";
-        assertThat(logs.contains(infoLogLevel)).isTrue();
-        assertThat(logs.contains("cdi, resteasy")).isTrue();
-    }
-
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleUberJarTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleUberJarTest.java
@@ -7,7 +7,6 @@ import static org.awaitility.Awaitility.await;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
@@ -17,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.devmode.util.DevModeTestUtils;
 
 public class MultiModuleUberJarTest extends QuarkusGradleWrapperTestBase {
-    private static Future<?> jarRun;
 
     @Test
     public void testUberJarForMultiModule() throws Exception {
@@ -44,20 +42,10 @@ public class MultiModuleUberJarTest extends QuarkusGradleWrapperTestBase {
             }, output, ConditionTimeoutException.class);
 
             String logs = FileUtils.readFileToString(output, "UTF-8");
-            assertThatOutputWorksCorrectly(logs);
 
-            // test that the http response is correct
-            assertThat(DevModeTestUtils.getHttpResponse("/hello", () -> {
-                return jarRun == null ? null : jarRun.isDone() ? "jar run mode has terminated" : null;
-            }).equals("hello common"));
+            assertThat(logs).contains("INFO").contains("cdi, resteasy");
         } finally {
             process.destroy();
         }
-    }
-
-    private void assertThatOutputWorksCorrectly(String logs) {
-        assertThat(logs.isEmpty()).isFalse();
-        assertThat(logs.contains("INFO")).isTrue();
-        assertThat(logs.contains("cdi, resteasy")).isTrue();
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/MutableJarFormatBootsInDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/MutableJarFormatBootsInDevModeTest.java
@@ -8,7 +8,6 @@ import static org.awaitility.Awaitility.await;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
@@ -18,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.devmode.util.DevModeTestUtils;
 
 public class MutableJarFormatBootsInDevModeTest extends QuarkusGradleWrapperTestBase {
-    private static Future<?> jarRun;
 
     @Test
     public void testFastJarFormatWorks() throws Exception {
@@ -47,22 +45,9 @@ public class MutableJarFormatBootsInDevModeTest extends QuarkusGradleWrapperTest
 
             String logs = FileUtils.readFileToString(output, "UTF-8");
 
-            assertThatOutputWorksCorrectly(logs);
-
-            // test that the application name and version are properly set
-            assertThat(DevModeTestUtils.getHttpResponse("/hello", () -> {
-                return jarRun == null ? null : jarRun.isDone() ? "jar run mode has terminated" : null;
-            }).equals("hello"));
+            assertThat(logs).contains("INFO").contains("cdi, resteasy");
         } finally {
             process.destroy();
         }
     }
-
-    private void assertThatOutputWorksCorrectly(String logs) {
-        assertThat(logs.isEmpty()).isFalse();
-        String infoLogLevel = "INFO";
-        assertThat(logs.contains(infoLogLevel)).isTrue();
-        assertThat(logs.contains("cdi, resteasy")).isTrue();
-    }
-
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
@@ -49,6 +49,8 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
                 .redirectError(logOutput)
                 .start();
 
+        Runtime.getRuntime().addShutdownHook(new Thread(p::destroyForcibly));
+
         //long timeout for native tests
         //that may also need to download docker
         boolean done = p.waitFor(10, TimeUnit.MINUTES);

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/UberJarFormatWorksTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/UberJarFormatWorksTest.java
@@ -7,7 +7,6 @@ import static org.awaitility.Awaitility.await;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
@@ -17,8 +16,6 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.devmode.util.DevModeTestUtils;
 
 public class UberJarFormatWorksTest extends QuarkusGradleWrapperTestBase {
-
-    private static Future<?> jarRun;
 
     @Test
     public void testUberJarFormatWorks() throws Exception {
@@ -45,23 +42,9 @@ public class UberJarFormatWorksTest extends QuarkusGradleWrapperTestBase {
 
             String logs = FileUtils.readFileToString(output, "UTF-8");
 
-            assertThatOutputWorksCorrectly(logs);
-
-            // test that the application name and version are properly set
-            assertThat(DevModeTestUtils.getHttpResponse("/hello", () -> {
-                return jarRun == null ? null : jarRun.isDone() ? "jar run mode has terminated" : null;
-            }).equals("hello"));
+            assertThat(logs).contains("INFO").contains("cdi, resteasy");
         } finally {
             process.destroy();
         }
-
     }
-
-    private void assertThatOutputWorksCorrectly(String logs) {
-        assertThat(logs.isEmpty()).isFalse();
-        String infoLogLevel = "INFO";
-        assertThat(logs.contains(infoLogLevel)).isTrue();
-        assertThat(logs.contains("cdi, resteasy")).isTrue();
-    }
-
 }


### PR DESCRIPTION
Also adds a shutdown hook for launched processes to kill those when tests are aborted w/ ctrl-c. A process, like the ones spawned by for example `FastJarFormatWorksTest`, can otherwise survive, still "hold" port 8080 and cause subsequent test failures.