### PR TITLE
Don't use Gradle daemon in Gradle integration tests

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
@@ -57,6 +57,7 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
         command.add(getGradleWrapperCommand());
         command.addAll(getSytemProperties());
         command.add("-Dorg.gradle.console=plain");
+        command.add("-Dorg.gradle.daemon=false");
         command.add("--stacktrace");
         command.add("--info");
         command.addAll(Arrays.asList(args));


### PR DESCRIPTION
There is a chance that the use of the daemon
is leading to ClassLoader leaks in our CI

Closes: #31603