### PR TITLE
Updated OpenAPI `mp.openapi.extensions.smallrye.openapi` key mapping

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/ConfigMappingTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/ConfigMappingTest.java
@@ -16,7 +16,7 @@ public class ConfigMappingTest {
             .withApplicationRoot((jar) -> jar
                     .addClasses(DefaultContentTypeResource.class, Greeting.class)
 
-                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.open-api-version=3.0.3\n"
+                    .addAsResource(new StringAsset("quarkus.smallrye-openapi.open-api-version=3.0.2\n"
                             + "quarkus.smallrye-openapi.servers=http:\\//www.server1.com,http:\\//www.server2.com\n"
                             + "quarkus.smallrye-openapi.info-title=My API\n"
                             + "quarkus.smallrye-openapi.info-version=1.2.3\n"
@@ -37,7 +37,7 @@ public class ConfigMappingTest {
                 .then()
                 .log().body().and()
                 .body("openapi",
-                        Matchers.equalTo("3.0.3"))
+                        Matchers.equalTo("3.0.2"))
                 .body("servers[0].url",
                         Matchers.startsWith("http://www.server"))
                 .body("servers[1].url",

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiConfigMapping.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiConfigMapping.java
@@ -55,7 +55,7 @@ public class OpenApiConfigMapping extends RelocateConfigSourceInterceptor {
 
     private static Map<String, String> relocations() {
         Map<String, String> relocations = new HashMap<>();
-        mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.OPEN_API_VERSION, QUARKUS_OPEN_API_VERSION);
+        mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.VERSION, QUARKUS_OPEN_API_VERSION);
         mapKey(relocations, org.eclipse.microprofile.openapi.OASConfig.SERVERS, QUARKUS_SERVERS);
         mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.INFO_TITLE, QUARKUS_INFO_TITLE);
         mapKey(relocations, io.smallrye.openapi.api.constants.OpenApiConstants.INFO_VERSION, QUARKUS_INFO_VERSION);


### PR DESCRIPTION
Relates to https://github.com/quarkusio/quarkus/issues/31197:

* The value string `"3.0.3"` ([`io.smallrye.openapi.api.constants.OpenApiConstants.OPEN_API_VERSION`](https://javadoc.io/doc/io.smallrye/smallrye-open-api-core/latest/constant-values.html#io.smallrye.openapi.api.constants.OpenApiConstants.OPEN_API_VERSION)) had previously been mapped to this MP key.
* Updated the OpenApiConfigMapping rules so that the `quarkus.smallrye-openapi.open-api-version` key is now mapped to this MP key.