### PR TITLE
Keycloak policy enforcer - document and test permission scope security checks including `@PermissionsAllowed` annotation

### DIFF
--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -328,36 +328,6 @@ export access_token=$(\
  )
 ----
 
-== Checking Permissions Programmatically
-
-In some cases, you may want to programmatically check whether a request is granted to access a protected resource. By
-injecting a `SecurityIdentity` instance in your beans, you are allowed to check permissions as follows:
-
-[source,java]
-----
-import io.quarkus.security.identity.SecurityIdentity;
-import io.smallrye.mutiny.Uni;
-
-@Path("/api/protected")
-public class ProtectedResource {
-
-    @Inject
-    SecurityIdentity identity;
-
-
-    @GET
-    public Uni<List<Permission>> get() {
-        return identity.checkPermission(new AuthPermission("{resource_name}")).onItem()
-                .transform(granted -> {
-                    if (granted) {
-                        return identity.getAttribute("permissions");
-                    }
-                    throw new ForbiddenException();
-                });
-    }
-}
-----
-
 == Injecting the Authorization Client
 
 In some cases, you may want to use the https://www.keycloak.org/docs/latest/authorization_services/#_service_client_api[Keycloak Authorization Client Java API] to perform
@@ -416,6 +386,92 @@ quarkus.keycloak.policy-enforcer.paths.1.enforcement-mode=ENFORCING
 ----
 
 Note only the default tenant configuration applies when controlling anonymous access to the public resource is required.
+
+== Checking Permission Scopes Programmatically
+
+In addition to resource permissions, you may want to specify method scopes. The scope usually represents an action that
+can be performed on a resource. You can create an enforcing Keycloak Authorization Policy with method scope like this:
+
+[source,properties]
+----
+# path policy with enforced scope 'read' for method 'GET'
+quarkus.keycloak.policy-enforcer.paths.1.name=Scope Permission Resource
+quarkus.keycloak.policy-enforcer.paths.1.path=/api/protected/standard-way
+quarkus.keycloak.policy-enforcer.paths.1.methods.get.method=GET
+quarkus.keycloak.policy-enforcer.paths.1.methods.get.scopes=read <1>
+
+# path policies without scope
+quarkus.keycloak.policy-enforcer.paths.2.name=Scope Permission Resource
+quarkus.keycloak.policy-enforcer.paths.2.path=/api/protected/programmatic-way
+quarkus.keycloak.policy-enforcer.paths.3.name=Scope Permission Resource
+quarkus.keycloak.policy-enforcer.paths.3.path=/api/protected/annotation-way
+----
+<1> User must have resource permission 'Scope Permission Resource' and scope 'read'
+
+Request path `/api/protected/standard-way` is now secured by the Keycloak Policy Enforcer and does not require
+any additions (such as `@RolesAllowed` annotation). In some cases, you may want to perform the same check programmatically.
+You are allowed to do that by injecting a `SecurityIdentity` instance in your beans, as demonstrated in the example below.
+Alternatively, if you annotate resource method with the `@PermissionsAllowed` annotation, you can achieve the same effect.
+The following example shows three resource method that all requires same 'read' scope:
+
+[source,java]
+----
+import java.security.BasicPermission;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.keycloak.representations.idm.authorization.Permission;
+
+import io.quarkus.security.PermissionsAllowed;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+@Path("/api/protected")
+public class ProtectedResource {
+
+    @Inject
+    SecurityIdentity identity;
+
+    @GET
+    @Path("/standard-way")
+    public Uni<List<Permission>> standardWay() { <1>
+        return Uni.createFrom().item(identity.<List<Permission>> getAttribute("permissions"));
+    }
+
+    @GET
+    @Path("/programmatic-way")
+    public Uni<List<Permission>> programmaticWay() {
+        var requiredPermission = new BasicPermission("Scope Permission Resource") {
+            @Override
+            public String getActions() {
+                return "read";
+            }
+        };
+        return identity.checkPermission(requiredPermission).onItem() <2>
+                .transform(granted -> {
+                    if (granted) {
+                        return identity.getAttribute("permissions");
+                    }
+                    throw new ForbiddenException();
+                });
+    }
+
+    @PermissionsAllowed("Scope Permission Resource:read") <3>
+    @GET
+    @Path("/annotation-way")
+    public Uni<List<Permission>> annotationWay() {
+        return Uni.createFrom().item(identity.<List<Permission>> getAttribute("permissions"));
+    }
+}
+----
+<1> Request sub-path `/standard-way` requires both resource permission and scope `read` according to the configuration properties we set in the `application.properties` before.
+<2> Request sub-path `/programmatic-way` only requires permission `Scope Permission Resource`, but we can enforce scope with `SecurityIdentity#checkPermission`.
+<3> The `@PermissionsAllowed` annotation only grants access to the requests with permission `Scope Permission Resource` and scope `read`.
+For more information, see the section xref:security-authorize-web-endpoints-reference.adoc#standard-security-annotations[Authorization using annotations] of the Security Authorization guide.
 
 == Multi-Tenancy
 

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityIdentityProxy.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityIdentityProxy.java
@@ -4,6 +4,7 @@ import java.security.Permission;
 import java.security.Principal;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -60,7 +61,13 @@ public class SecurityIdentityProxy implements SecurityIdentity {
 
     @Override
     public Uni<Boolean> checkPermission(Permission permission) {
-        return association.getIdentity().checkPermission(permission);
+        return association.getDeferredIdentity()
+                .flatMap(new Function<>() {
+                    @Override
+                    public Uni<? extends Boolean> apply(SecurityIdentity identity) {
+                        return identity.checkPermission(permission);
+                    }
+                });
     }
 
     @Override

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -5,8 +5,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.security.auth.AuthPermission;
-
 import jakarta.inject.Inject;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
@@ -19,6 +17,7 @@ import jakarta.ws.rs.core.Context;
 import org.keycloak.authorization.client.AuthzClient;
 import org.keycloak.representations.idm.authorization.Permission;
 
+import io.quarkus.security.PermissionsAllowed;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpServerRequest;
@@ -40,13 +39,7 @@ public class ProtectedResource {
 
     @GET
     public Uni<List<Permission>> permissions() {
-        return identity.checkPermission(new AuthPermission("Permission Resource")).onItem()
-                .transform(granted -> {
-                    if (granted) {
-                        return identity.getAttribute("permissions");
-                    }
-                    throw new ForbiddenException();
-                });
+        return Uni.createFrom().item(identity.<List<Permission>> getAttribute("permissions"));
     }
 
     @GET
@@ -64,6 +57,20 @@ public class ProtectedResource {
                     }
                     throw new ForbiddenException();
                 });
