### PR TITLE
Restore ability to only start domain socket  server

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -652,7 +652,7 @@ public class VertxHttpRecorder {
             LaunchMode launchMode,
             Supplier<Integer> eventLoops, List<String> websocketSubProtocols) throws IOException {
 
-        if (!httpConfiguration.hostEnabled) {
+        if (!httpConfiguration.hostEnabled && !httpConfiguration.domainSocketEnabled) {
             return CompletableFuture.completedFuture(null);
         }
 


### PR DESCRIPTION
This broke with the management interface work

Fixes: #31934

P.S. If we want a test for this, we need to add the native transport as a dependency