### PR TITLE
ActivateRequestContext for ResteasyReactiveLocaleResolver

### DIFF
--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/locale/ResteasyReactiveLocaleResolver.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/locale/ResteasyReactiveLocaleResolver.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -22,6 +23,7 @@ public class ResteasyReactiveLocaleResolver extends AbstractLocaleResolver {
     CurrentVertxRequest currentVertxRequest;
 
     @Override
+    @ActivateRequestContext
     protected Map<String, List<String>> getHeaders() {
         RoutingContext current = currentVertxRequest.getCurrent();
         if (current != null) {

--- a/integration-tests/smallrye-config/pom.xml
+++ b/integration-tests/smallrye-config/pom.xml
@@ -48,6 +48,21 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-testkit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-commons</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5-internal</artifactId>
       <scope>test</scope>
@@ -172,7 +187,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-
   </dependencies>
 
   <build>
@@ -185,6 +199,35 @@
             <goals>
               <goal>build</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <excludes>
+                <exclude>io.quarkus.it.smallrye.config.MappingValidationTest</exclude>
+                <exclude>io.quarkus.it.smallrye.config.MappingValidationTest$ValidationTest</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>fails</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>io.quarkus.it.smallrye.config.MappingValidationTest</include>
+              </includes>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/integration-tests/smallrye-config/src/test/java/io/quarkus/it/smallrye/config/MappingValidationTest.java
+++ b/integration-tests/smallrye-config/src/test/java/io/quarkus/it/smallrye/config/MappingValidationTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.it.smallrye.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.engine.JupiterTestEngine;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Event;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.config.ConfigValidationException;
+
+public class MappingValidationTest {
+    @Test
+    void validation() {
+        JupiterTestEngine engine = new JupiterTestEngine();
+        LauncherDiscoveryRequest request = request().selectors(selectClass(ValidationTest.class))
+                .build();
+        EngineExecutionResults results = EngineTestKit.execute(engine, request);
+
+        List<Event> failingEvents = results.testEvents().failed().list();
+        assertEquals(1, failingEvents.size());
+
+        Throwable exception = failingEvents.get(0).getPayload(TestExecutionResult.class).get().getThrowable().get();
+        Throwable cause = exception.getCause();
+        while (cause != null && cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        assertNotNull(cause);
+        assertEquals(ConfigValidationException.class.getName(), cause.getClass().getName());
+    }
+
+    @QuarkusTest
+    @TestProfile(ValidationTestProfile.class)
+    public static class ValidationTest {
+        @Inject
+        Cloud cloud;
+
+        @Test
+        void fail() {
+            Assertions.fail();
+        }
+    }
+
+    public static class ValidationTestProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.http.test-port", "9999");
+        }
+    }
+}


### PR DESCRIPTION
- Fixes #31434

This only occurs when an invalid mapping is injected directly in a place when a request context is not available (for instance, a test class).