+    }
+
+    @PermissionsAllowed("Scope Permission Resource:read")
+    @GET
+    @Path("/annotation/scope-read")
+    public Uni<List<Permission>> hasScopeReadPermission() {
+        return permissions();
+    }
+
+    @PermissionsAllowed("Scope Permission Resource:write")
+    @GET
+    @Path("/annotation/scope-write")
+    public Uni<List<Permission>> hasScopeWritePermission() {
+        return permissions();
     }
 
     @Path("/claim-protected")

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedScopeResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedScopeResource.java
@@ -1,0 +1,89 @@
+package io.quarkus.it.keycloak;
+
+import static io.quarkus.security.PermissionsAllowed.PERMISSION_TO_ACTION_SEPARATOR;
+
+import java.security.BasicPermission;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.keycloak.representations.idm.authorization.Permission;
+
+import io.quarkus.security.PermissionsAllowed;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+@Path("/api/permission/scopes")
+public class ProtectedScopeResource {
+
+    public static final String REQUIRED_PERMISSION = "Scope Permission Resource";
+    public static final String REQUIRED_ACTION = "read";
+
+    @Inject
+    SecurityIdentity identity;
+
+    @GET
+    @Path("/standard-way")
+    public Uni<List<Permission>> standardWay() {
+        return Uni.createFrom().item(identity.<List<Permission>> getAttribute("permissions"));
+    }
+
+    @GET
+    @Path("/standard-way-denied")
+    public Uni<List<Permission>> standardWayDenied() {
+        return Uni.createFrom().item(identity.<List<Permission>> getAttribute("permissions"));
+    }
+
+    @GET
+    @Path("/programmatic-way")
+    public Uni<List<Permission>> programmaticWay() {
+        var requiredPermission = new BasicPermission(REQUIRED_PERMISSION) {
+            @Override
+            public String getActions() {
+                return REQUIRED_ACTION;
+            }
+        };
+        return identity.checkPermission(requiredPermission).onItem()
+                .transform(granted -> {
+                    if (granted) {
+                        return identity.getAttribute("permissions");
+                    }
+                    throw new ForbiddenException();
+                });
+    }
+
+    @GET
+    @Path("/programmatic-way-denied")
+    public Uni<List<Permission>> programmaticWayDenied() {
+        var requiredPermission = new BasicPermission(REQUIRED_PERMISSION) {
+            @Override
+            public String getActions() {
+                return "write";
+            }
+        };
+        return identity.checkPermission(requiredPermission).onItem()
+                .transform(granted -> {
+                    if (granted) {
+                        return identity.getAttribute("permissions");
+                    }
+                    throw new ForbiddenException();
+                });
+    }
+
+    @PermissionsAllowed(REQUIRED_PERMISSION + PERMISSION_TO_ACTION_SEPARATOR + REQUIRED_ACTION)
+    @GET
+    @Path("/annotation-way")
+    public Uni<List<Permission>> annotationWay() {
+        return Uni.createFrom().item(identity.<List<Permission>> getAttribute("permissions"));
+    }
+
+    @PermissionsAllowed(REQUIRED_PERMISSION + PERMISSION_TO_ACTION_SEPARATOR + "write")
+    @GET
+    @Path("/annotation-way-denied")
+    public Uni<List<Permission>> annotationWayDenied() {
+        return Uni.createFrom().item(identity.<List<Permission>> getAttribute("permissions"));
+    }
+}

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedTenantResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedTenantResource.java
@@ -2,10 +2,7 @@ package io.quarkus.it.keycloak;
 
 import java.util.List;
 
