### PR TITLE
[WIP] Containerless REST client reactive of the RESTEasy endpoints

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver
@@ -1,0 +1,1 @@
+io.quarkus.rest.client.reactive.runtime.BuilderResolver

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -297,6 +297,7 @@
                 <module>reactive-messaging-hibernate-orm</module>
                 <module>rest-client</module>
                 <module>resteasy-reactive-kotlin</module>
+                <module>resteasy-rest-client-reactive</module>
                 <module>resteasy-rest-client-classic</module>
                 <module>rest-client-reactive</module>
                 <module>rest-client-reactive-kotlin-serialization</module>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -297,6 +297,7 @@
                 <module>reactive-messaging-hibernate-orm</module>
                 <module>rest-client</module>
                 <module>resteasy-reactive-kotlin</module>
+                <module>resteasy-rest-client-classic</module>
                 <module>rest-client-reactive</module>
                 <module>rest-client-reactive-kotlin-serialization</module>
                 <module>rest-client-reactive-multipart</module>

--- a/integration-tests/resteasy-rest-client-classic/pom.xml
+++ b/integration-tests/resteasy-rest-client-classic/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>quarkus-integration-tests-parent</artifactId>
+    <groupId>io.quarkus</groupId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>quarkus-integration-test-resteasy-rest-client-classic</artifactId>
+  <name>Quarkus - Integration Tests - RESTEasy and Client Classic</name>
+
+  <dependencies>
+    <!-- Client dependencies -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-client-jackson</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-validator</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
+    <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-validator-deployment</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>native-image</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+      <!-- add some custom config, the rest comes from parent -->
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/integration-tests/resteasy-rest-client-classic/src/main/java/io/quarkus/it/resteasy/rest/client/classic/Greet.java
+++ b/integration-tests/resteasy-rest-client-classic/src/main/java/io/quarkus/it/resteasy/rest/client/classic/Greet.java
@@ -1,0 +1,45 @@
+package io.quarkus.it.resteasy.rest.client.classic;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Greet {
+    private final String greeting;
+    private final String who;
+    private final int number;
+
+    public Greet(
+            @JsonProperty("greeting") String greeting,
+            @JsonProperty("who") String who,
+            @JsonProperty("number") int number) {
+        this.greeting = greeting;
+        this.who = who;
+        this.number = number;
+    }
+
+    @Pattern(regexp = "^[A-Z][a-z]+$")
+    public String getGreeting() {
+        return greeting;
+    }
+
+    @Pattern(regexp = "^[A-Z][a-z]+$")
+    public String getWho() {
+        return who;
+    }
+
+    @Min(1)
+    public int getNumber() {
+        return number;
+    }
+
+    @Override
+    public String toString() {
+        return "Greet{" +
+                "greeting='" + greeting + '\'' +
+                ", who='" + who + '\'' +
+                ", number=" + number +
+                '}';
+    }
+}

--- a/integration-tests/resteasy-rest-client-classic/src/main/java/io/quarkus/it/resteasy/rest/client/classic/GreetEndpoint.java
+++ b/integration-tests/resteasy-rest-client-classic/src/main/java/io/quarkus/it/resteasy/rest/client/classic/GreetEndpoint.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.resteasy.rest.client.classic;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+public interface GreetEndpoint {
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Valid
+    Greet greet(
+            @QueryParam("who") @DefaultValue("Person") @Pattern(regexp = "^[A-Z][a-z]+$") String name);
+}

--- a/integration-tests/resteasy-rest-client-classic/src/main/java/io/quarkus/it/resteasy/rest/client/classic/GreetEndpointBean.java
+++ b/integration-tests/resteasy-rest-client-classic/src/main/java/io/quarkus/it/resteasy/rest/client/classic/GreetEndpointBean.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.resteasy.rest.client.classic;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("")
+@ApplicationScoped
+public class GreetEndpointBean implements GreetEndpoint {
+    private final String greeting;
+    private final AtomicInteger number = new AtomicInteger(0);
+
+    GreetEndpointBean(
+            @ConfigProperty(name = "greeting", defaultValue = "Hello") String greeting) {
+        this.greeting = greeting;
+    }
+
+    @Override
+    public Greet greet(String name) {
+        return new Greet(greeting, name, number.incrementAndGet());
+    }
+}

