### PR TITLE
Better error message when classinfo is null

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
@@ -61,6 +61,8 @@ public class ResteasyBuiltinsProcessor {
             List<String> resourceClasses = resteasyDeployment.getDeployment().getScannedResourceClasses();
             for (String className : resourceClasses) {
                 ClassInfo classInfo = index.getIndex().getClassByName(DotName.createSimple(className));
+                if (classInfo == null)
+                    throw new IllegalStateException("Unable to find class info for " + className);
                 if (!hasSecurityAnnotation(classInfo)) {
                     for (MethodInfo methodInfo : classInfo.methods()) {
                         if (isRestEndpointMethod(index, methodInfo) && !hasSecurityAnnotation(methodInfo)) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
@@ -87,6 +87,8 @@ public class ResteasyReactiveCommonProcessor {
 
             for (DotName className : resourceClasses) {
                 ClassInfo classInfo = index.getIndex().getClassByName(className);
+                if (classInfo == null)
+                    throw new IllegalStateException("Unable to find class info for " + className);
                 if (!hasSecurityAnnotation(classInfo)) {
                     // collect class endpoints
                     Collection<MethodInfo> classEndpoints = collectClassEndpoints(classInfo, httpAnnotationToMethod,


### PR DESCRIPTION
in https://github.com/quarkusio/quarkus/issues/30254 it was found that classInfo can sometime be null in the setupdenyalljaxrs methods and we never got a reproducer to reproduce it. But the error message could at least be more informative and tell user (and us) which class is causing troubles in case this happens again.