### PR TITLE
Support Spring Data repositories with multiple Persistence Units

### DIFF
--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/EntityToPersistenceUnitBuildItem.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/EntityToPersistenceUnitBuildItem.java
@@ -1,0 +1,25 @@
+package io.quarkus.hibernate.orm.panache.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Used to record that a specific JPA entity is associated with a specific persistence unit
+ */
+public final class EntityToPersistenceUnitBuildItem extends MultiBuildItem {
+
+    private final String entityClass;
+    private final String persistenceUnitName;
+
+    public EntityToPersistenceUnitBuildItem(String entityClass, String persistenceUnitName) {
+        this.entityClass = entityClass;
+        this.persistenceUnitName = persistenceUnitName;
+    }
+
+    public String getEntityClass() {
+        return entityClass;
+    }
+
+    public String getPersistenceUnitName() {
+        return persistenceUnitName;
+    }
+}

--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/EntityToPersistenceUnitUtil.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/EntityToPersistenceUnitUtil.java
@@ -1,0 +1,62 @@
+package io.quarkus.hibernate.orm.panache.deployment;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+
+import io.quarkus.hibernate.orm.deployment.JpaModelPersistenceUnitMappingBuildItem;
+
+public final class EntityToPersistenceUnitUtil {
+
+    private EntityToPersistenceUnitUtil() {
+    }
+
+    /**
+     * Given the candidate entities, return a map with the persistence unit that single contains them
+     * or throw an exception if any of the candidates is part of more than one persistence unit
+     */
+    public static Map<String, String> determineEntityPersistenceUnits(
+            Optional<JpaModelPersistenceUnitMappingBuildItem> jpaModelPersistenceUnitMapping,
+            Set<String> candidates, String source) {
+        if (jpaModelPersistenceUnitMapping.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> result = new HashMap<>();
+        Map<String, Set<String>> collectedEntityToPersistenceUnits = jpaModelPersistenceUnitMapping.get()
+                .getEntityToPersistenceUnits();
+
+        Map<String, Set<String>> violatingEntities = new TreeMap<>();
+
+        for (Map.Entry<String, Set<String>> entry : collectedEntityToPersistenceUnits.entrySet()) {
+            String entityName = entry.getKey();
+            Set<String> selectedPersistenceUnits = entry.getValue();
+            boolean isCandidate = candidates.contains(entityName);
+
+            if (!isCandidate) {
+                continue;
+            }
+
+            if (selectedPersistenceUnits.size() == 1) {
+                result.put(entityName, selectedPersistenceUnits.iterator().next());
+            } else {
+                violatingEntities.put(entityName, selectedPersistenceUnits);
+            }
+        }
+
+        if (violatingEntities.size() > 0) {
+            StringBuilder message = new StringBuilder(
+                    String.format("%s entities do not support being attached to several persistence units:\n", source));
+            for (Map.Entry<String, Set<String>> violatingEntityEntry : violatingEntities
+                    .entrySet()) {
+                message.append("\t- ").append(violatingEntityEntry.getKey()).append(" is attached to: ")
+                        .append(String.join(",", violatingEntityEntry.getValue()));
+                throw new IllegalStateException(message.toString());
+            }
+        }
+
+        return result;
+    }
+}

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/SpringDataRepositoryCreator.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/SpringDataRepositoryCreator.java
@@ -54,10 +54,11 @@ public class SpringDataRepositoryCreator {
                 typeBundle);
     }
 
