### PR TITLE
Fix missing cancellation when sending streams to gRPC services

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcClientProcessor.java
@@ -4,7 +4,6 @@ import static io.quarkus.deployment.Feature.GRPC_CLIENT;
 import static io.quarkus.grpc.deployment.GrpcDotNames.ADD_BLOCKING_CLIENT_INTERCEPTOR;
 import static io.quarkus.grpc.deployment.GrpcDotNames.CONFIGURE_STUB;
 import static io.quarkus.grpc.deployment.GrpcDotNames.CREATE_CHANNEL_METHOD;
-import static io.quarkus.grpc.deployment.GrpcDotNames.MUTINY_CLIENT;
 import static io.quarkus.grpc.deployment.GrpcDotNames.RETRIEVE_CHANNEL_METHOD;
 import static io.quarkus.grpc.deployment.GrpcInterceptors.MICROMETER_INTERCEPTORS;
 import static io.quarkus.grpc.deployment.ResourceRegistrationUtils.registerResourcesForProperties;

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/GrpcReflectionTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/GrpcReflectionTest.java
@@ -114,8 +114,10 @@ public class GrpcReflectionTest {
     }
 
     private ServerReflectionResponse invoke(ServerReflectionRequest request) {
+        subscriber.reset();
         Multi<ServerReflectionResponse> multi = reflection.serverReflectionInfo(processor);
         multi.subscribe().withSubscriber(subscriber);
+        subscriber.awaitForSubscription();
         processor.onNext(request);
         return subscriber.awaitAndGetLast();
     }
