### PR TITLE
Fix OpenTelemetry JDBC instrumentation in native mode and resilient test

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -117,7 +117,7 @@
         {
             "category": "Misc4",
             "timeout": 120,
-            "test-modules": "picocli-native, gradle, micrometer-mp-metrics, micrometer-prometheus, logging-json, jaxp, jaxb, opentelemetry, webjars-locator",
+            "test-modules": "picocli-native, gradle, micrometer-mp-metrics, micrometer-prometheus, logging-json, jaxp, jaxb, opentelemetry, opentelemetry-jdbc-instrumentation, webjars-locator",
             "os-name": "ubuntu-latest"
         },
         {

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/OpenTelemetryAgroalDataSource.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/OpenTelemetryAgroalDataSource.java
@@ -9,8 +9,9 @@ import io.agroal.api.AgroalDataSource;
 import io.agroal.api.AgroalDataSourceMetrics;
 import io.agroal.api.AgroalPoolInterceptor;
 import io.agroal.api.configuration.AgroalDataSourceConfiguration;
-import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.jdbc.datasource.OpenTelemetryDataSource;
+import io.quarkus.arc.Arc;
 
 /**
  * The {@link AgroalDataSource} wrapper that activates OpenTelemetry JDBC instrumentation.
@@ -20,7 +21,7 @@ public class OpenTelemetryAgroalDataSource extends OpenTelemetryDataSource imple
     private final AgroalDataSource delegate;
 
     public OpenTelemetryAgroalDataSource(AgroalDataSource delegate) {
-        super(delegate, GlobalOpenTelemetry.get());
+        super(delegate, Arc.container().instance(OpenTelemetry.class).get());
         this.delegate = delegate;
     }
 

--- a/extensions/agroal/spi/src/main/java/io/quarkus/agroal/spi/OpenTelemetryInitBuildItem.java
+++ b/extensions/agroal/spi/src/main/java/io/quarkus/agroal/spi/OpenTelemetryInitBuildItem.java
@@ -1,0 +1,9 @@
+package io.quarkus.agroal.spi;
+
+import io.quarkus.builder.item.EmptyBuildItem;
+
+/**
+ * Marker build item that indicates that the OpenTelemetry extension has been initialized.
+ */
+public final class OpenTelemetryInitBuildItem extends EmptyBuildItem {
+}

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
@@ -25,6 +25,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.quarkus.agroal.spi.JdbcDataSourceBuildItem;
+import io.quarkus.agroal.spi.OpenTelemetryInitBuildItem;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.InterceptorBindingRegistrarBuildItem;
@@ -36,6 +37,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
@@ -155,6 +157,7 @@ public class OpenTelemetryProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
+    @Produce(OpenTelemetryInitBuildItem.class)
     void createOpenTelemetry(
             OpenTelemetryRecorder recorder,
             InstrumentationRecorder instrumentationRecorder,

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryJdbcInstrumentationTest.java
@@ -24,7 +24,7 @@ public abstract class OpenTelemetryJdbcInstrumentationTest {
     @AfterEach
     void reset() {
         given().get("/reset").then().statusCode(HTTP_OK);
-        await().atMost(5, SECONDS).until(() -> {
+        await().atMost(30, SECONDS).until(() -> {
             // make sure spans are cleared
             List<Map<String, Object>> spans = getSpans();
             if (spans.size() > 0) {
@@ -47,7 +47,7 @@ public abstract class OpenTelemetryJdbcInstrumentationTest {
                 .statusCode(200)
                 .body("message", Matchers.equalTo("Hit message."));
 
-        Awaitility.await().during(Duration.ofSeconds(2)).until(() -> !getSpans().isEmpty());
+        Awaitility.await().atMost(Duration.ofSeconds(55)).until(() -> !getSpans().isEmpty());
 
         // Assert insert has been traced
         boolean hitInserted = false;


### PR DESCRIPTION
closes #31720
supersedes: #31938
addresses also CI failures in: #31909

Test timeouts are raised as we saw in CI it takes longer to take longer till spans are available. Locally I never experienced failure with old timeouts.