### PR TITLE
CI Fork Maven Cache job config tweaks

### DIFF
--- a/.github/workflows/ci-fork-mvn-cache.yml
+++ b/.github/workflows/ci-fork-mvn-cache.yml
@@ -20,6 +20,7 @@ on:
   schedule:
     # first day of month at 12:10am
     - cron: '10 0 1 * *'
+  workflow_dispatch:
 
 concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"

--- a/.github/workflows/ci-fork-mvn-cache.yml
+++ b/.github/workflows/ci-fork-mvn-cache.yml
@@ -55,8 +55,10 @@ jobs:
           # refresh cache every month to avoid unlimited growth
           key: q2maven-${{ steps.get-date.outputs.date }}
       - name: Build
+        if: steps.cache-maven.outputs.cache-hit != 'true'
         run: |
           ./mvnw -T1C -e -B --settings .github/mvn-settings.xml -Dquickly-ci -Dtcks clean install
       - name: Delete Local Artifacts From Cache
+        if: steps.cache-maven.outputs.cache-hit != 'true'
         shell: bash
         run: rm -r ~/.m2/repository/io/quarkus


### PR DESCRIPTION
The "Quarkus CI Fork Maven Cache" job [1] runs on forks by schedule on the 1st of each month, and on each push to main (with some file exclusions).

This adds a workflow_dispatch trigger so that the job can be run manually, e.g if you delete your cache from the UI you can also then just trigger the job from the UI rather than having to actually push something to main again.

It also adds config to skip running the quarkus build when a cache hit occurred, because running the build in those cases will not result in updating the cache, it just burns resources. The cache key is set to a monthly fixed value so after the first successful population of the cache each month, most typically during the scheduled run, the cache is then fixed (whether a different setup could be used might be a wider change to consider later).

[1] https://github.com/quarkusio/quarkus/blob/9a520b9d45d5d647cdf20dce70d2d1dfec1bc6f3/.github/workflows/ci-fork-mvn-cache.yml