### PR TITLE
Upgrade to OpenTelemetry v1.23.1 and smallrye-reactive-messaging to v4.4.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -36,10 +36,10 @@
         <opentracing-jdbc.version>0.2.4</opentracing-jdbc.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
         <opentracing-mongo.version>0.1.5</opentracing-mongo.version>
-        <opentelemetry.version>1.22.0</opentelemetry.version>
-        <opentelemetry-alpha.version>1.22.0-alpha</opentelemetry-alpha.version>
-        <opentelemetry-aws.contrib.version>1.22.0-alpha</opentelemetry-aws.contrib.version>
-        <opentelemetry-aws-xray.contrib.version>1.22.0</opentelemetry-aws-xray.contrib.version>
+        <opentelemetry.version>1.23.1</opentelemetry.version>
+        <opentelemetry-alpha.version>1.23.0-alpha</opentelemetry-alpha.version>
+        <opentelemetry-aws.contrib.version>1.23.0-alpha</opentelemetry-aws.contrib.version>
+        <opentelemetry-aws-xray.contrib.version>1.23.0</opentelemetry-aws-xray.contrib.version>
         <jaeger.version>1.8.1</jaeger.version>
         <quarkus-http.version>5.0.1.Final</quarkus-http.version>
         <micrometer.version>1.10.4</micrometer.version><!-- keep in sync with hdrhistogram -->
@@ -67,7 +67,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.0</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.2.0</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>4.3.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>4.4.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>1.4.1</smallrye-stork.version>
         <jakarta.activation.version>2.1.1</jakarta.activation.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDevModeTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDevModeTest.java
