### PR TITLE
RuntimeUpdatesProcessor now supports hot replacement problems

### DIFF
--- a/integration-tests/test-extension/extension/deployment/src/main/java/io/quarkus/extest/deployment/HotReplacementProcessor.java
+++ b/integration-tests/test-extension/extension/deployment/src/main/java/io/quarkus/extest/deployment/HotReplacementProcessor.java
@@ -1,0 +1,12 @@
+package io.quarkus.extest.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
+import io.quarkus.extest.runtime.TestHotReplacementSetup;
+
+public class HotReplacementProcessor {
+    @BuildStep
+    public HotDeploymentWatchedFileBuildItem registerHotReplacementFile() {
+        return new HotDeploymentWatchedFileBuildItem(TestHotReplacementSetup.HOT_REPLACEMENT_FILE, false);
+    }
+}

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/HotReplacementException.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/HotReplacementException.java
@@ -1,0 +1,5 @@
+package io.quarkus.extest.runtime;
+
+public class HotReplacementException extends Exception {
+
+}

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/TestHotReplacementSetup.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/TestHotReplacementSetup.java
@@ -1,0 +1,49 @@
+package io.quarkus.extest.runtime;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import io.quarkus.dev.ErrorPageGenerators;
+import io.quarkus.dev.spi.HotReplacementContext;
+import io.quarkus.dev.spi.HotReplacementSetup;
+
+public class TestHotReplacementSetup implements HotReplacementSetup {
+
+    public final static String HOT_REPLACEMENT_FILE = "hot.replacement";
+
+    private static final String HOT_REPLACEMENT_EXCEPTION = HotReplacementException.class.getName();
+
+    private HotReplacementContext context;
+
+    @Override
+    public void setupHotDeployment(HotReplacementContext context) {
+        context.consumeNoRestartChanges(this::noRestartChanges);
+        this.context = context;
+        ErrorPageGenerators.register(HOT_REPLACEMENT_EXCEPTION, this::generatePage);
+    }
+
+    public void noRestartChanges(Set<String> changedFiles) {
+        if (changedFiles.contains(HOT_REPLACEMENT_FILE)) {
+            for (Path resourcePath : context.getResourcesDir()) {
+                Path myFile = resourcePath.resolve(HOT_REPLACEMENT_FILE);
+                if (Files.exists(myFile)) {
+                    try {
+                        String contents = Files.readString(myFile);
+                        if ("throw".equals(contents))
+                            throw new RuntimeException(new HotReplacementException());
+                        return;
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }
+            }
+        }
+    }
+
+    private String generatePage(Throwable x) {
+        return "Generated page for exception " + x;
+    }
+}

--- a/integration-tests/test-extension/extension/runtime/src/main/resources/META-INF/services/io.quarkus.dev.spi.HotReplacementSetup
+++ b/integration-tests/test-extension/extension/runtime/src/main/resources/META-INF/services/io.quarkus.dev.spi.HotReplacementSetup
@@ -1,0 +1,1 @@
+io.quarkus.extest.runtime.TestHotReplacementSetup

--- a/integration-tests/test-extension/tests/pom.xml
+++ b/integration-tests/test-extension/tests/pom.xml
@@ -30,6 +30,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5-internal</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
@@ -96,6 +101,30 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+            <execution>
+                <id>default-test</id>
+                <goals>
+                    <goal>test</goal>
+                </goals>
+                <configuration>
+                    <excludes>
+                    	<exclude>io/quarkus/it/extension/HotReplacementSetupDevModeTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </execution>
+            <execution>
+                <id>quarkus-test</id>
+                <goals>
+                    <goal>test</goal>
+                </goals>
+                <configuration>
+                    <includes>
+                    	<include>io/quarkus/it/extension/HotReplacementSetupDevModeTest.java</include>
+                    </includes>
+                </configuration>
+            </execution>
+        </executions>
         <configuration>
           <systemPropertyVariables>
             <!-- See io.quarkus.extest.runtime.classpath.RecordedClasspathEntries -->

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/HotReplacementSetupDevModeTest.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/HotReplacementSetupDevModeTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.it.extension;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.extest.runtime.TestHotReplacementSetup;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class HotReplacementSetupDevModeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(SystemPropertyTestEndpoint.class)
+                    .addAsResource(new StringAsset("nothing"), TestHotReplacementSetup.HOT_REPLACEMENT_FILE));
+
+    @Test
+    public void watched() {
+        RestAssured.get("/core/sysprop")
+                .then()
+                .statusCode(200);
+        TEST.modifyResourceFile(TestHotReplacementSetup.HOT_REPLACEMENT_FILE, text -> "throw");
+        RestAssured.get("/core/sysprop")
+                .then()
+                .statusCode(500)
+                .body(Matchers.containsString("Generated page for exception"));
+        TEST.modifyResourceFile(TestHotReplacementSetup.HOT_REPLACEMENT_FILE, text -> "nothing");
+        RestAssured.get("/core/sysprop")
+                .then()
+                .statusCode(200);
+    }
+}


### PR DESCRIPTION
Fixes #31013

This allows participants that implement `HotReplacementSetup` to throw problems which will:
- be printed in the console
- go via the `ErrorPageGenerators` process to be displayed in the web UI

I'm unsure about the fact that I only stop and map the first error from the list of `HotReplacementSetup` providers. But ATM we don't have support for `ErrorPageGenerators` for more than one kind of exception at a time.