### PR TITLE
Add debugging info to IllegalStateException (include the GACT string and the index)

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACT.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACT.java
@@ -66,8 +66,9 @@ public class GACT implements ArtifactKey, Serializable {
     public static String[] split(String str, String[] parts, int fromIndex) {
         int i = str.lastIndexOf(':', fromIndex - 1);
         if (i <= 0) {
-            throw new IllegalArgumentException("For " + str + " groupId and artifactId separating ':' is absent or not in the right place in '"
-                    + str.substring(0, fromIndex) + "' at index " + fromIndex);
+            throw new IllegalArgumentException("Invalid coordinates '" + str
+                    + "': groupId and artifactId separating character ':' is absent or not in the right place in the substring ending at index "
+                    + fromIndex + ": '" + str.substring(0, fromIndex));
         }
         parts[3] = str.substring(i + 1, fromIndex);
         fromIndex = i;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACT.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACT.java
@@ -66,8 +66,8 @@ public class GACT implements ArtifactKey, Serializable {
     public static String[] split(String str, String[] parts, int fromIndex) {
         int i = str.lastIndexOf(':', fromIndex - 1);
         if (i <= 0) {
-            throw new IllegalArgumentException("GroupId and artifactId separating ':' is absent or not in the right place in '"
-                    + str.substring(0, fromIndex) + "'");
+            throw new IllegalArgumentException("For " + str + " groupId and artifactId separating ':' is absent or not in the right place in '"
+                    + str.substring(0, fromIndex) + "' at index " + fromIndex);
         }
         parts[3] = str.substring(i + 1, fromIndex);
         fromIndex = i;


### PR DESCRIPTION
Got into a situation with bacon's dependency-generator where I had a misconfigured exclude among 150 org.apache.camel excludes - but the current GACT IllegalStateException was only giving me the groupId.     Could really use the full GACT string in the exception so I could tell which exclude needs to be changed.