### PR TITLE
Synthetic bean for Quarkus ExecutorService

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ExecutorBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ExecutorBuildItem.java
@@ -1,6 +1,6 @@
 package io.quarkus.deployment.builditem;
 
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
@@ -8,13 +8,14 @@ import io.quarkus.builder.item.SimpleBuildItem;
  * The main executor for blocking tasks
  */
 public final class ExecutorBuildItem extends SimpleBuildItem {
-    private final ExecutorService executor;
 
-    public ExecutorBuildItem(final ExecutorService executor) {
+    private final ScheduledExecutorService executor;
+
+    public ExecutorBuildItem(ScheduledExecutorService executor) {
         this.executor = executor;
     }
 
-    public ExecutorService getExecutorProxy() {
+    public ScheduledExecutorService getExecutorProxy() {
         return executor;
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ExecutorRecorder.java
@@ -4,7 +4,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
@@ -33,7 +33,7 @@ public class ExecutorRecorder {
         this.threadPoolConfig = threadPoolConfig;
     }
 
-    public ExecutorService setupRunTime(ShutdownContext shutdownContext,
+    public ScheduledExecutorService setupRunTime(ShutdownContext shutdownContext,
             LaunchMode launchMode, ThreadFactory threadFactory, ContextHandler<Object> contextHandler) {
         final EnhancedQueueExecutor underlying = createExecutor(threadPoolConfig, threadFactory, contextHandler);
         if (launchMode == LaunchMode.DEVELOPMENT) {

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ExecutorServiceProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ExecutorServiceProcessor.java
@@ -1,0 +1,23 @@
+package io.quarkus.arc.deployment;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import io.quarkus.arc.processor.BuiltinScope;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ExecutorBuildItem;
+
+public class ExecutorServiceProcessor {
+
+    @BuildStep
+    SyntheticBeanBuildItem executorServiceBean(ExecutorBuildItem executor) {
+        return SyntheticBeanBuildItem.configure(ScheduledExecutorService.class)
+                .types(ExecutorService.class, Executor.class)
+                .scope(BuiltinScope.APPLICATION.getInfo())
+                .setRuntimeInit()
+                .runtimeProxy(executor.getExecutorProxy())
+                .done();
+    }
+
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/executorservice/ExecutorServiceBeanTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/executorservice/ExecutorServiceBeanTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.arc.test.executorservice;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ExecutorServiceBeanTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+            });
+
+    @Inject
+    ExecutorService executorService;
+
+    @Inject
+    Executor executor;
+
+    @Inject
+    ScheduledExecutorService scheduledExecutorService;
+
+    @Test
+    public void testExecutorServiceBean() throws InterruptedException {
+        // unwrap the proxies first
+        ExecutorService es = assertNonNullProxy(executorService);
+        // all injection points should be satisifed by the same application scoped bean
+        assertTrue(es == assertNonNullProxy(executor));
+        assertTrue(es == assertNonNullProxy(scheduledExecutorService));
+        // verify execution
+        CountDownLatch latch = new CountDownLatch(3);
+        executorService.submit(() -> latch.countDown());
+        executor.execute(() -> latch.countDown());
+        ScheduledFuture<?> sf = scheduledExecutorService.scheduleWithFixedDelay(() -> latch.countDown(), 0, 50,
+                TimeUnit.MILLISECONDS);
+        assertTrue(latch.await(3, TimeUnit.SECONDS));
+        sf.cancel(true);
+    }
+
+    private <T> T assertNonNullProxy(T instance) {
+        assertNotNull(instance);
+        assertTrue(instance instanceof ClientProxy);
+        return ClientProxy.unwrap(instance);
+    }
+
+}


### PR DESCRIPTION
- i.e. make it possible to leverage the default blocking thread pool