### PR TITLE
Use CLI instead of Cli in help message

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -38,7 +38,7 @@ public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
     protected HelpOption helpOption;
 
     @CommandLine.Option(names = { "-v",
-            "--version" }, versionHelp = true, description = "Print Cli version information and exit.")
+            "--version" }, versionHelp = true, description = "Print CLI version information and exit.")
     public boolean showVersion;
 
     @CommandLine.Mixin(name = "output")

--- a/devtools/cli/src/main/java/io/quarkus/cli/Version.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Version.java
@@ -14,7 +14,7 @@ import io.smallrye.common.classloader.ClassPathUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 
-@CommandLine.Command(name = "version", header = "Display Cli version information.", hidden = true)
+@CommandLine.Command(name = "version", header = "Display CLI version information.", hidden = true)
 public class Version implements CommandLine.IVersionProvider, Callable<Integer> {
 
     private static String version;


### PR DESCRIPTION
Use CLI instead of Cli in help message

`Cli` word addition was introduced in https://github.com/quarkusio/quarkus/pull/29558