### PR TITLE
Upgrade to SnakeYaml 2.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -168,7 +168,7 @@
         <flyway.version>9.15.2</flyway.version>
         <yasson.version>3.0.2</yasson.version>
         <liquibase.version>4.20.0</liquibase.version>
-        <snakeyaml.version>1.33</snakeyaml.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
         <mongo-client.version>4.9.0</mongo-client.version>
         <mongo-crypt.version>1.7.1</mongo-crypt.version>

--- a/docs/src/main/java/io/quarkus/docs/generation/QuarkusBuildItemDoc.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/QuarkusBuildItemDoc.java
@@ -25,6 +25,7 @@ import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.JavaDocCapable;
 import org.jboss.forge.roaster.model.source.FieldSource;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
@@ -154,7 +155,7 @@ public class QuarkusBuildItemDoc {
 
     private Map<String, String> extractNames(Path root, Iterable<String> extensionDirs) throws IOException {
         Map<String, String> names = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        Yaml yaml = new Yaml(new SafeConstructor());
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         for (String extension : extensionDirs) {
             Path yamlPath = root
                     .resolve("extensions/" + extension + "/runtime/src/main/resources/META-INF/quarkus-extension.yaml");

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsole.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsole.java
@@ -17,6 +17,7 @@ import java.util.function.BiFunction;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
@@ -75,7 +76,7 @@ public class DevConsole implements Handler<RoutingContext> {
             synchronized (extensions) {
                 if (extensions.isEmpty()) {
                     try {
-                        final Yaml yaml = new Yaml(new SafeConstructor());
+                        final Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
                         ClassPathUtils.consumeAsPaths("/META-INF/quarkus-extension.yaml", p -> {
                             try {
                                 final String desc;


### PR DESCRIPTION
I'm not entirely sure this is safe as it's a major version and we have several other dependencies depending on it.

I tested the Quarkus GitHub Bot which uses the Jackson YAML mapper and it seems to work so let's see how CI goes.

Note: even if we are not affected by the CVE, it's the first version fixing the high severity CVE that was ongoing with SnakeYaml so could be good for security analysis tools.

Creating as draft for now to get a full CI run.