### PR TITLE
WIP - Bump mermaid-js to 9.4.0

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -138,7 +138,7 @@
         <webjar.jquery.version>3.6.1</webjar.jquery.version>
         <webjar.codemirror.version>5.62.2</webjar.codemirror.version>
         <!-- we don't add mermaid as a dependency as it brings a ton of things we don't use -->
-        <webjar.mermaid.version>9.1.1</webjar.mermaid.version>
+        <webjar.mermaid.version>9.4.0</webjar.mermaid.version>
         <webjar.d3js.version>6.6.0</webjar.d3js.version>
         <webjar.chartjs.version>3.7.1</webjar.chartjs.version>
 


### PR DESCRIPTION
Update mermaid-js to 9.4.0, because all versions between [9.1.1](https://www.npmjs.com/package/mermaid/v/9.1.1) and [9.3.0](https://www.npmjs.com/package/mermaid/v/9.3.0) use [moment-js 2.24.0](https://www.npmjs.com/package/moment/v/2.24.0) as a transitive dependency. moment-js 2.24.0 has two vulnerabilities with CVE identifiers: [CVE-2022-31129](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-31129), [CVE-2022-24785](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-24785). Both of them are with HIGH severity. Luckily, they have been fixed in [moment-js 2.29.4](https://www.npmjs.com/package/moment/v/2.29.4) and [mermaid-js 9.4.0](https://www.npmjs.com/package/mermaid/v/9.4.0) depends on this fixed version.

Therefore, I would like to propose a version update for mermaid-js.

Without this update, `quarkus-vertx-http-deployment` can get marked as a vulnerable library by a dependency checking tool. That is because mermaid-js is packed inside `quarkus-vertx-http-deployment`.