### PR TITLE
Make Scheduler not log in Dev UI log

### DIFF
--- a/extensions/scheduler/deployment/src/main/resources/dev-ui/scheduler/qwc-scheduler-log.js
+++ b/extensions/scheduler/deployment/src/main/resources/dev-ui/scheduler/qwc-scheduler-log.js
@@ -7,8 +7,8 @@ import { LogController } from 'log-controller';
  */
 export class QwcSchedulerLog extends LitElement {
     
-    jsonRpc = new JsonRpc("Scheduler");
-    logControl = new LogController(this, "qwc-scheduler-log");
+    jsonRpc = new JsonRpc("Scheduler", false);
+    logControl = new LogController(this);
 
     static styles = css`
         .text-error {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -84,6 +84,7 @@ public class BuildTimeContentProcessor {
         internalImportMapBuildItem.add("font/", contextRoot + "font/");
         internalImportMapBuildItem.add("controller/", contextRoot + "controller/");
         internalImportMapBuildItem.add("log-controller", contextRoot + "controller/log-controller.js");
+        internalImportMapBuildItem.add("storage-controller", contextRoot + "controller/storage-controller.js");
         internalImportMapBuildItem.add("router-controller", contextRoot + "controller/router-controller.js");
         internalImportMapBuildItem.add("notifier", contextRoot + "controller/notifier.js");
         internalImportMapBuildItem.add("jsonrpc", contextRoot + "controller/jsonrpc.js");

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/log-controller.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/log-controller.js
@@ -8,9 +8,9 @@ export class LogController {
     tab;
     items = [];
     
-    constructor(host, tab) {
+    constructor(host) {
         (this.host = host).addController(this);
-        this.tab = tab;
+        this.tab = host.tagName.toLowerCase();
     }
 
     hostConnected() {

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/storage-controller.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/storage-controller.js
@@ -1,0 +1,29 @@
+/**
+ * Storage for extensions
+ */
+export class StorageController {
+    
+    host;
+    _pre;
+    constructor(host) {
+        (this.host = host).addController(this);
+        this._pre = host.tagName.toLowerCase() + "-";
+    }
+
+    set(key, value){
+        localStorage.setItem(this._pre + key, value);
+    }
+    
+    has(key){
+        return localStorage.getItem(this._pre + key) === null;
+    }
+    
+    get(key){
+        return localStorage.getItem(this._pre + key);
+    }
+    
+    remove(key){
+        localStorage.removeItem(this._pre + key);
+    }
+    
+}

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-footer.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-footer.js
@@ -1,6 +1,7 @@
 import { LitElement, html, css} from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { LogController } from 'log-controller';
+import { StorageController } from 'storage-controller';
 import { devuiState } from 'devui-state';
 import { observeState } from 'lit-element-state';
 import '@vaadin/tabsheet';
@@ -15,6 +16,8 @@ import 'qwc/qwc-ws-status.js';
  */
 export class QwcFooter extends observeState(LitElement) {
         
+    storageControl = new StorageController(this);
+    
     static styles = css`
     
         vaadin-menu-bar {
@@ -148,7 +151,7 @@ export class QwcFooter extends observeState(LitElement) {
     }
 
     _restoreHeight(){
-        const storedHeight = localStorage.getItem("qwc-footer-height");
+        const storedHeight = this.storageControl.get("height");
         if(storedHeight){
             this._height = storedHeight;
         }else {
@@ -158,7 +161,7 @@ export class QwcFooter extends observeState(LitElement) {
     }
 
     _restoreState(){
-        const storedState = localStorage.getItem("qwc-footer-state");
+        const storedState = this.storageControl.get("state");
         if(storedState && storedState === "open"){
             this._open();
         }else {
@@ -167,7 +170,7 @@ export class QwcFooter extends observeState(LitElement) {
     }
 
     _restoreSelectedTab(){
-        const storedTab = localStorage.getItem("qwc-footer-selected-tab");
+        const storedTab = this.storageControl.get("selected-tab");
         if(storedTab){
             this._tabSelected(storedTab);
         }else {
@@ -243,7 +246,7 @@ export class QwcFooter extends observeState(LitElement) {
             this._controlButtons = LogController.getItemsForTab(devuiState.footer[0].componentName);
             this._selectedTab = 0;
         }
-        localStorage.setItem('qwc-footer-selected-tab', this._selectedTab);
+        this.storageControl.set('selected-tab', this._selectedTab);
     }
 
     _mousedown(e){
@@ -270,7 +273,7 @@ export class QwcFooter extends observeState(LitElement) {
         document.removeEventListener('mouseup', this._mouseup, true);
         
         if(this._height){
-            localStorage.setItem('qwc-footer-height', this._height);
+            this.storageControl.set('height', this._height);
         }
     }
 
@@ -311,7 +314,7 @@ export class QwcFooter extends observeState(LitElement) {
         this._dragClass = "dragOpen";
         this._controlsClass = "controlsOpen";
         this._isOpen=true;
-        localStorage.setItem('qwc-footer-state', "open");
+        this.storageControl.set('state', "open");
     }
     
     _close(){
@@ -324,7 +327,7 @@ export class QwcFooter extends observeState(LitElement) {
         this._dragClass = "dragClose";
         this._controlsClass = "controlsClose";
         this._isOpen=false;
-        localStorage.setItem('qwc-footer-state', "close");
+        this.storageControl.set('state', "close");
     }
     
     _controlButtonClicked(e){

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-header.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-header.js
@@ -1,5 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { RouterController } from 'router-controller';
+import { StorageController } from 'storage-controller';
 import { observeState } from 'lit-element-state';
 import { themeState } from 'theme-state';
 import { devuiState } from 'devui-state';
@@ -10,6 +11,8 @@ import '@vaadin/tabs';
  * This component represent the Dev UI Header
  */
 export class QwcHeader extends observeState(LitElement) {
+    
+    storageControl = new StorageController(this);
     
     static styles = css`
         
@@ -122,7 +125,7 @@ export class QwcHeader extends observeState(LitElement) {
     }
 
     _restoreThemePreference() {
-        const storedValue = localStorage.getItem("qwc-header-theme-preference");
+        const storedValue = this.storageControl.get("theme-preference");
         if(storedValue){
             this._selectedTheme = storedValue;
         }else {
@@ -160,7 +163,7 @@ export class QwcHeader extends observeState(LitElement) {
         this._selectedTheme = e.detail.value.name;
         this._createThemeOptions();
         this._changeToSelectedTheme();
-        localStorage.setItem('qwc-header-theme-preference', this._selectedTheme);
+        this.storageControl.set('theme-preference', this._selectedTheme);
     }
 
     _changeToSelectedTheme(){

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-jsonrpc-messages.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-jsonrpc-messages.js
@@ -1,13 +1,15 @@
 import { LitElement, html, css} from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { LogController } from 'log-controller';
+import { StorageController } from 'storage-controller';
 
 /**
  * This component represent the Dev UI Json RPC Message log
  */
 export class QwcJsonrpcMessages extends LitElement {
     
-    logControl = new LogController(this, "qwc-jsonrpc-messages");
+    logControl = new LogController(this);
+    storageControl = new StorageController(this);
     
     static styles = css`
         .log {
@@ -42,12 +44,20 @@ export class QwcJsonrpcMessages extends LitElement {
         _zoom: {state:true},
         _increment: {state: false},
         _followLog: {state: false},
+        _isOn: {state: false},
     };
     
     constructor() {
         super();
+        const stored = this.storageControl.get("onOffSwitch");
+        if(stored && stored === "on"){
+            this._isOn = true;
+        }else {
+            this._isOn = false;
+        }
+        
         this.logControl
-                .addToggle("On/off switch", true, (e) => {
+                .addToggle("On/off switch", this._isOn, (e) => {
                     this._toggleOnOffClicked(e);
                 }).addItem("Zoom out", "font-awesome-solid:magnifying-glass-minus", "grey", (e) => {
                     this._zoomOut();
@@ -69,7 +79,7 @@ export class QwcJsonrpcMessages extends LitElement {
     
     connectedCallback() {
         super.connectedCallback();
-        this._toggleOnOff(true);
+        this._toggleOnOff(this._isOn);
     }
     
     disconnectedCallback() {
@@ -132,6 +142,11 @@ export class QwcJsonrpcMessages extends LitElement {
             stopEntry.id = Math.floor(Math.random() * 999999);
             stopEntry.isLine = true;
             this._addLogEntry(stopEntry);
+            this.storageControl.remove("onOffSwitch");
+            this._isOn = false;
+        }else{
+            this.storageControl.set("onOffSwitch", "on");
+            this._isOn = true;
         }
     }
     

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-menu.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-menu.js
@@ -2,6 +2,7 @@ import { LitElement, html, css} from 'lit';
 import { devuiState } from 'devui-state';
 import { observeState } from 'lit-element-state';
 import { RouterController } from 'router-controller';
+import { StorageController } from 'storage-controller';
 import '@vaadin/icon';
 
 /**
@@ -9,6 +10,8 @@ import '@vaadin/icon';
  * It creates the menuItems during build and dynamically add the routes and import the relevant components
  */
 export class QwcMenu extends observeState(LitElement) {
+    
+    storageControl = new StorageController(this);
     
     static styles = css`
             .left {
@@ -103,7 +106,7 @@ export class QwcMenu extends observeState(LitElement) {
     }
     
     _restoreState(){
-        const storedState = localStorage.getItem("qwc-menu-state");
+        const storedState = this.storageControl.get("state");
         if(storedState && storedState === "small"){
             this._smaller();
         }else{
@@ -198,13 +201,13 @@ export class QwcMenu extends observeState(LitElement) {
     _smaller() {
         this._show = false;
         this._width = 50;
-        localStorage.setItem('qwc-menu-state', "small");
+        this.storageControl.set('state', "small");
     }
 
     _larger() {
         this._show = true;
         this._width = 250;
-        localStorage.setItem('qwc-menu-state', "large");
+        this.storageControl.set('state', "large");
     }
     
     _quarkus(e) {

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-server-log.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-server-log.js
@@ -15,7 +15,7 @@ import 'qui-badge';
  */
 export class QwcServerLog extends LitElement {
     
-    logControl = new LogController(this, "qwc-server-log");
+    logControl = new LogController(this);
     jsonRpc = new JsonRpc("DevUI", false);
     
     static styles = css`


### PR DESCRIPTION
This PR make the scheduler log not repeat in Dev UI log (sorry @mkouba I forgot to get back to you w.r.t this)

It also:

- Makes Dev UI Off by default (as this is only useful to extension developers)
- Remember the state of the selected on/off in Dev UI Log, so that extension developer can switch it on only once
- Make storage available for all extensions to use via a controller