### PR TITLE
Dump build logs when MavenIT fails

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/BuildIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/BuildIT.java
@@ -226,7 +226,12 @@ class BuildIT extends MojoTestBase {
             }
         }
         MavenProcessInvocationResult result = running.execute(args, Collections.emptyMap());
-        assertThat(result.getProcess().waitFor()).isZero();
+        int exitCode = result.getProcess().waitFor();
+        if (exitCode != 0) {
+            System.err.println(running.log()); //dump the log in order to make it easier find error in CI
+            assertThat(exitCode).isZero(); // make sure the build fails
+        }
+
     }
 
     private void ensureManifestOfJarIsReadableByJarInputStream(File jar) throws IOException {


### PR DESCRIPTION
This makes it possible to view the exact
problem in CI logs instead of forcing
us to run the test locally and locate the build output is (I doubt more than 2 or 3 people know where it is)