### PR TITLE
Fix randomly failures when deploying to OpenShift/K8s on JVM/Native

### DIFF
--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
@@ -171,7 +171,7 @@ public class S2iProcessor {
 
     @BuildStep(onlyIf = { IsNormalNotRemoteDev.class, S2iBuild.class }, onlyIfNot = NativeBuild.class)
     public void s2iBuildFromJar(S2iConfig s2iConfig, ContainerImageConfig containerImageConfig,
-            KubernetesClientBuildItem kubernetesClientSupplier,
+            KubernetesClientBuildItem kubernetesClientBuilder,
             ContainerImageInfoBuildItem containerImage,
             ArchiveRootBuildItem archiveRoot, OutputTargetBuildItem out, PackageConfig packageConfig,
             List<GeneratedFileSystemResourceBuildItem> generatedResources,
@@ -201,7 +201,7 @@ public class S2iProcessor {
                     "No Openshift manifests were generated so no s2i process will be taking place");
             return;
         }
-        try (KubernetesClient kubernetesClient = kubernetesClientSupplier.getClient().get()) {
+        try (KubernetesClient kubernetesClient = kubernetesClientBuilder.buildClient()) {
             String namespace = Optional.ofNullable(kubernetesClient.getNamespace()).orElse("default");
             LOG.info("Performing s2i binary build with jar on server: " + kubernetesClient.getMasterUrl()
                     + " in namespace:" + namespace + ".");
@@ -215,7 +215,7 @@ public class S2iProcessor {
 
     @BuildStep(onlyIf = { IsNormalNotRemoteDev.class, S2iBuild.class, NativeBuild.class })
     public void s2iBuildFromNative(S2iConfig s2iConfig, ContainerImageConfig containerImageConfig,
-            KubernetesClientBuildItem kubernetesClientSupplier,
+            KubernetesClientBuildItem kubernetesClientBuilder,
             ContainerImageInfoBuildItem containerImage,
             ArchiveRootBuildItem archiveRoot, OutputTargetBuildItem out, PackageConfig packageConfig,
             List<GeneratedFileSystemResourceBuildItem> generatedResources,
@@ -234,7 +234,7 @@ public class S2iProcessor {
             return;
         }
 
-        try (KubernetesClient kubernetesClient = kubernetesClientSupplier.getClient().get()) {
+        try (KubernetesClient kubernetesClient = kubernetesClientBuilder.buildClient()) {
             String namespace = Optional.ofNullable(kubernetesClient.getNamespace()).orElse("default");
             LOG.info("Performing s2i binary build with native image on server: " + kubernetesClient.getMasterUrl()
                     + " in namespace:" + namespace + ".");

--- a/extensions/kubernetes-client/deployment-internal/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientBuildStep.java
+++ b/extensions/kubernetes-client/deployment-internal/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientBuildStep.java
@@ -1,9 +1,11 @@
 package io.quarkus.kubernetes.client.deployment;
 
-import static io.quarkus.kubernetes.client.runtime.KubernetesClientUtils.*;
+import static io.quarkus.kubernetes.client.runtime.KubernetesClientUtils.createConfig;
 
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.QuarkusBuildCloseablesBuildItem;
 import io.quarkus.kubernetes.client.runtime.KubernetesClientBuildConfig;
+import io.quarkus.kubernetes.client.runtime.QuarkusHttpClientFactory;
 import io.quarkus.kubernetes.client.spi.KubernetesClientBuildItem;
 import io.quarkus.runtime.TlsConfig;
 
@@ -12,7 +14,9 @@ public class KubernetesClientBuildStep {
     private KubernetesClientBuildConfig buildConfig;
 
     @BuildStep
-    public KubernetesClientBuildItem process(TlsConfig tlsConfig) {
-        return new KubernetesClientBuildItem(createConfig(buildConfig, tlsConfig));
+    public KubernetesClientBuildItem process(TlsConfig tlsConfig, QuarkusBuildCloseablesBuildItem closeablesBuildItem) {
+        QuarkusHttpClientFactory httpClientFactory = new QuarkusHttpClientFactory();
+        closeablesBuildItem.add(httpClientFactory);
+        return new KubernetesClientBuildItem(createConfig(buildConfig, tlsConfig), httpClientFactory);
     }
 }

--- a/extensions/kubernetes-client/runtime-internal/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.http.HttpClient$Factory
+++ b/extensions/kubernetes-client/runtime-internal/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.http.HttpClient$Factory
@@ -1,1 +1,0 @@
-io.quarkus.kubernetes.client.runtime.QuarkusHttpClientFactory

--- a/extensions/kubernetes-client/spi/src/main/java/io/quarkus/kubernetes/client/spi/KubernetesClientBuildItem.java
+++ b/extensions/kubernetes-client/spi/src/main/java/io/quarkus/kubernetes/client/spi/KubernetesClientBuildItem.java
@@ -1,26 +1,30 @@
 package io.quarkus.kubernetes.client.spi;
 
-import java.util.function.Supplier;
-
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.http.HttpClient;
 import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class KubernetesClientBuildItem extends SimpleBuildItem {
 
     private final Config config;
+    private final HttpClient.Factory httpClientFactory;
 
-    public KubernetesClientBuildItem(Config config) {
+    public KubernetesClientBuildItem(Config config, HttpClient.Factory httpClientFactory) {
         this.config = config;
-    }
-
-    public Supplier<KubernetesClient> getClient() {
-        return () -> new KubernetesClientBuilder().withConfig(config).build();
+        this.httpClientFactory = httpClientFactory;
     }
 
     public Config getConfig() {
         return config;
     }
 
+    public HttpClient.Factory getHttpClientFactory() {
+        return httpClientFactory;
+    }
+
+    public KubernetesClient buildClient() {
+        return new KubernetesClientBuilder().withConfig(config).withHttpClientFactory(httpClientFactory).build();
+    }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeDeployer.java
@@ -17,13 +17,14 @@ public class KnativeDeployer {
     @BuildStep
     public void checkEnvironment(Optional<SelectedKubernetesDeploymentTargetBuildItem> selectedDeploymentTarget,
             List<GeneratedKubernetesResourceBuildItem> resources,
-            KubernetesClientBuildItem clientSupplier, BuildProducer<KubernetesDeploymentClusterBuildItem> deploymentCluster) {
+            KubernetesClientBuildItem kubernetesClientBuilder,
+            BuildProducer<KubernetesDeploymentClusterBuildItem> deploymentCluster) {
         selectedDeploymentTarget.ifPresent(target -> {
-            if (!KubernetesDeploy.INSTANCE.checkSilently()) {
+            if (!KubernetesDeploy.INSTANCE.checkSilently(kubernetesClientBuilder)) {
                 return;
             }
             if (target.getEntry().getName().equals(KNATIVE)) {
-                try (DefaultKnativeClient client = clientSupplier.getClient().get().adapt(DefaultKnativeClient.class)) {
+                try (DefaultKnativeClient client = kubernetesClientBuilder.buildClient().adapt(DefaultKnativeClient.class)) {
                     if (client.isSupported()) {
                         deploymentCluster.produce(new KubernetesDeploymentClusterBuildItem(KNATIVE));
                     } else {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployerPrerequisite.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployerPrerequisite.java
@@ -10,11 +10,13 @@ import io.quarkus.container.spi.FallbackContainerImageRegistryBuildItem;
 import io.quarkus.deployment.IsNormalNotRemoteDev;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.kubernetes.client.spi.KubernetesClientBuildItem;
 
 public class KubernetesDeployerPrerequisite {
 
     @BuildStep(onlyIf = IsNormalNotRemoteDev.class)
     public void prepare(ContainerImageInfoBuildItem containerImage,
+            KubernetesClientBuildItem kubernetesClientBuilder,
             Optional<SelectedKubernetesDeploymentTargetBuildItem> selectedDeploymentTarget,
             Optional<FallbackContainerImageRegistryBuildItem> fallbackRegistry,
             List<PreventImplicitContainerImagePushBuildItem> preventImplicitContainerImagePush,
@@ -23,7 +25,7 @@ public class KubernetesDeployerPrerequisite {
 
         // we don't want to throw an exception at this step and fail the build because it could prevent
         // the Kubernetes resources from being generated
-        if (!KubernetesDeploy.INSTANCE.checkSilently() || !selectedDeploymentTarget.isPresent()) {
+        if (!KubernetesDeploy.INSTANCE.checkSilently(kubernetesClientBuilder) || !selectedDeploymentTarget.isPresent()) {
             return;
         }
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftDeployer.java
@@ -18,13 +18,14 @@ public class OpenshiftDeployer {
     @BuildStep
     public void checkEnvironment(Optional<SelectedKubernetesDeploymentTargetBuildItem> selectedDeploymentTarget,
             List<GeneratedKubernetesResourceBuildItem> resources,
-            KubernetesClientBuildItem clientSupplier, BuildProducer<KubernetesDeploymentClusterBuildItem> deploymentCluster) {
+            KubernetesClientBuildItem kubernetesClientBuilder,
+            BuildProducer<KubernetesDeploymentClusterBuildItem> deploymentCluster) {
         selectedDeploymentTarget.ifPresent(target -> {
-            if (!KubernetesDeploy.INSTANCE.checkSilently()) {
+            if (!KubernetesDeploy.INSTANCE.checkSilently(kubernetesClientBuilder)) {
                 return;
             }
             if (target.getEntry().getName().equals(OPENSHIFT)) {
-                try (var openShiftClient = clientSupplier.getClient().get().adapt(OpenShiftClient.class)) {
+                try (var openShiftClient = kubernetesClientBuilder.buildClient().adapt(OpenShiftClient.class)) {
                     if (openShiftClient.isSupported()) {
                         deploymentCluster.produce(new KubernetesDeploymentClusterBuildItem(OPENSHIFT));
                     } else {


### PR DESCRIPTION
Finally, I've found out the root cause of this issue. There were several places where a new KubernetesClient was being created:
- Some places use `Clients.fromConfig`.
- Other places use `KubernetesClientUtils.createConfig`.
- And other places use `KubernetesClientBuildItem.getClient`

And the problem is that every time we invoke any of these methods, Fabric8 KubernetesClient tries to locate one HttpClient.Factory and it seems that the logic to get one HttpClient.Factory sometimes gets the `VertxHttpClientFactory` implementation over the expected one `QuarkusHttpClientFactory`.

The previous solution about keeping the Disable Http Dns system property worked fine because this property was used either by `VertxHttpClientFactory` or `QuarkusHttpClientFactory`.

However, I've updated the pull request with a better solution and more efficient one as it avoids finding a HttpClient.Factory via the ServiceLoader logic in Fabric8 Kubernetes Client, but instead it directly provides the expected `QuarkusHttpClientFactory` implementation always.

Also, the warning message that always appeared, it's now gone:

```
[WARNING] [io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider] Default DNS servers: [/[2001:4860:4860:0:0:0:0:8888]:53, /[2001:4860:4860:0:0:0:0:8844]:53] (Google Public DNS as a fallback)
[WARNING] There are multiple httpclient implementation in the classpath, choosing the first non-default implementation. You should exclude dependencies that aren't needed or use an explicit association of the HttpClient.Factory.
```

Fix https://github.com/quarkusio/quarkus/issues/31476