### PR TITLE
Address CloserTest flakiness

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/CloserTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/CloserTest.java
@@ -38,7 +38,8 @@ public class CloserTest {
                             .addClasses(PerRequestResource.class, SingletonResource.class, CounterResource.class,
                                     Counter.class);
                 }
-            });
+            }).overrideRuntimeConfigKey("quarkus.thread-pool.max-threads", "1")
+            .overrideRuntimeConfigKey("quarkus.vertx.event-loops-pool-size", "1");
 
     @Test
     public void test() {


### PR DESCRIPTION
The idea here is to use a single thread in both
Quarkus executors in order to make sure that
a second request (in this case that one that
reads the state altered by the Closer)
can only be serviced after the previous one completes