### PR TITLE
Exclude banned dependency commons-logging in the BOM 

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4111,6 +4111,12 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient-cache</artifactId>
                 <version>${httpclient.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>

--- a/extensions/apache-httpclient/runtime/pom.xml
+++ b/extensions/apache-httpclient/runtime/pom.xml
@@ -20,12 +20,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
#30813 is related but this does not fix it because it does not add any automatic solution to add exclusion for all (or selected) banned dependencies.