### PR TITLE
Container runtime detection cached in sys prop, container-docker extension 

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
@@ -29,7 +29,7 @@ import io.quarkus.deployment.pkg.builditem.JarBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.steps.MainClassBuildStep;
 import io.quarkus.runtime.LaunchMode;
-import io.quarkus.runtime.util.ContainerRuntimeUtil;
+import io.quarkus.runtime.util.ContainerRuntimeUtil.ContainerRuntime;
 import io.quarkus.utilities.JavaBinFinder;
 
 public class AppCDSBuildStep {
@@ -39,7 +39,6 @@ public class AppCDSBuildStep {
     public static final String CLASSES_LIST_FILE_NAME = "classes.lst";
     private static final String CONTAINER_IMAGE_BASE_BUILD_DIR = "/tmp/quarkus";
     private static final String CONTAINER_IMAGE_APPCDS_DIR = CONTAINER_IMAGE_BASE_BUILD_DIR + "/appcds";
-    public static final ContainerRuntimeUtil.ContainerRuntime CONTAINER_RUNTIME = detectContainerRuntime(false);
 
     @BuildStep(onlyIf = AppCDSRequired.class)
     public void requested(OutputTargetBuildItem outputTarget, BuildProducer<AppCDSRequestedBuildItem> producer)
@@ -204,12 +203,10 @@ public class AppCDSBuildStep {
     // generate the classes file on the host
     private List<String> dockerRunCommands(OutputTargetBuildItem outputTarget, String containerImage,
             String containerWorkingDir) {
-        if (CONTAINER_RUNTIME == ContainerRuntimeUtil.ContainerRuntime.UNAVAILABLE) {
-            throw new IllegalStateException("No container runtime was found. "
-                    + "Make sure you have either Docker or Podman installed in your environment.");
-        }
+        ContainerRuntime containerRuntime = detectContainerRuntime(true);
+
         List<String> command = new ArrayList<>(10);
-        command.add(CONTAINER_RUNTIME.getExecutableName());
+        command.add(containerRuntime.getExecutableName());
         command.add("run");
         command.add("-v");
         command.add(outputTarget.getOutputDirectory().toAbsolutePath().toString() + ":" + CONTAINER_IMAGE_BASE_BUILD_DIR

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.deployment.pkg.steps;
 
-import static io.quarkus.deployment.pkg.steps.AppCDSBuildStep.CONTAINER_RUNTIME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
@@ -19,10 +18,8 @@ class NativeImageBuildContainerRunnerTest {
     @DisabledIfSystemProperty(named = "avoid-containers", matches = "true")
     @Test
     void testBuilderImageBeingPickedUp() {
-        if (CONTAINER_RUNTIME == ContainerRuntimeUtil.ContainerRuntime.UNAVAILABLE) {
-            throw new IllegalStateException("No container runtime was found. "
-                    + "Make sure you have either Docker or Podman installed in your environment.");
-        }
+        ContainerRuntimeUtil.ContainerRuntime containerRuntime = ContainerRuntimeUtil.detectContainerRuntime(true);
+
         NativeConfig nativeConfig = new NativeConfig();
         nativeConfig.containerRuntime = Optional.empty();
         boolean found;
@@ -31,7 +28,7 @@ class NativeImageBuildContainerRunnerTest {
 
         nativeConfig.builderImage = "graalvm";
         localRunner = new NativeImageBuildLocalContainerRunner(nativeConfig, Path.of("/tmp"));
-        command = localRunner.buildCommand(CONTAINER_RUNTIME.getExecutableName(), Collections.emptyList(),
+        command = localRunner.buildCommand(containerRuntime.getExecutableName(), Collections.emptyList(),
                 Collections.emptyList());
         found = false;
         for (String part : command) {
@@ -44,7 +41,7 @@ class NativeImageBuildContainerRunnerTest {
 
         nativeConfig.builderImage = "mandrel";
         localRunner = new NativeImageBuildLocalContainerRunner(nativeConfig, Path.of("/tmp"));
-        command = localRunner.buildCommand(CONTAINER_RUNTIME.getExecutableName(), Collections.emptyList(),
+        command = localRunner.buildCommand(containerRuntime.getExecutableName(), Collections.emptyList(),
                 Collections.emptyList());
         found = false;
         for (String part : command) {
@@ -57,7 +54,7 @@ class NativeImageBuildContainerRunnerTest {
 
         nativeConfig.builderImage = "RandomString";
         localRunner = new NativeImageBuildLocalContainerRunner(nativeConfig, Path.of("/tmp"));
-        command = localRunner.buildCommand(CONTAINER_RUNTIME.getExecutableName(), Collections.emptyList(),
+        command = localRunner.buildCommand(containerRuntime.getExecutableName(), Collections.emptyList(),
                 Collections.emptyList());
         found = false;
         for (String part : command) {

--- a/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerConfig.java
+++ b/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerConfig.java
@@ -50,9 +50,10 @@ public class DockerConfig {
 
     /**
      * Name of binary used to execute the docker commands.
+     * This setting can override the global container runtime detection.
      */
-    @ConfigItem(defaultValue = "docker")
-    public String executableName;
+    @ConfigItem
+    public Optional<String> executableName;
 
     /**
      * Configuration for Docker Buildx options

--- a/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
+++ b/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
@@ -204,7 +204,7 @@ public class DockerProcessor {
             boolean buildSuccessful = ExecUtil.exec(out.getOutputDirectory().toFile(), reader, executableName,
                     dockerArgs);
             if (!buildSuccessful) {
-                throw dockerException(dockerArgs);
+                throw dockerException(executableName, dockerArgs);
             }
 
             dockerConfig.buildx.platform
@@ -250,7 +250,8 @@ public class DockerProcessor {
                     containerImageConfig.username.get(),
                     "-p" + containerImageConfig.password.get());
             if (!loginSuccessful) {
-                throw dockerException(new String[] { "-u", containerImageConfig.username.get(), "-p", "********" });
+                throw dockerException(executableName,
+                        new String[] { "-u", containerImageConfig.username.get(), "-p", "********" });
             }
         }
     }
@@ -326,7 +327,7 @@ public class DockerProcessor {
             String[] tagArgs = { "tag", image, additionalTag };
             boolean tagSuccessful = ExecUtil.exec(executableName, tagArgs);
             if (!tagSuccessful) {
-                throw dockerException(tagArgs);
+                throw dockerException(executableName, tagArgs);
             }
         }
     }
@@ -336,14 +337,15 @@ public class DockerProcessor {
         String[] pushArgs = { "push", image };
         boolean pushSuccessful = ExecUtil.exec(executableName, pushArgs);
         if (!pushSuccessful) {
-            throw dockerException(pushArgs);
+            throw dockerException(executableName, pushArgs);
         }
         log.info("Successfully pushed docker image " + image);
     }
 
-    private RuntimeException dockerException(String[] dockerArgs) {
+    private RuntimeException dockerException(String executableName, String[] dockerArgs) {
         return new RuntimeException(
-                "Execution of 'docker " + String.join(" ", dockerArgs) + "' failed. See docker output for more details");
+                "Execution of '" + executableName + " " + String.join(" ", dockerArgs)
+                        + "' failed. See docker output for more details");
     }
 
     private DockerfilePaths getDockerfilePaths(DockerConfig dockerConfig, boolean forNative,

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -65,7 +65,6 @@ public final class IntegrationTestUtil {
     public static final int DEFAULT_PORT = 8081;
     public static final int DEFAULT_HTTPS_PORT = 8444;
     public static final long DEFAULT_WAIT_TIME_SECONDS = 60;
-    public static final ContainerRuntimeUtil.ContainerRuntime CONTAINER_RUNTIME = detectContainerRuntime(false);
 
     private IntegrationTestUtil() {
     }
@@ -337,13 +336,11 @@ public final class IntegrationTestUtil {
     private static void createNetworkIfNecessary(
             final ArtifactLauncher.InitContext.DevServicesLaunchResult devServicesLaunchResult) {
         if (devServicesLaunchResult.manageNetwork() && (devServicesLaunchResult.networkId() != null)) {
-            if (CONTAINER_RUNTIME == ContainerRuntimeUtil.ContainerRuntime.UNAVAILABLE) {
-                throw new IllegalStateException("No container runtime was found. "
-                        + "Make sure you have either Docker or Podman installed in your environment.");
-            }
+            ContainerRuntimeUtil.ContainerRuntime containerRuntime = detectContainerRuntime(true);
+
             try {
                 int networkCreateResult = new ProcessBuilder().redirectError(DISCARD).redirectOutput(DISCARD)
-                        .command(CONTAINER_RUNTIME.getExecutableName(), "network", "create",
+                        .command(containerRuntime.getExecutableName(), "network", "create",
                                 devServicesLaunchResult.networkId())
                         .start().waitFor();
                 if (networkCreateResult > 0) {
@@ -356,7 +353,7 @@ public final class IntegrationTestUtil {
                     public void run() {
                         try {
                             new ProcessBuilder().redirectError(DISCARD).redirectOutput(DISCARD)
-                                    .command(CONTAINER_RUNTIME.getExecutableName(), "network", "rm",
+                                    .command(containerRuntime.getExecutableName(), "network", "rm",
                                             devServicesLaunchResult.networkId())
                                     .start()
                                     .waitFor();


### PR DESCRIPTION
~~Do not merge yet, ongoing testing on Windows Docker and Podman...~~

Followup on #31490

* As per our discussion on #31490, the container runtime detected is cached in a sys prop, not in a file now.
* Removed superfluous calls to `podman` when `docker` is hinted by `quarkus.native.container-runtime` and vice versa.
* Fixed a scenario when there is neither `podman` nor `docker` and it's O.K. as it's not needed.
* Switched `extensions/container-image/container-image-docker` to use Core's container runtime autodetection too, with the current property `quarkus.docker.executable-name` being an optional way to override the detection system.

The experience with  `extensions/container-image/container-image-docker` is much improved on Podman only systems, because one doesn't have to explicitly specify `quarkus.docker.executable-name=podman` to make it work. 