### PR TITLE
Make sure PUs are active in PostgresOpenTelemetryJdbcInstrumentationIT

### DIFF
--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/main/resources/application.properties
@@ -47,6 +47,7 @@ quarkus.datasource.db2.jdbc.max-size=1
 %oracle-profile.quarkus.datasource."oracle".password=quarkus
 %oracle-profile.quarkus.datasource."oracle".username=SYSTEM
 %oracle-profile.quarkus.hibernate-orm."oracle".database.generation=drop-and-create
+%oracle-profile.quarkus.hibernate-orm."oracle".active=true
 %oracle-profile.quarkus.hibernate-orm.mariadb.active=false
 %oracle-profile.quarkus.hibernate-orm.postgresql.active=false
 %oracle-profile.quarkus.hibernate-orm.db2.active=false

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/Db2LifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/Db2LifecycleManager.java
@@ -27,6 +27,7 @@ public class Db2LifecycleManager implements QuarkusTestResourceLifecycleManager 
         properties.put("quarkus.datasource.db2.password", QUARKUS);
         properties.put("quarkus.datasource.db2.username", QUARKUS);
         properties.put("quarkus.hibernate-orm.db2.database.generation", "drop-and-create");
+        properties.put("quarkus.hibernate-orm.db2.active", "true");
         properties.put("quarkus.hibernate-orm.oracle.active", "false");
         properties.put("quarkus.hibernate-orm.postgresql.active", "false");
         properties.put("quarkus.hibernate-orm.mariadb.active", "false");

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/MariaDbLifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/MariaDbLifecycleManager.java
@@ -27,6 +27,7 @@ public class MariaDbLifecycleManager implements QuarkusTestResourceLifecycleMana
         properties.put("quarkus.datasource.mariadb.password", QUARKUS);
         properties.put("quarkus.datasource.mariadb.username", QUARKUS);
         properties.put("quarkus.hibernate-orm.mariadb.database.generation", "drop-and-create");
+        properties.put("quarkus.hibernate-orm.mariadb.active", "true");
         properties.put("quarkus.hibernate-orm.oracle.active", "false");
         properties.put("quarkus.hibernate-orm.postgresql.active", "false");
         properties.put("quarkus.hibernate-orm.db2.active", "false");

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgreSqlLifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgreSqlLifecycleManager.java
@@ -27,6 +27,7 @@ public class PostgreSqlLifecycleManager implements QuarkusTestResourceLifecycleM
         properties.put("quarkus.datasource.postgresql.password", QUARKUS);
         properties.put("quarkus.datasource.postgresql.username", QUARKUS);
         properties.put("quarkus.hibernate-orm.postgresql.database.generation", "drop-and-create");
+        properties.put("quarkus.hibernate-orm.postgresql.active", "true");
         properties.put("quarkus.hibernate-orm.oracle.active", "false");
         properties.put("quarkus.hibernate-orm.mariadb.active", "false");
         properties.put("quarkus.hibernate-orm.db2.active", "false");


### PR DESCRIPTION
I have seen PostgresOpenTelemetryJdbcInstrumentationIT failing with all persistence units being disabled so trying to activate them explicitly as there might be some weird race conditions.