### PR TITLE
Fix removed resource artifact ref in keycloak-admin-client-reactive

### DIFF
--- a/extensions/keycloak-admin-client-reactive/runtime/pom.xml
+++ b/extensions/keycloak-admin-client-reactive/runtime/pom.xml
@@ -76,7 +76,7 @@
                 <configuration>
                     <removedResources>
                         <artifact>
-                            <key>org.keycloak:keycloak-admin-client</key>
+                            <key>org.keycloak:keycloak-admin-client-jakarta</key>
                             <resources>org/keycloak/admin/client/JacksonProvider.class</resources>
                         </artifact>
                     </removedResources>


### PR DESCRIPTION
It was still referencing the non-jakarta artifact which is not a dependency anymore.