### PR TITLE
Dev UI: RestEasy Reactive

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -222,6 +222,7 @@
         <lit.version>2.6.1</lit.version>
         <lit-state.version>1.7.0</lit-state.version>
         <vaadin.version>23.3.8</vaadin.version>
+        <echarts.version>5.4.1</echarts.version>
         <vaadin-router.version>1.7.4</vaadin-router.version>
         <wc-codemirror.version>2.1.0</wc-codemirror.version>
     </properties>
@@ -3221,6 +3222,12 @@
                 <groupId>org.mvnpm</groupId>
                 <artifactId>vaadin-web-components</artifactId>
                 <version>${vaadin.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mvnpm</groupId>
+                <artifactId>echarts</artifactId>
+                <version>${echarts.version}</version>
                 <scope>runtime</scope>
             </dependency>
             <!-- Code editor -->

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/devui/ResteasyReactiveDevUIProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/devui/ResteasyReactiveDevUIProcessor.java
@@ -1,0 +1,48 @@
+package io.quarkus.resteasy.reactive.server.deployment.devui;
+
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.devui.spi.page.Page;
+import io.quarkus.resteasy.reactive.server.runtime.devui.ResteasyReactiveJsonRPCService;
+
+public class ResteasyReactiveDevUIProcessor {
+
+    private static final String EXTENSION_NAME = "RESTEasy Reactive";
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    public void createPages(BuildProducer<CardPageBuildItem> cardPageProducer) {
+
+        CardPageBuildItem cardPageBuildItem = new CardPageBuildItem(EXTENSION_NAME);
+
+        // Endpoint Scores
+        cardPageBuildItem.addPage(Page.webComponentPageBuilder()
+                .componentLink("qwc-resteasy-reactive-endpoint-scores.js")
+                .title("Endpoint scores")
+                .icon("font-awesome-solid:chart-bar"));
+
+        // Exception mappers
+        cardPageBuildItem.addPage(Page.webComponentPageBuilder()
+                .componentLink("qwc-resteasy-reactive-exception-mappers.js")
+                .title("Exception Mappers")
+                .icon("font-awesome-solid:bomb"));
+
+        // Parameter converter providers
+        cardPageBuildItem.addPage(Page.webComponentPageBuilder()
+                .componentLink("qwc-resteasy-reactive-parameter-converter-providers.js")
+                .title("Parameter converter providers")
+                .icon("font-awesome-solid:arrow-right-arrow-left"));
+
+        // Custom Card
+        cardPageBuildItem.setCustomCard("qwc-resteasy-reactive-card.js");
+
+        cardPageProducer.produce(cardPageBuildItem);
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    public void createJsonRPCService(BuildProducer<JsonRPCProvidersBuildItem> jsonRPCServiceProducer) {
+        jsonRPCServiceProducer.produce(new JsonRPCProvidersBuildItem(EXTENSION_NAME, ResteasyReactiveJsonRPCService.class));
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/resteasy-reactive/qwc-resteasy-reactive-card.js
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/resteasy-reactive/qwc-resteasy-reactive-card.js
@@ -1,0 +1,71 @@
+import { LitElement, html, css} from 'lit';
+import { pages } from 'resteasy-reactive-data';
+import { JsonRpc } from 'jsonrpc';
+import 'echarts-gauge-grade';
+import '@vaadin/icon';
+
+export class QwcResteasyReactiveCard extends LitElement {
+    jsonRpc = new JsonRpc("RESTEasy Reactive");
+    
+    static styles = css`
+        .graph {
+            height: 200px;
+        }
+        .extensionLink {
+            color: var(--lumo-contrast);
+            font-size: small;
+            cursor: pointer;
+            text-decoration: none;
+        }
+        .extensionLink:hover {
+            filter: brightness(80%);
+        }
+    `;
+    
+    static properties = {
+        _pages: {state: false},
+        _latestScores: {state: true},
+    };
+    
+    constructor() {
+        super();
+        this._pages = pages;
+        this._latestScores = null;
+    }
+    
+    connectedCallback() {
+        super.connectedCallback();
+        this.jsonRpc.getEndpointScores().then(endpointScores => {
+            this._latestScores = endpointScores.result;
+        });
+    }
+    
+    render() {
+        
+        if(this._latestScores){
+            return html`<div class="graph" @click=${this._refresh}>
+                <echarts-gauge-grade 
+                            percentage="${this._latestScores.score}"
+                            percentageFontSize="14"
+                            sectionColors="--lumo-error-color,--lumo-warning-color,--lumo-success-color"
+                        </echarts-gauge-grade>
+            </div>
+            ${this._renderPagesLinks()}`;
+        }
+    }
+    
+    _renderPagesLinks(){
+        return html`<a class="extensionLink" href="${this._pages[0].id}">
+                <vaadin-icon class="icon" icon="${this._pages[0].icon}"></vaadin-icon>
+                ${this._pages[0].title}
+            </a>`;
+    }
+    
+    _refresh(){
+        this._latestScores = null;
+        this.jsonRpc.getEndpointScores().then(endpointScores => {
+            this._latestScores = endpointScores.result;
+        });
+    }
+}
+customElements.define('qwc-resteasy-reactive-card', QwcResteasyReactiveCard);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/resteasy-reactive/qwc-resteasy-reactive-endpoint-scores.js
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/resteasy-reactive/qwc-resteasy-reactive-endpoint-scores.js
@@ -1,0 +1,204 @@
+import { LitElement, html, css} from 'lit';
+import { JsonRpc } from 'jsonrpc';
+
+import '@vaadin/details';
+import '@vaadin/horizontal-layout';
+import 'echarts-gauge-grade';
+import 'qui-badge';
+
+/**
+ * This component shows the Rest Easy Reactive Endpoint scores
+ */
+export class QwcResteasyReactiveEndpointScores extends LitElement {
+    jsonRpc = new JsonRpc("RESTEasy Reactive");
+
+    static styles = css`
+        
+        .heading{
+            display: flex;
+            gap: 20px;
+            width: 100em;
+            padding: 20px;
+            background: var(--lumo-contrast-5pct);
+            border-bottom: 1px solid var(--lumo-contrast-10pct);
+        }
+        .details {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+        .diagnostics {
+            display: flex;
+            justify-content: space-evenly;
+            gap: 20px;
+            height: 350px;
+        }
+        .diagnosticsText {
+            display: flex;
+            justify-content: space-evenly;
+            gap: 20px;
+        }
+        .diagnostic {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            width: 100%;
+        }
+        .diagnosticText {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            width: 33%;
+            overflow-wrap: break-word;
+        }
+    
+        .information {
+            border-top: 1px solid var(--lumo-contrast-10pct);
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+        .message {
+            text-align: center;
+            padding-left: 20px;
+            padding-right: 20px;
+            color: var(--lumo-contrast-70pct);
+        }
+        .infoTable {
+            border: none;
+        }
+        .col1{
+            text-align: right;
+            width: 200px;
+            font-weight: bolder;
+        }
+        
+        .httpMethod{
+            color: var(--lumo-primary-text-color);
+        }
+    `;
+
+    static properties = {
+        _latestScores: {state: true}
+    };
+
+    constructor() {
+        super();
+        this._latestScores = null;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._refresh();
+    }
+
+    render() {
+        if(this._latestScores){
+            return html`${this._latestScores.endpoints.map(endpoint=>{
+                return html`${this._renderEndpoint(endpoint)}`;
+            })}`;
+        }
+    }
+
+    _renderEndpoint(endpoint){
+        let level = this._getLevel(endpoint.score);
+        
+        return html`
+            <vaadin-details opened theme="reverse">
+                
+                <div class="heading" slot="summary">
+                    <qui-badge level='${level}'><span>${endpoint.score}/100</span></qui-badge>
+                    <div>
+                        <code class="httpMethod">${endpoint.httpMethod}</code> <code>${endpoint.fullPath}</code>
+                    </div>
+                    
+                </div>
+                
+                <div class="details">
+                    ${this._renderDiagnostics(endpoint.diagnostics)}
+                    ${this._renderInformation(endpoint)}
+                </div>
+          </vaadin-details>`;
+    }
+
+    _renderDiagnostics(diagnostics){
+        const map = new Map(Object.entries(diagnostics));
+        const graphTemplates = [];
+        const textTemplates = [];
+        for (let [key, value] of map) {
+            graphTemplates.push(html`${this._renderDiagnosticGraph(value, key)}`);
+            textTemplates.push(html`${this._renderDiagnosticText(value)}`);
+        }
+
+        return html`<div class="diagnostics">
+                        ${graphTemplates}
+                    </div>
+                    <div class="diagnosticsText">
+                        ${textTemplates}
+                    </div>`;
+    }
+
+    _renderDiagnosticGraph(diagnostic, heading){
+        let score = diagnostic[0].score;
+        let level = this._getLevel(score);
+        
+        return html`<div class="diagnostic">
+                        <echarts-gauge-grade 
+                            title="${heading}" 
+                            percentage="${score}"
+                            sectionColors="--lumo-${level}-color">
+                        </echarts-gauge-grade>    
+                    </div>`;
+    }
+    
+    _renderDiagnosticText(diagnostic){
+        let whatToDo = html``;
+        
+        return html`<div class="diagnosticText">
+                        <div class="message">${diagnostic[0].message}</div>
+                    </div>`;
+    }
+    
+    _renderInformation(endpoint){
+        return html`<div class="information">
+                        <table class="infoTable">
+                            ${this._renderMediaType("Produces", endpoint.producesHeaders)}
+                            ${this._renderMediaType("Consumes", endpoint.consumesHeaders)}
+                    
+                            <tr>
+                                <td class="col1">Resource Class:</td>
+                                <td>${endpoint.className}</td>
+                            </tr>
+                        </table>
+                    </div>`;
+    }
+
+    _renderMediaType(type,mediaType) {
+        if(mediaType && mediaType.length>0){
+            return html`<tr>
+                            <td class="col1">${type}:</td>
+                            <td>${mediaType.map(mt=>
+                                html`<qui-badge><span>${mt}</span></qui-badge>`
+                            )}</td>
+                        </tr>`;
+        }
+    }
+
+    _getLevel(score){
+        let level = "error";
+        if(score === 66){
+            level = "warning";
+        }else if(score === 100){
+            level = "success";
+        }
+        return level;
+    }
+
+    _refresh(){
+        this.jsonRpc.getEndpointScores().then(endpointScores => {
+            this._latestScores = endpointScores.result;
+        });
+    }
+
+}
+customElements.define('qwc-resteasy-reactive-endpoint-scores', QwcResteasyReactiveEndpointScores);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/resteasy-reactive/qwc-resteasy-reactive-exception-mappers.js
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/resteasy-reactive/qwc-resteasy-reactive-exception-mappers.js
@@ -1,0 +1,45 @@
+import { LitElement, html, css} from 'lit';
+import { JsonRpc } from 'jsonrpc';
+import '@vaadin/grid';
+import '@vaadin/grid/vaadin-grid-sort-column.js';
+
+/**
+ * This component shows the Rest Easy Reactive Exception mappers
+ */
+export class QwcResteasyReactiveExceptionMappers extends LitElement {
+    jsonRpc = new JsonRpc("RESTEasy Reactive");
+
+    static styles = css`
+        .datatable {
+            height: 100%;
+            padding-bottom: 10px;
+        }`;
+
+    static properties = {
+        _exceptionMappers: {state: true},
+    };
+
+    constructor() {
+        super();
+        this._exceptionMappers = null;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.jsonRpc.getExceptionMappers().then(exceptionMappers => {
+            this._exceptionMappers = exceptionMappers.result;
+        });
+    }
+
+    render() {
+        if(this._exceptionMappers){
+            
+            return html`<vaadin-grid .items="${this._exceptionMappers}" class="datatable" theme="row-stripes">
+                <vaadin-grid-sort-column header="Priority" path="priority" resizable auto-width></vaadin-grid-sort-column>
+                <vaadin-grid-sort-column header="Exception" path="name" resizable auto-width></vaadin-grid-sort-column>
+                <vaadin-grid-sort-column header="Mapper" path="className" resizable auto-width></vaadin-grid-sort-column>
+            </vaadin-grid>`;
+        }
+    }
+}
+customElements.define('qwc-resteasy-reactive-exception-mappers', QwcResteasyReactiveExceptionMappers);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/resteasy-reactive/qwc-resteasy-reactive-parameter-converter-providers.js
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/resteasy-reactive/qwc-resteasy-reactive-parameter-converter-providers.js
@@ -1,0 +1,44 @@
+import { LitElement, html, css} from 'lit';
+import { JsonRpc } from 'jsonrpc';
+import '@vaadin/grid';
+import '@vaadin/grid/vaadin-grid-sort-column.js';
+
+/**
+ * This component shows the Rest Easy Reactive Parameter Converter Providers
+ */
+export class QwcResteasyReactiveParameterConverterProviders extends LitElement {
+    jsonRpc = new JsonRpc("RESTEasy Reactive");
+
+    static styles = css`
+        .datatable {
+            height: 100%;
+            padding-bottom: 10px;
+        }`;
+
+    static properties = {
+        _paramConverterProviders: {state: true},
+    };
+
+    constructor() {
+        super();
+        this._paramConverterProviders = null;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.jsonRpc.getParamConverterProviders().then(paramConverterProviders => {
+            this._paramConverterProviders = paramConverterProviders.result;
+        });
+    }
+
+    render() {
+        if(this._paramConverterProviders){
+            
+            return html`<vaadin-grid .items="${this._paramConverterProviders}" class="datatable" theme="row-stripes">
+                <vaadin-grid-sort-column header="Priority" path="priority" resizable auto-width></vaadin-grid-sort-column>
+                <vaadin-grid-sort-column header="Class Name" path="className" resizable auto-width></vaadin-grid-sort-column>
+            </vaadin-grid>`;
+        }
+    }
+}
+customElements.define('qwc-resteasy-reactive-parameter-converter-providers', QwcResteasyReactiveParameterConverterProviders);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/devui/ResteasyReactiveExceptionMapper.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/devui/ResteasyReactiveExceptionMapper.java
@@ -1,0 +1,25 @@
+package io.quarkus.resteasy.reactive.server.runtime.devui;
+
+public class ResteasyReactiveExceptionMapper {
+    private final String name;
+    private final String className;
+    private final int priority;
+
+    public ResteasyReactiveExceptionMapper(String name, String className, int priority) {
+        this.name = name;
+        this.className = className;
+        this.priority = priority;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/devui/ResteasyReactiveJsonRPCService.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/devui/ResteasyReactiveJsonRPCService.java
@@ -1,0 +1,43 @@
+package io.quarkus.resteasy.reactive.server.runtime.devui;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.resteasy.reactive.server.core.RuntimeExceptionMapper;
+import org.jboss.resteasy.reactive.server.util.ScoreSystem;
+
+import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveRecorder;
+
+public class ResteasyReactiveJsonRPCService {
+
+    public ScoreSystem.EndpointScores getEndpointScores() {
+        ScoreSystem.EndpointScores result = ScoreSystem.latestScores;
+        if (result != null) {
+            return result;
+        }
+
+        return new ScoreSystem.EndpointScores(0, Collections.emptyList());
+    }
+
+    public List<ResteasyReactiveExceptionMapper> getExceptionMappers() {
+        List<ResteasyReactiveExceptionMapper> all = new ArrayList<>();
+        var mappers = RuntimeExceptionMapper.getMappers();
+        for (var entry : mappers.entrySet()) {
+            all.add(new ResteasyReactiveExceptionMapper(entry.getKey().getName(), entry.getValue().getClassName(),
+                    entry.getValue().getPriority()));
+        }
+        return all;
+    }
+
+    public List<ResteasyReactiveParamConverterProvider> getParamConverterProviders() {
+        List<ResteasyReactiveParamConverterProvider> all = new ArrayList<>();
+        var providers = ResteasyReactiveRecorder.getCurrentDeployment().getParamConverterProviders()
+                .getParamConverterProviders();
+        for (var provider : providers) {
+            all.add(new ResteasyReactiveParamConverterProvider(provider.getClassName(),
+                    provider.getPriority()));
+        }
+        return all;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/devui/ResteasyReactiveParamConverterProvider.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/devui/ResteasyReactiveParamConverterProvider.java
@@ -1,0 +1,19 @@
+package io.quarkus.resteasy.reactive.server.runtime.devui;
+
+public class ResteasyReactiveParamConverterProvider {
+    private final String className;
+    private final int priority;
+
+    public ResteasyReactiveParamConverterProvider(String className, int priority) {
+        this.className = className;
+        this.priority = priority;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -76,17 +76,26 @@ public class BuildTimeContentProcessor {
         InternalImportMapBuildItem internalImportMapBuildItem = new InternalImportMapBuildItem();
 
         internalImportMapBuildItem.add("devui/", contextRoot + "/");
+        // Quarkus Web Components
         internalImportMapBuildItem.add("qwc/", contextRoot + "qwc/");
+        // Quarkus UI
         internalImportMapBuildItem.add("qui/", contextRoot + "qui/");
         internalImportMapBuildItem.add("qui-badge", contextRoot + "qui/qui-badge.js");
         internalImportMapBuildItem.add("qui-alert", contextRoot + "qui/qui-alert.js");
+        // Echarts
+        internalImportMapBuildItem.add("echarts/", contextRoot + "echarts/");
+        internalImportMapBuildItem.add("echarts-gauge-grade", contextRoot + "echarts/echarts-gauge-grade.js");
+
+        // Other assets
         internalImportMapBuildItem.add("icon/", contextRoot + "icon/");
         internalImportMapBuildItem.add("font/", contextRoot + "font/");
+        // Controllers
         internalImportMapBuildItem.add("controller/", contextRoot + "controller/");
         internalImportMapBuildItem.add("log-controller", contextRoot + "controller/log-controller.js");
         internalImportMapBuildItem.add("router-controller", contextRoot + "controller/router-controller.js");
         internalImportMapBuildItem.add("notifier", contextRoot + "controller/notifier.js");
         internalImportMapBuildItem.add("jsonrpc", contextRoot + "controller/jsonrpc.js");
+        // State
         internalImportMapBuildItem.add("state/", contextRoot + "state/");
         internalImportMapBuildItem.add("theme-state", contextRoot + "state/theme-state.js");
         internalImportMapBuildItem.add("connection-state", contextRoot + "state/connection-state.js");

--- a/extensions/vertx-http/dev-ui-resources/pom.xml
+++ b/extensions/vertx-http/dev-ui-resources/pom.xml
@@ -32,6 +32,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.mvnpm</groupId>
+            <artifactId>echarts</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mvnpm.at.vanillawc</groupId>
             <artifactId>wc-codemirror</artifactId>
             <scope>runtime</scope>

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/echarts/echarts-abstract-canvas.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/echarts/echarts-abstract-canvas.js
@@ -1,0 +1,81 @@
+import { LitElement, html, css } from 'lit';
+import 'echarts/dist/echarts.min.js';
+import { themeState } from 'theme-state';
+
+/**
+ * This is an abstract components used as a base for all echarts components
+ */
+class EchartsAbstractCanvas extends LitElement {
+    static get styles() {
+        return css`
+        :host {
+            display: block;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+        }
+      `;
+    }
+
+    static properties = {
+        _width: {state: true},
+        _height: {state: true},
+    };
+
+    constructor() {
+        super();
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._rh = (e) => this._handleResize(e);
+        window.addEventListener('resize', this._rh);
+
+        this.themeStateObserver = () => this.reload();
+        themeState.addObserver(this.themeStateObserver);
+    }
+      
+    disconnectedCallback() {
+        window.removeEventListener('resize', this._rh);
+        themeState.removeObserver(this.themeStateObserver);
+        super.disconnectedCallback();      
+    }
+
+    render() {
+        if(!this._height){
+            this._height = parseFloat(getComputedStyle(this).getPropertyValue('height'), 10) - 20;
+        }
+        if(!this._width){
+            this._width = parseFloat(getComputedStyle(this).getPropertyValue('width'), 10) - 20;
+        }
+        return html`<div class="canvasContainer" style="width:${this._width}px;height:${this._height}px;"></div>`;
+    }
+
+    _handleResize(e){
+        this._width = parseFloat(getComputedStyle(this).getPropertyValue('width'), 10) - 20;
+        this._height = parseFloat(getComputedStyle(this).getPropertyValue('height'), 10) - 20;
+
+        this._chart.resize();
+    }
+
+    firstUpdated(){
+        super.firstUpdated();
+        let canvasContainer = this.shadowRoot.querySelector('.canvasContainer');
+        this._chart = echarts.init(canvasContainer);
+        var option = this.getOption();
+        this._chart.setOption(option);
+    }
+
+    getOption(){
+        throw new Error("Method 'getOption()' must be implemented.");
+    }
+
+    reload(){
+        var option = this.getOption();
+        this._chart.setOption(option);
+        this.requestUpdate();
+    }
+
+}
+
+export { EchartsAbstractCanvas };

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/echarts/echarts-gauge-grade.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/echarts/echarts-gauge-grade.js
@@ -1,0 +1,168 @@
+import { EchartsAbstractCanvas } from './echarts-abstract-canvas.js';
+/**
+ * This wraps the Gauge Grade echart into a component
+ * see https://echarts.apache.org/examples/en/editor.html?c=gauge-grade
+ */
+class EchartsGaugeGrade extends EchartsAbstractCanvas {
+
+    static get properties() {
+        return {
+            percentage: { type: Number },
+            percentageFontSize: { type: Number },
+            title: { type: String },
+            titleFontSize: { type: Number },
+            sectionTitles: { type: String },
+            sectionColors: { type: String },
+            primaryTextColor: { type: String },
+            secondaryTextColor: { type: String },
+        };
+    }
+
+    constructor() {
+        super();
+        this.title = null;
+        this.titleFontSize = 18;
+        this.percentage = 50;
+        this.percentageFontSize = 28;
+        this.sectionTitles = null;
+        this.sectionColors = "grey";
+        this.primaryTextColor = "--lumo-body-text-color";
+        this.secondaryTextColor = "--lumo-secondary-text-color";
+    }
+
+    getOption(){
+        let textColor = this.primaryTextColor;
+        if(textColor.startsWith('--')){
+            textColor = getComputedStyle(this.shadowRoot.host).getPropertyValue(textColor);
+        }
+
+        let secondaryColor = this.secondaryTextColor;
+        if(secondaryColor.startsWith('--')){
+            secondaryColor = getComputedStyle(this.shadowRoot.host).getPropertyValue(secondaryColor);
+        }
+        
+        const sectionColorsArray = this.sectionColors.split(',');
+        let sectionColorsLength = sectionColorsArray.length;
+        let partSize = (1/sectionColorsLength);
+        const colors = [];
+
+        for (var cc = 0; cc < sectionColorsLength; cc++) {
+            let p = cc + 1;
+            let max = (p * partSize).toFixed(2);
+            let colorString = sectionColorsArray[cc];
+            if(colorString.startsWith("--")){
+                colorString = getComputedStyle(this.shadowRoot.host).getPropertyValue(colorString);
+            }
+            colors.push([max, colorString]);
+        }
+
+        const partsSize = sectionColorsLength + 1;
+        const st = this.sectionTitles;
+        const serie = new Object();
+        serie.type = 'gauge';
+        serie.startAngle = 180;
+        serie.endAngle = 0;
+        serie.center = [];
+        serie.center.push('50%');
+        serie.center.push('75%');
+        serie.radius = '90%';
+        serie.min = 0;
+        serie.max = 1;
+        serie.splitNumber = partsSize*2;
+
+        serie.axisLine = this._createAxisElement(null,6,colors);
+
+        const pointer = new Object();
+        pointer.icon = 'path://M12.8,0.7l12,40.1H0.7L12.8,0.7z';
+        pointer.length = '12%';
+        pointer.width = 20;
+        pointer.offsetCenter = [];
+        pointer.offsetCenter.push(0);
+        pointer.offsetCenter.push('-60%');
+        
+        const itemStyle = new Object();
+        itemStyle.color = 'inherit';
+        pointer.itemStyle = itemStyle;
+        serie.pointer = pointer;
+
+        serie.axisTick = this._createAxisElement(2,12,secondaryColor);
+        serie.splitLine = this._createAxisElement(5,20,secondaryColor);
+
+        const axisLabel = new Object();
+        axisLabel.color = secondaryColor;
+        axisLabel.fontSize = 20;
+        axisLabel.distance = -60;
+        axisLabel.rotate = 'tangential';
+        axisLabel.formatter = function (value) {
+            if(st && st!== "null"){
+
+                var titles = st.split(',');
+                let numberOfSections = titles.length;
+
+
+                let partSize = (1/numberOfSections).toFixed(2);
+
+                for (var i = 0; i < numberOfSections; i++) {
+                    let part = i + 1;
+
+                    let min = i * partSize;
+                    let max = part * partSize;
+
+                    min = min + 0.1;
+                    max = max - 0.1;
+
+                    if(value > min && value < max ){
+                        return titles[i];
+                    }
+                }
+            }
+            return '';
+        };
+
+        serie.axisLabel = axisLabel;
+        
+        
+        const title = new Object();
+        title.offsetCenter = [0, '-10%'];
+        title.fontSize = this.titleFontSize;
+        title.color = textColor;
+        serie.title = title;
+
+        const detail = new Object();
+        detail.fontSize = this.percentageFontSize;
+        detail.offsetCenter = [0, '-35%'];
+        detail.valueAnimation = true;
+        detail.formatter = function (value) {
+            return Math.round(value * 100) + '%';
+        };
+        detail.color = 'inherit';
+        serie.detail = detail;
+        
+        const data1 = new Object();
+        data1.name = this.title;
+        data1.value = this.percentage/100;
+        const data = [data1];
+        serie.data = data;
+
+        const gaugeGradeOption = new Object();
+        gaugeGradeOption.series = [serie];
+        
+        return gaugeGradeOption;
+        
+    }
+
+    _createAxisElement(width, length, color){
+        const axisTick = new Object();
+        if(length){
+            axisTick.length = length;
+        }
+        const lineStyle = new Object();
+        lineStyle.color = color;
+        if(width){
+            lineStyle.width = width;
+        }
+        axisTick.lineStyle = lineStyle;
+        return axisTick;
+    }
+}
+customElements.define('echarts-gauge-grade', EchartsGaugeGrade);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/util/ScoreSystem.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/util/ScoreSystem.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.MessageBodyWriter;
@@ -35,7 +36,9 @@ public class ScoreSystem {
         public final String httpMethod;
         public final String fullPath;
         public final List<MediaType> produces;
+        public final List<String> producesHeaders;
         public final List<MediaType> consumes;
+        public final List<String> consumesHeaders;
         public final Map<Category, List<Diagnostic>> diagnostics;
         public final int score;
         public final List<RequestFilterEntry> requestFilterEntries;
@@ -47,7 +50,13 @@ public class ScoreSystem {
             this.httpMethod = httpMethod;
             this.fullPath = fullPath;
             this.produces = produces;
+            this.producesHeaders = produces.stream()
+                    .map(MediaType::toString)
+                    .collect(Collectors.toList());
             this.consumes = consumes;
+            this.consumesHeaders = consumes.stream()
+                    .map(MediaType::toString)
+                    .collect(Collectors.toList());
             this.diagnostics = diagnostics;
             this.score = score;
             this.requestFilterEntries = requestFilterEntries;


### PR DESCRIPTION
This PR migrates the Dev UI Screens for RestEasy Reactive to the new Dev UI.

It contains an optional custom card that shows the score on the extensions page. Let me know if you want to keep that.
This PR also pull in apache echarts and some custom components to wrap it in Web components

Comparing to the old Dev UI:

![resteasy_reactive_echarts](https://user-images.githubusercontent.com/6836179/223319531-cd4e5ff7-bb55-4d30-a105-89dece19ba4b.gif)

The custom card:
![resteasy_reactive_custom_card](https://user-images.githubusercontent.com/6836179/223319560-a5bf4f1f-e170-460c-bbeb-73d46698fd19.gif)

