### PR TITLE
Add missing default methods in the JSON Transactional commands

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/json/ReactiveTransactionalJsonCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/json/ReactiveTransactionalJsonCommands.java
@@ -27,6 +27,21 @@ public interface ReactiveTransactionalJsonCommands<K> extends ReactiveTransactio
      * Group: json
      *
      * @param key the key, must not be {@code null}
+     * @param value the value, encoded to JSON
+     * @param <T> the type for the value
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     **/
+    default <T> Uni<Void> jsonSet(K key, T value) {
+        return jsonSet(key, "$", value);
+    }
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/json.set/">JSON.SET</a>.
+     * Summary: Sets the JSON value at path in key.
+     * Group: json
+     *
+     * @param key the key, must not be {@code null}
      * @param path the path, must not be {@code null}
      * @param json the JSON object to store, must not be {@code null}
      * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
@@ -52,6 +67,22 @@ public interface ReactiveTransactionalJsonCommands<K> extends ReactiveTransactio
      * Execute the command <a href="https://redis.io/commands/json.set/">JSON.SET</a>.
      * Summary: Sets the JSON value at path in key.
      * Group: json
+     * <p>
+     * This variant uses {@code $} as path.
+     *
+     * @param key the key, must not be {@code null}
+     * @param json the JSON object to store, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     **/
+    default Uni<Void> jsonSet(K key, JsonObject json) {
+        return jsonSet(key, "$", json);
+    }
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/json.set/">JSON.SET</a>.
+     * Summary: Sets the JSON value at path in key.
+     * Group: json
      *
      * @param key the key, must not be {@code null}
      * @param path the path, must not be {@code null}
@@ -60,6 +91,20 @@ public interface ReactiveTransactionalJsonCommands<K> extends ReactiveTransactio
      *         otherwise. In the case of failure, the transaction is discarded.
      */
     Uni<Void> jsonSet(K key, String path, JsonArray json);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/json.set/">JSON.SET</a>.
+     * Summary: Sets the JSON value at path in key.
+     * Group: json
+     *
+     * @param key the key, must not be {@code null}
+     * @param json the JSON array to store, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     **/
+    default Uni<Void> jsonSet(K key, JsonArray json) {
+        return jsonSet(key, "$", json);
+    }
 
     /**
      * Execute the command <a href="https://redis.io/commands/json.set/">JSON.SET</a>.
@@ -254,6 +299,22 @@ public interface ReactiveTransactionalJsonCommands<K> extends ReactiveTransactio
      *         otherwise. In the case of failure, the transaction is discarded.
      */
     <T> Uni<Void> jsonArrPop(K key, Class<T> clazz, String path, int index);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/json.arrpop/">JSON.ARRPOP</a>.
+     * Summary: Removes and returns an element from the index in the array.
+     * Group: json
+     * <p>
+     *
+     * @param key the key, must not be {@code null}
+     * @param clazz the type of the popped object
+     * @param path path the path, defaults to root if not provided.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     **/
+    default <T> Uni<Void> jsonArrPop(K key, Class<T> clazz, String path) {
+        return jsonArrPop(key, clazz, path, -1);
+    }
 
     /**
      * Execute the command <a href="https://redis.io/commands/json.arrtrim/">JSON.ARRTRIM</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/json/TransactionalJsonCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/json/TransactionalJsonCommands.java
@@ -24,10 +24,49 @@ public interface TransactionalJsonCommands<K> extends TransactionalRedisCommands
      * Group: json
      *
      * @param key the key, must not be {@code null}
+     * @param value the value, encoded to JSON
+     * @param <T> the type for the value
+     **/
+    default <T> void jsonSet(K key, T value) {
+        jsonSet(key, "$", value);
+    }
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/json.set/">JSON.SET</a>.
+     * Summary: Sets the JSON value at path in key.
+     * Group: json
+     *
+     * @param key the key, must not be {@code null}
      * @param path the path, must not be {@code null}
      * @param json the JSON object to store, must not be {@code null}
      */
     void jsonSet(K key, String path, JsonObject json);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/json.set/">JSON.SET</a>.
