### PR TITLE
Changed old documentation anchors markup for the XREF macro for proper synergy with the downstream documentation

### DIFF
--- a/docs/src/main/asciidoc/amazon-lambda.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda.adoc
@@ -54,18 +54,18 @@ mvn archetype:generate \
 If you prefer to use Gradle, you can quickly and easily generate a Gradle project via https://code.quarkus.io/[code.quarkus.io]
 adding the `quarkus-amazon-lambda` extension as a dependency.
 
-Copy the build.gradle, gradle.properties and settings.gradle into the above generated Maven archetype project, to follow along with this guide.
+Copy the build.gradle, gradle.properties and settings.gradle into the above-generated Maven archetype project, to follow along with this guide.
 
 Execute: gradle wrapper to set up the gradle wrapper (recommended).
 
-For full Gradle details <<gradle, see below>>.
+For full Gradle details, see the xref:gradle[Gradle build] section below.
 ====
 
 [[choose]]
 == Choose Your Lambda
 
 The `quarkus-amazon-lambda` extension scans your project for a class that directly implements the Amazon `RequestHandler<?, ?>` or `RequestStreamHandler` interface.
-It must find a class in your project that implements this interface or it will throw a build time failure.
+It must find a class in your project that implements this interface, or it will throw a build time failure.
 If it finds more than one handler class, a build time exception will also be thrown.
 
 Sometimes, though, you might have a few related lambdas that share code and creating multiple maven modules is just
@@ -273,7 +273,7 @@ call must set a specific environment variable:
 There is nothing special about the POM other than the inclusion of the `quarkus-amazon-lambda` extension
 as a dependency.  The extension automatically generates everything you might need for your lambda deployment.
 
-NOTE: In previous versions of this extension you had to set up your pom or gradle
+NOTE: In previous versions of this extension, you had to set up your pom or gradle
 to zip up your executable for native deployments, but this is not the case anymore.
 
 [[gradle]]
@@ -452,13 +452,13 @@ Please check link:{amazon-services-guide}[those guides] on how to use the variou
 With minimal integration, it is possible to leverage the AWS Java SDK v2,
 which can be used to invoke services such as SQS, SNS, S3 and DynamoDB.
 
-For native image, however the URL Connection client must be preferred over the Apache HTTP Client
+For native image, however, the URL Connection client must be preferred over the Apache HTTP Client
 when using synchronous mode, due to issues in the GraalVM compilation (at present).
 
 Add `quarkus-jaxb` as a dependency in your Maven `pom.xml`, or Gradle `build.gradle` file.
 
 You must also force your AWS service client for SQS, SNS, S3 et al., to use the URL Connection client,
-which connects to AWS services over HTTPS, hence the inclusion of the SSL enabled property, as described in the <<https>> section above.
+which connects to AWS services over HTTPS, hence the inclusion of the SSL enabled property, as described in the xref:https[] section above.
 
 [source,java]
 ----

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -428,7 +428,7 @@ The behavior of `quarkus ext ls` will vary depending on context.
 
 If you invoke the Quarkus CLI from outside of a project, Quarkus will list all the extensions available for the Quarkus release used by the CLI itself.
 
-You can also list extensions for a specific release of Quarkus using `-P` or `-S`, as described in <<specifying-quarkus-version,Specifying the Quarkus version>>.
+You can also list extensions for a specific release of Quarkus using `-P` or `-S`, as described in xref:specifying-quarkus-version[Specifying the Quarkus version].
 
 This mode uses the `--origins` format by default.
 

--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -9,7 +9,7 @@ include::_attributes.adoc[]
 :summary: Hardcoded values in your code is a no go (even if we all did it at some point ;-)). In this guide, we learn how to configure your application.
 
 IMPORTANT: The content of this guide and been revised and split into additional topics. Please check the
-<<additional-information,Additional Information>> section.
+xref:additional-information[Additional Information] section.
 
 
 Hardcoded values in your code are a _no-go_ (even if we all did it at some point ;-)).
@@ -48,8 +48,9 @@ It generates:
 A Quarkus application uses the https://github.com/smallrye/smallrye-config[SmallRye Config] API to provide all
 mechanisms related with configuration.
 
-By default, Quarkus reads configuration properties from <<config-reference.adoc#configuration-sources,several sources>>.
+By default, Quarkus reads configuration properties from xref:config-reference.adoc#configuration-sources[several sources].
 For the purpose of this guide, we will use an application configuration file located in `src/main/resources/application.properties`.
+
 Edit the file with the following content:
 
 .application.properties

--- a/docs/src/main/asciidoc/doc-reference.adoc
+++ b/docs/src/main/asciidoc/doc-reference.adoc
@@ -254,7 +254,45 @@ When cross-referencing content, always use the inter-document `xref:` syntax and
 ----
 xref:{doc-guides}/doc-concept.adoc[Quarkus Documentation concepts] <1>
 ----
-<1> The cross reference starts with `xref:`, uses a cross-reference source attribute(`\{doc-guides}`), and provides a readable description: `[Quarkus Documentation concepts]`.
+<1> The cross-reference starts with `xref:`, uses a cross-reference source attribute(`\{doc-guides}`), and provides a readable description: `[Quarkus Documentation concepts]`.
+
+=== Anchors
+
+Quarkus documentation provides several ways a contributor can create and call anchors.
+To reach consistency and a better single-sourcing experience with Quarkus documentation, we ask contributors to use the `xref` approach for documenting and calling anchors.
+
+.Example
+* An anchor to a chapter inside the same `.adoc` file
+** Create an ID anchor:
++
+[source,asciidoc]
+--
+ [[<anchor-ID>]]
+--
+
+** Call the anchor
++
+[source,asciidoc]
+--
+xref:<anchor-ID>[]
+--
+
+* A cross-file anchor
+** Create an ID anchor:
++
+[source,asciidoc]
+--
+[[<anchor-ID>]]
+--
+
+** Call the anchor
++
+[source,asciidoc]
+--
+xref:<target-file>.adoc#<anchord-ID>[]
+--
+
+NOTE: The `[]` part of your `xref` anchors sets up a desired anchor label in cases where the default label does not fit the content.
 
 === Reference source code 
 

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -45,7 +45,7 @@ This guide also covers the testing of the endpoint.
 
 == Solution
 
-We recommend that you follow the instructions from <<bootstrapping-the-project,Bootstrapping project>> and onwards to create the application step by step.
+We recommend that you follow the instructions from xref:bootstrapping-the-project[Bootstrapping project] and onwards to create the application step by step.
 
 However, you can go right to the completed example.
 
@@ -69,12 +69,12 @@ For Linux & MacOS users
 :create-app-code:
 include::{includes}/devtools/create-app.adoc[]
 
