### PR TITLE
RESTEasy Reactive: Handle separator for bean params

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/SingleQueryParamWithSeparatorTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/SingleQueryParamWithSeparatorTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.resteasy.reactive.server.test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.resteasy.reactive.RestQuery;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.Separator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SingleQueryParamWithSeparatorTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClass(TestResource.class))
+            .setExpectedException(DeploymentException.class);
+
+    @Test
+    public void test() {
+        fail("Should never have been called");
+    }
+
+    @Path("test")
+    public static class TestResource {
+
+        @GET
+        @Path("endpoint")
+        public RestResponse<String> endpoint(@RestQuery @Separator(",") String parameter) {
+            return RestResponse.ResponseBuilder.ok(parameter).build();
+        }
+
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SeparatorQueryParamTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SeparatorQueryParamTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.resteasy.reactive.server.test.simple;
 
-import static io.restassured.RestAssured.*;
+import static io.restassured.RestAssured.get;
 
 import java.util.List;
 
@@ -63,6 +63,15 @@ public class SeparatorQueryParamTest {
     @Test
     public void multipleQueryParams() {
         get("/hello?name=foo,bar&name=one,two,three&name=yolo")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("hello foo bar one two three yolo"))
+                .header("x-size", "6");
+    }
+
+    @Test
+    public void multipleQueryParamsBean() {
+        get("/hello/bean?name=foo,bar&name=one,two,three&name=yolo")
                 .then()
                 .statusCode(200)
                 .body(Matchers.equalTo("hello foo bar one two three yolo"))

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -278,7 +278,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                 clazz.setPath(sanitizePath(path));
             }
             if (factoryCreator != null) {
-                clazz.setFactory((BeanFactory<Object>) factoryCreator.apply(classInfo.name().toString()));
+                clazz.setFactory(factoryCreator.apply(classInfo.name().toString()));
             }
             Map<String, String> classLevelExceptionMappers = this.classLevelExceptionMappers.get(classInfo.name());
             if (classLevelExceptionMappers != null) {
@@ -1238,10 +1238,12 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         } else if (queryParam != null) {
             builder.setName(queryParam.value().asString());
             builder.setType(ParameterType.QUERY);
+            builder.setSeparator(getSeparator(anns));
             convertible = true;
         } else if (restQueryParam != null) {
             builder.setName(valueOrDefault(restQueryParam.value(), sourceName));
             builder.setType(ParameterType.QUERY);
+            builder.setSeparator(getSeparator(anns));
             convertible = true;
         } else if (cookieParam != null) {
             builder.setName(cookieParam.value().asString());
@@ -1437,6 +1439,9 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
         }
         if (suspendedAnnotation != null && !elementType.equals(AsyncResponse.class.getName())) {
             throw new RuntimeException("Can only inject AsyncResponse on methods marked @Suspended");
+        }
+        if (builder.isSingle() && builder.getSeparator() != null) {
+            throw new DeploymentException("Single parameters should not be marked with @Separator");
         }
         builder.setElementType(elementType);
         return builder;

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/IndexedParameter.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/IndexedParameter.java
@@ -29,6 +29,7 @@ public class IndexedParameter<T extends IndexedParameter<T>> {
     protected String elementType;
     protected boolean single;
     protected boolean optional;
+    protected String separator;
 
     public boolean isObtainedAsCollection() {
         return !single
@@ -206,6 +207,15 @@ public class IndexedParameter<T extends IndexedParameter<T>> {
 
     public T setOptional(boolean optional) {
         this.optional = optional;
+        return (T) this;
+    }
+
+    public String getSeparator() {
+        return separator;
+    }
+
+    public T setSeparator(String separator) {
+        this.separator = separator;
         return (T) this;
     }
 }

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -115,6 +115,7 @@ public class ServerEndpointIndexer
         this.converterSupplierIndexerExtension = builder.converterSupplierIndexerExtension;
     }
 
+    @Override
     protected void addWriterForType(AdditionalWriters additionalWriters, Type paramType) {
         DotName dotName = paramType.name();
         if (dotName.equals(JSONP_JSON_VALUE)
@@ -130,6 +131,7 @@ public class ServerEndpointIndexer
         }
     }
 
+    @Override
     protected void addReaderForType(AdditionalReaders additionalReaders, Type paramType) {
         DotName dotName = paramType.name();
         if (dotName.equals(JSONP_JSON_NUMBER)
@@ -198,6 +200,7 @@ public class ServerEndpointIndexer
         return injectableBean.isFormParamRequired();
     }
 
+    @Override
     protected boolean doesMethodHaveBlockingSignature(MethodInfo info) {
         for (var i : methodScanners) {
             if (i.isMethodSignatureAsync(info)) {
@@ -344,7 +347,6 @@ public class ServerEndpointIndexer
         ParameterConverterSupplier converter = parameterResult.getConverter();
         DeclaredTypes declaredTypes = getDeclaredTypes(paramType, currentClassInfo, actualEndpointInfo);
         String mimeType = getPartMime(parameterResult.getAnns());
-        String separator = getSeparator(parameterResult.getAnns());
         String declaredType = declaredTypes.getDeclaredType();
 
         if (SUPPORTED_MULTIPART_FILE_TYPES.contains(DotName.createSimple(declaredType))) {
@@ -354,9 +356,10 @@ public class ServerEndpointIndexer
                 elementType, declaredType, declaredTypes.getDeclaredUnresolvedType(),
                 type, single, signature,
                 converter, defaultValue, parameterResult.isObtainedAsCollection(), parameterResult.isOptional(), encoded,
-                parameterResult.getCustomParameterExtractor(), mimeType, separator);
+                parameterResult.getCustomParameterExtractor(), mimeType, parameterResult.getSeparator());
     }
 
+    @Override
     protected void handleOtherParam(Map<String, String> existingConverters, String errorLocation, boolean hasRuntimeConverters,
             ServerIndexedParameter builder, String elementType) {
         try {
@@ -368,6 +371,7 @@ public class ServerEndpointIndexer
         }
     }
 
+    @Override
     protected void handleSortedSetParam(Map<String, String> existingConverters, String errorLocation,
             boolean hasRuntimeConverters, ServerIndexedParameter builder, String elementType) {
         ParameterConverterSupplier converter = extractConverter(elementType, index,
@@ -375,6 +379,7 @@ public class ServerEndpointIndexer
         builder.setConverter(new SortedSetConverter.SortedSetSupplier(converter));
     }
 
+    @Override
     protected void handleOptionalParam(Map<String, String> existingConverters,
             Map<DotName, AnnotationInstance> parameterAnnotations,
             String errorLocation,
@@ -409,6 +414,7 @@ public class ServerEndpointIndexer
         builder.setConverter(new OptionalConverter.OptionalSupplier(converter));
     }
 
+    @Override
     protected void handleSetParam(Map<String, String> existingConverters, String errorLocation, boolean hasRuntimeConverters,
             ServerIndexedParameter builder, String elementType) {
         ParameterConverterSupplier converter = extractConverter(elementType, index,
@@ -416,6 +422,7 @@ public class ServerEndpointIndexer
         builder.setConverter(new SetConverter.SetSupplier(converter));
     }
 
+    @Override
     protected void handleListParam(Map<String, String> existingConverters, String errorLocation, boolean hasRuntimeConverters,
             ServerIndexedParameter builder, String elementType) {
         ParameterConverterSupplier converter = extractConverter(elementType, index,
@@ -423,6 +430,7 @@ public class ServerEndpointIndexer
         builder.setConverter(new ListConverter.ListSupplier(converter));
     }
 
+    @Override
     protected void handleArrayParam(Map<String, String> existingConverters, String errorLocation, boolean hasRuntimeConverters,
             ServerIndexedParameter builder, String elementType) {
         ParameterConverterSupplier converter = extractConverter(elementType, index,
@@ -430,6 +438,7 @@ public class ServerEndpointIndexer
         builder.setConverter(new ArrayConverter.ArraySupplier(converter, elementType));
     }
 
+    @Override
     protected void handlePathSegmentParam(ServerIndexedParameter builder) {
         builder.setConverter(new PathSegmentParamConverter.Supplier());
     }
@@ -439,6 +448,7 @@ public class ServerEndpointIndexer
         return path.substring(0, path.length() - 1);
     }
 
+    @Override
     protected void handleTemporalParam(ServerIndexedParameter builder, DotName paramType,
             Map<DotName, AnnotationInstance> parameterAnnotations,
             MethodInfo currentMethodInfo) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/QueryParamExtractor.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/QueryParamExtractor.java
@@ -1,9 +1,5 @@
 package org.jboss.resteasy.reactive.server.core.parameters;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 
 @SuppressWarnings("ForLoopReplaceableByForEach")
@@ -22,27 +18,7 @@ public class QueryParamExtractor implements ParameterExtractor {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public Object extractParameter(ResteasyReactiveRequestContext context) {
-        Object queryParameter = context.getQueryParameter(name, single, encoded);
-        if (separator != null) {
-            if (queryParameter instanceof List) { // it's List<String>
-                List<String> list = (List<String>) queryParameter;
-                List<String> result = new ArrayList<>(list.size());
-                for (int i = 0; i < list.size(); i++) {
-                    String[] parts = list.get(i).split(separator);
-                    result.addAll(Arrays.asList(parts));
-                }
-                queryParameter = result;
-            } else if (queryParameter instanceof String) {
-                List<String> result = new ArrayList<>(1);
-                String[] parts = ((String) queryParameter).split(separator);
-                result.addAll(Arrays.asList(parts));
-                queryParameter = result;
-            } else {
-                // can't really happen
-            }
-        }
-        return queryParameter;
+        return context.getQueryParameter(name, single, encoded, separator);
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/injection/ResteasyReactiveInjectionContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/injection/ResteasyReactiveInjectionContext.java
@@ -3,7 +3,7 @@ package org.jboss.resteasy.reactive.server.injection;
 public interface ResteasyReactiveInjectionContext {
     Object getHeader(String name, boolean single);
 
-    Object getQueryParameter(String name, boolean single, boolean encoded);
+    Object getQueryParameter(String name, boolean single, boolean encoded, String separator);
 
     String getPathParameter(String name, boolean encoded);
 


### PR DESCRIPTION
Fixes #31050

My approach is to move the separator handling in the `getQueryParam` method of the request context and to pass the separator when the generated bytecode calls that method during injection. If that isn't a good idea, please let me know what would be a better way to do it and I'll do that instead.