### PR TITLE
Allow to run MP LRA TCK with externally managed coordinator

### DIFF
--- a/tcks/microprofile-lra/src/main/java/io/quarkus/tck/lra/LRACoordinatorManager.java
+++ b/tcks/microprofile-lra/src/main/java/io/quarkus/tck/lra/LRACoordinatorManager.java
@@ -6,6 +6,7 @@ import java.net.ServerSocket;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 public class LRACoordinatorManager {
@@ -18,16 +19,20 @@ public class LRACoordinatorManager {
 
     public void beforeClass(
             @Observes(precedence = DEFAULT_PRECEDENCE) org.jboss.arquillian.test.spi.event.suite.BeforeSuite event) {
-        LOGGER.debug("Starting LRA coordinator on port " + coordinatorPort);
-        coordinatorContainer = new GenericContainer<>(DockerImageName.parse("quay.io/jbosstm/lra-coordinator:latest"))
-                // lra-coordinator is a Quarkus service
-                .withEnv("QUARKUS_HTTP_PORT", String.valueOf(coordinatorPort))
-                // need to run with host network because coordinator calls the TCK services from the container
-                .withNetworkMode("host");
+        if (System.getProperty("lra.coordinator.url") == null) {
+            LOGGER.debug("Starting LRA coordinator on port " + coordinatorPort);
+            coordinatorContainer = new GenericContainer<>(DockerImageName.parse("quay.io/jbosstm/lra-coordinator:latest"))
+                    // lra-coordinator is a Quarkus service
+                    .withEnv("QUARKUS_HTTP_PORT", String.valueOf(coordinatorPort))
+                    // need to run with host network because coordinator calls the TCK services from the container
+                    .withNetworkMode("host")
+                    .waitingFor(Wait.forLogMessage(".*lra-coordinator-quarkus.*", 1));
+            ;
 
-        coordinatorContainer.start();
+            coordinatorContainer.start();
 
-        System.setProperty("lra.coordinator.url", String.format("http://localhost:%d/lra-coordinator", coordinatorPort));
+            System.setProperty("lra.coordinator.url", String.format("http://localhost:%d/lra-coordinator", coordinatorPort));
+        }
     }
 
     public void afterClass(


### PR DESCRIPTION
We can reuse this back to back in the published coordinator image testing - https://github.com/jbosstm/lra-coordinator-quarkus