### PR TITLE
Higher timeouts for Native tests Data 1 and Maven tests

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -8,7 +8,7 @@
         },
         {
             "category": "Data1",
-            "timeout": 70,
+            "timeout": 80,
             "test-modules": "jpa-h2, jpa-h2-embedded, jpa-mariadb, jpa-mssql, jpa-derby, jpa-without-entity, hibernate-orm-tenancy/datasource, hibernate-orm-tenancy/connection-resolver, hibernate-orm-tenancy/connection-resolver-legacy-qualifiers",
             "os-name": "ubuntu-latest"
         },

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -355,7 +355,7 @@ jobs:
       MAVEN_OPTS: -Xmx2g -XX:MaxMetaspaceSize=1g
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.run_maven == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
-    timeout-minutes: 60
+    timeout-minutes: 80
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
For the Maven tests, it's specifically to see if it solves the problem on Windows or if there is something else hidden.