### PR TITLE
Disable Vert.x websockets when websocket extensions are not present 

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -92,8 +92,8 @@
         },
         {
             "category": "HTTP",
-            "timeout": 90,
-            "test-modules": "elytron-resteasy, resteasy-jackson, elytron-resteasy-reactive, resteasy-mutiny, resteasy-reactive-kotlin/standard, vertx, vertx-http, vertx-web, vertx-web-jackson, vertx-graphql, virtual-http, rest-client, rest-client-reactive, rest-client-reactive-stork, rest-client-reactive-multipart",
+            "timeout": 95,
+            "test-modules": "elytron-resteasy, resteasy-jackson, elytron-resteasy-reactive, resteasy-mutiny, resteasy-reactive-kotlin/standard, vertx, vertx-http, vertx-web, vertx-web-jackson, vertx-graphql, virtual-http, rest-client, rest-client-reactive, rest-client-reactive-stork, rest-client-reactive-multipart, websockets",
             "os-name": "ubuntu-latest"
         },
         {

--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -128,6 +128,7 @@ public interface Capability {
     String VERTX = QUARKUS_PREFIX + ".vertx";
     String VERTX_CORE = VERTX + ".core";
     String VERTX_HTTP = VERTX + ".http";
+    String VERTX_WEBSOCKETS = VERTX + ".websockets";
 
     String APICURIO_REGISTRY = QUARKUS_PREFIX + ".apicurio.registry";
     String APICURIO_REGISTRY_AVRO = APICURIO_REGISTRY + ".avro";

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -23,6 +23,8 @@ import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.builder.BuildException;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -348,6 +350,7 @@ class VertxHttpProcessor {
             Optional<RequireVirtualHttpBuildItem> requireVirtual,
             EventLoopCountBuildItem eventLoopCount,
             List<WebsocketSubProtocolsBuildItem> websocketSubProtocols,
+            Capabilities capabilities,
             VertxHttpRecorder recorder) throws IOException {
         boolean startVirtual = requireVirtual.isPresent() || httpBuildTimeConfig.virtual;
         if (startVirtual) {
@@ -361,7 +364,7 @@ class VertxHttpProcessor {
                 eventLoopCount.getEventLoopCount(),
                 websocketSubProtocols.stream().map(bi -> bi.getWebsocketSubProtocols())
                         .collect(Collectors.toList()),
-                launchMode.isAuxiliaryApplication());
+                launchMode.isAuxiliaryApplication(), !capabilities.isPresent(Capability.VERTX_WEBSOCKETS));
     }
 
     @BuildStep

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -128,6 +128,8 @@ public class VertxHttpRecorder {
 
     public static final String MAX_REQUEST_SIZE_KEY = "io.quarkus.max-request-size";
 
+    private static final String DISABLE_WEBSOCKETS_PROP_NAME = "vertx.disableWebsockets";
+
     /**
      * Order mark for route with priority over the default route (add an offset from this mark)
      **/
@@ -163,7 +165,6 @@ public class VertxHttpRecorder {
 
         /** JVM system property that disables URI validation, don't use this in production. */
         private static final String DISABLE_URI_VALIDATION_PROP_NAME = "vertx.disableURIValidation";
-
         /**
          * Disables HTTP headers validation, so we can save some processing and save some allocations.
          */
@@ -297,8 +298,13 @@ public class VertxHttpRecorder {
     public void startServer(Supplier<Vertx> vertx, ShutdownContext shutdown,
             LaunchMode launchMode,
             boolean startVirtual, boolean startSocket, Supplier<Integer> ioThreads, List<String> websocketSubProtocols,
-            boolean auxiliaryApplication)
+            boolean auxiliaryApplication, boolean disableWebSockets)
             throws IOException {
+
+        // disable websockets if we have determined at build time that we should and the user has not overridden the relevant Vert.x property
+        if (disableWebSockets && !System.getProperties().containsKey(DISABLE_WEBSOCKETS_PROP_NAME)) {
+            System.setProperty(DISABLE_WEBSOCKETS_PROP_NAME, "true");
+        }
 
         if (startVirtual) {
             initializeVirtual(vertx.get());

--- a/extensions/websockets/server/runtime/pom.xml
+++ b/extensions/websockets/server/runtime/pom.xml
@@ -60,6 +60,9 @@
                         <excludedArtifact>org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec</excludedArtifact>
                         <excludedArtifact>javax.websocket:javax.websocket-api</excludedArtifact>
                     </excludedArtifacts>
+                    <capabilities>
+                        <provides>io.quarkus.vertx.websockets</provides>
+                    </capabilities>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/opentelemetry/pom.xml
+++ b/integration-tests/opentelemetry/pom.xml
@@ -132,6 +132,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <vertx.disableWebsockets>false</vertx.disableWebsockets>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -155,6 +164,9 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skipTests>${native.surefire.skip}</skipTests>
+                            <systemPropertyVariables>
+                                <vertx.disableWebsockets>false</vertx.disableWebsockets>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
 
@@ -168,6 +180,7 @@
                                 </goals>
                                 <configuration>
                                     <systemPropertyVariables>
+                                        <vertx.disableWebsockets>false</vertx.disableWebsockets>
                                         <native.image.path>
                                             ${project.build.directory}/${project.build.finalName}-runner
                                         </native.image.path>

--- a/integration-tests/websockets/src/test/java/io/quarkus/websockets/ChatIT.java
+++ b/integration-tests/websockets/src/test/java/io/quarkus/websockets/ChatIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.websockets;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ChatIT extends ChatTest {
+}


### PR DESCRIPTION
The reason this is done is that @franz1981 found that due to
type pollution, the Netty Websockets handler introduces
non-trivial performance overhead, which users that are not
using websockets have no reason to pay.

Closes: #31716