### PR TITLE
Fail the doc build on CI if INFO

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build Docs
         run: |
-          ./mvnw -e -B --settings .github/mvn-settings.xml clean package -pl docs
+          ./mvnw -e -B --settings .github/mvn-settings.xml clean package -pl docs -Dasciidoctor.fail-if=INFO
 
       - name: Store PR id
         run: echo ${{ github.event.number }} > pr-id.txt

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,6 +22,7 @@
 
         <asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>
         <asciidoctorj-pdf.version>1.5.0-beta.8</asciidoctorj-pdf.version>
+        <asciidoctor.fail-if>WARN</asciidoctor.fail-if>
         <roaster-jdt.version>2.26.0.Final</roaster-jdt.version>
         <maven-model-helper.version>21</maven-model-helper.version>
         <eclipse-collections.version>11.1.0</eclipse-collections.version>
@@ -2911,7 +2912,7 @@
                     <enableVerbose>true</enableVerbose>
                     <logHandler>
                         <failIf>
-                          <severity>WARN</severity>
+                          <severity>${asciidoctor.fail-if}</severity>
                         </failIf>
                     </logHandler>
                     <sourceDirectory>target/asciidoc/sources</sourceDirectory>

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
@@ -29,7 +29,7 @@ public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
     ElasticsearchNamedBackendsBuildTimeConfig namedBackends;
 
     /**
-     * A <<bean-reference-note-anchor,bean reference>> to a component
+     * A xref:hibernate-search-orm-elasticsearch.adoc#bean-reference-note-anchor[bean reference] to a component
      * that should be notified of any failure occurring in a background process
      * (mainly index operations).
      *
@@ -174,12 +174,13 @@ public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
     @ConfigGroup
     public static class AnalysisConfig {
         /**
-         * A <<bean-reference-note-anchor,bean reference>> to the component
+         * A xref:hibernate-search-orm-elasticsearch.adoc#bean-reference-note-anchor[bean reference] to the component
          * used to configure full text analysis (e.g. analyzers, normalizers).
          *
          * The referenced bean must implement `ElasticsearchAnalysisConfigurer`.
          *
-         * See <<analysis-configurer>> for more information.
+         * See xref:hibernate-search-orm-elasticsearch.adoc#analysis-configurer[Setting up the analyzers] for more
+         * information.
          *
          * [NOTE]
          * ====
@@ -198,7 +199,7 @@ public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
     @ConfigGroup
     public static class LayoutConfig {
         /**
-         * A <<bean-reference-note-anchor,bean reference>> to the component
+         * A xref:hibernate-search-orm-elasticsearch.adoc#bean-reference-note-anchor[bean reference] to the component
          * used to configure layout (e.g. index names, index aliases).
          *
          * The referenced bean must implement `IndexLayoutStrategy`.
@@ -239,7 +240,7 @@ public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
          * The strategy to use for coordinating between threads or even separate instances of the application,
          * in particular in automatic indexing.
          *
-         * See <<coordination>> for more information.
+         * See xref:hibernate-search-orm-elasticsearch.adoc#coordination[coordination] for more information.
          *
          * @asciidoclet
          */

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
@@ -297,7 +297,7 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          * ====
          * Indexing synchronization is only relevant when coordination is disabled (which is the default).
          *
-         * With the <<coordination,`outbox-polling` coordination strategy>>,
+         * With the xref:hibernate-search-orm-elasticsearch.adoc#coordination[`outbox-polling` coordination strategy],
          * indexing happens in background threads and is always asynchronous;
          * the behavior is equivalent to the `write-sync` synchronization strategy.
          * ====
@@ -339,7 +339,7 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          * ^!icon:check[role=lime]
          * !===
          *
-         * This property also accepts a <<bean-reference-note-anchor,bean reference>>
+         * This property also accepts a xref:hibernate-search-orm-elasticsearch.adoc#bean-reference-note-anchor[bean reference]
          * to a custom implementations of `AutomaticIndexingSynchronizationStrategy`.
          *
          * See


### PR DESCRIPTION
Optional includes missing are INFO and we use them.
Missing pointers are also INFO.

We used to miss some of these errors and I catch them regularly doing a
full build but better catch them right away.