### PR TITLE
ArC - introduce the concept of synthetic injection points 

### DIFF
--- a/docs/src/main/asciidoc/cdi-integration.adoc
+++ b/docs/src/main/asciidoc/cdi-integration.adoc
@@ -273,7 +273,7 @@ _Solution_: If you need to register a synthetic bean then use the `SyntheticBean
 @BuildStep
 SyntheticBeanBuildItem syntheticBean() {
    return SyntheticBeanBuildItem.configure(String.class)
-             .qualifiers(new MyQualifierLiteral())
+             .qualifiers(AnnotationInstance.builder(MyQualifier.class).build())
              .creator(mc -> mc.returnValue(mc.load("foo"))) <1>
              .done();
 }
@@ -285,8 +285,8 @@ Therefore, there are some limitations in how a synthetic bean instance is create
 You can:
 
 1. Generate the bytecode of the `Contextual#create(CreationalContext<T>)` method directly via `ExtendedBeanConfigurator.creator(Consumer<MethodCreator>)`.
-2. Pass a `io.quarkus.arc.BeanCreator` implementation class via `ExtendedBeanConfigurator#creator(Class<? extends BeanCreator<U>>)`, and possibly specify some parameters via `ExtendedBeanConfigurator#param()`.
-3. Produce the runtime instance through a proxy returned from a <<writing-extensions.adoc#bytecode-recording,`@Recorder` method>> and set it via `ExtendedBeanConfigurator#runtimeValue(RuntimeValue<?>)` or `ExtendedBeanConfigurator#supplier(Supplier<?>)`.
+2. Pass a subclass of `io.quarkus.arc.BeanCreator` via `ExtendedBeanConfigurator#creator(Class<? extends BeanCreator<U>>)`, and possibly specify some build-time parameters via `ExtendedBeanConfigurator#param()` and synthetic injection points via `ExtendedBeanConfigurator#addInjectionPoint()`.
+3. Produce the runtime instance through a proxy returned from a <<writing-extensions.adoc#bytecode-recording,`@Recorder` method>> and set it via `ExtendedBeanConfigurator#runtimeValue(RuntimeValue<?>)`, `ExtendedBeanConfigurator#supplier(Supplier<?>)` or `ExtendedBeanConfigurator#createWith(Function<SyntheticCreationalContext<?>, <?>)`.
 
 .`SyntheticBeanBuildItem` Example 2
 [source,java]
