### PR TITLE
Make sure PUs are active in PostgresOpenTelemetryJdbcInstrumentationIT

### DIFF
--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/main/resources/application.properties
@@ -41,12 +41,3 @@ quarkus.hibernate-orm.db2.database.generation=none
 quarkus.datasource.db2.db-kind=db2
 quarkus.datasource.db2.jdbc.driver=${driver}
 quarkus.datasource.db2.jdbc.max-size=1
-
-# Oracle test profile properties
-%oracle-profile.quarkus.datasource."oracle".jdbc.url=jdbc:otel:oracle:thin:@localhost:1521/XE
-%oracle-profile.quarkus.datasource."oracle".password=quarkus
-%oracle-profile.quarkus.datasource."oracle".username=SYSTEM
-%oracle-profile.quarkus.hibernate-orm."oracle".database.generation=drop-and-create
-%oracle-profile.quarkus.hibernate-orm.mariadb.active=false
-%oracle-profile.quarkus.hibernate-orm.postgresql.active=false
-%oracle-profile.quarkus.hibernate-orm.db2.active=false

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/Db2LifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/Db2LifecycleManager.java
@@ -27,6 +27,7 @@ public class Db2LifecycleManager implements QuarkusTestResourceLifecycleManager 
         properties.put("quarkus.datasource.db2.password", QUARKUS);
         properties.put("quarkus.datasource.db2.username", QUARKUS);
         properties.put("quarkus.hibernate-orm.db2.database.generation", "drop-and-create");
+        properties.put("quarkus.hibernate-orm.db2.active", "true");
         properties.put("quarkus.hibernate-orm.oracle.active", "false");
         properties.put("quarkus.hibernate-orm.postgresql.active", "false");
         properties.put("quarkus.hibernate-orm.mariadb.active", "false");

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/MariaDbLifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/MariaDbLifecycleManager.java
@@ -27,6 +27,7 @@ public class MariaDbLifecycleManager implements QuarkusTestResourceLifecycleMana
         properties.put("quarkus.datasource.mariadb.password", QUARKUS);
         properties.put("quarkus.datasource.mariadb.username", QUARKUS);
         properties.put("quarkus.hibernate-orm.mariadb.database.generation", "drop-and-create");
+        properties.put("quarkus.hibernate-orm.mariadb.active", "true");
         properties.put("quarkus.hibernate-orm.oracle.active", "false");
         properties.put("quarkus.hibernate-orm.postgresql.active", "false");
         properties.put("quarkus.hibernate-orm.db2.active", "false");

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleLifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleLifecycleManager.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.opentelemetry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class OracleLifecycleManager implements QuarkusTestResourceLifecycleManager {
+
+    @Override
+    public Map<String, String> start() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("quarkus.datasource.oracle.jdbc.url", "jdbc:otel:oracle:thin:@localhost:1521/XE");
+        properties.put("quarkus.datasource.oracle.password", "quarkus");
+        properties.put("quarkus.datasource.oracle.username", "SYSTEM");
+        properties.put("quarkus.hibernate-orm.oracle.database.generation", "drop-and-create");
+        properties.put("quarkus.hibernate-orm.oracle.active", "true");
+        properties.put("quarkus.hibernate-orm.mariadb.active", "false");
+        properties.put("quarkus.hibernate-orm.postgresql.active", "false");
+        properties.put("quarkus.hibernate-orm.db2.active", "false");
+
+        return properties;
+    }
+
+    @Override
+    public void stop() {
+        // EMPTY
+    }
+
+}

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleOpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleOpenTelemetryJdbcInstrumentationTest.java
@@ -2,25 +2,16 @@ package io.quarkus.it.opentelemetry;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
-import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-@TestProfile(OracleOpenTelemetryJdbcInstrumentationTest.OracleTestProfile.class)
+@QuarkusTestResource(value = OracleLifecycleManager.class, restrictToAnnotatedClass = true)
 public class OracleOpenTelemetryJdbcInstrumentationTest extends OpenTelemetryJdbcInstrumentationTest {
 
     @Test
     void testOracleQueryTraced() {
         testQueryTraced("oracle", "OracleHit");
-    }
-
-    public static class OracleTestProfile implements QuarkusTestProfile {
-
-        @Override
-        public String getConfigProfile() {
-            return "oracle-profile";
-        }
     }
 
 }

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgreSqlLifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgreSqlLifecycleManager.java
@@ -27,6 +27,7 @@ public class PostgreSqlLifecycleManager implements QuarkusTestResourceLifecycleM
         properties.put("quarkus.datasource.postgresql.password", QUARKUS);
         properties.put("quarkus.datasource.postgresql.username", QUARKUS);
         properties.put("quarkus.hibernate-orm.postgresql.database.generation", "drop-and-create");
+        properties.put("quarkus.hibernate-orm.postgresql.active", "true");
         properties.put("quarkus.hibernate-orm.oracle.active", "false");
         properties.put("quarkus.hibernate-orm.mariadb.active", "false");
         properties.put("quarkus.hibernate-orm.db2.active", "false");


### PR DESCRIPTION
folow-up: https://github.com/quarkusio/quarkus/pull/31499 (activates PU)

We have seen OpenTelemetry JDBC integration tests failing, like here https://github.com/quarkusio/quarkus/pull/31356. This modules tests multiple DBs and as CI has limited resources (we hit OOM in past), each database test needs to run separately. Oracle test starts too slow to be started by test lifecycle as it always hit 1 minute timeout for no action, that's why it is started by maven plugin instead. Now that we activate PU units, tests are failing because Oracle tests are started with enabled previous PU (and properties). This PR forces restart before testing Oracle by using test lifecycle manager, thus correct config properties are used.