### PR TITLE
Support SpringDI List injection with @Inject

### DIFF
--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -283,7 +283,7 @@ The following table shows how Spring DI annotations can be converted to CDI and 
 
 |@Autowired
 |@Inject
-|
+|If the type is `java.util.List`, the `io.quarkus.arc.All` qualifier is added.
 
 |@Qualifier
 |@Named

--- a/extensions/spring-di/deployment/src/test/java/io/quarkus/spring/di/deployment/ListOfBeansTest.java
+++ b/extensions/spring-di/deployment/src/test/java/io/quarkus/spring/di/deployment/ListOfBeansTest.java
@@ -19,16 +19,22 @@ public class ListOfBeansTest {
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(Foo.class, ServiceAlpha.class, ServiceBravo.class, Service.class,
+                    .addClasses(Foo.class, Bar.class, ServiceAlpha.class, ServiceBravo.class, Service.class,
                             Converter.class, ConverterAlpha.class, ConverterBravo.class));
 
     @Inject
     Foo foo;
 
+    @Inject
+    Bar bar;
+
     @Test
     public void testInjection() {
         assertThat(foo.services).hasSize(2).extractingResultOf("ping").containsExactlyInAnyOrder("alpha", "bravo");
         assertThat(foo.converters).hasSize(2).extractingResultOf("pong").containsExactlyInAnyOrder("alpha", "bravo");
+
+        assertThat(bar.services).hasSize(2).extractingResultOf("ping").containsExactlyInAnyOrder("alpha", "bravo");
+        assertThat(bar.converters).hasSize(2).extractingResultOf("pong").containsExactlyInAnyOrder("alpha", "bravo");
     }
 
     @org.springframework.stereotype.Service
@@ -41,6 +47,23 @@ public class ListOfBeansTest {
 
         @Autowired
         Foo(List<Converter> converters) {
+            this.converters = converters;
+        }
+    }
+
+    /**
+     * Test Spring with JSR-303 support
+     */
+    @org.springframework.stereotype.Service
+    public static class Bar {
+
+        @Inject
+        List<Service> services;
+
+        final List<Converter> converters;
+
+        @Inject
+        Bar(List<Converter> converters) {
             this.converters = converters;
         }
 


### PR DESCRIPTION
Relates to #5668

Spring has support for JSR-303 annotations, so features of `@Autowired` are also applicable to `@Inject` fields/methods. 
Also mention the `@All` qualifier in the conversion table of the userguide.