### PR TITLE
Reactive Datasource: support CredentialsProvider changing values

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1880,6 +1880,13 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-reactive-datasource-deployment</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+                <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-reactive-db2-client</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/extensions/reactive-datasource/deployment/pom.xml
+++ b/extensions/reactive-datasource/deployment/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -45,6 +50,17 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/ChangingCredentialsProviderBase.java
+++ b/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/ChangingCredentialsProviderBase.java
@@ -1,0 +1,38 @@
+package io.quarkus.reactive.datasource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.credentials.CredentialsProvider;
+
+public abstract class ChangingCredentialsProviderBase implements CredentialsProvider {
+
+    private static final Logger log = Logger.getLogger(ChangingCredentialsProviderBase.class.getName());
+
+    private final String user2;
+    private final String password2;
+
+    private volatile Map<String, String> properties;
+
+    protected ChangingCredentialsProviderBase(String user1, String password1, String user2, String password2) {
+        properties = new HashMap<>();
+        properties.put(USER_PROPERTY_NAME, user1);
+        properties.put(PASSWORD_PROPERTY_NAME, password1);
+        this.user2 = user2;
+        this.password2 = password2;
+    }
+
+    public void changeProperties() {
+        properties = new HashMap<>();
+        properties.put(USER_PROPERTY_NAME, user2);
+        properties.put(PASSWORD_PROPERTY_NAME, password2);
+    }
+
+    @Override
+    public Map<String, String> getCredentials(String credentialsProviderName) {
+        log.info("credentials provider returning " + properties);
+        return properties;
+    }
+}

--- a/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/ChangingCredentialsTestBase.java
+++ b/extensions/reactive-datasource/deployment/src/test/java/io/quarkus/reactive/datasource/ChangingCredentialsTestBase.java
@@ -1,0 +1,36 @@
+package io.quarkus.reactive.datasource;
+
+import static io.restassured.RestAssured.given;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Test;
+
+public abstract class ChangingCredentialsTestBase {
+
+    private String user1;
+    private String user2;
+
+    protected ChangingCredentialsTestBase(String user1, String user2) {
+        this.user1 = user1;
+        this.user2 = user2;
+    }
+
+    @Test
+    public void testConnect() throws Exception {
+        given()
+                .when().get("/test")
+                .then()
+                .statusCode(200)
+                .body(CoreMatchers.equalTo(user1));
+
+        SECONDS.sleep(2); // sleep longer than pool idle connection timeout
+
+        given()
+                .when().get("/test")
+                .then()
+                .statusCode(200)
+                .body(CoreMatchers.equalTo(user2));
+    }
+
+}

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ConnectOptionsSupplier.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ConnectOptionsSupplier.java
@@ -1,0 +1,67 @@
+package io.quarkus.reactive.datasource.runtime;
+
+import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntUnaryOperator;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
+import io.quarkus.credentials.CredentialsProvider;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.sqlclient.SqlConnectOptions;
+
+public class ConnectOptionsSupplier<CO extends SqlConnectOptions> implements Supplier<Future<CO>> {
+
+    private final Vertx vertx;
+    private final CredentialsProvider credentialsProvider;
+    private final String credentialsProviderName;
+    private final List<CO> connectOptionsList;
+    private final UnaryOperator<CO> connectOptionsCopy;
+    private final Handler<Promise<CO>> blockingCodeHandler;
+
+    public ConnectOptionsSupplier(Vertx vertx, CredentialsProvider credentialsProvider, String credentialsProviderName,
+            List<CO> connectOptionsList, UnaryOperator<CO> connectOptionsCopy) {
+        this.vertx = vertx;
+        this.credentialsProvider = credentialsProvider;
+        this.credentialsProviderName = credentialsProviderName;
+        this.connectOptionsList = connectOptionsList;
+        this.connectOptionsCopy = connectOptionsCopy;
+        blockingCodeHandler = new BlockingCodeHandler();
+    }
+
+    @Override
+    public Future<CO> get() {
+        return vertx.executeBlocking(blockingCodeHandler, false);
+    }
+
+    private class BlockingCodeHandler implements Handler<Promise<CO>>, IntUnaryOperator {
+
+        final AtomicInteger idx = new AtomicInteger();
+
+        @Override
+        public void handle(Promise<CO> promise) {
+            Map<String, String> credentials = credentialsProvider.getCredentials(credentialsProviderName);
+            String user = credentials.get(USER_PROPERTY_NAME);
+            String password = credentials.get(PASSWORD_PROPERTY_NAME);
+
+            int nextIdx = idx.getAndUpdate(this);
+
+            CO connectOptions = connectOptionsCopy.apply(connectOptionsList.get(nextIdx));
+            connectOptions.setUser(user).setPassword(password);
+
+            promise.complete(connectOptions);
+        }
+
+        @Override
+        public int applyAsInt(int previousIdx) {
+            return previousIdx == connectOptionsList.size() - 1 ? 0 : previousIdx + 1;
+        }
+    }
+}

