### PR TITLE
Interpret negative/zero body-limit as infinite when logging REST Client request body

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/logging/DefaultClientLogger.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/logging/DefaultClientLogger.java
@@ -57,6 +57,8 @@ public class DefaultClientLogger implements ClientLogger {
     private String bodyToString(Buffer body) {
         if (body == null) {
             return "";
+        } else if (bodySize <= 0) {
+            return body.toString();
         } else {
             String bodyAsString = body.toString();
             return bodyAsString.substring(0, Math.min(bodySize, bodyAsString.length()));


### PR DESCRIPTION
Currently, if body-limit is set to -1 or zero, there will be either an IOOB exception, or an empty String.

Instead, interpret body-limit <= 0 as 'no limit'.