### PR TITLE
ArC fixes for spec compatibility, round 4

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ShutdownEvent.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ShutdownEvent.java
@@ -14,7 +14,7 @@ package io.quarkus.runtime;
  *
  * The annotated method can access other injected beans.
  */
-public class ShutdownEvent {
+public class ShutdownEvent extends jakarta.enterprise.event.Shutdown {
 
     private final ShutdownReason shutdownReason;
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/StartupEvent.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/StartupEvent.java
@@ -17,5 +17,5 @@ package io.quarkus.runtime;
  * The annotated method can access other injected beans.
  *
  */
-public class StartupEvent {
+public class StartupEvent extends jakarta.enterprise.event.Startup {
 }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -682,7 +682,9 @@ public class ArcProcessor {
     @BuildStep
     List<AdditionalApplicationArchiveMarkerBuildItem> marker() {
         return Arrays.asList(new AdditionalApplicationArchiveMarkerBuildItem("META-INF/beans.xml"),
-                new AdditionalApplicationArchiveMarkerBuildItem("META-INF/services/jakarta.enterprise.inject.spi.Extension"));
+                new AdditionalApplicationArchiveMarkerBuildItem("META-INF/services/jakarta.enterprise.inject.spi.Extension"),
+                new AdditionalApplicationArchiveMarkerBuildItem(
+                        "META-INF/services/jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension"));
     }
 
     @BuildStep

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -946,6 +946,11 @@ public class BeanDeployment {
                 continue;
             }
 
+            if (beanClass.interfaceNames().contains(DotNames.BUILD_COMPATIBLE_EXTENSION)) {
+                // Skip build compatible extensions
+                continue;
+            }
+
             boolean hasBeanDefiningAnnotation = false;
             if (annotationStore.hasAnyAnnotation(beanClass, beanDefiningAnnotations)) {
                 hasBeanDefiningAnnotation = true;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
@@ -32,6 +32,7 @@ import jakarta.enterprise.inject.Stereotype;
 import jakarta.enterprise.inject.TransientReference;
 import jakarta.enterprise.inject.Typed;
 import jakarta.enterprise.inject.Vetoed;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.EventMetadata;
@@ -108,6 +109,7 @@ public final class DotNames {
     public static final DotName CLASS = create(Class.class);
     public static final DotName ENUM = create(Enum.class);
     public static final DotName EXTENSION = create(Extension.class);
+    public static final DotName BUILD_COMPATIBLE_EXTENSION = create(BuildCompatibleExtension.class);
     public static final DotName OPTIONAL = create(Optional.class);
     public static final DotName OPTIONAL_INT = create(OptionalInt.class);
     public static final DotName OPTIONAL_LONG = create(OptionalLong.class);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
@@ -5,7 +5,9 @@ import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -18,6 +20,7 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.processor.InjectionPointInfo.TypeAndQualifiers;
@@ -50,8 +53,8 @@ public class Injection {
     static List<Injection> forBean(AnnotationTarget beanTarget, BeanInfo declaringBean, BeanDeployment beanDeployment,
             InjectionPointModifier transformer) {
         if (Kind.CLASS.equals(beanTarget.kind())) {
-            List<Injection> injections = new ArrayList<>();
-            forClassBean(beanTarget.asClass(), beanTarget.asClass(), beanDeployment, injections, transformer, false);
+            List<Injection> injections = forClassBean(beanTarget.asClass(), beanTarget.asClass(), beanDeployment,
+                    transformer, false, new HashSet<>());
 
             Set<AnnotationTarget> injectConstructors = injections.stream().filter(Injection::isConstructor)
                     .map(Injection::getTarget).collect(Collectors.toSet());
@@ -142,11 +145,14 @@ public class Injection {
         throw new IllegalArgumentException("Unsupported annotation target");
     }
 
-    private static void forClassBean(ClassInfo beanClass, ClassInfo classInfo, BeanDeployment beanDeployment,
-            List<Injection> injections, InjectionPointModifier transformer, boolean skipConstructors) {
+    // returns injections in the order they should be performed
+    private static List<Injection> forClassBean(ClassInfo beanClass, ClassInfo classInfo, BeanDeployment beanDeployment,
+            InjectionPointModifier transformer, boolean skipConstructors, Set<MethodOverrideKey> seenMethods) {
+
+        List<Injection> injections = new ArrayList<>();
 
         List<AnnotationInstance> injectAnnotations = getAllInjectionPoints(beanDeployment, classInfo, DotNames.INJECT,
-                skipConstructors);
+                skipConstructors, seenMethods);
 
         for (AnnotationInstance injectAnnotation : injectAnnotations) {
             AnnotationTarget injectTarget = injectAnnotation.target();
@@ -186,7 +192,7 @@ public class Injection {
 
         for (DotName resourceAnnotation : beanDeployment.getResourceAnnotations()) {
             List<AnnotationInstance> resourceAnnotations = getAllInjectionPoints(beanDeployment, classInfo,
-                    resourceAnnotation, true);
+                    resourceAnnotation, true, seenMethods);
             for (AnnotationInstance resourceAnnotationInstance : resourceAnnotations) {
                 if (Kind.FIELD == resourceAnnotationInstance.target().kind()
                         && resourceAnnotationInstance.target().asField().annotations().stream()
@@ -203,10 +209,16 @@ public class Injection {
         if (!classInfo.superName().equals(DotNames.OBJECT)) {
             ClassInfo info = getClassByName(beanDeployment.getBeanArchiveIndex(), classInfo.superName());
             if (info != null) {
-                forClassBean(beanClass, info, beanDeployment, injections, transformer, true);
+                List<Injection> superInjections = forClassBean(beanClass, info, beanDeployment, transformer, true, seenMethods);
+
+                // injections are discovered bottom-up to easily skip overriden methods,
+                // but they need to be performed top-down per the AtInject specification
+                superInjections.addAll(injections);
+                injections = superInjections;
             }
         }
 
+        return injections;
     }
 
     static Injection forDisposer(MethodInfo disposerMethod, ClassInfo beanClass, BeanDeployment beanDeployment,
@@ -300,7 +312,8 @@ public class Injection {
     }
 
     private static List<AnnotationInstance> getAllInjectionPoints(BeanDeployment beanDeployment, ClassInfo beanClass,
-            DotName name, boolean skipConstructors) {
+            DotName annotationName, boolean skipConstructors, Set<MethodOverrideKey> seenMethods) {
+        // order is significant: fields must be injected before methods
         List<AnnotationInstance> injectAnnotations = new ArrayList<>();
 
         // note that we can't treat static injection as a failure, because
@@ -308,7 +321,7 @@ public class Injection {
         // hence, we just print a warning
 
         for (FieldInfo field : beanClass.fields()) {
-            AnnotationInstance inject = beanDeployment.getAnnotation(field, name);
+            AnnotationInstance inject = beanDeployment.getAnnotation(field, annotationName);
             if (inject != null) {
                 if (Modifier.isFinal(field.flags()) || Modifier.isStatic(field.flags())) {
                     LOGGER.warn("An injection field must be non-static and non-final - ignoring: "
@@ -319,11 +332,19 @@ public class Injection {
                 }
             }
         }
+
         for (MethodInfo method : beanClass.methods()) {
             if (skipConstructors && method.name().equals(Methods.INIT)) {
                 continue;
             }
-            AnnotationInstance inject = beanDeployment.getAnnotation(method, name);
+
+            MethodOverrideKey key = new MethodOverrideKey(method);
+            if (isOverriden(key, seenMethods)) {
+                continue;
+            }
+            seenMethods.add(key);
+
+            AnnotationInstance inject = beanDeployment.getAnnotation(method, annotationName);
             if (inject != null) {
                 if (Modifier.isStatic(method.flags())) {
                     LOGGER.warn("An initializer method must be non-static - ignoring: "
@@ -334,7 +355,111 @@ public class Injection {
                 }
             }
         }
+
         return injectAnnotations;
+    }
+
+    // ---
+    // this is close to `Methods.MethodKey` and `Methods.isOverridden()`, but it's actually more precise
+    // the `Methods` code is used on many places to avoid processing methods in case a method with the same
+    // signature has already been processed, and that's _not_ the definition of overriding
+
+    static class MethodOverrideKey {
+        final String name;
+        final List<DotName> params;
+        final DotName returnType;
+        final String visibility;
+        final MethodInfo method; // this is intentionally ignored for equals/hashCode
+
+        public MethodOverrideKey(MethodInfo method) {
+            this.method = Objects.requireNonNull(method, "Method must not be null");
+            this.name = method.name();
+            this.returnType = method.returnType().name();
+            this.params = new ArrayList<>();
+            for (Type i : method.parameterTypes()) {
+                params.add(i.name());
+            }
+            if (Modifier.isPublic(method.flags()) || Modifier.isProtected(method.flags())) {
+                this.visibility = "";
+            } else if (Modifier.isPrivate(method.flags())) {
+                // private methods cannot be overridden
+                this.visibility = method.declaringClass().name().toString();
+            } else {
+                // package-private methods can only be overridden in the same package
+                this.visibility = method.declaringClass().name().packagePrefix();
+            }
+        }
+
+        private MethodOverrideKey(String name, List<DotName> params, DotName returnType, String visibility, MethodInfo method) {
+            this.name = name;
+            this.params = params;
+            this.returnType = returnType;
+            this.visibility = visibility;
+            this.method = method;
+        }
+
+        MethodOverrideKey withoutVisibility() {
+            return new MethodOverrideKey(name, params, returnType, "", method);
+        }
+
+        String packageName() {
+            return method.declaringClass().name().packagePrefix();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (!(o instanceof MethodOverrideKey))
+                return false;
+            MethodOverrideKey methodKey = (MethodOverrideKey) o;
+            return Objects.equals(name, methodKey.name)
+                    && Objects.equals(params, methodKey.params)
+                    && Objects.equals(returnType, methodKey.returnType)
+                    && Objects.equals(visibility, methodKey.visibility);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, params, returnType, visibility);
+        }
+    }
+
+    /**
+     * Returns whether given {@code method} is overridden by any of given {@code previousMethods}. This method
+     * only works correctly during a bottom-up traversal of class inheritance hierarchy, during which all seen
+     * methods are recorded into {@code previousMethods}.
+     * <p>
+     * This is not entirely precise according to the JLS rules for method overriding, but seems good enough.
+     */
+    static boolean isOverriden(MethodOverrideKey method, Set<MethodOverrideKey> previousMethods) {
+        short flags = method.method.flags();
+        if (Modifier.isPublic(flags) || Modifier.isProtected(flags)) {
+            // if there's an override, it must be public or perhaps protected,
+            // so it always has the same visibility
+            return previousMethods.contains(method);
+        } else if (Modifier.isPrivate(flags)) {
+            // private methods are never overridden
+            return false;
+        } else { // package-private
+            // if there's an override, it must be in the same package and:
+            // 1. either package-private (so it has the same visibility)
+            if (previousMethods.contains(method)) {
+                return true;
+            }
+
+            // 2. or public/protected (so it has a different visibility: empty string)
+            String packageName = method.packageName();
+            MethodOverrideKey methodWithoutVisibility = method.withoutVisibility();
+            for (MethodOverrideKey previousMethod : previousMethods) {
+                if (methodWithoutVisibility.equals(previousMethod)
+                        && packageName.equals(previousMethod.packageName())) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -355,98 +355,30 @@ final class Methods {
         }
 
         @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + name.hashCode();
-            result = prime * result + params.hashCode();
-            result = prime * result + returnType.hashCode();
-            return result;
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (!(o instanceof MethodKey))
+                return false;
+            MethodKey methodKey = (MethodKey) o;
+            return Objects.equals(name, methodKey.name)
+                    && Objects.equals(params, methodKey.params)
+                    && Objects.equals(returnType, methodKey.returnType);
         }
 
         @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null) {
-                return false;
-            }
-            if (!(obj instanceof MethodKey)) {
-                return false;
-            }
-            MethodKey other = (MethodKey) obj;
-            if (!name.equals(other.name)) {
-                return false;
-            }
-            if (!params.equals(other.params)) {
-                return false;
-            }
-            if (!returnType.equals(other.returnType)) {
-                return false;
-            }
-            return true;
+        public int hashCode() {
+            return Objects.hash(name, params, returnType);
         }
-
     }
 
-    static boolean isOverriden(MethodInfo method, Collection<MethodInfo> previousMethods) {
-        for (MethodInfo other : previousMethods) {
-            if (Methods.matchesSignature(method, other)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    static boolean isOverriden(Methods.MethodKey method, Collection<Methods.MethodKey> previousMethods) {
+    /**
+     * Note that this in fact <em>does not</em> detect method overrides. It is only useful
+     * to skip processing of a method in case a method with the same name and signature
+     * has already been processed. (Same name and signature does not mean override!)
+     */
+    static boolean isOverriden(Methods.MethodKey method, Set<Methods.MethodKey> previousMethods) {
         return previousMethods.contains(method);
-    }
-
-    static boolean matchesSignature(MethodInfo method, MethodInfo subclassMethod) {
-        if (!method.name().equals(subclassMethod.name())) {
-            return false;
-        }
-        List<Type> parameters = method.parameterTypes();
-        List<Type> subParameters = subclassMethod.parameterTypes();
-
-        int paramCount = parameters.size();
-        if (paramCount != subParameters.size()) {
-            return false;
-        }
-
-        if (paramCount == 0) {
-            return true;
-        }
-
-        for (int i = 0; i < paramCount; i++) {
-            if (!Methods.isTypeEqual(parameters.get(i), subParameters.get(i))) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    static boolean isTypeEqual(Type a, Type b) {
-        return Methods.toRawType(a).equals(Methods.toRawType(b));
-    }
-
-    static DotName toRawType(Type a) {
-        switch (a.kind()) {
-            case CLASS:
-            case PRIMITIVE:
-            case ARRAY:
-                return a.name();
-            case PARAMETERIZED_TYPE:
-                return a.asParameterizedType().name();
-            case TYPE_VARIABLE:
-            case UNRESOLVED_TYPE_VARIABLE:
-            case TYPE_VARIABLE_REFERENCE:
-            case WILDCARD_TYPE:
-            default:
-                return DotNames.OBJECT;
-        }
     }
 
     static void addDelegateTypeMethods(IndexView index, ClassInfo delegateTypeClass, Set<MethodKey> methods) {

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/Basics.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/Basics.java
@@ -1,27 +1,11 @@
 package io.quarkus.arc.processor;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 import org.jboss.jandex.DotName;
-import org.jboss.jandex.Index;
-import org.jboss.jandex.Indexer;
 
 public final class Basics {
 
     public static DotName name(Class<?> clazz) {
         return DotName.createSimple(clazz.getName());
-    }
-
-    public static Index index(Class<?>... classes) throws IOException {
-        Indexer indexer = new Indexer();
-        for (Class<?> clazz : classes) {
-            try (InputStream stream = Basics.class.getClassLoader()
-                    .getResourceAsStream(clazz.getName().replace('.', '/') + ".class")) {
-                indexer.index(stream);
-            }
-        }
-        return indexer.complete();
     }
 
 }

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoInjectionsTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoInjectionsTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.arc.processor;
 
-import static io.quarkus.arc.processor.Basics.index;
 import static io.quarkus.arc.processor.Basics.name;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -13,7 +12,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
@@ -33,11 +31,10 @@ public class BeanInfoInjectionsTest {
     @Test
     public void testInjections() throws IOException {
 
-        Index index = index(Foo.class, Bar.class, FooQualifier.class, AbstractList.class, AbstractCollection.class,
+        Index index = Index.of(Foo.class, Bar.class, FooQualifier.class, AbstractList.class, AbstractCollection.class,
                 Collection.class, List.class,
                 Iterable.class, Object.class, String.class);
-        DotName barName = name(Bar.class);
-        ClassInfo barClass = index.getClassByName(barName);
+        ClassInfo barClass = index.getClassByName(Bar.class);
         Type fooType = Type.create(name(Foo.class), Kind.CLASS);
         Type listStringType = ParameterizedType.create(name(List.class),
                 new Type[] { Type.create(name(String.class), Kind.CLASS) }, null);

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoQualifiersTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoQualifiersTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.arc.processor;
 
-import static io.quarkus.arc.processor.Basics.index;
 import static io.quarkus.arc.processor.Basics.name;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -30,7 +29,7 @@ public class BeanInfoQualifiersTest {
 
     @Test
     public void testQualifiers() throws IOException {
-        Index index = index(Foo.class, Bar.class, FooQualifier.class, AbstractList.class, AbstractCollection.class,
+        Index index = Index.of(Foo.class, Bar.class, FooQualifier.class, AbstractList.class, AbstractCollection.class,
                 List.class, Collection.class, Object.class, String.class, Iterable.class);
         DotName fooName = name(Foo.class);
         DotName fooQualifierName = name(FooQualifier.class);

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoTypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanInfoTypesTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.arc.processor;
 
-import static io.quarkus.arc.processor.Basics.index;
 import static io.quarkus.arc.processor.Basics.name;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,7 +32,7 @@ public class BeanInfoTypesTest {
     @Test
     public void testResolver() throws IOException {
 
-        Index index = index(Foo.class, Bar.class, FooQualifier.class, AbstractList.class, AbstractCollection.class,
+        Index index = Index.of(Foo.class, Bar.class, FooQualifier.class, AbstractList.class, AbstractCollection.class,
                 Collection.class, List.class,
                 Iterable.class, Object.class, String.class);
 

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/DotNamesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/DotNamesTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.arc.processor;
 
-import static io.quarkus.arc.processor.Basics.index;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,7 +17,7 @@ public class DotNamesTest {
 
     @Test
     public void testSimpleName() throws IOException {
-        Index index = index(Nested.class, NestedNested.class, DotNamesTest.class);
+        Index index = Index.of(Nested.class, NestedNested.class, DotNamesTest.class);
         Assertions.assertEquals("Nested",
                 DotNames.simpleName(index.getClassByName(DotName.createSimple(Nested.class.getName()))));
         assertEquals("DotNamesTest$Nested",

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/MethodUtilsTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/MethodUtilsTest.java
@@ -1,120 +1,104 @@
 package io.quarkus.arc.processor;
 
-import static io.quarkus.arc.processor.Basics.index;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.MethodInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- *
- * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
- *         <br>
- *         Date: 17/07/2019
- */
+import io.quarkus.arc.processor.types.Bottom;
+import io.quarkus.arc.processor.types.Top;
+import io.quarkus.arc.processor.types.extrapkg.Middle;
+import io.quarkus.arc.processor.types.extrapkg.Middle2;
+
 public class MethodUtilsTest {
 
     private Index index;
 
     @BeforeEach
     public void setUp() throws IOException {
-        index = index(SomeClass.class, SuperClass.class, SuperSuperClass.class, TheRoot.class);
+        index = Index.of(SomeClass.class, SuperClass.class, SuperSuperClass.class, TheRoot.class,
+                Top.class, Middle.class, Middle2.class, Bottom.class);
     }
 
-    private Set<MethodInfo> gatherMethodsFromClasses(Class<?>... classes) {
+    private Set<Methods.MethodKey> gatherMethodsFromClasses(Class<?>... classes) {
         return Arrays.stream(classes)
-                .map(this::classInfo)
+                .map(index::getClassByName)
                 .map(ClassInfo::methods)
                 .flatMap(List::stream)
+                .map(Methods.MethodKey::new)
                 .collect(Collectors.toSet());
     }
 
     @Test
     public void shouldFindDirectOverriding() {
-        ClassInfo aClass = classInfo(SomeClass.class.getName());
-        ClassInfo superClass = classInfo(SuperClass.class.getName());
+        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class);
 
-        MethodInfo parentMethod = superClass.firstMethod("fromSuperClass");
-        assertThat(Methods.isOverriden(parentMethod, aClass.methods())).isTrue();
+        MethodInfo parentMethod = index.getClassByName(SuperClass.class).firstMethod("fromSuperClass");
+
+        assertThat(Methods.isOverriden(new Methods.MethodKey(parentMethod), methods)).isTrue();
     }
 
     @Test
     public void shouldFindGenericOverriding() {
-        Collection<MethodInfo> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
+        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
 
-        ClassInfo grandma = classInfo(SuperSuperClass.class);
+        MethodInfo genericMethod = index.getClassByName(SuperSuperClass.class).firstMethod("generic");
 
-        MethodInfo genericMethod = grandma.firstMethod("generic");
-
-        assertThat(Methods.isOverriden(genericMethod, methods)).isTrue();
+        assertThat(Methods.isOverriden(new Methods.MethodKey(genericMethod), methods)).isTrue();
     }
 
     @Test
     public void shouldNotFindNonOverridenFromSuperClass() {
-        ClassInfo aClass = classInfo(SomeClass.class.getName());
-        ClassInfo superClass = classInfo(SuperClass.class.getName());
+        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class);
 
-        MethodInfo parentMethod = superClass.firstMethod("notOverridenFromSuperClass");
-        assertThat(Methods.isOverriden(parentMethod, aClass.methods())).isFalse();
+        MethodInfo parentMethod = index.getClassByName(SuperClass.class).firstMethod("notOverridenFromSuperClass");
+
+        assertThat(Methods.isOverriden(new Methods.MethodKey(parentMethod), methods)).isFalse();
     }
 
     @Test
     public void shouldNotFindNonGenericNonOverridenFromSuperSuperClass() {
-        Collection<MethodInfo> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
+        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
 
-        ClassInfo grandma = classInfo(SuperSuperClass.class.getName());
+        MethodInfo parentMethod = index.getClassByName(SuperSuperClass.class).firstMethod("notOverridenNonGeneric");
 
-        MethodInfo parentMethod = grandma.firstMethod("notOverridenNonGeneric");
-        assertThat(Methods.isOverriden(parentMethod, methods)).isFalse();
+        assertThat(Methods.isOverriden(new Methods.MethodKey(parentMethod), methods)).isFalse();
     }
 
     @Test
     public void shouldNotFindGenericNonOverridenFromSuperSuperClass() {
-        Collection<MethodInfo> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
+        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
 
-        ClassInfo grandma = classInfo(SuperSuperClass.class.getName());
+        MethodInfo parentMethod = index.getClassByName(SuperSuperClass.class).firstMethod("notOverridenGeneric");
 
-        MethodInfo parentMethod = grandma.firstMethod("notOverridenGeneric");
-        assertThat(Methods.isOverriden(parentMethod, methods)).isFalse();
+        assertThat(Methods.isOverriden(new Methods.MethodKey(parentMethod), methods)).isFalse();
     }
 
     @Test
     public void shouldNotFindAlmostMatchingGeneric() {
-        Collection<MethodInfo> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
+        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class);
 
-        ClassInfo grandma = classInfo(SuperSuperClass.class.getName());
+        MethodInfo parentMethod = index.getClassByName(SuperSuperClass.class).firstMethod("almostMatchingGeneric");
 
-        MethodInfo parentMethod = grandma.firstMethod("almostMatchingGeneric");
-        assertThat(Methods.isOverriden(parentMethod, methods)).isFalse();
+        assertThat(Methods.isOverriden(new Methods.MethodKey(parentMethod), methods)).isFalse();
     }
 
     @Test
     public void shouldFindOverridenInTheMiddleOfHierarchy() {
-        Collection<MethodInfo> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class, SuperSuperClass.class);
+        Set<Methods.MethodKey> methods = gatherMethodsFromClasses(SomeClass.class, SuperClass.class, SuperSuperClass.class);
 
-        ClassInfo root = classInfo(TheRoot.class.getName());
+        MethodInfo parentMethod = index.getClassByName(TheRoot.class).firstMethod("generic");
 
-        MethodInfo parentMethod = root.firstMethod("generic");
-        assertThat(Methods.isOverriden(parentMethod, methods)).isTrue();
-    }
-
-    private ClassInfo classInfo(Class<?> aClass) {
-        return index.getClassByName(DotName.createSimple(aClass.getName()));
-    }
-
-    private ClassInfo classInfo(String name) {
-        return index.getClassByName(DotName.createSimple(name));
+        assertThat(Methods.isOverriden(new Methods.MethodKey(parentMethod), methods)).isTrue();
     }
 
     public static class SomeClass extends SuperClass<Boolean> {
@@ -140,7 +124,6 @@ public class MethodUtilsTest {
         }
 
         void almostMatchingGeneric(V param) {
-
         }
     }
 
@@ -163,7 +146,6 @@ public class MethodUtilsTest {
 
     public static class TheRoot<U, V, X> {
         void generic(X param) {
-
         }
     }
 }

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/OverrideDetectionTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/OverrideDetectionTest.java
@@ -1,0 +1,226 @@
+package io.quarkus.arc.processor;
+
+import static io.quarkus.arc.processor.Injection.isOverriden;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.arc.processor.Injection.MethodOverrideKey;
+import io.quarkus.arc.processor.types.Bottom;
+import io.quarkus.arc.processor.types.Top;
+import io.quarkus.arc.processor.types.extrapkg.Middle;
+import io.quarkus.arc.processor.types.extrapkg.Middle2;
+
+public class OverrideDetectionTest {
+    private Index index;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        index = Index.of(SomeClass.class, SuperClass.class, SuperSuperClass.class, TheRoot.class,
+                Top.class, Middle.class, Middle2.class, Bottom.class);
+    }
+
+    private Set<MethodOverrideKey> allMethodsOf(Class<?>... classes) {
+        return Arrays.stream(classes)
+                .map(index::getClassByName)
+                .map(ClassInfo::methods)
+                .flatMap(List::stream)
+                .map(MethodOverrideKey::new)
+                .collect(Collectors.toSet());
+    }
+
+    @Test
+    public void shouldFindDirectOverriding() {
+        Set<MethodOverrideKey> methods = allMethodsOf(SomeClass.class);
+
+        MethodInfo parentMethod = index.getClassByName(SuperClass.class).firstMethod("fromSuperClass");
+
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isTrue();
+    }
+
+    @Test
+    public void shouldFindGenericOverriding() {
+        Set<MethodOverrideKey> methods = allMethodsOf(SomeClass.class, SuperClass.class);
+
+        MethodInfo genericMethod = index.getClassByName(SuperSuperClass.class).firstMethod("generic");
+
+        assertThat(isOverriden(new MethodOverrideKey(genericMethod), methods)).isTrue();
+    }
+
+    @Test
+    public void shouldNotFindNonOverridenFromSuperClass() {
+        Set<MethodOverrideKey> methods = allMethodsOf(SomeClass.class);
+
+        MethodInfo parentMethod = index.getClassByName(SuperClass.class).firstMethod("notOverridenFromSuperClass");
+
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isFalse();
+    }
+
+    @Test
+    public void shouldNotFindNonGenericNonOverridenFromSuperSuperClass() {
+        Set<MethodOverrideKey> methods = allMethodsOf(SomeClass.class, SuperClass.class);
+
+        MethodInfo parentMethod = index.getClassByName(SuperSuperClass.class).firstMethod("notOverridenNonGeneric");
+
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isFalse();
+    }
+
+    @Test
+    public void shouldNotFindGenericNonOverridenFromSuperSuperClass() {
+        Set<MethodOverrideKey> methods = allMethodsOf(SomeClass.class, SuperClass.class);
+
+        MethodInfo parentMethod = index.getClassByName(SuperSuperClass.class).firstMethod("notOverridenGeneric");
+
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isFalse();
+    }
+
+    @Test
+    public void shouldNotFindAlmostMatchingGeneric() {
+        Set<MethodOverrideKey> methods = allMethodsOf(SomeClass.class, SuperClass.class);
+
+        MethodInfo parentMethod = index.getClassByName(SuperSuperClass.class).firstMethod("almostMatchingGeneric");
+
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isFalse();
+    }
+
+    @Test
+    public void shouldFindOverridenInTheMiddleOfHierarchy() {
+        Set<MethodOverrideKey> methods = allMethodsOf(SomeClass.class, SuperClass.class, SuperSuperClass.class);
+
+        MethodInfo parentMethod = index.getClassByName(TheRoot.class).firstMethod("generic");
+
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isTrue();
+    }
+
+    @Test
+    public void visibilityMiddleBottom() {
+        Set<MethodOverrideKey> methods = allMethodsOf(Bottom.class);
+
+        ClassInfo parent = index.getClassByName(Middle.class);
+
+        MethodInfo parentMethod = parent.firstMethod("packagePrivateMethod");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isFalse();
+
+        parentMethod = parent.firstMethod("privateMethod");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isFalse();
+
+        parentMethod = parent.firstMethod("packagePrivateMethodToBecomeProtected");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isFalse();
+
+        parentMethod = parent.firstMethod("packagePrivateMethodToBecomePublic");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isFalse();
+    }
+
+    @Test
+    public void visibilityTopMiddleBottom() {
+        Set<MethodOverrideKey> methods = allMethodsOf(Middle.class, Bottom.class);
+
+        ClassInfo parent = index.getClassByName(Top.class);
+
+        MethodInfo parentMethod = parent.firstMethod("publicMethod");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isTrue();
+
+        parentMethod = parent.firstMethod("protectedMethod");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isTrue();
+
+        parentMethod = parent.firstMethod("packagePrivateMethod");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isTrue();
+
+        parentMethod = parent.firstMethod("privateMethod");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isFalse();
+
+        parentMethod = parent.firstMethod("protectedMethodToBecomePublic");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isTrue();
+
+        parentMethod = parent.firstMethod("packagePrivateMethodToBecomeProtected");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isTrue();
+
+        parentMethod = parent.firstMethod("packagePrivateMethodToBecomePublic");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isTrue();
+    }
+
+    @Test
+    public void visibilityTopMiddle2() {
+        Set<MethodOverrideKey> methods = allMethodsOf(Middle2.class);
+
+        ClassInfo parent = index.getClassByName(Top.class);
+
+        MethodInfo parentMethod = parent.firstMethod("publicMethod");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isTrue();
+
+        parentMethod = parent.firstMethod("protectedMethod");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isTrue();
+
+        parentMethod = parent.firstMethod("packagePrivateMethod");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isFalse();
+
+        parentMethod = parent.firstMethod("privateMethod");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isFalse();
+
+        parentMethod = parent.firstMethod("protectedMethodToBecomePublic");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isTrue();
+
+        parentMethod = parent.firstMethod("packagePrivateMethodToBecomeProtected");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isFalse();
+
+        parentMethod = parent.firstMethod("packagePrivateMethodToBecomePublic");
+        assertThat(isOverriden(new MethodOverrideKey(parentMethod), methods)).isFalse();
+    }
+
+    public static class SomeClass extends SuperClass<Boolean> {
+        @Override
+        void generic(Integer param) {
+        }
+
+        @Override
+        void nonGeneric(String param) {
+        }
+
+        @Override
+        void fromSuperClass(int param) {
+        }
+    }
+
+    public static class SuperClass<V> extends SuperSuperClass<Integer, V> {
+        void fromSuperClass(int param) {
+        }
+
+        void notOverridenFromSuperClass(int param) {
+        }
+
+        void almostMatchingGeneric(V param) {
+        }
+    }
+
+    public static class SuperSuperClass<V, U> extends TheRoot<String, U, V> {
+        void generic(V arg) {
+        }
+
+        void almostMatchingGeneric(Integer arg) {
+        }
+
+        void nonGeneric(String param) {
+        }
+
+        void notOverridenGeneric(V arg) {
+        }
+
+        void notOverridenNonGeneric(String param) {
+        }
+    }
+
+    public static class TheRoot<U, V, X> {
+        void generic(X param) {
+        }
+    }
+}

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/SubclassSkipPredicateTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/SubclassSkipPredicateTest.java
@@ -13,6 +13,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ public class SubclassSkipPredicateTest {
 
     @Test
     public void testPredicate() throws IOException {
-        IndexView index = Basics.index(Base.class, Submarine.class, Long.class, Number.class);
+        IndexView index = Index.of(Base.class, Submarine.class, Long.class, Number.class);
         AssignabilityCheck assignabilityCheck = new AssignabilityCheck(index, null);
         SubclassSkipPredicate predicate = new SubclassSkipPredicate(assignabilityCheck::isAssignableFrom, null,
                 Collections.emptySet());

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.inject.spi.DefinitionException;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
@@ -30,7 +31,7 @@ public class TypesTest {
 
     @Test
     public void testGetTypeClosure() throws IOException {
-        IndexView index = Basics.index(Foo.class, Baz.class, Producer.class, Object.class, List.class, Collection.class,
+        IndexView index = Index.of(Foo.class, Baz.class, Producer.class, Object.class, List.class, Collection.class,
                 Iterable.class, Set.class, Eagle.class, Bird.class, Animal.class, AnimalHolder.class, MyRawBean.class,
                 MyBean.class, MyInterface.class, MySuperInterface.class);
         DotName bazName = DotName.createSimple(Baz.class.getName());

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/types/Bottom.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/types/Bottom.java
@@ -1,0 +1,42 @@
+package io.quarkus.arc.processor.types;
+
+import io.quarkus.arc.processor.types.extrapkg.Middle;
+
+public class Bottom extends Middle {
+    @Override
+    public String publicMethod(String param) {
+        return null;
+    }
+
+    @Override
+    protected String protectedMethod(String param) {
+        return null;
+    }
+
+    @Override
+    String packagePrivateMethod(String param) {
+        return null;
+    }
+
+    // no override
+    private String privateMethod(String param) {
+        return null;
+    }
+
+    // ---
+
+    @Override
+    public String protectedMethodToBecomePublic(String param) {
+        return null;
+    }
+
+    @Override
+    protected String packagePrivateMethodToBecomeProtected(String param) {
+        return null;
+    }
+
+    @Override
+    public String packagePrivateMethodToBecomePublic(String param) {
+        return null;
+    }
+}

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/types/Top.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/types/Top.java
@@ -1,0 +1,41 @@
+package io.quarkus.arc.processor.types;
+
+// inheritance hierarchy:
+//
+// Top------>Middle------>Bottom
+//    \
+//     +---->Middle2
+//
+// Top and Bottom are in the same package,
+// Middle and Middle2 are in a different package
+public class Top {
+    public String publicMethod(String param) {
+        return null;
+    }
+
+    protected String protectedMethod(String param) {
+        return null;
+    }
+
+    String packagePrivateMethod(String param) {
+        return null;
+    }
+
+    private String privateMethod(String param) {
+        return null;
+    }
+
+    // ---
+
+    protected String protectedMethodToBecomePublic(String param) {
+        return null;
+    }
+
+    String packagePrivateMethodToBecomeProtected(String param) {
+        return null;
+    }
+
+    String packagePrivateMethodToBecomePublic(String param) {
+        return null;
+    }
+}

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/types/extrapkg/Middle.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/types/extrapkg/Middle.java
@@ -1,0 +1,27 @@
+package io.quarkus.arc.processor.types.extrapkg;
+
+import io.quarkus.arc.processor.types.Top;
+
+public class Middle extends Top {
+    // no override
+    String packagePrivateMethod(String param) {
+        return null;
+    }
+
+    // no override
+    private String privateMethod(String param) {
+        return null;
+    }
+
+    // ---
+
+    // no override
+    String packagePrivateMethodToBecomeProtected(String param) {
+        return null;
+    }
+
+    // no override
+    String packagePrivateMethodToBecomePublic(String param) {
+        return null;
+    }
+}

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/types/extrapkg/Middle2.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/types/extrapkg/Middle2.java
@@ -1,0 +1,42 @@
+package io.quarkus.arc.processor.types.extrapkg;
+
+import io.quarkus.arc.processor.types.Top;
+
+public class Middle2 extends Top {
+    @Override
+    public String publicMethod(String param) {
+        return null;
+    }
+
+    @Override
+    protected String protectedMethod(String param) {
+        return null;
+    }
+
+    // no override
+    String packagePrivateMethod(String param) {
+        return null;
+    }
+
+    // no override
+    private String privateMethod(String param) {
+        return null;
+    }
+
+    // ---
+
+    @Override
+    public String protectedMethodToBecomePublic(String param) {
+        return null;
+    }
+
+    // no override
+    protected String packagePrivateMethodToBecomeProtected(String param) {
+        return null;
+    }
+
+    // no override
+    public String packagePrivateMethodToBecomePublic(String param) {
+        return null;
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/order/InjectionOrderTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/order/InjectionOrderTest.java
@@ -1,0 +1,131 @@
+package io.quarkus.arc.test.injection.order;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InjectionOrderTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Consumer.class, Dependency.class);
+
+    @Test
+    public void test() {
+        Consumer consumer = Arc.container().select(Consumer.class).get();
+
+        assertFalse(ConsumerSuperclass.superConstructorInjected); // subclass calls different ctor
+        assertTrue(consumer.superFieldInjected());
+        assertFalse(ConsumerSuperclass.superInitializerInjected); // overridden in a subclass
+        assertTrue(ConsumerSuperclass.superPrivateInitializerInjected); // not overridden, it's private
+        assertFalse(ConsumerSuperclass.superPrivateInitializerInjectedBeforeField);
+
+        assertTrue(Consumer.constructorInjected);
+        assertTrue(consumer.fieldInjected());
+        assertTrue(Consumer.initializerInjected);
+        assertFalse(Consumer.initializerInjectedBeforeField);
+        assertTrue(Consumer.privateInitializerInjected);
+
+        assertFalse(Consumer.subclassInjectedBeforeSuperclass);
+    }
+
+    static class ConsumerSuperclass {
+        static boolean superConstructorInjected;
+        static boolean superInitializerInjected;
+        static boolean superPrivateInitializerInjected;
+        static boolean superPrivateInitializerInjectedBeforeField;
+
+        @Inject
+        private Dependency dependency;
+
+        ConsumerSuperclass() {
+            onSuperInjection();
+        }
+
+        @Inject
+        ConsumerSuperclass(Dependency dependency) {
+            superConstructorInjected = true;
+            onSuperInjection();
+        }
+
+        @Inject
+        void init(Dependency dependency) {
+            superInitializerInjected = true;
+            onSuperInjection();
+        }
+
+        @Inject
+        private void privateInit(Dependency dependency) {
+            superPrivateInitializerInjected = true;
+            if (this.dependency == null) {
+                superPrivateInitializerInjectedBeforeField = true;
+            }
+            onSuperInjection();
+        }
+
+        boolean superFieldInjected() {
+            return this.dependency != null;
+        }
+
+        void onSuperInjection() {
+        }
+    }
+
+    @Dependent
+    static class Consumer extends ConsumerSuperclass {
+        static boolean constructorInjected;
+        static boolean initializerInjected;
+        static boolean initializerInjectedBeforeField;
+        static boolean privateInitializerInjected;
+        static boolean privateInitializerInjectedBeforeField;
+
+        static boolean subclassInjectedBeforeSuperclass;
+
+        @Inject
+        private Dependency dependency;
+
+        @Inject
+        Consumer(Dependency dependency) {
+            super();
+            constructorInjected = true;
+        }
+
+        @Inject
+        @Override
+        void init(Dependency dependency) {
+            initializerInjected = true;
+            if (this.dependency == null) {
+                initializerInjectedBeforeField = true;
+            }
+        }
+
+        @Inject
+        private void privateInit(Dependency dependency) {
+            privateInitializerInjected = true;
+            if (this.dependency == null) {
+                privateInitializerInjectedBeforeField = true;
+            }
+        }
+
+        boolean fieldInjected() {
+            return this.dependency != null;
+        }
+
+        @Override
+        void onSuperInjection() {
+            if (Consumer.initializerInjected || Consumer.privateInitializerInjected || fieldInjected()) {
+                Consumer.subclassInjectedBeforeSuperclass = true;
+            }
+        }
+    }
+
+    @Dependent
+    static class Dependency {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/staticmethod/StaticMethodInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/staticmethod/StaticMethodInjectionTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.arc.test.injection.staticmethod;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class StaticMethodInjectionTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Head.class, CombineHarvester.class);
+
+    @Test
+    public void testInjection() {
+        assertNotNull(Arc.container().instance(CombineHarvester.class).get());
+        assertNotNull(CombineHarvester.head);
+        assertEquals(1, Head.COUNTER.get());
+    }
+
+    @Dependent
+    static class Head {
+
+        static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+        public Head() {
+            COUNTER.incrementAndGet();
+        }
+
+    }
+
+    @Dependent
+    static class CombineHarvester {
+
+        static Head head;
+
+        // The parameter is injected
+        CombineHarvester(Head head) {
+            CombineHarvester.head = head;
+        }
+
+        // This one is ignored
+        @Inject
+        static void init(Head head) {
+            CombineHarvester.head = head;
+        }
+
+    }
+}


### PR DESCRIPTION
Related to #28558

- ignore static methods annotated `@Inject`, similarly to static fields
- fix dependency injection order
  - this is to pass the AtInject TCK
  - to review the `BeanGenerator` changes, I suggest to hide whitespace changes
- implement CDI 4.0 startup/shutdown events
  - I believe it's best if we let current Quarkus events just extend the CDI 4.0 event classes, so that they are basically the same
- improve bean archive detection
  - treat archives that contain Build Compatible Extensions just like we treat archives that contain Portable Extensions (which is what CDI requires)
  - archives that contain `beans.xml` with `bean-discovery-mode="none"` are no longer treated as bean archives
