### PR TITLE
OpenShift binary build fails when current namespace is different

### DIFF
--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.container.image.openshift.deployment;
 
+import static io.quarkus.container.image.openshift.deployment.OpenshiftUtils.getNamespace;
 import static io.quarkus.container.image.openshift.deployment.OpenshiftUtils.mergeConfig;
 import static io.quarkus.container.util.PathsUtil.findMainSourcesRoot;
 import static io.quarkus.deployment.pkg.steps.JarResultBuildStep.DEFAULT_FAST_JAR_DIRECTORY_NAME;
@@ -264,7 +265,7 @@ public class OpenshiftProcessor {
             return;
         }
 
-        try (KubernetesClient kubernetesClient = kubernetesClientBuilder.buildClient()) {
+        try (KubernetesClient kubernetesClient = buildClient(kubernetesClientBuilder)) {
             String namespace = Optional.ofNullable(kubernetesClient.getNamespace()).orElse("default");
             LOG.info("Starting (in-cluster) container image build for jar using: " + config.buildStrategy + " on server: "
                     + kubernetesClient.getMasterUrl() + " in namespace:" + namespace + ".");
@@ -324,7 +325,7 @@ public class OpenshiftProcessor {
             return;
         }
 
-        try (KubernetesClient kubernetesClient = kubernetesClientBuilder.buildClient()) {
+        try (KubernetesClient kubernetesClient = buildClient(kubernetesClientBuilder)) {
             String namespace = Optional.ofNullable(kubernetesClient.getNamespace()).orElse("default");
 
             LOG.info("Starting (in-cluster) container image build for jar using: " + config.buildStrategy + " on server: "
@@ -541,6 +542,11 @@ public class OpenshiftProcessor {
         configuration.setHttp2Disable(true);
 
         return new KubernetesClientBuilder().withConfig(configuration).withHttpClientFactory(httpClientFactory);
+    }
+
+    private static KubernetesClient buildClient(KubernetesClientBuildItem kubernetesClientBuilder) {
+        getNamespace().ifPresent(kubernetesClientBuilder.getConfig()::setNamespace);
+        return kubernetesClientBuilder.buildClient();
     }
 
     // visible for test

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftUtils.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftUtils.java
@@ -28,6 +28,9 @@ import io.fabric8.openshift.client.OpenShiftClient;
  */
 public class OpenshiftUtils {
 
+    private static final String OPENSHIFT_NAMESPACE = "quarkus.openshift.namespace";
+    private static final String KUBERNETES_NAMESPACE = "quarkus.kubernetes.namespace";
+
     /**
      * Wait for the references ImageStreamTags to become available.
      *
@@ -141,5 +144,13 @@ public class OpenshiftUtils {
         result.buildStrategy = openshiftConfig.buildStrategy;
 
         return result;
+    }
+
+    /**
+     * @return the openshift namespace set in the OpenShift extension.
+     */
+    public static Optional<String> getNamespace() {
+        return ConfigProvider.getConfig().getOptionalValue(OPENSHIFT_NAMESPACE, String.class)
+                .or(() -> ConfigProvider.getConfig().getOptionalValue(KUBERNETES_NAMESPACE, String.class));
     }
 }


### PR DESCRIPTION
If we select either `quarkus.kubernetes.namespace=XX` or `quarkus.openshift.namespace=XX`, the namespace `XX` should be used instead of the namespace that is configured by default (via `oc project YY` for example).

Fix https://github.com/quarkusio/quarkus/issues/26180