### PR TITLE
Update instructions on running container built with Dockerfile with debug port

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
@@ -15,7 +15,7 @@
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005.
-# Additionally you will have to include set -e JAVA_DEBUG=true and -e JAVA_DEBUG_PORT=*:5005
+# Additionally you will have to set -e JAVA_DEBUG=true and -e JAVA_DEBUG_PORT=*:5005
 # when running the container
 #
 # Then run the container using :

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
@@ -14,7 +14,9 @@
 # docker run -i --rm -p 8080:8080 quarkus/{project.artifact-id}-{type}
 #
 # If you want to include the debug port into your docker image
-# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
+# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005.
+# Additionally you will have to include set -e JAVA_DEBUG=true and -e JAVA_DEBUG_PORT=*:5005
+# when running the container
 #
 # Then run the container using :
 #


### PR DESCRIPTION
The `run-java.sh` (found under `/opt/jboss/container/java/run/run-java.sh` in the container) 
script needs `JAVA_DEBUG` to enabled debugging, but we also need to override the host and port by using `JAVA_DEBUG_PORT=*:5005` because otherwise the JVM process listens on the container's `localhost` 
which is not accessible from the host machine trying to connect remotely.

See this for the relevant part of the source of the `ubi/openjdk-17` Docker image.

Fixes: #31330