+     * Summary: Sets the JSON value at path in key.
+     * Group: json
+     * <p>
+     * This variant uses {@code $} as path.
+     *
+     * @param key the key, must not be {@code null}
+     * @param json the JSON object to store, must not be {@code null}
+     **/
+    default void jsonSet(K key, JsonObject json) {
+        jsonSet(key, "$", json);
+    }
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/json.set/">JSON.SET</a>.
+     * Summary: Sets the JSON value at path in key.
+     * Group: json
+     *
+     * @param key the key, must not be {@code null}
+     * @param json the JSON array to store, must not be {@code null}
+     **/
+    default void jsonSet(K key, JsonArray json) {
+        jsonSet(key, "$", json);
+    }
 
     /**
      * Execute the command <a href="https://redis.io/commands/json.set/">JSON.SET</a>.
@@ -219,6 +258,20 @@ public interface TransactionalJsonCommands<K> extends TransactionalRedisCommands
      *        Out-of-range indexes round to their respective array ends.
      */
     <T> void jsonArrPop(K key, Class<T> clazz, String path, int index);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/json.arrpop/">JSON.ARRPOP</a>.
+     * Summary: Removes and returns an element from the index in the array.
+     * Group: json
+     * <p>
+     *
+     * @param key the key, must not be {@code null}
+     * @param clazz the type of the popped object
+     * @param path path the path, defaults to root if not provided.
+     **/
+    default <T> void jsonArrPop(K key, Class<T> clazz, String path) {
+        jsonArrPop(key, clazz, path, -1);
+    }
 
     /**
      * Execute the command <a href="https://redis.io/commands/json.arrtrim/">JSON.ARRTRIM</a>.

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalJsonCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalJsonCommandsTest.java
@@ -27,6 +27,7 @@ public class TransactionalJsonCommandsTest extends DatasourceTestBase {
 
     Person person = new Person("luke", "skywalker");
     Person person2 = new Person("leia", "skywalker");
+    Person person3 = new Person("anakin", "skywalker");
 
     @BeforeEach
     void initialize() {
@@ -62,8 +63,12 @@ public class TransactionalJsonCommandsTest extends DatasourceTestBase {
 
             json.jsonSet("sister", "$", new JsonObject(Json.encode(person2)));
             json.jsonGet("sister", Person.class);
+
+            json.jsonSet("someone", person3);
+            json.jsonGetObject("someone");
+
         });
-        assertThat(result.size()).isEqualTo(12);
+        assertThat(result.size()).isEqualTo(14);
         assertThat(result.discarded()).isFalse();
 
         assertThat((Void) result.get(0)).isNull();
@@ -82,6 +87,7 @@ public class TransactionalJsonCommandsTest extends DatasourceTestBase {
         assertThat(actual.getJsonArray("a")).isEmpty();// cleared
         assertThat((Void) result.get(10)).isNull();
         assertThat((Person) result.get(11)).isEqualTo(person2);
+        assertThat(((JsonObject) result.get(13)).mapTo(Person.class)).isEqualTo(person3);
     }
 
     @Test
@@ -100,9 +106,11 @@ public class TransactionalJsonCommandsTest extends DatasourceTestBase {
                     .chain(() -> json.jsonStrLen(key, "$.sister.lastname")) // 8 -> 10
                     .chain(() -> json.jsonGet(key)) // 9 {...}
                     .chain(() -> json.jsonSet("sister", "$", new JsonObject(Json.encode(person2))))
-                    .chain(() -> json.jsonGet("sister", Person.class));
+                    .chain(() -> json.jsonGet("sister", Person.class))
+                    .chain(() -> json.jsonSet("someone", person3))
+                    .chain(() -> json.jsonGetObject("someone"));
         }).await().atMost(Duration.ofSeconds(5));
-        assertThat(result.size()).isEqualTo(12);
+        assertThat(result.size()).isEqualTo(14);
         assertThat(result.discarded()).isFalse();
 
         assertThat((Void) result.get(0)).isNull();
@@ -121,6 +129,8 @@ public class TransactionalJsonCommandsTest extends DatasourceTestBase {
         assertThat(actual.getJsonArray("a")).isEmpty();// cleared
         assertThat((Void) result.get(10)).isNull();
         assertThat((Person) result.get(11)).isEqualTo(person2);
+        assertThat((Person) result.get(11)).isEqualTo(person2);
+        assertThat(((JsonObject) result.get(13)).mapTo(Person.class)).isEqualTo(person3);
     }
 
 }


### PR DESCRIPTION
A few default methods were missing in the JSON transactional command classes. This PR adds them.
These commands are syntactic sugar but are commonly used.