### PR TITLE
Make OIDC connection error log messages more visible

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -417,7 +417,7 @@ public class OidcCommonUtils {
             if (resp.statusCode() == 200) {
                 return resp.bodyAsJsonObject();
             } else {
-                LOG.tracef("Discovery has failed, status code: %d", resp.statusCode());
+                LOG.warnf("Discovery has failed, status code: %d", resp.statusCode());
                 throw new OidcEndpointAccessException(resp.statusCode());
             }
         }).onFailure(oidcEndpointNotAvailable())

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -109,8 +109,8 @@ public class OidcRecorder {
                     @Override
                     public TenantConfigContext apply(Throwable t) {
                         if (t instanceof OIDCException) {
-                            // OIDC server is not available yet - try to create the connection when the first request arrives
-                            LOG.debugf("Tenant '%s': '%s'."
+                            LOG.warnf("Tenant '%s': '%s'."
+                                    + " OIDC server is not available yet, an attempt to connect will be made duiring the first request."
                                     + " Access to resources protected by this tenant may fail"
                                     + " if OIDC server will not become available",
                                     tenantId, t.getMessage());
@@ -257,7 +257,7 @@ public class OidcRecorder {
 
     protected static OIDCException toOidcException(Throwable cause, String authServerUrl) {
         final String message = OidcCommonUtils.formatConnectionErrorMessage(authServerUrl);
-        LOG.debug(message);
+        LOG.warn(message);
         return new OIDCException("OIDC Server is not available", cause);
     }
 


### PR DESCRIPTION
Fixes #29427.

As suggested in #29427, increasing the log level should make it more visible without having to see first low level Netty error messages about Sockets, and then trying to find how to enable debug/trace levels, etc.

The other thing is that sometimes the same error is reported with more traces and sometimes with fewer of them, I think, it is because when the connection is retried as part of the Uni sequence, it will add more traces. The OIDC related message is still coming on top I believe in all cases. 
