### PR TITLE
Knative deployer uses hasApiGroup to check for Knative support

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeDeployer.java
@@ -5,7 +5,7 @@ import static io.quarkus.kubernetes.deployment.Constants.KNATIVE;
 import java.util.List;
 import java.util.Optional;
 
-import io.fabric8.knative.client.DefaultKnativeClient;
+import io.fabric8.knative.client.KnativeClient;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.kubernetes.client.spi.KubernetesClientBuildItem;
@@ -24,8 +24,8 @@ public class KnativeDeployer {
                 return;
             }
             if (target.getEntry().getName().equals(KNATIVE)) {
-                try (DefaultKnativeClient client = kubernetesClientBuilder.buildClient().adapt(DefaultKnativeClient.class)) {
-                    if (client.isSupported()) {
+                try (KnativeClient client = kubernetesClientBuilder.buildClient().adapt(KnativeClient.class)) {
+                    if (client.hasApiGroup("knative.dev", false)) {
                         deploymentCluster.produce(new KubernetesDeploymentClusterBuildItem(KNATIVE));
                     } else {
                         throw new IllegalStateException(


### PR DESCRIPTION
Fix #31787 

This PR reverts (the reverted changes of) #30743 

The [`isSupported`](https://github.com/fabric8io/kubernetes-client/blob/271abd99284969c40085d1735a986337fa6bf437/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/SupportTestingClient.java#L44) method and its interface ([`SupportTestingClient`](https://github.com/fabric8io/kubernetes-client/blob/271abd99284969c40085d1735a986337fa6bf437/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/SupportTestingClient.java#L31)) are deprecated and will be removed (https://github.com/fabric8io/kubernetes-client/issues/4659).


The recommended approach is to use `Client#supports(Class)` or `Client#supports(String, String)`. However, Knative has many resources (+versions) and its unclear which types/classes should be used for the check. So in this case, using `hasApiGroup` with the lenient matcher seems like reasonable choice to be able to target multiple Knative versions and APIs (Functions, Serving, Eventing, and so on).