--- a/extensions/reactive-mssql-client/deployment/pom.xml
+++ b/extensions/reactive-mssql-client/deployment/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-datasource-deployment</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsProvider.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsProvider.java
@@ -1,0 +1,13 @@
+package io.quarkus.reactive.mssql.client;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.reactive.datasource.ChangingCredentialsProviderBase;
+
+@ApplicationScoped
+public class ChangingCredentialsProvider extends ChangingCredentialsProviderBase {
+
+    public ChangingCredentialsProvider() {
+        super("sa", "A_Str0ng_Required_Password", "user2", "user2_Has_A_Str0ng_Required_Password");
+    }
+}

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsTest.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.reactive.mssql.client;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.reactive.datasource.ChangingCredentialsTestBase;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChangingCredentialsTest extends ChangingCredentialsTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(ChangingCredentialsProvider.class)
+                    .addClass(ChangingCredentialsTestResource.class)
+                    .addAsResource("application-changing-credentials.properties", "application.properties"));
+
+    public ChangingCredentialsTest() {
+        super("dbo", "user2");
+    }
+}

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsTestResource.java
@@ -1,0 +1,41 @@
+package io.quarkus.reactive.mssql.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.mssqlclient.MSSQLPool;
+
+@Path("/test")
+public class ChangingCredentialsTestResource {
+
+    @Inject
+    MSSQLPool client;
+
+    @Inject
+    ChangingCredentialsProvider credentialsProvider;
+
+    void addUser(@Observes StartupEvent ignored) {
+        client.query("CREATE LOGIN user2 WITH PASSWORD = 'user2_Has_A_Str0ng_Required_Password'").executeAndAwait();
+        client.query("CREATE USER user2 FOR LOGIN user2").executeAndAwait();
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<Response> connect() {
+        return client.query("SELECT CURRENT_USER").execute()
+                .map(rowSet -> {
+                    assertEquals(1, rowSet.size());
+                    return Response.ok(rowSet.iterator().next().getString(0)).build();
+                }).eventually(credentialsProvider::changeProperties);
+    }
+
+}

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-changing-credentials.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-changing-credentials.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=mssql
+quarkus.datasource.credentials-provider=changing
+quarkus.datasource.reactive.url=${reactive-mssql.url}
+quarkus.datasource.reactive.max-size=1
+quarkus.datasource.reactive.idle-timeout=PT1S

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -90,6 +90,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-datasource-deployment</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -209,6 +215,9 @@
                                             <bind>
                                                 <volume>
                                                     ${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d${volume.access.modifier}
+                                                </volume>
+                                                <volume>
+                                                    ${project.basedir}/src/test/resources/setup.sql:/docker-entrypoint-initdb.d/setup.sql
                                                 </volume>
                                             </bind>
                                         </volumes>

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/ChangingCredentialsProvider.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/ChangingCredentialsProvider.java
@@ -1,0 +1,13 @@
+package io.quarkus.reactive.mysql.client;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.reactive.datasource.ChangingCredentialsProviderBase;
+
+@ApplicationScoped
+public class ChangingCredentialsProvider extends ChangingCredentialsProviderBase {
+
+    public ChangingCredentialsProvider() {
+        super("hibernate_orm_test", "hibernate_orm_test", "user2", "user2");
+    }
+}

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/ChangingCredentialsTest.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/ChangingCredentialsTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.reactive.mysql.client;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.reactive.datasource.ChangingCredentialsTestBase;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChangingCredentialsTest extends ChangingCredentialsTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(ChangingCredentialsProvider.class)
+                    .addClass(ChangingCredentialsTestResource.class)
+                    .addAsResource("application-changing-credentials.properties", "application.properties"));
+
+    public ChangingCredentialsTest() {
+        super("hibernate_orm_test@%", "user2@%");
+    }
+}

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/ChangingCredentialsTestResource.java
@@ -1,0 +1,34 @@
+package io.quarkus.reactive.mysql.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.mysqlclient.MySQLPool;
+
+@Path("/test")
+public class ChangingCredentialsTestResource {
+
+    @Inject
+    MySQLPool client;
+
+    @Inject
+    ChangingCredentialsProvider credentialsProvider;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<Response> connect() {
+        return client.query("SELECT CURRENT_USER").execute()
+                .map(rowSet -> {
+                    assertEquals(1, rowSet.size());
+                    return Response.ok(rowSet.iterator().next().getString(0)).build();
+                }).eventually(credentialsProvider::changeProperties);
+    }
+
+}

