### PR TITLE
Fix cli update for Maven

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
@@ -102,7 +102,7 @@ public interface BuildSystemRunner {
 
     Integer projectInfo(boolean perModule) throws Exception;
 
-    Integer updateProject(String targetPlatformVersion, String targetPlatformStreamId, boolean perModule) throws Exception;
+    Integer updateProject(String targetPlatformVersion, String targetPlatformStream, boolean perModule) throws Exception;
 
     BuildCommandArgs prepareAction(String action, BuildOptions buildOptions, RunModeOption runMode, List<String> params);
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -20,9 +20,9 @@ import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.cli.registry.RegistryClientMixin;
+import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.registry.config.RegistriesConfigLocator;
-import io.quarkus.runtime.util.StringUtil;
 
 public class GradleRunner implements BuildSystemRunner {
     public static final String[] windowsWrapper = { "gradlew.cmd", "gradlew.bat" };
@@ -136,22 +136,11 @@ public class GradleRunner implements BuildSystemRunner {
     }
 
     @Override
-    public Integer updateProject(String targetPlatformVersion, String targetPlatformStreamId, boolean perModule)
+    public Integer updateProject(String targetPlatformVersion, String targetPlatformStream, boolean perModule)
             throws Exception {
-        ArrayDeque<String> args = new ArrayDeque<>();
-        args.add("quarkusUpdate");
-        if (!StringUtil.isNullOrEmpty(targetPlatformVersion)) {
-            args.add("--platform-version");
-            args.add(targetPlatformVersion);
-        }
-        if (!StringUtil.isNullOrEmpty(targetPlatformStreamId)) {
-            args.add("--stream-id");
-            args.add(targetPlatformStreamId);
-        }
-        if (perModule) {
-            args.add("--per-module");
-        }
-        return run(prependExecutable(args));
+        MessageWriter.info().error(
+                "quarkus update is not yet available for Gradle projects. See https://github.com/quarkusio/quarkus/issues/31658 for more information.");
+        return 1;
     }
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
@@ -75,7 +75,7 @@ public class JBangRunner implements BuildSystemRunner {
     }
 
     @Override
-    public Integer updateProject(String targetPlatformVersion, String targetPlatformStreamId, boolean perModule)
+    public Integer updateProject(String targetPlatformVersion, String targetPlatformStream, boolean perModule)
             throws Exception {
         throw new UnsupportedOperationException("Not there yet. ;)");
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/TargetQuarkusVersionGroup.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/TargetQuarkusVersionGroup.java
@@ -4,8 +4,8 @@ import picocli.CommandLine;
 
 public class TargetQuarkusVersionGroup {
 
-    @CommandLine.Option(paramLabel = "targetStreamId", names = { "-S",
-            "--stream-id" }, description = "A target stream id, for example:%n  2.0")
+    @CommandLine.Option(paramLabel = "targetStream", names = { "-S",
+            "--stream" }, description = "A target stream, for example:%n  2.0")
     public String streamId;
 
     @CommandLine.Option(paramLabel = "targetPlatformVersion", names = { "-P",

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
@@ -88,6 +88,8 @@ public class QuarkusUpdate extends QuarkusPlatformTask {
         invoker.latestCatalog(targetCatalog);
         invoker.targetPlatformVersion(targetPlatformVersion);
         invoker.perModule(perModule);
+        // This is currently not supported with gradle
+        invoker.generateRewriteConfig(false);
         invoker.appModel(extension().getApplicationModel());
         try {
             invoker.execute();

--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -40,10 +40,10 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
     private String platformVersion;
 
     /**
-     * Target streamId (e.g: 2.0)
+     * Target stream (e.g: 2.0)
      */
-    @Parameter(property = "streamId", required = false)
-    private String streamId;
+    @Parameter(property = "stream", required = false)
+    private String stream;
 
     @Override
     protected void validateParameters() throws MojoExecutionException {
@@ -61,8 +61,8 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
                 targetPrimaryBom = ArtifactCoords.pom(targetPrimaryBom.getGroupId(), targetPrimaryBom.getArtifactId(),
                         platformVersion);
                 targetCatalog = getExtensionCatalogResolver().resolveExtensionCatalog(List.of(targetPrimaryBom));
-            } else if (streamId != null) {
-                var platformStream = PlatformStreamCoords.fromString(streamId);
+            } else if (stream != null) {
+                var platformStream = PlatformStreamCoords.fromString(stream);
                 targetCatalog = getExtensionCatalogResolver().resolveExtensionCatalog(platformStream);
                 platformVersion = getPrimaryBom(targetCatalog).getVersion();
             } else {


### PR DESCRIPTION
- `quarkus update` in a Maven project now delegates to the CLI version of the `quarkus-maven-plugin`
- `quarkus update` is not doing anything an shows a warning pointing to an issue for more info
- Fixes #31629 

```
~/D/q/code-with-quarkus> qss update -S 3.0
[INFO] Scanning for projects...
[INFO]
[INFO] ---------------------< org.acme:code-with-quarkus >---------------------
[INFO] Building code-with-quarkus 1.0.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:update (default-cli) @ code-with-quarkus ---
[WARNING] quarkus:update goal is experimental, its options and output might change in future versions
[INFO] Looking for the newly published extensions in registry.quarkus.io
[INFO] Instructions to update this project from '2.16.4.Final' to '3.0.0.Alpha4':
[INFO]
[INFO] Recommended Quarkus platform BOM updates:
[INFO] Update: io.quarkus.platform:quarkus-bom:pom:2.16.4.Final -> 3.0.0.Alpha4
[INFO]
[INFO] Project update recipe has been created:
/var/folders/j8/sj85tl7d2pq_vnhbpj4t5lwm0000gn/T/quarkus-project-recipe-13722540005474724642.yaml
[INFO] The command to update this project:
mvn org.openrewrite.maven:rewrite-maven-plugin:4.39.0:run \
  -Drewrite.configLocation=/var/folders/j8/sj85tl7d2pq_vnhbpj4t5lwm0000gn/T/quarkus-project-recipe-13722540005474724642.yaml \
  -DactiveRecipes=io.quarkus.openrewrite.Quarkus -e
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.647 s
[INFO] Finished at: 2023-03-07T16:45:04+01:00
[INFO] ------------------------------------------------------------------------
```