### PR TITLE
Include the artifact in the bean discovery mode warning

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
@@ -189,7 +189,9 @@ public class BeanArchiveProcessor {
                                 || text.contains("bean-discovery-mode=\"all\"")) {
                             LOGGER.warnf("Detected bean archive with bean discovery mode of 'all', "
                                     + "this is not portable in CDI Lite and is treated as 'annotated' in Quarkus! "
-                                    + "Path to beans.xml: %s", pathVisit.getPath());
+                                    + "Path to beans.xml: %s",
+                                    archive.getKey() != null ? archive.getKey().toGacString() + ":" + pathVisit.getPath()
+                                            : pathVisit.getPath());
                         }
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);


### PR DESCRIPTION
Otherwise it is not possible to know which dependency contain the problematic beans.xml.

Related to #31378.