### PR TITLE
Synthetic beans - make it possible to use a recorded proxy directly

### DIFF
--- a/docs/src/main/asciidoc/cdi-integration.adoc
+++ b/docs/src/main/asciidoc/cdi-integration.adoc
@@ -286,7 +286,7 @@ You can:
 
 1. Generate the bytecode of the `Contextual#create(CreationalContext<T>)` method directly via `ExtendedBeanConfigurator.creator(Consumer<MethodCreator>)`.
 2. Pass a subclass of `io.quarkus.arc.BeanCreator` via `ExtendedBeanConfigurator#creator(Class<? extends BeanCreator<U>>)`, and possibly specify some build-time parameters via `ExtendedBeanConfigurator#param()` and synthetic injection points via `ExtendedBeanConfigurator#addInjectionPoint()`.
-3. Produce the runtime instance through a proxy returned from a <<writing-extensions.adoc#bytecode-recording,`@Recorder` method>> and set it via `ExtendedBeanConfigurator#runtimeValue(RuntimeValue<?>)`, `ExtendedBeanConfigurator#supplier(Supplier<?>)` or `ExtendedBeanConfigurator#createWith(Function<SyntheticCreationalContext<?>, <?>)`.
+3. Produce the runtime instance through a proxy returned from a <<writing-extensions.adoc#bytecode-recording,`@Recorder` method>> and set it via `ExtendedBeanConfigurator#runtimeValue(RuntimeValue<?>)`, `ExtendedBeanConfigurator#runtimeProxy(Object)`,  `ExtendedBeanConfigurator#supplier(Supplier<?>)` or `ExtendedBeanConfigurator#createWith(Function<SyntheticCreationalContext<?>, <?>)`.
 
 .`SyntheticBeanBuildItem` Example 2
 [source,java]

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/synthetic/SyntheticBeanBuildItemProxyTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/synthetic/SyntheticBeanBuildItemProxyTest.java
@@ -1,0 +1,108 @@
+package io.quarkus.arc.test.synthetic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Method;
+import java.util.function.Consumer;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Vetoed;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem.ExtendedBeanConfigurator;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.deployment.builditem.StaticBytecodeRecorderBuildItem;
+import io.quarkus.deployment.recording.BytecodeRecorderImpl;
+import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SyntheticBeanBuildItemProxyTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(SyntheticBeanBuildItemProxyTest.class, SynthBean.class))
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+
+                    @Override
+                    public void execute(BuildContext context) {
+                        BytecodeRecorderImpl bytecodeRecorder = new BytecodeRecorderImpl(true,
+                                TestRecorder.class.getSimpleName(),
+                                "test", "" + TestRecorder.class.hashCode(), true, s -> null);
+                        // We need to use reflection due to some class loading problems
+                        Object recorderProxy = bytecodeRecorder.getRecordingProxy(TestRecorder.class);
+                        try {
+                            Method test = recorderProxy.getClass().getDeclaredMethod("test");
+                            Object proxy = test.invoke(recorderProxy);
+                            ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem.configure(SynthBean.class)
+                                    .scope(ApplicationScoped.class)
+                                    .unremovable();
+                            // No creator
+                            assertThrows(IllegalStateException.class,
+                                    () -> configurator.done());
+                            // Not a returned proxy
+                            assertThrows(IllegalArgumentException.class,
+                                    () -> configurator.runtimeProxy(new SynthBean()));
+                            context.produce(configurator
+                                    .runtimeProxy(proxy)
+                                    .done());
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                        context.produce(new StaticBytecodeRecorderBuildItem(bytecodeRecorder));
+                    }
+                }).produces(StaticBytecodeRecorderBuildItem.class).produces(SyntheticBeanBuildItem.class).build();
+            }
+        };
+    }
+
+    @Recorder
+    public static class TestRecorder {
+
+        public SynthBean test() {
+            SynthBean bean = new SynthBean();
+            bean.setValue("ok");
+            return bean;
+        }
+
+    }
+
+    @Test
+    public void testBeans() {
+        SynthBean bean = Arc.container().instance(SynthBean.class).get();
+        assertNotNull(bean);
+        assertEquals("ok", bean.getValue());
+    }
+
+    @Vetoed
+    public static class SynthBean {
+
+        private String value;
+
+        public SynthBean() {
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+    }
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
@@ -127,6 +127,15 @@ public class ArcRecorder {
         };
     }
 
+    public Function<SyntheticCreationalContext<?>, Object> createFunction(Object returnedProxy) {
+        return new Function<SyntheticCreationalContext<?>, Object>() {
+            @Override
+            public Object apply(SyntheticCreationalContext<?> t) {
+                return returnedProxy;
+            }
+        };
+    }
+
     public void initTestApplicationClassPredicate(Set<String> applicationBeanClasses) {
         PreloadedTestApplicationClassPredicate predicate = Arc.container()
                 .instance(PreloadedTestApplicationClassPredicate.class).get();


### PR DESCRIPTION
- i.e. it is not necessary to wrap the proxy with a RuntimeValue
- also check that a proxy argument is an instance of a ReturnedProxy