### PR TITLE
Update maven-invoker-plugin to 3.4.0 and add to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,6 +80,7 @@ updates:
       - dependency-name: io.fabric8:docker-maven-plugin
       - dependency-name: net.revelc.code.formatter:formatter-maven-plugin
       - dependency-name: net.revelc.code:impsort-maven-plugin
+      - dependency-name: org.apache.maven.plugins:maven-invoker-plugin
       # Narayana
       - dependency-name: org.jboss.narayana.jta:*
       - dependency-name: org.jboss.narayana.jts:*

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -123,7 +123,7 @@
         <docker-maven-plugin.version>0.42.0</docker-maven-plugin.version>
         <formatter-maven-plugin.version>2.22.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.8.0</impsort-maven-plugin.version>
-        <maven-invoker-plugin.version>3.2.2</maven-invoker-plugin.version>
+        <maven-invoker-plugin.version>3.4.0</maven-invoker-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
         <truststore-maven-plugin.version>3.0.0</truststore-maven-plugin.version>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -38,7 +38,7 @@
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <!-- Keeping 3.0.0.M3 because 3.2.1 requires class changes -->
         <enforcer-api.version>3.0.0-M3</enforcer-api.version>
-        <maven-invoker-plugin.version>3.2.2</maven-invoker-plugin.version>
+        <maven-invoker-plugin.version>3.4.0</maven-invoker-plugin.version>
         <maven-core.version>3.8.7</maven-core.version>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>


### PR DESCRIPTION
https://github.com/apache/maven-invoker-plugin/releases

Although it now brings a recent groovy version (4.0.9), I kept the explicit groovy deps as per https://github.com/quarkusio/quarkus/pull/31301#issuecomment-1437595319.