--- a/extensions/reactive-mysql-client/deployment/src/test/resources/application-changing-credentials.properties
+++ b/extensions/reactive-mysql-client/deployment/src/test/resources/application-changing-credentials.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=mysql
+quarkus.datasource.credentials-provider=changing
+quarkus.datasource.reactive.url=${reactive-mysql.url}
+quarkus.datasource.reactive.max-size=1
+quarkus.datasource.reactive.idle-timeout=PT1S

--- a/extensions/reactive-mysql-client/deployment/src/test/resources/setup.sql
+++ b/extensions/reactive-mysql-client/deployment/src/test/resources/setup.sql
@@ -1,0 +1,3 @@
+CREATE USER 'user2'@'%' IDENTIFIED BY 'user2';
+GRANT ALL PRIVILEGES ON hibernate_orm_test.* TO 'user2'@'%';
+FLUSH PRIVILEGES;

--- a/extensions/reactive-oracle-client/deployment/pom.xml
+++ b/extensions/reactive-oracle-client/deployment/pom.xml
@@ -73,6 +73,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-datasource-deployment</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/ChangingCredentialsProvider.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/ChangingCredentialsProvider.java
@@ -1,0 +1,13 @@
+package io.quarkus.reactive.oracle.client;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.reactive.datasource.ChangingCredentialsProviderBase;
+
+@ApplicationScoped
+public class ChangingCredentialsProvider extends ChangingCredentialsProviderBase {
+
+    public ChangingCredentialsProvider() {
+        super("SYSTEM", "hibernate_orm_test", "user2", "user2");
+    }
+}

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/ChangingCredentialsTest.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/ChangingCredentialsTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.reactive.oracle.client;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.reactive.datasource.ChangingCredentialsTestBase;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChangingCredentialsTest extends ChangingCredentialsTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(ChangingCredentialsProvider.class)
+                    .addClass(ChangingCredentialsTestResource.class)
+                    .addAsResource("application-changing-credentials.properties", "application.properties"));
+
+    public ChangingCredentialsTest() {
+        super("SYSTEM", "USER2");
+    }
+}

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/ChangingCredentialsTestResource.java
@@ -1,0 +1,41 @@
+package io.quarkus.reactive.oracle.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.oracleclient.OraclePool;
+
+@Path("/test")
+public class ChangingCredentialsTestResource {
+
+    @Inject
+    OraclePool client;
+
+    @Inject
+    ChangingCredentialsProvider credentialsProvider;
+
+    void addUser(@Observes StartupEvent ignored) {
+        client.query("CREATE USER user2 IDENTIFIED BY user2").executeAndAwait();
+        client.query("GRANT CREATE SESSION TO user2").executeAndAwait();
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<Response> connect() {
+        return client.query("SELECT USER FROM DUAL").execute()
+                .map(rowSet -> {
+                    assertEquals(1, rowSet.size());
+                    return Response.ok(rowSet.iterator().next().getString(0)).build();
+                }).eventually(credentialsProvider::changeProperties);
+    }
+
+}

--- a/extensions/reactive-oracle-client/deployment/src/test/resources/application-changing-credentials.properties
+++ b/extensions/reactive-oracle-client/deployment/src/test/resources/application-changing-credentials.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=oracle
+quarkus.datasource.credentials-provider=changing
+quarkus.datasource.reactive.url=${reactive-oracledb.url}
+quarkus.datasource.reactive.max-size=1
+quarkus.datasource.reactive.idle-timeout=PT1S

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-datasource-deployment</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/ChangingCredentialsProvider.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/ChangingCredentialsProvider.java
@@ -1,0 +1,13 @@
+package io.quarkus.reactive.pg.client;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.reactive.datasource.ChangingCredentialsProviderBase;
+
+@ApplicationScoped
+public class ChangingCredentialsProvider extends ChangingCredentialsProviderBase {
+
+    public ChangingCredentialsProvider() {
+        super("hibernate_orm_test", "hibernate_orm_test", "user2", "user2");
+    }
+}

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/ChangingCredentialsTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/ChangingCredentialsTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.reactive.pg.client;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.reactive.datasource.ChangingCredentialsTestBase;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChangingCredentialsTest extends ChangingCredentialsTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(ChangingCredentialsProvider.class)
+                    .addClass(ChangingCredentialsTestResource.class)
+                    .addAsResource("application-changing-credentials.properties", "application.properties"));
+
+    public ChangingCredentialsTest() {
+        super("hibernate_orm_test", "user2");
+    }
+}

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/ChangingCredentialsTestResource.java
@@ -1,0 +1,40 @@
+package io.quarkus.reactive.pg.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.pgclient.PgPool;
+
+@Path("/test")
+public class ChangingCredentialsTestResource {
+
+    @Inject
+    PgPool client;
+
+    @Inject
+    ChangingCredentialsProvider credentialsProvider;
+
+    void addUser(@Observes StartupEvent ignored) {
+        client.query("CREATE USER user2 WITH PASSWORD 'user2' SUPERUSER").executeAndAwait();
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<Response> connect() {
+        return client.query("SELECT CURRENT_USER").execute()
+                .map(pgRowSet -> {
+                    assertEquals(1, pgRowSet.size());
+                    return Response.ok(pgRowSet.iterator().next().getString(0)).build();
+                }).eventually(credentialsProvider::changeProperties);
+    }
+
+}

--- a/extensions/reactive-pg-client/deployment/src/test/resources/application-changing-credentials.properties
+++ b/extensions/reactive-pg-client/deployment/src/test/resources/application-changing-credentials.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.credentials-provider=changing
+quarkus.datasource.reactive.url=${reactive-postgres.url}
+quarkus.datasource.reactive.max-size=1
+quarkus.datasource.reactive.idle-timeout=PT1S


### PR DESCRIPTION
Instead of:

- creating pgConnectOptions after calling the CredentialsProvider on startup
- using static pool configuration

We:

- use dynamic pool configuration
- call the Credentials provider every time a new connection must be created

This PR allows to support use cases like password rotation.

See also https://issues.redhat.com/projects/QUARKUS/issues/QUARKUS-2995