### PR TITLE
Higher sleep delay before timeout for ReadTimeoutTestCase

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/ReadTimeoutTestCase.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/ReadTimeoutTestCase.java
@@ -36,7 +36,7 @@ public class ReadTimeoutTestCase {
         socket.getOutputStream().write(
                 "POST /post HTTP/1.1\r\nHost: localhost\r\nContent-length:9\r\n\r\n12345".getBytes(StandardCharsets.UTF_8));
         socket.getOutputStream().flush();
-        Thread.sleep(600);
+        Thread.sleep(1200);
         socket.getOutputStream().write(
                 "6789".getBytes(StandardCharsets.UTF_8));
         socket.getOutputStream().flush();


### PR DESCRIPTION
We had a few failures of this test case, let's see if a slightly higher delay fixes it for us.