### PR TITLE
Bump `org.jetbrains.annotations` from `17.0.0` to the latest(`24.0.0`)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -125,6 +125,7 @@ updates:
       - dependency-name: org.jetbrains.kotlin:*
       - dependency-name: org.jetbrains.kotlinx:*
       - dependency-name: org.jetbrains.dokka:*
+      - dependency-name: org.jetbrains:*
       # TCKs
       - dependency-name: org.eclipse.microprofile.config:microprofile-config-tck
       - dependency-name: org.eclipse.microprofile.context-propagation:microprofile-context-propagation-tck

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -428,7 +428,7 @@
             <dependency>
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
-                <version>17.0.0</version>
+                <version>24.0.0</version>
             </dependency>
             <!-- Kotlin Coroutines BOM -->
             <dependency>


### PR DESCRIPTION
In `bom/application/pom.xml`:

![image](https://user-images.githubusercontent.com/29922079/220042799-1c1962d2-98a4-486f-846e-39c2e29eaa88.png)

Are we able to bump this dependency?

https://github.com/JetBrains/java-annotations