@@ -26,7 +26,7 @@ public class OpenTelemetryDevModeTest {
         //and the hot replacement stuff is not messing things up
         RestAssured.when().get("/hello").then()
                 .statusCode(200)
-                .body(is("HTTP GET"));
+                .body(is("GET"));
 
         RestAssured.when().get("/tracer").then()
                 .statusCode(200)

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryHttpCDILegacyTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryHttpCDILegacyTest.java
@@ -57,7 +57,7 @@ public class OpenTelemetryHttpCDILegacyTest {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
-        assertEquals("/hello", server.getName());
+        assertEquals("GET /hello", server.getName());
         assertEquals(SERVER, server.getKind());
         // verify that OpenTelemetryServerFilter took place
         assertStringAttribute(server, SemanticAttributes.CODE_NAMESPACE,
@@ -81,7 +81,7 @@ public class OpenTelemetryHttpCDILegacyTest {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(3);
 
         final SpanData server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
-        assertEquals("/hello/withSpan", server.getName());
+        assertEquals("GET /hello/withSpan", server.getName());
 
         final SpanData internalFromBean = getSpanByKindAndParentId(spans, INTERNAL, server.getSpanId());
         assertEquals("withSpan", internalFromBean.getName());

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryHttpCDITest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryHttpCDITest.java
@@ -57,7 +57,7 @@ public class OpenTelemetryHttpCDITest {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         final SpanData server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
-        assertEquals("/hello", server.getName());
+        assertEquals("GET /hello", server.getName());
         // verify that OpenTelemetryServerFilter took place
         assertStringAttribute(server, SemanticAttributes.CODE_NAMESPACE,
                 "io.quarkus.opentelemetry.deployment.OpenTelemetryHttpCDITest$HelloResource");
@@ -79,7 +79,7 @@ public class OpenTelemetryHttpCDITest {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(3);
 
         final SpanData server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
-        assertEquals("/hello/withSpan", server.getName());
+        assertEquals("GET /hello/withSpan", server.getName());
 
         final SpanData withSpan = getSpanByKindAndParentId(spans, INTERNAL, server.getSpanId());
         assertEquals("withSpan", withSpan.getName());

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryMDCTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryMDCTest.java
@@ -65,7 +65,7 @@ public class OpenTelemetryMDCTest {
         List<MdcEntry> expectedMdcEntries = getExpectedMDCEntries(spans);
 
         final SpanData server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
-        assertEquals("/hello", server.getName());
+        assertEquals("GET /hello", server.getName());
 
         final SpanData programmatic = getSpanByKindAndParentId(spans, INTERNAL, server.getSpanId());
         assertEquals("something", programmatic.getName());

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryResourceTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryResourceTest.java
@@ -45,7 +45,7 @@ public class OpenTelemetryResourceTest {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(1);
 
         final SpanData server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
-        assertEquals("/hello", server.getName());
+        assertEquals("GET /hello", server.getName());
         assertEquals("authservice", server.getResource().getAttribute(AttributeKey.stringKey("service.name")));
         assertEquals(config.getRawValue("quarkus.uuid"),
                 server.getResource().getAttribute(AttributeKey.stringKey("service.instance.id")));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/RestClientOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/RestClientOpenTelemetryTest.java
@@ -63,13 +63,13 @@ public class RestClientOpenTelemetryTest {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
-        assertEquals("HTTP GET", client.getName());
+        assertEquals("GET", client.getName());
         assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
         assertEquals(uri.toString() + "hello", client.getAttributes().get(HTTP_URL));
 
         SpanData server = getSpanByKindAndParentId(spans, SERVER, client.getSpanId());
-        assertEquals("/hello", server.getName());
+        assertEquals("GET /hello", server.getName());
         assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
         assertEquals("/hello", server.getAttributes().get(HTTP_ROUTE));
@@ -88,7 +88,7 @@ public class RestClientOpenTelemetryTest {
 
         SpanData client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
         assertEquals(CLIENT, client.getKind());
-        assertEquals("HTTP GET", client.getName());
+        assertEquals("GET", client.getName());
         assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
         assertEquals(uri.toString() + "hello?query=1", client.getAttributes().get(HTTP_URL));
@@ -107,7 +107,7 @@ public class RestClientOpenTelemetryTest {
 
         SpanData client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
         assertEquals(CLIENT, client.getKind());
-        assertEquals("HTTP GET", client.getName());
+        assertEquals("GET", client.getName());
         assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
         assertEquals(uri.toString() + "hello?query=1", client.getAttributes().get(HTTP_URL));
@@ -124,14 +124,14 @@ public class RestClientOpenTelemetryTest {
 
         SpanData client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
         assertEquals(CLIENT, client.getKind());
-        assertEquals("HTTP GET", client.getName());
+        assertEquals("GET", client.getName());
         assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
         assertEquals(uri.toString() + "hello/another", client.getAttributes().get(HTTP_URL));
 
         SpanData server = getSpanByKindAndParentId(spans, SERVER, client.getSpanId());
         assertEquals(SERVER, server.getKind());
-        assertEquals("/hello/{path}", server.getName());
+        assertEquals("GET /hello/{path}", server.getName());
         assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
         assertEquals("/hello/{path}", server.getAttributes().get(HTTP_ROUTE));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxClientOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxClientOpenTelemetryTest.java
@@ -69,14 +69,14 @@ public class VertxClientOpenTelemetryTest {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
-        assertEquals("HTTP GET", client.getName());
+        assertEquals("GET", client.getName());
         assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
         assertEquals(uri.toString() + "hello", client.getAttributes().get(HTTP_URL));
 
         SpanData server = getSpanByKindAndParentId(spans, SERVER, client.getSpanId());
         assertEquals(SERVER, server.getKind());
-        assertEquals("/hello", server.getName());
+        assertEquals("GET /hello", server.getName());
         assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
         assertEquals("/hello", server.getAttributes().get(HTTP_ROUTE));
@@ -101,14 +101,14 @@ public class VertxClientOpenTelemetryTest {
 
         SpanData client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
         assertEquals(CLIENT, client.getKind());
-        assertEquals("HTTP GET", client.getName());
+        assertEquals("GET", client.getName());
         assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
         assertEquals(uri.toString() + "hello/naruto", client.getAttributes().get(HTTP_URL));
 
         SpanData server = getSpanByKindAndParentId(spans, SERVER, client.getSpanId());
         assertEquals(SERVER, server.getKind());
-        assertEquals("/hello/:name", server.getName());
+        assertEquals("GET /hello/:name", server.getName());
         assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
         assertEquals("/hello/:name", server.getAttributes().get(HTTP_ROUTE));

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryTest.java
@@ -107,7 +107,7 @@ public class VertxOpenTelemetryTest {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         final SpanData server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
-        assertEquals("/tracer", server.getName());
+        assertEquals("GET /tracer", server.getName());
         assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals("1.1", server.getAttributes().get(HTTP_FLAVOR));
         assertEquals("/tracer?id=1", server.getAttributes().get(HTTP_TARGET));
@@ -134,7 +134,7 @@ public class VertxOpenTelemetryTest {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(1);
         assertEquals(1, spans.size());
 
-        assertEquals("/hello/:name", spans.get(0).getName());
+        assertEquals("GET /hello/:name", spans.get(0).getName());
         assertEquals(HTTP_OK, spans.get(0).getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(GET.toString(), spans.get(0).getAttributes().get(HTTP_METHOD));
         assertEquals("/hello/:name", spans.get(0).getAttributes().get(HTTP_ROUTE));
@@ -147,7 +147,7 @@ public class VertxOpenTelemetryTest {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(1);
         assertEquals(1, spans.size());
 
-        assertEquals("/*", spans.get(0).getName());
+        assertEquals("GET /*", spans.get(0).getName());
         assertEquals("/*", spans.get(0).getAttributes().get(HTTP_ROUTE));
         assertEquals(HTTP_NOT_FOUND, spans.get(0).getAttributes().get(HTTP_STATUS_CODE));
     }
@@ -162,7 +162,7 @@ public class VertxOpenTelemetryTest {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(1);
         assertEquals(1, spans.size());
 
-        assertEquals("/hello/:name", spans.get(0).getName());
+        assertEquals("GET /hello/:name", spans.get(0).getName());
         assertEquals(HTTP_NOT_FOUND, spans.get(0).getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(GET.toString(), spans.get(0).getAttributes().get(HTTP_METHOD));
         assertEquals("/hello/:name", spans.get(0).getAttributes().get(HTTP_ROUTE));

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/grpc/GrpcAttributesGetter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/grpc/GrpcAttributesGetter.java
@@ -6,17 +6,17 @@ enum GrpcAttributesGetter implements RpcAttributesGetter<GrpcRequest> {
     INSTANCE;
 
     @Override
-    public String system(final GrpcRequest grpcRequest) {
+    public String getSystem(final GrpcRequest grpcRequest) {
         return "grpc";
     }
 
     @Override
-    public String service(final GrpcRequest grpcRequest) {
+    public String getService(final GrpcRequest grpcRequest) {
         return grpcRequest.getMethodDescriptor().getServiceName();
     }
 
     @Override
-    public String method(final GrpcRequest grpcRequest) {
+    public String getMethod(final GrpcRequest grpcRequest) {
         return grpcRequest.getMethodDescriptor().getBareMethodName();
     }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/grpc/GrpcTracingServerInterceptor.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/grpc/GrpcTracingServerInterceptor.java
@@ -66,17 +66,17 @@ public class GrpcTracingServerInterceptor implements ServerInterceptor {
 
     private static class GrpcServerNetServerAttributesGetter extends InetSocketAddressNetServerAttributesGetter<GrpcRequest> {
         @Override
-        public String transport(final GrpcRequest grpcRequest) {
+        public String getTransport(final GrpcRequest grpcRequest) {
             return SemanticAttributes.NetTransportValues.IP_TCP;
         }
 
         @Override
-        public String hostName(GrpcRequest grpcRequest) {
+        public String getHostName(GrpcRequest grpcRequest) {
             return null;
         }
 
         @Override
-        public Integer hostPort(GrpcRequest grpcRequest) {
+        public Integer getHostPort(GrpcRequest grpcRequest) {
             return null;
         }
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/restclient/OpenTelemetryClientFilter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/restclient/OpenTelemetryClientFilter.java
@@ -143,7 +143,7 @@ public class OpenTelemetryClientFilter implements ClientRequestFilter, ClientRes
             implements HttpClientAttributesGetter<ClientRequestContext, ClientResponseContext> {
 
         @Override
-        public String url(final ClientRequestContext request) {
+        public String getUrl(final ClientRequestContext request) {
             URI uri = request.getUri();
             if (uri.getUserInfo() != null) {
                 return UriBuilder.fromUri(uri).userInfo(null).build().toString();
@@ -152,28 +152,28 @@ public class OpenTelemetryClientFilter implements ClientRequestFilter, ClientRes
         }
 
         @Override
-        public String flavor(final ClientRequestContext request, final ClientResponseContext response) {
+        public String getFlavor(final ClientRequestContext request, final ClientResponseContext response) {
             return null;
         }
 
         @Override
-        public String method(final ClientRequestContext request) {
+        public String getMethod(final ClientRequestContext request) {
             return request.getMethod();
         }
 
         @Override
-        public List<String> requestHeader(final ClientRequestContext request, final String name) {
+        public List<String> getRequestHeader(final ClientRequestContext request, final String name) {
             return request.getStringHeaders().getOrDefault(name, emptyList());
         }
 
         @Override
-        public Integer statusCode(ClientRequestContext clientRequestContext,
+        public Integer getStatusCode(ClientRequestContext clientRequestContext,
                 ClientResponseContext clientResponseContext, Throwable error) {
             return clientResponseContext.getStatus();
         }
 
         @Override
-        public List<String> responseHeader(final ClientRequestContext request, final ClientResponseContext response,
+        public List<String> getResponseHeader(final ClientRequestContext request, final ClientResponseContext response,
                 final String name) {
             return response.getHeaders().getOrDefault(name, emptyList());
         }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/EventBusInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/EventBusInstrumenterVertxTracer.java
@@ -90,57 +90,57 @@ public class EventBusInstrumenterVertxTracer implements InstrumenterVertxTracer<
         INSTANCE;
 
         @Override
-        public String system(final Message message) {
+        public String getSystem(final Message message) {
             return "vert.x";
         }
 
         @Override
-        public String destinationKind(final Message message) {
+        public String getDestinationKind(final Message message) {
             return message.isSend() ? "queue" : "topic";
         }
 
         @Override
-        public String destination(final Message message) {
+        public String getDestination(final Message message) {
             return message.address();
         }
 
         @Override
-        public boolean temporaryDestination(final Message message) {
+        public boolean isTemporaryDestination(final Message message) {
             return false;
         }
 
         @Override
-        public String protocol(final Message message) {
+        public String getProtocol(final Message message) {
             return null;
         }
 
         @Override
-        public String protocolVersion(final Message message) {
+        public String getProtocolVersion(final Message message) {
             return "4.0";
         }
 
         @Override
-        public String url(final Message message) {
+        public String getUrl(final Message message) {
             return null;
         }
 
         @Override
-        public String conversationId(final Message message) {
+        public String getConversationId(final Message message) {
             return message.replyAddress();
         }
 
         @Override
-        public Long messagePayloadSize(final Message message) {
+        public Long getMessagePayloadSize(final Message message) {
             return null;
         }
 
         @Override
-        public Long messagePayloadCompressedSize(final Message message) {
+        public Long getMessagePayloadCompressedSize(final Message message) {
             return null;
         }
 
         @Override
-        public String messageId(final Message message, final Message message2) {
+        public String getMessageId(final Message message, final Message message2) {
             return null;
         }
     }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/HttpInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/HttpInstrumenterVertxTracer.java
@@ -120,7 +120,7 @@ public class HttpInstrumenterVertxTracer implements InstrumenterVertxTracer<Http
                 .addAttributesExtractor(
                         HttpServerAttributesExtractor.create(serverAttributesExtractor, new HttpServerNetAttributesGetter()))
                 .addAttributesExtractor(new AdditionalServerAttributesExtractor())
-                .addContextCustomizer(HttpRouteHolder.get())
+                .addContextCustomizer(HttpRouteHolder.create(serverAttributesExtractor))
                 .buildServerInstrumenter(new HttpRequestTextMapGetter());
     }
 
@@ -166,7 +166,7 @@ public class HttpInstrumenterVertxTracer implements InstrumenterVertxTracer<Http
 
     private static class ServerAttributesExtractor implements HttpServerAttributesGetter<HttpRequest, HttpResponse> {
         @Override
-        public String flavor(final HttpRequest request) {
+        public String getFlavor(final HttpRequest request) {
             if (request instanceof HttpServerRequest) {
                 HttpVersion version = ((HttpServerRequest) request).version();
                 if (version != null) {
@@ -188,17 +188,17 @@ public class HttpInstrumenterVertxTracer implements InstrumenterVertxTracer<Http
         }
 
         @Override
-        public String target(final HttpRequest request) {
+        public String getTarget(final HttpRequest request) {
             return request.uri();
         }
 
         @Override
-        public String route(final HttpRequest request) {
+        public String getRoute(final HttpRequest request) {
             return null;
         }
 
         @Override
-        public String scheme(final HttpRequest request) {
+        public String getScheme(final HttpRequest request) {
             if (request instanceof HttpServerRequest) {
                 return ((HttpServerRequest) request).scheme();
             }
@@ -206,22 +206,22 @@ public class HttpInstrumenterVertxTracer implements InstrumenterVertxTracer<Http
         }
 
         @Override
-        public String method(final HttpRequest request) {
+        public String getMethod(final HttpRequest request) {
             return request.method().name();
         }
 
         @Override
-        public List<String> requestHeader(final HttpRequest request, final String name) {
+        public List<String> getRequestHeader(final HttpRequest request, final String name) {
             return request.headers().getAll(name);
         }
 
         @Override
-        public Integer statusCode(HttpRequest httpRequest, HttpResponse httpResponse, Throwable error) {
+        public Integer getStatusCode(HttpRequest httpRequest, HttpResponse httpResponse, Throwable error) {
             return httpResponse != null ? httpResponse.statusCode() : null;
         }
 
         @Override
-        public List<String> responseHeader(final HttpRequest request, final HttpResponse response, final String name) {
+        public List<String> getResponseHeader(final HttpRequest request, final HttpResponse response, final String name) {
             return response != null ? response.headers().getAll(name) : Collections.emptyList();
         }
 
@@ -268,13 +268,13 @@ public class HttpInstrumenterVertxTracer implements InstrumenterVertxTracer<Http
     private static class HttpServerNetAttributesGetter implements NetServerAttributesGetter<HttpRequest> {
         @Nullable
         @Override
-        public String transport(HttpRequest httpRequest) {
+        public String getTransport(HttpRequest httpRequest) {
             return null;
         }
 
         @Nullable
         @Override
-        public String hostName(HttpRequest httpRequest) {
+        public String getHostName(HttpRequest httpRequest) {
             if (httpRequest instanceof HttpServerRequest) {
                 return VertxUtil.extractRemoteHostname((HttpServerRequest) httpRequest);
             }
@@ -283,7 +283,7 @@ public class HttpInstrumenterVertxTracer implements InstrumenterVertxTracer<Http
 
         @Nullable
         @Override
-        public Integer hostPort(HttpRequest httpRequest) {
+        public Integer getHostPort(HttpRequest httpRequest) {
             if (httpRequest instanceof HttpServerRequest) {
                 Long remoteHostPort = VertxUtil.extractRemoteHostPort((HttpServerRequest) httpRequest);
                 if (remoteHostPort == null) {
@@ -313,32 +313,32 @@ public class HttpInstrumenterVertxTracer implements InstrumenterVertxTracer<Http
 
     private static class ClientAttributesExtractor implements HttpClientAttributesGetter<HttpRequest, HttpResponse> {
         @Override
-        public String url(final HttpRequest request) {
+        public String getUrl(final HttpRequest request) {
             return request.absoluteURI();
         }
 
         @Override
-        public String flavor(final HttpRequest request, final HttpResponse response) {
+        public String getFlavor(final HttpRequest request, final HttpResponse response) {
             return null;
         }
 
         @Override
-        public String method(final HttpRequest request) {
+        public String getMethod(final HttpRequest request) {
             return request.method().name();
         }
 
         @Override
-        public List<String> requestHeader(final HttpRequest request, final String name) {
+        public List<String> getRequestHeader(final HttpRequest request, final String name) {
             return request.headers().getAll(name);
         }
 
         @Override
-        public Integer statusCode(HttpRequest httpRequest, HttpResponse httpResponse, Throwable error) {
+        public Integer getStatusCode(HttpRequest httpRequest, HttpResponse httpResponse, Throwable error) {
             return httpResponse.statusCode();
         }
 
         @Override
-        public List<String> responseHeader(final HttpRequest request, final HttpResponse response, final String name) {
+        public List<String> getResponseHeader(final HttpRequest request, final HttpResponse response, final String name) {
             return response.headers().getAll(name);
         }
     }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/SqlClientInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/SqlClientInstrumenterVertxTracer.java
@@ -120,27 +120,27 @@ public class SqlClientInstrumenterVertxTracer implements
             io.opentelemetry.instrumentation.api.instrumenter.db.SqlClientAttributesGetter<QueryTrace> {
 
         @Override
-        public String rawStatement(final QueryTrace queryTrace) {
+        public String getRawStatement(final QueryTrace queryTrace) {
             return queryTrace.rawStatement();
         }
 
         @Override
-        public String system(final QueryTrace queryTrace) {
+        public String getSystem(final QueryTrace queryTrace) {
             return queryTrace.system();
         }
 
         @Override
-        public String user(final QueryTrace queryTrace) {
+        public String getUser(final QueryTrace queryTrace) {
             return queryTrace.user();
         }
 
         @Override
-        public String name(final QueryTrace queryTrace) {
+        public String getName(final QueryTrace queryTrace) {
             return null;
         }
 
         @Override
-        public String connectionString(final QueryTrace queryTrace) {
+        public String getConnectionString(final QueryTrace queryTrace) {
             return queryTrace.connectionString();
         }
     }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/VertxUtil.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/VertxUtil.java
@@ -86,7 +86,7 @@ public final class VertxUtil {
             }
         }
         if (httpRequest.remoteAddress() != null) {
-            Integer.toUnsignedLong(httpRequest.remoteAddress().port());
+            return Integer.toUnsignedLong(httpRequest.remoteAddress().port());
         }
         return null;
     }

--- a/integration-tests/opentelemetry-grpc/src/test/java/io/quarkus/it/opentelemetry/grpc/OpenTelemetryGrpcTest.java
+++ b/integration-tests/opentelemetry-grpc/src/test/java/io/quarkus/it/opentelemetry/grpc/OpenTelemetryGrpcTest.java
@@ -61,7 +61,7 @@ public class OpenTelemetryGrpcTest {
         // First span is the rest server call. It does not have a parent span.
         Map<String, Object> rest = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
         assertEquals(SpanKind.SERVER.toString(), rest.get("kind"));
-        assertEquals("/grpc/{name}", rest.get("name"));
+        assertEquals("GET /grpc/{name}", rest.get("name"));
         assertEquals("/grpc/{name}", getAttributes(rest).get(HTTP_ROUTE.getKey()));
         assertEquals("/grpc/Naruto", getAttributes(rest).get(HTTP_TARGET.getKey()));
         assertEquals(HTTP_OK, getAttributes(rest).get(HTTP_STATUS_CODE.getKey()));

--- a/integration-tests/opentelemetry-reactive-messaging/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
+++ b/integration-tests/opentelemetry-reactive-messaging/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
@@ -110,7 +110,7 @@ public class OpenTelemetryTestCase {
         Assertions.assertNotNull(spanData.get("spanId"));
         verifyResource(spanData, parentSpanData);
 
-        Assertions.assertEquals("/direct", spanData.get("name"));
+        Assertions.assertEquals("GET /direct", spanData.get("name"));
         Assertions.assertEquals(SpanKind.SERVER.toString(), spanData.get("kind"));
         Assertions.assertTrue((Boolean) spanData.get("ended"));
         Assertions.assertFalse((Boolean) spanData.get("parent_remote"));
@@ -137,9 +137,9 @@ public class OpenTelemetryTestCase {
         Assertions.assertTrue((Boolean) spanData.get("ended"));
         Assertions.assertFalse((Boolean) spanData.get("parent_remote"));
 
-        Assertions.assertEquals("topic", spanData.get("attr_messaging.destination_kind"));
+        Assertions.assertEquals("topic", spanData.get("attr_messaging.destination.kind"));
         Assertions.assertEquals("kafka", spanData.get("attr_messaging.system"));
-        Assertions.assertEquals(topic, spanData.get("attr_messaging.destination"));
+        Assertions.assertEquals(topic, spanData.get("attr_messaging.destination.name"));
     }
 
     private static void verifyConsumer(Map<String, Object> spanData,
@@ -155,12 +155,12 @@ public class OpenTelemetryTestCase {
         Assertions.assertTrue((Boolean) spanData.get("ended"));
         Assertions.assertEquals(parentRemote, spanData.get("parent_remote"));
 
-        Assertions.assertEquals("topic", spanData.get("attr_messaging.destination_kind"));
+        Assertions.assertEquals("topic", spanData.get("attr_messaging.destination.kind"));
         Assertions.assertEquals("opentelemetry-integration-test - kafka-consumer-" + channel,
-                spanData.get("attr_messaging.consumer_id"));
+                spanData.get("attr_messaging.consumer.id"));
         Assertions.assertEquals("kafka", spanData.get("attr_messaging.system"));
-        Assertions.assertEquals(topic, spanData.get("attr_messaging.destination"));
-        Assertions.assertEquals("opentelemetry-integration-test", spanData.get("attr_messaging.kafka.consumer_group"));
+        Assertions.assertEquals(topic, spanData.get("attr_messaging.destination.name"));
+        Assertions.assertEquals("opentelemetry-integration-test", spanData.get("attr_messaging.kafka.consumer.group"));
         Assertions.assertEquals("0", spanData.get("attr_messaging.kafka.partition"));
         Assertions.assertEquals("kafka-consumer-" + channel, spanData.get("attr_messaging.kafka.client_id"));
         Assertions.assertEquals("0", spanData.get("attr_messaging.kafka.message.offset"));

--- a/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveClientTest.java
+++ b/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveClientTest.java
@@ -56,7 +56,7 @@ public class OpenTelemetryReactiveClientTest {
         // First span is the client call. It does not have a parent span.
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
-        assertEquals("HTTP GET", client.get("name"));
+        assertEquals("GET", client.get("name"));
         assertEquals(HTTP_OK, ((Map<?, ?>) client.get("attributes")).get(HTTP_STATUS_CODE.getKey()));
         assertEquals(HttpMethod.GET.name(), ((Map<?, ?>) client.get("attributes")).get(HTTP_METHOD.getKey()));
 
@@ -64,7 +64,7 @@ public class OpenTelemetryReactiveClientTest {
         Map<String, Object> server = getSpanByKindAndParentId(spans, SERVER, client.get("spanId"));
         assertEquals(SpanKind.SERVER.toString(), server.get("kind"));
         assertEquals(server.get("parentSpanId"), client.get("spanId"));
-        assertEquals("/reactive", server.get("name"));
+        assertEquals("GET /reactive", server.get("name"));
         assertEquals("/reactive", ((Map<?, ?>) server.get("attributes")).get(HTTP_ROUTE.getKey()));
         assertEquals("/reactive?name=Naruto", ((Map<?, ?>) server.get("attributes")).get(HTTP_TARGET.getKey()));
         assertEquals(HTTP_OK, ((Map<?, ?>) server.get("attributes")).get(HTTP_STATUS_CODE.getKey()));
@@ -91,7 +91,7 @@ public class OpenTelemetryReactiveClientTest {
         // First span is the client call. It does not have a parent span.
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, "0000000000000000");
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
-        assertEquals("HTTP POST", client.get("name"));
+        assertEquals("POST", client.get("name"));
         assertEquals(HTTP_OK, ((Map<?, ?>) client.get("attributes")).get(HTTP_STATUS_CODE.getKey()));
         assertEquals(HttpMethod.POST.name(), ((Map<?, ?>) client.get("attributes")).get(HTTP_METHOD.getKey()));
 
@@ -99,7 +99,7 @@ public class OpenTelemetryReactiveClientTest {
         Map<String, Object> server = getSpanByKindAndParentId(spans, SERVER, client.get("spanId"));
         assertEquals(SpanKind.SERVER.toString(), server.get("kind"));
         assertEquals(server.get("parentSpanId"), client.get("spanId"));
-        assertEquals("/reactive", server.get("name"));
+        assertEquals("POST /reactive", server.get("name"));
         assertEquals("/reactive", ((Map<?, ?>) server.get("attributes")).get(HTTP_ROUTE.getKey()));
         assertEquals("/reactive", ((Map<?, ?>) server.get("attributes")).get(HTTP_TARGET.getKey()));
         assertEquals(HTTP_OK, ((Map<?, ?>) server.get("attributes")).get(HTTP_STATUS_CODE.getKey()));

--- a/integration-tests/opentelemetry-vertx/src/test/java/io/quarkus/it/opentelemetry/vertx/HelloRouterTest.java
+++ b/integration-tests/opentelemetry-vertx/src/test/java/io/quarkus/it/opentelemetry/vertx/HelloRouterTest.java
@@ -8,8 +8,8 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_ROUTE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_DESTINATION;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_DESTINATION_KIND;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_SYSTEM;
 import static io.restassured.RestAssured.get;
@@ -59,7 +59,7 @@ class HelloRouterTest {
         assertEquals(1, spans.size());
 
         assertEquals(SERVER.toString(), spans.get(0).get("kind"));
-        assertEquals("/hello", spans.get(0).get("name"));
+        assertEquals("GET /hello", spans.get(0).get("name"));
         assertEquals(HTTP_OK, ((Map<?, ?>) spans.get(0).get("attributes")).get(HTTP_STATUS_CODE.toString()));
         assertEquals(HttpMethod.GET.toString(), ((Map<?, ?>) spans.get(0).get("attributes")).get(HTTP_METHOD.toString()));
         assertEquals("/hello", ((Map<?, ?>) spans.get(0).get("attributes")).get(HTTP_ROUTE.toString()));
@@ -78,7 +78,7 @@ class HelloRouterTest {
         assertEquals(1, spans.size());
 
         assertEquals(SERVER.toString(), spans.get(0).get("kind"));
-        assertEquals("/hello/:name", spans.get(0).get("name"));
+        assertEquals("GET /hello/:name", spans.get(0).get("name"));
         assertEquals(HTTP_OK, ((Map<?, ?>) spans.get(0).get("attributes")).get(HTTP_STATUS_CODE.toString()));
         assertEquals(HttpMethod.GET.toString(), ((Map<?, ?>) spans.get(0).get("attributes")).get(HTTP_METHOD.toString()));
         assertEquals("/hello/:name", ((Map<?, ?>) spans.get(0).get("attributes")).get(HTTP_ROUTE.toString()));
@@ -99,7 +99,7 @@ class HelloRouterTest {
         assertEquals(1, spans.size());
 
         assertEquals(SERVER.toString(), spans.get(0).get("kind"));
-        assertEquals("/hello", spans.get(0).get("name"));
+        assertEquals("POST /hello", spans.get(0).get("name"));
         assertEquals(HTTP_OK, ((Map<?, ?>) spans.get(0).get("attributes")).get(HTTP_STATUS_CODE.toString()));
         assertEquals(HttpMethod.POST.toString(), ((Map<?, ?>) spans.get(0).get("attributes")).get(HTTP_METHOD.toString()));
         assertEquals("/hello", ((Map<?, ?>) spans.get(0).get("attributes")).get(HTTP_ROUTE.toString()));
@@ -136,14 +136,14 @@ class HelloRouterTest {
         assertEquals(PRODUCER.toString(), producer.get("kind"));
         assertEquals("vert.x", ((Map<?, ?>) producer.get("attributes")).get(MESSAGING_SYSTEM.toString()));
         assertEquals("topic", ((Map<?, ?>) producer.get("attributes")).get(MESSAGING_DESTINATION_KIND.toString()));
-        assertEquals("bus", ((Map<?, ?>) producer.get("attributes")).get(MESSAGING_DESTINATION.toString()));
+        assertEquals("bus", ((Map<?, ?>) producer.get("attributes")).get(MESSAGING_DESTINATION_NAME.toString()));
         assertEquals(producer.get("parentSpanId"), server.get("spanId"));
 
         Map<String, Object> consumer = getSpanByKindAndParentId(spans, CONSUMER, producer.get("spanId"));
         assertEquals(CONSUMER.toString(), consumer.get("kind"));
         assertEquals("vert.x", ((Map<?, ?>) consumer.get("attributes")).get(MESSAGING_SYSTEM.toString()));
         assertEquals("topic", ((Map<?, ?>) consumer.get("attributes")).get(MESSAGING_DESTINATION_KIND.toString()));
-        assertEquals("bus", ((Map<?, ?>) consumer.get("attributes")).get(MESSAGING_DESTINATION.toString()));
+        assertEquals("bus", ((Map<?, ?>) consumer.get("attributes")).get(MESSAGING_DESTINATION_NAME.toString()));
         assertEquals(MessageOperation.RECEIVE.toString().toLowerCase(Locale.ROOT),
                 ((Map<?, ?>) consumer.get("attributes")).get(MESSAGING_OPERATION.toString()));
         assertEquals(consumer.get("parentSpanId"), producer.get("spanId"));

--- a/integration-tests/opentelemetry-vertx/src/test/java/io/quarkus/it/opentelemetry/vertx/SqlClientTest.java
+++ b/integration-tests/opentelemetry-vertx/src/test/java/io/quarkus/it/opentelemetry/vertx/SqlClientTest.java
@@ -93,7 +93,7 @@ public class SqlClientTest {
         assertEquals(spans.get(0).getTraceId(), spans.get(1).getTraceId());
         assertEquals(spans.get(0).getSpanId(), spans.get(1).getParentSpanId());
 
-        assertEquals("/sqlClient", spans.get(0).getName());
+        assertEquals("GET /sqlClient", spans.get(0).getName());
         assertEquals(HTTP_OK, spans.get(0).getAttributes().get(HTTP_STATUS_CODE));
 
         assertEquals("SELECT USERS", spans.get(1).getName());

--- a/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTest.java
+++ b/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTest.java
@@ -82,7 +82,7 @@ public class OpenTelemetryTest {
 
         verifyResource(spanData);
 
-        assertEquals("/direct", spanData.get("name"));
+        assertEquals("GET /direct", spanData.get("name"));
         assertEquals(SERVER.toString(), spanData.get("kind"));
         assertTrue((Boolean) spanData.get("ended"));
 
@@ -119,7 +119,7 @@ public class OpenTelemetryTest {
         Map<String, Object> server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
         assertEquals(SERVER.toString(), server.get("kind"));
         verifyResource(server);
-        assertEquals("/nopath", server.get("name"));
+        assertEquals("GET /nopath", server.get("name"));
         assertEquals(SERVER.toString(), server.get("kind"));
         assertTrue((Boolean) server.get("ended"));
         assertEquals(SpanId.getInvalid(), server.get("parent_spanId"));
@@ -140,7 +140,7 @@ public class OpenTelemetryTest {
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, server.get("spanId"));
         assertEquals(CLIENT.toString(), client.get("kind"));
         verifyResource(client);
-        assertEquals("HTTP GET", client.get("name"));
+        assertEquals("GET", client.get("name"));
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
         assertTrue((Boolean) client.get("ended"));
         assertTrue((Boolean) client.get("parent_valid"));
@@ -153,7 +153,7 @@ public class OpenTelemetryTest {
         Map<String, Object> clientServer = getSpanByKindAndParentId(spans, SERVER, client.get("spanId"));
         assertEquals(SERVER.toString(), clientServer.get("kind"));
         verifyResource(clientServer);
-        assertEquals("HTTP GET", clientServer.get("name"));
+        assertEquals("GET", clientServer.get("name"));
         assertEquals(SERVER.toString(), clientServer.get("kind"));
         assertTrue((Boolean) clientServer.get("ended"));
         assertTrue((Boolean) clientServer.get("parent_valid"));
@@ -188,7 +188,7 @@ public class OpenTelemetryTest {
         Map<String, Object> server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
         assertEquals(SERVER.toString(), server.get("kind"));
         verifyResource(server);
-        assertEquals("/slashpath", server.get("name"));
+        assertEquals("GET /slashpath", server.get("name"));
         assertEquals(SERVER.toString(), server.get("kind"));
         assertTrue((Boolean) server.get("ended"));
         assertEquals(SpanId.getInvalid(), server.get("parent_spanId"));
@@ -208,7 +208,7 @@ public class OpenTelemetryTest {
 
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, server.get("spanId"));
         assertEquals(CLIENT.toString(), client.get("kind"));
-        assertEquals("HTTP GET", client.get("name"));
+        assertEquals("GET", client.get("name"));
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
         assertTrue((Boolean) client.get("ended"));
         assertTrue((Boolean) client.get("parent_valid"));
@@ -221,7 +221,7 @@ public class OpenTelemetryTest {
         Map<String, Object> clientServer = getSpanByKindAndParentId(spans, SERVER, client.get("spanId"));
         assertEquals(SERVER.toString(), clientServer.get("kind"));
         verifyResource(clientServer);
-        assertEquals("HTTP GET", clientServer.get("name"));
+        assertEquals("GET", clientServer.get("name"));
         assertEquals(SERVER.toString(), clientServer.get("kind"));
         assertTrue((Boolean) clientServer.get("ended"));
         assertTrue((Boolean) clientServer.get("parent_valid"));
@@ -256,7 +256,7 @@ public class OpenTelemetryTest {
         Map<String, Object> server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
         assertEquals(SERVER.toString(), server.get("kind"));
         verifyResource(server);
-        assertEquals("/chained", server.get("name"));
+        assertEquals("GET /chained", server.get("name"));
         assertEquals(SERVER.toString(), server.get("kind"));
         assertTrue((Boolean) server.get("ended"));
         assertEquals(SpanId.getInvalid(), server.get("parent_spanId"));
@@ -310,7 +310,7 @@ public class OpenTelemetryTest {
 
         verifyResource(spanData);
 
-        assertEquals("/direct", spanData.get("name"));
+        assertEquals("GET /direct", spanData.get("name"));
         assertEquals(SERVER.toString(), spanData.get("kind"));
         assertTrue((Boolean) spanData.get("ended"));
 
@@ -346,7 +346,7 @@ public class OpenTelemetryTest {
 
         verifyResource(spanData);
 
-        assertEquals("/deep/path", spanData.get("name"));
+        assertEquals("GET /deep/path", spanData.get("name"));
         assertEquals(SERVER.toString(), spanData.get("kind"));
         assertTrue((Boolean) spanData.get("ended"));
 
@@ -382,7 +382,7 @@ public class OpenTelemetryTest {
 
         verifyResource(spanData);
 
-        assertEquals("/param/{paramId}", spanData.get("name"));
+        assertEquals("GET /param/{paramId}", spanData.get("name"));
         assertEquals(SERVER.toString(), spanData.get("kind"));
         assertTrue((Boolean) spanData.get("ended"));
 
@@ -419,7 +419,7 @@ public class OpenTelemetryTest {
         Map<String, Object> server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
         assertEquals(SERVER.toString(), server.get("kind"));
         verifyResource(server);
-        assertEquals("/client/ping/{message}", server.get("name"));
+        assertEquals("GET /client/ping/{message}", server.get("name"));
         assertEquals(SERVER.toString(), server.get("kind"));
         assertTrue((Boolean) server.get("ended"));
         assertEquals(SpanId.getInvalid(), server.get("parent_spanId"));
@@ -438,7 +438,7 @@ public class OpenTelemetryTest {
         assertNotNull(server.get("attr_http.user_agent"));
 
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, server.get("spanId"));
-        assertEquals("HTTP GET", client.get("name"));
+        assertEquals("GET", client.get("name"));
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
         assertTrue((Boolean) client.get("ended"));
         assertTrue((Boolean) client.get("parent_valid"));
@@ -450,7 +450,7 @@ public class OpenTelemetryTest {
         Map<String, Object> clientServer = getSpanByKindAndParentId(spans, SERVER, client.get("spanId"));
         assertEquals(SERVER.toString(), clientServer.get("kind"));
         verifyResource(clientServer);
-        assertEquals("/client/pong/{message}", clientServer.get("name"));
+        assertEquals("GET /client/pong/{message}", clientServer.get("name"));
         assertEquals(SERVER.toString(), clientServer.get("kind"));
         assertTrue((Boolean) clientServer.get("ended"));
         assertTrue((Boolean) clientServer.get("parent_valid"));
@@ -484,7 +484,7 @@ public class OpenTelemetryTest {
         Map<String, Object> server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
         assertEquals(SERVER.toString(), server.get("kind"));
         verifyResource(server);
-        assertEquals("/client/async-ping/{message}", server.get("name"));
+        assertEquals("GET /client/async-ping/{message}", server.get("name"));
         assertEquals(SERVER.toString(), server.get("kind"));
         assertTrue((Boolean) server.get("ended"));
         assertEquals(SpanId.getInvalid(), server.get("parent_spanId"));
@@ -503,7 +503,7 @@ public class OpenTelemetryTest {
         assertNotNull(server.get("attr_http.user_agent"));
 
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, server.get("spanId"));
-        assertEquals("HTTP GET", client.get("name"));
+        assertEquals("GET", client.get("name"));
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
         assertTrue((Boolean) client.get("ended"));
         assertTrue((Boolean) client.get("parent_valid"));
@@ -515,7 +515,7 @@ public class OpenTelemetryTest {
         Map<String, Object> clientServer = getSpanByKindAndParentId(spans, SERVER, client.get("spanId"));
         assertEquals(SERVER.toString(), clientServer.get("kind"));
         verifyResource(clientServer);
-        assertEquals("/client/pong/{message}", clientServer.get("name"));
+        assertEquals("GET /client/pong/{message}", clientServer.get("name"));
         assertEquals(SERVER.toString(), clientServer.get("kind"));
         assertTrue((Boolean) clientServer.get("ended"));
         assertTrue((Boolean) clientServer.get("parent_valid"));
@@ -548,7 +548,7 @@ public class OpenTelemetryTest {
 
         verifyResource(spanData);
 
-        assertEquals("/template/path/{value}", spanData.get("name"));
+        assertEquals("GET /template/path/{value}", spanData.get("name"));
         assertEquals(SERVER.toString(), spanData.get("kind"));
         assertTrue((Boolean) spanData.get("ended"));
 

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
@@ -131,19 +131,19 @@ public class BasicTest {
         String serverSpanId = null;
         String serverTraceId = null;
         String clientSpanId = null;
-
+        // brunobat: This tests has been remade, for resilience, in another branch and will be merged in the future.
         for (Map<String, Object> spanData : getSpans()) {
             Assertions.assertNotNull(spanData);
             Assertions.assertNotNull(spanData.get("spanId"));
 
             if (spanData.get("kind").equals(SpanKind.SERVER.toString())
-                    && spanData.get("name").equals("/call-hello-client")) {
+                    && spanData.get("name").equals("POST /call-hello-client")) {
                 outsideServerFound = true;
                 // Server Span
                 serverSpanId = (String) spanData.get("spanId");
                 serverTraceId = (String) spanData.get("traceId");
 
-                Assertions.assertEquals("/call-hello-client", spanData.get("name"));
+                Assertions.assertEquals("POST /call-hello-client", spanData.get("name"));
                 Assertions.assertEquals(SpanKind.SERVER.toString(), spanData.get("kind"));
                 Assertions.assertTrue((Boolean) spanData.get("ended"));
 
@@ -160,10 +160,10 @@ public class BasicTest {
                 Assertions.assertNotNull(spanData.get("attr_http.client_ip"));
                 Assertions.assertNotNull(spanData.get("attr_http.user_agent"));
             } else if (spanData.get("kind").equals(SpanKind.CLIENT.toString())
-                    && spanData.get("name").equals("HTTP POST")) {
+                    && spanData.get("name").equals("POST")) {
                 clientFound = true;
                 // Client span
-                Assertions.assertEquals("HTTP POST", spanData.get("name"));
+                Assertions.assertEquals("POST", spanData.get("name"));
 
                 Assertions.assertEquals(SpanKind.CLIENT.toString(), spanData.get("kind"));
                 Assertions.assertTrue((Boolean) spanData.get("ended"));
@@ -183,11 +183,11 @@ public class BasicTest {
 
                 clientSpanId = (String) spanData.get("spanId");
             } else if (spanData.get("kind").equals(SpanKind.SERVER.toString())
-                    && spanData.get("name").equals("/hello")) {
+                    && spanData.get("name").equals("POST /hello")) {
                 clientServerFound = true;
                 // Server span of client
 
-                Assertions.assertEquals("/hello", spanData.get("name"));
+                Assertions.assertEquals("POST /hello", spanData.get("name"));
                 Assertions.assertEquals(SpanKind.SERVER.toString(), spanData.get("kind"));
                 Assertions.assertTrue((Boolean) spanData.get("ended"));
 

--- a/tcks/microprofile-opentelemetry/pom.xml
+++ b/tcks/microprofile-opentelemetry/pom.xml
@@ -23,7 +23,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>
-                        <dependency>org.eclipse.microprofile.telemetry.tracing:microprofile-telemetry-tracing-tck</dependency>
+                        <!--  brunobat: Otel 1.23.x breaks the current version of the MP TCK                      -->
+                        <!--  <dependency>org.eclipse.microprofile.telemetry.tracing:microprofile-telemetry-tracing-tck</dependency>-->
                     </dependenciesToScan>
                 </configuration>
             </plugin>


### PR DESCRIPTION
SDK version had a minor fix. 
Getters and setters semantic changes.
Semantic conventions changed, most prominently the span name. Now: Method + Route
Includes upgrade for smallrye-reactive-messaging v 4.4.0
Disable MP Telemetry TCK because it's not compatible with this OTel version. 