### PR TITLE
Add more options to exclude classes from the default JAXBContext

### DIFF
--- a/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/AbstractJaxbContextTest.java
+++ b/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/AbstractJaxbContextTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.jaxb.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringWriter;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public abstract class AbstractJaxbContextTest {
+
+    @Inject
+    JAXBContext jaxbContext;
+
+    @Inject
+    Marshaller marshaller;
+
+    @Inject
+    Unmarshaller unmarshaller;
+
+    @Test
+    @ActivateRequestContext
+    public void shouldInjectJaxbBeans() {
+        assertThat(jaxbContext).isNotNull();
+        assertThat(marshaller).isNotNull();
+        assertThat(unmarshaller).isNotNull();
+    }
+
+    @Test
+    @ActivateRequestContext
+    public void marshalModelOne() throws JAXBException {
+        io.quarkus.jaxb.deployment.one.Model model = new io.quarkus.jaxb.deployment.one.Model();
+        model.setName1("name1");
+
+        StringWriter sw = new StringWriter();
+        marshaller.marshal(model, sw);
+
+        assertThat(sw.toString()).isEqualTo("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+                + "<model><name1>name1</name1></model>");
+    }
+
+    @Test
+    @ActivateRequestContext
+    public void marshalModelTwo() throws JAXBException {
+        io.quarkus.jaxb.deployment.two.Model model = new io.quarkus.jaxb.deployment.two.Model();
+        model.setName2("name2");
+        Assertions.assertThatExceptionOfType(JAXBException.class)
+                .isThrownBy(() -> marshaller.marshal(model, new StringWriter()))
+                .withMessage("class io.quarkus.jaxb.deployment.two.Model nor any of its super class is known to this context.");
+    }
+}

--- a/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/ClassExcludeTest.java
+++ b/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/ClassExcludeTest.java
@@ -1,0 +1,17 @@
+package io.quarkus.jaxb.deployment;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ClassExcludeTest extends AbstractJaxbContextTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(
+                            io.quarkus.jaxb.deployment.one.Model.class,
+                            io.quarkus.jaxb.deployment.two.Model.class)
+                    .addPackage("io.quarkus.jaxb.deployment.info"))
+            .overrideConfigKey("quarkus.jaxb.exclude-classes", "io.quarkus.jaxb.deployment.two.Model");
+}

--- a/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/PackageExcludeTest.java
+++ b/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/PackageExcludeTest.java
@@ -1,0 +1,17 @@
+package io.quarkus.jaxb.deployment;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class PackageExcludeTest extends AbstractJaxbContextTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(
+                            io.quarkus.jaxb.deployment.one.Model.class,
+                            io.quarkus.jaxb.deployment.two.Model.class)
+                    .addPackage("io.quarkus.jaxb.deployment.info"))
+            .overrideConfigKey("quarkus.jaxb.exclude-classes", "io.quarkus.jaxb.deployment.two.*");
+}

--- a/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbConfig.java
+++ b/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbConfig.java
@@ -18,6 +18,8 @@ public class JaxbConfig {
 
     /**
      * Exclude classes to automatically be bound to the default JAXB context.
+     * Values with suffix {@code .*}, i.e. {@code org.acme.*}, are considered packages and exclude all classes that are members
+     * of these packages
      */
     @ConfigItem
     public Optional<List<String>> excludeClasses;


### PR DESCRIPTION
Following this [discussion](https://github.com/quarkusio/quarkus/discussions/31882), I would like to thank @Sgitario for his kind assistance and his invitation to try to contribute.

Here is a pull request with:
* A `quarkus.jaxb.exclude-packages` to exclude classes from given packages from the default JAXBContext
* A `quarkus.jaxb.exclude-pattern` to exclude classes whose names matches the pattern from the default JAXBContext

To reply to @Sgitario 's comment from the discussion:
> Though, I would merge the `exclude-classes` and `exclude-packages` into `exclude-classes` (and use the `startWith` matching).

I'm thinking of cases such as classes named User and UserAccount, a startWith matching may not work as intended, if only the User class is to be excluded for some reason.

> Moreover, I would not add pattern matching at least it's essential since we used not to try adding too many superficial configuration options.

The motivation behind pattern matching is to provide adequate tooling for developer using xjc with third-party XSD. The sheer number of classes can grow up pretty quickly and one have little control over them.

I agree having both exclude-packages and pattern matching is somehow redundant. Pattern matching can easily exclude packages.

Of course, I will proceed with what ever option you prefer. :)