### PR TITLE
Support generation of secured Route in OpenShift

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyOpenshiftRouteConfigurator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyOpenshiftRouteConfigurator.java
@@ -2,6 +2,7 @@ package io.quarkus.kubernetes.deployment;
 
 import io.dekorate.kubernetes.config.Configurator;
 import io.dekorate.openshift.config.OpenshiftConfigFluent;
+import io.dekorate.openshift.config.TLSConfig;
 
 public class ApplyOpenshiftRouteConfigurator extends Configurator<OpenshiftConfigFluent> {
 
@@ -21,6 +22,16 @@ public class ApplyOpenshiftRouteConfigurator extends Configurator<OpenshiftConfi
             }
 
             routeBuilder.withTargetPort(routeConfig.targetPort);
+            if (routeConfig.tls != null) {
+                TLSConfig tls = new TLSConfig();
+                routeConfig.tls.caCertificate.ifPresent(tls::setCaCertificate);
+                routeConfig.tls.certificate.ifPresent(tls::setCertificate);
+                routeConfig.tls.destinationCACertificate.ifPresent(tls::setDestinationCACertificate);
+                routeConfig.tls.key.ifPresent(tls::setKey);
+                routeConfig.tls.termination.ifPresent(tls::setTermination);
+                routeConfig.tls.insecureEdgeTerminationPolicy.ifPresent(tls::setInsecureEdgeTerminationPolicy);
+                routeBuilder.withTls(tls);
+            }
             routeBuilder.endRoute();
         }
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RouteConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RouteConfig.java
@@ -34,4 +34,8 @@ public class RouteConfig {
     @ConfigItem
     Map<String, String> annotations;
 
+    /**
+     * @return the TLS configuration.
+     */
+    TLSConfig tls;
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/TLSConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/TLSConfig.java
@@ -1,0 +1,38 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public class TLSConfig {
+    /**
+     * @return the cert authority certificate contents.
+     */
+    Optional<String> caCertificate;
+
+    /**
+     * @return the certificate contents.
+     */
+    Optional<String> certificate;
+
+    /**
+     * @return the contents of the ca certificate of the final destination.
+     */
+    Optional<String> destinationCACertificate;
+
+    /**
+     * @return the desired behavior for insecure connections to a route. Options are: `allow`, `disable`, and `redirect`.
+     */
+    Optional<String> insecureEdgeTerminationPolicy;
+
+    /**
+     * @return the key file contents.
+     */
+    Optional<String> key;
+
+    /**
+     * @return the termination type.
+     */
+    Optional<String> termination;
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRoutePropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRoutePropertiesTest.java
@@ -65,6 +65,7 @@ public class OpenshiftWithRoutePropertiesTest {
                 });
                 assertThat(r.getSpec().getPort().getTargetPort().getStrVal()).isEqualTo("http");
                 assertThat(r.getSpec().getHost()).isEqualTo("foo.bar.io");
+                assertThat(r.getSpec().getTls()).isNull();
             });
         });
     }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRouteSecuredTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRouteSecuredTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.TLSConfig;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class OpenshiftWithRouteSecuredTest {
+
+    private static final String APP_NAME = "openshift-with-route-secured";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(APP_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource(APP_NAME + ".properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.yml"));
+        List<HasMetadata> openshiftList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("openshift.yml"));
+
+        assertThat(openshiftList).filteredOn(i -> "Route".equals(i.getKind())).singleElement().satisfies(i -> {
+            assertThat(i).isInstanceOfSatisfying(Route.class, r -> {
+                TLSConfig tls = r.getSpec().getTls();
+                assertNotNull(tls, "TLS configuration was not created!");
+                assertEquals("THE CERTIFICATE", tls.getCertificate());
+                assertEquals("THE CA CERTIFICATE", tls.getCaCertificate());
+                assertEquals("Redirect", tls.getInsecureEdgeTerminationPolicy());
+                assertEquals("THE KEY", tls.getKey());
+                assertEquals("reencrypt", tls.getTermination());
+                assertEquals("THE DESTINATION CERTIFICATE", tls.getDestinationCACertificate());
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-route-secured.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-route-secured.properties
@@ -1,0 +1,9 @@
+quarkus.http.port=9090
+quarkus.kubernetes.deployment-target=openshift
+quarkus.openshift.route.expose=true
+quarkus.openshift.route.tls.certificate=THE CERTIFICATE
+quarkus.openshift.route.tls.ca-certificate=THE CA CERTIFICATE
+quarkus.openshift.route.tls.insecure-edge-termination-policy=Redirect
+quarkus.openshift.route.tls.key=THE KEY
+quarkus.openshift.route.tls.termination=reencrypt
+quarkus.openshift.route.tls.destination-ca-certificate=THE DESTINATION CERTIFICATE


### PR DESCRIPTION
This is supported in Dekorate from latest release: https://github.com/dekorateio/dekorate/releases/tag/3.5.0

Fix https://github.com/quarkusio/quarkus/issues/20644