### PR TITLE
Fix OTel endpoint resolution and improve documentation

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -429,7 +429,7 @@ Write the SPI loader text file at `resources/META-INF/services` with name `io.op
 Then activate on the configuration:
 [source,properties]
 ----
-quarkus.opentelemetry.tracer.sampler=custom-spi-sampler
+quarkus.otel.traces.sampler=custom-spi-sampler
 ----
 
 As you can see, CDI is much simpler to work with.

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
@@ -1,7 +1,6 @@
 package io.quarkus.opentelemetry.deployment.exporter.otlp;
 
 import static io.quarkus.opentelemetry.runtime.config.build.ExporterType.Constants.CDI_VALUE;
-import static io.quarkus.opentelemetry.runtime.config.build.ExporterType.Constants.OTLP_VALUE;
 
 import java.util.function.BooleanSupplier;
 
@@ -23,16 +22,14 @@ import io.quarkus.opentelemetry.runtime.exporter.otlp.OtlpRecorder;
 public class OtlpExporterProcessor {
 
     static class OtlpExporterEnabled implements BooleanSupplier {
-        OtlpExporterBuildConfig exporBuildConfig;
+        OtlpExporterBuildConfig exportBuildConfig;
         OtelBuildConfig otelBuildConfig;
 
         public boolean getAsBoolean() {
             return otelBuildConfig.enabled &&
                     otelBuildConfig.traces.enabled.orElse(Boolean.TRUE) &&
-                    (otelBuildConfig.traces.exporter.contains(OTLP_VALUE) ||
-                            otelBuildConfig.traces.exporter.contains(CDI_VALUE))
-                    &&
-                    exporBuildConfig.enabled;
+                    otelBuildConfig.traces.exporter.contains(CDI_VALUE) &&
+                    exportBuildConfig.enabled;
         }
     }
 

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpRecorderTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpRecorderTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.opentelemetry.runtime.exporter.otlp;
 
+import static io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterRuntimeConfig.Constants.DEFAULT_GRPC_BASE_URI;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Optional;
@@ -8,50 +9,58 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterRuntimeConfig;
 import io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterTracesConfig;
-import io.quarkus.runtime.LaunchMode;
 
 class OtlpRecorderTest {
 
     @Test
     public void resolveEndpoint_legacyWins() {
         assertEquals("http://localhost:1111/",
-                OtlpRecorder.resolveEndpoint(LaunchMode.NORMAL, createOtlpExporterRuntimeConfig(
-                        "http://localhost:4317/",
+                OtlpRecorder.resolveEndpoint(createOtlpExporterRuntimeConfig(
+                        DEFAULT_GRPC_BASE_URI,
                         "http://localhost:1111/",
                         "http://localhost:2222/")));
     }
 
     @Test
+    public void resolveEndpoint_newWins() {
+        assertEquals("http://localhost:2222/",
+                OtlpRecorder.resolveEndpoint(createOtlpExporterRuntimeConfig(
+                        "http://localhost:1111/",
+                        DEFAULT_GRPC_BASE_URI,
+                        "http://localhost:2222/")));
+    }
+
+    @Test
+    public void resolveEndpoint_globalWins() {
+        assertEquals("http://localhost:1111/",
+                OtlpRecorder.resolveEndpoint(createOtlpExporterRuntimeConfig(
+                        "http://localhost:1111/",
+                        DEFAULT_GRPC_BASE_URI,
+                        DEFAULT_GRPC_BASE_URI)));
+    }
+
+    @Test
     public void resolveEndpoint_legacyTraceWins() {
         assertEquals("http://localhost:2222/",
-                OtlpRecorder.resolveEndpoint(LaunchMode.NORMAL, createOtlpExporterRuntimeConfig(
-                        "http://localhost:4317/",
+                OtlpRecorder.resolveEndpoint(createOtlpExporterRuntimeConfig(
+                        DEFAULT_GRPC_BASE_URI,
                         null,
                         "http://localhost:2222/")));
     }
 
     @Test
     public void resolveEndpoint_legacyGlobalWins() {
-        assertEquals("http://localhost:4317/",
-                OtlpRecorder.resolveEndpoint(LaunchMode.NORMAL, createOtlpExporterRuntimeConfig(
-                        "http://localhost:4317/",
+        assertEquals(DEFAULT_GRPC_BASE_URI,
+                OtlpRecorder.resolveEndpoint(createOtlpExporterRuntimeConfig(
+                        DEFAULT_GRPC_BASE_URI,
                         null,
                         null)));
     }
 
     @Test
     public void resolveEndpoint_testIsSet() {
-        assertEquals("http://localhost:4317/",
-                OtlpRecorder.resolveEndpoint(LaunchMode.DEVELOPMENT, createOtlpExporterRuntimeConfig(
-                        null,
-                        null,
-                        null)));
-    }
-
-    @Test
-    public void resolveEndpoint_NothingSet() {
-        assertEquals("",
-                OtlpRecorder.resolveEndpoint(LaunchMode.NORMAL, createOtlpExporterRuntimeConfig(
+        assertEquals(DEFAULT_GRPC_BASE_URI,
+                OtlpRecorder.resolveEndpoint(createOtlpExporterRuntimeConfig(
                         null,
                         null,
                         null)));


### PR DESCRIPTION
Improvements on the documentation.
Disable our custom exporter if user chooses stock OTel. 
Fix exporter endpoint resolution. The legacy was always winning even if not set.