### PR TITLE
Enable Podman and Docker Windows quarkus-container-image-docker testing

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
@@ -1,7 +1,8 @@
 
 package io.quarkus.deployment;
 
-import java.io.File;
+import static io.quarkus.runtime.util.ContainerRuntimeUtil.ContainerRuntime.UNAVAILABLE;
+
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -11,23 +12,20 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.console.StartupLogCompressor;
-import io.quarkus.deployment.util.ExecUtil;
+import io.quarkus.runtime.util.ContainerRuntimeUtil;
 
 public class IsDockerWorking implements BooleanSupplier {
 
     private static final Logger LOGGER = Logger.getLogger(IsDockerWorking.class.getName());
     public static final int DOCKER_HOST_CHECK_TIMEOUT = 1000;
-    public static final int DOCKER_CMD_CHECK_TIMEOUT = 3000;
 
     private final List<Strategy> strategies;
 
@@ -36,8 +34,7 @@ public class IsDockerWorking implements BooleanSupplier {
     }
 
     public IsDockerWorking(boolean silent) {
-        this.strategies = List.of(new TestContainersStrategy(silent), new DockerHostStrategy(),
-                new DockerBinaryStrategy(silent));
+        this.strategies = List.of(new TestContainersStrategy(silent), new DockerHostStrategy(), new DockerBinaryStrategy());
     }
 
     @Override
@@ -170,41 +167,11 @@ public class IsDockerWorking implements BooleanSupplier {
 
     private static class DockerBinaryStrategy implements Strategy {
 
-        private final boolean silent;
-        private final String binary;
-
-        private DockerBinaryStrategy(boolean silent) {
-            this.silent = silent;
-            this.binary = ConfigProvider.getConfig().getOptionalValue("quarkus.native.container-runtime", String.class)
-                    .orElse("docker");
-        }
-
         @Override
         public Result get() {
-            try {
-                if (!ExecUtil.execSilentWithTimeout(Duration.ofMillis(DOCKER_CMD_CHECK_TIMEOUT), binary, "-v")) {
-                    LOGGER.warnf("'%s -v' returned an error code. Make sure your Docker binary is correct", binary);
-                    return Result.UNKNOWN;
-                }
-            } catch (Exception e) {
-                LOGGER.warnf("No %s binary found or general error: %s", binary, e);
-                return Result.UNKNOWN;
-            }
-
-            try {
-                OutputFilter filter = new OutputFilter();
-                if (ExecUtil.execWithTimeout(new File("."), filter, Duration.ofMillis(DOCKER_CMD_CHECK_TIMEOUT),
-                        binary, "version", "--format", "'{{.Server.Version}}'")) {
-                    LOGGER.debugf("Docker daemon found. Version: %s", filter.getOutput());
-                    return Result.AVAILABLE;
-                } else {
-                    if (!silent) {
-                        LOGGER.warn("Could not determine version of Docker daemon");
-                    }
-                    return Result.UNAVAILABLE;
-                }
-            } catch (Exception e) {
-                LOGGER.warn("Unexpected error occurred while determining Docker daemon version", e);
+            if (ContainerRuntimeUtil.detectContainerRuntime(false) != UNAVAILABLE) {
+                return Result.AVAILABLE;
+            } else {
                 return Result.UNKNOWN;
             }
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
@@ -175,7 +175,7 @@ public class IsDockerWorking implements BooleanSupplier {
 
         private DockerBinaryStrategy(boolean silent) {
             this.silent = silent;
-            this.binary = ConfigProvider.getConfig().getOptionalValue("quarkus.docker.executable-name", String.class)
+            this.binary = ConfigProvider.getConfig().getOptionalValue("quarkus.native.container-runtime", String.class)
                     .orElse("docker");
         }
 
@@ -194,7 +194,7 @@ public class IsDockerWorking implements BooleanSupplier {
             try {
                 OutputFilter filter = new OutputFilter();
                 if (ExecUtil.execWithTimeout(new File("."), filter, Duration.ofMillis(DOCKER_CMD_CHECK_TIMEOUT),
-                        "docker", "version", "--format", "'{{.Server.Version}}'")) {
+                        binary, "version", "--format", "'{{.Server.Version}}'")) {
                     LOGGER.debugf("Docker daemon found. Version: %s", filter.getOutput());
                     return Result.AVAILABLE;
                 } else {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
@@ -29,6 +29,7 @@ import io.quarkus.deployment.pkg.builditem.JarBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.steps.MainClassBuildStep;
 import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.util.ContainerRuntimeUtil;
 import io.quarkus.utilities.JavaBinFinder;
 
 public class AppCDSBuildStep {
@@ -38,7 +39,7 @@ public class AppCDSBuildStep {
     public static final String CLASSES_LIST_FILE_NAME = "classes.lst";
     private static final String CONTAINER_IMAGE_BASE_BUILD_DIR = "/tmp/quarkus";
     private static final String CONTAINER_IMAGE_APPCDS_DIR = CONTAINER_IMAGE_BASE_BUILD_DIR + "/appcds";
-    public static final String DOCKER_EXECUTABLE = detectContainerRuntime().getExecutableName();
+    public static final ContainerRuntimeUtil.ContainerRuntime CONTAINER_RUNTIME = detectContainerRuntime(false);
 
     @BuildStep(onlyIf = AppCDSRequired.class)
     public void requested(OutputTargetBuildItem outputTarget, BuildProducer<AppCDSRequestedBuildItem> producer)
@@ -203,8 +204,12 @@ public class AppCDSBuildStep {
     // generate the classes file on the host
     private List<String> dockerRunCommands(OutputTargetBuildItem outputTarget, String containerImage,
             String containerWorkingDir) {
+        if (CONTAINER_RUNTIME == ContainerRuntimeUtil.ContainerRuntime.UNAVAILABLE) {
+            throw new IllegalStateException("No container runtime was found. "
+                    + "Make sure you have either Docker or Podman installed in your environment.");
+        }
         List<String> command = new ArrayList<>(10);
-        command.add(DOCKER_EXECUTABLE);
+        command.add(CONTAINER_RUNTIME.getExecutableName());
         command.add("run");
         command.add("-v");
         command.add(outputTarget.getOutputDirectory().toAbsolutePath().toString() + ":" + CONTAINER_IMAGE_BASE_BUILD_DIR

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
@@ -1,6 +1,7 @@
 package io.quarkus.deployment.pkg.steps;
 
 import static io.quarkus.deployment.pkg.steps.LinuxIDUtil.getLinuxID;
+import static io.quarkus.runtime.util.ContainerRuntimeUtil.detectContainerRuntime;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,7 +14,6 @@ import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
 import org.apache.commons.lang3.SystemUtils;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.util.IoUtils;
@@ -38,8 +38,7 @@ public class AppCDSBuildStep {
     public static final String CLASSES_LIST_FILE_NAME = "classes.lst";
     private static final String CONTAINER_IMAGE_BASE_BUILD_DIR = "/tmp/quarkus";
     private static final String CONTAINER_IMAGE_APPCDS_DIR = CONTAINER_IMAGE_BASE_BUILD_DIR + "/appcds";
-    public static final String DOCKER_EXECUTABLE = ConfigProvider.getConfig()
-            .getOptionalValue("quarkus.native.container-runtime", String.class).orElse("docker");
+    public static final String DOCKER_EXECUTABLE = detectContainerRuntime().getExecutableName();
 
     @BuildStep(onlyIf = AppCDSRequired.class)
     public void requested(OutputTargetBuildItem outputTarget, BuildProducer<AppCDSRequestedBuildItem> producer)

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.util.IoUtils;
@@ -37,6 +38,8 @@ public class AppCDSBuildStep {
     public static final String CLASSES_LIST_FILE_NAME = "classes.lst";
     private static final String CONTAINER_IMAGE_BASE_BUILD_DIR = "/tmp/quarkus";
     private static final String CONTAINER_IMAGE_APPCDS_DIR = CONTAINER_IMAGE_BASE_BUILD_DIR + "/appcds";
+    public static final String DOCKER_EXECUTABLE = ConfigProvider.getConfig()
+            .getOptionalValue("quarkus.native.container-runtime", String.class).orElse("docker");
 
     @BuildStep(onlyIf = AppCDSRequired.class)
     public void requested(OutputTargetBuildItem outputTarget, BuildProducer<AppCDSRequestedBuildItem> producer)
@@ -202,7 +205,7 @@ public class AppCDSBuildStep {
     private List<String> dockerRunCommands(OutputTargetBuildItem outputTarget, String containerImage,
             String containerWorkingDir) {
         List<String> command = new ArrayList<>(10);
-        command.add("docker");
+        command.add(DOCKER_EXECUTABLE);
         command.add("run");
         command.add("-v");
         command.add(outputTarget.getOutputDirectory().toAbsolutePath().toString() + ":" + CONTAINER_IMAGE_BASE_BUILD_DIR

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -9,15 +9,12 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.SystemUtils;
-import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.runtime.util.ContainerRuntimeUtil;
 
 public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContainerRunner {
-
-    private static final Logger LOGGER = Logger.getLogger(NativeImageBuildLocalContainerRunner.class.getName());
 
     public NativeImageBuildLocalContainerRunner(NativeConfig nativeConfig, Path outputDir) {
         super(nativeConfig, outputDir);

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -1,6 +1,8 @@
 package io.quarkus.deployment.pkg.steps;
 
 import static io.quarkus.deployment.pkg.steps.LinuxIDUtil.getLinuxID;
+import static io.quarkus.runtime.util.ContainerRuntimeUtil.ContainerRuntime.DOCKER;
+import static io.quarkus.runtime.util.ContainerRuntimeUtil.ContainerRuntime.PODMAN;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -12,24 +14,21 @@ import org.apache.commons.lang3.SystemUtils;
 
 import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.util.FileUtil;
-import io.quarkus.runtime.util.ContainerRuntimeUtil;
 
 public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContainerRunner {
 
     public NativeImageBuildLocalContainerRunner(NativeConfig nativeConfig, Path outputDir) {
         super(nativeConfig, outputDir);
         if (SystemUtils.IS_OS_LINUX) {
-            ArrayList<String> containerRuntimeArgs = new ArrayList<>(Arrays.asList(baseContainerRuntimeArgs));
-            if (containerRuntime == ContainerRuntimeUtil.ContainerRuntime.DOCKER
-                    && containerRuntime.isRootless()) {
+            final ArrayList<String> containerRuntimeArgs = new ArrayList<>(Arrays.asList(baseContainerRuntimeArgs));
+            if (containerRuntime == DOCKER && containerRuntime.isRootless()) {
                 Collections.addAll(containerRuntimeArgs, "--user", String.valueOf(0));
             } else {
                 String uid = getLinuxID("-ur");
                 String gid = getLinuxID("-gr");
                 if (uid != null && gid != null && !uid.isEmpty() && !gid.isEmpty()) {
                     Collections.addAll(containerRuntimeArgs, "--user", uid + ":" + gid);
-                    if (containerRuntime == ContainerRuntimeUtil.ContainerRuntime.PODMAN
-                            && containerRuntime.isRootless()) {
+                    if (containerRuntime == PODMAN && containerRuntime.isRootless()) {
                         // Needed to avoid AccessDeniedExceptions
                         containerRuntimeArgs.add("--userns=keep-id");
                     }
@@ -41,16 +40,19 @@ public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContai
 
     @Override
     protected List<String> getContainerRuntimeBuildArgs() {
-        List<String> containerRuntimeArgs = super.getContainerRuntimeBuildArgs();
-        String volumeOutputPath = outputPath;
+        final List<String> containerRuntimeArgs = super.getContainerRuntimeBuildArgs();
+        final String volumeOutputPath;
         if (SystemUtils.IS_OS_WINDOWS) {
-            volumeOutputPath = FileUtil.translateToVolumePath(volumeOutputPath);
+            volumeOutputPath = FileUtil.translateToVolumePath(outputPath);
+        } else {
+            volumeOutputPath = outputPath;
         }
 
-        String selinuxBindOption = ":z";
-        if (SystemUtils.IS_OS_MAC
-                && ContainerRuntimeUtil.detectContainerRuntime() == ContainerRuntimeUtil.ContainerRuntime.PODMAN) {
+        final String selinuxBindOption;
+        if (SystemUtils.IS_OS_MAC && containerRuntime == PODMAN) {
             selinuxBindOption = "";
+        } else {
+            selinuxBindOption = ":z";
         }
 
         Collections.addAll(containerRuntimeArgs, "-v",

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.deployment.pkg.steps;
 
-import static io.quarkus.deployment.pkg.steps.AppCDSBuildStep.DOCKER_EXECUTABLE;
+import static io.quarkus.deployment.pkg.steps.AppCDSBuildStep.CONTAINER_RUNTIME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.deployment.pkg.NativeConfig;
+import io.quarkus.runtime.util.ContainerRuntimeUtil;
 
 class NativeImageBuildContainerRunnerTest {
 
@@ -18,6 +19,10 @@ class NativeImageBuildContainerRunnerTest {
     @DisabledIfSystemProperty(named = "avoid-containers", matches = "true")
     @Test
     void testBuilderImageBeingPickedUp() {
+        if (CONTAINER_RUNTIME == ContainerRuntimeUtil.ContainerRuntime.UNAVAILABLE) {
+            throw new IllegalStateException("No container runtime was found. "
+                    + "Make sure you have either Docker or Podman installed in your environment.");
+        }
         NativeConfig nativeConfig = new NativeConfig();
         nativeConfig.containerRuntime = Optional.empty();
         boolean found;
@@ -26,7 +31,8 @@ class NativeImageBuildContainerRunnerTest {
 
         nativeConfig.builderImage = "graalvm";
         localRunner = new NativeImageBuildLocalContainerRunner(nativeConfig, Path.of("/tmp"));
-        command = localRunner.buildCommand(DOCKER_EXECUTABLE, Collections.emptyList(), Collections.emptyList());
+        command = localRunner.buildCommand(CONTAINER_RUNTIME.getExecutableName(), Collections.emptyList(),
+                Collections.emptyList());
         found = false;
         for (String part : command) {
             if (part.contains("ubi-quarkus-graalvmce-builder-image")) {
@@ -38,7 +44,8 @@ class NativeImageBuildContainerRunnerTest {
 
         nativeConfig.builderImage = "mandrel";
         localRunner = new NativeImageBuildLocalContainerRunner(nativeConfig, Path.of("/tmp"));
-        command = localRunner.buildCommand(DOCKER_EXECUTABLE, Collections.emptyList(), Collections.emptyList());
+        command = localRunner.buildCommand(CONTAINER_RUNTIME.getExecutableName(), Collections.emptyList(),
+                Collections.emptyList());
         found = false;
         for (String part : command) {
             if (part.contains("ubi-quarkus-mandrel-builder-image")) {
@@ -50,7 +57,8 @@ class NativeImageBuildContainerRunnerTest {
 
         nativeConfig.builderImage = "RandomString";
         localRunner = new NativeImageBuildLocalContainerRunner(nativeConfig, Path.of("/tmp"));
-        command = localRunner.buildCommand(DOCKER_EXECUTABLE, Collections.emptyList(), Collections.emptyList());
+        command = localRunner.buildCommand(CONTAINER_RUNTIME.getExecutableName(), Collections.emptyList(),
+                Collections.emptyList());
         found = false;
         for (String part : command) {
             if (part.equals("RandomString")) {

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.deployment.pkg.steps;
 
+import static io.quarkus.deployment.pkg.steps.AppCDSBuildStep.DOCKER_EXECUTABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
@@ -25,33 +26,36 @@ class NativeImageBuildContainerRunnerTest {
 
         nativeConfig.builderImage = "graalvm";
         localRunner = new NativeImageBuildLocalContainerRunner(nativeConfig, Path.of("/tmp"));
-        command = localRunner.buildCommand("docker", Collections.emptyList(), Collections.emptyList());
+        command = localRunner.buildCommand(DOCKER_EXECUTABLE, Collections.emptyList(), Collections.emptyList());
         found = false;
         for (String part : command) {
             if (part.contains("ubi-quarkus-graalvmce-builder-image")) {
                 found = true;
+                break;
             }
         }
         assertThat(found).isTrue();
 
         nativeConfig.builderImage = "mandrel";
         localRunner = new NativeImageBuildLocalContainerRunner(nativeConfig, Path.of("/tmp"));
-        command = localRunner.buildCommand("docker", Collections.emptyList(), Collections.emptyList());
+        command = localRunner.buildCommand(DOCKER_EXECUTABLE, Collections.emptyList(), Collections.emptyList());
         found = false;
         for (String part : command) {
             if (part.contains("ubi-quarkus-mandrel-builder-image")) {
                 found = true;
+                break;
             }
         }
         assertThat(found).isTrue();
 
         nativeConfig.builderImage = "RandomString";
         localRunner = new NativeImageBuildLocalContainerRunner(nativeConfig, Path.of("/tmp"));
-        command = localRunner.buildCommand("docker", Collections.emptyList(), Collections.emptyList());
+        command = localRunner.buildCommand(DOCKER_EXECUTABLE, Collections.emptyList(), Collections.emptyList());
         found = false;
         for (String part : command) {
             if (part.equals("RandomString")) {
                 found = true;
+                break;
             }
         }
         assertThat(found).isTrue();

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java
@@ -5,6 +5,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -18,6 +21,16 @@ public final class ContainerRuntimeUtil {
     private static final Logger log = Logger.getLogger(ContainerRuntimeUtil.class);
     private static final String DOCKER_EXECUTABLE = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class)
             .getOptionalValue("quarkus.native.container-runtime", String.class).orElse(null);
+    /*
+     * Caching the value in a file helps us only as much as one JVM execution is concerned.
+     * Test suite's pom.xml sets things like <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>,
+     * so the file could appear in /tmp/ or C:\Users\karm\AppData\Local\Temp\ or in fact in
+     * quarkus/integration-tests/something/target.
+     * There is no point in reaching it in `Path.of(Paths.get("").toAbsolutePath().toString(), "target",
+     * "quarkus_container_runtime.txt")`
+     * as the file is deleted between JVM executions anyway.
+     */
+    static final Path CONTAINER_RUNTIME = Path.of(System.getProperty("java.io.tmpdir"), "quarkus_container_runtime.txt");
 
     private ContainerRuntimeUtil() {
     }
@@ -25,46 +38,101 @@ public final class ContainerRuntimeUtil {
     /**
      * @return {@link ContainerRuntime#DOCKER} if it's available, or {@link ContainerRuntime#PODMAN}
      *         if the podman
-     *         executable exists in the environment or if the docker executable is an alias to podman
+     *         executable exists in the environment or if the docker executable is an alias to podman,
+     *         or {@link ContainerRuntime#UNAVAILABLE} if no container runtime is available and the required arg is false.
      * @throws IllegalStateException if no container runtime was found to build the image
      */
     public static ContainerRuntime detectContainerRuntime() {
-        // Docker version 19.03.14, build 5eb3275d40
-        String dockerVersionOutput = getVersionOutputFor(ContainerRuntime.DOCKER);
-        boolean dockerAvailable = dockerVersionOutput.contains("Docker version");
-        // Check if Podman is installed
-        // podman version 2.1.1
-        String podmanVersionOutput = getVersionOutputFor(ContainerRuntime.PODMAN);
-        boolean podmanAvailable = podmanVersionOutput.startsWith("podman version");
-        if (DOCKER_EXECUTABLE != null) {
-            if (DOCKER_EXECUTABLE.trim().equalsIgnoreCase("docker") && dockerAvailable) {
+        return detectContainerRuntime(true);
+    }
+
+    public static ContainerRuntime detectContainerRuntime(boolean required) {
+        final ContainerRuntime containerRuntime = loadConfig();
+        if (containerRuntime != null) {
+            return containerRuntime;
+        } else {
+            // Docker version 19.03.14, build 5eb3275d40
+            final String dockerVersionOutput = getVersionOutputFor(ContainerRuntime.DOCKER);
+            boolean dockerAvailable = dockerVersionOutput.contains("Docker version");
+            // Check if Podman is installed
+            // podman version 2.1.1
+            final String podmanVersionOutput = getVersionOutputFor(ContainerRuntime.PODMAN);
+            boolean podmanAvailable = podmanVersionOutput.startsWith("podman version");
+            if (DOCKER_EXECUTABLE != null) {
+                if (DOCKER_EXECUTABLE.trim().equalsIgnoreCase("docker") && dockerAvailable) {
+                    storeConfig(ContainerRuntime.DOCKER);
+                    return ContainerRuntime.DOCKER;
+                } else if (DOCKER_EXECUTABLE.trim().equalsIgnoreCase("podman") && podmanAvailable) {
+                    storeConfig(ContainerRuntime.PODMAN);
+                    return ContainerRuntime.PODMAN;
+                } else {
+                    log.warn("quarkus.native.container-runtime config property must be set to either podman or docker " +
+                            "and the executable must be available. Ignoring it.");
+                }
+            }
+            if (dockerAvailable) {
+                // Check if "docker" is an alias to "podman"
+                if (dockerVersionOutput.equals(podmanVersionOutput)) {
+                    storeConfig(ContainerRuntime.PODMAN);
+                    return ContainerRuntime.PODMAN;
+                }
+                storeConfig(ContainerRuntime.DOCKER);
                 return ContainerRuntime.DOCKER;
-            } else if (DOCKER_EXECUTABLE.trim().equalsIgnoreCase("podman") && podmanAvailable) {
+            } else if (podmanAvailable) {
+                storeConfig(ContainerRuntime.PODMAN);
                 return ContainerRuntime.PODMAN;
             } else {
-                log.warn("quarkus.native.container-runtime config property must be set to either podman or docker " +
-                        "and the executable must be available. Ignoring it.");
+                if (required) {
+                    throw new IllegalStateException("No container runtime was found. "
+                            + "Make sure you have either Docker or Podman installed in your environment.");
+                } else {
+                    storeConfig(ContainerRuntime.UNAVAILABLE);
+                    return ContainerRuntime.UNAVAILABLE;
+                }
             }
         }
+    }
 
-        if (dockerAvailable) {
-            // Check if "docker" is an alias to "podman"
-            if (dockerVersionOutput.equals(podmanVersionOutput)) {
-                return ContainerRuntime.PODMAN;
+    private static ContainerRuntime loadConfig() {
+        try {
+            if (Files.isReadable(CONTAINER_RUNTIME)) {
+                final String runtime = Files.readString(CONTAINER_RUNTIME, StandardCharsets.UTF_8);
+                if (ContainerRuntime.DOCKER.name().equalsIgnoreCase(runtime)) {
+                    return ContainerRuntime.DOCKER;
+                } else if (ContainerRuntime.PODMAN.name().equalsIgnoreCase(runtime)) {
+                    return ContainerRuntime.PODMAN;
+                } else if (ContainerRuntime.UNAVAILABLE.name().equalsIgnoreCase(runtime)) {
+                    return ContainerRuntime.UNAVAILABLE;
+                } else {
+                    log.warnf("The file %s contains an unknown value %s. Ignoring it.",
+                            CONTAINER_RUNTIME.toAbsolutePath(), runtime);
+                    return null;
+                }
+            } else {
+                return null;
             }
-            return ContainerRuntime.DOCKER;
-        } else if (podmanAvailable) {
-            return ContainerRuntime.PODMAN;
-        } else {
-            throw new IllegalStateException("No container runtime was found to. "
-                    + "Make sure you have Docker or Podman installed in your environment.");
+        } catch (IOException e) {
+            log.warnf("Error reading file %s. Ignoring it. See: %s",
+                    CONTAINER_RUNTIME.toAbsolutePath(), e);
+            return null;
+        }
+    }
+
+    private static void storeConfig(ContainerRuntime containerRuntime) {
+        try {
+            Files.writeString(CONTAINER_RUNTIME, containerRuntime.name(), StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            CONTAINER_RUNTIME.toFile().deleteOnExit();
+        } catch (IOException e) {
+            log.warnf("Error writing to file %s. Ignoring it. See: %s",
+                    CONTAINER_RUNTIME.toAbsolutePath(), e);
         }
     }
 
     private static String getVersionOutputFor(ContainerRuntime containerRuntime) {
         Process versionProcess = null;
         try {
-            ProcessBuilder pb = new ProcessBuilder(containerRuntime.getExecutableName(), "--version")
+            final ProcessBuilder pb = new ProcessBuilder(containerRuntime.getExecutableName(), "--version")
                     .redirectErrorStream(true);
             versionProcess = pb.start();
             versionProcess.waitFor();
@@ -100,7 +168,7 @@ public final class ContainerRuntimeUtil {
                             bufferedReader.lines().collect(Collectors.joining(System.lineSeparator())));
                     return false;
                 } else {
-                    Predicate<String> stringPredicate;
+                    final Predicate<String> stringPredicate;
                     // Docker includes just "rootless" under SecurityOptions, while podman includes "rootless: <boolean>"
                     if (containerRuntime == ContainerRuntime.DOCKER) {
                         stringPredicate = line -> line.trim().equals("rootless");
@@ -126,19 +194,26 @@ public final class ContainerRuntimeUtil {
      */
     public enum ContainerRuntime {
         DOCKER,
-        PODMAN;
+        PODMAN,
+        UNAVAILABLE;
 
-        private final boolean rootless;
-
-        ContainerRuntime() {
-            this.rootless = getRootlessStateFor(this);
-        }
+        private Boolean rootless;
 
         public String getExecutableName() {
             return this.name().toLowerCase();
         }
 
         public boolean isRootless() {
+            if (rootless != null) {
+                return rootless;
+            } else {
+                if (this != ContainerRuntime.UNAVAILABLE) {
+                    rootless = getRootlessStateFor(this);
+                } else {
+                    throw new IllegalStateException("No container runtime was found. "
+                            + "Make sure you have either Docker or Podman installed in your environment.");
+                }
+            }
             return rootless;
         }
     }

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java
@@ -11,9 +11,13 @@ import java.util.stream.Collectors;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
+import io.smallrye.config.SmallRyeConfig;
+
 public final class ContainerRuntimeUtil {
 
     private static final Logger log = Logger.getLogger(ContainerRuntimeUtil.class);
+    private static final String DOCKER_EXECUTABLE = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class)
+            .getOptionalValue("quarkus.native.container-runtime", String.class).orElse(null);
 
     private ContainerRuntimeUtil() {
     }
@@ -32,13 +36,10 @@ public final class ContainerRuntimeUtil {
         // podman version 2.1.1
         String podmanVersionOutput = getVersionOutputFor(ContainerRuntime.PODMAN);
         boolean podmanAvailable = podmanVersionOutput.startsWith("podman version");
-
-        final String executable = ConfigProvider.getConfig()
-                .getOptionalValue("quarkus.native.container-runtime", String.class).orElse(null);
-        if (executable != null) {
-            if (executable.trim().equalsIgnoreCase("docker") && dockerAvailable) {
+        if (DOCKER_EXECUTABLE != null) {
+            if (DOCKER_EXECUTABLE.trim().equalsIgnoreCase("docker") && dockerAvailable) {
                 return ContainerRuntime.DOCKER;
-            } else if (executable.trim().equalsIgnoreCase("podman") && podmanAvailable) {
+            } else if (DOCKER_EXECUTABLE.trim().equalsIgnoreCase("podman") && podmanAvailable) {
                 return ContainerRuntime.PODMAN;
             } else {
                 log.warn("quarkus.native.container-runtime config property must be set to either podman or docker " +

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
@@ -80,31 +81,37 @@ public final class ContainerRuntimeUtil {
 
     private static boolean getRootlessStateFor(ContainerRuntime containerRuntime) {
         Process rootlessProcess = null;
+        ProcessBuilder pb = null;
         try {
-            ProcessBuilder pb = new ProcessBuilder(containerRuntime.getExecutableName(), "info")
-                    .redirectErrorStream(true);
+            pb = new ProcessBuilder(containerRuntime.getExecutableName(), "info").redirectErrorStream(true);
             rootlessProcess = pb.start();
             int exitCode = rootlessProcess.waitFor();
             if (exitCode != 0) {
                 log.warnf("Command \"%s\" exited with error code %d. " +
-                        "Rootless container runtime detection might not be reliable.",
-                        containerRuntime.getExecutableName(), exitCode);
+                        "Rootless container runtime detection might not be reliable or the container service is not running at all.",
+                        String.join(" ", pb.command()), exitCode);
             }
             try (InputStream inputStream = rootlessProcess.getInputStream();
                     InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
                     BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
-                Predicate<String> stringPredicate;
-                // Docker includes just "rootless" under SecurityOptions, while podman includes "rootless: <boolean>"
-                if (containerRuntime == ContainerRuntime.DOCKER) {
-                    stringPredicate = line -> line.trim().equals("rootless");
+                if (exitCode != 0) {
+                    log.debugf("Command \"%s\" output: %s", String.join(" ", pb.command()),
+                            bufferedReader.lines().collect(Collectors.joining(System.lineSeparator())));
+                    return false;
                 } else {
-                    stringPredicate = line -> line.trim().equals("rootless: true");
+                    Predicate<String> stringPredicate;
+                    // Docker includes just "rootless" under SecurityOptions, while podman includes "rootless: <boolean>"
+                    if (containerRuntime == ContainerRuntime.DOCKER) {
+                        stringPredicate = line -> line.trim().equals("rootless");
+                    } else {
+                        stringPredicate = line -> line.trim().equals("rootless: true");
+                    }
+                    return bufferedReader.lines().anyMatch(stringPredicate);
                 }
-                return bufferedReader.lines().anyMatch(stringPredicate);
             }
         } catch (IOException | InterruptedException e) {
             // If an exception is thrown in the process, assume we are not running rootless (default docker installation)
-            log.debugf(e, "Failure to read info output from %s", containerRuntime.getExecutableName());
+            log.debugf(e, "Failure to read info output from %s", String.join(" ", pb.command()));
             return false;
         } finally {
             if (rootlessProcess != null) {

--- a/integration-tests/awt/pom.xml
+++ b/integration-tests/awt/pom.xml
@@ -27,6 +27,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-multipart</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-docker</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>
@@ -45,6 +49,8 @@
             <scope>test</scope>
         </dependency>
 
+
+
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -59,7 +65,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-multipart-deployment</artifactId>
@@ -99,7 +104,19 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-docker-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -127,6 +144,26 @@
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                <maven.home>${maven.home}</maven.home>
+                                <quarkus.http.host>localhost</quarkus.http.host>
+                                <quarkus.http.port>8081</quarkus.http.port>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/integration-tests/awt/src/main/docker/Dockerfile.native
+++ b/integration-tests/awt/src/main/docker/Dockerfile.native
@@ -1,0 +1,15 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+# Dependencies for AWT
+RUN microdnf install freetype fontconfig \
+    && microdnf clean all
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root target/*-runner /work/application
+# Permissions fix for Windows
+RUN chmod "ugo+x" /work/application
+EXPOSE 8081
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -5,15 +5,12 @@ import static io.quarkus.test.common.LauncherUtil.updateConfigForPort;
 import static io.quarkus.test.common.LauncherUtil.waitForCapturedListeningData;
 import static io.quarkus.test.common.LauncherUtil.waitForStartedFunction;
 import static java.lang.ProcessBuilder.Redirect.DISCARD;
-import static java.lang.ProcessBuilder.Redirect.PIPE;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.ServerSocket;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,14 +21,16 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import org.apache.commons.io.input.TeeInputStream;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.util.ContainerRuntimeUtil;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
 import io.smallrye.config.common.utils.StringUtil;
 
 public class DefaultDockerContainerLauncher implements DockerContainerArtifactLauncher {
+
+    private static final Logger log = Logger.getLogger(DefaultDockerContainerLauncher.class);
 
     private int httpPort;
     private int httpsPort;
@@ -42,16 +41,11 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
     private String containerImage;
     private boolean pullRequired;
     private Map<Integer, Integer> additionalExposedPorts;
-
     private final Map<String, String> systemProps = new HashMap<>();
-
     private boolean isSsl;
-
-    private String containerName;
-
+    private final String containerName = "quarkus-integration-test-" + RandomStringUtils.random(5, true, false);
     private String containerRuntimeBinaryName;
-
-    private ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
     @Override
     public void init(DockerContainerArtifactLauncher.DockerInitContext initContext) {
@@ -77,7 +71,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         containerRuntimeBinaryName = determineBinary();
 
         if (pullRequired) {
-            System.out.println("Pulling container image '" + containerImage + "'");
+            log.infof("Pulling container image '%s'", containerImage);
             try {
                 int pullResult = new ProcessBuilder().redirectError(DISCARD).redirectOutput(DISCARD)
                         .command(containerRuntimeBinaryName, "pull", containerImage).start().waitFor();
@@ -98,21 +92,21 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
             httpsPort = getRandomPort();
         }
 
-        List<String> args = new ArrayList<>();
+        final List<String> args = new ArrayList<>();
         args.add(containerRuntimeBinaryName);
         args.add("run");
         if (!argLine.isEmpty()) {
             args.addAll(argLine);
         }
         args.add("--name");
-        containerName = "quarkus-integration-test-" + RandomStringUtils.random(5, true, false);
         args.add(containerName);
+        args.add("-i"); // Interactive, write logs to stdout
         args.add("--rm");
         args.add("-p");
         args.add(httpPort + ":" + httpPort);
         args.add("-p");
         args.add(httpsPort + ":" + httpsPort);
-        for (var entry : additionalExposedPorts.entrySet()) {
+        for (Map.Entry<Integer, Integer> entry : additionalExposedPorts.entrySet()) {
             args.add("-p");
             args.add(entry.getKey() + ":" + entry.getValue());
         }
@@ -125,7 +119,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         if (DefaultJarLauncher.HTTP_PRESENT) {
             args.addAll(toEnvVar("quarkus.http.port", "" + httpPort));
             args.addAll(toEnvVar("quarkus.http.ssl-port", "" + httpsPort));
-            // this won't be correct when using the random port but it's really only used by us for the rest client tests
+            // This won't be correct when using the random port, but it's really only used by us for the rest client tests
             // in the main module, since those tests hit the application itself
             args.addAll(toEnvVar("test.url", TestHTTPResourceManager.getUri()));
         }
@@ -138,31 +132,31 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         }
         args.add(containerImage);
 
-        Path logFile = PropertyTestUtil.getLogFilePath();
-        Files.deleteIfExists(logFile);
-        Files.createDirectories(logFile.getParent());
+        final Path logFile = PropertyTestUtil.getLogFilePath();
+        try {
+            Files.deleteIfExists(logFile);
+            Files.createDirectories(logFile.getParent());
+        } catch (FileSystemException e) {
+            log.warnf("Log file %s deletion failed, could happen on Windows, we can carry on.", logFile);
+        }
 
-        Path containerLogFile = Paths.get("target", "container.log");
-        Files.createDirectories(containerLogFile.getParent());
-        FileOutputStream containerLogOutputStream = new FileOutputStream(containerLogFile.toFile(), true);
+        log.infof("Executing \"%s\"", String.join(" ", args));
 
-        System.out.println("Executing \"" + String.join(" ", args) + "\"");
+        final Function<IntegrationTestStartedNotifier.Context, IntegrationTestStartedNotifier.Result> startedFunction = createStartedFunction();
 
-        Function<IntegrationTestStartedNotifier.Context, IntegrationTestStartedNotifier.Result> startedFunction = createStartedFunction();
-
-        // the idea here is to obtain the logs of the application simply by redirecting all its output the a file
-        // this is done in contrast with the JarLauncher and NativeImageLauncher because in the case of the container
-        // the log itself is written inside the container
-        Process quarkusProcess = new ProcessBuilder(args).redirectError(PIPE).redirectOutput(PIPE).start();
-        InputStream tee = new TeeInputStream(quarkusProcess.getInputStream(), new FileOutputStream(logFile.toFile()));
-        executorService.submit(() -> tee.transferTo(containerLogOutputStream));
+        // We rely on the container writing log to stdout. If it just writes to a logfile inside itself, we would have
+        // to mount /work/ directory to get quarkus.log.
+        final Process containerProcess = new ProcessBuilder(args)
+                .redirectErrorStream(true)
+                .redirectOutput(ProcessBuilder.Redirect.appendTo(logFile.toFile()))
+                .start();
 
         if (startedFunction != null) {
-            IntegrationTestStartedNotifier.Result result = waitForStartedFunction(startedFunction, quarkusProcess,
+            final IntegrationTestStartedNotifier.Result result = waitForStartedFunction(startedFunction, containerProcess,
                     waitTimeSeconds, logFile);
             isSsl = result.isSsl();
         } else {
-            ListeningAddress result = waitForCapturedListeningData(quarkusProcess, logFile, waitTimeSeconds);
+            final ListeningAddress result = waitForCapturedListeningData(containerProcess, logFile, waitTimeSeconds);
             updateConfigForPort(result.getPort());
             isSsl = result.isSsl();
         }
@@ -188,10 +182,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
 
     private List<String> toEnvVar(String property, String value) {
         if ((property != null) && (!property.isEmpty())) {
-            List<String> result = new ArrayList<>(2);
-            result.add("--env");
-            result.add(String.format("%s=%s", convertPropertyToEnvVar(property), value));
-            return result;
+            return List.of("--env", String.format("%s=%s", convertPropertyToEnvVar(property), value));
         }
         return Collections.emptyList();
     }
@@ -203,14 +194,13 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
     @Override
     public void close() {
         try {
-            Process dockerStopProcess = new ProcessBuilder(containerRuntimeBinaryName, "stop", containerName)
+            final Process dockerStopProcess = new ProcessBuilder(containerRuntimeBinaryName, "stop", containerName)
                     .redirectError(DISCARD)
                     .redirectOutput(DISCARD).start();
             dockerStopProcess.waitFor(10, TimeUnit.SECONDS);
         } catch (IOException | InterruptedException e) {
-            System.out.println("Unable to stop container '" + containerName + "'");
+            log.errorf("Unable to stop container '%s'", containerName);
         }
         executorService.shutdown();
     }
-
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
@@ -130,7 +130,7 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
             args.add("-Dtest.url=" + TestHTTPResourceManager.getUri());
         }
         Path logFile = PropertyTestUtil.getLogFilePath();
-        args.add("-Dquarkus.log.file.path=" + logFile.toAbsolutePath().toString());
+        args.add("-Dquarkus.log.file.path=" + logFile.toAbsolutePath());
         args.add("-Dquarkus.log.file.enable=true");
         args.add("-Dquarkus.log.category.\"io.quarkus\".level=INFO");
         if (testProfile != null) {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -253,7 +253,7 @@ public final class LauncherUtil {
 
                         long now = System.currentTimeMillis();
                         // if we have seen info that the app is started in the log a while ago
-                        // or waiting the the next check interval will exceed the bailout time, it's time to finish waiting:
+                        // or waiting the next check interval will exceed the bailout time, it's time to finish waiting:
                         if (now + LOG_CHECK_INTERVAL > bailoutTime || now - 2 * LOG_CHECK_INTERVAL > timeStarted) {
                             if (started) {
                                 dataDetermined(null, null); // no http, all is null

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.junit;
 
+import static io.quarkus.runtime.util.ContainerRuntimeUtil.detectContainerRuntime;
 import static io.quarkus.test.common.PathTestHelper.getAppClassLocationForTestLocation;
 import static io.quarkus.test.common.PathTestHelper.getTestClassesLocation;
 import static java.lang.ProcessBuilder.Redirect.DISCARD;
@@ -34,7 +35,6 @@ import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.jandex.Index;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -64,9 +64,7 @@ public final class IntegrationTestUtil {
     public static final int DEFAULT_PORT = 8081;
     public static final int DEFAULT_HTTPS_PORT = 8444;
     public static final long DEFAULT_WAIT_TIME_SECONDS = 60;
-
-    private static final String DOCKER_BINARY = ConfigProvider.getConfig()
-            .getOptionalValue("quarkus.native.container-runtime", String.class).orElse("docker");
+    private static final String DOCKER_BINARY = detectContainerRuntime().getExecutableName();
 
     private IntegrationTestUtil() {
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -34,6 +34,7 @@ import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.jandex.Index;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -64,7 +65,8 @@ public final class IntegrationTestUtil {
     public static final int DEFAULT_HTTPS_PORT = 8444;
     public static final long DEFAULT_WAIT_TIME_SECONDS = 60;
 
-    private static final String DOCKER_BINARY = "docker";
+    private static final String DOCKER_BINARY = ConfigProvider.getConfig()
+            .getOptionalValue("quarkus.native.container-runtime", String.class).orElse("docker");
 
     private IntegrationTestUtil() {
     }


### PR DESCRIPTION
This PR addresses problems I experienced trying to run `quarkus-container-image-docker` driven tests on Windows with [Podman for Windows](https://github.com/containers/podman/blob/main/docs/tutorials/podman-for-windows.md) and with Docker Desktop for Windows.

I used the changes to Quarkus 2.16 branch to [integrate Quarkus PrimeFaces test](https://github.com/quarkiverse/quarkus-primefaces/pull/12) run that uses a builder image to compile a Linux native executable and then builds a runtime image and runs it for tests. It enables people who work with Windows to test the native workflow despite the fact we do not support Windows MSVC toolchain with e.g. AWT dependency.

# Notes

 * `quarkus.docker.executable-name` and `quarkus.native.container-runtime`, the former actually comes from
    the quarkus-container-image-docker and the latter from the core. It is used instead of the hardcoded "docker"

 * `Caused by: java.nio.file.FileSystemException: target\quarkus.log: The process cannot access the file because it is being used by another process`
    is now wrapped in a try block with a logged warning.

 * Logs from the container: The former logic did not work for me on Windows, the log was left in the container
   and there was nothing to pipe to a file. Was it formerly used with mounting the volume? I added `-i` so as the container
   pours the log to stdout and capture that. WDYT @geoand 🤔?

 * Added quarkus-container-image-docker based test to the AWT extension test to try these changes.

# Testing

I used the AWT integration test like this to test Podman and Docker on Linux and Windows:

```
mvnw clean verify -f integration-tests/pom.xml -pl awt -Ddocker -Dnative
  -Dnative.surefire.skip
  -Dquarkus.native.container-build=true
  -Dquarkus.container-image.build=true
  -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17
  -Dquarkus.native.container-runtime=podman
  -Dquarkus.docker.executable-name=podman
```
(with `docker` in docker variants)

Logs for Quarkus main:

| System     | Podman                        | Docker    |
|------------|-------------------------------|-----------|
| CentOS 8   | 4.0.2 :heavy_check_mark: [logs](https://karms.biz/pastebin/linux-awt-podman-q-main.log.txt)| 20.10.21 :heavy_check_mark: [logs](https://karms.biz/pastebin/linux-awt-docker-q-main.log.txt)|
| Windows 10 | 4.1.0 :heavy_check_mark: [logs](https://karms.biz/pastebin/windows-awt-podman-q-main.log.txt)|  20.10.22 :heavy_check_mark: [logs](https://karms.biz/pastebin/windows-awt-docker-q-main.log.txt) |