--- a/integration-tests/resteasy-rest-client-classic/src/test/java/io/quarkus/it/resteasy/rest/client/classic/Constants.java
+++ b/integration-tests/resteasy-rest-client-classic/src/test/java/io/quarkus/it/resteasy/rest/client/classic/Constants.java
@@ -1,0 +1,5 @@
+package io.quarkus.it.resteasy.rest.client.classic;
+
+class Constants {
+    static final String DEFAULT_TEST_URL = "http://localhost:8081";
+}

--- a/integration-tests/resteasy-rest-client-classic/src/test/java/io/quarkus/it/resteasy/rest/client/classic/GreetClient.java
+++ b/integration-tests/resteasy-rest-client-classic/src/test/java/io/quarkus/it/resteasy/rest/client/classic/GreetClient.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.resteasy.rest.client.classic;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(baseUri = Constants.DEFAULT_TEST_URL)
+public interface GreetClient extends GreetEndpoint {
+}

--- a/integration-tests/resteasy-rest-client-classic/src/test/java/io/quarkus/it/resteasy/rest/client/classic/GreetEndpointIT.java
+++ b/integration-tests/resteasy-rest-client-classic/src/test/java/io/quarkus/it/resteasy/rest/client/classic/GreetEndpointIT.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.resteasy.rest.client.classic;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+import java.net.URI;
+
+@QuarkusIntegrationTest
+class GreetEndpointIT extends GreetEndpointTest {
+    GreetEndpointIT() {
+        super(buildRestClient());
+    }
+
+    private static GreetClient buildRestClient() {
+        return RestClientBuilder.newBuilder()
+                .baseUri(URI.create(Constants.DEFAULT_TEST_URL))
+                .build(GreetClient.class);
+    }
+}

--- a/integration-tests/resteasy-rest-client-classic/src/test/java/io/quarkus/it/resteasy/rest/client/classic/GreetEndpointTest.java
+++ b/integration-tests/resteasy-rest-client-classic/src/test/java/io/quarkus/it/resteasy/rest/client/classic/GreetEndpointTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.it.resteasy.rest.client.classic;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.ws.rs.WebApplicationException;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@QuarkusTest
+@TestProfile(GreetEndpointTest.PolishGreeting.class)
+class GreetEndpointTest {
+
+    private final GreetClient client;
+
+    GreetEndpointTest(@RestClient GreetClient client) {
+        this.client = client;
+    }
+
+    @Test
+    void greet() {
+        var g = client.greet("Mark");
+
+        assertThat(g)
+                .isNotNull()
+                .extracting(Greet::getGreeting, Greet::getWho, Greet::getNumber)
+                .containsExactly("Witaj", "Mark", 1);
+    }
+
+    @Test
+    void validationFailure() {
+        assertThatCode(() -> client.greet("marky"))
+                .isInstanceOf(WebApplicationException.class)
+                .hasMessageContaining("Unknown error, status code 400");
+    }
+
+    public static class PolishGreeting implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("greeting", "Witaj");
+        }
+    }
+}

--- a/integration-tests/resteasy-rest-client-classic/src/test/resources/application.properties
+++ b/integration-tests/resteasy-rest-client-classic/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+quarkus.rest-client.logging.scope=request-response
+quarkus.rest-client.logging.body-limit=1024
+quarkus.log.category."org.apache.http.wire".level=DEBUG