-For Windows users
+For Windows users:
 
 - If using cmd , (don't use backward slash `\` and put everything on the same line)
 - If using Powershell , wrap `-D` parameters in double quotes e.g. `"-DprojectArtifactId=getting-started"`
 
-It generates the following in  `./getting-started`:
+It generates the following in `./getting-started`:
 
 * the Maven structure
 * an `org.acme.GreetingResource` resource exposed on `/hello`

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -315,7 +315,7 @@ Then, attach your debugger to `localhost:5005`.
 
 == Import in your IDE
 
-Once you have a <<project-creation, project generated>>, you can import it in your favorite IDE.
+Once you have a xref:project-creation[project generated], you can import it in your favorite IDE.
 The only requirement is the ability to import a Gradle project.
 
 **Eclipse**

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -98,11 +98,11 @@ They will often map to Hibernate ORM configuration properties but could have dif
 
 Also, Quarkus will set many Hibernate ORM configuration settings automatically, and will often use more modern defaults.
 
-Please see below section <<hibernate-configuration-properties, Hibernate ORM configuration properties>> for the list of properties you can set in `{config-file}`.
+For a list of the items that you can set in `{config-file}`, see xref:hibernate-configuration-properties[Hibernate ORM configuration properties].
 
 An `EntityManagerFactory` will be created based on the Quarkus `datasource` configuration as long as the Hibernate ORM extension is listed among your project dependencies.
 
-The dialect will be selected based on the JDBC driver - unless you set one explicitly.
+Unless you set one explicitly, the dialect will be selected based on the JDBC driver.
 
 You can then happily inject your `EntityManager`:
 
@@ -181,7 +181,7 @@ include::{generated-dir}/config/quarkus-hibernate-orm.adoc[opts=optional, levelo
 
 [NOTE]
 ====
-Do not mix <<persistence-xml,`persistence.xml`>> and `quarkus.hibernate-orm.*` properties in `{config-file}`.
+Do not mix xref:persistence-xml[`persistence.xml`] and `quarkus.hibernate-orm.*` properties in `{config-file}`.
 Quarkus will raise an exception.
 Make up your mind on which approach you want to use.
 
@@ -450,7 +450,7 @@ the https://jakarta.ee/specifications/persistence/3.0/jakarta-persistence-spec-3
 or the http://hibernate.org/dtd/hibernate-mapping-3.0.dtd[`hbm.xml` format (specific to Hibernate ORM, deprecated)]:
 
 * in `application.properties` through the (build-time) link:#quarkus-hibernate-orm_quarkus.hibernate-orm.mapping-files[`quarkus.hibernate-orm.mapping-files`] property.
-* in <<persistence-xml,`persistence.xml`>> through the `<mapping-file>` element.
+* in xref:persistence-xml[`persistence.xml`] through the `<mapping-file>` element.
 
 XML mapping files are parsed at build time.
 
@@ -769,22 +769,22 @@ configure your datasource as in the above examples and it will set up Hibernate 
 More details about this connection pool can be found in xref:datasource.adoc[Quarkus - Datasources].
 
 Second Level Cache::
-as explained above in section <<caching,Caching>>, you don't need to pick an implementation.
+As explained earlier in the xref:caching[Caching] section, you don't need to pick an implementation.
 A suitable implementation based on technologies from link:https://infinispan.org/[Infinispan] and link:https://github.com/ben-manes/caffeine[Caffeine] is included as a transitive dependency of the Hibernate ORM extension, and automatically integrated during the build.
 
 === Limitations
 
 XML mapping with duplicate files in the classpath::
-<<xml-mapping,XML mapping>> files are expected to have a unique path.
-+
+xref:xml-mapping[XML mapping] files are expected to have a unique path.
+
 In practice, it's only possible to have duplicate XML mapping files in the classpath in very specific scenarios.
-For example, if two JARs include a `META-INF/orm.xml` file (with the exact same path, but in different JARs),
+For example, if two JARs include a `META-INF/orm.xml` file (with the same path but in different JARs),
 then the mapping file path `META-INF/orm.xml` can only be referenced from a `persistence.xml`
 **in the same JAR as the `META-INF/orm.xml` file**.
 
 JMX::
 Management beans are not working in GraalVM native images;
-therefore Hibernate's capability to register statistics and management operations with the JMX bean is disabled when compiling into a native image.
+therefore, Hibernate's capability to register statistics and management operations with the JMX bean is disabled when compiling into a native image.
 This limitation is likely permanent, as it's not a goal for native images
 to implement support for JMX. All such metrics can be accessed in other ways.
 
@@ -793,18 +793,17 @@ Hibernate ORM's capability to integrate with JACC is disabled when building Graa
 as JACC is not available - nor useful - in native mode.
 
 Binding the Session to ThreadLocal context::
-It is not possible to use the `ThreadLocalSessionContext` helper of Hibernate ORM as support for it is not implemented.
-Since Quarkus provides out of the box support for CDI, we believe using injection or programmatic CDI lookup to be a better approach.
+It is impossible to use the `ThreadLocalSessionContext` helper of Hibernate ORM as support for it is not implemented.
+Since Quarkus provides out-of-the-box CDI support, injection or programmatic CDI lookup is a better approach.
 This feature also didn't integrate well with reactive components and more modern context propagation techniques, making us believe this legacy feature has no future.
-If you badly need to bind it to a ThreadLocal it should be trivial to implement in your own code.
+If you badly need to bind it to a ThreadLocal, it should be trivial to implement in your own code.
 
 JNDI::
 The JNDI technology is commonly used in other runtimes to integrate different components.
-A common use case is Java Enterprise servers to bind the TransactionManager and the Datasource components to a name, and then have Hibernate ORM
-configured to look these components up by name.
-But in Quarkus this use case doesn't apply as components are injected directly, making JNDI support an unnecessary legacy.
-As a precaution, to avoid unexpected use of JNDI, the whole support for JNDI has been disabled in the Hibernate ORM extension for Quarkus.
-This is both a security precaution and an optimisation.
+A common use case is Java Enterprise servers to bind the TransactionManager and the Datasource components to a name and then have Hibernate ORM configured to look these components up by name.
+But in Quarkus, this use case doesn't apply as components are injected directly, making JNDI support an unnecessary legacy.
+To avoid unexpected use of JNDI, full support for JNDI has been disabled in the Hibernate ORM extension for Quarkus.
+This is both a security precaution and an optimization.
 
 === Other notable differences
 
@@ -901,7 +900,7 @@ public class CustomTenantResolver implements TenantResolver {
 <1> Annotate the TenantResolver implementation with the `@PersistenceUnitExtension` qualifier
 to tell Quarkus it should be used in the default persistence unit.
 +
-For <<multiple-persistence-units,named persistence units>>, use `@PersistenceUnitExtension("nameOfYourPU")`.
+For xref:multiple-persistence-units[named persistence units], use `@PersistenceUnitExtension("nameOfYourPU")`.
 <2> The bean is made `@RequestScoped` as the tenant resolution depends on the incoming request.
 
 From the implementation above, tenants are resolved from the request path so that in case no tenant could be inferred, the default tenant identifier is returned.
@@ -1065,7 +1064,7 @@ INSERT INTO known_fruits(id, name) VALUES (3, 'Blackberries');
 If you need a more dynamic configuration for the different tenants you want to support and don't want to end up with multiple entries in your configuration file,
 you can use the `io.quarkus.hibernate.orm.runtime.tenant.TenantConnectionResolver` interface to implement your own logic for retrieving a connection.
 Creating an application-scoped bean that implements this interface
-and annotating it with `@PersistenceUnitExtension` (or `@PersistenceUnitExtension("nameOfYourPU")` for a <<multiple-persistence-units,named persistence unit>>)
+and annotating it with `@PersistenceUnitExtension` (or `@PersistenceUnitExtension("nameOfYourPU")` for a xref:multiple-persistence-units[named persistence unit])
 will replace the current Quarkus default implementation `io.quarkus.hibernate.orm.runtime.tenant.DataSourceTenantConnectionResolver`.
 Your custom connection resolver would allow for example to read tenant information from a database and create a connection per tenant at runtime based on it.
 
@@ -1090,7 +1089,7 @@ public static class MyInterceptor extends EmptyInterceptor { // <2>
 <1> Annotate the interceptor implementation with the `@PersistenceUnitExtension` qualifier
 to tell Quarkus it should be used in the default persistence unit.
 +
-For <<multiple-persistence-units,named persistence units>>, use `@PersistenceUnitExtension("nameOfYourPU")`
+For xref:multiple-persistence-units[named persistence units], use `@PersistenceUnitExtension("nameOfYourPU")`
 <2> Either extend `org.hibernate.EmptyInterceptor` or implement `org.hibernate.Interceptor` directly.
 <3> Implement methods as necessary.
 
@@ -1132,5 +1131,5 @@ public class MyStatementInspector implements StatementInspector { // <2>
 <1> Annotate the statement inspector implementation with the `@PersistenceUnitExtension` qualifier
 to tell Quarkus it should be used in the default persistence unit.
 +
-For <<multiple-persistence-units,named persistence units>>, use `@PersistenceUnitExtension("nameOfYourPU")`
+For xref:multiple-persistence-units[named persistence units], use `@PersistenceUnitExtension("nameOfYourPU")`
 <2> Implement `org.hibernate.engine.jdbc.spi.StatementInspector`.

--- a/docs/src/main/asciidoc/hibernate-reactive.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive.adoc
@@ -102,7 +102,7 @@ Also, Quarkus will set many Hibernate Reactive configuration settings automatica
 
 WARNING: Configuring Hibernate Reactive using the standard `persistence.xml` configuration file is not supported.
 
-Please, see section <<hr-configuration-properties, Hibernate Reactive configuration properties>> for the list of properties you can set in `{config-file}`.
+See section xref:hr-configuration-properties[Hibernate Reactive configuration properties] for the list of properties you can set in `{config-file}`.
 
 A `Mutiny.SessionFactory` will be created based on the Quarkus `datasource` configuration as long as the Hibernate Reactive extension is listed among your project dependencies.
 

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -50,7 +50,7 @@ public class ExampleResource {
 }
 ----
 
-NOTE: If you use JBoss Logging but one of your libraries uses a different logging API, you may need to configure a <<logging-adapters,Logging Adapter>>.
+NOTE: If you use JBoss Logging but one of your libraries uses a different logging API, you may need to configure a xref:logging-adapters[logging adapter].
 
 === Logging with Panache
 
@@ -176,18 +176,20 @@ opening the door to optimization opportunities.
 As an example, in native execution the minimum level enables lower level checks (e.g. `isTraceEnabled`) to be folded to `false`,
 resulting in dead code elimination for code that will never to be executed.
 
-All possible properties are listed in <<loggingConfigurationReference, the logging configuration reference>>.
+All possible properties are listed in the xref:loggingConfigurationReference[logging configuration reference] section.
 
-NOTE: If you are adding these properties via command line make sure `"` is escaped.
+NOTE: If you are adding these properties by using the command line, make sure `"` is escaped.
 For example `-Dquarkus.log.category.\"org.hibernate\".level=TRACE`.
 
 === Logging categories
 
-Logging is done on a per-category basis.  Each category can be independently configured.
+Logging is done on a per-category basis.
+Each category can be independently configured.
 A configuration which applies to a category will also apply to all sub-categories of that category,
 unless there is a more specific matching sub-category configuration.
 For every category the same settings that are configured on ( console / file / syslog ) apply.
-These can also be overridden by attaching a one or more named handlers to a category. See example in <<category-named-handlers-example>>
+These can also be overridden by attaching one or more named handlers to a category.
+See example in the xref:category-named-handlers-example[] output.
 
 [cols="<m,<m,<2",options="header"]
 |===
@@ -198,8 +200,7 @@ These can also be overridden by attaching a one or more named handlers to a cate
 |quarkus.log.category."<category-name>".handlers=[<handler>]|empty footnote:[By default, the configured category gets the same handlers attached as the one on the root logger.]|The names of the handlers that you want to attach to a specific category.
 |===
 
-NOTE: The quotes shown in the property name are required as categories normally contain '.' which must
-be escaped. An example is shown in <<category-example>>.
+NOTE: The quotes shown in the property name are required as categories normally contain '.', which must be escaped. See the example in xref:category-example[].
 
 === Root logger configuration
 
@@ -282,8 +283,8 @@ implementation("io.quarkus:quarkus-logging-json")
 ----
 
 The presence of this extension will, by default, replace the output format configuration from the console configuration.
-This means that the format string and the color settings (if any) will be ignored.  The other console configuration items
-(including those controlling asynchronous logging and the log level) will continue to be applied.
+This means that the format string and the color settings (if any) will be ignored.
+The other console configuration items, including those controlling asynchronous logging and the log level, will continue to be applied.
 
 For some, it will make sense to use logging that is humanly readable (unstructured) in dev mode and JSON logging (structured) in production mode. This can be achieved using different profiles, as shown in the following configuration.
 
@@ -296,14 +297,15 @@ For some, it will make sense to use logging that is humanly readable (unstructur
 
 ===== Configuration
 
-The JSON logging extension can be configured in various ways.  The following properties are supported:
+The JSON logging extension can be configured in various ways.
+The following properties are supported:
 
 include::{generated-dir}/config/quarkus-logging-json.adoc[opts=optional, leveloffset=+1]
 
 WARNING: Enabling pretty printing might cause certain processors and JSON parsers to fail.
 
-NOTE: Printing the details can be expensive as the values are retrieved from the caller. The details include the
-source class name, source file name, source method name and source line number.
+NOTE: Printing the details can be expensive as the values are retrieved from the caller.
+The details include the source class name, source file name, source method name, and source line number.
 
 == Log Handlers
 
@@ -312,7 +314,8 @@ Quarkus comes with three different log handlers: **console**, **file** and **sys
 
 === Console log handler
 
-The console log handler is enabled by default.  It outputs all log events to the console of your application (typically to the system's `stdout`).
+The console log handler is enabled by default.
+It outputs all log events to the console of your application (typically to the system's `stdout`).
 
 For details of its configuration options, see link:#quarkus-log-logging-log-config_quarkus.log.console-console-logging[the Console Logging configuration reference].
 
@@ -490,7 +493,7 @@ test {
 }
 ----
 
-See also: <<getting-started-testing.adoc#test-from-ide,Running `@QuarkusTest` from an IDE>>
+See also xref:getting-started-testing.adoc#test-from-ide[Running `@QuarkusTest` from an IDE].
 
 [[logging-adapters]]
 == Logging Adapters

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -102,10 +102,10 @@ include::{includes}/devtools/extension-add.adoc[]
 
 Extensions are passed using a comma-separated list.
 
-The extension name is the GAV name of the extension: e.g. `io.quarkus:quarkus-agroal`.
-But you can pass a partial name and Quarkus will do its best to find the right extension.
-For example, `agroal`, `Agroal` or `agro`  will expand to `io.quarkus:quarkus-agroal`.
-If no extension is found or if more than one extension matches, you will see a red check mark  ❌ in the command result.
+The extension name is the GAV name of the extension: e.g., `io.quarkus:quarkus-agroal`.
+However, you can pass a partial name, and Quarkus will do its best to find the right extension.
+For example, `agroal`, `Agroal`, or `agro` will expand to `io.quarkus:quarkus-agroal`.
+If no extension is found or more than one extension matches, you will see a red check mark ❌ in the command result.
 
 [source,shell]
 ----
@@ -133,12 +133,9 @@ The Quarkus Maven plugin makes use of `javac`,
 and by default it picks up compiler flags to pass to
 `javac` from `maven-compiler-plugin`.
 
-If you need to customize the compiler flags used by the plugin (for instance in <<dev-mode,development mode>>),
-add a `configuration` section to the `plugin` block and set the
-`compilerArgs` property just as you would when configuring
-`maven-compiler-plugin`.  You can also set `source`, `target`, and
-`jvmArgs`.  For example, to pass `--enable-preview` to both the JVM
-and `javac`:
+If you need to customize the compiler flags used by the plugin, like in xref:dev-mode[development mode], add a `configuration` section to the `plugin` block and set the `compilerArgs` property just as you would when configuring `maven-compiler-plugin`.
+You can also set `source`, `target`, and `jvmArgs`.
+For example, to pass `--enable-preview` to both the JVM and `javac`:
 
 [source,xml]
 ----
@@ -298,7 +295,7 @@ Then, attach your debugger to `localhost:5005`.
 
 == Import in your IDE
 
-Once you have a <<project-creation, project generated>>, you can import it in your favorite IDE.
+Once you have a xref:project-creation[project generated], you can import it in your favorite IDE.
 The only requirement is the ability to import a Maven project.
 
 **Eclipse**
@@ -395,7 +392,7 @@ This goal will resolve all the runtime, build time, test and dev mode dependenci
 Native executables make Quarkus applications ideal for containers and serverless workloads.
 
 Make sure to have `GRAALVM_HOME` configured and pointing to the latest release of GraalVM version {graalvm-version}.
-Verify that your `pom.xml` has the proper `native` profile (see <<build-tool-maven>>).
+Verify that your `pom.xml` has the proper `native` profile as shown in xref:build-tool-maven[].
 
 Create a native executable using:
 
@@ -403,7 +400,7 @@ include::{includes}/devtools/build-native.adoc[]
 
 A native executable will be present in `target/`.
 
-To run Integration Tests on the native executable, make sure to have the proper Maven plugin configured (see <<build-tool-maven>>) and launch the `verify` goal.
+To run Integration Tests on the native executable, make sure to have the proper xref:build-tool-maven[Maven plugin configured] and launch the `verify` goal.
 
 [source,shell]
 ----
@@ -445,7 +442,7 @@ To create an executable that will run in a container, use the following:
 include::{includes}/devtools/build-native.adoc[]
 :!build-additional-parameters:
 
-The produced executable will be a 64-bit Linux executable, so depending on your operating system it may no longer be runnable.
+The produced executable will be a 64-bit Linux executable, so depending on your operating system, it may no longer be runnable.
 However, it's not an issue as we are going to copy it to a Docker container.
 Note that in this case the build itself runs in a Docker container too, so you don't need to have GraalVM installed locally.
 
@@ -465,7 +462,7 @@ You can follow the xref:building-native-image.adoc[Build a native executable gui
 [[build-tool-maven]]
 == Maven configuration
 
-If you have not used <<project-creation,project scaffolding>>, add the following elements in your `pom.xml`
+If you have not used xref:project-creation[project scaffolding], add the following elements in your `pom.xml`:
 
 [source,xml,subs=attributes+]
 ----

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -174,7 +174,7 @@ MongoDB with Panache uses the link:{mongodb-doc-root-url}/fundamentals/data-form
 
 You will be allowed to use the following annotations to customize this mapping:
 
-- `@BsonId`: allows you to customize the ID field, see <<custom-ids,Custom IDs>>.
+- `@BsonId`: allows you to customize the ID field, see xref:custom-ids[Custom IDs].
 - `@BsonProperty`: customize the serialized name of the field.
 - `@BsonIgnore`: ignore a field during the serialization.
 
@@ -324,7 +324,7 @@ MongoDB with Panache uses the link:{mongodb-doc-root-url}/fundamentals/data-form
 
 You will be allowed to use the following annotations to customize this mapping:
 
-- `@BsonId`: allows you to customize the ID field, see <<custom-ids,Custom IDs>>.
+- `@BsonId`: allows you to customize the ID field, see xref:custom-ids[Custom IDs].
 - `@BsonProperty`: customize the serialized name of the field.
 - `@BsonIgnore`: ignore a field during the serialization.
 

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -307,7 +307,7 @@ docker run -ti --rm -p 27017:27017 mongo:4.4
 
 [NOTE]
 ====
-If you use <<dev-services,Dev Services>>, launching the container manually is not necessary!
+If you use xref:dev-services[Dev Services], launching the container manually is not necessary!
 ====
 
 

--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -327,7 +327,7 @@ The static file to serve must be a valid document conforming to the https://swag
 An OpenAPI document that conforms to the  OpenAPI Specification is itself a valid JSON object, that can be represented in `yaml` or `json` formats.
 
 To see this in action, we'll put OpenAPI documentation under `META-INF/openapi.yaml` for our `/fruits` endpoints.
-Quarkus also supports alternative <<open-document-paths, OpenAPI document paths>> if you prefer.
+Quarkus also supports alternative xref:open-document-paths[OpenAPI document paths] if you prefer.
 
 [source,yaml]
 ----

--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -17,9 +17,9 @@ The API combines both the imperative and the non-blocking reactive style of codi
 In the development mode, all files located in the `src/main/resources/templates` folder are watched for changes and modifications are immediately visible in your application.
 Furthermore, Qute attempts to detect most of the template problems at build time and fail fast.
 
-In this guide, you will find an <<hello_world_example,introductory example>>, the description of the <<core_features,core features>> and <<quarkus_integration,Quarkus integration>> details.
+In this guide, you will find an xref:hello_world_example[introductory example], the description of the xref:core_features[core features] and xref:quarkus_integration[Quarkus integration] details.
 
-NOTE: Qute is primarily designed as a Quarkus extension. It is possible to use it as a "standalone" library too. However, in such case some features are not available. In general, any feature mentioned under the <<quarkus_integration>> section is missing. You can find more information about the limitations and possibilities in the <<standalone>> section.
+NOTE: Qute is primarily designed as a Quarkus extension. It is possible to use it as a "standalone" library too. However, in such case some features are not available. In general, any feature mentioned under the xref:quarkus_integration[] section is missing. You can find more information about the limitations and possibilities in the xref:standalone[] section.
 
 [[the_simplest_example]]
 == The Simplest Example
@@ -46,9 +46,10 @@ Qute.fmt("I am {#if ok}happy{#else}sad{/if}!", Map.of("ok", true)); <5>
 <2> You can provide a data map instead.
 <3> A builder-like API is available for more complex formatting requirements.
 <4> Note that for a "text/html" template the special chars are replaced with html entities by default.
-<5> You can use any <<basic-building-blocks,building block>> in the template. In this case, the <<if_section>> is used to render the appropriate part of the message based on the input data.
+<5> You can use any xref:basic-building-blocks[building block] in the template.
+In this case, the xref:if_section[] is used to render the appropriate part of the message based on the input data.
 
-TIP: In <<quarkus_integration,Quarkus>>, the engine used to format the messages is the same as the one injected by `@Inject Engine`. Therefore, you can make use of any Quarkus-specific integration feature such as <<template_extension_methods>>, <<injecting-beans-directly-in-templates>> or even <<type-safe-message-bundles>>.
+TIP: Based on xref:quarkus_integration[Quarkus integration], the engine used to format the messages is the same as the one injected by `@Inject Engine`. Therefore, you can make use of any Quarkus-specific integration feature such as xref:template_extension_methods[], xref:injecting-beans-directly-in-templates[] or even xref:type-safe-message-bundles[].
 
 
 The format object returned by the `Qute.fmt(String)` method can be evaluated lazily and used e.g. as a log message:
@@ -89,7 +90,7 @@ Let's use the convenient builder:
 Engine engine = Engine.builder().addDefaults().build();
 ----
 
-TIP: In Quarkus, there is a preconfigured `Engine` available for injection - see <<quarkus_integration>>.
+TIP: In Quarkus, there is a preconfigured `Engine` available for injection - see xref:quarkus_integration[].
 
 Once we have an `Engine` instance we could parse the template contents:
 
@@ -98,7 +99,7 @@ Once we have an `Engine` instance we could parse the template contents:
 Template hello = engine.parse(helloHtmlContent);
 ----
 
-TIP: In Quarkus, you can simply inject the template definition. The template is automatically parsed and cached - see <<quarkus_integration>>.
+TIP: In Quarkus, you can simply inject the template definition. The template is automatically parsed and cached - see xref:quarkus_integration[].
 
 Finally, create a *template instance*, set the data and render the output:
 
@@ -108,7 +109,7 @@ Finally, create a *template instance*, set the data and render the output:
 hello.data("name", "Jim").render(); <1> <2>
 ----
 <1> `Template.data(String, Object)` is a convenient method that creates a template instance and sets the data in one step.
-<2> `TemplateInstance.render()` triggers a synchronous rendering, i.e. the current thread is blocked until the rendering is finished. However, there are also asynchronous ways to trigger the rendering and consume the results. For example there is the `TemplateInstance.renderAsync()` method that returns `CompletionStage<String>` or `TemplateInstance.createMulti()` that returns Mutiny's `Multi<String>`.
+<2> `TemplateInstance.render()` triggers a synchronous rendering, i.e. the current thread is blocked until the rendering is finished. However, there are also asynchronous ways to trigger the rendering and consume the results. For example, there is the `TemplateInstance.renderAsync()` method that returns `CompletionStage<String>` or `TemplateInstance.createMulti()` that returns Mutiny's `Multi<String>`.
 
 So the workflow is simple: 
 
@@ -133,13 +134,13 @@ Can be multiline and may contain expressions and sections: `{! {#if true} !}`.
 The content of a comment is completely ignored when rendering the output.
 
 Expressions::
-An <<expressions,expression>> outputs an evaluated value. 
+An xref:expressions[expression] outputs an evaluated value.
 It consists of one or more parts.
 A part may represent simple properties: `{foo}`, `{item.name}`, and virtual methods: `{item.get(name)}`, `{name ?: 'John'}`.
 An expression may also start with a namespace: `{inject:colors}`.
 
 Sections::
-A <<sections,section>> may contain static text, expressions and nested sections: `{#if foo.active}{foo.name}{/if}`.
+A xref:sections[section] may contain static text, expressions and nested sections: `{#if foo.active}{foo.name}{/if}`.
 The name in the closing tag is optional: `{#if active}ACTIVE!{/}`.
 A section can be empty: `{#myTag image=true /}`.
 A section may also declare nested section blocks: `{#if item.valid} Valid. {#else} Invalid. {/if}` and decide which block to render.
@@ -257,13 +258,13 @@ In this case, all whitespace characters from a standalone line will be printed t
 An expression is evaluated and outputs the value.
 It has one or more parts, where each part represents either a property accessor (aka Field Access Expression) or a virtual method invocation (aka Method Invocation Expression).
 
-When accessing the properties you can either use the dot notation or bracket notation.
-In the `object.property` (dot notation) syntax, the `property` must be a <<identifiers,valid identifier>>.
-In the `object[property_name]` (bracket notation) syntax, the `property_name` has to be a non-null <<literals, literal>> value.
+When accessing the properties, you can either use the dot notation or bracket notation.
+In the `object.property` (dot notation) syntax, the `property` must be a xref:identifiers[valid identifier].
+In the `object[property_name]` (bracket notation) syntax, the `property_name` has to be a non-null xref:literals[literal] value.
 
 An expression can start with an optional namespace followed by a colon (`:`).
 A valid namespace consist of alphanumeric characters and underscores.
-Namespace expressions are resolved differently - see also <<expression_resolution>>.
+Namespace expressions are resolved differently - see also xref:expression_resolution[].
 
 .Property Accessor Examples
 [source]
@@ -279,9 +280,9 @@ Namespace expressions are resolved differently - see also <<expression_resolutio
 <4> namespace `global`, one part: `colors`
 
 A part of an expression can be a _virtual method_ in which case the name can be followed by a list of comma-separated parameters in parentheses. 
-A parameter of a virtual method can be either a nested expression or a <<literals, literal>> value.
+A parameter of a virtual method can be either a nested expression or a xref:literals[literal] value.
 We call these methods _"virtual"_ because they do not have to be backed by a real Java method.
-You can learn more about virtual methods in the <<virtual_methods,following section>>.
+You can learn more about virtual methods in the xref:virtual_methods[following section].
 
 .Virtual Method Example
 [source]
@@ -324,7 +325,7 @@ You can learn more about virtual methods in the <<virtual_methods,following sect
 [[expression_resolution]]
 ==== Resolution
 
-The first part of the expression is always resolved against the <<current_context_object, current context object>>.
+The first part of the expression is always resolved against the xref:current_context_object[current context object].
 If no result is found for the first part it's resolved against the parent context object (if available).
 For an expression that starts with a namespace the current context object is found using all the available ``NamespaceResolver``s.
 For an expression that does not start with a namespace the current context object is *derived from the position* of the tag.
@@ -366,10 +367,10 @@ This could be useful to access data for which the key is overridden:
 [[current_context_object]]
 ==== Current Context
 
-If an expression does not specify a namespace the _current context object_ is derived from the position of the tag.
+If an expression does not specify a namespace, the _current context object_ is derived from the position of the tag.
 By default, the current context object represents the data passed to the template instance.
 However, sections may change the current context object.
-A typical example is the <<let_section,`let`>> section that can be used to define named local variables:
+A typical example is the xref:let_section[`let`] section that can be used to define named local variables:
 
 [source,html]
 ----
@@ -396,26 +397,26 @@ NOTE: The current context can be accessed via the implicit binding `this`.
 |`{pets.orEmpty.size}` outputs `0` if `pets` is not resolvable or `null`
 
 |Ternary Operator
-|Shorthand for if-then-else statement. Unlike in <<if_section>> nested operators are not supported.
+|Shorthand for if-then-else statement. Unlike in xref:if_section[] nested operators are not supported.
 |`{item.isActive ? item.name : 'Inactive item'}` outputs the value of `item.name` if `item.isActive` resolves to `true`.
 
 |Logical AND Operator
-|Outputs `true` if both parts are not `falsy` as described in the <<if_section>>. The parameter is only evaluated if needed.
+|Outputs `true` if both parts are not `falsy` as described in the xref:if_section[]. The parameter is only evaluated if needed.
 |`{person.isActive && person.hasStyle}`
 
 |Logical OR Operator
-|Outputs `true` if any of the parts is not `falsy` as described in the <<if_section>>. The parameter is only evaluated if needed.
+|Outputs `true` if any of the parts is not `falsy` as described in the xref:if_section[]. The parameter is only evaluated if needed.
 |`{person.isActive \|\| person.hasStyle}`
 
 |===
 
-TIP: The condition in a ternary operator evaluates to `true` if the value is not considered `falsy` as described in the <<if_section>>.
+TIP: The condition in a ternary operator evaluates to `true` if the value is not considered `falsy` as described in the xref:if_section[].
 
 NOTE: In fact, the operators are implemented as "virtual methods" that consume one parameter and can be used with infix notation. For example `{person.name or 'John'}` is translated to `{person.name.or('John')}` and `{item.isActive ? item.name : 'Inactive item'}` is translated to `{item.isActive.ifTruthy(item.name).or('Inactive item')}`
 
 ==== Arrays
 
-You can iterate over elements of an array with the <<loop_section>>. 
+You can iterate over elements of an array with the xref:loop_section[].
 Moreover, it's also possible to get the length of the specified array and access the elements directly via an index value.
 Additionally, you can access the first/last `n` elements via the `take(n)/takeLast(n)` methods.
 
@@ -490,7 +491,8 @@ class Item {
 }
 ----
 
-NOTE: Virtual methods are usually evaluated by value resolvers generated for <<template_extension_methods,@TemplateExtension methods>>, <<template_data,@TemplateData>> or classes used in <<typesafe_expressions,parameter declarations>>. However, a custom value resolver that is not backed by any Java class/method can be registered as well.
+NOTE: Virtual methods are usually evaluated by value resolvers generated for xref:template_extension_methods[@TemplateExtension methods], xref:template_data[@TemplateData] or classes used in xref:typesafe_expressions[parameter declarations].
+However, a custom value resolver that is not backed by any Java class/method can be registered as well.
 
 A virtual method with single parameter can be called using the infix notation:
 
@@ -556,16 +558,16 @@ If a `completed` log message is missing then you have a good candidate to explor
 
 It can happen that an expression may not be evaluated at runtime.
 For example, if there is an expression `{person.age}` and there is no property `age` declared on the `Person` class.
-The behavior differs based on whether the <<strict_rendering>> is enabled or not.
+The behavior differs based on whether the xref:strict_rendering[] is enabled or not.
 
 If enabled then a missing property will always result in a `TemplateException` and the rendering is aborted.
 You can use _default values_ and _safe expressions_ in order to suppress the error.
 
 If disabled then the special constant `NOT_FOUND` is written to the output by default.
 
-TIP: In Quarkus, it's possible to change the default strategy via the `quarkus.qute.property-not-found-strategy` as described in the <<configuration-reference>>.
+TIP: In Quarkus, it's possible to change the default strategy via the `quarkus.qute.property-not-found-strategy` as described in xref:configuration-reference[].
 
-NOTE: Similar errors are detected at build time if <<typesafe_expressions>> and <<typesafe_templates>> are used.
+NOTE: Similar errors are detected at build time if xref:typesafe_expressions[type-safe expressions] and xref:typesafe_templates[type-safe templates] are used.
 
 [[sections]]
 === Sections
@@ -581,7 +583,7 @@ Names are separated from the values by the equals sign.
 Names and values can be prefixed and suffixed with any number of spaces, e.g. `{#let id='Foo'}` and `{#let id  = 'Foo'}` are equivalents where the name of the parameter is `id` and the value is `Foo`.
 Values can be grouped using parentheses, e.g. `{#let id=(item.id ?: 42)}` where the name is `id` and the value is `item.id ?: 42`. 
 Sections can interpret parameter values in any way, e.g. take the value as is.
-However, in most cases the parameter value is registered as an <<expressions,expression>> and evaluated before use.
+However, in most cases, the parameter value is registered as an xref:expressions[expression] and evaluated before use.
 
 A section may contain several content *blocks*. 
 The "main" block is always present.
@@ -830,7 +832,8 @@ All other blocks are ignored (this behavior differs to the Java `switch` where a
 {/when}
 ----
 <1> If there is exactly one parameter it's tested for equality.
-<2> It's possible to use <<when_operators,an operator>> to specify the matching logic. Unlike in the <<if_section>> nested operators are not supported.
+<2> It's possible to use xref:when_operators[an operator] to specify the matching logic.
+Unlike in the xref:if_section[if section], nested operators are not supported.
 <3> `else` is block is executed if no other block matches the value.
 
 .Example using the `switch`/`case` name aliases
@@ -912,11 +915,11 @@ This section allows you to define named local variables:
   Age: {age}
 {/let} <3>
 ----
-<1> The local variable is initialized with an expression that can also represent a <<literals,literal>>, i.e. `isActive=false` and `age=10`.
-<2> The infix notation is only supported if parentheses are used for grouping, e.g. `price=(order.price + 10)` is equivalent to `price=order.price.plus(10)`.
-<3> Keep in mind that the variable is not available outside the `let` section that defines it.
+<1> The local variable is initialized with an expression that can also represent a xref:literals[literal], i.e., `isActive=false` and `age=10`.
+<2> The infix notation is only supported if parentheses are used for grouping, e.g., `price=(order.price + 10)` is equivalent to `price=order.price.plus(10)`.
+<3> Keep in mind that the variable is unavailable outside the `let` section that defines it.
 
-If a key of a section parameter (aka the name of the local variable) ends with a `?` then the local variable is only set if the key without the `?` suffix resolves to `null` or _"not found"_:
+If a key of a section parameter, such as the name of the local variable, ends with a `?`, then the local variable is only set if the key without the `?` suffix resolves to `null` or _"not found"_:
 
 [source,html]
 ----
@@ -955,9 +958,9 @@ This could be useful to simplify the template structure:
 
 [IMPORTANT]
 ====
-Note that the `with` section should not be used in <<typesafe_templates>> or templates that define <<typesafe_expressions>>.
+Note that the `with` section should not be used in xref:typesafe_templates[] or templates that define xref:typesafe_expressions[].
 The reason is that it prevents Qute from validating the nested expressions.
-If possible it should be replaced with the `{#let}` section which declares an explicit binding:
+If possible replace it with the `{#let}` section which declares an explicit binding:
 
 [source,html]
 ----
@@ -1168,7 +1171,7 @@ The snippet above should render something like:
 </ol>
 ----
 
-TIP: In Quarkus, it is also possible to define a <<type_safe_fragments,type-safe fragment>>.
+TIP: In Quarkus, it is also possible to define a xref:type_safe_fragments[type-safe fragment].
 
 You can also include a fragment with an `{#include}` section inside another template or the template that defines the fragment.
 
@@ -1208,8 +1211,11 @@ a lot of
 {#include [strong] val='information' /} <3>
 !</p>
 ----
-<1> Defines a hidden fragment with identifier `strong`. In this particular case, we use the `false` boolean literal as the value of the `rendered` parameter. However, it's possible to use any expression there.
-<2> Include the fragment `strong` and pass the value. Note the syntax `[strong]` which is translated to include the fragment `strong` from the current template.
+<1> Defines a hidden fragment with identifier `strong`.
+In this particular case, we use the `false` boolean literal as the value of the `rendered` parameter.
+However, it's possible to use any expression there.
+<2> Include the fragment `strong` and pass the value.
+Note the syntax `[strong]` which is translated to include the fragment `strong` from the current template.
 <3> Include the fragment `strong` and pass the value.
 
 The snippet above renders something like:
@@ -1227,20 +1233,22 @@ a lot of
 ==== Eval Section
 
 This section can be used to parse and evaluate a template dynamically.
-The behavior is very similar to the <<include_helper>> but:
+The behavior is very similar to the xref:include_helper[] but:
 
-1. The template content is passed directly, i.e. not obtained via an `io.quarkus.qute.TemplateLocator`,
+1. The template content is passed directly, i.e., not obtained via an `io.quarkus.qute.TemplateLocator`,
 2. It's not possible to override parts of the evaluated template.
 
 [source,html]
 ----
 {#eval myData.template name='Mia' /} <1><2><3>
 ----
-<1> The result of `myData.template` will be used as the template. The template is executed with the <<current_context_object>>, i.e. can reference data from the template it's included into.
+<1> The `myData.template` result will be used as the template.
+The template is executed with the xref:current_context_object[], i.e., it can reference data from the template it's included.
 <2> It's also possible to define optional parameters that can be used in the evaluated template.
-<3> The content of the section is always ignored. 
+<3> The content of the section is always ignored.
 
-NOTE: The evaluated template is parsed and evaluated every time the section is executed. In other words, it's not possible to cache the parsed value to conserve resources and optimize the performance.
+NOTE: The evaluated template is parsed and evaluated every time the section is executed.
+In other words, it's not possible to cache the parsed value to conserve resources and optimize performance.
 
 ==== Cached Section
 
@@ -1261,9 +1269,9 @@ engineBuilder
      })).build();
 ----
 
-TIP: If the `quarkus-cache` extension is present in a Quarkus application then the `CacheSectionHelper` is registered and configured _automatically_. The name of the cache is `qute-cache`. It can be configured <<cache#configuring-the-underlying-caching-provider,in a standard way>> and even managed programmatically via `@Inject @CacheName("qute-cache") Cache`.
+TIP: If the `quarkus-cache` extension is present in a Quarkus application, then the `CacheSectionHelper` is registered and configured _automatically_. The name of the cache is `qute-cache`. It can be configured xref:cache#configuring-the-underlying-caching-provider[in a standard way] and even managed programmatically via `@Inject @CacheName("qute-cache") Cache`.
 
-Then the `{#cached}` section can be used in a template:
+Then, the `{#cached}` section can be used in a template:
 
 [source,html]
 ----
@@ -1349,10 +1357,12 @@ engineBuilder.addValueResolver(ValueResolver.builder()
 [[template-locator]]
 ==== Template Locator
 
-A template can be either registered manually or automatically via a template locator. The locators are used whenever the `Engine.getTemplate()` method is called and the engine has no template for a given id stored in the cache.
-The locator is responsible to use the correct character encoding when reading the contents of a template.
+A template can be either registered manually or automatically via a template locator.
+The locators are used whenever the `Engine.getTemplate()` method is called, and the engine has no template for a given id stored in the cache.
+The locator is responsible for using the correct character encoding when reading the contents of a template.
 
-NOTE: In Quarkus, all templates from the `src/main/resources/templates` are located automatically and the encoding set via `quarkus.qute.default-charset` (UTF-8 by default) is used. Custom locators can be <<template-locator-registration,registered>> via the `@Locate` annotation.
+NOTE: In Quarkus, all templates from the `src/main/resources/templates` are located automatically and the encoding set via `quarkus.qute.default-charset` (UTF-8 by default) is used.
+Custom locators can be xref:template-locator-registration[registered] by using the `@Locate` annotation.
 
 ==== Content Filters
 
@@ -1377,7 +1387,7 @@ The strict rendering enables the developers to catch insidious errors caused by 
 If enabled then any expression that cannot be resolved, i.e. is evaluated to an instance of `io.quarkus.qute.Results.NotFound`, will always result in a `TemplateException` and the rendering is aborted.
 A `NotFound` value is considered an error because it basically means that no value resolver was able to resolve the expression correctly.
 
-NOTE: `null` is a valid value though. It is considered `falsy` as described in the <<if_section>> and does not produce any output.
+NOTE: `null` is a valid value though. It is considered `falsy` as described in the xref:if_section[] and does not produce any output.
 
 Strict rendering is enabled by default.
 However, you can disable this functionality via `io.quarkus.qute.EngineBuilder.strictRendering(boolean)`.
@@ -1498,7 +1508,7 @@ The `@EngineConfiguration` annotation can be also used to register ``ValueResolv
 [[template-locator-registration]]
 ==== Template Locator Registration
 
-The easiest way to register <<template-locator,template locators>> is to make them CDI beans.
+The easiest way to register xref:template-locator[template locators] is to make them CDI beans.
 As the custom locator is not available during the build time when a template validation is done, you need to disable the validation via the `@Locate` annotation.
 
 .Custom Locator Example
@@ -1544,7 +1554,8 @@ class MyService {
 }
 ----
 
-NOTE: When using `quarkus-resteasy-qute` the content negotiation is performed automatically. See <<resteasy_integration>>.
+NOTE: When using `quarkus-resteasy-qute` the content negotiation is performed automatically.
+For more information, see the xref:resteasy_integration[] section.
 
 [[injecting-beans-directly-in-templates]]
 === Injecting Beans Directly In Templates
@@ -1561,9 +1572,10 @@ A CDI bean annotated with `@Named` can be referenced in any template through `cd
 
 NOTE: `@Named @Dependent` beans are shared across all expressions in a template for a single rendering operation, and destroyed after the rendering finished.
 
-All expressions with `cdi` and `inject` namespaces are validated during build.
-For the expression `cdi:personService.findPerson(10).name` the implementation class of the injected bean must either declare the `findPerson` method or a matching <<template_extension_methods,template extension method>> must exist.
-For the expression `inject:foo.price` the implementation class of the injected bean must either have the `price` property (e.g. a `getPrice()` method) or a matching <<template_extension_methods,template extension method>> must exist.
+All expressions with `cdi` and `inject` namespaces are validated during the build.
+For the expression `cdi:personService.findPerson(10).name`, the implementation class of the injected bean must either declare the `findPerson` method or a matching xref:template_extension_methods[template extension method] must exist.
+
+For the expression `inject:foo.price`, the implementation class of the injected bean must either have the `price` property (e.g. a `getPrice()` method) or a matching xref:template_extension_methods[template extension method] must exist.
 
 NOTE: A `ValueResolver` is also generated for all beans annotated with `@Named` so that it's possible to access its properties without reflection.
 
@@ -1609,7 +1621,7 @@ Type variables are not handled in a special way and should never be used.
 
 IMPORTANT: A value resolver is automatically generated for all types used in parameter declarations so that it's possible to access its properties without reflection.
 
-TIP: Method parameters of <<typesafe_templates,type-safe templates>> are automatically turned into parameter declarations.
+TIP: Method parameters of xref:typesafe_templates[type-safe templates] are automatically turned into parameter declarations.
 
 Note that sections can override names that would otherwise match a parameter declaration:
 
@@ -1640,11 +1652,12 @@ The default value is used in the template if the parameter key resolves to `null
 For example, if there's a parameter declaration `{@String foo="Ping"}` and `foo` is not found then you can use `{foo}` and the output will be `Ping`.
 On the other hand, if the value is set (e.g. via `TemplateInstance.data("foo", "Pong")`) then the output of `{foo}` will be `Pong`.
 
-The type of a default value must be assignable to the type of the parameter declaration, i.e. the following parameter declaration is incorrect and results in a build failure: `{@org.acme.Foo foo=1}`.
+The type of a default value must be assignable to the type of the parameter declaration. For example, see the incorrect parameter declaration that results in a build failure: `{@org.acme.Foo foo=1}`.
 
-TIP: The default value is actually an <<expressions,expression>>. So the default value does not have to be a literal (such as `42` or `true`). For example, you can leverage the `@TemplateEnum` and specify an enum constant as a default value of a parameter declaration: `{@org.acme.MyEnum myEnum=MyEnum:FOO}`. However, the infix notation is not supported in default values unless the parentheses are used for grouping, e.g. `{@org.acme.Foo foo=(foo1 ?: foo2)}``.
+TIP: The default value is an xref:expressions[expression]. So the default value does not have to be a literal (such as `42` or `true`). For example, you can leverage the `@TemplateEnum` and specify an enum constant as a default value of a parameter declaration: `{@org.acme.MyEnum myEnum=MyEnum:FOO}`.
+However, the infix notation is not supported in default values unless the parentheses are used for grouping, e.g., `{@org.acme.Foo foo=(foo1 ?: foo2)}``.
 
-IMPORTANT: The type of a default value is not validated in <<standalone, Qute standalone>>.
+IMPORTANT: The type of a default value is not validated in xref:standalone[Qute standalone].
 
 .More Parameter Declarations Examples 
 [source]
@@ -1664,7 +1677,7 @@ IMPORTANT: The type of a default value is not validated in <<standalone, Qute st
 [[typesafe_templates]]
 === Type-safe Templates
 You can also define type-safe templates in your Java code.
-If using <<resteasy_integration,templates in JAX-RS resources>>, you can rely on the following convention:
+If using xref:resteasy_integration[templates in JAX-RS resources], you can rely on the following convention:
 
 - Organise your template files in the `/src/main/resources/templates` directory, by grouping them into one directory per resource class. So, if
   your `ItemResource` class references two templates `hello` and `goodbye`, place them at `/src/main/resources/templates/ItemResource/hello.txt`
@@ -1705,7 +1718,7 @@ public class ItemResource {
 }
 ----
 <1> Declare a method that gives us a `TemplateInstance` for `templates/ItemResource/item.html` and declare its `Item item` parameter so we can validate the template.
-<2> The `item` parameter is automatically turned into a <<typesafe_expressions,parameter declaration>> and so all expressions that reference this name will be validated.
+<2> The `item` parameter is automatically turned into a xref:typesafe_expressions[parameter declaration] and so all expressions that reference this name will be validated.
 <3> Make the `Item` object accessible in the template.
 
 TIP: By default, the templates defined in a class annotated with `@CheckedTemplate` can only contain type-safe expressions, i.e. expressions that can be validated at build time. You can use `@CheckedTemplate(requireTypeSafeExpressions = false)` to relax this requirement.
@@ -1728,7 +1741,7 @@ public class Templates {
     public static native TemplateInstance hello(String name); <1>
 }
 ----
-<1> This declares a template with path `templates/hello.txt`. The `name` parameter is automatically turned into a  <<typesafe_expressions,parameter declaration>> and so all expressions that reference this name will be validated.
+<1> This declares a template with path `templates/hello.txt`. The `name` parameter is automatically turned into a  xref:typesafe_expressions[parameter declaration], so that all expressions referencing this name will be validated.
 
 Then declare one `public static native TemplateInstance method();` per template file.
 Use those static methods to build your template instances:
@@ -1787,7 +1800,7 @@ public class ItemResource {
 [[type_safe_fragments]]
 ==== Type-safe Fragments
 
-You can also define a type-safe <<fragments,fragment>> in your Java code.
+You can also define a type-safe xref:fragments[fragment] in your Java code.
 A _native static_ method with the name that contains a dollar sign `$` denotes a method that represents a fragment of a type-safe template.
 The name of the fragment is derived from the annotated method name. 
 The part before the last occurence of a dollar sign `$` is the method name of the related type-safe template.
@@ -1844,7 +1857,7 @@ NOTE: You can specify `@CheckedTemplate#ignoreFragments=true` in order to disabl
 [[template_extension_methods]]
 === Template Extension Methods
 
-Extension methods can be used to extend the data classes with new functionality (to extend the set of accessible properties and methods) or to resolve expressions for a specific <<namespace_extension_methods,namespace>>.
+Extension methods can be used to extend the data classes with new functionality (to extend the set of accessible properties and methods) or to resolve expressions for a specific xref:namespace_extension_methods[namespace].
 For example, it is possible to add _computed properties_ and _virtual methods_.
 
 A value resolver is automatically generated for a method annotated with `@TemplateExtension`.
@@ -1955,7 +1968,7 @@ NOTE: Superfluous matching conditions are ignored. The conditions sorted by prio
 
 An extension method may declare parameters.
 If no namespace is specified then the first parameter that is not annotated with `@TemplateAttribute` is used to pass the base object, i.e. `org.acme.Item` in the first example.
-If matching any name or using a regular expression then a string method parameter needs to be used to pass the property name.
+If matching any name or using a regular expression, then a string method parameter needs to be used to pass the property name.
 Parameters annotated with `@TemplateAttribute` are obtained via `TemplateInstance#getAttribute()`.
 All other parameters are resolved when rendering the template and passed to the extension method.
 
@@ -1981,7 +1994,7 @@ class BigDecimalExtensions {
 [[namespace_extension_methods]]
 ==== Namespace Extension Methods
 
-If `TemplateExtension#namespace()` is specified then the extension method is used to resolve expressions with the given <<expressions,namespace>>.
+If `TemplateExtension#namespace()` is specified then the extension method is used to resolve expressions with the given xref:expressions[namespace].
 Template extension methods that share the same namespace are grouped in one resolver ordered by `TemplateExtension#priority()`.
 The first matching extension method is used to resolve an expression.
 
@@ -2283,7 +2296,7 @@ Colors: {#each myColors}{it}{#if it_hasNext}, {/if}{/each} <3>
 <2> `age` resolves to `Globals#age`.
 <3> `myColors` resolves to `Globals#myColors()`.
 
-NOTE: Note that global variables implicitly add <<typesafe_expressions, parameter declarations>> to all templates and so any expression that references a global variable is validated during build.
+NOTE: Note that global variables implicitly add xref:typesafe_expressions[parameter declarations] to all templates and so any expression that references a global variable is validated during build.
 
 .The Output
 [source,html]
@@ -2296,7 +2309,7 @@ Colors: RED, BLUE
 ==== Resolving Conflicts
 
 Global variables may conflict with regular data objects.
-<<typesafe_templates,Type-safe templates>> override the global variables automatically.
+xref:typesafe_templates[Type-safe templates] override the global variables automatically.
 For example, the following definition overrides the global variable supplied by the `Globals#user()` method:
 
 .Type-safe Template Definition
@@ -2340,10 +2353,10 @@ As a result, you may encounter template exceptions like `Property "name" not fou
 
 There are several ways to solve this problem:
 
-* Make use of <<typesafe_templates,type-safe templates>> or <<typesafe_expressions,type-safe expressions>>
+* Make use of xref:typesafe_templates[type-safe templates] or xref:typesafe_expressions[type-safe expressions]
 ** In this case, an optimized value resolver is generated automatically and used at runtime
 ** This is the preferred solution
-* Annotate the model class with <<template_data,`@TemplateData`>> - a specialized value resolver is generated and used at runtime
+* Annotate the model class with xref:template_data[`@TemplateData`] - a specialized value resolver is generated and used at runtime
 * Annotate the model class with `@io.quarkus.runtime.annotations.RegisterForReflection` to make the reflection-based value resolver work
 
 
@@ -2401,11 +2414,13 @@ public class HelloResource {
     }
 }
 ----
-<1> If there is no `@Location` qualifier provided, the field name is used to locate the template. In this particular case, we're injecting a template with path `templates/hello.txt`.
-<2> `Template.data()` returns a new template instance that can be customized before the actual rendering is triggered. In this case, we put the name value under the key `name`. The data map is accessible during rendering. 
+<1> If there is no `@Location` qualifier provided, the field name is used to locate the template.
+In this particular case, we're injecting a template with path `templates/hello.txt`.
+<2> `Template.data()` returns a new template instance that can be customized before the actual rendering is triggered. In this case, we put the name value under the key `name`.
+The data map is accessible during rendering.
 <3> Note that we don't trigger the rendering - this is done automatically by a special `ContainerResponseFilter` implementation.
 
-TIP: Users are encouraged to use <<typesafe_templates,Type-safe templates>> that help to organize the templates for a specific JAX-RS resource and enable <<typesafe_expressions,type-safe expressions>> automatically.
+TIP: Users are encouraged to use xref:typesafe_templates[type-safe templates] that help to organize the templates for a specific JAX-RS resource and enable xref:typesafe_expressions[type-safe expressions] automatically.
 
 The content negotiation is performed automatically.
 The resulting output depends on the `Accept` header received from the client.
@@ -2621,7 +2636,7 @@ public class MyBean {
 <1> You can set a `Locale` instance or a locale tag string (IETF).
 
 
-NOTE: When using <<resteasy_integration,quarkus-resteasy-qute>> the `locale` attribute is derived from the `Accept-Language` header if not set by a user.
+NOTE: When using xref:resteasy_integration[quarkus-resteasy-qute], the `locale` attribute is derived from the `Accept-Language` header if not set by a user.
 
 The `@Localized` qualifier can be used to inject a localized message bundle interface.
 
@@ -2690,11 +2705,12 @@ Qute is primarily designed as a Quarkus extension.
 However. it is possible to use it as a "standalone" library.
 In this case, some features are not available and some additional configuration is needed.
 
-Engine:: First, no managed `Engine` instance is available out of the box.
+Engine::
+* First, no managed `Engine` instance is available out of the box.
 You'll need to configure a new instance via `Engine.builder()`.
 
-Templates:: 
-* By default, no <<template-locator,template locators>> are registered, i.e. `Engine.getTemplate(String)` will not work. 
+Templates::
+* By default, no xref:template-locator[template locators] are registered, i.e. `Engine.getTemplate(String)` will not work.
 * You can register a custom template locator using `EngineBuilder.addLocator()` or parse a template manually and put the result in the cache via `Engine.putTemplate(String, Template)`.
 
 Sections::
@@ -2702,9 +2718,9 @@ Sections::
 * The default set of value resolvers can be registered via the convenient `EngineBuilder.addDefaultSectionHelpers()` method and the `EngineBuilder.addDefaults()` method respectively.
 
 Value resolvers:: 
-* No <<value-resolvers,``ValueResolver``s>> are generated automatically.
-** <<template_extension_methods,`@TemplateExtension` methods>> will not work. 
-** <<template_data,`@TemplateData`>> and <<convenient-annotation-for-enums,`@TemplateEnum`>> annotations are ignored.
+* No xref:value-resolvers[`ValueResolvers`] are generated automatically.
+** xref:template_extension_methods[`@TemplateExtension` methods] will not work.
+** xref:template_data[`@TemplateData`] and xref:convenient-annotation-for-enums[`@TemplateEnum`] annotations are ignored.
 * The default set of value resolvers can be registered via the convenient `EngineBuilder.addDefaultValueResolvers()` method and the `EngineBuilder.addDefaults()` method respectively.
 +
 NOTE: Not all functionality provided by the built-in extension methods is covered by the default value resolvers. However, a custom value resolver can be easily built via the `ValueResolver.builder()`.
@@ -2717,7 +2733,7 @@ User-defined Tags::
 * A tag can be registered manually via `Engine.builder().addSectionHelper(new UserTagSectionHelper.Factory("tagName","tagTemplate.html")).build()`
 
 Type-safety::
-* <<typesafe_expressions>> are not validated.
-* <<type-safe-message-bundles,Type-safe message bundles>> are not supported.
+* xref:typesafe_expressions[Type-safe expressions] are not validated.
+* xref:type-safe-message-bundles[Type-safe message bundles] are not supported.
 
 Injection:: It is not possible to inject a `Template` instance and vice versa - a template cannot inject a `@Named` CDI bean via the `inject:` and `cdi:` namespace.

--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -876,9 +876,9 @@ paths:
 === Using Swagger UI
 
 Swagger UI is included by default when running in `dev` or `test` mode, and can optionally be added to `prod` mode.
-See <<openapi-swaggerui.adoc#dev-mode,the Swagger UI>> Guide for more details.
+For more information, see the xref:openapi-swaggerui.adoc#dev-mode[Swagger UI] guide.
 
-Navigate to link:http://localhost:8080/q/swagger-ui/[localhost:8080/q/swagger-ui/] and you will see the Swagger UI screen:
+Navigate to link:http://localhost:8080/q/swagger-ui/[localhost:8080/q/swagger-ui/] and observe the Swagger UI screen:
 
 image:reactive-routes-guide-screenshot01.png[alt=Swagger UI]
 

--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -53,7 +53,7 @@ import io.quarkus.redis.datasource.RedisDataSource;
 @Inject RedisDataSource highLevelApi;
 ----
 
-More details about the various APIs offered by the quarkus-redis extension are available in the <<apis>> section.
+More details about the various APIs offered by the quarkus-redis extension are available in the xref:apis[] section.
 
 [[apis]]
 == One extension, multiple APIs

--- a/docs/src/main/asciidoc/rest-data-panache.adoc
+++ b/docs/src/main/asciidoc/rest-data-panache.adoc
@@ -9,28 +9,29 @@ include::_attributes.adoc[]
 :summary: Hibernate ORM REST Data with Panache simplifies the creation of CRUD applications based on JAX-RS and Hibernate ORM.
 
 A lot of web applications are monotonous CRUD applications with REST APIs that are tedious to write.
-To streamline this task, REST Data with Panache extension can generate the basic CRUD endpoints for your entities and repositories.
+To streamline this task, REST Data with the Panache extension can generate the basic CRUD endpoints for your entities and repositories.
 
 While this extension is still experimental and provides a limited feature set, we hope to get an early feedback for it.
 Currently, this extension supports Hibernate ORM and MongoDB with Panache and can generate CRUD resources that work with `application/json` and `application/hal+json` content.
 
 == Setting up REST Data with Panache
 
-Quarkus provides the following extensions to set up REST Data with Panache. Please, check out the next compatibility table to use the right one according to the technology you're using:
+Quarkus provides the following extensions to set up REST Data with Panache.
+Please, check out the next compatibility table to use the right one according to the technology you're using:
 
 .Compatibility Table
 |===
 |Extension |Hibernate | RESTEasy
 
-|<<hr-hibernate-orm, quarkus-hibernate-orm-rest-data-panache>>
+|xref:hr-hibernate-orm[quarkus-hibernate-orm-rest-data-panache]
 |`ORM`
 |`Classic and Reactive`
 
-|<<hr-hibernate-reactive, quarkus-hibernate-reactive-rest-data-panache>>
+|xref:hr-hibernate-reactive[quarkus-hibernate-reactive-rest-data-panache]
 |`Reactive`
 |`Reactive`
 
-|<<hr-mongodb, quarkus-mongodb-rest-data-panache>>
+|xref:hr-mongodb[quarkus-mongodb-rest-data-panache]
 |`ORM`
 |`Classic and Reactive`
 |===
@@ -83,8 +84,8 @@ implementation("io.quarkus:quarkus-resteasy-reactive-jackson")
 // implementation("io.quarkus:quarkus-resteasy-jackson")
 ----
 
-* Implement the Panache entities and/or repositories as explained in the xref:hibernate-orm-panache.adoc[Hibernate ORM with Panache guide].
-* Define the interfaces for generation as explained in <<hr-generating-resources, the resource generation section>>.
+* Implement the Panache entities and/or repositories as explained in the xref:hibernate-orm-panache.adoc[Hibernate ORM with Panache] guide.
+* Define the interfaces for generation as explained in the xref:hr-generating-resources[] section.
 
 To see the Hibernate ORM REST Data with Panache in action, you can check out the {quickstarts-tree-url}/hibernate-orm-rest-data-panache-quickstart[hibernate-orm-rest-data-panache-quickstart] quickstart.
 
@@ -115,8 +116,8 @@ To see the Hibernate ORM REST Data with Panache in action, you can check out the
 </dependencies>
 ----
 
-* Implement the Panache entities and/or repositories as explained in the xref:hibernate-reactive-panache.adoc[Hibernate Reactive with Panache guide].
-* Define the interfaces for generation as explained in <<hr-generating-resources, the resource generation section>>.
+* Implement the Panache entities and/or repositories as explained in the xref:hibernate-reactive-panache.adoc[Hibernate Reactive with Panache] guide.
+* Define the interfaces for generation as explained in the xref:hr-generating-resources[] section.
 
 [[hr-mongodb]]
 === MongoDB
@@ -160,8 +161,8 @@ implementation("io.quarkus:quarkus-resteasy-reactive-jackson")
 // implementation("io.quarkus:quarkus-resteasy-jackson")
 ----
 
-* Implement the Panache entities and/or repositories as explained in the xref:mongodb-panache.adoc[MongoDB with Panache guide].
-* Define the interfaces for generation as explained in <<hr-generating-resources, the resource generation section>>.
+* Implement the Panache entities and/or repositories as explained in the xref:mongodb-panache.adoc[MongoDB with Panache] guide.
+* Define the interfaces for generation as explained in the xref:hr-generating-resources[] section.
 
 [[hr-generating-resources]]
 == Generating resources

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -118,7 +118,7 @@ public class Endpoint {
 }
 ----
 
-See <<uri-parameters,URI parameters>> for more information about URI mapping.
+See xref:uri-parameters[URI parameters] for more information about URI mapping.
 
 You can set the root path for all rest endpoints using the `@ApplicationPath` annotation, as shown below.
 
@@ -207,7 +207,7 @@ link:{httpspec}#section-3.1.1.1[MIME (Media Type)] values, such as the following
 
 - `text/plain` which is the default for any endpoint returning a `String`.
 - `text/html` for HTML (such as with xref:qute.adoc[Qute templating])
-- `application/json` for a <<json,JSON REST endpoint>>
+- `application/json` for a xref:json[JSON REST endpoint]
 - `text/*` which is a sub-type wildcard for any text media type
 - `\*/*` which is a wildcard for any media type
 
@@ -223,7 +223,7 @@ case they override any eventual class annotation.
 The link:{jaxrsapi}/jakarta/ws/rs/core/MediaType.html[`MediaType`] class has many constants you
 can use to point to specific pre-defined media types.
 
-See <<negotiation>> for more information.
+See the xref:negotiation[] section for more information.
 
 === Accessing request parameters
 
@@ -241,7 +241,7 @@ The following HTTP request elements may be obtained by your endpoint method:
 |[[path-parameter]]Path parameter
 |link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestPath.html[`@RestPath`] (or nothing)
 |URI template parameter (simplified version of the https://tools.ietf.org/html/rfc6570[URI Template specification]),
-see <<uri-parameters,URI parameters>> for more information.
+see xref:uri-parameters[URI parameters] for more information.
 
 |Query parameter
 |link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestQuery.html[`@RestQuery`]
@@ -325,7 +325,7 @@ link:{jaxrsapi}/jakarta/ws/rs/FormParam.html[`@FormParam`] or
 link:{jaxrsapi}/jakarta/ws/rs/MatrixParam.html[`@MatrixParam`] for this,
 but they require you to specify the parameter name.
 
-See <<parameter-mapping>> for more advanced use-cases.
+See xref:parameter-mapping[] for more advanced use-cases.
 
 [NOTE]
 ====
@@ -390,7 +390,7 @@ public class Endpoint {
     }
 }
 ----
-<1>  `BeanParam` is required to comply with the JAX-RS specification so that libraries like OpenAPI can introspect the parameters.
+<1> `BeanParam` is required to comply with the JAX-RS specification so that libraries like OpenAPI can introspect the parameters.
 
 === Declaring URI parameters
 
@@ -427,7 +427,7 @@ public class Endpoint {
 === Accessing the request body
 
 Any method parameter with no annotation will receive the method body.footnote:[Unless it is a
-<<path-parameter,URI template parameter>> or a <<context-objects,context object>>.], after it has been mapped from
+xref:path-parameter[URI template parameter] or a xref:context-objects[context object].], after it has been mapped from
 its HTTP representation to the Java type of the parameter.
 
 The following parameter types will be supported out of the box:
@@ -470,11 +470,11 @@ link:{jsonpapi}/jakarta/json/JsonStructure.html[`JsonStructure`], link:{jsonpapi
 |Vert.x Buffer
 
 |any other type
-|Will be <<json,mapped from JSON to that type>>
+|Will be xref:json[mapped from JSON to that type]
 
 |===
 
-NOTE: You can add support for more <<readers-writers,body parameter types>>.
+NOTE: You can add support for more xref:readers-writers[body parameter types].
 
 [[multipart]]
 === Handling Multipart Form data
@@ -516,10 +516,10 @@ public class MultipartResource {
 The `description` parameter will contain the data contained in the part of HTTP request called `description` (because
 link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestForm.html[`@RestForm`] does not define a value, the field name is used),
 while the `file` parameter will contain data about the uploaded file in the `image` part of HTTP request, and
-the `person` parameter will read the `Person` entity using the `JSON` <<json,body reader>>.
+the `person` parameter will read the `Person` entity using the `JSON` xref:json[body reader].
 
 The size of every part in a multipart request must conform to the value of `quarkus.http.limits.max-form-attribute-size`, for which the default is 2048 bytes.
-Any request with a part size exceeding this configuration will result in HTTP status code 413.
+Any request with a part-size exceeding this configuration will result in HTTP status code 413.
 
 NOTE: link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/multipart/FileUpload.html[`FileUpload`]
 provides access to various metadata of the uploaded file. If however all you need is a handle to the uploaded file, `java.nio.file.Path` or `java.io.File` could be used.
@@ -528,9 +528,9 @@ If you need access to all uploaded files for all parts regardless of their names
 
 NOTE: link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/PartType.html[`@PartType`] is used to aid
 in deserialization of the corresponding part of the request into the desired Java type. It is only required if
-you need to use <<readers-writers,a special body parameter type>> for that particular parameter.
+you need to use a xref:readers-writers[special body parameter type] for that particular parameter.
 
-NOTE: Just like for any other request parameter type, you can also group them into a <<parameter-grouping,container class>>.
+NOTE: Just like for any other request parameter type, you can also group them into a xref:parameter-grouping[container class].
 
 WARNING: When handling file uploads, it is very important to move the file to permanent storage (like a database, a dedicated file system or a cloud storage) in your code that handles the POJO.
 Otherwise, the file will no longer be accessible when the request terminates.
@@ -597,7 +597,7 @@ public static class Resource {
 
 As part of reading the multipart body, RESTEasy Reactive invokes the proper MessageBodyReaderlink:{jaxrsapi}/jakarta/ws/rs/ext/MessageBodyReader.html[`MessageBodyReader`] for each part of the request.
 If an `IOException` occurs for one of these parts (for example if Jackson was unable to deserialize a JSON part), then a `org.jboss.resteasy.reactive.server.multipart.MultipartPartReadingException` is thrown.
-If this exception is not handled by the application as mentioned in <<exception-mapping>>, an HTTP 400 response is returned by default.
+If this exception is not handled by the application as mentioned in xref:exception-mapping[], an HTTP 400 response is returned by default.
 
 ==== Multipart output
 
@@ -678,10 +678,10 @@ WARNING: For the time being, returning Multipart data is limited to be blocking 
 
 In order to return an HTTP response, simply return the resource you want from your method. The method
 return type and its optional content type will be used to decide how to serialise it to the HTTP
-response (see <<negotiation>> for more advanced information).
+response. See the xref:negotiation[] section for more advanced information.
 
-You can return any of the pre-defined types that you can read from the <<resource-types,HTTP response>>,
-and any other type will be mapped <<json,from that type to JSON>>.
+You can return any of the pre-defined types that you can read from the xref:resource-types[HTTP response],
+and any other type will be mapped xref:json[from that type to JSON].
 
 In addition, the following return types are also supported:
 
@@ -703,7 +703,7 @@ In addition, the following return types are also supported:
 
 |===
 
-Alternately, you can also return a <<reactive,reactive type>> such as link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni`],
+Alternately, you can also return a xref:reactive[reactive type], such as link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni`],
 link:{mutinyapi}/io/smallrye/mutiny/Multi.html[`Multi`] or
 link:{jdkapi}/java/util/concurrent/CompletionStage.html[`CompletionStage`]
 that resolve to one of the mentioned return types.
@@ -887,8 +887,7 @@ public class Endpoint {
 
 This allows you to not block the event-loop thread while the book is being fetched from the
 database, and allows Quarkus to serve more requests until your book is ready to
-be sent to the client and terminate this request. Check out our
-<<execution-model,Execution Model documentation>> for more information.
+be sent to the client and terminate this request.See xref:execution-model[Execution Model documentation] for more information.
 
 The link:{jdkapi}/java/util/concurrent/CompletionStage.html[`CompletionStage`] return
 type is also supported.
@@ -930,7 +929,8 @@ public class Endpoint {
 
 NOTE: Response filters are **not** invoked on streamed responses, because they would give a false
 impression that you can set headers or HTTP status codes, which is not true after the initial
-response. Exception mappers are also not invoked because part of the response may already have been written.
+response.
+Exception mappers are also not invoked because part of the response may already have been written.
 
 === Server-Sent Event (SSE) support
 
@@ -938,7 +938,7 @@ If you want to stream JSON objects in your response, you can use
 https://html.spec.whatwg.org/multipage/server-sent-events.html[Server-Sent Events]
 by just annotating your endpoint method with
 link:{jaxrsapi}/jakarta/ws/rs/Produces.html[`@Produces(MediaType.SERVER_SENT_EVENTS)`]
-and specifying that each element should be <<json,serialised to JSON>> with
+and specifying that each element should be xref:json[serialised to JSON] with
 `@RestStreamElementType(MediaType.APPLICATION_JSON)`.
 
 [source,java]
@@ -1027,7 +1027,7 @@ method takes parameters of the following type:
 |Advanced: Runtime access to JAX-RS providers
 
 |link:{jaxrsapi}/jakarta/ws/rs/core/Request.html[`Request`]
-|Advanced: Access to the current HTTP method and <<preconditions>>
+|Advanced: Access to the current HTTP method and xref:preconditions[precondition]
 
 |link:{jaxrsapi}/jakarta/ws/rs/core/ResourceContext.html[`ResourceContext`]
 |Advanced: access to instances of endpoints
@@ -1148,8 +1148,8 @@ Instead of importing `io.quarkus:quarkus-resteasy-reactive`, you can import eith
 |===
 
 In both cases, importing those modules will allow HTTP message bodies to be read from JSON
-and serialised to JSON, for <<resource-types,all the types not already registered with a more specific
-serialisation>>.
+and serialised to JSON, for xref:resource-types[all the types not already registered with a more specific
+serialisation].
 
 ==== Advanced Jackson-specific features
 
@@ -1278,8 +1278,9 @@ public class User {
 }
 ----
 
-Depending on the JAX-RS method that returns this user, we might want to exclude the `id` field from serialization - for example you might want an insecure method
-to not expose this field. The way we can achieve that in RESTEasy Reactive is shown in the following example:
+Depending on the JAX-RS method that returns this user, we might want to exclude the `id` field from serialization.
+For example, you might want an insecure method to not expose this field.
+The way we can achieve that in RESTEasy Reactive is shown in the following example:
 
 [source,java]
 ----
@@ -1351,8 +1352,8 @@ To enable XML support, add the `quarkus-resteasy-reactive-jaxb` extension to you
 |===
 
 Importing this module will allow HTTP message bodies to be read from XML
-and serialised to XML, for <<resource-types,all the types not already registered with a more specific
-serialisation>>.
+and serialised to XML, for xref:resource-types[all the types not already registered with a more specific
+serialisation].
 
 The JAXB Resteasy Reactive extension will automatically detect the classes that are used in the resources and require JAXB serialization. Then, it will register these classes into the default `JAXBContext` which is internally used by the JAXB message reader and writer. 
 
@@ -1746,10 +1747,9 @@ by default:
 - `org.reactivestreams.Publisher`
 - Kotlin `suspended` methods
 
-This 'best guess' approach means that the majority of operations will run on the correct thread by default. If you are
-writing reactive code then your method will generally return one of these types, and will be executed on the IO thread.
-If you are writing blocking code your methods will usually return the result directly, and these will be run on a worker
-thread.
+This 'best guess' approach means most operations will run on the correct thread by default.
+If you are writing reactive code, your method will generally return one of these types and will be executed on the IO thread.
+If you are writing blocking code, your methods will usually return the result directly, and these will be run on a worker thread.
 
 You can override this behaviour using the
 https://javadoc.io/doc/io.smallrye.common/smallrye-common-annotation/1.5.0/io/smallrye/common/annotation/Blocking.html[`@Blocking`]
@@ -1814,11 +1814,11 @@ Hibernate and JDBC. An explicit `@Blocking` or `@NonBlocking` on the class will 
 
 ==== Overriding the default behaviour
 
-If you want to override the default behaviour you can annotate a `jakarta.ws.rs.core.Application` subclass in your application
-with `@Blocking` or `@NonBlocking`, and this will set the default for every method that does not have an explicit annotation.
+If you want to override the default behavior, you can annotate a `jakarta.ws.rs.core.Application` subclass in your application with `@Blocking` or `@NonBlocking`,
+and this will set the default for every method that does not have an explicit annotation.
 
-Behaviour can still be overridden on a class or method level by annotating them directly, however all endpoints without
-an annotation will now follow the default, no matter their method signature.
+Behavior can still be overridden on a class or method level by annotating them directly, however,
+all endpoints without an annotation will now follow the default, no matter their method signature.
 
 [[exception-mapping]]
 === Exception mapping
@@ -1949,7 +1949,7 @@ Your exception mapper may declare any of the following parameter types:
 |An exception type
 |Defines the exception type you want to handle
 
-|Any of the <<context-objects,Context objects>>
+|Any of the xref:context-objects[context objects]
 |
 
 |link:{jaxrsapi}/jakarta/ws/rs/container/ContainerRequestContext.html[`ContainerRequestContext`]
@@ -2063,7 +2063,7 @@ Your filters may declare any of the following parameter types:
 |===
 |Type|Usage
 
-|Any of the <<context-objects,Context objects>>
+|Any of the xref:context-objects[context objects]
 |
 
 |link:{jaxrsapi}/jakarta/ws/rs/container/ContainerRequestContext.html[`ContainerRequestContext`]
@@ -2400,8 +2400,8 @@ However, you can change this default behavior and constrain a provider to:
 
 === Parameter mapping
 
-All <<request-parameters,Request Parameters>> can be declared as link:{jdkapi}/java/lang/String.html[`String`], but also
-any of the following types:
+All xref:request-parameters[Request Parameters] can be declared as link:{jdkapi}/java/lang/String.html[`String`],
+but also any of the following types:
 
 - Types for which a link:{jaxrsapi}/jakarta/ws/rs/ext/ParamConverter.html[`ParamConverter`] is available via a registered
 link:{jaxrsapi}/jakarta/ws/rs/ext/ParamConverterProvider.html[`ParamConverterProvider`].
@@ -2504,8 +2504,8 @@ public class Endpoint {
 
 ==== Handling dates
 
-RESTEasy Reactive supports the use of the implementations of `java.time.Temporal` (like `java.time.LocalDateTime`) as query, path or form params. Furthermore, it provides the `@org.jboss.resteasy.reactive.DateFormat` annotation which can be used to
-set a custom expected pattern (otherwise the JDK's default format for each type is used implicitly).
+RESTEasy Reactive supports the use of the implementations of `java.time.Temporal` (like `java.time.LocalDateTime`) as query, path, or form params.
+Furthermore, it provides the `@org.jboss.resteasy.reactive.DateFormat` annotation, which can be used to set a custom expected pattern. Otherwise, the JDK's default format for each type is used implicitly.
 
 === Preconditions
 
@@ -2606,10 +2606,9 @@ And we would get the following response:
 HTTP/1.1 304 Not Modified
 ----
 
-Because the resource has not been modified since that date. This saves on sending the resource,
-but can also help your users detect concurrent modification, for example, let's suppose that one
-client wants to update the resource, but another user has modified it since. You can follow the
-previous `GET` request with this update:
+Because the resource has not been modified since that date, this saves on sending the resource but can also help your users detect the concurrent modification.
+For example, one client wants to update the resource, but another user has modified it since.
+You can follow the previous `GET` request with this update:
 
 [source]
 ----

--- a/docs/src/main/asciidoc/security-jwt-build.adoc
+++ b/docs/src/main/asciidoc/security-jwt-build.adoc
@@ -133,7 +133,7 @@ import io.smallrye.jwt.build.Jwt;
 String jwt = Jwt.upn("Alice").sign();
 ----
 
-Note the `sign` step can be combined with the <<encrypt-claims, encrypt>> step to produce `inner-signed and encrypted` tokens, see <<innersign-encrypt-claims, Sign the claims and encrypt the nested JWT token>> section.
+Note the `sign` step can be combined with the xref:encrypt-claims[encrypt] step to produce `inner-signed and encrypted` tokens, see xref:innersign-encrypt-claims[Sign the claims and encrypt the nested JWT token] section.
 
 [[encrypt-claims]]
 == Encrypt the claims
@@ -201,7 +201,7 @@ String jwt = Jwt.subject("Bob").encrypt();
 Note that when the token is directly encrypted by the public RSA or EC key it is not possible to verify which party sent the token.
 Therefore, the secret keys should be preferred for directly encrypting the tokens, for example, when using JWT as cookies where a secret key is managed by the Quarkus endpoint with only this endpoint being both a producer and a consumer of the encrypted token.
 
-If you would like to use RSA or EC public keys to encrypt the token then it is recommended to sign the token first if the signing key is available, see the next <<innersign-encrypt-claims, Sign the claims and encrypt the nested JWT token>> section.
+If you would like to use RSA or EC public keys to encrypt the token then it is recommended to sign the token first if the signing key is available, see the next xref:innersign-encrypt-claims[Sign the claims and encrypt the nested JWT token] section.
 
 [[innersign-encrypt-claims]]
 == Sign the claims and encrypt the nested JWT token

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -288,7 +288,7 @@ mp.jwt.verify.issuer=https://example.com/issuer #<2>
 
 quarkus.native.resources.includes=publicKey.pem #<3>
 ----
-<1> We are setting public key location to point to a classpath publicKey.pem location. We will add this key in part B, <<Adding a Public Key>>.
+<1> We are setting public key location to point to a classpath publicKey.pem location. We will add this key in part B, xref:Adding a Public Key[].
 <2> We are setting the issuer to the URL string `https://example.com/issuer`.
 <3> We are including the public key as a resource in the native executable.
 
@@ -642,6 +642,7 @@ Note you can also use the injected `JsonWebToken` to access the individual claim
 
 Please see link:https://download.eclipse.org/microprofile/microprofile-jwt-auth-1.2/microprofile-jwt-auth-spec-1.2.html#_cdi_injection_requirements[MP JWT CDI Injection Requirements] for more details.
 
+[[supported-public-key-formats]]
 === Supported Public Key Formats
 
 Public Keys may be formatted in any of the following formats, specified in order of
@@ -732,16 +733,15 @@ public class SecuredResource {
 }
 ----
 
-Please also see the <<add-smallrye-jwt, How to Add SmallRye JWT directly>> section about using `JWTParser` without the `HTTP` support provided by `quarkus-smallrye-jwt`.
+Please also see the xref:add-smallrye-jwt[How to Add SmallRye JWT directly] section about using `JWTParser` without the `HTTP` support provided by `quarkus-smallrye-jwt`.
 
 === Token Decryption
 
-If your application needs to accept the tokens with the encrypted claims or with the encrypted inner signed claims then all you have to do is to set
+If your application needs to accept the tokens with the encrypted claims or the encrypted inner-signed claims, all you have to do is set
 `smallrye.jwt.decrypt.key.location` pointing to the decryption key.
 
-If this is the only key property which is set then the incoming token is expected to contain the encrypted claims only.
-If either `mp.jwt.verify.publickey` or `mp.jwt.verify.publickey.location` verification properties are also set then the incoming token is expected to contain
-the encrypted inner-signed token.
+If this is the only key property that is set, the incoming token is expected to contain the encrypted claims only.
+If either `mp.jwt.verify.publickey` or `mp.jwt.verify.publickey.location` verification properties are also set then the incoming token is expected to contain the encrypted inner-signed token.
 
 See xref:security-jwt-build.adoc[Generate JWT tokens with SmallRye JWT] and learn how to generate the encrypted or inner-signed and then encrypted tokens fast.
 
@@ -975,9 +975,12 @@ Note that you can't access the injected `JsonWebToken` in the public methods if 
 [[add-smallrye-jwt]]
 === How to Add SmallRye JWT directly
 
-If you work with Quarkus extensions which do not support `HTTP` (for example, `Quarkus GRPC`) or provide their own extension specific `HTTP` support conflicting with the one offered by `quarkus-smallrye-jwt` and `Vert.x HTTP` (example, `Quarkus Amazon Lambda`) and you would like to <<jwt-parser, Parse and Verify JsonWebToken with JWTParser>> then please use `smallrye-jwt` directly instead of `quarkus-smallrye-jwt`.
+To xref:jwt-parser[parse and verify JsonWebToken with JWTParser], use `smallrye-jwt` instead of `quarkus-smallrye-jwt` directly for the following situations:
 
-Add this dependency:
+* You work with Quarkus extensions that do not support `HTTP`, such as `Quarkus GRPC`.
+* You provide an extension-specific `HTTP`, the support of which conflicts with the support of those offered by `quarkus-smallrye-jwt` and `Vert.x HTTP`, such as `Quarkus Amazon Lambda`.
+
+Start with adding the `smallrye-jwt` dependency:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml
@@ -1014,7 +1017,7 @@ include::{generated-dir}/config/quarkus-smallrye-jwt.adoc[opts=optional, levelof
 [cols="<m,<m,<2",options="header"]
 |===
 |Property Name|Default|Description
-|mp.jwt.verify.publickey|none|The `mp.jwt.verify.publickey` config property allows the Public Key text itself to be supplied as a string.  The Public Key will be parsed from the supplied string in the order defined in section <<Supported Public Key Formats>>.
+|mp.jwt.verify.publickey|none|The `mp.jwt.verify.publickey` config property allows the Public Key text itself to be supplied as a string.  The Public Key will be parsed from the supplied string in the order defined in section xref:supported-public-key-formats[].
 |mp.jwt.verify.publickey.location|none|Config property allows for an external or internal location of Public Key to be specified.  The value may be a relative path or a URL. If the value points to an HTTPS based JWK set then, for it to work in native mode, the `quarkus.ssl.native` property must also be set to `true`, see xref:native-and-ssl.adoc[Using SSL With Native Executables] for more details.
 |mp.jwt.verify.publickey.algorithm|`RS256`|Signature algorithm. Set it to `ES256` to support the Elliptic Curve signature algorithm.
 |mp.jwt.decrypt.key.location|none|Config property allows for an external or internal location of Private Decryption Key to be specified.

--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -136,9 +136,9 @@ quarkus.oauth2.introspection-url=http://oauth-server/introspect
 ----
 
 You need to specify the introspection URL of your authentication server and the `client-id` / `client-secret` that your application will use to authenticate itself to the authentication server. +
-The extension will then use this information to validate the token and recover the information associate with it.
+The extension will then use this information to validate the token and recover the information associated with it.
 
-For all configuration properties, see the <<config-reference,Configuration reference>> section at the end of this guide.
+For all configuration properties, see the xref:config-reference[Configuration reference] section at the end of this guide.
 
 == Run the application
 
@@ -353,7 +353,7 @@ values that Quarkus will use.
 
 [NOTE]
 ====
-For more details about `@QuarkusTestResource` refer to  xref:getting-started-testing.adoc#quarkus-test-resource[this part of the documentation].
+For more details about `@QuarkusTestResource` refer to xref:getting-started-testing.adoc#quarkus-test-resource[this part of the documentation].
 ====
 
 Let's create an implementation of `QuarkusTestResourceLifecycleManager` called `MockAuthorizationServerTestResource` like so:

--- a/docs/src/main/asciidoc/security-properties.adoc
+++ b/docs/src/main/asciidoc/security-properties.adoc
@@ -53,7 +53,7 @@ quarkus.security.users.file.plain-text=true
 
 ==== Users.properties
 
-The `quarkus.security.users.file.users` configuration property specifies a classpath resource which is a properties file with a user to password mapping, one per line. The following <<test-users-example>> illustrates the format:
+The `quarkus.security.users.file.users` configuration property specifies a classpath resource which is a properties file with a user to password mapping, one per line. The following xref:test-users-example[] illustrates the format:
 
 [#test-users-example]
 .example test-users.properties file
@@ -113,7 +113,7 @@ be generated for the first example above by running the command `echo -n scott:M
 
 ==== Embedded Users
 
-The user to password mappings are specified in the `application.properties` file by properties keys of the form `quarkus.security.users.embedded.users.<user>=<password>`. The following <<password-example>> illustrates the syntax with 4 user to password mappings:
+The user to password mappings are specified in the `application.properties` file by properties keys of the form `quarkus.security.users.embedded.users.<user>=<password>`. The following xref:password-example[] illustrates the syntax with 4 user to password mappings:
 
 [#password-example]
 .Example Passwords
@@ -129,7 +129,7 @@ quarkus.security.users.embedded.users.noadmin=n0Adm1n
 
 ==== Embedded Roles
 
-The user to role mappings are specified in the `application.properties` file by properties keys of the form `quarkus.security.users.embedded.roles.<user>=role1[,role2[,role3[,...]]]`. The following <<roles-example>> illustrates the syntax with 4 user to role mappings:
+The user to role mappings are specified in the `application.properties` file by properties keys of the form `quarkus.security.users.embedded.roles.<user>=role1[,role2[,role3[,...]]]`. The following xref:roles-example[] illustrates the syntax with 4 user to role mappings:
 
 [#roles-example]
 .Example Roles

--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -1004,10 +1004,9 @@ if the connection to the quarkus service is established from the same host.
 This can happen if access to the service goes through a proxy which is often the case
 if you're setting up a service mesh with a proxy like Envoy.
 
-IMPORTANT: This will only work on platforms that support <<native-transport>>.
+IMPORTANT: This will only work on platforms that support xref:native-transport[].
 
-Enable the appropriate <<native-transport>> and set the following
-environment property:
+Enable the appropriate xref:native-transport[] and set the following environment property:
 
 ----
 quarkus.http.domain-socket=/var/run/io.quarkus.app.socket


### PR DESCRIPTION
Closing https://issues.redhat.com/browse/QDOCS-175

The old  anchor syntax, [anchor] ->  <<call the anchor >>, even thought working competently fine in upstream docs, doesn't render properly for the single-sourced documentation. Thus, I am proposing a change  to a variance that works properly in both repositories and allows for future automation.

This is a little step forward to a better synergy between Upstream and Downsream.
