### PR TITLE
Adjust API in transaction.adoc code snippet

### DIFF
--- a/docs/src/main/asciidoc/transaction.adoc
+++ b/docs/src/main/asciidoc/transaction.adoc
@@ -189,7 +189,7 @@ public class TransactionExample {
                     if (throwable instanceof SomeException) {
                         return RunOptions.ExceptionResult.COMMIT;
                     }
-                    return RunOptions.ExceptionResult.ROLLBACK;
+                    return TransactionExceptionResult.ROLLBACK;
                 })
                 .call(() -> {
                     //do work


### PR DESCRIPTION
Transaction API has changed on Quarkus 2.16. 

I think that references to old `RunOptions.ExceptionResult.ROLLBACK` should be replaced by `TransactionExceptionResult.ROLLBACK`

This PR patch the latest transaction API doc