### PR TITLE
Fix documentation for quarkus.hibernate-orm.enabled

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/JavaDocParser.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/JavaDocParser.java
@@ -34,16 +34,17 @@ final class JavaDocParser {
     private static final String NEW_LINE = "\n";
     private static final String LINK_NODE = "a";
     private static final String BOLD_NODE = "b";
+    private static final String STRONG_NODE = "strong";
     private static final String BIG_NODE = "big";
     private static final String CODE_NODE = "code";
     private static final String DEL_NODE = "del";
     private static final String ITALICS_NODE = "i";
+    private static final String EMPHASIS_NODE = "em";
     private static final String TEXT_NODE = "#text";
     private static final String UNDERLINE_NODE = "u";
     private static final String NEW_LINE_NODE = "br";
     private static final String PARAGRAPH_NODE = "p";
     private static final String SMALL_NODE = "small";
-    private static final String EMPHASIS_NODE = "em";
     private static final String LIST_ITEM_NODE = "li";
     private static final String HREF_ATTRIBUTE = "href";
     private static final String STRIKE_NODE = "strike";
@@ -220,11 +221,12 @@ final class JavaDocParser {
                     sb.append(BACKTICK);
                     break;
                 case BOLD_NODE:
-                case EMPHASIS_NODE:
+                case STRONG_NODE:
                     sb.append(STAR);
                     appendHtml(sb, childNode);
                     sb.append(STAR);
                     break;
+                case EMPHASIS_NODE:
                 case ITALICS_NODE:
                     sb.append(UNDERSCORE);
                     appendHtml(sb, childNode);

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/JavaDocConfigDescriptionParserTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/JavaDocConfigDescriptionParserTest.java
@@ -70,9 +70,14 @@ public class JavaDocConfigDescriptionParserTest {
         String parsed = parser.parseConfigDescription(javaDoc);
         assertEquals(expectedOutput, parsed);
 
+        javaDoc = "hello <strong>world</strong>";
+        expectedOutput = "hello *world*";
+        parsed = parser.parseConfigDescription(javaDoc);
+        assertEquals(expectedOutput, parsed);
+
         // Emphasized
         javaDoc = "<em>hello world</em>";
-        expectedOutput = "*hello world*";
+        expectedOutput = "_hello world_";
         parsed = parser.parseConfigDescription(javaDoc);
         assertEquals(expectedOutput, parsed);
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfig.java
@@ -15,7 +15,7 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class HibernateOrmConfig {
 
     /**
-     * Whether Hibernate ORM is enabled <strong>during the build</strong>.
+     * Whether Hibernate ORM is enabled *during the build*.
      *
      * If Hibernate ORM is disabled during the build, all processing related to Hibernate ORM will be skipped,
      * but it will not be possible to activate Hibernate ORM at runtime:


### PR DESCRIPTION
We use the AsciiDoc format but we have HTML markups.

Fixes https://github.com/quarkusio/quarkus/issues/31418