### PR TITLE
Add hibernate-community-dialects to BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5408,6 +5408,11 @@
                 <version>${hibernate-commons-annotations.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-community-dialects</artifactId>
+                <version>${hibernate-orm.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hibernate.reactive</groupId>
                 <artifactId>hibernate-reactive-core-jakarta</artifactId>
                 <version>${hibernate-reactive.version}</version>


### PR DESCRIPTION
3 days ago Sanne start upgrade to Hibernate 6.x in Quarkus
For https://github.com/quarkiverse/quarkus-jdbc-sqlite/ need to move from third party to official community dialect.
Adding this dependency to Quarkus BOM because it's will be updated automatically in quarkiverse instead of version hardcode in my module

@Sanne , @yrodiere CC