### PR TITLE
Remove leftover expose properties in K8s/OCP configuration

### DIFF
--- a/extensions/kubernetes/openshift/deployment/src/main/resources/dev-templates/deploy.html
+++ b/extensions/kubernetes/openshift/deployment/src/main/resources/dev-templates/deploy.html
@@ -14,14 +14,14 @@
         </select>
     </div>
     <div class="form-group">
-        <label for="quarkus.openshift.expose">Expose</label>
-        <select name="quarkus.openshift.expose" class="form-control">
+        <label for="quarkus.openshift.route.expose">Expose</label>
+        <select name="quarkus.openshift.route.expose" class="form-control">
             <option value="true">Yes</option>
             <option value="false">No</option>
         </select>
     </div>
     <div class="form-group">
-        <label for="quarkus.openshift.expose">Allow untrusted SSL Certificates</label>
+        <label for="quarkus.kubernetes-client.trust-certs">Allow untrusted SSL Certificates</label>
         <select name="quarkus.kubernetes-client.trust-certs" class="form-control">
             <option value="false" selected="selected">No</option>
             <option value="true">Yes</option>

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyOpenshiftRouteConfigurator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyOpenshiftRouteConfigurator.java
@@ -6,16 +6,14 @@ import io.dekorate.openshift.config.OpenshiftConfigFluent;
 public class ApplyOpenshiftRouteConfigurator extends Configurator<OpenshiftConfigFluent> {
 
     private final RouteConfig routeConfig;
-    private final boolean defaultExpose;
 
-    public ApplyOpenshiftRouteConfigurator(RouteConfig routeConfig, boolean defaultExpose) {
+    public ApplyOpenshiftRouteConfigurator(RouteConfig routeConfig) {
         this.routeConfig = routeConfig;
-        this.defaultExpose = defaultExpose;
     }
 
     @Override
     public void visit(OpenshiftConfigFluent config) {
-        if (routeConfig.expose || defaultExpose) {
+        if (routeConfig.expose) {
             var routeBuilder = config.editOrNewRoute();
             routeBuilder.withExpose(true);
             if (routeConfig.host.isPresent()) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -262,15 +262,6 @@ public class KubernetesConfig implements PlatformConfiguration {
     ResourcesConfig resources;
 
     /**
-     * If true, a Kubernetes Ingress will be created
-     *
-     * @deprecated Use the {@code quarkus.kubernetes.ingress.expose} instead
-     */
-    @ConfigItem
-    @Deprecated
-    boolean expose;
-
-    /**
      * Ingress configuration
      */
     IngressConfig ingress;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -300,15 +300,6 @@ public class OpenshiftConfig implements PlatformConfiguration {
     Optional<String> containerName;
 
     /**
-     * If true, an Openshift Route will be created
-     *
-     * @deprecated Use the {@code quarkus.openshift.route.exposition} instead
-     */
-    @ConfigItem
-    @Deprecated
-    boolean expose;
-
-    /**
      * Openshift route configuration
      */
     RouteConfig route;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
@@ -139,7 +139,7 @@ public class OpenshiftProcessor {
             result.add(new ConfiguratorBuildItem(new AddPortToOpenshiftConfig(value)));
         });
 
-        result.add(new ConfiguratorBuildItem(new ApplyOpenshiftRouteConfigurator(config.route, config.expose)));
+        result.add(new ConfiguratorBuildItem(new ApplyOpenshiftRouteConfigurator(config.route)));
 
         // Handle remote debug configuration for container ports
         if (config.remoteDebug.enabled) {


### PR DESCRIPTION
These properties were deleted as part of https://github.com/quarkusio/quarkus/pull/30977, but I forgot deleting them from the config objects.