### PR TITLE
Introduce the ability to arbitrarily configure a cache

### DIFF
--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheProcessor.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheProcessor.java
@@ -47,6 +47,7 @@ import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem.ValidationErrorBuildItem;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.cache.CacheManager;
+import io.quarkus.cache.CaffeineCacheBuilderCustomizer;
 import io.quarkus.cache.deployment.exception.ClassTargetException;
 import io.quarkus.cache.deployment.exception.KeyGeneratorConstructorException;
 import io.quarkus.cache.deployment.exception.PrivateMethodTargetException;
@@ -83,6 +84,11 @@ class CacheProcessor {
     @BuildStep
     AnnotationsTransformerBuildItem annotationsTransformer() {
         return new AnnotationsTransformerBuildItem(new CacheAnnotationsTransformer());
+    }
+
+    @BuildStep
+    void unremoveableBeans(BuildProducer<UnremovableBeanBuildItem> producer) {
+        producer.produce(UnremovableBeanBuildItem.beanTypes(CaffeineCacheBuilderCustomizer.class));
     }
 
     @BuildStep

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/CacheWithCustomizersTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/CacheWithCustomizersTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.cache.test.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import io.quarkus.cache.Cache;
+import io.quarkus.cache.CacheManager;
+import io.quarkus.cache.CacheName;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.cache.CaffeineCacheBuilderCustomizer;
+import io.quarkus.cache.runtime.caffeine.CaffeineCacheImpl;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CacheWithCustomizersTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().withApplicationRoot(
+            jar -> jar.addClasses(TestResource.class, AppliesToAllCachesCustomizer.class)
+                    .addAsResource("cache-config-test.properties", "application.properties"));
+
+    private static final String CACHE_NAME = "test-cache";
+
+    @Inject
+    CacheManager cacheManager;
+
+    @CacheName("no-config-cache")
+    Cache noConfigCache;
+
+    @CacheName("test-cache-2")
+    Cache testCache2;
+
+    @CacheName("test-cache-3")
+    Cache testCache3;
+
+    @Test
+    void testConfig() {
+        CaffeineCacheImpl cache = (CaffeineCacheImpl) cacheManager.getCache(CACHE_NAME).get();
+        assertEquals(50, cache.getCacheInfo().initialCapacity);
+        assertEquals(100L, cache.getCacheInfo().maximumSize);
+    }
+
+    @Test
+    void testCache2Config() {
+        CaffeineCacheImpl cache = (CaffeineCacheImpl) testCache2;
+        assertEquals(50, cache.getCacheInfo().initialCapacity);
+        assertNull(cache.getCacheInfo().maximumSize);
+    }
+
+    @Test
+    void testCache3Config() {
+        CaffeineCacheImpl cache = (CaffeineCacheImpl) testCache3;
+        assertEquals(50, cache.getCacheInfo().initialCapacity);
+        assertNull(cache.getCacheInfo().maximumSize);
+    }
+
+    @Singleton
+    public static class AppliesToAllCachesCustomizer implements CaffeineCacheBuilderCustomizer {
+
+        @Override
+        public void customize(Caffeine<Object, Object> cacheBuilder) {
+            cacheBuilder.initialCapacity(50);
+        }
+    }
+
+    @Path("/test")
+    public static class TestResource {
+
+        @GET
+        @CacheResult(cacheName = CACHE_NAME)
+        public String foo(String key) {
+            return "bar";
+        }
+    }
+}

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheInterceptorTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/CacheInterceptorTest.java
@@ -28,7 +28,7 @@ public class CacheInterceptorTest {
         // We need a CaffeineCache instance to test the default key logic.
         CaffeineCacheInfo cacheInfo = new CaffeineCacheInfo();
         cacheInfo.name = "test-cache";
-        CaffeineCache cache = new CaffeineCacheImpl(cacheInfo, false);
+        CaffeineCache cache = new CaffeineCacheImpl(cacheInfo, null, false);
 
         DefaultCacheKey expectedKey = new DefaultCacheKey(cacheInfo.name);
         Object actualKey = getCacheKey(cache, Collections.emptyList(), new Object[] {});

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CaffeineCacheBuilderCustomizer.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CaffeineCacheBuilderCustomizer.java
@@ -1,0 +1,30 @@
+package io.quarkus.cache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+/**
+ * Meant to be implemented by CDI beans that provides arbitrary customization for the {@link Caffeine} builder that get created by Quarkus based on user configuration.
+ * <p>
+ * If an implementation is annotated with {@link CacheName} then the customizer only applies to that cache, otherwise if no such qualifier is present,
+ * then the customizer is applied to all caches.
+ */
+public interface CaffeineCacheBuilderCustomizer extends Comparable<CaffeineCacheBuilderCustomizer> {
+
+    int MINIMUM_PRIORITY = Integer.MIN_VALUE;
+
+    int DEFAULT_PRIORITY = 0;
+
+    void customize(Caffeine<Object, Object> cacheBuilder);
+
+    /**
+     * Defines the priority that the customizers are applied.
+     * A lower integer value means that the customizer will be applied after a customizer with a higher priority
+     */
+    default int priority() {
+        return DEFAULT_PRIORITY;
+    }
+
+    default int compareTo(CaffeineCacheBuilderCustomizer o) {
+        return Integer.compare(o.priority(), priority());
+    }
+}

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
@@ -3,6 +3,7 @@ package io.quarkus.cache.runtime.caffeine;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -24,6 +25,7 @@ import com.github.benmanes.caffeine.cache.stats.StatsCounter;
 
 import io.quarkus.cache.CacheException;
 import io.quarkus.cache.CaffeineCache;
+import io.quarkus.cache.CaffeineCacheBuilderCustomizer;
 import io.quarkus.cache.runtime.AbstractCache;
 import io.quarkus.cache.runtime.NullValueConverter;
 import io.smallrye.mutiny.Uni;
@@ -42,7 +44,8 @@ public class CaffeineCacheImpl extends AbstractCache implements CaffeineCache {
     private final StatsCounter statsCounter;
     private final boolean recordStats;
 
-    public CaffeineCacheImpl(CaffeineCacheInfo cacheInfo, boolean recordStats) {
+    public CaffeineCacheImpl(CaffeineCacheInfo cacheInfo, List<CaffeineCacheBuilderCustomizer> customizers,
+            boolean recordStats) {
         this.cacheInfo = cacheInfo;
         Caffeine<Object, Object> builder = Caffeine.newBuilder();
         if (cacheInfo.initialCapacity != null) {
@@ -70,6 +73,11 @@ public class CaffeineCacheImpl extends AbstractCache implements CaffeineCache {
         } else {
             LOGGER.tracef("Caffeine stats recording is disabled for cache [%s]", cacheInfo.name);
             statsCounter = StatsCounter.disabledStatsCounter();
+        }
+        if (customizers != null && !customizers.isEmpty()) {
+            for (CaffeineCacheBuilderCustomizer customizer : customizers) {
+                customizer.customize(builder);
+            }
         }
         cache = builder.buildAsync();
     }


### PR DESCRIPTION
Relates to: #25921

This currently does **not** work because `com.github.benmanes.caffeine.cache.Caffeine` does not allow us to set the same property twice.

@ben-manes is there any alternative to this other than us having to handle the state of each property ourselves and applying the final result?