### PR TITLE
Move to quarkus.console.color instead of deprecated quarkus.log.console.color

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -400,7 +400,7 @@ can nonetheless have additional named handlers attached to it using the `quarkus
 ----
 quarkus.log.console.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n
 quarkus.log.console.level=DEBUG
-quarkus.log.console.color=false
+quarkus.console.color=false
 
 quarkus.log.category."io.quarkus".level=INFO
 ----

--- a/integration-tests/narayana-jta/src/main/resources/application.properties
+++ b/integration-tests/narayana-jta/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 quarkus.log.console.enable=true
 quarkus.log.console.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n
 quarkus.log.console.level=INFO
-quarkus.log.console.color=false
+quarkus.console.color=false
 
 quarkus.log.category."com.arjuna".level=INFO
 quarkus.log.category."io.quarkus".level=INFO

--- a/integration-tests/narayana-stm/src/main/resources/application.properties
+++ b/integration-tests/narayana-stm/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 quarkus.log.console.enable=true
 quarkus.log.console.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n
 quarkus.log.console.level=INFO
-quarkus.log.console.color=false
+quarkus.console.color=false
 
 quarkus.log.category."com.arjuna".level=INFO
 quarkus.log.category."io.quarkus".level=INFO


### PR DESCRIPTION
Move to quarkus.console.color instead of deprecated quarkus.log.console.color

Deprecation introduced in Quarkus 2.1 - https://github.com/quarkusio/quarkus/commit/1eedf1e548fa34a7071595515eba6ef622c8d292

Warning visible since 3.0.0.Alpha4 releases thanks to https://github.com/quarkusio/quarkus/commit/19c4457140a62f641cdc4bad7846153cbd065324