### PR TITLE
Added dev cli help for test command

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/console/QuarkusGroupCommand.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/QuarkusGroupCommand.java
@@ -1,0 +1,20 @@
+package io.quarkus.deployment.console;
+
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommand;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Option;
+
+public abstract class QuarkusGroupCommand implements GroupCommand {
+
+    @Option(shortName = 'h', hasValue = false, overrideRequired = true)
+    public boolean help;
+
+    @Override
+    public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+        commandInvocation.getShell().write(commandInvocation.getHelpInfo());
+        return CommandResult.SUCCESS;
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiFunction;
 
+import io.quarkus.deployment.console.QuarkusGroupCommand;
 import org.aesh.command.Command;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandException;
@@ -197,24 +198,24 @@ public class TestTracingProcessor {
         return new ConsoleCommandBuildItem(new TestCommand());
     }
 
-    @GroupCommandDefinition(name = "test", description = "Test Commands", groupCommands = { TagsCommand.class,
-            PatternCommand.class })
-    public static class TestCommand implements Command {
+    @GroupCommandDefinition(name = "test", description = "Test Commands")
+    public static class TestCommand extends QuarkusGroupCommand {
 
         @Override
-        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
-            return CommandResult.SUCCESS;
+        public List<Command> getCommands() {
+            return List.of(new TagsCommand(), new PatternCommand());
         }
+
     }
 
-    @GroupCommandDefinition(name = "tags", description = "Tag Commands", groupCommands = { IncludeTagsCommand.class,
-            ExcludeTagsCommand.class })
-    public static class TagsCommand implements Command {
+    @GroupCommandDefinition(name = "tags", description = "Tag Commands")
+    public static class TagsCommand extends QuarkusGroupCommand {
 
         @Override
-        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
-            return CommandResult.SUCCESS;
+        public List<Command> getCommands() {
+            return List.of(new IncludeTagsCommand(), new ExcludeTagsCommand());
         }
+
     }
 
     @CommandDefinition(name = "include", description = "Sets the current included tags")
@@ -269,15 +270,14 @@ public class TestTracingProcessor {
         }
     }
 
-    @GroupCommandDefinition(name = "pattern", description = "Include/Exclude pattern Commands", groupCommands = {
-            IncludePatternCommand.class,
-            ExcludePatternCommand.class })
-    public static class PatternCommand implements Command {
+    @GroupCommandDefinition(name = "pattern", description = "Include/Exclude pattern Commands")
+    public static class PatternCommand extends QuarkusGroupCommand {
 
         @Override
-        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
-            return CommandResult.SUCCESS;
+        public List<Command> getCommands() {
+            return List.of(new IncludePatternCommand(), new ExcludePatternCommand());
         }
+
     }
 
     @CommandDefinition(name = "include", description = "Sets the current include pattern")

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -21,11 +21,11 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.stream.Collectors;
 
+import io.quarkus.deployment.console.QuarkusGroupCommand;
 import org.aesh.command.Command;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
-import org.aesh.command.GroupCommand;
 import org.aesh.command.GroupCommandDefinition;
 import org.aesh.command.completer.CompleterInvocation;
 import org.aesh.command.completer.OptionCompleter;
@@ -653,21 +653,13 @@ public final class LoggingResourceProcessor {
     }
 
     @GroupCommandDefinition(name = "log", description = "Logging Commands")
-    public static class LogCommand implements GroupCommand {
-
-        @Option(shortName = 'h', hasValue = false, overrideRequired = true)
-        public boolean help;
+    public static class LogCommand extends QuarkusGroupCommand {
 
         @Override
         public List<Command> getCommands() {
             return List.of(new SetLogLevelCommand());
         }
 
-        @Override
-        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
-            commandInvocation.getShell().writeln(commandInvocation.getHelpInfo());
-            return CommandResult.SUCCESS;
-        }
     }
 
     @CommandDefinition(name = "set-level", description = "Sets the log level for a logger")

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresCommand.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresCommand.java
@@ -2,23 +2,16 @@ package io.quarkus.devservices.postgresql.deployment;
 
 import java.util.List;
 
+import io.quarkus.deployment.console.QuarkusGroupCommand;
 import org.aesh.command.Command;
-import org.aesh.command.CommandException;
-import org.aesh.command.CommandResult;
-import org.aesh.command.GroupCommand;
 import org.aesh.command.GroupCommandDefinition;
-import org.aesh.command.invocation.CommandInvocation;
-import org.aesh.command.option.Option;
 
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 
 @GroupCommandDefinition(name = "postgres", description = "Postgresql Commands")
-public class PostgresCommand implements GroupCommand {
+public class PostgresCommand extends QuarkusGroupCommand {
 
     private final DevServicesLauncherConfigResultBuildItem devServicesLauncherConfigResultBuildItem;
-
-    @Option(shortName = 'h', hasValue = false, overrideRequired = true)
-    public boolean help;
 
     public PostgresCommand(DevServicesLauncherConfigResultBuildItem devServicesLauncherConfigResultBuildItem) {
         this.devServicesLauncherConfigResultBuildItem = devServicesLauncherConfigResultBuildItem;
@@ -29,9 +22,4 @@ public class PostgresCommand implements GroupCommand {
         return List.of(new PsqlCommand(devServicesLauncherConfigResultBuildItem));
     }
 
-    @Override
-    public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
-        commandInvocation.getShell().writeln(commandInvocation.getHelpInfo());
-        return CommandResult.SUCCESS;
-    }
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/ConfigEditorProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/ConfigEditorProcessor.java
@@ -16,17 +16,16 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.quarkus.deployment.console.QuarkusGroupCommand;
 import org.aesh.command.Command;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
-import org.aesh.command.GroupCommand;
 import org.aesh.command.GroupCommandDefinition;
 import org.aesh.command.completer.CompleterInvocation;
 import org.aesh.command.completer.OptionCompleter;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Argument;
-import org.aesh.command.option.Option;
 import org.aesh.command.validator.CommandValidator;
 import org.aesh.command.validator.CommandValidatorException;
 
@@ -313,12 +312,9 @@ public class ConfigEditorProcessor {
     }
 
     @GroupCommandDefinition(name = "config", description = "Config Editing Commands")
-    public static class ConfigCommandGroup implements GroupCommand {
+    public static class ConfigCommandGroup extends QuarkusGroupCommand {
 
         final ConfigDescriptionsManager configDescriptionsManager;
-
-        @Option(shortName = 'h', hasValue = false, overrideRequired = true)
-        public boolean help;
 
         public ConfigCommandGroup(ConfigDescriptionsManager configDescriptionsManager) {
             this.configDescriptionsManager = configDescriptionsManager;
@@ -329,11 +325,6 @@ public class ConfigEditorProcessor {
             return List.of(new SetConfigCommand(configDescriptionsManager));
         }
 
-        @Override
-        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
-            commandInvocation.getShell().writeln(commandInvocation.getHelpInfo());
-            return CommandResult.SUCCESS;
-        }
     }
 
     @CommandDefinition(name = "set", description = "Sets a config value", validator = SetValidator.class)


### PR DESCRIPTION
I've noticed that in the dev cli (`quarkus:dev`, pressing `:`), the `test` command had no `-h` option associated. Added this and refactored the code a bit by adding a `QuarkusGroupCommand` base class.

Connected to #22345