### PR TITLE
Higher timeout for CreateProjectTest#createMultipleTimes

### DIFF
--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/CreateProjectTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/CreateProjectTest.java
@@ -231,7 +231,7 @@ public class CreateProjectTest extends PlatformAwareTestBase {
     }
 
     @Test
-    @Timeout(3)
+    @Timeout(6)
     @DisplayName("Should create correctly multiple times in parallel with multiple threads")
     void createMultipleTimes() throws InterruptedException {
         final ExecutorService executorService = Executors.newFixedThreadPool(4);


### PR DESCRIPTION
I doubt it will fix the issues we are seeing but let's try that first.

AFAICS, it's always JDK 17 failing for whatever reason.