### PR TITLE
Preserve Mockito's subclass behavior

### DIFF
--- a/test-framework/junit5-mockito/pom.xml
+++ b/test-framework/junit5-mockito/pom.xml
@@ -31,7 +31,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-subclass</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
With Mockito 5, the library has switched to using inline mocks by [default](https://github.com/mockito/mockito/releases/tag/v5.0.0).

We almost certainly can support this, but it needs more investigation (one point for example 
that jumps out from #31251 is that we need to see when it makes sense to clear inline mocks).

For the time being it makes sense to preserve the mocking behavior users are used to since Quarkus 1.x.

Closes: #31251