### PR TITLE
Upgrade JAXB to 4.0.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -168,11 +168,9 @@ updates:
       - dependency-name: com.github.javaparser:javaparser-core
       - dependency-name: com.h2database:h2
       - dependency-name: io.github.crac:org-crac
-      # Jakarta 9/10 preparation
       - dependency-name: jakarta.*:*
       - dependency-name: org.eclipse.*:*
-      - dependency-name: org.glassfish.expressly:expressly
-      - dependency-name: com.sun.xml.bind:jaxb-impl
+      - dependency-name: org.glassfish.*:*
     ignore:
       # this one cannot be upgraded due to the usage of proxies in new versions
       # the proxy implements interfaces in a random order which causes issues

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -82,7 +82,7 @@
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
         <jakarta.websocket-api.version>2.1.0</jakarta.websocket-api.version>
         <jakarta.xml.bind-api.version>4.0.0</jakarta.xml.bind-api.version>
-        <jaxb-runtime.version>4.0.1</jaxb-runtime.version>
+        <jaxb-runtime.version>4.0.2</jaxb-runtime.version>
         <asm.version>9.4</asm.version>
         <commons-io.version>2.11.0</commons-io.version>
         <jboss-metadata-web.version>15.4.0</jboss-metadata-web.version>
@@ -4350,6 +4350,11 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
+                <version>${jaxb-runtime.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-core</artifactId>
                 <version>${jaxb-runtime.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Noticed while debugging an issue that we could upgrade to 4.0.2.