--- a/integration-tests/resteasy-rest-client-reactive/pom.xml
+++ b/integration-tests/resteasy-rest-client-reactive/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>quarkus-integration-tests-parent</artifactId>
+    <groupId>io.quarkus</groupId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>quarkus-integration-test-resteasy-rest-client-reactive</artifactId>
+  <name>Quarkus - Integration Tests - RESTEasy and Client Reactive</name>
+
+  <dependencies>
+    <!-- Client dependencies -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-validator</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
+    <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-client-reactive-jackson-deployment</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-validator-deployment</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>native-image</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+      <!-- add some custom config, the rest comes from parent -->
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/integration-tests/resteasy-rest-client-reactive/src/main/java/io/quarkus/it/resteasy/rest/client/reactive/Greet.java
+++ b/integration-tests/resteasy-rest-client-reactive/src/main/java/io/quarkus/it/resteasy/rest/client/reactive/Greet.java
@@ -1,0 +1,45 @@
+package io.quarkus.it.resteasy.rest.client.reactive;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Greet {
+    private final String greeting;
+    private final String who;
+    private final int number;
+
+    public Greet(
+            @JsonProperty("greeting") String greeting,
+            @JsonProperty("who") String who,
+            @JsonProperty("number") int number) {
+        this.greeting = greeting;
+        this.who = who;
+        this.number = number;
+    }
+
+    @Pattern(regexp = "^[A-Z][a-z]+$")
+    public String getGreeting() {
+        return greeting;
+    }
+
+    @Pattern(regexp = "^[A-Z][a-z]+$")
+    public String getWho() {
+        return who;
+    }
+
+    @Min(1)
+    public int getNumber() {
+        return number;
+    }
+
+    @Override
+    public String toString() {
+        return "Greet{" +
+                "greeting='" + greeting + '\'' +
+                ", who='" + who + '\'' +
+                ", number=" + number +
+                '}';
+    }
+}

--- a/integration-tests/resteasy-rest-client-reactive/src/main/java/io/quarkus/it/resteasy/rest/client/reactive/GreetEndpoint.java
+++ b/integration-tests/resteasy-rest-client-reactive/src/main/java/io/quarkus/it/resteasy/rest/client/reactive/GreetEndpoint.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.resteasy.rest.client.reactive;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+public interface GreetEndpoint {
+    // FIXME: Hibernate Validator doesn't like the @Valid annotation here,
+    //        as that's also used as a reactive REST client. Instead, it is
+    //        moved to the implementation bean.
+    @GET
+    @Path("") // FIXME: this @Path shouln't be needed, but it is
+    @Produces(MediaType.APPLICATION_JSON)
+    Greet greet(
+            @QueryParam("who") @DefaultValue("Person") @Pattern(regexp = "^[A-Z][a-z]+$") String name);
+}

--- a/integration-tests/resteasy-rest-client-reactive/src/main/java/io/quarkus/it/resteasy/rest/client/reactive/GreetEndpointBean.java
+++ b/integration-tests/resteasy-rest-client-reactive/src/main/java/io/quarkus/it/resteasy/rest/client/reactive/GreetEndpointBean.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.resteasy.rest.client.reactive;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("")
+@ApplicationScoped
+public class GreetEndpointBean implements GreetEndpoint {
+    private final String greeting;
+    private final AtomicInteger number = new AtomicInteger(0);
+
+    GreetEndpointBean(
+            @ConfigProperty(name = "greeting", defaultValue = "Hello") String greeting) {
+        this.greeting = greeting;
+    }
+
+    @Override
+    @Valid
+    public Greet greet(String name) {
+        return new Greet(greeting, name, number.incrementAndGet());
+    }
+}

--- a/integration-tests/resteasy-rest-client-reactive/src/test/java/io/quarkus/it/resteasy/rest/client/reactive/Constants.java
+++ b/integration-tests/resteasy-rest-client-reactive/src/test/java/io/quarkus/it/resteasy/rest/client/reactive/Constants.java
@@ -1,0 +1,5 @@
+package io.quarkus.it.resteasy.rest.client.reactive;
+
+class Constants {
+    static final String DEFAULT_TEST_URL = "http://localhost:8081";
+}

--- a/integration-tests/resteasy-rest-client-reactive/src/test/java/io/quarkus/it/resteasy/rest/client/reactive/GreetClient.java
+++ b/integration-tests/resteasy-rest-client-reactive/src/test/java/io/quarkus/it/resteasy/rest/client/reactive/GreetClient.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.resteasy.rest.client.reactive;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(baseUri = Constants.DEFAULT_TEST_URL)
+public interface GreetClient extends GreetEndpoint {
+}

