### PR TITLE
Bump Dekorate to 3.5.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -161,7 +161,7 @@
         <kotlin.version>1.8.10</kotlin.version>
         <kotlin.coroutine.version>1.6.4</kotlin.coroutine.version>
         <kotlin-serialization.version>1.5.0</kotlin-serialization.version>
-        <dekorate.version>3.4.1</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
+        <dekorate.version>3.5.0</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>
         <jboss-logmanager.version>1.1.1</jboss-logmanager.version>


### PR DESCRIPTION
Changes: https://github.com/dekorateio/dekorate/releases/tag/3.5.0

To use the same Kubernetes Client version by Dekorate and Quarkus. Relates: https://github.com/quarkusio/quarkus/pull/31781