### PR TITLE
HTTP response compression - fix Undertow and RESTEasy Classsic support

### DIFF
--- a/docs/src/main/asciidoc/resteasy.adoc
+++ b/docs/src/main/asciidoc/resteasy.adoc
@@ -720,7 +720,7 @@ This configuration option would recognize strings in this format (shown as a reg
 
 Once GZip support has been enabled you can use it on an endpoint by adding the `@org.jboss.resteasy.annotations.GZIP` annotation to your endpoint method.
 
-NOTE: The configuration property `quarkus.http.enable-compression` has no effect on compression support of RESTEasy Classic endpoints.
+NOTE: There is also the `quarkus.http.enable-compression` configuration property which enables HTTP response compression globally. If enabled then a response body is compressed if the `Content-Type` HTTP header is set and the value is a compressed media type as configured via the `quarkus.http.compress-media-types` configuration property.
 
 == Multipart Support
 

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/HttpCompressionHandler.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/HttpCompressionHandler.java
@@ -37,13 +37,14 @@ public class HttpCompressionHandler implements Handler<RoutingContext> {
                                 break;
                             case UNDEFINED:
                                 String contentType = headers.get(HttpHeaders.CONTENT_TYPE);
-                                int paramIndex = contentType.indexOf(';');
-                                if (paramIndex > -1) {
-                                    contentType = contentType.substring(0, paramIndex);
-                                }
-                                if (contentType != null
-                                        && compressedMediaTypes.contains(contentType)) {
-                                    headers.remove(HttpHeaders.CONTENT_ENCODING);
+                                if (contentType != null) {
+                                    int paramIndex = contentType.indexOf(';');
+                                    if (paramIndex > -1) {
+                                        contentType = contentType.substring(0, paramIndex);
+                                    }
+                                    if (compressedMediaTypes.contains(contentType)) {
+                                        headers.remove(HttpHeaders.CONTENT_ENCODING);
+                                    }
                                 }
                                 break;
                             default:

--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
@@ -95,7 +95,8 @@ public class ResteasyStandaloneBuildStep {
             ResteasyStandaloneBuildItem standalone,
             Optional<RequireVirtualHttpBuildItem> requireVirtual,
             ExecutorBuildItem executorBuildItem,
-            ResteasyVertxConfig resteasyVertxConfig) throws Exception {
+            ResteasyVertxConfig resteasyVertxConfig,
+            HttpBuildTimeConfig httpBuildTimeConfig) throws Exception {
 
         if (standalone == null) {
             return;
@@ -105,7 +106,7 @@ public class ResteasyStandaloneBuildStep {
         // Handler used for both the default and non-default deployment path (specified as application path or resteasyConfig.path)
         // Routes use the order VertxHttpRecorder.DEFAULT_ROUTE_ORDER + 1 to ensure the default route is called before the resteasy one
         Handler<RoutingContext> handler = recorder.vertxRequestHandler(vertx.getVertx(),
-                executorBuildItem.getExecutorProxy(), resteasyVertxConfig);
+                executorBuildItem.getExecutorProxy(), resteasyVertxConfig, httpBuildTimeConfig);
 
         final boolean noCustomAuthCompletionExMapper;
         final boolean noCustomAuthFailureExMapper;

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -186,7 +186,8 @@ public class UndertowBuildStep {
             ExecutorBuildItem executorBuildItem,
             ServletRuntimeConfig servletRuntimeConfig,
             ServletContextPathBuildItem servletContextPathBuildItem,
-            Capabilities capabilities) throws Exception {
+            Capabilities capabilities,
+            HttpBuildTimeConfig httpBuildTimeConfig) throws Exception {
 
         if (capabilities.isPresent(Capability.SECURITY)) {
             recorder.setupSecurity(servletDeploymentManagerBuildItem.getDeploymentManager());
@@ -194,7 +195,7 @@ public class UndertowBuildStep {
         Handler<RoutingContext> ut = recorder.startUndertow(shutdown, executorBuildItem.getExecutorProxy(),
                 servletDeploymentManagerBuildItem.getDeploymentManager(),
                 wrappers.stream().map(HttpHandlerWrapperBuildItem::getValue).collect(Collectors.toList()),
-                servletRuntimeConfig);
+                servletRuntimeConfig, httpBuildTimeConfig);
 
         if (servletContextPathBuildItem.getServletContextPath().equals("/")) {
             undertowProducer.accept(new DefaultRouteBuildItem(ut));

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/compress/CompressionDisabledTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/compress/CompressionDisabledTestCase.java
@@ -1,0 +1,29 @@
+package io.quarkus.undertow.test.compress;
+
+import static io.restassured.RestAssured.get;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+public class CompressionDisabledTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(SimpleServlet.class))
+            .overrideConfigKey("quarkus.http.enable-compression", "false");
+
+    @Test
+    public void testCompressed() throws Exception {
+        ExtractableResponse<Response> response = get(SimpleServlet.SERVLET_ENDPOINT)
+                .then().statusCode(200).extract();
+        assertTrue(response.header("Content-Encoding") == null, response.headers().toString());
+        assertEquals("ok", response.asString());
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/compress/CompressionEnabledTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/compress/CompressionEnabledTestCase.java
@@ -1,0 +1,25 @@
+package io.quarkus.undertow.test.compress;
+
+import static io.restassured.RestAssured.get;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CompressionEnabledTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(SimpleServlet.class))
+            .overrideConfigKey("quarkus.http.enable-compression", "true");
+
+    @Test
+    public void testCompressed() throws Exception {
+        String bodyStr = get(SimpleServlet.SERVLET_ENDPOINT).then().statusCode(200).header("Content-Encoding", "gzip").extract()
+                .asString();
+        assertEquals("ok", bodyStr);
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/compress/SimpleServlet.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/compress/SimpleServlet.java
@@ -1,0 +1,24 @@
+package io.quarkus.undertow.test.compress;
+
+import java.io.IOException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet(urlPatterns = SimpleServlet.SERVLET_ENDPOINT)
+public class SimpleServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_ENDPOINT = "/simple";
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        // this one must be listed in the quarkus.http.compress-media-types
+        resp.setHeader("Content-type", "text/plain");
+        resp.getWriter().write("ok");
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
@@ -64,14 +64,12 @@ public class HttpBuildTimeConfig {
     public Duration testTimeout;
 
     /**
-     * If responses should be compressed.
+     * If enabled then the response body is compressed if the {@code Content-Type} header is set and the value is a compressed
+     * media type as configured via {@link #compressMediaTypes}.
      *
-     * Note that this will attempt to compress all responses, to avoid compressing
-     * already compressed content (such as images) you need to set the following header:
-     *
-     * Content-Encoding: identity
-     *
-     * Which will tell vert.x not to compress the response.
+     * Note that the RESTEasy Reactive and Reactive Routes extensions also make it possible to enable/disable compression
+     * declaratively using the annotations {@link io.quarkus.vertx.http.Compressed} and
+     * {@link io.quarkus.vertx.http.Uncompressed}.
      */
     @ConfigItem
     public boolean enableCompression;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCompressionHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCompressionHandler.java
@@ -1,0 +1,59 @@
+package io.quarkus.vertx.http.runtime;
+
+import java.util.Set;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * A simple wrapping handler that removes the {@code Content-Encoding: identity} HTTP header if the {@code Content-Type}
+ * header is set and the value is a compressed media type as configured via
+ * {@link io.quarkus.vertx.http.runtime.HttpBuildTimeConfig#compressMediaTypes}.
+ */
+public class HttpCompressionHandler implements Handler<RoutingContext> {
+
+    private final Handler<RoutingContext> routeHandler;
+    private final Set<String> compressedMediaTypes;
+
+    public HttpCompressionHandler(Handler<RoutingContext> routeHandler, Set<String> compressedMediaTypes) {
+        this.routeHandler = routeHandler;
+        this.compressedMediaTypes = compressedMediaTypes;
+    }
+
+    @Override
+    public void handle(RoutingContext context) {
+        context.addEndHandler(new Handler<AsyncResult<Void>>() {
+            @Override
+            public void handle(AsyncResult<Void> result) {
+                if (result.succeeded()) {
+                    compressIfNeeded(context, compressedMediaTypes);
+                }
+            }
+        });
+        routeHandler.handle(context);
+    }
+
+    public static void compressIfNeeded(RoutingContext context, Set<String> compressedMediaTypes) {
+        MultiMap headers = context.response().headers();
+        // "Content-Encoding: identity" header means that compression is enabled in the config
+        // and this header is set to disable the compression by default
+        String contentEncoding = headers.get(HttpHeaders.CONTENT_ENCODING);
+        if (contentEncoding != null && HttpHeaders.IDENTITY.toString().equals(contentEncoding)) {
+            // Just remove the header if the compression should be enabled for the current HTTP response
+            String contentType = headers.get(HttpHeaders.CONTENT_TYPE);
+            if (contentType != null) {
+                int paramIndex = contentType.indexOf(';');
+                if (paramIndex > -1) {
+                    contentType = contentType.substring(0, paramIndex);
+                }
+                if (compressedMediaTypes.contains(contentType)) {
+                    headers.remove(HttpHeaders.CONTENT_ENCODING);
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
- honor the quarkus.http.compress-media-types in Undertow Servlet and RESTEasy Classsic extensions
- fixes #31415 and #26112