### PR TITLE
Suppress config changed warning for quarkus.test.arg-line

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -354,6 +354,7 @@ public class ConfigGenerationBuildStep {
         suppressNonRuntimeConfigChanged.produce(new SuppressNonRuntimeConfigChangedWarningBuildItem("quarkus.uuid"));
         suppressNonRuntimeConfigChanged.produce(new SuppressNonRuntimeConfigChangedWarningBuildItem("quarkus.default-locale"));
         suppressNonRuntimeConfigChanged.produce(new SuppressNonRuntimeConfigChangedWarningBuildItem("quarkus.locales"));
+        suppressNonRuntimeConfigChanged.produce(new SuppressNonRuntimeConfigChangedWarningBuildItem("quarkus.test.arg-line"));
     }
 
     /**


### PR DESCRIPTION
- Fixes #31626 

The config `quarkus.test.arg-line` has a special behaviour in the sense that we need it available in the failsafe plugin to pass to the test launcher, but with https://github.com/quarkusio/quarkus/issues/31405 it is also propagate to the Quarkus app being executed.

Easiest fix is to just supress the warnings for this, but maybe we run into issues with other configurations.