### PR TITLE
Qute type-safe messages - change the default bundle name strategy

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -2459,21 +2459,6 @@ In the development mode, all files located in `src/main/resources/templates` are
 The basic idea is that every message is potentially a very simple template.
 In order to prevent type errors a message is defined as an annotated method of a *message bundle interface*.
 Quarkus generates the *message bundle implementation* at build time.
-Subsequently, the bundles can be used at runtime:
-
-1. Directly in your code via `io.quarkus.qute.i18n.MessageBundles#get()`; e.g. `MessageBundles.get(AppMessages.class).hello_name("Lucie")`
-2. Injected in your beans via `@Inject`; e.g. `@Inject AppMessages`
-3. Referenced in the templates via the message bundle namespace:
-+
-[source,html]
-----
- {msg:hello_name('Lucie')} <1> <2> <3>
- {msg:message(myKey,'Lu')} <4>
-----
-<1> `msg` is the default namespace.
-<2> `hello_name` is the message key.
-<3> `Lucie` is the parameter of the message bundle interface method.  
-<4> It is also possible to obtain a localized message for a key resolved at runtime using a reserved key `message`. The validation is skipped in this case though.
 
 .Message Bundle Interface Example
 [source,java]
@@ -2492,9 +2477,49 @@ public interface AppMessages {
 <2> Each method must be annotated with `@Message`. The value is a qute template. If no value is provided, then a corresponding value from a localized file is taken. If no such file exists an exception is thrown and the build fails.
 <3> The method parameters can be used in the template.
 
+The message bundles can be used at runtime:
+
+1. Directly in your code via `io.quarkus.qute.i18n.MessageBundles#get()`; e.g. `MessageBundles.get(AppMessages.class).hello_name("Lucie")`
+2. Injected in your beans via `@Inject`; e.g. `@Inject AppMessages`
+3. Referenced in the templates via the message bundle namespace:
++
+[source,html]
+----
+ {msg:hello_name('Lucie')} <1> <2> <3>
+ {msg:message(myKey,'Lu')} <4>
+----
+<1> `msg` is the default namespace.
+<2> `hello_name` is the message key.
+<3> `Lucie` is the parameter of the message bundle interface method.  
+<4> It is also possible to obtain a localized message for a key resolved at runtime using a reserved key `message`. The validation is skipped in this case though.
+
+
+==== Default Bundle Name
+
+The bundle name is defaulted unless it's specified with `@MessageBundle#value()`.
+For a top-level class the `msg` value is used by default.
+For a nested class the name starts with `msg` followed by an underscore, followed by the simple names of all enclosing classes in the hierarchy (top-level class goes first) seperated by underscores.
+
+For example, the name of the following message bundle will be defaulted to `msg_Index`:
+
+[source,java]
+----
+class Index {
+
+    @MessageBundle
+    interface Bundle {
+
+        @Message("Hello {name}!")
+        String hello(String name);
+   }
+}
+----
+
+NOTE: The bundle name is also used as a part of the name of a localized file, e.g. `msg_Index` in the `msg_Index_de.properties`.
+
 ==== Bundle Name and Message Keys
 
-Keys are used directly in templates.
+Message keys are used directly in templates.
 The bundle name is used as a namespace in template expressions. 
 The `@MessageBundle` can be used to define the default strategy used to generate message keys from method names. 
 However, the `@Message` can override this strategy and even define a custom key.

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedFileBundleLocaleMergeTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedFileBundleLocaleMergeTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute.deployment.i18n;
 
+import static io.quarkus.qute.i18n.MessageBundle.DEFAULT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -59,7 +60,7 @@ public class LocalizedFileBundleLocaleMergeTest {
         assertEquals("Abschied", deMessages.farewell());
     }
 
-    @MessageBundle
+    @MessageBundle(DEFAULT_NAME)
     public interface Messages {
 
         @Message("Ahoj svete!")

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedFileDefaultLocaleMergeTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedFileDefaultLocaleMergeTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute.deployment.i18n;
 
+import static io.quarkus.qute.i18n.MessageBundle.DEFAULT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -38,7 +39,7 @@ public class LocalizedFileDefaultLocaleMergeTest {
         assertEquals("Hello world!", messages.helloWorld());
     }
 
-    @MessageBundle
+    @MessageBundle(DEFAULT_NAME)
     public interface Messages {
 
         @Message("Hello world!")

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedFileResourceBundleNameTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedFileResourceBundleNameTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute.deployment.i18n;
 
+import static io.quarkus.qute.i18n.MessageBundle.DEFAULT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.inject.Inject;
@@ -42,7 +43,7 @@ public class LocalizedFileResourceBundleNameTest {
         assertEquals("Ahoj!", foo.instance().setAttribute("locale", "cs-CZ").render());
     }
 
-    @MessageBundle
+    @MessageBundle(DEFAULT_NAME)
     public interface Messages1 {
 
         @Message

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleCustomDefaultLocaleTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleCustomDefaultLocaleTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute.deployment.i18n;
 
+import static io.quarkus.qute.i18n.MessageBundle.DEFAULT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Locale;
@@ -37,7 +38,7 @@ public class MessageBundleCustomDefaultLocaleTest {
         assertEquals("Hello world!", foo.instance().setAttribute("locale", Locale.ENGLISH).render());
     }
 
-    @MessageBundle
+    @MessageBundle(DEFAULT_NAME)
     public interface Messages {
 
         @Message("Ahoj světe!")

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleDefaultedNameTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleDefaultedNameTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.i18n.MessageBundles;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MessageBundleDefaultedNameTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Views.class)
+                    .addAsResource(new StringAsset(
+                            "{msg_Views_Index:hello(name)}"),
+                            "templates/Index/index.html")
+                    .addAsResource(new StringAsset("hello=Ahoj {name}!"), "messages/msg_Views_Index_cs.properties"));
+
+    @Test
+    public void testBundle() {
+        assertEquals("Hello world!",
+                Views.Index.Templates.index("world").render());
+        assertEquals("Ahoj svete!", Views.Index.Templates.index("svete")
+                .setAttribute(MessageBundles.ATTRIBUTE_LOCALE, Locale.forLanguageTag("cs")).render());
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleExpressionValidationTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleExpressionValidationTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute.deployment.i18n;
 
+import static io.quarkus.qute.i18n.MessageBundle.DEFAULT_NAME;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -49,7 +50,7 @@ public class MessageBundleExpressionValidationTest {
         fail();
     }
 
-    @MessageBundle
+    @MessageBundle(DEFAULT_NAME)
     public interface WrongBundle {
 
         // item has no "foo" property, "bar" and "baf" are not parameters, string has no "baz" property

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleLocaleTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleLocaleTest.java
@@ -23,7 +23,7 @@ public class MessageBundleLocaleTest {
             .withApplicationRoot((jar) -> jar
                     .addClasses(Messages.class)
                     .addAsResource(new StringAsset(
-                            "{msg:helloWorld}"),
+                            "{msg_MessageBundleLocaleTest:helloWorld}"),
                             "templates/foo.html"));
 
     @Inject

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleLogicalLineTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleLogicalLineTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute.deployment.i18n;
 
+import static io.quarkus.qute.i18n.MessageBundle.DEFAULT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Locale;
@@ -38,7 +39,7 @@ public class MessageBundleLogicalLineTest {
                 foo.instance().setAttribute(MessageBundles.ATTRIBUTE_LOCALE, Locale.forLanguageTag("cs")).render());
     }
 
-    @MessageBundle(locale = "en")
+    @MessageBundle(value = DEFAULT_NAME, locale = "en")
     public interface Messages {
 
         @Message("Hello {name}!")

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTemplateExpressionValidationTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTemplateExpressionValidationTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute.deployment.i18n;
 
+import static io.quarkus.qute.i18n.MessageBundle.DEFAULT_NAME;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -46,7 +47,7 @@ public class MessageBundleTemplateExpressionValidationTest {
         fail();
     }
 
-    @MessageBundle
+    @MessageBundle(value = DEFAULT_NAME)
     public interface MyBundle {
 
         @Message("Hello {item.name}")

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleValidationTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleValidationTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute.deployment.i18n;
 
+import static io.quarkus.qute.i18n.MessageBundle.DEFAULT_NAME;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -44,7 +45,7 @@ public class MessageBundleValidationTest {
         fail();
     }
 
-    @MessageBundle
+    @MessageBundle(DEFAULT_NAME)
     public interface Hellos {
 
         @Message("Hello {foo}")

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/Views.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/Views.java
@@ -1,0 +1,27 @@
+package io.quarkus.qute.deployment.i18n;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+
+public class Views {
+
+    public static class Index {
+
+        @CheckedTemplate
+        static class Templates {
+
+            static native TemplateInstance index(String name);
+
+        }
+
+        @MessageBundle
+        public interface Messages {
+
+            @Message("Hello {name}!")
+            String hello(String name);
+        }
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/DataNamespaceMessageBundleFailureTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/DataNamespaceMessageBundleFailureTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute.deployment.typesafe;
 
+import static io.quarkus.qute.i18n.MessageBundle.DEFAULT_NAME;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -46,7 +47,7 @@ public class DataNamespaceMessageBundleFailureTest {
         fail();
     }
 
-    @MessageBundle
+    @MessageBundle(value = DEFAULT_NAME)
     public interface Hellos {
 
         @Message("Hello {data:item.name}")

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/Message.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/Message.java
@@ -61,6 +61,7 @@ public @interface Message {
      * The key of a message.
      *
      * @return the message key
+     * @see MessageBundle#defaultKey()
      */
     String key() default DEFAULT_NAME;
 

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundle.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundle.java
@@ -39,19 +39,41 @@ public @interface MessageBundle {
     String DEFAULT_NAME = "msg";
 
     /**
-     * The name is used as a namespace in templates expressions.
+     * Constant value for {@link #value()} indicating that the name should be defaulted.
+     * <p>
+     * For a top-level class the {@value #DEFAULT_NAME} is used.
+     * <p>
+     * For a nested class the name starts with the {@value #DEFAULT_NAME} followed by an undercore, followed by the simple names
+     * of all enclosing classes in the hierarchy (top-level class goes first) seperated by underscores.
      *
-     * By default, the namespace {@value #DEFAULT_NAME} is used:
+     * For example, the name of the following message bundle will be defaulted to {@code msg_Index} and it could
+     * be used in a template via <code>{msg_Index:hello(name)}</code>:
      *
      * <pre>
-     * {msg:hello_world}
+     * <code>
+     * class Index {
+     *
+     *    &#64;MessageBundle
+     *    interface Bundle {
+     *
+     *       &#64;Message("Hello {name}!")
+     *       String hello(String name);
+     *    }
+     * }
+     * </code>
      * </pre>
-     *
-     * If multiple bundles declare the same name the build fails.
-     *
-     * @return the name
      */
-    String value() default DEFAULT_NAME;
+    String DEFAULTED_NAME = "<<defaulted name>>";
+
+    /**
+     * The name is used as a namespace in templates expressions - <code>{msg:hello_world}</code>, and as a part of the name of a
+     * message bundle localized file - <code>msg_de.properties</code>.
+     * <p>
+     * If multiple bundles declare the same name then the build fails.
+     *
+     * @return the name of the bundle
+     */
+    String value() default DEFAULTED_NAME;
 
     /**
      * The value may be one of the following: {@link Message#ELEMENT_NAME}, {@link Message#HYPHENATED_ELEMENT_NAME} and

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundles.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundles.java
@@ -67,7 +67,7 @@ public final class MessageBundles {
         ArcContainer container = Arc.container();
         // For every bundle register a new resolver
         for (Entry<String, Map<String, Class<?>>> entry : context.getBundleInterfaces().entrySet()) {
-            final String bundle = entry.getKey();
+            final String bundleName = entry.getKey();
             final Map<String, Resolver> interfaces = new HashMap<>();
             Resolver resolver = null;
             for (Entry<String, Class<?>> locEntry : entry.getValue().entrySet()) {
@@ -115,7 +115,7 @@ public final class MessageBundles {
 
                 @Override
                 public String getNamespace() {
-                    return bundle;
+                    return bundleName;
                 }
             });
         }

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/MessageBundleRecorder.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/MessageBundleRecorder.java
@@ -35,7 +35,7 @@ public class MessageBundleRecorder {
         // message id -> message template
         Map<String, String> getMessageTemplates();
 
-        // bundle -> (locale -> interface class)
+        // bundle name -> (locale -> interface class)
         Map<String, Map<String, Class<?>>> getBundleInterfaces();
 
     }


### PR DESCRIPTION
- use an approach similar to type-safe templates
- default bundle name of nested class includes the simple names declaring classes

For example, the default bundle name of `Messages` from the following class is `msg_Views_Index` and in a  template `{msg_Views_Index:hello(name)}`.

```java
import io.quarkus.qute.CheckedTemplate;
import io.quarkus.qute.TemplateInstance;
import io.quarkus.qute.i18n.Message;
import io.quarkus.qute.i18n.MessageBundle;

public class Views {

    public static class Index {

        @CheckedTemplate
        static class Templates {

            static native TemplateInstance index(String name);

        }

        @MessageBundle
        public interface Bundle {

            @Message("Hello {name}!")
            String hello(String name);
        }
    }
}
```