### PR TITLE
Upgrade to Hibernate ORM 6.2.0.CR4

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -97,7 +97,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>6.2.0.CR3</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
+        <hibernate-orm.version>6.2.0.CR4</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
         <bytebuddy.version>1.12.18</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
         <hibernate-reactive.version>1.1.9.Final</hibernate-reactive.version>

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
@@ -26,7 +26,7 @@ import org.hibernate.query.sqm.mutation.internal.SqmMultiTableMutationStrategyPr
 import org.hibernate.resource.transaction.internal.TransactionCoordinatorBuilderInitiator;
 import org.hibernate.service.internal.ProvidedService;
 import org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryInitiator;
-import org.hibernate.sql.ast.internal.JdbcParameterRendererInitiator;
+import org.hibernate.sql.ast.internal.ParameterMarkerStrategyInitiator;
 import org.hibernate.sql.results.jdbc.internal.JdbcValuesMappingProducerProviderInitiator;
 import org.hibernate.tool.schema.internal.SchemaManagementToolInitiator;
 
@@ -232,7 +232,7 @@ public class PreconfiguredServiceRegistryBuilder {
         serviceInitiators.add(SqmMultiTableMutationStrategyProviderInitiator.INSTANCE);
 
         // Default implementation
-        serviceInitiators.add(JdbcParameterRendererInitiator.INSTANCE);
+        serviceInitiators.add(ParameterMarkerStrategyInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
         return serviceInitiators;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/StandardHibernateORMInitiatorListProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/StandardHibernateORMInitiatorListProvider.java
@@ -19,7 +19,7 @@ import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInit
 import org.hibernate.query.sqm.mutation.internal.SqmMultiTableMutationStrategyProviderInitiator;
 import org.hibernate.resource.transaction.internal.TransactionCoordinatorBuilderInitiator;
 import org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryInitiator;
-import org.hibernate.sql.ast.internal.JdbcParameterRendererInitiator;
+import org.hibernate.sql.ast.internal.ParameterMarkerStrategyInitiator;
 import org.hibernate.sql.results.jdbc.internal.JdbcValuesMappingProducerProviderInitiator;
 import org.hibernate.tool.schema.internal.SchemaManagementToolInitiator;
 
@@ -102,7 +102,7 @@ public final class StandardHibernateORMInitiatorListProvider implements InitialI
         serviceInitiators.add(SqmMultiTableMutationStrategyProviderInitiator.INSTANCE);
 
         // Default implementation
-        serviceInitiators.add(JdbcParameterRendererInitiator.INSTANCE);
+        serviceInitiators.add(ParameterMarkerStrategyInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
 


### PR DESCRIPTION
Upgrading this first, as a pre-requisite to then being able to sent the Hibernate Reactive upgrades as a follow-up.

N.B. a Service has changed name