### PR TITLE
Maven test utils: Regexp accounts for terminal colours

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -373,7 +373,7 @@ public class QuarkusDev extends QuarkusTask {
                 .debugPort(System.getProperty("debugPort"))
                 .suspend(System.getProperty("suspend"));
         if (System.getProperty(IO_QUARKUS_DEVMODE_ARGS) == null) {
-            builder.jvmArgs("-Dquarkus.test.basic-console=true")
+            builder.jvmArgs("-Dquarkus.console.basic=true")
                     .jvmArgs("-Dio.quarkus.force-color-support=true");
         }
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/IDELauncherImpl.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/IDELauncherImpl.java
@@ -33,7 +33,7 @@ public class IDELauncherImpl implements Closeable {
 
     public static Closeable launch(Path classesDir, Map<String, Object> context) {
         System.setProperty(FORCE_COLOR_SUPPORT, "true");
-        System.setProperty("quarkus.test.basic-console", "true"); //IDE's don't support raw mode
+        System.setProperty("quarkus.console.basic", "true"); //IDE's don't support raw mode
         final Path projectDir = BuildToolHelper.getProjectDir(classesDir);
         if (projectDir == null) {
             throw new IllegalStateException("Failed to locate project dir for " + classesDir);

--- a/integration-tests/maven/src/test/resources-filtered/projects/multijar-module/runner/src/main/resources/application.properties
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multijar-module/runner/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 #quarkus.test.continuous-testing=enabled
-#quarkus.test.basic-console=true
+#quarkus.console.basic=true
 quarkus.live-reload.instrumentation=false
 greeting=hello
+

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule/runner/src/main/resources/application.properties
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule/runner/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 greeting=bonjour
 quarkus.test.continuous-testing=enabled
-quarkus.test.basic-console=true
+quarkus.console.basic=true
+

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/ContinuousTestingTestUtils.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/ContinuousTestingTestUtils.java
@@ -49,7 +49,7 @@ public class ContinuousTestingTestUtils {
     }
 
     public static String appProperties(String... props) {
-        return "quarkus.test.continuous-testing=enabled\nquarkus.test.display-test-output=true\nquarkus.test.basic-console=true\nquarkus.test.disable-console-input=true\n"
+        return "quarkus.test.continuous-testing=enabled\nquarkus.test.display-test-output=true\nquarkus.console.basic=true\nquarkus.test.disable-console-input=true\n"
                 + String.join("\n", Arrays.asList(props));
     }
 

--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/continuoustesting/ContinuousTestingMavenTestUtils.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/continuoustesting/ContinuousTestingMavenTestUtils.java
@@ -76,7 +76,7 @@ public class ContinuousTestingMavenTestUtils {
     }
 
     public static String appProperties(String... props) {
-        return "quarkus.test.continuous-testing=enabled\nquarkus.test.display-test-output=true\nquarkus.test.basic-console=true\nquarkus.test.disable-console-input=true\n"
+        return "quarkus.test.continuous-testing=enabled\nquarkus.test.display-test-output=true\nquarkus.console.basic=true\nquarkus.test.disable-console-input=true\n"
                 + String.join("\n", Arrays.asList(props));
     }
 


### PR DESCRIPTION
Fixes #31689

While testing #31490 on Windows, it turned out that Maven Integration tests don't work for me on my Windows 10 workstation.

It ends up rather abruptly with:
```
[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestMojoIT>LaunchMojoTestBase.testThatTheTestsAreReRunMultiModule:56 Tests were run, but the log is not parseable with the patterns we know. This is the log:
 17:39:14.
Starting test run, 1 tests to run.
Running 1/1. Running: #JUnit Jupiter
Running 1/1. Running: com.acme.ResourceTest#ResourceTest
2023-03-07 17:39:16,205 WARN  [io.qua.con.build] (Test runner thread) The 'quarkus.test.basic-console' config property is deprecated and should not be used anymore
2023-03-07 17:39:16,723 INFO  [io.quarkus] (Test runner thread) quarkus-quickstart-multimodule-main 1.0-SNAPSHOT on JVM (powered by Quarkus 999-SNAPSHOT) started in 0.564s. Listening on: http://localhost:8081
2023-03-07 17:39:16,723 INFO  [io.quarkus] (Test runner thread) Profile test activated.
2023-03-07 17:39:16,724 INFO  [io.quarkus] (Test runner thread) Installed features: [cdi, resteasy, smallrye-context-propagation, vertx]
Running 1/1. Running: com.acme.ResourceTest#testHelloEndpoint()
2023-03-07 17:39:17,003 INFO  [io.quarkus] (Test runner thread) quarkus-quickstart-multimodule-main(test application) stopped in 0.005s
2023-03-07 17:39:17,011 ERROR [io.qua.test] (Test runner thread) ==================== TEST REPORT #2 ==================== [Error Occurred After Shutdown]
2023-03-07 17:39:17,012 ERROR [io.qua.test] (Test runner thread) Test ResourceTest#testHelloEndpoint() failed
 [Error Occurred After Shutdown]: java.lang.AssertionError: 1 expectation failed.
Response body doesn't match expectation.
Expected: is "hello"
  Actual: 1d630f72-8684-4f1c-a766-4b438eda4b3a

        at io.restassured.internal.ValidatableResponseOptionsImpl.body(ValidatableResponseOptionsImpl.java:238)
        at com.acme.ResourceTest.testHelloEndpoint(ResourceTest.java:21)

2023-03-07 17:39:17,016 ERROR [io.qua.test] (Test runner thread) >>>>>>>>>>>>>>>>>>>> Summary: <<<<<<<<<<<<<<<<<<<<
com.acme.ResourceTest#testHelloEndpoint(ResourceTest.java:21) ResourceTest#testHelloEndpoint() 1 expectation failed.
Response body doesn't match expectation.
Expected: is "hello"
  Actual: 1d630f72-8684-4f1c-a766-4b438eda4b3a [Error Occurred After Shutdown]
2023-03-07 17:39:17,018 ERROR [io.qua.test] (Test runner thread) >>>>>>>>>>>>>>>>>>>> 1 TEST FAILED <<<<<<<<<<<<<<<<<<<< [Error Occurred After Shutdown]
1 test failed (1 passing, 0 skipped), 1 test was run in 881ms. Tests completed at 17:39:17 due to changes to HelloResource$Blah.class and 1 other files.
```
As you can see, the `1 test failed (1 passing, 0 skipped),` bit should easily match the regexp in [TestModeContinuousTestingMavenTestUtils.java](https://github.com/quarkusio/quarkus/blob/main/test-framework/maven/src/main/java/io/quarkus/maven/it/continuoustesting/TestModeContinuousTestingMavenTestUtils.java#L24), i.e.:
```java
private static final Pattern SOME_PASSING = Pattern
        .compile("(\\d\\d*) tests? failed \\((\\d\\d*) passing, (\\d\\d*) skipped\\)", Pattern.MULTILINE);
```
Being bitten by something similar in the past, I added additional logging that also dumps the buffer to a file, getting:

```
[ERROR] Failures:
[ERROR]   TestMojoIT>LaunchMojoTestBase.testThatTheTestsAreReRunMultiModule:56 Tests were run, but the log is not parseable with the patterns we know,
i.e. neither "All (\d+) tests are passing \((\d+) skipped\)" nor "(\d+) tests? failed \((\d+) passing, (\d+) skipped\)".
 Note that possible terminal control characters might not be seen here.
Check the text file dump too: C:\tmp\quarkus_main\integration-tests\maven\target\quarkus-maven-test-debug-log13996201237018610376.txt. This is the log:
<removed for brevity>
```

![1](https://user-images.githubusercontent.com/691097/223747610-e27ce6b6-941b-4efb-966f-6a6614a4c5ee.png)

i.e.

```
[39m[91m1 test failed[39m ([32m1 passing[39m, [94m0 skipped[39m), [91m1 test was run in 889ms. Tests completed at 14:55:51 due to changes to HelloResource$Blah.class and 1 other files.[39m
```

So, despite having the [quarkus.console.basic](https://quarkus.io/guides/all-config#quarkus-core_quarkus.console.basic) set, the output is formatted on Windows.

This patch updates deprecated `quarkus.test.basic-console` to `quarkus.console.basic`, but that on its own doesn't help.
The patch also makes the regexp more resilient, accounting for terminal control symbols.

The maven suite then passes for me on Windows:

```
[INFO] Results:
[INFO]
[WARNING] Tests run: 166, Failures: 0, Errors: 0, Skipped: 6
[INFO]
[INFO]
[INFO] --- maven-failsafe-plugin:3.0.0-M9:verify (default) @ quarkus-integration-test-maven ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  47:00 min
[INFO] Finished at: 2023-03-08T14:27:20+01:00
[INFO] ------------------------------------------------------------------------
```

Why hasn't it failed on GHA CI before?  I am not sure. I am running tests on an old, physical desktop PC in a generally popular developer terminal [cmder](https://cmder.net/). It could be the case that when executed headless, it might behave differently.





