### PR TITLE
ArC fixes for spec compatibility, round 5

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -11,9 +11,10 @@ include::_attributes.adoc[]
 :sectnums:
 :sectnumlevels: 4
 
-Quarkus DI solution (also called ArC) is based on the https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html[Contexts and Dependency Injection for Java 2.0, window="_blank"] specification.
-However, it is not a full CDI implementation verified by the TCK.
-Only a subset of the CDI features is implemented - see also <<supported_features,the list of supported features>> and <<limitations,the list of limitations>>.
+Quarkus DI solution (also called ArC) is based on the https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0.html[Jakarta Contexts and Dependency Injection 4.0, window="_blank"] specification.
+It aims to implement the CDI Lite specification, with selected improvements on top.
+It is not a CDI Full implementation and is not verified by the TCK yet.
+See also <<supported_features,the list of supported features>> and <<limitations,the list of limitations>>.
 
 TIP: If you're new to CDI then we recommend you to read the xref:cdi.adoc[Introduction to CDI] first.
 
@@ -741,6 +742,7 @@ class Services {
 +
 NOTE: Interceptors can use `InvocationContext.getMethod()` to detect static methods and adjust the behavior accordingly.
 
+[[unproxyable_classes_transformation]]
 === Ability to handle 'final' classes and methods
 
 In normal CDI, classes that are marked as `final` and / or have `final` methods are not eligible for proxy creation,
@@ -1080,6 +1082,32 @@ NOTE: These endpoints are only available in the development mode, i.e. when you 
 
 In the development mode, it is also possible to enable monitoring of business method invocations and fired events.
 Simply set the `quarkus.arc.dev-mode.monitoring-enabled` configuration property to `true` and explore the relevant Dev UI pages.
+
+[[strict_mode]]
+== Strict Mode
+
+By default, ArC does not perform all validations required by the CDI specification.
+It also improves CDI usability in many ways, some of them being directly against the specification.
+
+To be able to eventually pass the CDI Lite TCK, ArC also has a _strict_ mode.
+This mode enables additional validations and disables certain improvements that conflict with the specification.
+
+To enable the strict mode, use the following configuration:
+
+[source,properties]
+----
+quarkus.arc.strict-compatibility=true
+----
+
+Some other features affect specification compatibility as well:
+
+* <<unproxyable_classes_transformation,Transformation of unproxyable classes>>
+* <<remove_unused_beans,Unused beans removal>>
+
+To get a behavior closer to the specification, these features should also be disabled.
+
+Applications are recommended to use the default, non-strict mode, which makes CDI more convenient to use.
+The "strictness" of the strict mode (the set of additional validations and the set of disabled improvements on top of the CDI specification) may change over time.
 
 [[arc-configuration-reference]]
 == ArC Configuration Reference

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
@@ -178,6 +178,22 @@ public class ArcConfig {
     public boolean detectWrongAnnotations;
 
     /**
+     * If set to {@code true}, the container will perform additional validations mandated by the CDI specification.
+     * Some improvements on top of the CDI specification may be disabled. Applications that work as expected
+     * in the strict mode should work without a change in the default, non-strict mode.
+     * <p>
+     * The strict mode is mainly introduced to allow passing the CDI Lite TCK. Applications are recommended
+     * to use the default, non-strict mode, which makes CDI more convenient to use. The "strictness" of
+     * the strict mode (the set of additional validations and the set of disabled improvements on top of
+     * the CDI specification) may change over time.
+     * <p>
+     * Note that {@link #transformUnproxyableClasses} and {@link #removeUnusedBeans} also has effect on specification
+     * compatibility. You may want to disable these features to get behavior closer to the specification.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean strictCompatibility;
+
+    /**
      * Dev mode configuration.
      */
     @ConfigItem

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -373,6 +373,7 @@ public class ArcProcessor {
         builder.setJtaCapabilities(capabilities.isPresent(Capability.TRANSACTIONS));
         builder.setGenerateSources(BootstrapDebug.DEBUG_SOURCES_DIR != null);
         builder.setAllowMocking(launchModeBuildItem.getLaunchMode() == LaunchMode.TEST);
+        builder.setStrictCompatibility(arcConfig.strictCompatibility);
 
         if (arcConfig.selectedAlternatives.isPresent()) {
             final List<Predicate<ClassInfo>> selectedAlternatives = initClassPredicates(

--- a/independent-projects/arc/arquillian/src/main/java/io/quarkus/arc/arquillian/Deployer.java
+++ b/independent-projects/arc/arquillian/src/main/java/io/quarkus/arc/arquillian/Deployer.java
@@ -129,6 +129,9 @@ final class Deployer {
                             Thread.currentThread().getContextClassLoader(), new ConcurrentHashMap<>(),
                             beanArchiveIndex))
                     .setApplicationIndex(applicationIndex)
+                    .setStrictCompatibility(true)
+                    .setTransformUnproxyableClasses(false)
+                    .setRemoveUnusedBeans(false)
                     .setBuildCompatibleExtensions(buildCompatibleExtensions)
                     .setAdditionalBeanDefiningAnnotations(Set.of(new BeanDefiningAnnotation(
                             DotName.createSimple(ExtraBean.class.getName()), null)))

--- a/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
@@ -281,11 +281,6 @@
                     <exclude name="testDeploymentFails"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.lookup.clientProxy.unproxyable.finalMethod.PublicFinalMethodNotProxyableTest">
-                <methods>
-                    <exclude name="testClassWithPublicFinalMethodCannotBeProxied"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.BeanTypeParamFieldTest">
                 <methods>
                     <exclude name="testDeploymentFails"/>
@@ -304,11 +299,6 @@
                     <exclude name="testExtensionNotDiscoveredAsSimpleBean"/>
                     <exclude name="testSimpleBeanOnlyIfConstructorIsInitializer"/>
                     <exclude name="testAbstractClassDeclaredInJavaNotDiscovered"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.lookup.clientProxy.unproxyable.finalMethod.ProtectedFinalMethodNotProxyableTest">
-                <methods>
-                    <exclude name="testClassWithPublicFinalMethodCannotBeProxied"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.interceptors.tests.bindings.aroundConstruct.ConstructorInterceptionTest">
@@ -387,11 +377,6 @@
                     <exclude name="testDuplicateBeanNamePrefix"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.lookup.clientProxy.unproxyable.finalMethod.NonPrivateNonStaticSuperclassMethodTest">
-                <methods>
-                    <exclude name="testClassWithPublicFinalMethodCannotBeProxied"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.implementation.simple.definition.dependentWithPublicField.DependentWithPublicFieldTest">
                 <methods>
                     <exclude name="testNonDependentScopedBeanCanNotHavePublicField"/>
@@ -431,11 +416,6 @@
                     <exclude name="testEventProvidesMethodForFiringEventsWithCombinationOfTypeAndBindings"/>
                     <exclude name="testEventSelectedFiresAndObserversNotified"/>
                     <exclude name="testEventFireThrowsExceptionIfEventObjectTypeContainsUnresovableTypeVariable"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.lookup.clientProxy.unproxyable.finalMethod.PackagePrivateFinalMethodNotProxyableTest">
-                <methods>
-                    <exclude name="testClassWithPublicFinalMethodCannotBeProxied"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.interceptors.definition.InterceptorDefinitionTest">

--- a/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
@@ -145,15 +145,6 @@
                     <exclude name="testExceptions"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.interceptors.invocation.InterceptorInvocationTest">
-                <methods>
-                    <exclude name="testDisposerMethodsAreIntercepted"/>
-                    <exclude name="testInitializerMethodsNotIntercepted"/>
-                    <exclude name="testProducerMethodsAreIntercepted"/>
-                    <exclude name="testLifecycleCallbacksAreIntercepted"/>
-                    <exclude name="testObjectMethodsAreNotIntercepted"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.interceptors.tests.bindings.broken.InvalidTransitiveInterceptorBindingAnnotationsTest">
                 <methods>
                     <exclude name="testInterceptorBindingsWithConflictingAnnotationMembersNotOk"/>

--- a/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
@@ -174,11 +174,6 @@
                     <exclude name="testObjectMethodsAreNotIntercepted"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.lookup.byname.broken.prefix.ExpandedNamePrefix2Test">
-                <methods>
-                    <exclude name="testDuplicateBeanNamePrefix"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.interceptors.tests.bindings.broken.InvalidTransitiveInterceptorBindingAnnotationsTest">
                 <methods>
                     <exclude name="testInterceptorBindingsWithConflictingAnnotationMembersNotOk"/>
@@ -372,11 +367,6 @@
                     <exclude name="testMultipleLifecycleInterceptors"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.lookup.byname.broken.prefix.NamePrefixTest">
-                <methods>
-                    <exclude name="testDuplicateBeanNamePrefix"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.implementation.simple.definition.dependentWithPublicField.DependentWithPublicFieldTest">
                 <methods>
                     <exclude name="testNonDependentScopedBeanCanNotHavePublicField"/>
@@ -427,11 +417,6 @@
                     <exclude name="testObserver"/>
                     <exclude name="testInjectionPoint"/>
                     <exclude name="testInjectionPointDefinition"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.lookup.byname.broken.prefix.ExpandedNamePrefixTest">
-                <methods>
-                    <exclude name="testDuplicateBeanNamePrefix"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.definition.scope.inOtherBda.ScopeDefinedInOtherBDATest">

--- a/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
@@ -408,9 +408,6 @@
             </class>
             <class name="org.jboss.cdi.tck.tests.inheritance.generics.MemberLevelInheritanceTest">
                 <methods>
-                    <exclude name="testObserverResolution"/>
-                    <exclude name="testObserver"/>
-                    <exclude name="testInjectionPoint"/>
                     <exclude name="testInjectionPointDefinition"/>
                 </methods>
             </class>

--- a/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
@@ -382,12 +382,6 @@
                     <exclude name="testNonDependentScopedBeanCanNotHavePublicField"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.event.observer.wildcardAndTypeVariable.ObserverMethodWithParametertizedTypeTest">
-                <methods>
-                    <exclude name="testObserverMethodCanObserveArrayWildcard"/>
-                    <exclude name="testObserverMethodCanObserveArrayTypeVariable"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.interceptors.definition.interceptorOrder.InterceptorOrderTest">
                 <methods>
                     <exclude name="testInterceptorsInvocationOrder"/>

--- a/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
@@ -43,11 +43,6 @@
                     <exclude name="testContextualDestroyCatchesException"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.initializer.broken.generic.GenericInitializerMethodTest">
-                <methods>
-                    <exclude name="testGenericInitializerMethodNotAllowed"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.interceptors.tests.contract.lifecycleCallback.LifecycleCallbackInterceptorTest">
                 <methods>
                     <exclude name="testPostConstructInterceptor"/>

--- a/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
@@ -224,11 +224,6 @@
                     <exclude name="testGetInjectableReferenceOnBeanManager"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.interceptors.definition.broken.observer.async.InterceptorWithAsyncObserverMethodTest">
-                <methods>
-                    <exclude name="testInterceptorWithAsyncObserverMethodNotOk"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.interceptors.tests.order.aroundInvoke.AroundInvokeOrderTest">
                 <methods>
                     <exclude name="testInvocationOrder"/>
@@ -404,11 +399,6 @@
             <class name="org.jboss.cdi.tck.tests.definition.scope.inOtherBda.ScopeDefinedInOtherBDATest">
                 <methods>
                     <exclude name="testCustomScopeInOtherBDAisBeanDefiningAnnotation"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.interceptors.definition.broken.observer.InterceptorWithObserverMethodTest">
-                <methods>
-                    <exclude name="testInterceptorWithObserverMethodNotOk"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.injection.intercepted.InterceptedBeanFieldInjectionTest">

--- a/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
@@ -85,11 +85,6 @@
                     <exclude name="testNonDependentScopedProducerMethodWithParameterizedTypeWithTypeVariable"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.interceptors.definition.broken.nonDependent.NonDependentInterceptorTest">
-                <methods>
-                    <exclude name="testDeploymentWithScopedInterceptor"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.interceptors.tests.contract.lifecycleCallback.exceptions.LifecycleCallbackInterceptorExceptionTest">
                 <methods>
                     <exclude name="testLifecycleCallbackInterceptorCanCatchException"/>

--- a/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
@@ -362,11 +362,6 @@
                     <exclude name="testMultipleLifecycleInterceptors"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.simple.definition.dependentWithPublicField.DependentWithPublicFieldTest">
-                <methods>
-                    <exclude name="testNonDependentScopedBeanCanNotHavePublicField"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.interceptors.definition.interceptorOrder.InterceptorOrderTest">
                 <methods>
                     <exclude name="testInterceptorsInvocationOrder"/>

--- a/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
@@ -61,11 +61,6 @@
                     <exclude name="testPublicLifecycleInterceptorMethod"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.disposal.method.definition.broken.unresolvedMethod.UnresolvedDisposalMethodDefinitionTest">
-                <methods>
-                    <exclude name="testUnresolvedDisposalMethod"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.interceptors.tests.contract.invocationContext.InvocationContextTest">
                 <methods>
                     <exclude name="testGetTargetMethod"/>

--- a/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/cdi-tck-runner/src/test/resources/testng.xml
@@ -75,11 +75,6 @@
                     <exclude name="testTooManyScopesSpecifiedInJava"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.producer.method.broken.parameterizedTypeWithTypeParameter.ParameterizedReturnTypeWithTypeVariableTest">
-                <methods>
-                    <exclude name="testNonDependentScopedProducerMethodWithParameterizedTypeWithTypeVariable"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.interceptors.tests.contract.lifecycleCallback.exceptions.LifecycleCallbackInterceptorExceptionTest">
                 <methods>
                     <exclude name="testLifecycleCallbackInterceptorCanCatchException"/>
@@ -192,11 +187,6 @@
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptedBeanTypeParamInitializerTest">
                 <methods>
                     <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.producer.method.broken.parameterizedTypeWithTypeParameter.ParametrizedReturnTypeWithTypeVariable02Test">
-                <methods>
-                    <exclude name="testNonDependentScopedProducerMethodWithParameterizedTypeWithTypeVariable"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.definition.scope.ScopeDefinitionTest">
@@ -432,11 +422,6 @@
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptorTypeParamInitializerTest">
                 <methods>
                     <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.producer.field.definition.broken.typeVariable2.RequestScopedProducerFieldWithTypeVariableTest">
-                <methods>
-                    <exclude name="testRequestScopedProducerFieldParameterizedWithTypeVariableNotAllowed"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.event.observer.ObserverNotificationTest">

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -1388,8 +1388,7 @@ public class BeanDeployment {
                 // Skip vetoed interceptors
                 continue;
             }
-            interceptors
-                    .add(Interceptors.createInterceptor(interceptorClass, this, injectionPointTransformer, annotationStore));
+            interceptors.add(Interceptors.createInterceptor(interceptorClass, this, injectionPointTransformer));
         }
         if (LOGGER.isTraceEnabled()) {
             for (InterceptorInfo interceptor : interceptors) {
@@ -1415,8 +1414,7 @@ public class BeanDeployment {
                 // Skip vetoed decorators
                 continue;
             }
-            decorators
-                    .add(Decorators.createDecorator(decoratorClass, this, injectionPointTransformer, annotationStore));
+            decorators.add(Decorators.createDecorator(decoratorClass, this, injectionPointTransformer));
         }
         if (LOGGER.isTraceEnabled()) {
             for (DecoratorInfo decorator : decorators) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -116,6 +116,8 @@ public class BeanDeployment {
 
     private final boolean jtaCapabilities;
 
+    final boolean strictCompatibility;
+
     private final AlternativePriorities alternativePriorities;
 
     private final List<Predicate<ClassInfo>> excludeTypes;
@@ -217,6 +219,7 @@ public class BeanDeployment {
         this.transformPrivateInjectedFields = builder.transformPrivateInjectedFields;
         this.failOnInterceptedPrivateMethod = builder.failOnInterceptedPrivateMethod;
         this.jtaCapabilities = builder.jtaCapabilities;
+        this.strictCompatibility = builder.strictCompatibility;
         this.alternativePriorities = builder.alternativePriorities;
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -122,12 +122,7 @@ public class BeanInfo implements InjectionTargetInfo {
         for (Type type : types) {
             Beans.analyzeType(type, beanDeployment);
         }
-        if (qualifiers.isEmpty()
-                || (qualifiers.size() <= 2 && qualifiers.stream()
-                        .allMatch(a -> DotNames.NAMED.equals(a.name()) || DotNames.ANY.equals(a.name())))) {
-            qualifiers.add(BuiltinQualifier.DEFAULT.getInstance());
-        }
-        qualifiers.add(BuiltinQualifier.ANY.getInstance());
+        Beans.addImplicitQualifiers(qualifiers);
         this.qualifiers = qualifiers;
         this.injections = injections;
         this.declaringBean = declaringBean;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -488,6 +488,7 @@ public class BeanProcessor {
         boolean transformPrivateInjectedFields;
         boolean failOnInterceptedPrivateMethod;
         boolean allowMocking;
+        boolean strictCompatibility;
 
         AlternativePriorities alternativePriorities;
         final List<Predicate<ClassInfo>> excludeTypes;
@@ -522,6 +523,7 @@ public class BeanProcessor {
             transformPrivateInjectedFields = false;
             failOnInterceptedPrivateMethod = false;
             allowMocking = false;
+            strictCompatibility = false;
 
             excludeTypes = new ArrayList<>();
 
@@ -765,6 +767,24 @@ public class BeanProcessor {
          */
         public Builder setGenerateSources(boolean value) {
             this.generateSources = value;
+            return this;
+        }
+
+        /**
+         * If set to {@code true}, the container will perform additional validations mandated by the CDI specification.
+         * Some improvements on top of the CDI specification may be disabled. Applications that work as expected
+         * in the strict mode should work without a change in the default, non-strict mode.
+         * <p>
+         * The strict mode is mainly introduced to allow passing the CDI Lite TCK. Applications are recommended
+         * to use the default, non-strict mode, which makes CDI more convenient to use. The "strictness" of
+         * the strict mode (the set of additional validations and the set of disabled improvements on top of
+         * the CDI specification) may change over time.
+         * <p>
+         * Note that {@link #setTransformUnproxyableClasses(boolean)} also has effect on specification compatibility.
+         * Set it to {@code false} when unproxyable bean types should always lead to a deployment problem.
+         */
+        public Builder setStrictCompatibility(boolean strictCompatibility) {
+            this.strictCompatibility = strictCompatibility;
             return this;
         }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -617,6 +617,15 @@ public final class Beans {
         return false;
     }
 
+    static void addImplicitQualifiers(Set<AnnotationInstance> qualifiers) {
+        if (qualifiers.isEmpty()
+                || (qualifiers.size() <= 2 && qualifiers.stream()
+                        .allMatch(a -> DotNames.NAMED.equals(a.name()) || DotNames.ANY.equals(a.name())))) {
+            qualifiers.add(BuiltinQualifier.DEFAULT.getInstance());
+        }
+        qualifiers.add(BuiltinQualifier.ANY.getInstance());
+    }
+
     static List<MethodInfo> getCallbacks(ClassInfo beanClass, DotName annotation, IndexView index) {
         List<MethodInfo> callbacks = new ArrayList<>();
         collectCallbacks(beanClass, callbacks, annotation, index, new HashSet<>());

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -181,6 +181,14 @@ public final class Beans {
             }
         }
 
+        if (scope != null // `null` is just like `@Dependent`
+                && !BuiltinScope.DEPENDENT.is(scope)
+                && producerMethod.returnType().kind() == Kind.PARAMETERIZED_TYPE
+                && Types.containsTypeVariable(producerMethod.returnType())) {
+            throw new DefinitionException("Producer method return type is a parameterized type with a type variable, "
+                    + "its scope must be @Dependent: " + producerMethod);
+        }
+
         List<Injection> injections = Injection.forBean(producerMethod, declaringBean, beanDeployment, transformer);
         BeanInfo bean = new BeanInfo(producerMethod, beanDeployment, scope, beanTypes, qualifiers, injections, declaringBean,
                 disposer, isAlternative, stereotypes, name, isDefaultBean, null, priority);
@@ -288,6 +296,14 @@ public final class Beans {
                         producerField);
                 return null;
             }
+        }
+
+        if (scope != null // `null` is just like `@Dependent`
+                && !BuiltinScope.DEPENDENT.is(scope)
+                && producerField.type().kind() == Kind.PARAMETERIZED_TYPE
+                && Types.containsTypeVariable(producerField.type())) {
+            throw new DefinitionException("Producer field type is a parameterized type with a type variable, "
+                    + "its scope must be @Dependent: " + producerField);
         }
 
         BeanInfo bean = new BeanInfo(producerField, beanDeployment, scope, types, qualifiers, Collections.emptyList(),

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Injection.java
@@ -162,6 +162,13 @@ public class Injection {
                             InjectionPointInfo.fromField(injectTarget.asField(), beanClass, beanDeployment, transformer))));
                     break;
                 case METHOD:
+                    // the spec doesn't forbid generic bean constructors and Weld is fine with them too
+                    if (!injectTarget.asMethod().isConstructor()
+                            && !injectTarget.asMethod().typeParameters().isEmpty()) {
+                        throw new DefinitionException(
+                                "Initializer method may not be generic (declare type parameters): " + injectTarget);
+                    }
+
                     injections.add(new Injection(injectTarget,
                             InjectionPointInfo.fromMethod(injectTarget.asMethod(), beanClass, beanDeployment, transformer)));
                     break;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
@@ -20,6 +20,7 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationTarget.Kind;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ArrayType;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
@@ -336,6 +337,14 @@ public class InjectionPointInfo {
                 }
             }
             return ParameterizedType.create(parameterizedType.name(), typeParams, parameterizedType.owner());
+        } else if (type.kind() == org.jboss.jandex.Type.Kind.ARRAY) {
+            ArrayType arrayType = type.asArrayType();
+            Type component = arrayType.component();
+            if (component.kind() == org.jboss.jandex.Type.Kind.TYPE_VARIABLE
+                    || component.kind() == org.jboss.jandex.Type.Kind.PARAMETERIZED_TYPE) {
+                component = resolveType(component, beanClass, beanDeployment, resolvedTypeVariables);
+            }
+            return ArrayType.create(component, type.asArrayType().dimensions());
         }
         return type;
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Interceptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Interceptors.java
@@ -42,6 +42,12 @@ final class Interceptors {
             if (priority == null && annotation.name().equals(DotNames.ARC_PRIORITY)) {
                 priority = annotation.value().asInt();
             }
+
+            // rudimentary, but good enough for now (should also look at inherited annotations and stereotypes)
+            ScopeInfo scope = beanDeployment.getScope(annotation.name());
+            if (scope != null && !BuiltinScope.DEPENDENT.is(scope)) {
+                throw new DefinitionException("Interceptor declares scope other than @Dependent: " + interceptorClass);
+            }
         }
         if (bindings.isEmpty()) {
             throw new DefinitionException("Interceptor has no bindings: " + interceptorClass);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Interceptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Interceptors.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc.processor;
 
+import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -8,6 +10,9 @@ import jakarta.enterprise.inject.spi.DefinitionException;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.MethodInfo;
 import org.jboss.logging.Logger;
 
 final class Interceptors {
@@ -24,10 +29,10 @@ final class Interceptors {
      * @return a new interceptor info
      */
     static InterceptorInfo createInterceptor(ClassInfo interceptorClass, BeanDeployment beanDeployment,
-            InjectionPointModifier transformer, AnnotationStore store) {
+            InjectionPointModifier transformer) {
         Set<AnnotationInstance> bindings = new HashSet<>();
         Integer priority = null;
-        for (AnnotationInstance annotation : store.getAnnotations(interceptorClass)) {
+        for (AnnotationInstance annotation : beanDeployment.getAnnotations(interceptorClass)) {
             bindings.addAll(beanDeployment.extractInterceptorBindings(annotation));
             // can also be a transitive binding
             Set<AnnotationInstance> transitiveInterceptorBindings = beanDeployment
@@ -49,18 +54,55 @@ final class Interceptors {
                 throw new DefinitionException("Interceptor declares scope other than @Dependent: " + interceptorClass);
             }
         }
+
         if (bindings.isEmpty()) {
             throw new DefinitionException("Interceptor has no bindings: " + interceptorClass);
         }
+
         if (priority == null) {
             LOGGER.info("The interceptor " + interceptorClass + " does not declare any @Priority. " +
                     "It will be assigned a default priority value of 0.");
             priority = 0;
         }
+
+        checkInterceptorFieldsAndMethods(interceptorClass, beanDeployment);
+
         return new InterceptorInfo(interceptorClass, beanDeployment,
                 bindings.size() == 1 ? Collections.singleton(bindings.iterator().next())
                         : Collections.unmodifiableSet(bindings),
                 Injection.forBean(interceptorClass, null, beanDeployment, transformer), priority);
+    }
+
+    private static void checkInterceptorFieldsAndMethods(ClassInfo interceptorClass, BeanDeployment beanDeployment) {
+        ClassInfo aClass = interceptorClass;
+        while (aClass != null) {
+            for (MethodInfo method : aClass.methods()) {
+                if (beanDeployment.hasAnnotation(method, DotNames.PRODUCES)) {
+                    throw new DefinitionException("Interceptor declares a producer method: " + interceptorClass);
+                }
+                // the following 3 checks rely on the annotation store returning parameter annotations for methods
+                if (beanDeployment.hasAnnotation(method, DotNames.DISPOSES)) {
+                    throw new DefinitionException("Interceptor declares a disposer method: " + interceptorClass);
+                }
+                if (beanDeployment.hasAnnotation(method, DotNames.OBSERVES)) {
+                    throw new DefinitionException("Interceptor declares an observer method: " + interceptorClass);
+                }
+                if (beanDeployment.hasAnnotation(method, DotNames.OBSERVES_ASYNC)) {
+                    throw new DefinitionException("Interceptor declares an async observer method: " + interceptorClass);
+                }
+            }
+
+            for (FieldInfo field : aClass.fields()) {
+                if (beanDeployment.hasAnnotation(field, DotNames.PRODUCES)) {
+                    throw new DefinitionException("Interceptor declares a producer field: " + interceptorClass);
+                }
+            }
+
+            DotName superClass = aClass.superName();
+            aClass = superClass != null && !superClass.equals(DotNames.OBJECT)
+                    ? getClassByName(beanDeployment.getBeanArchiveIndex(), superClass)
+                    : null;
+        }
     }
 
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -50,14 +50,7 @@ final class Methods {
 
     public static final String TO_STRING = "toString";
 
-    private static final List<String> IGNORED_METHODS = initIgnoredMethods();
-
-    private static List<String> initIgnoredMethods() {
-        List<String> ignored = new ArrayList<>();
-        ignored.add(INIT);
-        ignored.add(CLINIT);
-        return ignored;
-    }
+    static final Set<String> IGNORED_METHODS = Set.of(INIT, CLINIT);
 
     private Methods() {
     }

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/AnnotationLiteralProcessorTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/AnnotationLiteralProcessorTest.java
@@ -379,8 +379,12 @@ public class AnnotationLiteralProcessorTest {
         assertEquals(incorrectLiteral, annotation);
         assertEquals(annotation, incorrectLiteral);
 
+        assertEquals(correctLiteral, incorrectLiteral);
+        assertEquals(incorrectLiteral, correctLiteral);
+
         assertEquals(correctLiteral.hashCode(), annotation.hashCode());
         assertEquals(incorrectLiteral.hashCode(), annotation.hashCode());
+        assertEquals(correctLiteral.hashCode(), incorrectLiteral.hashCode());
 
         assertEquals("@io.quarkus.arc.processor.AnnotationLiteralProcessorTest$MemberlessAnnotation()",
                 annotation.toString());

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventTypeAssignabilityRules.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventTypeAssignabilityRules.java
@@ -42,6 +42,16 @@ final class EventTypeAssignabilityRules {
     }
 
     boolean matchesNoBoxing(Type observedType, Type eventType) {
+        if (Types.isArray(observedType) && Types.isArray(eventType)) {
+            final Type observedComponentType = Types.getArrayComponentType(observedType);
+            for (Type type : new HierarchyDiscovery(Types.getArrayComponentType(eventType)).getTypeClosure()) {
+                if (matchesNoBoxing(observedComponentType, type)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         if (observedType instanceof TypeVariable<?>) {
             /*
              * An event type is considered assignable to a type variable if the event type is assignable to the upper bound, if

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
@@ -90,6 +90,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         private final List<Predicate<BeanInfo>> exclusions;
         private AlternativePriorities alternativePriorities;
         private final List<BuildCompatibleExtension> buildCompatibleExtensions;
+        private boolean strictCompatibility = false;
 
         public Builder() {
             resourceReferenceProviders = new ArrayList<>();
@@ -206,6 +207,11 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
             return this;
         }
 
+        public Builder strictCompatibility(boolean strictCompatibility) {
+            this.strictCompatibility = strictCompatibility;
+            return this;
+        }
+
         public ArcTestContainer build() {
             return new ArcTestContainer(this);
         }
@@ -240,6 +246,8 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
 
     private final List<BuildCompatibleExtension> buildCompatibleExtensions;
 
+    private final boolean strictCompatibility;
+
     public ArcTestContainer(Class<?>... beanClasses) {
         this.resourceReferenceProviders = Collections.emptyList();
         this.beanClasses = Arrays.asList(beanClasses);
@@ -261,6 +269,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         this.exclusions = Collections.emptyList();
         this.alternativePriorities = null;
         this.buildCompatibleExtensions = Collections.emptyList();
+        this.strictCompatibility = false;
     }
 
     public ArcTestContainer(Builder builder) {
@@ -284,6 +293,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         this.exclusions = builder.exclusions;
         this.alternativePriorities = builder.alternativePriorities;
         this.buildCompatibleExtensions = builder.buildCompatibleExtensions;
+        this.strictCompatibility = builder.strictCompatibility;
     }
 
     // this is where we start Arc, we operate on a per-method basis
@@ -398,7 +408,8 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
                     .setComputingBeanArchiveIndex(BeanArchives.buildComputingBeanArchiveIndex(getClass().getClassLoader(),
                             new ConcurrentHashMap<>(), immutableBeanArchiveIndex))
                     .setApplicationIndex(applicationIndex)
-                    .setBuildCompatibleExtensions(buildCompatibleExtensions);
+                    .setBuildCompatibleExtensions(buildCompatibleExtensions)
+                    .setStrictCompatibility(strictCompatibility);
             if (!resourceAnnotations.isEmpty()) {
                 builder.addResourceAnnotations(resourceAnnotations.stream()
                         .map(c -> DotName.createSimple(c.getName()))

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/MyQualifier.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/MyQualifier.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 @Qualifier
@@ -17,5 +18,6 @@ import jakarta.inject.Qualifier;
 @Target({ TYPE, METHOD, FIELD, PARAMETER })
 @Retention(RUNTIME)
 public @interface MyQualifier {
-
+    class Literal extends AnnotationLiteral<MyQualifier> implements MyQualifier {
+    }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/TestLiteral.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/TestLiteral.java
@@ -1,0 +1,8 @@
+package io.quarkus.arc.test;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+
+import org.junit.jupiter.api.Test;
+
+public class TestLiteral extends AnnotationLiteral<Test> implements Test {
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/all/ListAllTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/all/ListAllTest.java
@@ -12,7 +12,6 @@ import jakarta.annotation.PreDestroy;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.spi.InjectionPoint;
-import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -23,6 +22,7 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.test.ArcTestContainer;
 import io.quarkus.arc.test.MyQualifier;
+import io.quarkus.arc.test.TestLiteral;
 
 public class ListAllTest {
 
@@ -52,8 +52,7 @@ public class ListAllTest {
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> bravoHandle.get());
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> Arc.container().listAll(Service.class, new AnnotationLiteral<Test>() {
-                }));
+                .isThrownBy(() -> Arc.container().listAll(Service.class, new TestLiteral()));
     }
 
     interface Service {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/illegal/NormalScopedWithPublicFieldTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/illegal/NormalScopedWithPublicFieldTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.arc.test.bean.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class NormalScopedWithPublicFieldTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(IllegalBean.class)
+            .strictCompatibility(true)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Non-static public field"));
+    }
+
+    @ApplicationScoped
+    static class IllegalBean {
+        public String nonStaticPublicField;
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerTest.java
@@ -189,8 +189,7 @@ public class BeanManagerTest {
         assertTrue(interceptors.isEmpty());
         // alpha is @Nonbinding
         interceptors = beanManager.resolveInterceptors(InterceptionType.AROUND_INVOKE, new DummyBinding.Literal(false, true),
-                new AnnotationLiteral<UselessBinding>() {
-                });
+                new UselessBinding.Literal());
         assertEquals(2, interceptors.size());
         assertEquals(DummyInterceptor.class, interceptors.get(0).getBeanClass());
         assertEquals(LowPriorityInterceptor.class, interceptors.get(1).getBeanClass());
@@ -224,8 +223,7 @@ public class BeanManagerTest {
     public void testResolveObservers() {
         BeanManager beanManager = Arc.container().beanManager();
         Set<ObserverMethod<? super Long>> observers = beanManager.resolveObserverMethods(Long.valueOf(1),
-                new AnnotationLiteral<High>() {
-                });
+                new High.Literal());
         assertEquals(1, observers.size());
         assertEquals(Number.class, observers.iterator().next().getObservedType());
     }
@@ -254,6 +252,8 @@ public class BeanManagerTest {
     @Documented
     @Qualifier
     public @interface High {
+        class Literal extends AnnotationLiteral<High> implements High {
+        }
     }
 
     @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -332,7 +332,7 @@ public class BeanManagerTest {
         boolean bravo();
 
         @SuppressWarnings("serial")
-        static class Literal extends AnnotationLiteral<DummyBinding> implements DummyBinding {
+        class Literal extends AnnotationLiteral<DummyBinding> implements DummyBinding {
 
             private final boolean alpha;
             private final boolean bravo;
@@ -361,7 +361,8 @@ public class BeanManagerTest {
     @Documented
     @InterceptorBinding
     public @interface UselessBinding {
-
+        class Literal extends AnnotationLiteral<UselessBinding> implements UselessBinding {
+        }
     }
 
     @DummyBinding(alpha = true, bravo = true)

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/observers/ObservertransformerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/observers/ObservertransformerTest.java
@@ -59,8 +59,7 @@ public class ObservertransformerTest {
 
         @SuppressWarnings("serial")
         Event<String> event = Arc.container().beanManager().getEvent().select(String.class,
-                new AnnotationLiteral<AlphaQualifier>() {
-                });
+                new AlphaQualifier.Literal());
         event.fire("foo");
         // Reception was transformed to IF_EXISTS so test1() is not invoked
         assertEquals(List.of("foo_MyObserver2"), MyObserver.EVENTS);
@@ -91,7 +90,8 @@ public class ObservertransformerTest {
     @Target({ TYPE, METHOD, FIELD, PARAMETER })
     @Retention(RUNTIME)
     public @interface AlphaQualifier {
-
+        class Literal extends AnnotationLiteral<AlphaQualifier> implements AlphaQualifier {
+        }
     }
 
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/finalmethod/FinalMethodIllegalTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/finalmethod/FinalMethodIllegalTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.arc.test.clientproxy.finalmethod;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.DeploymentException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class FinalMethodIllegalTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Moo.class)
+            .strictCompatibility(true)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DeploymentException.class, error);
+        assertTrue(error.getMessage().contains("must not declare non-static final methods"));
+    }
+
+    @ApplicationScoped
+    static class Moo {
+        final int getVal() {
+            return -1;
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/qualifiers/DelegateQualifiersTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/qualifiers/DelegateQualifiersTest.java
@@ -7,7 +7,6 @@ import jakarta.decorator.Decorator;
 import jakarta.decorator.Delegate;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
-import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Test;
@@ -27,8 +26,7 @@ public class DelegateQualifiersTest {
     public void testDecoration() {
         @SuppressWarnings("serial")
         ToUpperCaseConverter converter = Arc.container()
-                .instance(ToUpperCaseConverter.class, new AnnotationLiteral<MyQualifier>() {
-                }).get();
+                .instance(ToUpperCaseConverter.class, new MyQualifier.Literal()).get();
         assertEquals("HOLA!", converter.convert(" holA!"));
         assertEquals(" HOLA!", converter.convertNoDelegation(" holA!"));
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/DecoratorWithAsyncObserverTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/DecoratorWithAsyncObserverTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.arc.test.decorators.validation;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.event.ObservesAsync;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DecoratorWithAsyncObserverTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyDecorator.class, Converter.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Decorator declares an async observer method"));
+    }
+
+    interface Converter<T> {
+        T convert(String value);
+    }
+
+    @Decorator
+    @Priority(1)
+    static class MyDecorator implements Converter<Number> {
+        @Inject
+        @Delegate
+        Converter<Number> delegate;
+
+        @Override
+        public Number convert(String value) {
+            return null;
+        }
+
+        void observeAsync(@ObservesAsync String ignored) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/DecoratorWithDisposerMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/DecoratorWithDisposerMethodTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.arc.test.decorators.validation;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DecoratorWithDisposerMethodTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyDecorator.class, Converter.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Decorator declares a disposer method"));
+    }
+
+    interface Converter<T> {
+        T convert(String value);
+    }
+
+    @Decorator
+    @Priority(1)
+    static class MyDecorator implements Converter<Number> {
+        @Inject
+        @Delegate
+        Converter<Number> delegate;
+
+        @Override
+        public Number convert(String value) {
+            return null;
+        }
+
+        void dispose(@Disposes String ignored) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/DecoratorWithObserverTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/DecoratorWithObserverTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.arc.test.decorators.validation;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DecoratorWithObserverTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyDecorator.class, Converter.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Decorator declares an observer method"));
+    }
+
+    interface Converter<T> {
+        T convert(String value);
+    }
+
+    @Decorator
+    @Priority(1)
+    static class MyDecorator implements Converter<Number> {
+        @Inject
+        @Delegate
+        Converter<Number> delegate;
+
+        @Override
+        public Number convert(String value) {
+            return null;
+        }
+
+        void observe(@Observes String ignored) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/DecoratorWithProducerFieldTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/DecoratorWithProducerFieldTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.arc.test.decorators.validation;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DecoratorWithProducerFieldTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyDecorator.class, Converter.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Decorator declares a producer field"));
+    }
+
+    interface Converter<T> {
+        T convert(String value);
+    }
+
+    @Decorator
+    @Priority(1)
+    static class MyDecorator implements Converter<Number> {
+        @Inject
+        @Delegate
+        Converter<Number> delegate;
+
+        @Override
+        public Number convert(String value) {
+            return null;
+        }
+
+        @Produces
+        String produce = "";
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/DecoratorWithProducerMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/DecoratorWithProducerMethodTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.arc.test.decorators.validation;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DecoratorWithProducerMethodTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyDecorator.class, Converter.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Decorator declares a producer method"));
+    }
+
+    interface Converter<T> {
+        T convert(String value);
+    }
+
+    @Decorator
+    @Priority(1)
+    static class MyDecorator implements Converter<Number> {
+        @Inject
+        @Delegate
+        Converter<Number> delegate;
+
+        @Override
+        public Number convert(String value) {
+            return null;
+        }
+
+        @Produces
+        String produce() {
+            return "";
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/select/EventSelectTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/select/EventSelectTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.arc.test.event.select;
 
-import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.enterprise.util.TypeLiteral;
 
 import org.junit.jupiter.api.Assertions;
@@ -61,8 +60,7 @@ public class EventSelectTest {
     public void testEventSelectThrowsExceptionIfAnnotationIsNotBindingType() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             SecuritySensor sensor = Arc.container().select(SecuritySensor.class).get();
-            sensor.securityEvent.select(new AnnotationLiteral<NotABindingType>() {
-            });
+            sensor.securityEvent.select(new NotABindingType.Literal());
         }, "Event#select should throw IllegalArgumentException if the annotation is not a binding type.");
     }
 
@@ -70,8 +68,7 @@ public class EventSelectTest {
     public void testEventSelectWithSubtypeThrowsExceptionIfAnnotationIsNotBindingType() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             SecuritySensor sensor = Arc.container().select(SecuritySensor.class).get();
-            sensor.securityEvent.select(BreakInEvent.class, new AnnotationLiteral<NotABindingType>() {
-            });
+            sensor.securityEvent.select(BreakInEvent.class, new NotABindingType.Literal());
         }, "Event#select should throw IllegalArgumentException when selecting a subtype and using annotation that is not a binding type.");
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/select/NotABindingType.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/event/select/NotABindingType.java
@@ -6,8 +6,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+
 @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface NotABindingType {
+    class Literal extends AnnotationLiteral<NotABindingType> implements NotABindingType {
+    }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/inheritance/QualifiersInheritanceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/inheritance/QualifiersInheritanceTest.java
@@ -32,8 +32,7 @@ public class QualifiersInheritanceTest {
         // Bravo is not eligible because it has @InheritedQualifier("bravo")
         assertTrue(container.select(SuperBean.class, new InheritedQualifier.Literal("super")).isResolvable());
         // @NonInheritedQualifier is not inherited
-        assertFalse(container.select(SuperBean.class, new AnnotationLiteral<NonInheritedQualifier>() {
-        }).isResolvable());
+        assertFalse(container.select(SuperBean.class, new NonInheritedQualifier.Literal()).isResolvable());
     }
 
     @InheritedQualifier("super")
@@ -84,6 +83,7 @@ public class QualifiersInheritanceTest {
     @Qualifier
     @Retention(RUNTIME)
     @interface NonInheritedQualifier {
-
+        class Literal extends AnnotationLiteral<NonInheritedQualifier> implements NonInheritedQualifier {
+        }
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/generics/AssignabilityWithGenericsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/assignability/generics/AssignabilityWithGenericsTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +44,15 @@ public class AssignabilityWithGenericsTest {
     public void testParameterizedTypeWithTypeVariable() {
         InstanceHandle<StringListConsumer> instance = Arc.container().instance(StringListConsumer.class);
         assertTrue(instance.isAvailable());
-        assertNotNull(instance.get().getList());
+        StringListConsumer obj = instance.get();
+        assertNotNull(obj.getList());
+        assertEquals(2, obj.getList().size());
+        assertEquals("qux", obj.getList().get(0));
+        assertEquals("quux", obj.getList().get(1));
+        assertNotNull(obj.getArray());
+        assertEquals(2, obj.getArray().length);
+        assertEquals("bar", obj.getArray()[0]);
+        assertEquals("baz", obj.getArray()[1]);
     }
 
     @Test
@@ -108,8 +115,15 @@ public class AssignabilityWithGenericsTest {
         @Inject
         List<T> list;
 
+        @Inject
+        T[] array;
+
         public List<T> getList() {
             return list;
+        }
+
+        public T[] getArray() {
+            return array;
         }
     }
 
@@ -120,8 +134,11 @@ public class AssignabilityWithGenericsTest {
         String foo = "foo";
 
         @Produces
+        String[] barBaz = { "bar", "baz" };
+
+        @Produces
         List<String> produceList() {
-            return new ArrayList<>();
+            return List.of("qux", "quux");
         }
 
         @Produces

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/illegal/GenericInitializerMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/illegal/GenericInitializerMethodTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.arc.test.injection.illegal;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,28 +12,25 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.test.ArcTestContainer;
 
-public class TypeVariableInitializerInjectionPointTest {
-
+public class GenericInitializerMethodTest {
     @RegisterExtension
-    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Head.class).shouldFail().build();
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Head.class)
+            .shouldFail()
+            .build();
 
     @Test
-    public void testError() {
+    public void trigger() {
         Throwable failure = container.getFailure();
         assertNotNull(failure);
         assertTrue(failure instanceof DefinitionException);
-        assertEquals(
-                "Type variable is not a legal injection point type: io.quarkus.arc.test.injection.illegal.TypeVariableInitializerInjectionPointTest$Head#setIt():it",
-                failure.getMessage());
+        assertTrue(failure.getMessage().contains("Initializer method may not be generic (declare type parameters)"));
     }
 
     @Dependent
-    static class Head<T> {
-
+    static class Head {
         @Inject
-        void setIt(T it) {
+        <T> void inject() {
         }
-
     }
-
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/illegal/TypeVariableFieldInjectionPointTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/illegal/TypeVariableFieldInjectionPointTest.java
@@ -16,7 +16,7 @@ import io.quarkus.arc.test.ArcTestContainer;
 public class TypeVariableFieldInjectionPointTest {
 
     @RegisterExtension
-    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Head.class).shouldFail().build();;
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Head.class).shouldFail().build();
 
     @Test
     public void testError() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/ArcContainerSelectTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/ArcContainerSelectTest.java
@@ -17,7 +17,6 @@ import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.InjectionPoint;
-import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.enterprise.util.TypeLiteral;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -29,6 +28,7 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableInstance;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.TestLiteral;
 
 public class ArcContainerSelectTest {
 
@@ -51,8 +51,7 @@ public class ArcContainerSelectTest {
         assertTrue(strings.contains("washcloth"));
         assertTrue(Washcloth.INIT.get());
         assertTrue(Washcloth.DESTROYED.get());
-        assertThatThrownBy(() -> Arc.container().select(Alpha.class, new AnnotationLiteral<Test>() {
-        }))
+        assertThatThrownBy(() -> Arc.container().select(Alpha.class, new TestLiteral()))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/InvalidQualifierInstanceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/InvalidQualifierInstanceTest.java
@@ -3,7 +3,6 @@ package io.quarkus.arc.test.instance;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -12,6 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.TestLiteral;
 
 public class InvalidQualifierInstanceTest {
 
@@ -21,8 +21,7 @@ public class InvalidQualifierInstanceTest {
     @SuppressWarnings("serial")
     @Test
     public void testIllegalArgumentException() {
-        assertThatThrownBy(() -> Arc.container().instance(Alpha.class).get().instance.select(new AnnotationLiteral<Test>() {
-        }))
+        assertThatThrownBy(() -> Arc.container().instance(Alpha.class).get().instance.select(new TestLiteral()))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/illegal/InterceptorWithAsyncObserverTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/illegal/InterceptorWithAsyncObserverTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.arc.test.interceptors.illegal;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.event.ObservesAsync;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptorWithAsyncObserverTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyInterceptor.class, MyInterceptorBinding.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Interceptor declares an async observer method"));
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return ctx.proceed();
+        }
+
+        void observeAsync(@ObservesAsync String ignored) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/illegal/InterceptorWithDisposerMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/illegal/InterceptorWithDisposerMethodTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.arc.test.interceptors.illegal;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptorWithDisposerMethodTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyInterceptor.class, MyInterceptorBinding.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Interceptor declares a disposer method"));
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return ctx.proceed();
+        }
+
+        void dispose(@Disposes String ignored) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/illegal/InterceptorWithObserverTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/illegal/InterceptorWithObserverTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.arc.test.interceptors.illegal;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptorWithObserverTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyInterceptor.class, MyInterceptorBinding.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Interceptor declares an observer method"));
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return ctx.proceed();
+        }
+
+        void observe(@Observes String ignored) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/illegal/InterceptorWithProducerFieldTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/illegal/InterceptorWithProducerFieldTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.arc.test.interceptors.illegal;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptorWithProducerFieldTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyInterceptor.class, MyInterceptorBinding.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Interceptor declares a producer field"));
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return ctx.proceed();
+        }
+
+        @Produces
+        String produce = "";
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/illegal/InterceptorWithProducerMethodTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/illegal/InterceptorWithProducerMethodTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.arc.test.interceptors.illegal;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptorWithProducerMethodTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyInterceptor.class, MyInterceptorBinding.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Interceptor declares a producer method"));
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return ctx.proceed();
+        }
+
+        @Produces
+        String produce() {
+            return "";
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/illegal/NonDependentInterceptorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/illegal/NonDependentInterceptorTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.arc.test.interceptors.illegal;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class NonDependentInterceptorTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyInterceptor.class, MyInterceptorBinding.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Interceptor declares scope other than @Dependent"));
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/initializer/InitializerMethodInterceptionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/initializer/InitializerMethodInterceptionTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.arc.test.interceptors.initializer;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.interceptors.initializer.subpkg.MyDependency;
+import io.quarkus.arc.test.interceptors.initializer.subpkg.MySuperclass;
+
+public class InitializerMethodInterceptionTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyDependency.class, MyBean.class, MyInterceptorBinding.class,
+            MyInterceptor.class);
+
+    @Test
+    public void testInterception() {
+        MyBean bean = Arc.container().instance(MyBean.class).get();
+        assertNotNull(bean);
+        assertTrue(bean.publicInitializerCalled);
+        assertTrue(bean.protectedInitializerCalled);
+        assertTrue(bean.packagePrivateInitializerCalled);
+        assertTrue(bean.privateInitializerCalled);
+
+        // initializer methods invoked by the container are not intercepted
+        assertFalse(MyInterceptor.intercepted);
+    }
+
+    // note that `MySuperclass` is intentionally in a different package
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean extends MySuperclass {
+    }
+
+    @Target({ TYPE, METHOD })
+    @Retention(RUNTIME)
+    @Documented
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor {
+        static boolean intercepted = false;
+
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            intercepted = true;
+            return ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/initializer/subpkg/MyDependency.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/initializer/subpkg/MyDependency.java
@@ -1,0 +1,7 @@
+package io.quarkus.arc.test.interceptors.initializer.subpkg;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class MyDependency {
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/initializer/subpkg/MySuperclass.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/initializer/subpkg/MySuperclass.java
@@ -1,0 +1,30 @@
+package io.quarkus.arc.test.interceptors.initializer.subpkg;
+
+import jakarta.inject.Inject;
+
+public class MySuperclass {
+    public boolean publicInitializerCalled;
+    public boolean protectedInitializerCalled;
+    public boolean packagePrivateInitializerCalled;
+    public boolean privateInitializerCalled;
+
+    @Inject
+    public void publicInject(MyDependency ignored) {
+        publicInitializerCalled = true;
+    }
+
+    @Inject
+    protected void protectedInject(MyDependency ignored) {
+        protectedInitializerCalled = true;
+    }
+
+    @Inject
+    void packagePrivateInject(MyDependency ignored) {
+        packagePrivateInitializerCalled = true;
+    }
+
+    @Inject
+    private void privateInject(MyDependency ignored) {
+        privateInitializerCalled = true;
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/name/NamePrefixCollisionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/name/NamePrefixCollisionTest.java
@@ -13,11 +13,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.test.ArcTestContainer;
 
-public class AmbiguousNameTest {
-
+public class NamePrefixCollisionTest {
     @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
-            .beanClasses(Bravo.class, Alpha.class)
+            .beanClasses(Alpha.class, Bravo.class)
+            .strictCompatibility(true)
             .shouldFail()
             .build();
 
@@ -26,17 +26,16 @@ public class AmbiguousNameTest {
         Throwable error = container.getFailure();
         assertNotNull(error);
         assertTrue(error instanceof DeploymentException);
-        assertTrue(error.getMessage().contains("Unresolvable ambiguous bean name detected"));
+        assertTrue(error.getMessage().contains("identical to a bean name prefix used elsewhere"));
     }
 
-    @Named("A")
+    @Named("x")
     @Singleton
     static class Alpha {
     }
 
-    @Named("A")
+    @Named("x.y")
     @Dependent
     static class Bravo {
     }
-
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/ArrayPayloadTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/ArrayPayloadTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.arc.test.observers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ArrayPayloadTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Observer.class, Emitter.class);
+
+    @Test
+    public void testObservers() {
+        Emitter emitter = Arc.container().instance(Emitter.class).get();
+        Observer observer = Arc.container().instance(Observer.class).get();
+
+        Integer[] integerArray = new Integer[] { 42 };
+        emitter.emitIntegerArray(integerArray);
+        Integer[] observedIntegerArray = observer.integerArray.get();
+        assertNotNull(observedIntegerArray);
+        assertEquals(1, observedIntegerArray.length);
+        assertEquals(42, observedIntegerArray[0]);
+
+        List<?>[] listArray = new List[] { List.of(42) };
+        emitter.emitListArray(listArray);
+        List<?>[] observedListArray = observer.listArray.get();
+        assertNotNull(observedListArray);
+        assertEquals(1, observedListArray.length);
+        assertEquals(List.of(42), observedListArray[0]);
+    }
+
+    @Singleton
+    static class Observer {
+        AtomicReference<Integer[]> integerArray = new AtomicReference<>();
+        AtomicReference<List<?>[]> listArray = new AtomicReference<>();
+
+        <T extends Integer> void observeIntegerArray(@Observes T[] value) {
+            integerArray.set(value);
+        }
+
+        void observeListArray(@Observes List<?>[] value) {
+            listArray.set(value);
+        }
+    }
+
+    @Dependent
+    static class Emitter {
+        @Inject
+        Event<Integer[]> integerArrayEvent;
+
+        @Inject
+        Event<List<?>[]> listArrayEvent;
+
+        void emitIntegerArray(Integer[] value) {
+            integerArrayEvent.fire(value);
+        }
+
+        void emitListArray(List<?>[] value) {
+            listArrayEvent.fire(value);
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/inheritance/ObserverInheritanceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/inheritance/ObserverInheritanceTest.java
@@ -2,10 +2,6 @@ package io.quarkus.arc.test.observers.inheritance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.annotation.Annotation;
-
-import jakarta.enterprise.util.AnnotationLiteral;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -35,12 +31,7 @@ public class ObserverInheritanceTest {
     @SuppressWarnings("serial")
     @BeforeEach
     public void setUp() {
-        observingBean = Arc.container().instance(ObservingBean.class, new AnnotationLiteral<ObservingBean.THIS>() {
-            @Override
-            public Class<? extends Annotation> annotationType() {
-                return super.annotationType();
-            }
-        }).get();
+        observingBean = Arc.container().instance(ObservingBean.class, new ObservingBean.THIS.Literal()).get();
         observingSubBean = Arc.container().instance(ObservingSubBean.class).get();
         nonObservingSubBean = Arc.container().instance(NonObservingSubBean.class).get();
         emittingBean = Arc.container().instance(EmittingBean.class).get();

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/inheritance/ObservingBean.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/inheritance/ObservingBean.java
@@ -7,6 +7,7 @@ import java.lang.annotation.Target;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 /**
@@ -32,6 +33,7 @@ public class ObservingBean {
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.FIELD, ElementType.TYPE })
     public @interface THIS {
-
+        class Literal extends AnnotationLiteral<THIS> implements THIS {
+        }
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/DisposerWithQualifiersTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/DisposerWithQualifiersTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.arc.test.producer.disposer;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DisposerWithQualifiersTest {
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(Producer.class, Dependency.class, Foo.class, Bar.class);
+
+    @Test
+    public void testDisposers() {
+        InstanceHandle<String> handle = Arc.container().instance(String.class, new Foo.Literal());
+        assertEquals("produced", handle.get());
+        assertEquals(0, Producer.destroyed.size());
+        handle.destroy();
+        assertEquals(1, Producer.destroyed.size());
+        assertEquals("produced", Producer.destroyed.get(0));
+    }
+
+    @Singleton
+    static class Producer {
+        static final List<String> destroyed = new ArrayList<>();
+
+        @Singleton
+        @Produces
+        @Foo
+        String produce(@Bar Dependency ignored) {
+            return "produced";
+        }
+
+        void disposeFoo(@Disposes @Any String str) {
+            destroyed.add(str);
+        }
+
+        // this one should be ignored
+        void disposeBar(@Disposes @Bar String str) {
+            destroyed.add(str);
+        }
+    }
+
+    @Singleton
+    @Bar
+    static class Dependency {
+    }
+
+    @Qualifier
+    @Inherited
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    public @interface Foo {
+        class Literal extends AnnotationLiteral<Foo> implements Foo {
+        }
+    }
+
+    @Qualifier
+    @Inherited
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    public @interface Bar {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/UnusedDisposerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/disposer/UnusedDisposerTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.arc.test.producer.disposer;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class UnusedDisposerTest {
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Producer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains(
+                "No producer method or field declared by the bean class that is assignable to the disposed parameter of a disposer method"));
+    }
+
+    @Singleton
+    static class Producer {
+        @Singleton
+        @Produces
+        String produce() {
+            return "produced";
+        }
+
+        void disposeString(@Disposes String str) {
+        }
+
+        void disposeInteger(@Disposes Integer integer) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/NonDependentProducerFieldWithTypeVariableTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/NonDependentProducerFieldWithTypeVariableTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.arc.test.producer.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class NonDependentProducerFieldWithTypeVariableTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Producer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage()
+                .contains("Producer field type is a parameterized type with a type variable, its scope must be @Dependent"));
+    }
+
+    @Dependent
+    static class Producer<T> {
+        @Produces
+        @ApplicationScoped
+        List<T> produce = new ArrayList<>();
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/NonDependentProducerMethodWithTypeVariableTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/illegal/NonDependentProducerMethodWithTypeVariableTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.arc.test.producer.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class NonDependentProducerMethodWithTypeVariableTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Producer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains(
+                "Producer method return type is a parameterized type with a type variable, its scope must be @Dependent"));
+    }
+
+    @Dependent
+    static class Producer<T> {
+        @Produces
+        @ApplicationScoped
+        List<T> produce() {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/Alpha.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/Alpha.java
@@ -8,6 +8,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, METHOD })
@@ -15,5 +16,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface Alpha {
-
+    class Literal extends AnnotationLiteral<Alpha> implements Alpha {
+    }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/Bravo.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/Bravo.java
@@ -8,6 +8,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.interceptor.InterceptorBinding;
 
 @Target({ TYPE, METHOD })
@@ -15,5 +16,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Documented
 @InterceptorBinding
 public @interface Bravo {
-
+    class Literal extends AnnotationLiteral<Bravo> implements Bravo {
+    }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/RemoveUnusedInterceptorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/RemoveUnusedInterceptorTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.InterceptionType;
-import jakarta.enterprise.util.AnnotationLiteral;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -30,10 +29,8 @@ public class RemoveUnusedInterceptorTest extends RemoveUnusedComponentsTest {
         assertPresent(HasObserver.class);
         assertNotPresent(Counter.class);
         // Both AlphaInterceptor and BravoInterceptor were removed
-        assertTrue(container.beanManager().resolveInterceptors(InterceptionType.AROUND_INVOKE, new AnnotationLiteral<Alpha>() {
-        }).isEmpty());
-        assertTrue(container.beanManager().resolveInterceptors(InterceptionType.AROUND_INVOKE, new AnnotationLiteral<Bravo>() {
-        }).isEmpty());
+        assertTrue(container.beanManager().resolveInterceptors(InterceptionType.AROUND_INVOKE, new Alpha.Literal()).isEmpty());
+        assertTrue(container.beanManager().resolveInterceptors(InterceptionType.AROUND_INVOKE, new Bravo.Literal()).isEmpty());
 
     }
 


### PR DESCRIPTION
Related to #28558

- introduce the strict compatibility switch
- validate non-static final methods of normal-scoped beans
  - only in the strict mode, as we make them non-final through bytecode transformation by default
- fix event resolution in case of array types
  - copied a missing piece of code from Weld
- validate bean name prefix collisions
  - only in the strict mode, as this is hardly relevant to Quarkus
- fix disposer resolution for producers with qualifiers
- validate presence of a matching producer for disposer methods
- fix resolution of array types that use type variables
- validate non-static public fields of normal-scoped beans
  - only in the strict mode, as this prevents public producer fields
- validate that interceptors do not declare a scope other than `@Dependent`
- validate that interceptors/decorators do not declare producers/disposers/observers
- validate generic initializer methods
- validate scope of producers with a parameterized type with a type variable
- skip intercepting method calls during bean injection
- remove incorrect annotation literals for memberless annotations