### PR TITLE
Check the expiry date for inactive OIDC tokens

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -132,7 +132,8 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                         @Override
                         public Uni<SecurityIdentity> apply(TokenVerificationResult codeAccessTokenResult, Throwable t) {
                             if (t != null) {
-                                return Uni.createFrom().failure(new AuthenticationFailedException(t));
+                                return Uni.createFrom().failure(t instanceof AuthenticationFailedException ? t
+                                        : new AuthenticationFailedException(t));
                             }
                             if (codeAccessTokenResult != null) {
                                 if (tokenAutoRefreshPrepared(codeAccessTokenResult, vertxContext,

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowTokenIntrospectionResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowTokenIntrospectionResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+
+@Path("/code-flow-token-introspection")
+@Authenticated
+public class CodeFlowTokenIntrospectionResource {
+
+    @Inject
+    SecurityIdentity identity;
+
+    @GET
+    public String access() {
+        return identity.getPrincipal().getName();
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
@@ -23,6 +23,7 @@ public class CustomSecurityIdentityAugmentor implements SecurityIdentityAugmento
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-github")
                         || routingContext.normalizedPath().endsWith("bearer-user-info-github-service")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-dynamic-github")
+                        || routingContext.normalizedPath().endsWith("code-flow-token-introspection")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-github-cached-in-idtoken"))) {
             QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
             UserInfo userInfo = identity.getAttribute("userinfo");

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -38,6 +38,9 @@ public class CustomTenantResolver implements TenantResolver {
         if (path.endsWith("code-flow-user-info-github-cached-in-idtoken")) {
             return "code-flow-user-info-github-cached-in-idtoken";
         }
+        if (path.endsWith("code-flow-token-introspection")) {
+            return "code-flow-token-introspection";
+        }
         if (path.endsWith("bearer")) {
             return "bearer";
         }

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -97,6 +97,18 @@ quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.client-id=quarkus-web-
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 
 
+quarkus.oidc.code-flow-token-introspection.provider=github
+quarkus.oidc.code-flow-token-introspection.auth-server-url=${keycloak.url}/realms/quarkus/
+quarkus.oidc.code-flow-token-introspection.authorization-path=/
+quarkus.oidc.code-flow-token-introspection.user-info-path=protocol/openid-connect/userinfo
+quarkus.oidc.code-flow-token-introspection.introspection-path=protocol/openid-connect/token/introspect
+quarkus.oidc.code-flow-token-introspection.token.refresh-expired=true
+quarkus.oidc.code-flow-token-introspection.token.refresh-token-time-skew=298
+quarkus.oidc.code-flow-token-introspection.authentication.verify-access-token=true
+quarkus.oidc.code-flow-token-introspection.client-id=quarkus-web-app
+quarkus.oidc.code-flow-token-introspection.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+quarkus.oidc.code-flow-token-introspection.code-grant.headers.X-Custom=XTokenIntrospection
+
 quarkus.oidc.token-cache.max-size=1
 
 quarkus.oidc.bearer.auth-server-url=${keycloak.url}/realms/quarkus/


### PR DESCRIPTION
Fixes #31714.

The code update is straightforward, just add an extra expiry verification check, but testing it is much trickier, as we need to write a test confirming that the opaque token refreshment has taken place and the valid token was used to get UserInfo.

So I updated the OIDC wiremock support to return UserInfo depending on the value of the token, the existing/original code which was returning UserInfo was expecting a JWT token so I added a basic Matcher there since JWT tokens signed with RSA keys typically start with `ey`.
The OIDC wiremock was already written awhile back to return opaque tokens `admin` and `alice`, not sure why, but in any case, now, UserInfo would set the user name which woud be equal to this opaque token name - and thus the test can confirm that after the first opaque access token has expired, the next one was used to get UserInfo 