### PR TITLE
Allows JSON-RPC method to return Uni<?> and add support for @Blocking and @NonBlocking

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -59,6 +59,8 @@ import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarResultsBuildItem;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
 import io.smallrye.mutiny.Multi;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
@@ -272,9 +274,15 @@ public class DevUIProcessor {
                                     params.put(parameterName, parameterClass);
                                 }
                                 JsonRpcMethod jsonRpcMethod = new JsonRpcMethod(clazz, method.name(), params);
+                                jsonRpcMethod.setExplicitlyBlocking(method.hasAnnotation(Blocking.class));
+                                jsonRpcMethod
+                                        .setExplicitlyNonBlocking(method.hasAnnotation(NonBlocking.class));
                                 jsonRpcMethods.put(jsonRpcMethodName, jsonRpcMethod);
                             } else {
                                 JsonRpcMethod jsonRpcMethod = new JsonRpcMethod(clazz, method.name(), null);
+                                jsonRpcMethod.setExplicitlyBlocking(method.hasAnnotation(Blocking.class));
+                                jsonRpcMethod
+                                        .setExplicitlyNonBlocking(method.hasAnnotation(NonBlocking.class));
                                 jsonRpcMethods.put(jsonRpcMethodName, jsonRpcMethod);
                             }
                         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/comms/ReflectionInfo.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/comms/ReflectionInfo.java
@@ -4,25 +4,47 @@ import java.lang.reflect.Method;
 import java.util.Map;
 
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
 
 /**
  * Contains reflection info on the beans that needs to be called from the jsonrpc router
  */
 public class ReflectionInfo {
+    private final boolean blocking;
+    private final boolean nonBlocking;
     public Class bean;
     public Object instance;
     public Method method;
     public Map<String, Class> params;
 
-    public ReflectionInfo(Class bean, Object instance, Method method, Map<String, Class> params) {
+    public ReflectionInfo(Class bean, Object instance, Method method, Map<String, Class> params, boolean explicitlyBlocking,
+            boolean explicitlyNonBlocking) {
         this.bean = bean;
         this.instance = instance;
         this.method = method;
         this.params = params;
+        this.blocking = explicitlyBlocking;
+        this.nonBlocking = explicitlyNonBlocking;
+        if (blocking && nonBlocking) {
+            throw new IllegalArgumentException("The method " + method.getDeclaringClass().getName() + "." + method.getName()
+                    + " cannot be annotated with @Blocking and @NonBlocking");
+        }
     }
 
-    public boolean isSubscription() {
+    public boolean isReturningMulti() {
         Class<?> returnType = this.method.getReturnType();
         return returnType.getName().equals(Multi.class.getName());
+    }
+
+    public boolean isExplicitlyBlocking() {
+        return blocking;
+    }
+
+    public boolean isExplicitlyNonBlocking() {
+        return nonBlocking;
+    }
+
+    public boolean isReturningUni() {
+        return method.getReturnType().getName().equals(Uni.class.getName());
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcMethod.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcMethod.java
@@ -7,6 +7,9 @@ public final class JsonRpcMethod {
     private String methodName;
     private Map<String, Class> params;
 
+    private boolean isExplicitlyBlocking;
+    private boolean isExplicitlyNonBlocking;
+
     public JsonRpcMethod() {
     }
 
@@ -42,6 +45,22 @@ public final class JsonRpcMethod {
 
     public void setParams(Map<String, Class> params) {
         this.params = params;
+    }
+
+    public boolean getExplicitlyBlocking() {
+        return isExplicitlyBlocking;
+    }
+
+    public void setExplicitlyBlocking(boolean blocking) {
+        isExplicitlyBlocking = blocking;
+    }
+
+    public boolean getExplicitlyNonBlocking() {
+        return isExplicitlyNonBlocking;
+    }
+
+    public void setExplicitlyNonBlocking(boolean nonblocking) {
+        isExplicitlyNonBlocking = nonblocking;
     }
 
     @Override

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcWriter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/jsonrpc/JsonRpcWriter.java
@@ -3,6 +3,7 @@ package io.quarkus.devui.runtime.jsonrpc;
 import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.CODE;
 import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.ERROR;
 import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.ID;
+import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.INTERNAL_ERROR;
 import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.JSONRPC;
 import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.MESSAGE;
 import static io.quarkus.devui.runtime.jsonrpc.JsonRpcKeys.MESSAGE_TYPE;
@@ -36,6 +37,17 @@ public class JsonRpcWriter {
         JsonObject jsonRpcError = JsonObject.of(
                 CODE, METHOD_NOT_FOUND,
                 MESSAGE, "Method [" + jsonRpcMethodName + "] not found");
+
+        return JsonObject.of(
+                ID, id,
+                JSONRPC, VERSION,
+                ERROR, jsonRpcError);
+    }
+
+    public static JsonObject writeErrorResponse(int id, String jsonRpcMethodName, Throwable exception) {
+        JsonObject jsonRpcError = JsonObject.of(
+                CODE, INTERNAL_ERROR,
+                MESSAGE, "Method [" + jsonRpcMethodName + "] failed: " + exception.getMessage());
 
         return JsonObject.of(
                 ID, id,


### PR DESCRIPTION
Now, JSON-PRC methods not annotated with @NonBlocking and not returning a Uni are invoked on a worker thread.
Methods annotated with @Blocking are also called on a worker thread, regardless the return type.
Methods annotated with @NonBlocking are called on the event loop even if the method does not return a Uni.