@@ -338,6 +338,47 @@ void accessFoo(TestRecorder recorder) {
 ====
 
 NOTE: It is also possible to use the `BeanRegistrationPhaseBuildItem` to register a synthetic bean. However, we recommend extension authors to stick with `SyntheticBeanBuildItem` which is more idiomatic for Quarkus.
+
+=== Synthetic Injection Points
+
+A synthetic bean may register a synthetic injection point via the `ExtendedBeanConfigurator#addInjectionPoint()` method.
+This injection point is validated at build time and considered when <<cdi-reference.adoc#remove_unused_beans,detecting unused beans>>.
+The injected reference is accessible through the `SyntheticCreationalContext#getInjectedReference()` methods at runtime.
+
+.Synthetic Injection Point - Build Step Example
+[source,java]
+----
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+
+@BuildStep
+@Record(RUNTIME_INIT) <1>
+SyntheticBeanBuildItem syntheticBean(TestRecorder recorder) {
+   return SyntheticBeanBuildItem.configure(Foo.class)
+                .scope(Singleton.class)
+                .addInjectionPoint(ClassType.create(DotName.createSimple(Bar.class))) <2>
+                .createWith(recorder.createFoo()) <3>
+                .done();
+}
+----
+<1> The bean instance is initialized during `RUNTIME_INIT`.
+<2> A synthetic injection point with required type `Bar` was added; this is an equivalent of `@Inject Bar`.
+<3> The bean instance is created with a function returned from a recorder method.
+
+.Synthetic Injection Point - Recorder Example
+[source,java]
+----
+@Recorder
+public class TestRecorder {
+
+   public Function<SyntheticCreationalContext<Foo>, Foo> createFoo() {
+     return (context) -> {
+        return new Foo(context.getInjectedReference(Bar.class)); <1>
+     };
+   }
+}
+----
+<1> Pass a contextual reference of `Bar` to the constructor of `Foo`.
 
 [[synthetic_observers]]
 == Use Case - Synthetic Observers

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeansProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeansProcessor.java
@@ -4,12 +4,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import jakarta.enterprise.inject.CreationException;
 
 import org.jboss.jandex.DotName;
 
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem.BeanConfiguratorBuildItem;
 import io.quarkus.arc.processor.BeanConfigurator;
 import io.quarkus.arc.runtime.ArcRecorder;
@@ -32,15 +33,15 @@ public class SyntheticBeansProcessor {
     void initStatic(ArcRecorder recorder, List<SyntheticBeanBuildItem> syntheticBeans,
             BeanRegistrationPhaseBuildItem beanRegistration, BuildProducer<BeanConfiguratorBuildItem> configurators) {
 
-        Map<String, Supplier<?>> suppliersMap = new HashMap<>();
+        Map<String, Function<SyntheticCreationalContext<?>, ?>> functionsMap = new HashMap<>();
 
         for (SyntheticBeanBuildItem bean : syntheticBeans) {
             if (bean.hasRecorderInstance() && bean.isStaticInit()) {
-                configureSyntheticBean(recorder, suppliersMap, beanRegistration, bean);
+                configureSyntheticBean(recorder, functionsMap, beanRegistration, bean);
             }
         }
         // Init the map of bean instances
-        recorder.initStaticSupplierBeans(suppliersMap);
+        recorder.initStaticSupplierBeans(functionsMap);
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)
@@ -49,14 +50,14 @@ public class SyntheticBeansProcessor {
     ServiceStartBuildItem initRuntime(ArcRecorder recorder, List<SyntheticBeanBuildItem> syntheticBeans,
             BeanRegistrationPhaseBuildItem beanRegistration, BuildProducer<BeanConfiguratorBuildItem> configurators) {
 
-        Map<String, Supplier<?>> suppliersMap = new HashMap<>();
+        Map<String, Function<SyntheticCreationalContext<?>, ?>> functionsMap = new HashMap<>();
 
         for (SyntheticBeanBuildItem bean : syntheticBeans) {
             if (bean.hasRecorderInstance() && !bean.isStaticInit()) {
-                configureSyntheticBean(recorder, suppliersMap, beanRegistration, bean);
+                configureSyntheticBean(recorder, functionsMap, beanRegistration, bean);
             }
         }
-        recorder.initRuntimeSupplierBeans(suppliersMap);
+        recorder.initRuntimeSupplierBeans(functionsMap);
         return new ServiceStartBuildItem("runtime-bean-init");
     }
 
@@ -71,14 +72,17 @@ public class SyntheticBeansProcessor {
         }
     }
 
-    private void configureSyntheticBean(ArcRecorder recorder, Map<String, Supplier<?>> suppliersMap,
+    private void configureSyntheticBean(ArcRecorder recorder,
+            Map<String, Function<SyntheticCreationalContext<?>, ?>> functionsMap,
             BeanRegistrationPhaseBuildItem beanRegistration, SyntheticBeanBuildItem bean) {
         DotName implClazz = bean.configurator().getImplClazz();
         String name = createName(implClazz.toString(), bean.configurator().getQualifiers().toString());
         if (bean.configurator().getRuntimeValue() != null) {
-            suppliersMap.put(name, recorder.createSupplier(bean.configurator().getRuntimeValue()));
+            functionsMap.put(name, recorder.createFunction(bean.configurator().getRuntimeValue()));
         } else if (bean.configurator().getSupplier() != null) {
-            suppliersMap.put(name, bean.configurator().getSupplier());
+            functionsMap.put(name, recorder.createFunction(bean.configurator().getSupplier()));
+        } else if (bean.configurator().getFunction() != null) {
+            functionsMap.put(name, bean.configurator().getFunction());
         }
         BeanConfigurator<?> configurator = beanRegistration.getContext().configure(implClazz)
                 .read(bean.configurator());
@@ -98,16 +102,16 @@ public class SyntheticBeansProcessor {
             @Override
             public void accept(MethodCreator m) {
                 ResultHandle staticMap = m
-                        .readStaticField(FieldDescriptor.of(ArcRecorder.class, "supplierMap", Map.class));
-                ResultHandle supplier = m.invokeInterfaceMethod(
+                        .readStaticField(FieldDescriptor.of(ArcRecorder.class, "syntheticBeanProviders", Map.class));
+                ResultHandle function = m.invokeInterfaceMethod(
                         MethodDescriptor.ofMethod(Map.class, "get", Object.class, Object.class), staticMap,
                         m.load(name));
                 // Throw an exception if no supplier is found
-                m.ifNull(supplier).trueBranch().throwException(CreationException.class,
+                m.ifNull(function).trueBranch().throwException(CreationException.class,
                         createMessage(name, bean));
                 ResultHandle result = m.invokeInterfaceMethod(
-                        MethodDescriptor.ofMethod(Supplier.class, "get", Object.class),
-                        supplier);
+                        MethodDescriptor.ofMethod(Function.class, "apply", Object.class, Object.class),
+                        function, m.getMethodParam(0));
                 m.returnValue(result);
             }
         };

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/ConfigActiveFalseAndEntityTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/ConfigActiveFalseAndEntityTest.java
@@ -2,8 +2,10 @@ package io.quarkus.hibernate.orm.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.enterprise.inject.CreationException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
@@ -32,7 +34,8 @@ public class ConfigActiveFalseAndEntityTest {
         // So the bean cannot be null.
         assertThat(entityManagerFactory).isNotNull();
         // However, any attempt to use it at runtime will fail.
-        assertThatThrownBy(entityManagerFactory::getMetamodel)
+        CreationException e = assertThrows(CreationException.class, () -> entityManagerFactory.getMetamodel());
+        assertThat(e.getCause())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContainingAll(
                         "Cannot retrieve the EntityManagerFactory/SessionFactory for persistence unit <default>",
@@ -48,7 +51,8 @@ public class ConfigActiveFalseAndEntityTest {
         // So the bean cannot be null.
         assertThat(sessionFactory).isNotNull();
         // However, any attempt to use it at runtime will fail.
-        assertThatThrownBy(sessionFactory::getMetamodel)
+        CreationException e = assertThrows(CreationException.class, () -> sessionFactory.getMetamodel());
+        assertThat(e.getCause())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContainingAll(
                         "Cannot retrieve the EntityManagerFactory/SessionFactory for persistence unit <default>",

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/ConfigActiveFalseAndEntityTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/ConfigActiveFalseAndEntityTest.java
@@ -70,6 +70,8 @@ public class ConfigActiveFalseAndEntityTest {
         assertThat(entityManager).isNotNull();
         // However, any attempt to use it at runtime will fail.
         assertThatThrownBy(() -> entityManager.find(MyEntity.class, 0L))
+                // Note that unlike for EntityManagerFactory/SessionFactory we get an IllegalStateException because
+                // the real Session/EntityManager instance is created lazily through SessionLazyDelegator in HibernateOrmRecorder.sessionSupplier()
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContainingAll(
                         "Cannot retrieve the EntityManagerFactory/SessionFactory for persistence unit <default>",
@@ -87,6 +89,8 @@ public class ConfigActiveFalseAndEntityTest {
         assertThat(session).isNotNull();
         // However, any attempt to use it at runtime will fail.
         assertThatThrownBy(() -> session.find(MyEntity.class, 0L))
+                // Note that unlike for EntityManagerFactory/SessionFactory we get an IllegalStateException because
+                // the real Session/EntityManager instance is created lazily through SessionLazyDelegator in HibernateOrmRecorder.sessionSupplier()
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContainingAll(
                         "Cannot retrieve the EntityManagerFactory/SessionFactory for persistence unit <default>",

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/ConfigActiveFalseAndEntityTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/ConfigActiveFalseAndEntityTest.java
@@ -2,7 +2,9 @@ package io.quarkus.hibernate.reactive.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import jakarta.enterprise.inject.CreationException;
 import jakarta.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
@@ -30,7 +32,8 @@ public class ConfigActiveFalseAndEntityTest {
         // So the bean cannot be null.
         assertThat(entityManagerFactory).isNotNull();
         // However, any attempt to use it at runtime will fail.
-        assertThatThrownBy(entityManagerFactory::getMetamodel)
+        CreationException e = assertThrows(CreationException.class, () -> entityManagerFactory.getMetamodel());
+        assertThat(e.getCause())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContainingAll(
                         "Cannot retrieve the EntityManagerFactory/SessionFactory for persistence unit default-reactive",
@@ -46,7 +49,8 @@ public class ConfigActiveFalseAndEntityTest {
         // So the bean cannot be null.
         assertThat(sessionFactory).isNotNull();
         // However, any attempt to use it at runtime will fail.
-        assertThatThrownBy(sessionFactory::getMetamodel)
+        CreationException e = assertThrows(CreationException.class, () -> sessionFactory.getMetamodel());
+        assertThat(e.getCause())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContainingAll(
                         "Cannot retrieve the EntityManagerFactory/SessionFactory for persistence unit default-reactive",

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigActiveFalseAndIndexedEntityTest.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigActiveFalseAndIndexedEntityTest.java
@@ -2,7 +2,9 @@ package io.quarkus.hibernate.search.orm.elasticsearch.test.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import jakarta.enterprise.inject.CreationException;
 import jakarta.inject.Inject;
 
 import org.hibernate.Session;
@@ -39,7 +41,8 @@ public class ConfigActiveFalseAndIndexedEntityTest {
         // So the bean cannot be null.
         assertThat(searchMapping).isNotNull();
         // However, any attempt to use it at runtime will fail.
-        assertThatThrownBy(searchMapping::allIndexedEntities)
+        CreationException e = assertThrows(CreationException.class, () -> searchMapping.allIndexedEntities());
+        assertThat(e.getCause())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContainingAll(
                         "Cannot retrieve the SearchMapping for persistence unit <default>",
@@ -61,7 +64,8 @@ public class ConfigActiveFalseAndIndexedEntityTest {
         // So the bean cannot be null.
         assertThat(searchSession).isNotNull();
         // However, any attempt to use it at runtime will fail.
-        assertThatThrownBy(() -> searchSession.search(IndexedEntity.class))
+        CreationException e = assertThrows(CreationException.class, () -> searchSession.search(IndexedEntity.class));
+        assertThat(e.getCause())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContainingAll(
                         "Cannot retrieve the SearchSession for persistence unit <default>",

--- a/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
+++ b/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
@@ -23,6 +23,7 @@ import jakarta.enterprise.inject.Default;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.logging.Logger;
 
@@ -264,7 +265,8 @@ class LiquibaseProcessor {
                     .scope(ApplicationScoped.class) // this is what the existing code does, but it doesn't seem reasonable
                     .setRuntimeInit()
                     .unremovable()
-                    .supplier(recorder.liquibaseSupplier(dataSourceName));
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(LiquibaseFactoryProducer.class)))
+                    .createWith(recorder.liquibaseFunction(dataSourceName));
 
             if (DataSourceUtil.isDefault(dataSourceName)) {
                 configurator.addQualifier(Default.class);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
@@ -2,6 +2,7 @@ package io.quarkus.arc.processor;
 
 import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
 
+import java.util.Collections;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -68,7 +69,7 @@ public final class BeanConfigurator<T> extends BeanConfiguratorBase<BeanConfigur
                 priority = Beans.initStereotypeAlternativePriority(stereotypes, implClass, beanDeployment);
             }
 
-            beanConsumer.accept(new BeanInfo.Builder()
+            BeanInfo.Builder builder = new BeanInfo.Builder()
                     .implClazz(implClass)
                     .providerType(providerType)
                     .beanDeployment(beanDeployment)
@@ -85,8 +86,13 @@ public final class BeanConfigurator<T> extends BeanConfiguratorBase<BeanConfigur
                     .defaultBean(defaultBean)
                     .removable(removable)
                     .forceApplicationClass(forceApplicationClass)
-                    .targetPackageName(targetPackageName)
-                    .build());
+                    .targetPackageName(targetPackageName);
+
+            if (!injectionPoints.isEmpty()) {
+                builder.injections(Collections.singletonList(Injection.forSyntheticBean(injectionPoints)));
+            }
+
+            beanConsumer.accept(builder.build());
         }
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -142,7 +142,7 @@ public class BeanInfo implements InjectionTargetInfo {
         this.removable = isRemovable;
         this.params = params;
         // Identifier must be unique for a specific deployment
-        this.identifier = Hashes.sha1(toString());
+        this.identifier = Hashes.sha1(toString() + beanDeployment.toString());
         this.interceptedMethods = Collections.emptyMap();
         this.decoratedMethods = Collections.emptyMap();
         this.lifecycleInterceptors = Collections.emptyMap();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -109,7 +109,7 @@ public class BeanProcessor {
         this.observerRegistrars = initAndSort(builder.observerRegistrars, buildContext);
         this.contextRegistrars = initAndSort(builder.contextRegistrars, buildContext);
         this.beanDeploymentValidators = initAndSort(builder.beanDeploymentValidators, buildContext);
-        this.beanDeployment = new BeanDeployment(buildContext, builder);
+        this.beanDeployment = new BeanDeployment(name, buildContext, builder);
 
         // Make it configurable if we find that the set of annotations needs to grow
         this.injectionPointAnnotationsPredicate = Predicate.not(DotNames.DEPRECATED::equals);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -486,8 +486,12 @@ public final class Beans {
         message.append(injectionPoint.getType());
         message.append(" and qualifiers ");
         message.append(injectionPoint.getRequiredQualifiers());
-        message.append("\n\t- java member: ");
-        message.append(injectionPoint.getTargetInfo());
+        if (injectionPoint.isSynthetic()) {
+            message.append("\n\t- synthetic injection point");
+        } else {
+            message.append("\n\t- java member: ");
+            message.append(injectionPoint.getTargetInfo());
+        }
         message.append("\n\t- declared on ");
         message.append(target);
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
@@ -386,8 +386,12 @@ enum BuiltinBean {
     private static void validateInjectionPoint(InjectionTargetInfo injectionTarget, InjectionPointInfo injectionPoint,
             Consumer<Throwable> errors) {
         if (injectionTarget.kind() != TargetKind.BEAN || !BuiltinScope.DEPENDENT.is(injectionTarget.asBean().getScope())) {
+            String msg = injectionPoint.getTargetInfo();
+            if (msg.isBlank()) {
+                msg = injectionTarget.toString();
+            }
             errors.accept(new DefinitionException("Only @Dependent beans can access metadata about an injection point: "
-                    + injectionPoint.getTargetInfo()));
+                    + msg));
         }
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -207,6 +207,9 @@ public final class MethodDescriptors {
     public static final MethodDescriptor COLLECTIONS_EMPTY_MAP = MethodDescriptor.ofMethod(Collections.class, "emptyMap",
             Map.class);
 
+    public static final MethodDescriptor COLLECTIONS_EMPTY_SET = MethodDescriptor.ofMethod(Collections.class, "emptySet",
+            Set.class);
+
     public static final MethodDescriptor SETS_OF = MethodDescriptor.ofMethod(Sets.class, "of", Set.class, Object[].class);
 
     public static final MethodDescriptor ARC_CONTAINER = MethodDescriptor.ofMethod(Arc.class, "container", ArcContainer.class);
@@ -265,11 +268,11 @@ public final class MethodDescriptors {
 
     public static final MethodDescriptor INSTANCES_LIST_OF = MethodDescriptor
             .ofMethod(Instances.class, "listOf", List.class, InjectableBean.class, Type.class, Type.class,
-                    Set.class, CreationalContextImpl.class, Set.class, Member.class, int.class, boolean.class);
+                    Set.class, CreationalContext.class, Set.class, Member.class, int.class, boolean.class);
 
     public static final MethodDescriptor INSTANCES_LIST_OF_HANDLES = MethodDescriptor
             .ofMethod(Instances.class, "listOfHandles", List.class, InjectableBean.class, Type.class, Type.class,
-                    Set.class, CreationalContextImpl.class, Set.class, Member.class, int.class, boolean.class);
+                    Set.class, CreationalContext.class, Set.class, Member.class, int.class, boolean.class);
 
     public static final MethodDescriptor COMPONENTS_PROVIDER_UNABLE_TO_LOAD_REMOVED_BEAN_TYPE = MethodDescriptor.ofMethod(
             ComponentsProvider.class, "unableToLoadRemovedBeanType",

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/BeanCreator.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/BeanCreator.java
@@ -4,21 +4,36 @@ import java.util.Map;
 
 import jakarta.enterprise.context.spi.Contextual;
 import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.CreationException;
 
 /**
- * It can be used by synthetic {@link InjectableBean} definitions to produce a contextual instance.
+ * This interface is used by synthetic beans to produce a contextual instance.
  *
  * @param <T>
+ * @see InjectableBean
  * @see Contextual#create(CreationalContext)
  */
 public interface BeanCreator<T> {
 
     /**
      *
+     * @param context
+     * @return the contextual instance
+     */
+    default T create(SyntheticCreationalContext<T> context) {
+        return create(context, context.getParams());
+    }
+
+    /**
+     *
      * @param creationalContext
      * @param params
      * @return the contextual instance
+     * @deprecated Use {@link #create(SyntheticCreationalContext)} instead
      */
-    T create(CreationalContext<T> creationalContext, Map<String, Object> params);
+    @Deprecated(forRemoval = true)
+    default T create(CreationalContext<T> creationalContext, Map<String, Object> params) {
+        throw new CreationException("Creation logic not implemented");
+    }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/SyntheticCreationalContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/SyntheticCreationalContext.java
@@ -1,0 +1,44 @@
+package io.quarkus.arc;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.util.TypeLiteral;
+
+/**
+ * Creational context for synthetic beans.
+ *
+ * @see BeanCreator
+ */
+public interface SyntheticCreationalContext<T> extends CreationalContext<T> {
+
+    /**
+     *
+     * @return the build-time parameters
+     */
+    Map<String, Object> getParams();
+
+    /**
+     * Obtains a contextual reference for a synthetic injection point.
+     *
+     * @param <R>
+     * @param requiredType
+     * @param qualifiers
+     * @return a contextual reference for the given required type and qualifiers
+     * @throws IllegalArgumentException If a corresponding synthetic injection point was not defined
+     */
+    <R> R getInjectedReference(Class<R> requiredType, Annotation... qualifiers);
+
+    /**
+     * Obtains a contextual reference for a synthetic injection point.
+     *
+     * @param <R>
+     * @param requiredType
+     * @param qualifiers
+     * @return a contextual reference for the given required type and qualifiers
+     * @throws IllegalArgumentException If a corresponding synthetic injection point was not defined
+     */
+    <R> R getInjectedReference(TypeLiteral<R> requiredType, Annotation... qualifiers);
+
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CreationalContextImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CreationalContextImpl.java
@@ -105,6 +105,8 @@ public class CreationalContextImpl<T> implements CreationalContext<T>, Function<
     public static <T> CreationalContextImpl<T> unwrap(CreationalContext<T> ctx) {
         if (ctx instanceof CreationalContextImpl) {
             return (CreationalContextImpl<T>) ctx;
+        } else if (ctx instanceof SyntheticCreationalContextImpl) {
+            return unwrap(((SyntheticCreationalContextImpl<T>) ctx).creationalContext);
         } else {
             throw new IllegalArgumentException("Failed to unwrap CreationalContextImpl: " + ctx);
         }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Instances.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Instances.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 
@@ -59,7 +60,7 @@ public final class Instances {
     @SuppressWarnings("unchecked")
     public static <T> List<T> listOf(InjectableBean<?> targetBean, Type injectionPointType, Type requiredType,
             Set<Annotation> requiredQualifiers,
-            CreationalContextImpl<?> creationalContext, Set<Annotation> annotations, Member javaMember, int position,
+            CreationalContext<T> creationalContext, Set<Annotation> annotations, Member javaMember, int position,
             boolean isTransient) {
         List<InjectableBean<?>> beans = resolveAllBeans(requiredType, requiredQualifiers);
         if (beans.isEmpty()) {
@@ -71,7 +72,7 @@ public final class Instances {
                         annotations, javaMember, position, isTransient));
         try {
             for (InjectableBean<?> bean : beans) {
-                list.add(getBeanInstance((CreationalContextImpl<T>) creationalContext, (InjectableBean<T>) bean));
+                list.add(getBeanInstance(CreationalContextImpl.unwrap(creationalContext), (InjectableBean<T>) bean));
             }
         } finally {
             InjectionPointProvider.set(prev);
@@ -82,7 +83,7 @@ public final class Instances {
 
     public static <T> List<InstanceHandle<T>> listOfHandles(InjectableBean<?> targetBean, Type injectionPointType,
             Type requiredType, Set<Annotation> requiredQualifiers,
-            CreationalContextImpl<?> creationalContext, Set<Annotation> annotations, Member javaMember, int position,
+            CreationalContext<T> creationalContext, Set<Annotation> annotations, Member javaMember, int position,
             boolean isTransient) {
         Supplier<InjectionPoint> supplier = new Supplier<InjectionPoint>() {
             @Override
@@ -97,14 +98,14 @@ public final class Instances {
     @SuppressWarnings("unchecked")
     public static <T> List<InstanceHandle<T>> listOfHandles(Supplier<InjectionPoint> injectionPoint, Type requiredType,
             Set<Annotation> requiredQualifiers,
-            CreationalContextImpl<?> creationalContext) {
+            CreationalContext<T> creationalContext) {
         List<InjectableBean<?>> beans = resolveAllBeans(requiredType, requiredQualifiers);
         if (beans.isEmpty()) {
             return Collections.emptyList();
         }
         List<InstanceHandle<T>> list = new ArrayList<>(beans.size());
         for (InjectableBean<?> bean : beans) {
-            list.add(getHandle((CreationalContextImpl<T>) creationalContext, (InjectableBean<T>) bean, injectionPoint));
+            list.add(getHandle(CreationalContextImpl.unwrap(creationalContext), (InjectableBean<T>) bean, injectionPoint));
         }
         return List.copyOf(list);
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/SyntheticCreationalContextImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/SyntheticCreationalContextImpl.java
@@ -1,0 +1,102 @@
+package io.quarkus.arc.impl;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.util.TypeLiteral;
+
+import io.quarkus.arc.SyntheticCreationalContext;
+
+public final class SyntheticCreationalContextImpl<T> implements SyntheticCreationalContext<T> {
+
+    final CreationalContext<T> creationalContext;
+    private final Map<TypeAndQualifiers, Object> injectedReferences;
+    private final Map<String, Object> params;
+
+    public SyntheticCreationalContextImpl(CreationalContext<T> creationalContext, Map<String, Object> params,
+            Map<TypeAndQualifiers, Object> injectedReferences) {
+        this.creationalContext = Objects.requireNonNull(creationalContext);
+        this.params = Objects.requireNonNull(params);
+        this.injectedReferences = Objects.requireNonNull(injectedReferences);
+    }
+
+    @Override
+    public void push(T incompleteInstance) {
+        creationalContext.push(incompleteInstance);
+    }
+
+    @Override
+    public void release() {
+        creationalContext.release();
+    }
+
+    @Override
+    public Map<String, Object> getParams() {
+        return params;
+    }
+
+    @Override
+    public <R> R getInjectedReference(Class<R> requiredType, Annotation... qualifiers) {
+        return getReference(requiredType, qualifiers);
+    }
+
+    @Override
+    public <R> R getInjectedReference(TypeLiteral<R> requiredType, Annotation... qualifiers) {
+        return getReference(requiredType.getType(), qualifiers);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <R> R getReference(Type requiredType, Annotation... qualifiers) {
+        if (qualifiers.length == 0) {
+            qualifiers = new Annotation[] { Default.Literal.INSTANCE };
+        }
+        R ref = (R) injectedReferences.get(new TypeAndQualifiers(requiredType, qualifiers));
+        if (ref == null) {
+            throw new IllegalArgumentException("A synthetic injection point was not declared for required type [" + requiredType
+                    + " and qualifiers: " + Arrays.toString(qualifiers));
+        }
+        return ref;
+    }
+
+    public final static class TypeAndQualifiers {
+
+        private final Type requiredType;
+        private final Annotation[] qualifiers;
+
+        public TypeAndQualifiers(Type requiredType, Annotation[] qualifiers) {
+            this.requiredType = Objects.requireNonNull(requiredType);
+            this.qualifiers = qualifiers == null ? new Annotation[] { Default.Literal.INSTANCE } : qualifiers;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Arrays.hashCode(qualifiers);
+            result = prime * result + requiredType.hashCode();
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            TypeAndQualifiers other = (TypeAndQualifiers) obj;
+            return Objects.equals(requiredType, other.requiredType) && Arrays.equals(qualifiers, other.qualifiers);
+        }
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestClassLoader.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestClassLoader.java
@@ -1,0 +1,38 @@
+package io.quarkus.arc.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Objects;
+
+import io.quarkus.arc.ComponentsProvider;
+import io.quarkus.arc.ResourceReferenceProvider;
+
+class ArcTestClassLoader extends ClassLoader {
+
+    private final File componentsProviderFile;
+    private final File resourceReferenceProviderFile;
+
+    public ArcTestClassLoader(ClassLoader parent, File componentsProviderFile, File resourceReferenceProviderFile) {
+        super(parent);
+        this.componentsProviderFile = Objects.requireNonNull(componentsProviderFile);
+        this.resourceReferenceProviderFile = resourceReferenceProviderFile;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        if (("META-INF/services/" + ComponentsProvider.class.getName()).equals(name)) {
+            // return URL that points to the correct components provider
+            return Collections.enumeration(Collections.singleton(componentsProviderFile.toURI()
+                    .toURL()));
+        } else if (resourceReferenceProviderFile != null
+                && ("META-INF/services/" + ResourceReferenceProvider.class.getName()).equals(name)) {
+            return Collections.enumeration(Collections.singleton(resourceReferenceProviderFile.toURI()
+                    .toURL()));
+        }
+        return super.getResources(name);
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInjectionPointInstanceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInjectionPointInstanceTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
+import jakarta.inject.Singleton;
+
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.Type.Kind;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SyntheticInjectionPointInstanceTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(SomethingRemovable.class)
+            .removeUnusedBeans(true)
+            .beanRegistrars(new TestRegistrar()).build();
+
+    @SuppressWarnings("serial")
+    @Test
+    public void testBeanNotRemoved() {
+        List<String> list = Arc.container().instance(new TypeLiteral<List<String>>() {
+        }).get();
+        assertNotNull(list);
+        assertEquals(1, list.size());
+        assertEquals(SomethingRemovable.STR, list.get(0));
+    }
+
+    static class TestRegistrar implements BeanRegistrar {
+
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(List.class)
+                    // List, List<String>
+                    .addType(Type.create(DotName.createSimple(List.class.getName()), Kind.CLASS))
+                    .addType(ParameterizedType.create(DotName.createSimple(List.class.getName()),
+                            new Type[] { Type.create(DotName.createSimple(String.class.getName()), Kind.CLASS) }, null))
+                    .creator(ListCreator.class)
+                    .addInjectionPoint(ParameterizedType.create(DotName.createSimple(Instance.class),
+                            new Type[] { ClassType.create(DotName.createSimple(SomethingRemovable.class)) }, null))
+                    .unremovable()
+                    .done();
+        }
+
+    }
+
+    @Singleton
+    static class SomethingRemovable {
+
+        static final String STR = "I'm still here!";
+
+        @Override
+        public String toString() {
+            return STR;
+        }
+
+    }
+
+    public static class ListCreator implements BeanCreator<List<String>> {
+
+        @SuppressWarnings("serial")
+        @Override
+        public List<String> create(SyntheticCreationalContext<List<String>> context) {
+            return List.of(context.getInjectedReference(new TypeLiteral<Instance<SomethingRemovable>>() {
+            }).get().toString());
+        }
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInjectionPointMetadataInvalidTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInjectionPointMetadataInvalidTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.Type.Kind;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SyntheticInjectionPointMetadataInvalidTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanRegistrars(new TestRegistrar())
+            .shouldFail()
+            .build();
+
+    @Test
+    public void testMetadataNotAvailable() {
+        assertNotNull(container.getFailure());
+        assertTrue(container.getFailure().getMessage().contains(
+                "Only @Dependent beans can access metadata about an injection point:"));
+    }
+
+    static class TestRegistrar implements BeanRegistrar {
+
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(List.class)
+                    .addType(Type.create(DotName.createSimple(List.class.getName()), Kind.CLASS))
+                    .addType(ParameterizedType.create(DotName.createSimple(List.class),
+                            new Type[] { ClassType.create(DotName.createSimple(String.class)) }, null))
+                    .creator(ListCreator.class)
+                    .scope(ApplicationScoped.class)
+                    // This is not legal!
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(InjectionPoint.class)))
+                    .done();
+        }
+
+    }
+
+    public static class ListCreator implements BeanCreator<List<String>> {
+
+        @Override
+        public List<String> create(SyntheticCreationalContext<List<String>> context) {
+            return List.of(context.getInjectedReference(InjectionPoint.class).toString());
+        }
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInjectionPointMetadataTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInjectionPointMetadataTest.java
@@ -1,0 +1,97 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.Type.Kind;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SyntheticInjectionPointMetadataTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyDependentFoo.class, Consumer.class)
+            .beanRegistrars(new TestRegistrar()).build();
+
+    @SuppressWarnings("resource")
+    @Test
+    public void testMetadata() {
+        List<MyDependentFoo> list = Arc.container().instance(Consumer.class).get().list;
+        assertNotNull(list);
+        MyDependentFoo foo = list.get(0);
+        assertNotNull(foo.injectionPoint);
+        assertEquals(InjectableBean.Kind.SYNTHETIC, ((InjectableBean<?>) foo.injectionPoint.getBean()).getKind());
+        assertNull(foo.injectionPoint.getMember());
+        assertNotNull(foo.syntheticMetada);
+        assertEquals(Consumer.class, foo.syntheticMetada.getMember().getDeclaringClass());
+        assertEquals(InjectableBean.Kind.CLASS, ((InjectableBean<?>) foo.syntheticMetada.getBean()).getKind());
+    }
+
+    static class TestRegistrar implements BeanRegistrar {
+
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(List.class)
+                    // List, List<MyDependentFoo>
+                    .addType(Type.create(DotName.createSimple(List.class.getName()), Kind.CLASS))
+                    .addType(ParameterizedType.create(DotName.createSimple(List.class),
+                            new Type[] { ClassType.create(DotName.createSimple(MyDependentFoo.class)) }, null))
+                    .creator(ListCreator.class)
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(MyDependentFoo.class)))
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(InjectionPoint.class)))
+                    .unremovable()
+                    .done();
+        }
+
+    }
+
+    @Singleton
+    public static class Consumer {
+
+        @Inject
+        List<MyDependentFoo> list;
+
+    }
+
+    @Dependent
+    public static class MyDependentFoo {
+
+        InjectionPoint syntheticMetada;
+
+        @Inject
+        InjectionPoint injectionPoint;
+
+    }
+
+    public static class ListCreator implements BeanCreator<List<MyDependentFoo>> {
+
+        @Override
+        public List<MyDependentFoo> create(SyntheticCreationalContext<List<MyDependentFoo>> context) {
+            MyDependentFoo foo = context.getInjectedReference(MyDependentFoo.class);
+            foo.syntheticMetada = context.getInjectedReference(InjectionPoint.class);
+            return List.of(foo);
+        }
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInjectionPointUnavailableTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInjectionPointUnavailableTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import jakarta.enterprise.inject.CreationException;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.util.TypeLiteral;
+
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.Type.Kind;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SyntheticInjectionPointUnavailableTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanRegistrars(new TestRegistrar()).build();
+
+    @SuppressWarnings("serial")
+    @Test
+    public void testValidationFails() {
+        assertThrows(CreationException.class, () -> Arc.container().instance(new TypeLiteral<List<String>>() {
+        }).get());
+    }
+
+    static class TestRegistrar implements BeanRegistrar {
+
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(List.class)
+                    // List, List<String>
+                    .addType(Type.create(DotName.createSimple(List.class.getName()), Kind.CLASS))
+                    .addType(ParameterizedType.create(DotName.createSimple(List.class.getName()),
+                            new Type[] { Type.create(DotName.createSimple(String.class.getName()), Kind.CLASS) }, null))
+                    .creator(ListCreator.class)
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(BeanManager.class)))
+                    .unremovable()
+                    .done();
+        }
+
+    }
+
+    public static class ListCreator implements BeanCreator<List<String>> {
+
+        @Override
+        public List<String> create(SyntheticCreationalContext<List<String>> context) {
+            return List.of(context.getInjectedReference(BigDecimal.class).toString());
+        }
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInjectionPointUnremovableTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInjectionPointUnremovableTest.java
@@ -1,0 +1,80 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import jakarta.enterprise.util.TypeLiteral;
+import jakarta.inject.Singleton;
+
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SyntheticInjectionPointUnremovableTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(SomethingRemovable.class)
+            .removeUnusedBeans(true)
+            .beanRegistrars(new TestRegistrar()).build();
+
+    @SuppressWarnings("serial")
+    @Test
+    public void testBeanNotRemoved() {
+        List<String> list = Arc.container().instance(new TypeLiteral<List<String>>() {
+        }).get();
+        assertNotNull(list);
+        assertEquals(1, list.size());
+        assertEquals(SomethingRemovable.STR, list.get(0));
+    }
+
+    @Singleton
+    static class SomethingRemovable {
+
+        static final String STR = "I'm still here!";
+
+        @Override
+        public String toString() {
+            return STR;
+        }
+
+    }
+
+    static class TestRegistrar implements BeanRegistrar {
+
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(List.class)
+                    // List, List<String>
+                    .addType(ClassType.create(DotName.createSimple(List.class)))
+                    .addType(ParameterizedType.create(DotName.createSimple(List.class),
+                            new Type[] { ClassType.create(DotName.createSimple(String.class)) }, null))
+                    .creator(ListCreator.class)
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(SomethingRemovable.class)))
+                    .unremovable()
+                    .done();
+        }
+
+    }
+
+    public static class ListCreator implements BeanCreator<List<String>> {
+
+        @Override
+        public List<String> create(SyntheticCreationalContext<List<String>> context) {
+            return List.of(context.getInjectedReference(SomethingRemovable.class).toString());
+        }
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInjectionPointValidationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInjectionPointValidationTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.Type.Kind;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SyntheticInjectionPointValidationTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .shouldFail()
+            .beanRegistrars(new TestRegistrar()).build();
+
+    @Test
+    public void testValidationFails() {
+        assertNotNull(container.getFailure());
+        assertTrue(container.getFailure().getMessage().contains(
+                "Unsatisfied dependency for type java.math.BigInteger and qualifiers [@jakarta.enterprise.inject.Default]"),
+                container.getFailure().getMessage());
+    }
+
+    static class TestRegistrar implements BeanRegistrar {
+
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(List.class)
+                    // List, List<String>
+                    .addType(Type.create(DotName.createSimple(List.class.getName()), Kind.CLASS))
+                    .addType(ParameterizedType.create(DotName.createSimple(List.class.getName()),
+                            new Type[] { Type.create(DotName.createSimple(String.class.getName()), Kind.CLASS) }, null))
+                    .creator(ListCreator.class)
+                    // This injection point is not satisfied
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(BigInteger.class)))
+                    .unremovable()
+                    .done();
+        }
+
+    }
+
+    public static class ListCreator implements BeanCreator<List<String>> {
+
+        @Override
+        public List<String> create(CreationalContext<List<String>> creationalContext, Map<String, Object> params) {
+            return List.of();
+        }
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/contextnotactive/ClientProxyContextNotActiveTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/contextnotactive/ClientProxyContextNotActiveTest.java
@@ -21,7 +21,7 @@ public class ClientProxyContextNotActiveTest {
         RequestFoo foo = Arc.container().instance(RequestFoo.class).get();
         assertThatExceptionOfType(ContextNotActiveException.class).isThrownBy(() -> foo.ping())
                 .withMessageContaining(
-                        "RequestScoped context was not active when trying to obtain a bean instance for a client proxy of CLASS bean [class=io.quarkus.arc.test.clientproxy.contextnotactive.ClientProxyContextNotActiveTest$RequestFoo, id=3e5a77b35b0824bc957993f6db95a37e766e929e]")
+                        "RequestScoped context was not active when trying to obtain a bean instance for a client proxy of CLASS bean [class=io.quarkus.arc.test.clientproxy.contextnotactive.ClientProxyContextNotActiveTest$RequestFoo")
                 .withMessageContaining(
                         "you can activate the request context for a specific method using the @ActivateRequestContext interceptor binding");
     }


### PR DESCRIPTION
- a synthetic injection point can be registered by a synthetic bean via `BeanConfiguratorBase#addInjectionPoint()` 
- this injection point is validated at build time and considered when
detecting unused beans
- at runtime an injected reference is accessible through the `SyntheticCreationalContext#getInjectedReference()` methods

### TODO
- [x] update docs