-import javax.security.auth.AuthPermission;
-
 import jakarta.inject.Inject;
-import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
@@ -22,12 +19,6 @@ public class ProtectedTenantResource {
 
     @GET
     public Uni<List<Permission>> permissions() {
-        return identity.checkPermission(new AuthPermission("Permission Resource Tenant")).onItem()
-                .transform(granted -> {
-                    if (granted) {
-                        return identity.getAttribute("permissions");
-                    }
-                    throw new ForbiddenException();
-                });
+        return Uni.createFrom().item(identity.<List<Permission>> getAttribute("permissions"));
     }
 }

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedWebAppTenantResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedWebAppTenantResource.java
@@ -2,10 +2,7 @@ package io.quarkus.it.keycloak;
 
 import java.util.List;
 
-import javax.security.auth.AuthPermission;
-
 import jakarta.inject.Inject;
-import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
@@ -24,12 +21,6 @@ public class ProtectedWebAppTenantResource {
 
     @GET
     public Uni<List<Permission>> permissions() {
-        return identity.checkPermission(new AuthPermission("Permission Resource WebApp")).onItem()
-                .transform(granted -> {
-                    if (granted) {
-                        return identity.getAttribute("permissions");
-                    }
-                    throw new ForbiddenException();
-                });
+        return Uni.createFrom().item(identity.<List<Permission>> getAttribute("permissions"));
     }
 }

--- a/integration-tests/keycloak-authorization/src/main/resources/application.properties
+++ b/integration-tests/keycloak-authorization/src/main/resources/application.properties
@@ -59,6 +59,34 @@ quarkus.keycloak.policy-enforcer.paths.10.enforcement-mode=ENFORCING
 quarkus.keycloak.policy-enforcer.paths.11.path=/api/public-token
 quarkus.keycloak.policy-enforcer.paths.11.enforcement-mode=DISABLED
 
