### PR TITLE
Fix documentation of field lookupIfMissing in LookupUnlessProperty

### DIFF
--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupUnlessProperty.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/lookup/LookupUnlessProperty.java
@@ -71,7 +71,7 @@ public @interface LookupUnlessProperty {
     String stringValue();
 
     /**
-     * Determines if the bean should be suppressed when the property name specified by {@code name} has not been specified at
+     * Determines if the bean should be looked up when the property name specified by {@code name} has not been specified at
      * all
      */
     boolean lookupIfMissing() default false;


### PR DESCRIPTION
Fixing javadoc of field lookupIfMissing in LookupUnlessProperty

Closes: #31863