--- a/integration-tests/resteasy-rest-client-reactive/src/test/java/io/quarkus/it/resteasy/rest/client/reactive/GreetEndpointIT.java
+++ b/integration-tests/resteasy-rest-client-reactive/src/test/java/io/quarkus/it/resteasy/rest/client/reactive/GreetEndpointIT.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.resteasy.rest.client.reactive;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.Assumptions;
+
+import java.net.URI;
+
+@QuarkusIntegrationTest
+class GreetEndpointIT extends GreetEndpointTest {
+    GreetEndpointIT() {
+        super(buildRestClient());
+    }
+
+    private static GreetClient buildRestClient() {
+        Assumptions.abort(
+            "FIXME: org.jboss.resteasy.reactive.client.impl.WebTargetImpl.proxy(WebTargetImpl.java:449) " +
+            "java.lang.IllegalArgumentException: Not a REST client interface: " +
+            "interface io.quarkus.it.resteasy.rest.client.reactive.GreetRestClient. " +
+            "No @Path annotation found on the class or any methods of the interface " +
+            "and no HTTP method annotations (@POST, @PUT, @GET, @HEAD, @DELETE, etc) " +
+            "found on any of the methods"
+        );
+        return RestClientBuilder.newBuilder()
+                .baseUri(URI.create(Constants.DEFAULT_TEST_URL))
+                .build(GreetClient.class);
+    }
+}

--- a/integration-tests/resteasy-rest-client-reactive/src/test/java/io/quarkus/it/resteasy/rest/client/reactive/GreetEndpointTest.java
+++ b/integration-tests/resteasy-rest-client-reactive/src/test/java/io/quarkus/it/resteasy/rest/client/reactive/GreetEndpointTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.it.resteasy.rest.client.reactive;
+
+import io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyReactiveViolationException;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@QuarkusTest
+@TestProfile(GreetEndpointTest.FrenchGreeting.class)
+class GreetEndpointTest {
+
+    private final GreetClient client;
+
+    GreetEndpointTest(@RestClient GreetClient client) {
+        this.client = client;
+    }
+
+    @Test
+    void greet() {
+        var g = client.greet("John");
+
+        assertThat(g)
+                .isNotNull()
+                .extracting(Greet::getGreeting, Greet::getWho, Greet::getNumber)
+                .containsExactly("Bonjour", "John", 1);
+    }
+
+    @Test
+    void validationFailure() {
+        assertThatCode(() -> client.greet("johnny"))
+                .isInstanceOf(ResteasyReactiveViolationException.class)
+                .hasMessageContaining("greet.name: must match \"^[A-Z][a-z]+$\"");
+    }
+
+    public static class FrenchGreeting implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("greeting", "Bonjour");
+        }
+    }
+}

--- a/integration-tests/resteasy-rest-client-reactive/src/test/resources/application.properties
+++ b/integration-tests/resteasy-rest-client-reactive/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+quarkus.rest-client.logging.scope=request-response
+quarkus.rest-client.logging.body-limit=1024
+quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG


### PR DESCRIPTION
This PR adds integration tests for Classic and Reactive versions of RESTEasy. Both of them use the REST client, based on the REST endpoint.

Such a setup works well in classic deps. The reactive has a number of disparities.

I describe them here: https://github.com/openshift-knative/showcase/pull/8#issuecomment-1438400773

But you can also find `FIXME:` comments in this PR.

I've made some modifications to the reactive RestClientBuilderImpl, to pass the Reactive versions of RESTEasy integration test, but I couldn't make it work. I'm getting exception like: `FIXME: org.jboss.resteasy.reactive.client.impl.WebTargetImpl.proxy(WebTargetImpl.java:449) java.lang.IllegalArgumentException: Not a REST client interface: interface io.quarkus.it.resteasy.rest.client.reactive.GreetRestClient. No @Path annotation found on the class or any methods of the interface and no HTTP method annotations (@POST, @PUT, @GET, @HEAD, @DELETE, etc) found on any of the methods`.