### PR TITLE
Fix handling of required builders for gradle tasks

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageBuild.java
@@ -1,29 +1,21 @@
 
 package io.quarkus.gradle.tasks;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
-import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
 public abstract class ImageBuild extends ImageTask {
 
-    public enum Builder {
-        docker,
-        jib,
-        buildpack,
-        openshift
-    }
-
-    Builder builder = Builder.docker;
+    Optional<Builder> builder = Optional.empty();
 
     @Option(option = "builder", description = "The container image extension to use for building the image (e.g. docker, jib, buildpack, openshift).")
     public void setBuilder(Builder builder) {
-        this.builder = builder;
+        this.builder = Optional.of(builder);
     }
 
     @Inject
@@ -33,24 +25,13 @@ public abstract class ImageBuild extends ImageTask {
 
     @Override
     public Map<String, String> forcedProperties() {
-        return Map.of("quarkus.container-image.build", "true",
-                "quarkus.container-image.builder", builder.name());
+        return builder().map(b -> Map.of(QUARKUS_CONTAINER_IMAGE_BUILD, "true", QUARKUS_CONTAINER_IMAGE_BUILDER, b.name()))
+                .orElse(Collections.emptyMap());
     }
 
-    @TaskAction
-    public void checkRequiredExtensions() {
-        // Currently forcedDependencies() is not implemented for gradle.
-        // So, let's give users a meaningful warning message.
-        String requiredExtension = "quarkus-container-image-" + builder.name();
-        String requiredDependency = requiredExtension + "-deployment";
-        List<String> projectDependencies = getProject().getConfigurations().stream().flatMap(c -> c.getDependencies().stream())
-                .map(d -> d.getName())
-                .collect(Collectors.toList());
-
-        if (!projectDependencies.contains(requiredDependency)) {
-            getProject().getLogger().warn("Task: {} requires extensions: {}", getName(), requiredDependency);
-            getProject().getLogger().warn("To add the extensions to the project you can run the following command:");
-            getProject().getLogger().warn("\tgradle addExtension --extensions={}", requiredExtension);
-        }
+    public Optional<Builder> builder() {
+        return builder
+                .or(() -> builderFromSystemProperties())
+                .or(() -> availableBuilders().stream().findFirst());
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImagePush.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImagePush.java
@@ -19,7 +19,7 @@ public abstract class ImagePush extends ImageTask {
 
     @Override
     public Map<String, String> forcedProperties() {
-        return Map.of("quarkus.container-image.push", "true");
+        return Map.of(QUARKUS_CONTAINER_IMAGE_PUSH, "true");
     }
 
     @TaskAction
@@ -27,11 +27,11 @@ public abstract class ImagePush extends ImageTask {
         List<String> containerImageExtensions = getProject().getConfigurations().stream()
                 .flatMap(c -> c.getDependencies().stream())
                 .map(d -> d.getName())
-                .filter(n -> n.startsWith("quarkus-container-image"))
+                .filter(n -> n.startsWith(QUARKUS_CONTAINER_IMAGE_PREFIX))
                 .map(n -> n.replaceAll("-deployment$", ""))
                 .collect(Collectors.toList());
 
-        List<String> extensions = Arrays.stream(ImageBuild.Builder.values()).map(b -> "quarkus-container-image-" + b.name())
+        List<String> extensions = Arrays.stream(ImageBuild.Builder.values()).map(b -> QUARKUS_CONTAINER_IMAGE_PREFIX + b.name())
                 .collect(Collectors.toList());
 
         if (containerImageExtensions.isEmpty()) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageTask.java
@@ -1,9 +1,37 @@
 
 package io.quarkus.gradle.tasks;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.gradle.api.tasks.StopExecutionException;
+import org.gradle.api.tasks.TaskAction;
 
 public abstract class ImageTask extends QuarkusBuildProviderTask {
+
+    static final String QUARKUS_CONTAINER_IMAGE_PREFIX = "quarkus-container-image-";
+    static final String QUARKUS_CONTAINER_IMAGE_BUILD = "quarkus.container-image.build";
+    static final String QUARKUS_CONTAINER_IMAGE_PUSH = "quarkus.container-image.push";
+    static final String QUARKUS_CONTAINER_IMAGE_BUILDER = "quarkus.container-image.builder";
+
+    static final Map<String, Builder> BUILDERS = new HashMap<>();
+    static {
+        for (Builder builder : Builder.values()) {
+            BUILDERS.put(builder.name(), builder);
+        }
+    }
+
+    enum Builder {
+        docker,
+        jib,
+        buildpack,
+        openshift
+    }
 
     public ImageTask(QuarkusBuildConfiguration buildConfiguration, String description) {
         super(buildConfiguration, description);
@@ -11,6 +39,56 @@ public abstract class ImageTask extends QuarkusBuildProviderTask {
 
     @Override
     public Map<String, String> forcedProperties() {
-        return Map.of("quarkus.container-image.build", "true");
+        return Map.of(QUARKUS_CONTAINER_IMAGE_BUILD, "true");
+    }
+
+    Optional<Builder> builder() {
+        return builderFromSystemProperties();
+    }
+
+    Optional<Builder> builderFromSystemProperties() {
+        return Optional.ofNullable(System.getProperty(QUARKUS_CONTAINER_IMAGE_BUILDER))
+                .filter(BUILDERS::containsKey)
+                .map(BUILDERS::get);
+    }
+
+    List<Builder> availableBuilders() {
+        return getProject().getConfigurations().stream().flatMap(c -> c.getDependencies().stream())
+                .map(d -> d.getName())
+                .filter(n -> n.startsWith(QUARKUS_CONTAINER_IMAGE_PREFIX))
+                .map(n -> n.replace(QUARKUS_CONTAINER_IMAGE_PREFIX, ""))
+                .filter(BUILDERS::containsKey)
+                .map(BUILDERS::get)
+                .collect(Collectors.toList());
+    }
+
+    @TaskAction
+    public void checkRequiredExtensions() {
+        // Currently forcedDependencies() is not implemented for gradle.
+        // So, let's give users a meaningful warning message.
+        List<Builder> availableBuidlers = availableBuilders();
+        Optional<Builder> missingBuilder = builder().filter(Predicate.not(availableBuidlers::contains));
+        missingBuilder.map(builder -> QUARKUS_CONTAINER_IMAGE_PREFIX + builder.name()).ifPresent(missingDependency -> {
+            getProject().getLogger().warn("Task: {} requires extensions: {}", getName(), missingDependency);
+            getProject().getLogger().warn("To add the extensions to the project you can run the following command:");
+            getProject().getLogger().warn("\tgradle addExtension --extensions={}", missingDependency);
+            abort("Aborting.");
+        });
+
+        if (!missingBuilder.isPresent() && availableBuidlers.isEmpty()) {
+            getProject().getLogger().warn("Task: {} requires on of extensions: {}", getName(),
+                    Arrays.stream(Builder.values()).map(Builder::name).collect(Collectors.joining(", ", "[", "]")));
+            getProject().getLogger().warn("To add the extensions to the project you can run the following command:");
+            getProject().getLogger().warn("\tgradle addExtension --extensions=<extension name>");
+            abort("Aborting.");
+        }
+    }
+
+    void abort(String message, Object... args) {
+        getProject().getLogger().warn(message, args);
+        getProject().getTasks().stream().filter(t -> t != this).forEach(t -> {
+            t.setEnabled(false);
+        });
+        throw new StopExecutionException();
     }
 }


### PR DESCRIPTION
Resolves: #31698 

The pull request changes the gradle image build / push tasks so that they check the available builders before printing a warning.
In addition some code moved to the ImageTassk class and also some constants replaced String that were occurring multiple times in the code.