### PR TITLE
Generate Java 11 bytecode when using Bytebuddy in Hibernate ORM extensions

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateEntityEnhancer.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateEntityEnhancer.java
@@ -30,7 +30,7 @@ import net.bytebuddy.ClassFileVersion;
 public final class HibernateEntityEnhancer implements BiFunction<String, ClassVisitor, ClassVisitor> {
 
     private static final BytecodeProvider PROVIDER = new org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl(
-            ClassFileVersion.JAVA_V8);
+            ClassFileVersion.JAVA_V11);
 
     @Override
     public ClassVisitor apply(String className, ClassVisitor outputClassVisitor) {

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ProxyBuildingHelper.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ProxyBuildingHelper.java
@@ -46,7 +46,7 @@ final class ProxyBuildingHelper implements AutoCloseable {
         //Lazy initialization of Byte Buddy: we'll likely need it, but if we can avoid loading it
         //in some corner cases it's worth avoiding it.
         if (this.byteBuddyProxyHelper == null) {
-            bytecodeProvider = new BytecodeProviderImpl(ClassFileVersion.JAVA_V8);
+            bytecodeProvider = new BytecodeProviderImpl(ClassFileVersion.JAVA_V11);
             this.byteBuddyProxyHelper = bytecodeProvider.getByteBuddyProxyHelper();
         }
         return this.byteBuddyProxyHelper;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/BootstrapOnlyProxyFactoryFactoryInitiator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/BootstrapOnlyProxyFactoryFactoryInitiator.java
@@ -24,7 +24,7 @@ public final class BootstrapOnlyProxyFactoryFactoryInitiator implements Standard
 
     @Override
     public ProxyFactoryFactory initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
-        BytecodeProviderImpl bbProvider = new BytecodeProviderImpl(ClassFileVersion.JAVA_V8);
+        BytecodeProviderImpl bbProvider = new BytecodeProviderImpl(ClassFileVersion.JAVA_V11);
         return bbProvider.getProxyFactoryFactory();
     }
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/proxies/ProxyDefinitions.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/proxies/ProxyDefinitions.java
@@ -193,7 +193,7 @@ public final class ProxyDefinitions {
         @Override
         public ByteBuddyProxyHelper get() {
             if (helper == null) {
-                bytecodeProvider = new BytecodeProviderImpl(ClassFileVersion.JAVA_V8);
+                bytecodeProvider = new BytecodeProviderImpl(ClassFileVersion.JAVA_V11);
                 helper = bytecodeProvider.getByteBuddyProxyHelper();
             }
             return helper;


### PR DESCRIPTION
Because the baseline in Quarkus 3 is Java 11.

I'm not sure if this will actually prevent any problems, but in principle it seems safer to just be consistent.