### PR TITLE
Upgrade REST Assured to 5.3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -171,6 +171,7 @@ updates:
       - dependency-name: jakarta.*:*
       - dependency-name: org.eclipse.*:*
       - dependency-name: org.glassfish.*:*
+      - dependency-name: org.apache.groovy:*
     ignore:
       # this one cannot be upgraded due to the usage of proxies in new versions
       # the proxy implements interfaces in a random order which causes issues

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -137,7 +137,7 @@
         <derby-jdbc.version>10.14.2.0</derby-jdbc.version>
         <db2-jdbc.version>11.5.8.0</db2-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
-        <rest-assured.version>4.5.1</rest-assured.version>
+        <rest-assured.version>5.3.0</rest-assured.version>
         <junit.jupiter.version>5.9.2</junit.jupiter.version>
         <junit-pioneer.version>1.5.0</junit-pioneer.version>
         <infinispan.version>14.0.6.Final</infinispan.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -677,9 +677,9 @@
                     <version>${maven-invoker-plugin.version}</version>
                     <dependencies>
                         <dependency>
-                            <groupId>org.codehaus.groovy</groupId>
+                            <groupId>org.apache.groovy</groupId>
                             <artifactId>groovy</artifactId>
-                            <version>3.0.12</version>
+                            <version>4.0.9</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -184,7 +184,7 @@
 
                         <!-- RestAssured uses groovy, which seems to do some things with soft references that
                         prevent the ClassLoader from being GC'ed, see https://github.com/quarkusio/quarkus/issues/12498 -->
-                        <parentFirstArtifact>org.codehaus.groovy:groovy</parentFirstArtifact>
+                        <parentFirstArtifact>org.apache.groovy:groovy</parentFirstArtifact>
 
                         <!-- Load the junit engine parent first, so it is shared between the outer dev mode
                         process and the test application-->

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -63,7 +63,7 @@
         <mutiny.version>2.1.0</mutiny.version>
         <smallrye-common.version>1.13.2</smallrye-common.version>
         <vertx.version>4.3.8</vertx.version>
-        <rest-assured.version>4.5.1</rest-assured.version>
+        <rest-assured.version>5.3.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.14.2</jackson-bom.version>
         <smallrye-stork.version>1.3.0</smallrye-stork.version>

--- a/integration-tests/container-image/maven-invoker-way/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/pom.xml
@@ -49,12 +49,16 @@
             <exclusions>
                 <!-- Exclude Groovy because of classpath issue -->
                 <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
+                    <groupId>org.apache.groovy</groupId>
                     <artifactId>groovy</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
+                    <groupId>org.apache.groovy</groupId>
                     <artifactId>groovy-xml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.groovy</groupId>
+                    <artifactId>groovy-json</artifactId>
                 </exclusion>
             </exclusions>
             <scope>test</scope>


### PR DESCRIPTION
Another attempt at upgrading to REST Assured 5.x hoping that the Groovy 4 issues we had have at least been partially resolved.