### PR TITLE
Hibernate reactive panache - validation of interceptor bindings

### DIFF
--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/WithSession.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/WithSession.java
@@ -16,8 +16,8 @@ import jakarta.interceptor.InterceptorBinding;
  * triggered, then this session is reused. Otherwise, a new session is opened and eventually closed when the
  * {@link io.smallrye.mutiny.Uni} completes.
  * <p>
- * A method annotated with this annotation must return either {@link io.smallrye.mutiny.Uni}. If declared on a class then all
- * methods that are intercepted must return {@link io.smallrye.mutiny.Uni}.
+ * A method annotated with this annotation must return {@link io.smallrye.mutiny.Uni}. If declared on a class then all methods
+ * that return {@link io.smallrye.mutiny.Uni} are considered; all other methods are ignored.
  */
 @Inherited
 @InterceptorBinding

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/WithSessionOnDemand.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/WithSessionOnDemand.java
@@ -10,13 +10,14 @@ import jakarta.interceptor.InterceptorBinding;
 
 /**
  * Instructs Panache to trigger the {@link io.smallrye.mutiny.Uni} returned from the intercepted method within a scope of a
- * reactive {@link org.hibernate.reactive.mutiny.Mutiny.Session} (if needed). If a reactive session exists when the
- * {@link io.smallrye.mutiny.Uni} returned from the annotated method is triggered, then this session is reused. Otherwise, a new
- * session is opened <b>when needed</b> and eventually closed when the
+ * reactive {@link org.hibernate.reactive.mutiny.Mutiny.Session} (if needed).
+ * <p>
+ * If a reactive session exists when the {@link io.smallrye.mutiny.Uni} returned from the annotated method is triggered, then
+ * this session is reused. Otherwise, a new session is opened <b>when needed</b> and eventually closed when the
  * {@link io.smallrye.mutiny.Uni} completes.
  * <p>
- * A method annotated with this annotation must return {@link io.smallrye.mutiny.Uni}. If declared on a class then all methods
- * that are intercepted must return {@link io.smallrye.mutiny.Uni}.
+ * * A method annotated with this annotation must return {@link io.smallrye.mutiny.Uni}. If declared on a class then all methods
+ * that return {@link io.smallrye.mutiny.Uni} are considered; all other methods are ignored.
  */
 @Inherited
 @InterceptorBinding

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/WithTransaction.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/WithTransaction.java
@@ -10,13 +10,14 @@ import jakarta.interceptor.InterceptorBinding;
 
 /**
  * Instructs Panache to trigger the {@link io.smallrye.mutiny.Uni} returned from the intercepted method within a scope of a
- * reactive {@link org.hibernate.reactive.mutiny.Mutiny.Transaction}. If a reactive session exists when the
- * {@link io.smallrye.mutiny.Uni} returned from the annotated method is triggered, then this session is reused. Otherwise, a new
- * session is opened and eventually closed when the
- * {@link io.smallrye.mutiny.Uni} completes.
+ * reactive {@link org.hibernate.reactive.mutiny.Mutiny.Transaction}.
+ * <p>
+ * If a reactive session exists when the {@link io.smallrye.mutiny.Uni} returned from the annotated method is triggered, then
+ * this session is reused. Otherwise, a new
+ * session is opened and eventually closed when the {@link io.smallrye.mutiny.Uni} completes.
  * <p>
  * A method annotated with this annotation must return {@link io.smallrye.mutiny.Uni}. If declared on a class then all methods
- * that are intercepted must return {@link io.smallrye.mutiny.Uni}.
+ * that return {@link io.smallrye.mutiny.Uni} are considered; all other methods are ignored.
  *
  * @see org.hibernate.reactive.mutiny.Mutiny.SessionFactory#withTransaction(java.util.function.Function)
  */

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractUniInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractUniInterceptor.java
@@ -15,4 +15,8 @@ abstract class AbstractUniInterceptor {
         }
     }
 
+    protected boolean isUniReturnType(InvocationContext context) {
+        return context.getMethod().getReturnType().equals(Uni.class);
+    }
+
 }

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithSessionInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithSessionInterceptor.java
@@ -14,9 +14,12 @@ public class WithSessionInterceptor extends AbstractUniInterceptor {
 
     @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
-        // Note that intercepted methods annotated with @WithSession are validated at build time
-        // The build fails if a method does not return Uni
-        return SessionOperations.withSession(s -> proceedUni(context));
+        // Bindings are validated at build time - method-level binding declared on a method that does not return Uni results in a build failure
+        // However, a class-level binding implies that methods that do not return Uni are just a no-op
+        if (isUniReturnType(context)) {
+            return SessionOperations.withSession(s -> proceedUni(context));
+        }
+        return context.proceed();
     }
 
 }

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithSessionOnDemandInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithSessionOnDemandInterceptor.java
@@ -14,9 +14,12 @@ public class WithSessionOnDemandInterceptor extends AbstractUniInterceptor {
 
     @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
-        // Note that intercepted methods annotated with @WithSessionOnDemand are validated at build time
-        // The build fails if a method does not return Uni
-        return SessionOperations.withSessionOnDemand(() -> proceedUni(context));
+        // Bindings are validated at build time - method-level binding declared on a method that does not return Uni results in a build failure
+        // However, a class-level binding implies that methods that do not return Uni are just a no-op
+        if (isUniReturnType(context)) {
+            return SessionOperations.withSessionOnDemand(() -> proceedUni(context));
+        }
+        return context.proceed();
     }
 
 }

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithTransactionInterceptor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/WithTransactionInterceptor.java
@@ -14,9 +14,12 @@ public class WithTransactionInterceptor extends AbstractUniInterceptor {
 
     @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
-        // Note that intercepted methods annotated with @WithTransaction are validated at build time
-        // The build fails if the method does not return Uni
-        return SessionOperations.withTransaction(() -> proceedUni(context));
+        // Bindings are validated at build time - method-level binding declared on a method that does not return Uni results in a build failure
+        // However, a class-level binding implies that methods that do not return Uni are just a no-op
+        if (isUniReturnType(context)) {
+            return SessionOperations.withTransaction(() -> proceedUni(context));
+        }
+        return context.proceed();
     }
 
 }

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/WithTransactionClassLevelValidationTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/WithTransactionClassLevelValidationTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.hibernate.reactive.panache.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WithTransactionClassLevelValidationTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(Bean.class));
+
+    @Inject
+    Bean bean;
+
+    @Test
+    public void testBindingIgnored() {
+        assertEquals("ok", bean.ping());
+    }
+
+    @WithTransaction
+    @Unremovable
+    @ApplicationScoped
+    static class Bean {
+
+        // this method is just ignored by the interceptor
+        String ping() {
+            return "ok";
+        }
+
+    }
+}

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/WithTransactionMethodLevelValidationTest.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/panache/test/WithTransactionMethodLevelValidationTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.hibernate.reactive.panache.test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WithTransactionMethodLevelValidationTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setExpectedException(IllegalStateException.class)
+            .withApplicationRoot(root -> root
+                    .addClasses(Bean.class));
+
+    @Test
+    public void testValidationFailed() {
+        fail();
+    }
+
+    @Unremovable
+    @ApplicationScoped
+    static class Bean {
+
+        @WithTransaction
+        void ping() {
+        }
+
+    }
+}


### PR DESCRIPTION
- the build only fails if any of [WithSession, WithTransaction, WithSessionOnDemand] is declared on a method that does not return Uni
- if declared on a class then the methods that do not return Uni are effectively ignored