### PR TITLE
Update PR preview and teardown URL domains

### DIFF
--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Teardown surge preview
         id: deploy
-        run: npx surge teardown https://quarkus-io-pr-main-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }} || true
+        run: npx surge teardown https://quarkus-pr-main-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }} || true
       - name: Update PR status comment
         uses: actions-cool/maintain-one-comment@v3.0.0
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -75,13 +75,13 @@ jobs:
           ### Flags accepted can be found here https://jekyllrb.com/docs/configuration/options/#build-command-options
       - name: Publishing to surge for preview
         id: deploy
-        run: npx surge ./_site --domain https://quarkus-io-pr-main-${{ steps.pr.outputs.id }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+        run: npx surge ./_site --domain https://quarkus-pr-main-${{ steps.pr.outputs.id }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
       - name: Update PR status comment on success
         uses: actions-cool/maintain-one-comment@v3.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            🎊 PR Preview ${{ github.sha }} has been successfully built and deployed to https://quarkus-io-pr-main-${{ steps.pr.outputs.id }}-preview.surge.sh/version/main/guides/
+            🎊 PR Preview ${{ github.sha }} has been successfully built and deployed to https://quarkus-pr-main-${{ steps.pr.outputs.id }}-preview.surge.sh/version/main/guides/
             <img width="300" src="https://user-images.githubusercontent.com/507615/90250366-88233900-de6e-11ea-95a5-84f0762ffd39.png">
             <!-- Sticky Pull Request Comment -->
           body-include: '<!-- Sticky Pull Request Comment -->'


### PR DESCRIPTION
Removing the `-io-` might prevent the safety warning shown in Chrome

![image](https://user-images.githubusercontent.com/54133/223427634-6baaf451-3b37-485b-a0c5-2ad6ac410f82.png)
