### PR TITLE
Reinitialize sun.security.pkcs11.P11Util at runtime

### DIFF
--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -231,6 +231,8 @@ public class SecurityProcessor {
             runtimeReInitialized.produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.jcajce.spec.ECUtil"));
         }
 
+        // Reinitialize class because it embeds a java.lang.ref.Cleaner instance in the image heap
+        runtimeReInitialized.produce(new RuntimeReinitializedClassBuildItem("sun.security.pkcs11.P11Util"));
     }
 
     @BuildStep


### PR DESCRIPTION
Fixes build error:
```
Error: Detected a java.lang.ref.Cleaner object in the image heap which uses a daemon thread that invokes cleaning actions, but threads running in the image generator are no longer running at image runtime.  To see how this object got instantiated use --trace-object-instantiation=java.lang.ref.Cleaner. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
Detailed message:
Trace: Object was reached by
  trying to constant fold static field sun.security.pkcs11.P11Util.cleaner
    at sun.security.pkcs11.wrapper.PKCS11.<init>(PKCS11.java:170)
  parsing method sun.security.pkcs11.wrapper.PKCS11.<init>(PKCS11.java:154) reachable via the parsing context
    at static root method.(Unknown Source)
```

See https://github.com/oracle/graal/actions/runs/4320092514/jobs/7540249135#step:9:154

cc @jerboaa 