@@ -242,6 +244,14 @@ public class GrpcReflectionTest {
         @Override
         public void onSubscribe(Flow.Subscription subscription) {
             this.subscription = subscription;
+        }
+
+        public void reset() {
+            this.subscription = null;
+        }
+
+        public void awaitForSubscription() {
+            await().until(() -> subscription != null);
         }
 
         public T awaitAndGetLast() {

--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ClientCalls.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ClientCalls.java
@@ -1,5 +1,7 @@
 package io.quarkus.grpc.stubs;
 
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -7,6 +9,7 @@ import java.util.function.Function;
 import io.grpc.stub.StreamObserver;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.Subscriptions;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.subscription.UniEmitter;
 
@@ -34,57 +37,72 @@ public class ClientCalls {
     }
 
     public static <I, O> Uni<O> manyToOne(Multi<I> items, Function<StreamObserver<O>, StreamObserver<I>> delegate) {
-        return Uni.createFrom().emitter((new Consumer<UniEmitter<? super O>>() { // NOSONAR
+        return Uni.createFrom().emitter((new Consumer<UniEmitter<? super O>>() {
             @Override
             public void accept(UniEmitter<? super O> emitter) {
-                StreamObserver<I> request = delegate.apply(new UniStreamObserver<>(emitter));
-                items.subscribe().with(
-                        new Consumer<I>() {
-                            @Override
-                            public void accept(I v) {
-                                request.onNext(v);
-                            }
-                        },
-                        new Consumer<Throwable>() {
-                            @Override
-                            public void accept(Throwable throwable) {
-                                request.onError(throwable);
-                            }
-                        },
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                request.onCompleted();
-                            }
-                        });
+                AtomicReference<Flow.Subscription> cancellable = new AtomicReference<>();
+                UniStreamObserver<O> observer = new UniStreamObserver<>(emitter.onTermination(() -> {
+                    var subscription = cancellable.getAndSet(Subscriptions.CANCELLED);
+                    if (subscription != null) {
+                        subscription.cancel();
+                    }
+                }));
+                StreamObserver<I> request = delegate.apply(observer);
+                subscribeToUpstreamAndForwardToStreamObserver(items, cancellable, request);
             }
+
         }));
     }
 
+    private static <I> void subscribeToUpstreamAndForwardToStreamObserver(Multi<I> items,
+            AtomicReference<Flow.Subscription> cancellable,
+            StreamObserver<I> request) {
+        items.subscribe().with(
+                new Consumer<Flow.Subscription>() {
+                    @Override
+                    public void accept(Flow.Subscription subscription) {
+                        if (!cancellable.compareAndSet(null, subscription)) {
+                            subscription.cancel();
+                        } else {
+                            subscription.request(Long.MAX_VALUE);
+                        }
+                    }
+                },
+
+                new Consumer<I>() {
+                    @Override
+                    public void accept(I v) {
+                        if (cancellable.get() != null && cancellable.get() != Subscriptions.CANCELLED) {
+                            request.onNext(v);
+                        }
+                    }
+                },
+                new Consumer<Throwable>() {
+                    @Override
+                    public void accept(Throwable throwable) {
+                        request.onError(throwable);
+                    }
+                },
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        request.onCompleted();
+                    }
+                });
+    }
+
     public static <I, O> Multi<O> manyToMany(Multi<I> items, Function<StreamObserver<O>, StreamObserver<I>> delegate) {
-        return Multi.createFrom().emitter((new Consumer<MultiEmitter<? super O>>() { // NOSONAR
+        return Multi.createFrom().emitter((new Consumer<MultiEmitter<? super O>>() {
             @Override
             public void accept(MultiEmitter<? super O> emitter) {
-                StreamObserver<I> request = delegate.apply(new MultiStreamObserver<>(emitter));
-                items.subscribe().with(
-                        new Consumer<I>() {
-                            @Override
-                            public void accept(I v) {
-                                request.onNext(v);
-                            }
-                        },
-                        new Consumer<Throwable>() {
-                            @Override
-                            public void accept(Throwable throwable) {
-                                request.onError(throwable);
-                            }
-                        },
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                request.onCompleted();
-                            }
-                        });
+                AtomicReference<Flow.Subscription> cancellable = new AtomicReference<>();
+                StreamObserver<I> request = delegate.apply(new MultiStreamObserver<>(emitter.onTermination(() -> {
+                    var subscription = cancellable.getAndSet(Subscriptions.CANCELLED);
+                    if (subscription != null) {
+                        subscription.cancel();
+                    }
+                })));
+                subscribeToUpstreamAndForwardToStreamObserver(items, cancellable, request);
             }
         }));
 

--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ManyToManyObserver.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ManyToManyObserver.java
@@ -1,0 +1,96 @@
+package io.quarkus.grpc.stubs;
+
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import io.grpc.stub.StreamObserver;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.Subscriptions;
+import io.smallrye.mutiny.operators.AbstractMulti;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+
+public class ManyToManyObserver<I, O> extends AbstractMulti<O> implements StreamObserver<O> {
+
+    private final StreamObserver<I> processor;
+    private final Multi<I> source;
+    private final UpstreamSubscriber subscriber = new UpstreamSubscriber();
+    private final AtomicReference<Flow.Subscription> upstream = new AtomicReference<>();
+    private volatile MultiSubscriber<? super O> downstream;
+
+    public ManyToManyObserver(Multi<I> source, Function<StreamObserver<O>, StreamObserver<I>> function) {
+        this.processor = function.apply(this);
+        this.source = source;
+    }
+
+    @Override
+    public void subscribe(MultiSubscriber<? super O> subscriber) {
+        this.downstream = subscriber;
+        source.subscribe(this.subscriber);
+    }
+
+    @Override
+    public void onNext(O value) {
+        downstream.onItem(value);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        cancelUpstream();
+        downstream.onFailure(t);
+    }
+
+    @Override
+    public void onCompleted() {
+        cancelUpstream();
+        downstream.onComplete();
+    }
+
+    private void cancelUpstream() {
+        var subscription = upstream.getAndSet(Subscriptions.CANCELLED);
+        if (subscription != null) {
+            subscription.cancel();
+        }
+    }
+
+    class UpstreamSubscriber implements Flow.Subscriber<I>, Flow.Subscription {
+
+        @Override
+        public void onSubscribe(Flow.Subscription items) {
+            if (!upstream.compareAndSet(null, items)) {
+                items.cancel();
+            } else {
+                downstream.onSubscribe(this);
+                items.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(I item) {
+            processor.onNext(item);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            processor.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            processor.onCompleted();
+        }
+
+        @Override
+        public void request(long n) {
+            // Ignored
+            // TODO We would need to implement back-pressure, but there is no relation between the number of items
+            // TODO from the source and the number of items from the service.
+        }
+
+        @Override
+        public void cancel() {
+            cancelUpstream();
+        }
+    }
+
+}

--- a/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ManyToOneObserver.java
+++ b/extensions/grpc/stubs/src/main/java/io/quarkus/grpc/stubs/ManyToOneObserver.java
@@ -1,0 +1,92 @@
+package io.quarkus.grpc.stubs;
+
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import io.grpc.stub.StreamObserver;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.Subscriptions;
+import io.smallrye.mutiny.operators.AbstractUni;
+import io.smallrye.mutiny.subscription.UniSubscriber;
+import io.smallrye.mutiny.subscription.UniSubscription;
+
+public class ManyToOneObserver<I, O> extends AbstractUni<O> implements StreamObserver<O> {
+
+    private final StreamObserver<I> processor;
+    private final Multi<I> source;
+    private final UpstreamSubscriber subscriber = new UpstreamSubscriber();
+    private final AtomicReference<Flow.Subscription> upstream = new AtomicReference<>();
+    private volatile UniSubscriber<? super O> downstream;
+
+    public ManyToOneObserver(Multi<I> source, Function<StreamObserver<O>, StreamObserver<I>> function) {
+        this.processor = function.apply(this);
+        this.source = source;
+    }
+
+    @Override
+    public void subscribe(UniSubscriber<? super O> subscriber) {
+        this.downstream = subscriber;
+        source.subscribe(this.subscriber);
+    }
+
+    @Override
+    public void onNext(O value) {
+        cancelUpstream();
+        downstream.onItem(value);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        cancelUpstream();
+        downstream.onFailure(t);
+    }
+
+    @Override
+    public void onCompleted() {
+        cancelUpstream();
+    }
+
+    private void cancelUpstream() {
+        var subscription = upstream.getAndSet(Subscriptions.CANCELLED);
+        if (subscription != null) {
+            subscription.cancel();
+        }
+    }
+
+    class UpstreamSubscriber implements Flow.Subscriber<I>, UniSubscription {
+
+        @Override
+        public void onSubscribe(Flow.Subscription items) {
+            if (!upstream.compareAndSet(null, items)) {
+                items.cancel();
+            } else {
+                downstream.onSubscribe(this);
+                // TODO At some point we will need to improve the flow control with the max concurrent call per connection.
+                items.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void onNext(I item) {
+            processor.onNext(item);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            processor.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            processor.onCompleted();
+        }
+
+        @Override
+        public void cancel() {
+            cancelUpstream();
+        }
+
+    }
+
+}

--- a/integration-tests/grpc-streaming/src/main/java/io/quarkus/grpc/example/streaming/StreamingService.java
+++ b/integration-tests/grpc-streaming/src/main/java/io/quarkus/grpc/example/streaming/StreamingService.java
@@ -46,17 +46,9 @@ public class StreamingService extends MutinyStreamingGrpc.StreamingImplBase {
                 .call(() -> {
                     throw new RuntimeException("Any error");
                 })
-                .map(x -> {
-                    return StringReply.newBuilder()
-                            .setMessage(x.toString())
-                            .build();
-                })
+                .map(x -> StringReply.newBuilder().setMessage(x.toString()).build())
                 .collect().asList()
-                .replaceWith(StringReply.newBuilder()
-                        .setMessage("DONE")
-                        .build())
-                .onFailure()
-                .invoke(th -> System.err.println("Quick: " + th.getMessage()));
+                .replaceWith(StringReply.newBuilder().setMessage("DONE").build());
     }
 
     @Override
@@ -64,18 +56,33 @@ public class StreamingService extends MutinyStreamingGrpc.StreamingImplBase {
         AtomicInteger atomicInteger = new AtomicInteger(0);
         return request
                 .map(x -> {
-                    if (atomicInteger.getAndIncrement() == 5) {
-                        throw new RuntimeException("We reached 5, error here");
+                    if (atomicInteger.getAndIncrement() == 3) {
+                        throw new RuntimeException("We reached 3, error here");
                     }
-                    return StringReply.newBuilder()
-                            .setMessage(x.toString())
-                            .build();
+                    return StringReply.newBuilder().setMessage(x.toString()).build();
                 })
                 .collect().asList()
-                .replaceWith(StringReply.newBuilder()
-                        .setMessage("DONE")
-                        .build())
-                .onFailure()
-                .invoke(th -> System.err.println("Mid: " + th.getMessage()));
+                .replaceWith(StringReply.newBuilder().setMessage("DONE").build());
+    }
+
+    @Override
+    public Multi<StringReply> quickStringBiDiStream(Multi<StringRequest> request) {
+        return request
+                .call(() -> {
+                    throw new RuntimeException("Any error");
+                })
+                .map(x -> StringReply.newBuilder().setMessage(x.toString()).build());
+    }
+
+    @Override
+    public Multi<StringReply> midStringBiDiStream(Multi<StringRequest> request) {
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+        return request
+                .map(x -> {
+                    if (atomicInteger.getAndIncrement() == 3) {
+                        throw new RuntimeException("We reached 3, error here");
+                    }
+                    return StringReply.newBuilder().setMessage(x.toString()).build();
+                });
     }
 }

--- a/integration-tests/grpc-streaming/src/main/proto/streaming.proto
+++ b/integration-tests/grpc-streaming/src/main/proto/streaming.proto
@@ -14,6 +14,8 @@ service Streaming {
     rpc Pipe(stream Item) returns (stream Item) {}
     rpc QuickStringStream (stream StringRequest) returns (StringReply) {}
     rpc MidStringStream (stream StringRequest) returns (StringReply) {}
+    rpc QuickStringBiDiStream (stream StringRequest) returns (stream StringReply) {}
+    rpc MidStringBiDiStream (stream StringRequest) returns (stream StringReply) {}
 }
 
 message Item {


### PR DESCRIPTION
When sending a stream to a gRPC service and when that service sends back a failure, cancel the subscription to the stream.
