### PR TITLE
Fix formatting in integration-tests/java-17/src/main/java/io/quarkus/it/hibernate/panache/person

### DIFF
--- a/integration-tests/java-17/src/main/java/io/quarkus/it/hibernate/panache/person/PersonResource.java
+++ b/integration-tests/java-17/src/main/java/io/quarkus/it/hibernate/panache/person/PersonResource.java
@@ -25,7 +25,6 @@ public class PersonResource {
         return Response.created(URI.create("/persons/entity/" + id)).build();
     }
 
-
     @GET
     @Path("hql-project")
     @Transactional

--- a/integration-tests/java-17/src/test/java/io/quarkus/it/hibernate/panache/person/PersonResourceTest.java
+++ b/integration-tests/java-17/src/test/java/io/quarkus/it/hibernate/panache/person/PersonResourceTest.java
@@ -4,11 +4,11 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.is;
 
-import io.quarkus.test.TestTransaction;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.it.mongodb.panache.person.Person;
 import io.quarkus.it.mongodb.panache.person.Status;
+import io.quarkus.test.TestTransaction;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;


### PR DESCRIPTION
I don't understand why CI builds don't fail, but these files get reformatted every time I build Quarkus and it's annoying.