-    public void implementCrudRepository(ClassInfo repositoryToImplement, IndexView indexView) {
+    public Result implementCrudRepository(ClassInfo repositoryToImplement, IndexView indexView) {
         Map.Entry<DotName, DotName> extraTypesResult = extractIdAndEntityTypes(repositoryToImplement, indexView);
 
-        String idTypeStr = extraTypesResult.getKey().toString();
+        DotName idTypeDotName = extraTypesResult.getKey();
+        String idTypeStr = idTypeDotName.toString();
         DotName entityDotName = extraTypesResult.getValue();
         String entityTypeStr = entityDotName.toString();
 
@@ -118,6 +119,8 @@ public class SpringDataRepositoryCreator {
             customQueryMethodsAdder.add(classCreator, entityClassFieldCreator.getFieldDescriptor(),
                     repositoryToImplement, entityClassInfo, idTypeStr);
         }
+
+        return new Result(entityDotName, idTypeDotName, generatedClassName);
     }
 
     private Map.Entry<DotName, DotName> extractIdAndEntityTypes(ClassInfo repositoryToImplement, IndexView indexView) {
@@ -183,6 +186,30 @@ public class SpringDataRepositoryCreator {
             customImplNameToFieldDescriptor.put(customImplClassName,
                     customClassField.getFieldDescriptor());
             i++;
+        }
+    }
+
+    public static final class Result {
+        final DotName entityDotName;
+        final DotName idTypeDotName;
+        final String generatedClassName;
+
+        Result(DotName entityDotName, DotName idTypeDotName, String generatedClassName) {
+            this.entityDotName = entityDotName;
+            this.idTypeDotName = idTypeDotName;
+            this.generatedClassName = generatedClassName;
+        }
+
+        public DotName getEntityDotName() {
+            return entityDotName;
+        }
+
+        public DotName getIdTypeDotName() {
+            return idTypeDotName;
+        }
+
+        public String getGeneratedClassName() {
+            return generatedClassName;
         }
     }
 }

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/DefaultPersistenceUnitConfigTest.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/DefaultPersistenceUnitConfigTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.spring.data.deployment.multiple_pu;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.spring.data.deployment.multiple_pu.first.FirstEntity;
+import io.quarkus.spring.data.deployment.multiple_pu.first.FirstEntityRepository;
+import io.quarkus.spring.data.deployment.multiple_pu.second.SecondEntity;
+import io.quarkus.spring.data.deployment.multiple_pu.second.SecondEntityRepository;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class DefaultPersistenceUnitConfigTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(FirstEntity.class, SecondEntity.class,
+                            FirstEntityRepository.class, SecondEntityRepository.class,
+                            PanacheTestResource.class)
+                    .addAsResource("application-test.properties", "application.properties"));
+
+    @Test
+    public void panacheOperations() {
+        /**
+         * First entity operations
+         */
+        RestAssured.when().get("/persistence-unit/first/name-1").then().body(Matchers.is("1"));
+        RestAssured.when().get("/persistence-unit/first/name-2").then().body(Matchers.is("2"));
+
+        /**
+         * second entity operations
+         */
+        RestAssured.when().get("/persistence-unit/second/name-1").then().body(Matchers.is("1"));
+        RestAssured.when().get("/persistence-unit/second/name-2").then().body(Matchers.is("2"));
+    }
+}

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/ErroneousPersistenceUnitConfigTest.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/ErroneousPersistenceUnitConfigTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.spring.data.deployment.multiple_pu;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.spring.data.deployment.multiple_pu.first.FirstEntity;
+import io.quarkus.spring.data.deployment.multiple_pu.first.FirstEntityRepository;
+import io.quarkus.spring.data.deployment.multiple_pu.second.SecondEntity;
+import io.quarkus.spring.data.deployment.multiple_pu.second.SecondEntityRepository;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ErroneousPersistenceUnitConfigTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setExpectedException(IllegalStateException.class)
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(FirstEntity.class, SecondEntity.class,
+                            FirstEntityRepository.class, SecondEntityRepository.class,
+                            PanacheTestResource.class)
+                    .addAsResource("application-erroneous-multiple-persistence-units.properties", "application.properties"));
+
+    @Test
+    public void shouldNotReachHere() {
+        Assertions.fail();
+    }
+}

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/MultiplePersistenceUnitConfigTest.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/MultiplePersistenceUnitConfigTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.spring.data.deployment.multiple_pu;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.spring.data.deployment.multiple_pu.first.FirstEntity;
+import io.quarkus.spring.data.deployment.multiple_pu.first.FirstEntityRepository;
+import io.quarkus.spring.data.deployment.multiple_pu.second.SecondEntity;
+import io.quarkus.spring.data.deployment.multiple_pu.second.SecondEntityRepository;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class MultiplePersistenceUnitConfigTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(FirstEntity.class, SecondEntity.class,
+                            FirstEntityRepository.class, SecondEntityRepository.class,
+                            PanacheTestResource.class)
+                    .addAsResource("application-multiple-persistence-units.properties", "application.properties"));
+
+    @Test
+    public void panacheOperations() {
+        /**
+         * First entity operations
+         */
+        RestAssured.when().get("/persistence-unit/first/name-1").then().body(Matchers.is("1"));
+        RestAssured.when().get("/persistence-unit/first/name-2").then().body(Matchers.is("2"));
+
+        /**
+         * second entity operations
+         */
+        RestAssured.when().get("/persistence-unit/second/name-1").then().body(Matchers.is("1"));
+        RestAssured.when().get("/persistence-unit/second/name-2").then().body(Matchers.is("2"));
+    }
+}

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/PanacheTestResource.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/PanacheTestResource.java
@@ -1,0 +1,48 @@
+package io.quarkus.spring.data.deployment.multiple_pu;
+
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkus.spring.data.deployment.multiple_pu.first.FirstEntity;
+import io.quarkus.spring.data.deployment.multiple_pu.first.FirstEntityRepository;
+import io.quarkus.spring.data.deployment.multiple_pu.second.SecondEntity;
+import io.quarkus.spring.data.deployment.multiple_pu.second.SecondEntityRepository;
+
+@Path("/persistence-unit")
+public class PanacheTestResource {
+
+    private final FirstEntityRepository firstEntityRepository;
+    private final SecondEntityRepository secondEntityRepository;
+
+    public PanacheTestResource(FirstEntityRepository firstEntityRepository,
+            SecondEntityRepository secondEntityRepository) {
+        this.firstEntityRepository = firstEntityRepository;
+        this.secondEntityRepository = secondEntityRepository;
+    }
+
+    @GET
+    @Path("/first/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional
+    public Long createWithFirstPuAndReturnCount(@PathParam("name") String name) {
+        FirstEntity entity = new FirstEntity();
+        entity.name = name;
+        firstEntityRepository.save(entity);
+        return firstEntityRepository.count();
+    }
+
+    @GET
+    @Path("/second/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional
+    public Long createWithSecondPUAndReturnCount(@PathParam("name") String name) {
+        SecondEntity entity = new SecondEntity();
+        entity.name = name;
+        secondEntityRepository.save(entity);
+        return secondEntityRepository.count();
+    }
+}

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/first/FirstEntity.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/first/FirstEntity.java
@@ -1,0 +1,15 @@
+package io.quarkus.spring.data.deployment.multiple_pu.first;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class FirstEntity {
+
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    public String name;
+}

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/first/FirstEntityRepository.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/first/FirstEntityRepository.java
@@ -1,0 +1,8 @@
+package io.quarkus.spring.data.deployment.multiple_pu.first;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FirstEntityRepository extends CrudRepository<FirstEntity, Long> {
+}

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/second/SecondEntity.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/second/SecondEntity.java
@@ -1,0 +1,15 @@
+package io.quarkus.spring.data.deployment.multiple_pu.second;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class SecondEntity {
+
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    public String name;
+}

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/second/SecondEntityRepository.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/second/SecondEntityRepository.java
@@ -1,0 +1,11 @@
+package io.quarkus.spring.data.deployment.multiple_pu.second;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SecondEntityRepository extends org.springframework.data.repository.Repository<SecondEntity, Long> {
+
+    SecondEntity save(SecondEntity entity);
+
+    long count();
+}

--- a/extensions/spring-data-jpa/deployment/src/test/resources/application-erroneous-multiple-persistence-units.properties
+++ b/extensions/spring-data-jpa/deployment/src/test/resources/application-erroneous-multiple-persistence-units.properties
@@ -1,0 +1,12 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:first;DB_CLOSE_DELAY=-1
+
+quarkus.datasource.second.db-kind=h2
+quarkus.datasource.second.jdbc.url=jdbc:h2:mem:second;DB_CLOSE_DELAY=-1
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.packages=io.quarkus.spring.data.deployment.multiple_pu.first
+
+quarkus.hibernate-orm."second".database.generation=drop-and-create
+quarkus.hibernate-orm."second".datasource=second
+quarkus.hibernate-orm."second".packages=io.quarkus.spring.data.deployment.multiple_pu.first

--- a/extensions/spring-data-jpa/deployment/src/test/resources/application-multiple-persistence-units.properties
+++ b/extensions/spring-data-jpa/deployment/src/test/resources/application-multiple-persistence-units.properties
@@ -1,0 +1,12 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:first;DB_CLOSE_DELAY=-1
+
+quarkus.datasource.second.db-kind=h2
+quarkus.datasource.second.jdbc.url=jdbc:h2:mem:second;DB_CLOSE_DELAY=-1
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.packages=io.quarkus.spring.data.deployment.multiple_pu.first
+
+quarkus.hibernate-orm."second".database.generation=drop-and-create
+quarkus.hibernate-orm."second".datasource=second
+quarkus.hibernate-orm."second".packages=io.quarkus.spring.data.deployment.multiple_pu.second

--- a/extensions/spring-data-jpa/deployment/src/test/resources/application-test.properties
+++ b/extensions/spring-data-jpa/deployment/src/test/resources/application-test.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:test
+
+#quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.database.generation=drop-and-create


### PR DESCRIPTION
This support requires no extra configuration from users and is
accomplished using the support that Hibernate ORM Panache already
has for mapping entities to persistence units.

The tests are also straight-forward copies of the tests we have in Hibernate ORM Panache 

Closes: #24075