### PR TITLE
Add support for CredentialsProvider in Mongo connections

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/CredentialConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/CredentialConfig.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConvertWith;
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
 
 /**
  * Configures the credentials and authentication mechanism to connect to the MongoDB server.
@@ -48,4 +50,23 @@ public class CredentialConfig {
      */
     @ConfigItem
     public Map<String, String> authMechanismProperties;
+
+    /**
+     * The credentials provider name
+     */
+    @ConfigItem
+    @ConvertWith(TrimmedStringConverter.class)
+    public Optional<String> credentialsProvider = Optional.empty();
+
+    /**
+     * The credentials provider bean name.
+     * <p>
+     * It is the {@code &#64;Named} value of the credentials provider bean. It is used to discriminate if multiple
+     * CredentialsProvider beans are available.
+     * <p>
+     * For Vault it is: vault-credentials-provider. Not necessary if there is only one credentials provider available.
+     */
+    @ConfigItem
+    @ConvertWith(TrimmedStringConverter.class)
+    public Optional<String> credentialsProviderName = Optional.empty();
 }


### PR DESCRIPTION
Closes: #20277

I did not add a test because: 
* I did not see how we can do that (none of our other tests do it)
* Even if I did, I would not be able to verify on my machine as our existing tests fail for me with `[mongod error]/home/gandrian/.embedmongo/fileSets/de0c2b8f50ba7d3bc96e039e3d158b6c0e6f88d66dfc78533601ff522286a91b/mongod: error while loading shared libraries: libcrypto.so.1.1: cannot open shared object file: No such file or directory`