### PR TITLE
Add `format` command to CLI for source formatting

### DIFF
--- a/devtools/cli/pom.xml
+++ b/devtools/cli/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <quarkus.package.type>uber-jar</quarkus.package.type>
+        <roaster.version>2.28.0.Final</roaster.version>
     </properties>
 
     <artifactId>quarkus-cli</artifactId>
@@ -41,6 +42,17 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-netty</artifactId>
+        </dependency>
+        <!-- For the "quarkus format" command -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-ide-config</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.forge.roaster</groupId>
+            <artifactId>roaster-jdt</artifactId>
+            <version>${roaster.version}</version>
         </dependency>
         <!--
         Somehow, we need this as otherwise you end up with:

--- a/devtools/cli/src/main/java/io/quarkus/cli/Format.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Format.java
@@ -42,16 +42,14 @@ public class Format implements Callable<Integer> {
             formatterProperties = reader.getPropertiesFor("Quarkus");
         }
         Path root = Paths.get(".");
-        // Resolve the sources directory
-        Path src = root.resolve("src");
-        Files.walkFileTree(src, new SimpleFileVisitor<>() {
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 if (file.toString().endsWith(".java")) {
                     String source = Files.readString(file);
                     String formattedSource = Roaster.format(formatterProperties, source);
                     if (!formattedSource.equals(source)) {
-                        output.info(root.resolve(file).toString());
+                        output.info(root.relativize(file).toString());
                         Files.writeString(file, formattedSource);
                     }
                 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/Format.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Format.java
@@ -1,0 +1,63 @@
+package io.quarkus.cli;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+
+import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.util.FormatterProfileReader;
+
+import io.quarkus.cli.common.HelpOption;
+import io.quarkus.cli.common.OutputOptionMixin;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "format", aliases = "fmt", header = "Format your source code", description = "%n"
+        + "This command will format your sources using the same formatting rules used in the Quarkus Core project", footer = {
+                "%n"
+                        + "For example, the following command will format the current directory:" + "%n"
+                        + "quarkus format" + "%n" })
+public class Format implements Callable<Integer> {
+
+    @CommandLine.Mixin(name = "output")
+    protected OutputOptionMixin output;
+
+    @CommandLine.Mixin
+    protected HelpOption helpOption;
+
+    @CommandLine.Spec
+    protected CommandLine.Model.CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        Properties formatterProperties;
+        try (InputStream eclipseFormat = getClass().getClassLoader().getResourceAsStream("eclipse-format.xml")) {
+            FormatterProfileReader reader = FormatterProfileReader.fromEclipseXml(eclipseFormat);
+            formatterProperties = reader.getPropertiesFor("Quarkus");
+        }
+        Path root = Paths.get(".");
+        // Resolve the sources directory
+        Path src = root.resolve("src");
+        Files.walkFileTree(src, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if (file.toString().endsWith(".java")) {
+                    String source = Files.readString(file);
+                    String formattedSource = Roaster.format(formatterProperties, source);
+                    if (!formattedSource.equals(source)) {
+                        output.info(root.resolve(file).toString());
+                        Files.writeString(file, formattedSource);
+                    }
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        return 0;
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -23,7 +23,8 @@ import picocli.CommandLine.ScopeType;
 import picocli.CommandLine.UnmatchedArgumentException;
 
 @CommandLine.Command(name = "quarkus", subcommands = {
-        Create.class, Build.class, Dev.class, Test.class, ProjectExtensions.class, Image.class, Registry.class, Info.class,
+        Create.class, Build.class, Dev.class, Format.class, Test.class, ProjectExtensions.class, Image.class, Registry.class,
+        Info.class,
         Update.class,
         Completion.class }, scope = ScopeType.INHERIT, sortOptions = false, showDefaultValues = true, versionProvider = Version.class, subcommandsRepeatable = false, mixinStandardHelpOptions = false, commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n", headerHeading = "%n", parameterListHeading = "%n")
 public class QuarkusCli implements QuarkusApplication, Callable<Integer> {


### PR DESCRIPTION
- Add formatting feature to the Quarkus CLI for sources using the same formatting rules used in the Quarkus Core project
- Fixes #30337
