### PR TITLE
Supply missing extension metadata for reactive keycloak client

### DIFF
--- a/extensions/keycloak-admin-client-reactive/runtime/src/main/java/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/keycloak-admin-client-reactive/runtime/src/main/java/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,14 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "Reactive Keycloak Admin Client"
+metadata:
+  keywords:
+  - "keycloak"
+  - "keycloak-admin-client"
+  - "admin"
+  - "openid-connect"
+  - "reactive"
+  categories:
+    - "security"
+    - "reactive"
+  status: "stable"


### PR DESCRIPTION
I noticed that the reactive keycloak client isn't displaying very well on http://quarkus.io/extensions. The actual extension page is https://quarkus.io/extensions/io.quarkus/quarkus-keycloak-admin-client-reactive, but you can see the problem on the front page, too: 

<img width="631" alt="image" src="https://user-images.githubusercontent.com/11509290/225570387-5d0d718c-70c8-4fc3-b781-704c32c80624.png">

There's no categories, so you can't find this extension by filtering for 'reactive' category, and the name has a lot of boilerplate in it, so the most interesting parts are hidden by the overflow. 

I thought the extension metadata was incomplete, but it's actually totally missing. I've filled in something with what seem like the correct values to me. 