### PR TITLE
Add Stork support to the new Vert.x gRPC impl

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
@@ -73,6 +73,7 @@ import io.quarkus.grpc.runtime.GrpcClientRecorder;
 import io.quarkus.grpc.runtime.config.GrpcClientBuildTimeConfig;
 import io.quarkus.grpc.runtime.stork.GrpcStorkRecorder;
 import io.quarkus.grpc.runtime.stork.StorkMeasuringGrpcInterceptor;
+import io.quarkus.grpc.runtime.stork.VertxStorkMeasuringGrpcInterceptor;
 import io.quarkus.grpc.runtime.supports.Channels;
 import io.quarkus.grpc.runtime.supports.GrpcClientConfigProvider;
 import io.quarkus.grpc.runtime.supports.IOThreadClientInterceptor;
@@ -97,6 +98,7 @@ public class GrpcClientProcessor {
     @BuildStep
     void registerStorkInterceptor(BuildProducer<AdditionalBeanBuildItem> beans) {
         beans.produce(new AdditionalBeanBuildItem(StorkMeasuringGrpcInterceptor.class));
+        beans.produce(new AdditionalBeanBuildItem(VertxStorkMeasuringGrpcInterceptor.class));
     }
 
     @BuildStep
@@ -407,6 +409,7 @@ public class GrpcClientProcessor {
 
         // it's okay if this one is not used:
         superfluousInterceptors.remove(StorkMeasuringGrpcInterceptor.class.getName());
+        superfluousInterceptors.remove(VertxStorkMeasuringGrpcInterceptor.class.getName());
         if (!superfluousInterceptors.isEmpty()) {
             LOGGER.warnf("At least one unused gRPC client interceptor found: %s. If there are meant to be used globally, " +
                     "annotate them with @GlobalInterceptor.", String.join(", ", superfluousInterceptors));

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -94,11 +94,12 @@ public class GrpcServerRecorder {
         if (grpcContainer == null) {
             throw new IllegalStateException("gRPC not initialized, GrpcContainer not found");
         }
-        Vertx vertx = vertxSupplier.getValue();
         if (hasNoServices(grpcContainer.getServices()) && LaunchMode.current() != LaunchMode.DEVELOPMENT) {
             LOGGER.error("Unable to find beans exposing the `BindableService` interface - not starting the gRPC server");
+            return; // OK?
         }
 
+        Vertx vertx = vertxSupplier.getValue();
         GrpcServerConfiguration configuration = cfg.server;
         GrpcBuilderProvider<?> provider = GrpcBuilderProvider.findServerBuilderProvider(configuration);
 

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcClientConfiguration.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/GrpcClientConfiguration.java
@@ -35,6 +35,12 @@ public class GrpcClientConfiguration {
     public InProcess inProcess;
 
     /**
+     * Configure Stork usage with new Vert.x gRPC, if enabled.
+     */
+    @ConfigItem
+    public StorkConfig stork;
+
+    /**
      * The gRPC service port.
      */
     @ConfigItem(defaultValue = "9000")
@@ -168,7 +174,7 @@ public class GrpcClientConfiguration {
 
     /**
      * Use a custom load balancing policy.
-     * Accepted values are: {@code pick_value}, {@code round_robin}, {@code grpclb}.
+     * Accepted values are: {@code pick_first}, {@code round_robin}, {@code grpclb}.
      * This value is ignored if name-resolver is set to 'stork'.
      */
     @ConfigItem(defaultValue = "pick_first")

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/StorkConfig.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/StorkConfig.java
@@ -1,0 +1,40 @@
+package io.quarkus.grpc.runtime.config;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * Stork config for new Vert.x gRPC
+ */
+@ConfigGroup
+public class StorkConfig {
+    /**
+     * Number of threads on a delayed gRPC ClientCall
+     */
+    @ConfigItem(defaultValue = "10")
+    public int threads;
+
+    /**
+     * Deadline in milliseconds of delayed gRPC call
+     */
+    @ConfigItem(defaultValue = "5000")
+    public long deadline;
+
+    /**
+     * Number of retries on a gRPC ClientCall
+     */
+    @ConfigItem(defaultValue = "3")
+    public int retries;
+
+    /**
+     * Initial delay in seconds on refresh check
+     */
+    @ConfigItem(defaultValue = "60")
+    public long delay;
+
+    /**
+     * Refresh period in seconds
+     */
+    @ConfigItem(defaultValue = "120")
+    public long period;
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/AbstractStorkMeasuringCall.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/AbstractStorkMeasuringCall.java
@@ -1,0 +1,29 @@
+package io.quarkus.grpc.runtime.stork;
+
+import io.grpc.ClientCall;
+import io.grpc.ForwardingClientCall;
+import io.smallrye.stork.api.ServiceInstance;
+
+abstract class AbstractStorkMeasuringCall<ReqT, RespT> extends ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>
+        implements StorkMeasuringCollector {
+    final boolean recordTime;
+
+    protected AbstractStorkMeasuringCall(ClientCall<ReqT, RespT> delegate, boolean recordTime) {
+        super(delegate);
+        this.recordTime = recordTime;
+    }
+
+    protected abstract ServiceInstance serviceInstance();
+
+    public void recordReply() {
+        if (serviceInstance() != null && recordTime) {
+            serviceInstance().recordReply();
+        }
+    }
+
+    public void recordEnd(Throwable error) {
+        if (serviceInstance() != null) {
+            serviceInstance().recordEnd(error);
+        }
+    }
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/GrpcLoadBalancerProvider.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/GrpcLoadBalancerProvider.java
@@ -2,8 +2,8 @@ package io.quarkus.grpc.runtime.stork;
 
 import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
-import static io.quarkus.grpc.runtime.stork.StorkMeasuringGrpcInterceptor.STORK_MEASURE_TIME;
-import static io.quarkus.grpc.runtime.stork.StorkMeasuringGrpcInterceptor.STORK_SERVICE_INSTANCE;
+import static io.quarkus.grpc.runtime.stork.StorkMeasuringCollector.STORK_MEASURE_TIME;
+import static io.quarkus.grpc.runtime.stork.StorkMeasuringCollector.STORK_SERVICE_INSTANCE;
 
 import java.util.Collections;
 import java.util.Comparator;

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/GrpcStorkServiceDiscovery.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/GrpcStorkServiceDiscovery.java
@@ -121,7 +121,7 @@ public class GrpcStorkServiceDiscovery extends NameResolverProvider {
                                     socketAddresses.add(new InetSocketAddress(inetAddress, instance.getPort()));
                                 }
                             } catch (UnknownHostException e) {
-                                log.errorf(e, "Ignoring wrong host: '%s' for service name '%s'", instance.getHost(),
+                                log.warnf(e, "Ignoring wrong host: '%s' for service name '%s'", instance.getHost(),
                                         serviceName);
                             }
 

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/StorkGrpcChannel.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/StorkGrpcChannel.java
@@ -1,0 +1,212 @@
+package io.quarkus.grpc.runtime.stork;
+
+import static io.quarkus.grpc.runtime.stork.StorkMeasuringCollector.STORK_MEASURE_TIME;
+import static io.quarkus.grpc.runtime.stork.StorkMeasuringCollector.STORK_SERVICE_INSTANCE;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.Deadline;
+import io.grpc.MethodDescriptor;
+import io.grpc.internal.DelayedClientCall;
+import io.quarkus.grpc.runtime.config.StorkConfig;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.stork.Stork;
+import io.smallrye.stork.api.Service;
+import io.smallrye.stork.api.ServiceInstance;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.grpc.client.GrpcClient;
+import io.vertx.grpc.client.GrpcClientChannel;
+
+public class StorkGrpcChannel extends Channel implements AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(StorkGrpcChannel.class);
+
+    private final Map<Long, ServiceInstance> services = new ConcurrentHashMap<>();
+    private final Map<Long, Channel> channels = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService scheduler;
+
+    private final GrpcClient client;
+    private final String serviceName;
+    private final StorkConfig stork;
+    private final Executor executor;
+
+    private static class Context {
+        Service service;
+        boolean measureTime;
+        ServiceInstance instance;
+        InetSocketAddress address;
+        Channel channel;
+        AtomicReference<ServiceInstance> ref;
+    }
+
+    public StorkGrpcChannel(GrpcClient client, String serviceName, StorkConfig stork, Executor executor) {
+        this.client = client;
+        this.serviceName = serviceName;
+        this.stork = stork;
+        this.executor = executor;
+        this.scheduler = new ScheduledThreadPoolExecutor(stork.threads);
+        this.scheduler.scheduleAtFixedRate(this::refresh, stork.delay, stork.period, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(MethodDescriptor<RequestT, ResponseT> methodDescriptor,
+            CallOptions callOptions) {
+        Service service = Stork.getInstance().getService(serviceName);
+        if (service == null) {
+            throw new IllegalStateException("No service definition for serviceName " + serviceName + " found.");
+        }
+
+        Context context = new Context();
+        context.service = service;
+        // handle this calls here
+        Boolean measureTime = STORK_MEASURE_TIME.get();
+        context.measureTime = measureTime != null && measureTime;
+        context.ref = STORK_SERVICE_INSTANCE.get();
+
+        DelayedClientCall<RequestT, ResponseT> delayed = new StorkDelayedClientCall<>(executor, scheduler,
+                Deadline.after(stork.deadline, TimeUnit.MILLISECONDS));
+
+        asyncCall(methodDescriptor, callOptions, context)
+                .onFailure()
+                .retry()
+                .atMost(stork.retries)
+                .subscribe()
+                .asCompletionStage()
+                .thenApply(delayed::setCall)
+                .thenAccept(Runnable::run)
+                .exceptionally(t -> {
+                    delayed.cancel("Failed to create new Stork ClientCall", t);
+                    return null;
+                });
+
+        return delayed;
+    }
+
+    private <RequestT, ResponseT> Uni<ClientCall<RequestT, ResponseT>> asyncCall(
+            MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions, Context context) {
+        Uni<Context> entry = pickServiceInstanceWithChannel(context);
+        return entry.map(c -> {
+            ServiceInstance instance = c.instance;
+            long serviceId = instance.getId();
+            Channel channel = c.channel;
+            try {
+                services.put(serviceId, instance);
+                channels.put(serviceId, channel);
+                return channel.newCall(methodDescriptor, callOptions);
+            } catch (Exception ex) {
+                // remove, no good
+                services.remove(serviceId);
+                channels.remove(serviceId);
+                throw new IllegalStateException(ex);
+            }
+        });
+    }
+
+    @Override
+    public String authority() {
+        return null;
+    }
+
+    @Override
+    public void close() {
+        scheduler.shutdown();
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + String.format(" [%s]", serviceName);
+    }
+
+    private void refresh() {
+        // any better way to know which are OK / bad?
+        services.clear();
+        channels.clear();
+    }
+
+    private Uni<Context> pickServiceInstanceWithChannel(Context context) {
+        Uni<ServiceInstance> uni = pickServerInstance(context.service, context.measureTime);
+        return uni
+                .map(si -> {
+                    context.instance = si;
+                    if (si.gatherStatistics() && context.ref != null) {
+                        context.ref.set(si);
+                    }
+                    return context;
+                })
+                .invoke(this::checkSocketAddress)
+                .invoke(c -> {
+                    ServiceInstance instance = context.instance;
+                    InetSocketAddress isa = context.address;
+                    context.channel = channels.computeIfAbsent(instance.getId(), id -> {
+                        SocketAddress address = SocketAddress.inetSocketAddress(isa.getPort(), isa.getHostName());
+                        return new GrpcClientChannel(client, address);
+                    });
+                });
+    }
+
+    private Uni<ServiceInstance> pickServerInstance(Service service, boolean measureTime) {
+        return Uni.createFrom()
+                .deferred(() -> {
+                    if (services.isEmpty()) {
+                        return service.getInstances()
+                                .invoke(l -> l.forEach(s -> services.put(s.getId(), s)));
+                    } else {
+                        List<ServiceInstance> list = new ArrayList<>(services.values());
+                        return Uni.createFrom().item(list);
+                    }
+                })
+                .invoke(list -> {
+                    // list should not be empty + sort by id
+                    list.sort(Comparator.comparing(ServiceInstance::getId));
+                })
+                .map(list -> service.selectInstanceAndRecordStart(list, measureTime));
+    }
+
+    private void checkSocketAddress(Context context) {
+        ServiceInstance instance = context.instance;
+        Set<InetSocketAddress> socketAddresses = new HashSet<>();
+        try {
+            for (InetAddress inetAddress : InetAddress.getAllByName(instance.getHost())) {
+                socketAddresses.add(new InetSocketAddress(inetAddress, instance.getPort()));
+            }
+        } catch (UnknownHostException e) {
+            log.warn("Ignoring wrong host: '{}' for service name '{}'", instance.getHost(), serviceName, e);
+        }
+
+        if (!socketAddresses.isEmpty()) {
+            context.address = socketAddresses.iterator().next(); // pick first
+        } else {
+            long serviceId = instance.getId();
+            services.remove(serviceId);
+            channels.remove(serviceId);
+            throw new IllegalStateException("Failed to determine working socket addresses for service-name: " + serviceName);
+        }
+    }
+
+    private static class StorkDelayedClientCall<RequestT, ResponseT> extends DelayedClientCall<RequestT, ResponseT> {
+        public StorkDelayedClientCall(Executor callExecutor, ScheduledExecutorService scheduler, @Nullable Deadline deadline) {
+            super(callExecutor, scheduler, deadline);
+        }
+    }
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/StorkMeasuringCall.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/StorkMeasuringCall.java
@@ -1,0 +1,29 @@
+package io.quarkus.grpc.runtime.stork;
+
+import io.grpc.ClientCall;
+import io.grpc.ForwardingClientCall;
+import io.smallrye.stork.api.ServiceInstance;
+
+abstract class StorkMeasuringCall<ReqT, RespT> extends ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>
+        implements StorkMeasuringCollector {
+    final boolean recordTime;
+
+    protected StorkMeasuringCall(ClientCall<ReqT, RespT> delegate, boolean recordTime) {
+        super(delegate);
+        this.recordTime = recordTime;
+    }
+
+    protected abstract ServiceInstance serviceInstance();
+
+    public void recordReply() {
+        if (serviceInstance() != null && recordTime) {
+            serviceInstance().recordReply();
+        }
+    }
+
+    public void recordEnd(Throwable error) {
+        if (serviceInstance() != null) {
+            serviceInstance().recordEnd(error);
+        }
+    }
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/StorkMeasuringCallListener.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/StorkMeasuringCallListener.java
@@ -1,0 +1,32 @@
+package io.quarkus.grpc.runtime.stork;
+
+import io.grpc.ClientCall;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.Status;
+
+class StorkMeasuringCallListener<RespT>
+        extends ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT> {
+    final StorkMeasuringCollector collector;
+
+    public StorkMeasuringCallListener(ClientCall.Listener<RespT> responseListener, StorkMeasuringCollector collector) {
+        super(responseListener);
+        this.collector = collector;
+    }
+
+    @Override
+    public void onMessage(RespT message) {
+        collector.recordReply();
+        super.onMessage(message);
+    }
+
+    @Override
+    public void onClose(Status status, Metadata trailers) {
+        Exception error = null;
+        if (!status.isOk()) {
+            error = status.asException(trailers);
+        }
+        collector.recordEnd(error);
+        super.onClose(status, trailers);
+    }
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/StorkMeasuringCollector.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/StorkMeasuringCollector.java
@@ -1,0 +1,15 @@
+package io.quarkus.grpc.runtime.stork;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.grpc.Context;
+import io.smallrye.stork.api.ServiceInstance;
+
+interface StorkMeasuringCollector {
+    Context.Key<AtomicReference<ServiceInstance>> STORK_SERVICE_INSTANCE = Context.key("stork.service-instance");
+    Context.Key<Boolean> STORK_MEASURE_TIME = Context.key("stork.measure-time");
+
+    void recordReply();
+
+    void recordEnd(Throwable error);
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/StorkMeasuringGrpcInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/StorkMeasuringGrpcInterceptor.java
@@ -10,19 +10,12 @@ import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.Context;
-import io.grpc.ForwardingClientCall;
-import io.grpc.ForwardingClientCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
-import io.grpc.Status;
 import io.smallrye.stork.api.ServiceInstance;
 
 @ApplicationScoped
 public class StorkMeasuringGrpcInterceptor implements ClientInterceptor, Prioritized {
-
-    public static final Context.Key<AtomicReference<ServiceInstance>> STORK_SERVICE_INSTANCE = Context
-            .key("stork.service-instance");
-    public static final Context.Key<Boolean> STORK_MEASURE_TIME = Context.key("stork.measure-time");
 
     @Override
     public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method, CallOptions callOptions,
@@ -35,19 +28,22 @@ public class StorkMeasuringGrpcInterceptor implements ClientInterceptor, Priorit
         return Integer.MAX_VALUE - 100;
     }
 
-    private static class StorkMeasuringCall<ReqT, RespT> extends ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT> {
+    private static class StorkMeasuringCall<ReqT, RespT> extends AbstractStorkMeasuringCall<ReqT, RespT> {
         ServiceInstance serviceInstance;
-        final boolean recordTime;
 
-        protected StorkMeasuringCall(ClientCall<ReqT, RespT> delegate,
-                MethodDescriptor.MethodType type) {
-            super(delegate);
-            this.recordTime = type == MethodDescriptor.MethodType.UNARY;
+        protected StorkMeasuringCall(ClientCall<ReqT, RespT> delegate, MethodDescriptor.MethodType type) {
+            super(delegate, type == MethodDescriptor.MethodType.UNARY);
+        }
+
+        @Override
+        protected ServiceInstance serviceInstance() {
+            return serviceInstance;
         }
 
         @Override
         public void start(final ClientCall.Listener<RespT> responseListener, final Metadata metadata) {
-            Context context = Context.current().withValues(STORK_SERVICE_INSTANCE, new AtomicReference<>(),
+            Context context = Context.current().withValues(
+                    STORK_SERVICE_INSTANCE, new AtomicReference<>(),
                     STORK_MEASURE_TIME, recordTime);
             Context oldContext = context.attach();
             try {
@@ -56,44 +52,6 @@ public class StorkMeasuringGrpcInterceptor implements ClientInterceptor, Priorit
             } finally {
                 context.detach(oldContext);
             }
-        }
-
-        void recordReply() {
-            if (serviceInstance != null && recordTime) {
-                serviceInstance.recordReply();
-            }
-        }
-
-        void recordEnd(Throwable error) {
-            if (serviceInstance != null) {
-                serviceInstance.recordEnd(error);
-            }
-        }
-    }
-
-    private static class StorkMeasuringCallListener<RespT>
-            extends ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT> {
-        final StorkMeasuringCall<?, ?> collector;
-
-        public StorkMeasuringCallListener(ClientCall.Listener<RespT> responseListener, StorkMeasuringCall<?, ?> collector) {
-            super(responseListener);
-            this.collector = collector;
-        }
-
-        @Override
-        public void onMessage(RespT message) {
-            collector.recordReply();
-            super.onMessage(message);
-        }
-
-        @Override
-        public void onClose(Status status, Metadata trailers) {
-            Exception error = null;
-            if (!status.isOk()) {
-                error = status.asException(trailers);
-            }
-            collector.recordEnd(error);
-            super.onClose(status, trailers);
         }
     }
 }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/VertxStorkMeasuringGrpcInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/stork/VertxStorkMeasuringGrpcInterceptor.java
@@ -1,0 +1,68 @@
+package io.quarkus.grpc.runtime.stork;
+
+import static io.quarkus.grpc.runtime.stork.StorkMeasuringCollector.STORK_MEASURE_TIME;
+import static io.quarkus.grpc.runtime.stork.StorkMeasuringCollector.STORK_SERVICE_INSTANCE;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.Prioritized;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.Context;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.smallrye.stork.api.ServiceInstance;
+
+/**
+ * Similar to {@link StorkMeasuringGrpcInterceptor}, but with different entry points,
+ * since we use delayed {@link StorkGrpcChannel}.
+ */
+@ApplicationScoped
+public class VertxStorkMeasuringGrpcInterceptor implements ClientInterceptor, Prioritized {
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method, CallOptions callOptions,
+            Channel next) {
+        boolean recordTime = method.getType() == MethodDescriptor.MethodType.UNARY;
+        Context context = Context.current().withValues(
+                STORK_SERVICE_INSTANCE, new AtomicReference<>(),
+                STORK_MEASURE_TIME, recordTime);
+        Context oldContext = context.attach();
+        try {
+            return new VertxStorkMeasuringCall<>(next.newCall(method, callOptions), recordTime);
+        } finally {
+            context.detach(oldContext);
+        }
+    }
+
+    @Override
+    public int getPriority() {
+        return Integer.MAX_VALUE - 100;
+    }
+
+    private static class VertxStorkMeasuringCall<ReqT, RespT> extends AbstractStorkMeasuringCall<ReqT, RespT> {
+        ServiceInstance serviceInstance;
+
+        protected VertxStorkMeasuringCall(ClientCall<ReqT, RespT> delegate, boolean recordTime) {
+            super(delegate, recordTime);
+        }
+
+        @Override
+        protected ServiceInstance serviceInstance() {
+            return serviceInstance;
+        }
+
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata metadata) {
+            AtomicReference<ServiceInstance> ref = STORK_SERVICE_INSTANCE.get();
+            if (ref != null) {
+                serviceInstance = ref.get();
+            }
+            super.start(new StorkMeasuringCallListener<>(responseListener, this), metadata);
+        }
+    }
+}

--- a/integration-tests/grpc-mutual-auth/src/main/resources/application.properties
+++ b/integration-tests/grpc-mutual-auth/src/main/resources/application.properties
@@ -7,7 +7,7 @@ quarkus.grpc.clients.hello.name-resolver=stork
 quarkus.stork."hello-service".service-discovery.type=static
 quarkus.stork."hello-service".service-discovery.address-list=${quarkus.http.host}:9001
 #%test.quarkus.stork."hello-service".service-discovery.address-list=${quarkus.http.host}:9001
-#%vertx.quarkus.stork."hello-service".service-discovery.address-list=${quarkus.http.host}:8444
+%vertx.quarkus.stork."hello-service".service-discovery.address-list=${quarkus.http.host}:8444
 quarkus.stork."hello-service".load-balancer.type=round-robin
 
 quarkus.grpc.clients.hello.ssl.certificate=tls/client.pem

--- a/integration-tests/grpc-mutual-auth/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldMutualTlsServiceTest.java
+++ b/integration-tests/grpc-mutual-auth/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldMutualTlsServiceTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.grpc.examples.hello;
 
+import static io.quarkus.grpc.test.utils.GRPCTestUtils.stream;
+
 import java.io.InputStream;
 
 import org.junit.jupiter.api.AfterEach;

--- a/integration-tests/grpc-mutual-auth/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldMutualTlsServiceTestBase.java
+++ b/integration-tests/grpc-mutual-auth/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldMutualTlsServiceTestBase.java
@@ -2,7 +2,6 @@ package io.quarkus.grpc.examples.hello;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.InputStream;
 import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
@@ -16,10 +15,6 @@ import io.grpc.Channel;
 class HelloWorldMutualTlsServiceTestBase {
 
     Channel channel;
-
-    protected InputStream stream(String resource) {
-        return getClass().getClassLoader().getResourceAsStream(resource);
-    }
 
     @Test
     public void testHelloWorldServiceUsingBlockingStub() {

--- a/integration-tests/grpc-mutual-auth/src/test/java/io/quarkus/grpc/examples/hello/VertxHelloWorldMutualTlsEndpointTest.java
+++ b/integration-tests/grpc-mutual-auth/src/test/java/io/quarkus/grpc/examples/hello/VertxHelloWorldMutualTlsEndpointTest.java
@@ -2,8 +2,6 @@ package io.quarkus.grpc.examples.hello;
 
 import jakarta.inject.Inject;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.grpc.test.utils.VertxGRPCTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -11,7 +9,6 @@ import io.vertx.core.Vertx;
 
 @QuarkusTest
 @TestProfile(VertxGRPCTestProfile.class)
-@Disabled
 class VertxHelloWorldMutualTlsEndpointTest extends VertxHelloWorldMutualTlsEndpointTestBase {
 
     @Inject

--- a/integration-tests/grpc-mutual-auth/src/test/java/io/quarkus/grpc/examples/hello/VertxHelloWorldMutualTlsServiceIT.java
+++ b/integration-tests/grpc-mutual-auth/src/test/java/io/quarkus/grpc/examples/hello/VertxHelloWorldMutualTlsServiceIT.java
@@ -2,10 +2,9 @@ package io.quarkus.grpc.examples.hello;
 
 import java.util.Map;
 
-import jakarta.inject.Inject;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 
 import io.grpc.Channel;
 import io.quarkus.grpc.test.utils.GRPCTestUtils;
@@ -17,15 +16,19 @@ import io.vertx.grpc.client.GrpcClient;
 
 @QuarkusTest
 @TestProfile(VertxGRPCTestProfile.class)
-class VertxHelloWorldMutualTlsServiceTest extends HelloWorldMutualTlsServiceTestBase {
+@Disabled("quarkus.http.ssl.client-auth is set to 'required' but it is build time fixed to 'NONE'. " +
+        "Did you change the property quarkus.http.ssl.client-auth after building the application?" +
+        "" +
+        "How to get around this? ... As this would be a good / needed requirement for Vert.x based gRPC native test?")
+class VertxHelloWorldMutualTlsServiceIT extends HelloWorldMutualTlsServiceTestBase {
 
-    @Inject
     Vertx vertx;
 
     GrpcClient client;
 
     @BeforeEach
     public void init() throws Exception {
+        vertx = Vertx.vertx();
         Map.Entry<GrpcClient, Channel> pair = GRPCTestUtils.tls(vertx, "tls/ca.pem", "tls/client.pem", "tls/client.key");
         client = pair.getKey();
         channel = pair.getValue();
@@ -34,6 +37,7 @@ class VertxHelloWorldMutualTlsServiceTest extends HelloWorldMutualTlsServiceTest
     @AfterEach
     public void cleanup() {
         GRPCTestUtils.close(client);
+        GRPCTestUtils.close(vertx);
     }
 
 }

--- a/integration-tests/grpc-stork-response-time/pom.xml
+++ b/integration-tests/grpc-stork-response-time/pom.xml
@@ -32,6 +32,12 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-grpc</artifactId>
+      <version>${project.version}</version> <!--kept here to not pollute the BOM-->
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>

--- a/integration-tests/grpc-stork-response-time/src/main/resources/application.properties
+++ b/integration-tests/grpc-stork-response-time/src/main/resources/application.properties
@@ -13,3 +13,6 @@ quarkus.stork.hello-service2.service-discovery.address-list=localhost:9013,local
 quarkus.stork.hello-service2.load-balancer.type=least-response-time
 
 #quarkus.log.category."io.quarkus.grpc.runtime.stork".level=DEBUG
+
+%vertx.quarkus.grpc.clients.hello1.use-quarkus-grpc-client=true
+%vertx.quarkus.grpc.clients.hello2.use-quarkus-grpc-client=true

--- a/integration-tests/grpc-stork-response-time/src/test/java/io/quarkus/grpc/examples/stork/GrpcStorkResponseTimeCollectionTest.java
+++ b/integration-tests/grpc-stork-response-time/src/test/java/io/quarkus/grpc/examples/stork/GrpcStorkResponseTimeCollectionTest.java
@@ -1,54 +1,7 @@
 package io.quarkus.grpc.examples.stork;
 
-import static io.restassured.RestAssured.get;
-import static io.restassured.RestAssured.given;
-import static io.restassured.RestAssured.post;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-
 import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.response.Response;
 
 @QuarkusTest
-class GrpcStorkResponseTimeCollectionTest {
-
-    @Test
-    public void shouldCallConfigurableIfFaster() {
-        given().body("0")
-                .when().post("/test/delay")
-                .then().statusCode(200);
-        List<String> responses = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            Response response = get("/test/unary/1");
-            response.then().statusCode(200);
-            responses.add(response.asString());
-        }
-
-        assertThat(responses.stream().filter(r -> r.equals("moderately-slow")))
-                .hasSizeLessThan(5);
-        assertThat(responses.stream().filter(r -> r.equals("configurable")))
-                .hasSizeGreaterThan(5);
-    }
-
-    @Test
-    public void shouldCallModerateIfFaster() {
-        given().body("1000")
-                .when().post("/test/delay")
-                .then().statusCode(200);
-        List<String> responses = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            Response response = get("/test/unary/2");
-            response.then().statusCode(200);
-            responses.add(response.asString());
-        }
-
-        assertThat(responses.stream().filter(r -> r.equals("moderately-slow")))
-                .hasSizeGreaterThan(5);
-        assertThat(responses.stream().filter(r -> r.equals("configurable")))
-                .hasSizeLessThan(5);
-    }
+class GrpcStorkResponseTimeCollectionTest extends GrpcStorkResponseTimeCollectionTestBase {
 }

--- a/integration-tests/grpc-stork-response-time/src/test/java/io/quarkus/grpc/examples/stork/GrpcStorkResponseTimeCollectionTestBase.java
+++ b/integration-tests/grpc-stork-response-time/src/test/java/io/quarkus/grpc/examples/stork/GrpcStorkResponseTimeCollectionTestBase.java
@@ -1,0 +1,51 @@
+package io.quarkus.grpc.examples.stork;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.restassured.response.Response;
+
+class GrpcStorkResponseTimeCollectionTestBase {
+
+    @Test
+    public void shouldCallConfigurableIfFaster() {
+        given().body("0")
+                .when().post("/test/delay")
+                .then().statusCode(200);
+        List<String> responses = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Response response = get("/test/unary/1");
+            response.then().statusCode(200);
+            responses.add(response.asString());
+        }
+
+        assertThat(responses.stream().filter(r -> r.equals("moderately-slow")))
+                .hasSizeLessThan(5);
+        assertThat(responses.stream().filter(r -> r.equals("configurable")))
+                .hasSizeGreaterThan(5);
+    }
+
+    @Test
+    public void shouldCallModerateIfFaster() {
+        given().body("1000")
+                .when().post("/test/delay")
+                .then().statusCode(200);
+        List<String> responses = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Response response = get("/test/unary/2");
+            response.then().statusCode(200);
+            responses.add(response.asString());
+        }
+
+        assertThat(responses.stream().filter(r -> r.equals("moderately-slow")))
+                .hasSizeGreaterThan(5);
+        assertThat(responses.stream().filter(r -> r.equals("configurable")))
+                .hasSizeLessThan(5);
+    }
+}

--- a/integration-tests/grpc-stork-response-time/src/test/java/io/quarkus/grpc/examples/stork/VertxGrpcStorkResponseTimeCollectionTest.java
+++ b/integration-tests/grpc-stork-response-time/src/test/java/io/quarkus/grpc/examples/stork/VertxGrpcStorkResponseTimeCollectionTest.java
@@ -1,0 +1,10 @@
+package io.quarkus.grpc.examples.stork;
+
+import io.quarkus.grpc.test.utils.VertxGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(VertxGRPCTestProfile.class)
+class VertxGrpcStorkResponseTimeCollectionTest extends GrpcStorkResponseTimeCollectionTestBase {
+}

--- a/integration-tests/grpc-stork-simple/pom.xml
+++ b/integration-tests/grpc-stork-simple/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-grpc-stork-simple</artifactId>
+    <name>Quarkus - Integration Tests - gRPC - Stork - Simple</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-service-discovery-static-list</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-grpc</artifactId>
+            <version>${project.version}</version> <!--kept here to not pollute the BOM-->
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-code</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/grpc-stork-simple/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldNewService.java
+++ b/integration-tests/grpc-stork-simple/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldNewService.java
@@ -1,0 +1,18 @@
+package io.quarkus.grpc.examples.hello;
+
+import examples.HelloReply;
+import examples.HelloRequest;
+import examples.MutinyGreeterGrpc;
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class HelloWorldNewService extends MutinyGreeterGrpc.GreeterImplBase {
+
+    @Override
+    public Uni<HelloReply> sayHello(HelloRequest request) {
+        String name = request.getName();
+        return Uni.createFrom().item("Hello " + name)
+                .map(res -> HelloReply.newBuilder().setMessage(res).build());
+    }
+}

--- a/integration-tests/grpc-stork-simple/src/main/proto/helloworld.proto
+++ b/integration-tests/grpc-stork-simple/src/main/proto/helloworld.proto
@@ -1,0 +1,53 @@
+// Copyright 2015, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "examples";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/integration-tests/grpc-stork-simple/src/main/resources/application.properties
+++ b/integration-tests/grpc-stork-simple/src/main/resources/application.properties
@@ -1,0 +1,15 @@
+quarkus.grpc.clients.hello.host=hello-service
+quarkus.grpc.clients.hello.name-resolver=stork
+
+quarkus.stork."hello-service".service-discovery.type=static
+quarkus.stork."hello-service".service-discovery.address-list=badd-url:9000,${quarkus.http.host}:9001
+%vertx.quarkus.stork."hello-service".service-discovery.address-list=badd-url:8081,${quarkus.http.host}:8081
+quarkus.stork."hello-service".load-balancer.type=round-robin
+
+quarkus.grpc.server.port=9001
+
+quarkus.grpc.clients.hello.port=9001
+
+%vertx.quarkus.grpc.clients.hello.port=8081
+%vertx.quarkus.grpc.clients.hello.use-quarkus-grpc-client=true
+%vertx.quarkus.grpc.server.use-separate-server=false

--- a/integration-tests/grpc-stork-simple/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewServiceTest.java
+++ b/integration-tests/grpc-stork-simple/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewServiceTest.java
@@ -1,0 +1,8 @@
+package io.quarkus.grpc.examples.hello;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class HelloWorldNewServiceTest extends HelloWorldNewServiceTestBase {
+
+}

--- a/integration-tests/grpc-stork-simple/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewServiceTestBase.java
+++ b/integration-tests/grpc-stork-simple/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldNewServiceTestBase.java
@@ -1,0 +1,36 @@
+package io.quarkus.grpc.examples.hello;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import examples.GreeterGrpc;
+import examples.HelloReply;
+import examples.HelloRequest;
+import examples.MutinyGreeterGrpc;
+import io.quarkus.grpc.GrpcClient;
+
+class HelloWorldNewServiceTestBase {
+
+    @GrpcClient("hello")
+    GreeterGrpc.GreeterBlockingStub stub;
+
+    @GrpcClient("hello")
+    MutinyGreeterGrpc.MutinyGreeterStub mutiny;
+
+    @Test
+    public void testHelloWorldServiceUsingBlockingStub() {
+        HelloReply reply = stub.sayHello(HelloRequest.newBuilder().setName("neo-blocking").build());
+        Assertions.assertEquals(reply.getMessage(), "Hello neo-blocking");
+    }
+
+    @Test
+    public void testHelloWorldServiceUsingMutinyStub() {
+        HelloReply reply = mutiny
+                .sayHello(HelloRequest.newBuilder().setName("neo-blocking").build())
+                .await().atMost(Duration.ofSeconds(5));
+        Assertions.assertEquals(reply.getMessage(), "Hello neo-blocking");
+    }
+
+}

--- a/integration-tests/grpc-stork-simple/src/test/java/io/quarkus/grpc/examples/hello/VertxHelloWorldNewServiceTest.java
+++ b/integration-tests/grpc-stork-simple/src/test/java/io/quarkus/grpc/examples/hello/VertxHelloWorldNewServiceTest.java
@@ -1,0 +1,11 @@
+package io.quarkus.grpc.examples.hello;
+
+import io.quarkus.grpc.test.utils.VertxGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(VertxGRPCTestProfile.class)
+class VertxHelloWorldNewServiceTest extends HelloWorldNewServiceTestBase {
+
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -351,6 +351,7 @@
                 <module>grpc-external-proto</module>
                 <module>grpc-external-proto-test</module>
                 <module>grpc-stork-response-time</module>
+                <module>grpc-stork-simple</module>
                 <module>grpc-exceptions</module>
                 <module>google-cloud-functions-http</module>
                 <module>google-cloud-functions</module>


### PR DESCRIPTION
This PR adds a bit simplistic Stork support -- wrt existing Netty based one.
It does "copy" the concepts of the existing support, but it does it on the Channel level,
hence a few changes were needed to Stork intrerceptor, etc.

It also adds a basic use-case / example in the form of a test, on how load balancing is used.

What it does not add, is a more dynamic up-to-date state of services.
A simple clear + full refresh is periodically implemented atm.