### PR TITLE
Runtime configuration for HTTP permissions, policy, form authentication mechanism and realm

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
@@ -4,12 +4,14 @@ import static io.quarkus.vertx.http.deployment.RouteBuildItem.RouteType.APPLICAT
 
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.console.ConfiguredPathInfo;
 import io.quarkus.vertx.http.runtime.BasicRoute;
 import io.quarkus.vertx.http.runtime.HandlerType;
+import io.quarkus.vertx.http.runtime.RouteCandidate;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
@@ -145,6 +147,21 @@ public final class RouteBuildItem extends MultiBuildItem {
         public Builder route(String route) {
             this.routeFunction = new BasicRoute(route);
             this.notFoundPagePath = this.routePath = route;
+            return this;
+        }
+
+        /**
+         * Creates route if {@code routeCandidate} is resolved to the route path during runtime init.
+         * If {@code routeCandidate} supplies null, route is not going to be created.
+         * This way, extensions may create routes from runtime configuration properties.
+         *
+         * Only HTTP routes with {@link HandlerType#NORMAL} handler type and no {@code notFoundPage} are supported.
+         *
+         * @param routeCandidate route that may be resolved to null during runtime init
+         * @return Builder
+         */
+        public Builder route(Supplier<String> routeCandidate) {
+            this.routeFunction = new RouteCandidate(routeCandidate);
             return this;
         }
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/RuntimeRouteCandidateTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/RuntimeRouteCandidateTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.vertx.http;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.restassured.RestAssured;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+public class RuntimeRouteCandidateTest {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.root-path=/api\n" +
+            "route[1]=/build-time-route";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties"))
+            .addBuildChainCustomizer(buildCustomizer())
+            .overrideRuntimeConfigKey("route[1]", "/runtime-route");
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        context.produce(RouteBuildItem.builder()
+                                .route(new PathSupplier())
+                                .handler(new MyHandler())
+                                .build());
+                    }
+                }).produces(RouteBuildItem.class)
+                        .consumes(NonApplicationRootPathBuildItem.class)
+                        .build();
+            }
+        };
+    }
+
+    public static class MyHandler implements Handler<RoutingContext> {
+        @Override
+        public void handle(RoutingContext routingContext) {
+            routingContext.response()
+                    .setStatusCode(200)
+                    .end(routingContext.request().path());
+        }
+    }
+
+    @Test
+    public void testRouteCreatedFromRuntimeProperty() {
+        RestAssured.given().get("/runtime-route").then().statusCode(200).body(Matchers.equalTo("/api/runtime-route"));
+        RestAssured.given().get("/build-time-route").then().statusCode(404);
+    }
+
+    public static class PathSupplier implements Supplier<String> {
+
+        @Override
+        public String get() {
+            return ConfigProvider.getConfig().getConfigValue("route[1]").getRawValue();
+        }
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthBuildTimeConfig.java
@@ -1,0 +1,38 @@
+package io.quarkus.vertx.http.runtime;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * Authentication mechanism information used for configuring HTTP auth
+ * instance for the deployment.
+ */
+@ConfigGroup
+public class AuthBuildTimeConfig {
+
+    /**
+     * If basic auth should be enabled. If both basic and form auth is enabled then basic auth will be enabled in silent mode.
+     *
+     * If no authentication mechanisms are configured basic auth is the default.
+     */
+    @ConfigItem
+    public Optional<Boolean> basic;
+
+    /**
+     * If form authentication is enabled.
+     */
+    @ConfigItem(name = "form.enabled")
+    public boolean form;
+
+    /**
+     * If this is true and credentials are present then a user will always be authenticated
+     * before the request progresses.
+     *
+     * If this is false then an attempt will only be made to authenticate the user if a permission
+     * check is performed or the current user is required for some other reason.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean proactive;
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
@@ -12,13 +12,6 @@ import io.quarkus.runtime.annotations.ConfigItem;
  */
 @ConfigGroup
 public class AuthConfig {
-    /**
-     * If basic auth should be enabled. If both basic and form auth is enabled then basic auth will be enabled in silent mode.
-     *
-     * If no authentication mechanisms are configured basic auth is the default.
-     */
-    @ConfigItem
-    public Optional<Boolean> basic;
 
     /**
      * Form Auth config
@@ -44,13 +37,4 @@ public class AuthConfig {
     @ConfigItem(name = "policy")
     public Map<String, PolicyConfig> rolePolicy;
 
-    /**
-     * If this is true and credentials are present then a user will always be authenticated
-     * before the request progresses.
-     *
-     * If this is false then an attempt will only be made to authenticate the user if a permission
-     * check is performed or the current user is required for some other reason.
-     */
-    @ConfigItem(defaultValue = "true")
-    public boolean proactive;
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
@@ -21,12 +21,6 @@ public class FormAuthConfig {
     }
 
     /**
-     * If form authentication is enabled.
-     */
-    @ConfigItem
-    public boolean enabled;
-
-    /**
      * The login page. Redirect to login page can be disabled by setting `quarkus.http.auth.form.login-page=`.
      */
     @ConfigItem(defaultValue = "/login.html")

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
@@ -24,7 +24,7 @@ public class HttpBuildTimeConfig {
     @ConvertWith(NormalizeRootHttpPathConverter.class)
     public String rootPath;
 
-    public AuthConfig auth;
+    public AuthBuildTimeConfig auth;
 
     /**
      * Configures the engine to require/request client authentication.

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -14,6 +14,8 @@ import io.quarkus.vertx.http.runtime.cors.CORSConfig;
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public class HttpConfiguration {
 
+    public AuthConfig auth;
+
     /**
      * Enable the CORS filter.
      */

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RouteCandidate.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RouteCandidate.java
@@ -1,0 +1,43 @@
+package io.quarkus.vertx.http.runtime;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.vertx.ext.web.Route;
+import io.vertx.ext.web.Router;
+
+/**
+ * Creates {@link Function<Router, Route>} if {@link #path} underlying value
+ * is not null during runtime init.
+ */
+public class RouteCandidate implements Function<Router, Route> {
+
+    private Supplier<String> path;
+
+    public RouteCandidate() {
+    }
+
+    public RouteCandidate(Supplier<String> path) {
+        Objects.requireNonNull(path);
+        this.path = path;
+    }
+
+    public Supplier<String> getPath() {
+        return path;
+    }
+
+    public void setPath(Supplier<String> path) {
+        this.path = path;
+    }
+
+    /* RUNTIME_INIT */
+    @Override
+    public Route apply(Router router) {
+        final String resolvedPath = path.get();
+        if (resolvedPath == null) {
+            return null;
+        }
+        return router.route(resolvedPath);
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -959,6 +959,14 @@ public class VertxHttpRecorder {
             HandlerType type) {
 
         Route vr = route.apply(router.getValue());
+
+        // routes prepared during the build time for runtime configuration
+        // properties are nullable if user decided to not configure the property
+        // please see class 'RouteCandidate' for more details
+        if (vr == null) {
+            return;
+        }
+
         if (type == HandlerType.BLOCKING) {
             vr.blockingHandler(handler, false);
         } else if (type == HandlerType.FAILURE) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
@@ -83,14 +83,16 @@ public class PathMatchingHttpSecurityPolicy implements HttpSecurityPolicy {
                 });
     }
 
-    void init(HttpBuildTimeConfig config, Map<String, Supplier<HttpSecurityPolicy>> supplierMap) {
+    void init(HttpBuildTimeConfig config, Map<String, Supplier<HttpSecurityPolicy>> supplierMap,
+            Map<String, PolicyMappingConfig> permissions) {
+
         Map<String, HttpSecurityPolicy> permissionCheckers = new HashMap<>();
         for (Map.Entry<String, Supplier<HttpSecurityPolicy>> i : supplierMap.entrySet()) {
             permissionCheckers.put(i.getKey(), i.getValue().get());
         }
 
         Map<String, List<HttpMatcher>> tempMap = new HashMap<>();
-        for (Map.Entry<String, PolicyMappingConfig> entry : config.auth.permissions.entrySet()) {
+        for (Map.Entry<String, PolicyMappingConfig> entry : permissions.entrySet()) {
             HttpSecurityPolicy checker = permissionCheckers.get(entry.getValue().policy);
             if (checker == null) {
                 throw new RuntimeException("Unable to find HTTP security policy " + entry.getValue().policy);


### PR DESCRIPTION
closes #19162 but mainly this is preparation for #16728

This moves as much from auth config to runtime, as possible. I believe flags that enables auth mechanisms can't be moved as we need to determine which beans to create at build time. OpenAPI document that requires security provider information is also build during build time.