### PR TITLE
Update gitflow-incremental-builder from 4.3.0 to 4.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <gitflow-incremental-builder.version>4.3.0</gitflow-incremental-builder.version>
+        <gitflow-incremental-builder.version>4.4.1</gitflow-incremental-builder.version>
         <quarkus-platform-bom-plugin.version>0.0.80</quarkus-platform-bom-plugin.version>
 
         <skipDocs>false</skipDocs>


### PR DESCRIPTION
It's been 10 days since I released 4.4.0, so I better do the update manually.

https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/releases/tag/v4.4.0
https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/releases/tag/v4.4.1