### PR TITLE
Ensure logging category is properly set for @QuarkusIntegrationTest

### DIFF
--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -62,3 +62,7 @@ quarkus.test.enable-callbacks-for-integration-tests=true
 
 # @RolesAllowed value is configuration expression
 tester-config-exp=tester
+
+
+# used to make sure that @QuarkusIntegrationTest works properly when basic logging is turned off
+%prod.quarkus.log.category."io.quarkus".level=WARN

--- a/integration-tests/picocli-native/src/test/java/io/quarkus/it/picocli/PicocliTest.java
+++ b/integration-tests/picocli-native/src/test/java/io/quarkus/it/picocli/PicocliTest.java
@@ -38,10 +38,10 @@ public class PicocliTest {
     public void testMethodSubCommand(QuarkusMainLauncher launcher) {
         LaunchResult result = launcher.launch("with-method-sub-command", "hello", "-n", "World!");
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("Hello World!");
+        assertThat(result.getOutput()).contains("Hello World!");
         result = launcher.launch("with-method-sub-command", "goodBye", "-n", "Test?");
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("Goodbye Test?");
+        assertThat(result.getOutput()).contains("Goodbye Test?");
     }
 
     @Test
@@ -49,7 +49,7 @@ public class PicocliTest {
         org.jboss.logging.Logger.getLogger("test").error("error");
         LaunchResult result = launcher.launch("with-method-sub-command", "hello", "-n", "World!");
         assertThat(result.exitCode()).isZero();
-        assertThat(result.getOutput()).isEqualTo("Hello World!");
+        assertThat(result.getOutput()).contains("Hello World!");
     }
 
     @Test
@@ -58,14 +58,13 @@ public class PicocliTest {
         LaunchResult result = launcher.launch("with-method-sub-command", "loggingHello", "-n", "World!");
         assertThat(result.exitCode()).isZero();
         assertThat(result.getOutput()).contains("ERROR [io.qua.it.pic.WithMethodSubCommand] (main) Hello World!");
-        assertThat(result.getOutputStream().size()).isEqualTo(1);
         assertThat(result.getOutput()).doesNotContain("ERROR [test] (main) error");
     }
 
     @Test
     @Launch({ "command-used-as-parent", "-p", "testValue", "child" })
     public void testParentCommand(LaunchResult result) {
-        assertThat(result.getOutput()).isEqualTo("testValue");
+        assertThat(result.getOutput()).contains("testValue");
 
         assertThat(value).isNotNull();
     }
@@ -84,7 +83,7 @@ public class PicocliTest {
     @Test
     @Launch({ "dynamic-proxy" })
     public void testDynamicProxy(LaunchResult result) {
-        assertThat(result.getOutput()).isEqualTo("2007-12-03T10:15:30");
+        assertThat(result.getOutput()).contains("2007-12-03T10:15:30");
 
         assertThat(value).isNotNull();
     }
@@ -128,7 +127,7 @@ public class PicocliTest {
     @Test
     @Launch("default-value-provider")
     public void testDefaultValueProvider(LaunchResult result) {
-        assertThat(result.getOutput()).isEqualTo("default:default-value");
+        assertThat(result.getOutput()).contains("default:default-value");
 
         assertThat(value).isNotNull();
     }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -121,6 +121,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
             args.add("--net=" + devServicesLaunchResult.networkId());
         }
 
+        args.addAll(toEnvVar("quarkus.log.category.\"io.quarkus\".level", "INFO"));
         if (DefaultJarLauncher.HTTP_PRESENT) {
             args.addAll(toEnvVar("quarkus.http.port", "" + httpPort));
             args.addAll(toEnvVar("quarkus.http.ssl-port", "" + httpsPort));

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
@@ -110,6 +110,7 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
         Path logFile = PropertyTestUtil.getLogFilePath();
         args.add("-Dquarkus.log.file.path=" + logFile.toAbsolutePath().toString());
         args.add("-Dquarkus.log.file.enable=true");
+        args.add("-Dquarkus.log.category.\"io.quarkus\".level=INFO");
         if (testProfile != null) {
             args.add("-Dquarkus.profile=" + testProfile);
         }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
@@ -132,6 +132,7 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
         Path logFile = PropertyTestUtil.getLogFilePath();
         args.add("-Dquarkus.log.file.path=" + logFile.toAbsolutePath().toString());
         args.add("-Dquarkus.log.file.enable=true");
+        args.add("-Dquarkus.log.category.\"io.quarkus\".level=INFO");
         if (testProfile != null) {
             args.add("-Dquarkus.profile=" + testProfile);
         }


### PR DESCRIPTION
`@QuarkusIntegrationTest` uses the logging output to determine that the application has properly booted, so we need to make sure that user provided configuration does not turn off the necessary logging output

Fixes: #31640