+quarkus.keycloak.policy-enforcer.paths.12.name=Scope Permission Resource
+quarkus.keycloak.policy-enforcer.paths.12.path=/api/permission/annotation/scope-read
+
+quarkus.keycloak.policy-enforcer.paths.13.name=Scope Permission Resource
+quarkus.keycloak.policy-enforcer.paths.13.path=/api/permission/annotation/scope-write
+
+quarkus.keycloak.policy-enforcer.paths.14.name=Scope Permission Resource
+quarkus.keycloak.policy-enforcer.paths.14.path=/api/permission/scopes/programmatic-way
+
+quarkus.keycloak.policy-enforcer.paths.15.name=Scope Permission Resource
+quarkus.keycloak.policy-enforcer.paths.15.path=/api/permission/scopes/standard-way
+quarkus.keycloak.policy-enforcer.paths.15.methods.get.method=GET
+quarkus.keycloak.policy-enforcer.paths.15.methods.get.scopes=read
+
+quarkus.keycloak.policy-enforcer.paths.16.name=Scope Permission Resource
+quarkus.keycloak.policy-enforcer.paths.16.path=/api/permission/scopes/annotation-way
+
+quarkus.keycloak.policy-enforcer.paths.17.name=Scope Permission Resource
+quarkus.keycloak.policy-enforcer.paths.17.path=/api/permission/scopes/standard-way-denied
+quarkus.keycloak.policy-enforcer.paths.17.methods.get.method=GET
+quarkus.keycloak.policy-enforcer.paths.17.methods.get.scopes=write
+
+quarkus.keycloak.policy-enforcer.paths.18.name=Scope Permission Resource
+quarkus.keycloak.policy-enforcer.paths.18.path=/api/permission/scopes/annotation-way-denied
+
+quarkus.keycloak.policy-enforcer.paths.19.name=Scope Permission Resource
+quarkus.keycloak.policy-enforcer.paths.19.path=/api/permission/scopes/programmatic-way-denied
+
 # Service Tenant
 quarkus.oidc.tenant.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant.client-id=quarkus-app

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
@@ -112,7 +112,16 @@ public class PolicyEnforcerTest {
                 .then()
                 .statusCode(403);
         RestAssured.given().auth().oauth2(getAccessToken("jdoe"))
+                .when().get("/api/permission/annotation/scope-write")
+                .then()
+                .statusCode(403);
+        RestAssured.given().auth().oauth2(getAccessToken("jdoe"))
                 .when().get("/api/permission/scope?scope=read")
+                .then()
+                .statusCode(200)
+                .and().body(Matchers.containsString("read"));
+        RestAssured.given().auth().oauth2(getAccessToken("jdoe"))
+                .when().get("/api/permission/annotation/scope-read")
                 .then()
                 .statusCode(200)
                 .and().body(Matchers.containsString("read"));
@@ -219,6 +228,44 @@ public class PolicyEnforcerTest {
                 .when().get("/")
                 .then()
                 .statusCode(404);
+    }
+
+    @Test
+    public void testPermissionScopes() {
+        // 'jdoe' has scope 'read' and 'read' is required
+        RestAssured.given().auth().oauth2(getAccessToken("jdoe"))
+                .when().get("/api/permission/scopes/standard-way")
+                .then()
+                .statusCode(200)
+                .and().body(Matchers.containsString("read"));
+
+        // 'jdoe' has scope 'read' while 'write' is required
+        RestAssured.given().auth().oauth2(getAccessToken("jdoe"))
+                .when().get("/api/permission/scopes/standard-way-denied")
+                .then()
+                .statusCode(403);
+
+        RestAssured.given().auth().oauth2(getAccessToken("jdoe"))
+                .when().get("/api/permission/scopes/programmatic-way")
+                .then()
+                .statusCode(200)
+                .and().body(Matchers.containsString("read"));
+
+        RestAssured.given().auth().oauth2(getAccessToken("jdoe"))
+                .when().get("/api/permission/scopes/programmatic-way-denied")
+                .then()
+                .statusCode(403);
+
+        RestAssured.given().auth().oauth2(getAccessToken("jdoe"))
+                .when().get("/api/permission/scopes/annotation-way")
+                .then()
+                .statusCode(200)
+                .and().body(Matchers.containsString("read"));
+
+        RestAssured.given().auth().oauth2(getAccessToken("jdoe"))
+                .when().get("/api/permission/scopes/annotation-way-denied")
+                .then()
+                .statusCode(403);
     }
 
     protected String getAccessToken(String userName) {


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/31345 follow-up

This PR attempts to rewrite example how to programmatically check permissions to programmatic check of permisson scopes, because the way we add Keycloak authorization permissions to `SecurityIdentity`, we only add there permissions that we already checked. This fact is demonstrated in how I adjusted integration tests - you can see that I removed the check and tests that assert HTTP status 403 still succeeds - that's because the permission is in fact checked by policy enforcer and not by our check using `SecurityIdentty` inside Resource.

By this PR, I suggest to rewrite the example to permission scope resource. IMO in almost all cases users should use `quarkus.keycloak.policy-enforcer.paths.1.methods.get.scopes` configuration property to enforce permission scope requirements, however we should at least document existence of other method (programmatic check) and possibility to use `@PermissionsAllowed` annotation. Also I didn't find usage of `scopes`config property documented or tested anywhere, therefore I added tests.