### PR TITLE
RESTEasy Reactive: treat multipart file input as regular input

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FormData.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FormData.java
@@ -17,6 +17,10 @@ public class FormData {
     @PartType(MediaType.APPLICATION_JSON)
     public Map<String, Object> map;
 
+    @RestForm
+    @PartType(MediaType.APPLICATION_JSON)
+    public Map<String, Object> map2;
+
     @FormParam("names")
     @PartType(MediaType.TEXT_PLAIN)
     public List<String> names;
@@ -36,11 +40,24 @@ public class FormData {
 
     @RestForm
     @PartType(MediaType.APPLICATION_JSON)
+    @Valid
+    public Person person2;
+
+    @RestForm
+    @PartType(MediaType.APPLICATION_JSON)
     public Person[] persons;
 
     @RestForm
     @PartType(MediaType.APPLICATION_JSON)
     public List<Person> persons2;
+
+    @RestForm
+    @PartType(MediaType.APPLICATION_JSON)
+    public Person[] persons3;
+
+    @RestForm
+    @PartType(MediaType.APPLICATION_JSON)
+    public List<Person> persons4;
 
     @RestForm("htmlFile")
     private FileUpload htmlPart;

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultipartResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultipartResource.java
@@ -29,7 +29,9 @@ public class MultipartResource {
     @Path("/json")
     public Map<String, Object> greeting(@Valid @BeanParam FormData formData) {
         Map<String, Object> result = new HashMap<>(formData.map);
+        result.putAll(formData.map2);
         result.put("person", formData.person);
+        result.put("person2", formData.person2);
         result.put("htmlFileSize", formData.getHtmlPart().size());
         result.put("htmlFilePath", formData.getHtmlPart().uploadedFile().toAbsolutePath().toString());
         result.put("htmlFileContentType", formData.getHtmlPart().contentType());
@@ -38,6 +40,8 @@ public class MultipartResource {
         result.put("numbers2", formData.numbers2);
         result.put("persons", formData.persons);
         result.put("persons2", formData.persons2);
+        result.put("persons3", formData.persons3);
+        result.put("persons4", formData.persons4);
         return result;
     }
 
@@ -48,6 +52,7 @@ public class MultipartResource {
     @Path("/param/json")
     public Map<String, Object> greeting(
             @RestForm @PartType(MediaType.APPLICATION_JSON) Map<String, Object> map,
+            @RestForm @PartType(MediaType.APPLICATION_JSON) Map<String, Object> map2,
 
             @FormParam("names") @PartType(MediaType.TEXT_PLAIN) List<String> names,
 
@@ -56,14 +61,20 @@ public class MultipartResource {
             @RestForm @PartType(MediaType.TEXT_PLAIN) List<Integer> numbers2,
 
             @RestForm @PartType(MediaType.APPLICATION_JSON) @Valid Person person,
+            @RestForm @PartType(MediaType.APPLICATION_JSON) @Valid Person person2,
 
             @RestForm @PartType(MediaType.APPLICATION_JSON) Person[] persons,
 
             @RestForm @PartType(MediaType.APPLICATION_JSON) List<Person> persons2,
 
+            @RestForm @PartType(MediaType.APPLICATION_JSON) Person[] persons3,
+
+            @RestForm @PartType(MediaType.APPLICATION_JSON) List<Person> persons4,
             @RestForm("htmlFile") FileUpload htmlPart) {
         Map<String, Object> result = new HashMap<>(map);
+        result.putAll(map2);
         result.put("person", person);
+        result.put("person2", person2);
         result.put("htmlFileSize", htmlPart.size());
         result.put("htmlFilePath", htmlPart.uploadedFile().toAbsolutePath().toString());
         result.put("htmlFileContentType", htmlPart.contentType());
@@ -72,6 +83,8 @@ public class MultipartResource {
         result.put("numbers2", numbers2);
         result.put("persons", persons);
         result.put("persons2", persons2);
+        result.put("persons3", persons3);
+        result.put("persons4", persons4);
         return result;
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultipartTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultipartTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
+import io.restassured.builder.MultiPartSpecBuilder;
 
 public class MultipartTest {
 
@@ -36,6 +37,12 @@ public class MultipartTest {
 
     @Test
     public void testValid() throws IOException {
+        testValid("/multipart/json");
+    }
+
+    private void testValid(String url) throws IOException {
+        // NOTE: the multipart file name is ignored for String types, so we must convert them
+        // to byte[] in order to send a file name
         RestAssured.given()
                 .multiPart("map",
                         "{\n" +
@@ -44,7 +51,15 @@ public class MultipartTest {
                                 "    \"foo2\": \"bar2\"\n" +
                                 "  }\n" +
                                 "}")
+                .multiPart(new MultiPartSpecBuilder(("{\n" +
+                        "  \"foo2\": \"bar\",\n" +
+                        "  \"sub2\": {\n" +
+                        "    \"foo2\": \"bar2\"\n" +
+                        "  }\n" +
+                        "}").getBytes()).controlName("map2").fileName("something.js").build())
                 .multiPart("person", "{\"first\": \"Bob\", \"last\": \"Builder\"}", "application/json")
+                .multiPart(new MultiPartSpecBuilder("{\"first\": \"Bob\", \"last\": \"Builder\"}".getBytes())
+                        .controlName("person2").fileName("something.js").mimeType("application/json").build())
                 .multiPart("htmlFile", HTML_FILE, "text/html")
                 .multiPart("names", "name1")
                 .multiPart("names", "name2")
@@ -56,15 +71,27 @@ public class MultipartTest {
                 .multiPart("persons", "{\"first\": \"First2\", \"last\": \"Last2\"}", "application/json")
                 .multiPart("persons2", "{\"first\": \"First1\", \"last\": \"Last1\"}", "application/json")
                 .multiPart("persons2", "{\"first\": \"First2\", \"last\": \"Last2\"}", "application/json")
+                .multiPart(new MultiPartSpecBuilder("{\"first\": \"First1\", \"last\": \"Last1\"}".getBytes())
+                        .controlName("persons3").fileName("something.js").mimeType("application/json").build())
+                .multiPart(new MultiPartSpecBuilder("{\"first\": \"First2\", \"last\": \"Last2\"}".getBytes())
+                        .controlName("persons3").fileName("something.js").mimeType("application/json").build())
+                .multiPart(new MultiPartSpecBuilder("{\"first\": \"First1\", \"last\": \"Last1\"}".getBytes())
+                        .controlName("persons4").fileName("something.js").mimeType("application/json").build())
+                .multiPart(new MultiPartSpecBuilder("{\"first\": \"First2\", \"last\": \"Last2\"}".getBytes())
+                        .controlName("persons4").fileName("something.js").mimeType("application/json").build())
                 .accept("application/json")
                 .when()
-                .post("/multipart/json")
+                .post(url)
                 .then()
                 .statusCode(200)
                 .body("foo", equalTo("bar"))
                 .body("sub.foo2", equalTo("bar2"))
+                .body("foo2", equalTo("bar"))
+                .body("sub2.foo2", equalTo("bar2"))
                 .body("person.first", equalTo("Bob"))
                 .body("person.last", equalTo("Builder"))
+                .body("person2.first", equalTo("Bob"))
+                .body("person2.last", equalTo("Builder"))
                 .body("htmlFileSize", equalTo(Files.readAllBytes(HTML_FILE.toPath()).length))
                 .body("htmlFilePath", not(equalTo(HTML_FILE.toPath().toAbsolutePath().toString())))
                 .body("htmlFileContentType", equalTo("text/html"))
@@ -81,57 +108,20 @@ public class MultipartTest {
                 .body("persons2[0].first", equalTo("First1"))
                 .body("persons2[0].last", equalTo("Last1"))
                 .body("persons2[1].first", equalTo("First2"))
-                .body("persons2[1].last", equalTo("Last2"));
+                .body("persons2[1].last", equalTo("Last2"))
+                .body("persons3[0].first", equalTo("First1"))
+                .body("persons3[0].last", equalTo("Last1"))
+                .body("persons3[1].first", equalTo("First2"))
+                .body("persons3[1].last", equalTo("Last2"))
+                .body("persons4[0].first", equalTo("First1"))
+                .body("persons4[0].last", equalTo("Last1"))
+                .body("persons4[1].first", equalTo("First2"))
+                .body("persons4[1].last", equalTo("Last2"));
     }
 
     @Test
     public void testValidParam() throws IOException {
-        RestAssured.given()
-                .multiPart("map",
-                        "{\n" +
-                                "  \"foo\": \"bar\",\n" +
-                                "  \"sub\": {\n" +
-                                "    \"foo2\": \"bar2\"\n" +
-                                "  }\n" +
-                                "}")
-                .multiPart("person", "{\"first\": \"Bob\", \"last\": \"Builder\"}", "application/json")
-                .multiPart("htmlFile", HTML_FILE, "text/html")
-                .multiPart("names", "name1")
-                .multiPart("names", "name2")
-                .multiPart("numbers", 1)
-                .multiPart("numbers", 2)
-                .multiPart("numbers2", 1)
-                .multiPart("numbers2", 2)
-                .multiPart("persons", "{\"first\": \"First1\", \"last\": \"Last1\"}", "application/json")
-                .multiPart("persons", "{\"first\": \"First2\", \"last\": \"Last2\"}", "application/json")
-                .multiPart("persons2", "{\"first\": \"First1\", \"last\": \"Last1\"}", "application/json")
-                .multiPart("persons2", "{\"first\": \"First2\", \"last\": \"Last2\"}", "application/json")
-                .accept("application/json")
-                .when()
-                .post("/multipart/param/json")
-                .then()
-                .statusCode(200)
-                .body("foo", equalTo("bar"))
-                .body("sub.foo2", equalTo("bar2"))
-                .body("person.first", equalTo("Bob"))
-                .body("person.last", equalTo("Builder"))
-                .body("htmlFileSize", equalTo(Files.readAllBytes(HTML_FILE.toPath()).length))
-                .body("htmlFilePath", not(equalTo(HTML_FILE.toPath().toAbsolutePath().toString())))
-                .body("htmlFileContentType", equalTo("text/html"))
-                .body("names[0]", equalTo("name1"))
-                .body("names[1]", equalTo("name2"))
-                .body("numbers[0]", equalTo(1))
-                .body("numbers[1]", equalTo(2))
-                .body("numbers2[0]", equalTo(1))
-                .body("numbers2[1]", equalTo(2))
-                .body("persons[0].first", equalTo("First1"))
-                .body("persons[0].last", equalTo("Last1"))
-                .body("persons[1].first", equalTo("First2"))
-                .body("persons[1].last", equalTo("Last2"))
-                .body("persons2[0].first", equalTo("First1"))
-                .body("persons2[0].last", equalTo("Last1"))
-                .body("persons2[1].first", equalTo("First2"))
-                .body("persons2[1].last", equalTo("Last2"));
+        testValid("/multipart/param/json");
     }
 
     @Test

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartInputTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartInputTest.java
@@ -83,6 +83,22 @@ public class MultipartInputTest extends AbstractMultipartTest {
 
         // ensure that the 3 uploaded files where created on disk
         Assertions.assertEquals(3, uploadDir.toFile().listFiles().length);
+
+        // same with text as file
+        RestAssured.given()
+                .multiPart("name", "something.txt", "Alice".getBytes())
+                .multiPart("active", "true")
+                .multiPart("num", "25")
+                .multiPart("status", "WORKING")
+                .multiPart("htmlFile", HTML, "text/html")
+                .multiPart("xmlFile", XML, "text/xml")
+                .multiPart("txtFile", TXT, "text/plain")
+                .accept("text/plain")
+                .when()
+                .post("/multipart/simple/2")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Alice - true - 50 - WORKING - true - true - true"));
     }
 
     @Test
@@ -125,6 +141,22 @@ public class MultipartInputTest extends AbstractMultipartTest {
 
         // ensure that the 3 uploaded files where created on disk
         Assertions.assertEquals(3, uploadDir.toFile().listFiles().length);
+
+        // same with text as file
+        RestAssured.given()
+                .multiPart("name", "something.txt", "Alice".getBytes())
+                .multiPart("active", "true")
+                .multiPart("num", "25")
+                .multiPart("status", "WORKING")
+                .multiPart("htmlFile", HTML, "text/html")
+                .multiPart("xmlFile", XML, "text/xml")
+                .multiPart("txtFile", TXT, "text/plain")
+                .accept("text/plain")
+                .when()
+                .post("/multipart/param/simple/2")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Alice - true - 50 - WORKING - true - true - true"));
     }
 
     @Test

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/ClassInjectorTransformer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/ClassInjectorTransformer.java
@@ -769,52 +769,38 @@ public class ClassInjectorTransformer implements BiFunction<String, ClassVisitor
                 case PartType:
                     /*
                      * if (single) {
-                     * String param = (String) context.getFormParameter(name, true, false);
-                     * return MultipartSupport.convertFormAttribute(param, typeClass, genericType, MediaType.valueOf(mimeType),
-                     * context,
-                     * name);
+                     * return MultipartSupport.getConvertedFormAttribute(name, typeClass, genericType,
+                     * MediaType.valueOf(mimeType),
+                     * context);
                      * } else {
-                     * List<String> params = (List<String>) context.getFormParameter(name, false, false);
-                     * return MultipartSupport.convertFormAttributes(params, typeClass, genericType,
-                     * MediaType.valueOf(mimeType), context, name);
+                     * return MultipartSupport.getConvertedFormAttributes(name, typeClass, genericType,
+                     * MediaType.valueOf(mimeType),
+                     * context);
                      * }
                      */
-                    // ctx param
-                    injectMethod.visitIntInsn(Opcodes.ALOAD, 1);
                     // name
                     injectMethod.visitLdcInsn(param.getName());
-                    // single
-                    injectMethod.visitLdcInsn(param.isSingle());
-                    // encoded
-                    injectMethod.visitLdcInsn(false);
-                    injectMethod.visitMethodInsn(Opcodes.INVOKEINTERFACE, QUARKUS_REST_INJECTION_CONTEXT_BINARY_NAME,
-                            "getFormParameter",
-                            "(Ljava/lang/String;ZZ)Ljava/lang/Object;", true);
-                    injectMethod.visitTypeInsn(Opcodes.CHECKCAST, param.isSingle() ? STRING_BINARY_NAME : LIST_BINARY_NAME);
-                    // class, generic type, media type, context, name
+                    // class, generic type, media type
                     injectMethod.visitFieldInsn(Opcodes.GETSTATIC, this.thisName, fieldInfo.name() + "_type", CLASS_DESCRIPTOR);
                     injectMethod.visitFieldInsn(Opcodes.GETSTATIC, this.thisName, fieldInfo.name() + "_genericType",
                             TYPE_DESCRIPTOR);
                     injectMethod.visitFieldInsn(Opcodes.GETSTATIC, this.thisName, fieldInfo.name() + "_mediaType",
                             MEDIA_TYPE_DESCRIPTOR);
+                    // ctx param
                     injectMethod.visitIntInsn(Opcodes.ALOAD, 1);
                     injectMethod.visitTypeInsn(Opcodes.CHECKCAST, RESTEASY_REACTIVE_REQUEST_CONTEXT_BINARY_NAME);
-                    injectMethod.visitLdcInsn(param.getName());
-                    String firstParamDescriptor;
                     String returnDescriptor;
                     String methodName;
                     if (param.isSingle()) {
-                        firstParamDescriptor = STRING_DESCRIPTOR;
                         returnDescriptor = OBJECT_DESCRIPTOR;
-                        methodName = "convertFormAttribute";
+                        methodName = "getConvertedFormAttribute";
                     } else {
-                        firstParamDescriptor = LIST_DESCRIPTOR;
                         returnDescriptor = LIST_DESCRIPTOR;
-                        methodName = "convertFormAttributes";
+                        methodName = "getConvertedFormAttributes";
                     }
                     injectMethod.visitMethodInsn(Opcodes.INVOKESTATIC, MULTIPART_SUPPORT_BINARY_NAME, methodName,
-                            "(" + firstParamDescriptor + CLASS_DESCRIPTOR + TYPE_DESCRIPTOR + MEDIA_TYPE_DESCRIPTOR
-                                    + RESTEASY_REACTIVE_REQUEST_CONTEXT_DESCRIPTOR + STRING_DESCRIPTOR + ")" + returnDescriptor,
+                            "(" + STRING_DESCRIPTOR + CLASS_DESCRIPTOR + TYPE_DESCRIPTOR + MEDIA_TYPE_DESCRIPTOR
+                                    + RESTEASY_REACTIVE_REQUEST_CONTEXT_DESCRIPTOR + ")" + returnDescriptor,
                             false);
                     break;
                 default:

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/MultipartFormParamExtractor.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/MultipartFormParamExtractor.java
@@ -1,7 +1,5 @@
 package org.jboss.resteasy.reactive.server.core.parameters;
 
-import java.util.List;
-
 import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.reactive.multipart.FileUpload;
@@ -63,14 +61,12 @@ public class MultipartFormParamExtractor implements ParameterExtractor {
                 }
             case PartType:
                 if (single) {
-                    String param = (String) context.getFormParameter(name, true, false);
-                    return MultipartSupport.convertFormAttribute(param, typeClass, genericType, MediaType.valueOf(mimeType),
-                            context,
-                            name);
+                    return MultipartSupport.getConvertedFormAttribute(name, typeClass, genericType, MediaType.valueOf(mimeType),
+                            context);
                 } else {
-                    List<String> params = (List<String>) context.getFormParameter(name, false, false);
-                    return MultipartSupport.convertFormAttributes(params, typeClass, genericType, MediaType.valueOf(mimeType),
-                            context, name);
+                    return MultipartSupport.getConvertedFormAttributes(name, typeClass, genericType,
+                            MediaType.valueOf(mimeType),
+                            context);
                 }
             case FileUpload:
                 // special case


### PR DESCRIPTION
If the user doesn't care about the file name, treat it like a normal value