### PR TITLE
Bump owasp version to 8.1.2

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -174,7 +174,7 @@
 
         <!-- google cloud functions invoker-->
         <gcf-invoker.version>1.1.1</gcf-invoker.version>
-        <owasp-dependency-check-plugin.version>7.4.4</owasp-dependency-check-plugin.version>
+        <owasp-dependency-check-plugin.version>8.1.2</owasp-dependency-check-plugin.version>
 
         <!-- Jakarta JMS API -->
         <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
@@ -721,6 +721,7 @@
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         <nugetconfAnalyzerEnabled>false</nugetconfAnalyzerEnabled>
                         <nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
+                        <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
                     </configuration>
                 </plugin>
             </plugins>

--- a/docs/src/main/asciidoc/security-vulnerability-detection-concept.adoc
+++ b/docs/src/main/asciidoc/security-vulnerability-detection-concept.adoc
@@ -38,7 +38,7 @@ To add the OWASP Dependency check plugin to your Quarkus Maven project, add the 
 
 [IMPORTANT]
 ====
-Set the `owasp-dependency-check-plugin.version` value to `7.4.4` or later.
+Set the `owasp-dependency-check-plugin.version` value to `8.1.2` or later.
 ====
 
 Next, configure the plugin as follows:


### PR DESCRIPTION
This PR bumps the version but also disables an experimental RetireJsAnalyzer, as it generates a lot of noise in vertx-http