### PR TITLE
Fix native compilation when using quarkus-jdbc-oracle with elasticsearch-java

### DIFF
--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleNativeImage.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleNativeImage.java
@@ -3,7 +3,6 @@ package io.quarkus.jdbc.oracle.deployment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 
 /**
  * @author Sanne Grinovero <sanne@hibernate.org>
@@ -33,12 +32,6 @@ public final class OracleNativeImage {
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jndi.ldap.LdapCtxFactory"));
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jndi.dns.DnsContextFactory"));
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jndi.rmi.registry.RegistryContextFactory"));
-    }
-
-    @BuildStep
-    void runtimeInitialization(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClass) {
-        runtimeInitializedClass
-                .produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.BlockSource$ThreadedCachingBlockSource"));
     }
 
 }


### PR DESCRIPTION
Fixes #31624

I did some basic testing based on @xrobert35's [reproducer](https://github.com/xrobert35/quarkus-oracle-jdbc-error-example/tree/chore/3.0.0-Alpha), and the application does compile to native, starts and doesn't produce exceptions at runtime.

So, this is at least an improvement.

Credit goes to @zakkak ; I applied [his solution](https://github.com/quarkusio/quarkus/issues/31624#issuecomment-1457706253) without really understanding it, but hey, it works :)
