### PR TITLE
Bump smallrye-open-api from 3.2.0 to 3.3.0, fix OpenAPI security issues

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -58,7 +58,7 @@
         <smallrye-config.version>3.1.3</smallrye-config.version>
         <smallrye-health.version>4.0.1</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>3.2.0</smallrye-open-api.version>
+        <smallrye-open-api.version>3.3.0</smallrye-open-api.version>
         <smallrye-graphql.version>2.1.1</smallrye-graphql.version>
         <smallrye-opentracing.version>3.0.3</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>6.2.1</smallrye-fault-tolerance.version>
@@ -1848,7 +1848,7 @@
                 <artifactId>quarkus-vertx-http-dev-ui-resources</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-reactive-routes</artifactId>

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/resources/application.properties
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/resources/application.properties
@@ -2,3 +2,6 @@ quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:test
 
 quarkus.hibernate-orm.database.generation=drop-and-create
+
+# Scopes will not populate in the OpenAPI document unless the security scheme is Oauth2 or OIDC
+quarkus.smallrye-openapi.security-scheme=oauth2-implicit

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedWithScopesTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedWithScopesTestCase.java
@@ -1,0 +1,78 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.hamcrest.Matcher;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+class AutoSecurityRolesAllowedWithScopesTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ResourceBean.class, OpenApiResourceSecuredAtClassLevel.class,
+                            OpenApiResourceSecuredAtMethodLevel.class, OpenApiResourceSecuredAtMethodLevel2.class)
+                    .addAsResource(
+                            new StringAsset("quarkus.smallrye-openapi.security-scheme=oauth2-implicit\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-name=OAuth2\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-description=OAuth2 Authentication"),
+
+                            "application.properties"));
+
+    static Matcher<Iterable<Object>> schemeArray(String schemeName, Matcher<Iterable<?>> scopesMatcher) {
+        return allOf(
+                iterableWithSize(1),
+                hasItem(allOf(
+                        aMapWithSize(1),
+                        hasEntry(equalTo(schemeName), scopesMatcher))));
+    }
+
+    @Test
+    void testAutoSecurityRequirement() {
+        RestAssured.given()
+                .header("Accept", "application/json")
+                .when()
+                .get("/q/openapi")
+                .then()
+                .log().body()
+                .and()
+                .body("components.securitySchemes.OAuth2", allOf(
+                        hasEntry("type", "oauth2"),
+                        hasEntry("description", "OAuth2 Authentication")))
+                .and()
+                // OpenApiResourceSecuredAtMethodLevel
+                .body("paths.'/resource2/test-security/naked'.get.security", schemeArray("OAuth2", contains("admin")))
+                .body("paths.'/resource2/test-security/annotated'.get.security",
+                        schemeArray("JWTCompanyAuthentication", emptyIterable()))
+                .body("paths.'/resource2/test-security/methodLevel/1'.get.security", schemeArray("OAuth2", contains("user1")))
+                .body("paths.'/resource2/test-security/methodLevel/2'.get.security", schemeArray("OAuth2", contains("user2")))
+                .body("paths.'/resource2/test-security/methodLevel/public'.get.security", nullValue())
+                .body("paths.'/resource2/test-security/annotated/documented'.get.security",
+                        schemeArray("JWTCompanyAuthentication", emptyIterable()))
+                .body("paths.'/resource2/test-security/methodLevel/3'.get.security", schemeArray("OAuth2", contains("admin")))
+                .and()
+                // OpenApiResourceSecuredAtClassLevel
+                .body("paths.'/resource2/test-security/classLevel/1'.get.security", schemeArray("OAuth2", contains("user1")))
+                .body("paths.'/resource2/test-security/classLevel/2'.get.security", schemeArray("OAuth2", contains("user2")))
+                .body("paths.'/resource2/test-security/classLevel/3'.get.security", schemeArray("MyOwnName", emptyIterable()))
+                .body("paths.'/resource2/test-security/classLevel/4'.get.security", schemeArray("OAuth2", contains("admin")))
+                .and()
+                // OpenApiResourceSecuredAtMethodLevel2
+                .body("paths.'/resource3/test-security/annotated'.get.security",
+                        schemeArray("AtClassLevel", emptyIterable()));
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtClassLevel.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtClassLevel.java
@@ -16,16 +16,19 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @RolesAllowed("admin")
 public class OpenApiResourceSecuredAtClassLevel {
 
+    @SuppressWarnings("unused")
     private ResourceBean resourceBean;
 
     @GET
     @Path("/test-security/classLevel/1")
+    @RolesAllowed("user1")
     public String secureEndpoint1() {
         return "secret";
     }
 
     @GET
     @Path("/test-security/classLevel/2")
+    @RolesAllowed("user2")
     public String secureEndpoint2() {
         return "secret";
     }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel.java
@@ -15,6 +15,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Server(url = "serverUrl")
 public class OpenApiResourceSecuredAtMethodLevel {
 
+    @SuppressWarnings("unused")
     private ResourceBean resourceBean;
 
     @GET
@@ -34,14 +35,14 @@ public class OpenApiResourceSecuredAtMethodLevel {
 
     @GET
     @Path("/test-security/methodLevel/1")
-    @RolesAllowed("admin")
+    @RolesAllowed("user1")
     public String secureEndpoint1() {
         return "secret";
     }
 
     @GET
     @Path("/test-security/methodLevel/2")
-    @RolesAllowed("admin")
+    @RolesAllowed("user2")
     public String secureEndpoint2() {
         return "secret";
     }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel2.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel2.java
@@ -14,6 +14,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @SecurityRequirement(name = "AtClassLevel")
 public class OpenApiResourceSecuredAtMethodLevel2 {
 
+    @SuppressWarnings("unused")
     private ResourceBean resourceBean;
 
     @GET

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/filter/OpenIDConnectSecurityFilter.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/filter/OpenIDConnectSecurityFilter.java
@@ -1,8 +1,6 @@
 package io.quarkus.smallrye.openapi.runtime.filter;
 
 import org.eclipse.microprofile.openapi.OASFactory;
-import org.eclipse.microprofile.openapi.models.security.OAuthFlow;
-import org.eclipse.microprofile.openapi.models.security.OAuthFlows;
 import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
 
 /**
@@ -10,61 +8,31 @@ import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
  */
 public class OpenIDConnectSecurityFilter extends AutoSecurityFilter {
 
-    private AutoUrl authorizationUrl;
-    private AutoUrl refreshUrl;
-    private AutoUrl tokenUrl;
+    private AutoUrl openIdConnectUrl;
 
     public OpenIDConnectSecurityFilter() {
         super();
     }
 
     public OpenIDConnectSecurityFilter(String securitySchemeName, String securitySchemeDescription,
-            AutoUrl authorizationUrl,
-            AutoUrl refreshUrl,
-            AutoUrl tokenUrl) {
+            AutoUrl openIdConnectUrl) {
         super(securitySchemeName, securitySchemeDescription);
-        this.authorizationUrl = authorizationUrl;
-        this.refreshUrl = refreshUrl;
-        this.tokenUrl = tokenUrl;
+        this.openIdConnectUrl = openIdConnectUrl;
     }
 
-    public AutoUrl getAuthorizationUrl() {
-        return authorizationUrl;
+    public AutoUrl getOpenIdConnectUrl() {
+        return openIdConnectUrl;
     }
 
-    public void setAuthorizationUrl(AutoUrl authorizationUrl) {
-        this.authorizationUrl = authorizationUrl;
-    }
-
-    public AutoUrl getRefreshUrl() {
-        return refreshUrl;
-    }
-
-    public void setRefreshUrl(AutoUrl refreshUrl) {
-        this.refreshUrl = refreshUrl;
-    }
-
-    public AutoUrl getTokenUrl() {
-        return tokenUrl;
-    }
-
-    public void setTokenUrl(AutoUrl tokenUrl) {
-        this.tokenUrl = tokenUrl;
+    public void setOpenIdConnectUrl(AutoUrl openIdConnectUrl) {
+        this.openIdConnectUrl = openIdConnectUrl;
     }
 
     @Override
     protected SecurityScheme getSecurityScheme() {
         SecurityScheme securityScheme = OASFactory.createSecurityScheme();
-
-        securityScheme.setType(SecurityScheme.Type.OAUTH2);
-        OAuthFlows oAuthFlows = OASFactory.createOAuthFlows();
-        OAuthFlow oAuthFlow = OASFactory.createOAuthFlow();
-        oAuthFlow.authorizationUrl(this.authorizationUrl.getFinalUrlValue());
-        oAuthFlow.refreshUrl(this.refreshUrl.getFinalUrlValue());
-        oAuthFlow.tokenUrl(this.tokenUrl.getFinalUrlValue());
-        oAuthFlows.setImplicit(oAuthFlow);
-        securityScheme.setFlows(oAuthFlows);
-
+        securityScheme.setType(SecurityScheme.Type.OPENIDCONNECT);
+        securityScheme.setOpenIdConnectUrl(openIdConnectUrl.getFinalUrlValue());
         return securityScheme;
     }
 


### PR DESCRIPTION
- Handle method-level `@RolesAllowed` that override class-level `@RolesAllowed` values, fixes #30997
- Render `BaseStream<T, S>` as array of `T` in OpenAPI document, fixes #30248 (via smallrye-open-api 3.3.0)
- Do not place scopes in OpenAPI security requirements unless the security scheme is OAuth2 or OIDC, fixes #27373
- Include only OIDC discovery URL in OpenAPI when auto-security is active, fixes #21126
