### PR TITLE
Fix maven BuildIT failures

### DIFF
--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
@@ -313,8 +313,11 @@ public class JaxbProcessor {
 
         // parse class names to class
         Set<Class<?>> classes = getAllClassesFromClassNames(classNamesToBeBound);
-        // validate the context to fail at build time if it's not valid
-        validateContext(classes);
+        if (config.validateJaxbContext) {
+            // validate the context to fail at build time if it's not valid
+            validateContext(classes);
+        }
+
         // register the classes to be used at runtime
         jaxbContextConfig.addClassesToBeBound(classes);
     }

--- a/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbConfig.java
+++ b/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbConfig.java
@@ -9,6 +9,13 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED, name = "jaxb")
 public class JaxbConfig {
+
+    /**
+     * If enabled, it will validate the default JAXB context at build time.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean validateJaxbContext;
+
     /**
      * Exclude classes to automatically be bound to the default JAXB context.
      */

--- a/integration-tests/maven/src/test/resources-filtered/projects/classloader-linkage-error/src/main/resources/application.properties
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classloader-linkage-error/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 quarkus.class-loading.parent-first-artifacts=stax:stax-api
+# The dependency `stax-api` is not compatible with the dependency `quarkus-jaxb` because both add the same
+# type `javax.xml.namespace.QName`. This was done on purpose to validate the `parent-first-artifacts` property when building
+# projects with conflicts with Maven, so we need to skip the JaxbContext validation at build time.
+quarkus.jaxb.validate-jaxb-context=false


### PR DESCRIPTION
# Context
The dependency `stax-api` is not compatible with the dependency `quarkus-jaxb` because both add the same type `javax.xml.namespace.QName` (from `glassfish jaxb`). This dependency [was added](https://github.com/quarkusio/quarkus/pull/17392) on purpose to validate the `parent-first-artifacts` property when building projects with these conflicts with Maven. 

After this change was merged, the `javax.` types were replaced by the `quarkus-jaxb` extension as part of [the jakarta migration](https://github.com/quarkusio/quarkus/pull/27527), but never with the intention of using the default JAXBContext. 

Therefore, we need to skip the JaxbContext validation at build time. 
Note that in real scenarios, users would need to either exclude glassfish or the stax-api dependency.

This pull request should fix all the CI failures in the latest pull requests.