### PR TITLE
Fix deprecated ReflectiveClassBuildItem construct method and replace with builder()

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/CollectionClassProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/CollectionClassProcessor.java
@@ -8,14 +8,13 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 public class CollectionClassProcessor {
     @BuildStep
     ReflectiveClassBuildItem setupCollectionClasses() {
-        return new ReflectiveClassBuildItem(false, false,
-                ArrayList.class.getName(),
+        return ReflectiveClassBuildItem.builder(ArrayList.class.getName(),
                 HashMap.class.getName(),
                 HashSet.class.getName(),
                 LinkedList.class.getName(),
                 LinkedHashMap.class.getName(),
                 LinkedHashSet.class.getName(),
                 TreeMap.class.getName(),
-                TreeSet.class.getName());
+                TreeSet.class.getName()).build();
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/ConstructorPropertiesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ConstructorPropertiesProcessor.java
@@ -37,6 +37,6 @@ public class ConstructorPropertiesProcessor {
     }
 
     private ReflectiveClassBuildItem asReflectiveClassBuildItem(String annotatedClass) {
-        return new ReflectiveClassBuildItem(true, false, annotatedClass);
+        return ReflectiveClassBuildItem.builder(annotatedClass).methods().build();
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ConfigMappingUtils.java
@@ -91,13 +91,13 @@ public class ConfigMappingUtils {
                     new GeneratedClassBuildItem(isApplicationClass, mappingMetadata.getClassName(),
                             mappingMetadata.getClassBytes()));
             reflectiveClasses
-                    .produce(ReflectiveClassBuildItem.builder(mappingMetadata.getInterfaceType()).methods(true).build());
+                    .produce(ReflectiveClassBuildItem.builder(mappingMetadata.getInterfaceType()).methods().build());
             reflectiveClasses
-                    .produce(ReflectiveClassBuildItem.builder(mappingMetadata.getClassName()).constructors(true)
-                            .methods(true).build());
+                    .produce(ReflectiveClassBuildItem.builder(mappingMetadata.getClassName())
+                            .methods().build());
 
             for (Class<?> parent : getHierarchy(mappingMetadata.getInterfaceType())) {
-                reflectiveClasses.produce(ReflectiveClassBuildItem.builder(parent).methods(true).build());
+                reflectiveClasses.produce(ReflectiveClassBuildItem.builder(parent).methods().build());
             }
 
             generatedClassesNames.add(mappingMetadata.getClassName());
@@ -117,7 +117,8 @@ public class ConfigMappingUtils {
                     // E.g. Optional<Foo>
                     type = type.asParameterizedType().arguments().get(0);
                 }
-                reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, type.name().toString()));
+                reflectiveClasses
+                        .produce(ReflectiveClassBuildItem.builder(type.name().toString()).methods().build());
             }
         }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -278,9 +278,9 @@ public final class LoggingResourceProcessor {
 
             DiscoveredLogComponents discoveredLogComponents = discoverLogComponents(combinedIndexBuildItem.getIndex());
             if (!discoveredLogComponents.getNameToFilterClass().isEmpty()) {
-                reflectiveClassBuildItemBuildProducer.produce(new ReflectiveClassBuildItem(true, false, false,
-                        discoveredLogComponents.getNameToFilterClass().values().toArray(
-                                EMPTY_STRING_ARRAY)));
+                reflectiveClassBuildItemBuildProducer.produce(
+                        ReflectiveClassBuildItem.builder(discoveredLogComponents.getNameToFilterClass().values().toArray(
+                                EMPTY_STRING_ARRAY)).build());
                 serviceProviderBuildItemBuildProducer
                         .produce(ServiceProviderBuildItem.allProvidersFromClassPath(LogFilterFactory.class.getName()));
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -144,7 +144,8 @@ public class ConfigGenerationBuildStep {
             method.returnValue(configBuilder);
         }
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, builderClassName));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(builderClassName).build());
         staticInitConfigBuilder.produce(new StaticInitConfigBuilderBuildItem(builderClassName));
         runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(builderClassName));
     }
@@ -196,7 +197,8 @@ public class ConfigGenerationBuildStep {
             method.returnValue(configBuilder);
         }
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, builderClassName));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(builderClassName).build());
         staticInitConfigBuilder.produce(new StaticInitConfigBuilderBuildItem(builderClassName));
         runTimeConfigBuilder.produce(new RunTimeConfigBuilderBuildItem(builderClassName));
     }
@@ -300,7 +302,8 @@ public class ConfigGenerationBuildStep {
         Set<String> runtimeConfigBuilderClassNames = runTimeConfigBuilders.stream()
                 .map(RunTimeConfigBuilderBuildItem::getBuilderClassName).collect(toSet());
         reflectiveClass
-                .produce(new ReflectiveClassBuildItem(false, false, runtimeConfigBuilderClassNames.toArray(new String[0])));
+                .produce(ReflectiveClassBuildItem.builder(runtimeConfigBuilderClassNames.toArray(new String[0]))
+                        .build());
 
         RunTimeConfigurationGenerator.GenerateOperation
                 .builder()
@@ -514,7 +517,8 @@ public class ConfigGenerationBuildStep {
             ctor.returnVoid();
         }
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, className));
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder(className).build());
     }
 
     private static void generateMappingsConfigBuilder(
@@ -542,7 +546,8 @@ public class ConfigGenerationBuildStep {
             method.returnValue(configBuilder);
         }
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, className));
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder(className).build());
     }
 
     private static Set<String> discoverService(
@@ -552,7 +557,8 @@ public class ConfigGenerationBuildStep {
         Set<String> services = new HashSet<>();
         for (String service : classNamesNamedIn(classLoader, SERVICES_PREFIX + serviceClass.getName())) {
             services.add(service);
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, service));
+            reflectiveClass
+                    .produce(ReflectiveClassBuildItem.builder(service).build());
         }
         return services;
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/LocaleProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/LocaleProcessor.java
@@ -43,9 +43,8 @@ public class LocaleProcessor {
 
     @BuildStep(onlyIf = { NativeBuild.class, NonDefaultLocale.class })
     ReflectiveClassBuildItem setupReflectionClasses() {
-        return new ReflectiveClassBuildItem(false, false,
-                "sun.util.resources.provider.SupplementaryLocaleDataProvider",
-                "sun.util.resources.provider.LocaleDataProvider");
+        return ReflectiveClassBuildItem.builder("sun.util.resources.provider.SupplementaryLocaleDataProvider",
+                "sun.util.resources.provider.LocaleDataProvider").build();
     }
 
     @BuildStep(onlyIf = { NativeBuild.class, NonDefaultLocale.class })

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
@@ -491,7 +491,7 @@ public class MainClassBuildStep {
      */
     @BuildStep
     ReflectiveClassBuildItem applicationReflection() {
-        return new ReflectiveClassBuildItem(false, false, Application.APP_CLASS_NAME);
+        return ReflectiveClassBuildItem.builder(Application.APP_CLASS_NAME).build();
     }
 
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
@@ -212,8 +212,8 @@ public class ReflectiveHierarchyStep {
         reflectiveClass.produce(
                 ReflectiveClassBuildItem
                         .builder(name.toString())
-                        .methods(true)
-                        .fields(true)
+                        .methods()
+                        .fields()
                         .serialization(reflectiveHierarchyBuildItem.isSerialization())
                         .build());
 

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -111,8 +111,8 @@ class AgroalProcessor {
 
             if (aggregatedDataSourceBuildTimeConfig.getJdbcConfig().tracing) {
                 reflectiveClass
-                        .produce(new ReflectiveClassBuildItem(true, false,
-                                DataSources.TRACING_DRIVER_CLASSNAME));
+                        .produce(ReflectiveClassBuildItem.builder(DataSources.TRACING_DRIVER_CLASSNAME).methods()
+                                .build());
             }
 
             if (aggregatedDataSourceBuildTimeConfig.getJdbcConfig().telemetry) {
@@ -120,8 +120,8 @@ class AgroalProcessor {
             }
 
             reflectiveClass
-                    .produce(new ReflectiveClassBuildItem(true, false,
-                            aggregatedDataSourceBuildTimeConfig.getResolvedDriverClass()));
+                    .produce(ReflectiveClassBuildItem.builder(aggregatedDataSourceBuildTimeConfig.getResolvedDriverClass())
+                            .methods().build());
 
             aggregatedConfig.produce(aggregatedDataSourceBuildTimeConfig);
         }
@@ -140,15 +140,14 @@ class AgroalProcessor {
         resource.produce(new NativeImageResourceBuildItem(
                 "META-INF/services/" + io.agroal.api.security.AgroalSecurityProvider.class.getName()));
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false,
-                io.agroal.pool.ConnectionHandler[].class.getName(),
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(io.agroal.pool.ConnectionHandler[].class.getName(),
                 io.agroal.pool.ConnectionHandler.class.getName(),
                 io.agroal.api.security.AgroalDefaultSecurityProvider.class.getName(),
                 io.agroal.api.security.AgroalKerberosSecurityProvider.class.getName(),
                 java.sql.Statement[].class.getName(),
                 java.sql.Statement.class.getName(),
                 java.sql.ResultSet.class.getName(),
-                java.sql.ResultSet[].class.getName()));
+                java.sql.ResultSet[].class.getName()).build());
 
         // Enable SSL support by default
         sslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(Feature.AGROAL.getName()));

--- a/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -78,15 +78,15 @@ public class AmazonLambdaHttpProcessor {
     @BuildStep
     public void registerReflectionClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItemBuildProducer) {
         reflectiveClassBuildItemBuildProducer
-                .produce(new ReflectiveClassBuildItem(true, true, true,
-                        APIGatewayV2HTTPEvent.class,
+                .produce(ReflectiveClassBuildItem.builder(APIGatewayV2HTTPEvent.class,
                         APIGatewayV2HTTPEvent.RequestContext.class,
                         APIGatewayV2HTTPEvent.RequestContext.Http.class,
                         APIGatewayV2HTTPEvent.RequestContext.Authorizer.class,
                         APIGatewayV2HTTPEvent.RequestContext.CognitoIdentity.class,
                         APIGatewayV2HTTPEvent.RequestContext.IAM.class,
                         APIGatewayV2HTTPEvent.RequestContext.Authorizer.JWT.class,
-                        APIGatewayV2HTTPResponse.class, Headers.class, MultiValuedTreeMap.class));
+                        APIGatewayV2HTTPResponse.class, Headers.class, MultiValuedTreeMap.class)
+                        .methods().fields().build());
     }
 
     /**

--- a/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -77,8 +77,7 @@ public class AmazonLambdaHttpProcessor {
     @BuildStep
     public void registerReflectionClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItemBuildProducer) {
         reflectiveClassBuildItemBuildProducer
-                .produce(new ReflectiveClassBuildItem(true, true, true,
-                        AlbContext.class,
+                .produce(ReflectiveClassBuildItem.builder(AlbContext.class,
                         ApiGatewayAuthorizerContext.class,
                         ApiGatewayRequestIdentity.class,
                         AwsProxyRequest.class,
@@ -87,7 +86,7 @@ public class AmazonLambdaHttpProcessor {
                         CognitoAuthorizerClaims.class,
                         ErrorModel.class,
                         Headers.class,
-                        MultiValuedTreeMap.class));
+                        MultiValuedTreeMap.class).methods().fields().build());
     }
 
     /**

--- a/extensions/amazon-lambda-xray/deployment/src/main/java/io/quarkus/amazon/lambda/xray/XrayBuildStep.java
+++ b/extensions/amazon-lambda-xray/deployment/src/main/java/io/quarkus/amazon/lambda/xray/XrayBuildStep.java
@@ -20,9 +20,7 @@ public class XrayBuildStep {
         runtimeInitialized.produce(
                 new RuntimeInitializedClassBuildItem("com.amazonaws.xray.strategy.sampling.LocalizedSamplingStrategy"));
         runtimeInitialized.produce(new RuntimeInitializedClassBuildItem("com.amazonaws.xray.ThreadLocalStorage"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(
-                true, true, true,
-                "com.amazonaws.xray.handlers.config.AWSServiceHandlerManifest",
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.amazonaws.xray.handlers.config.AWSServiceHandlerManifest",
                 "com.amazonaws.xray.AWSXRay",
                 "com.amazonaws.xray.strategy.sampling.manifest.SamplingRuleManifest",
                 "com.amazonaws.xray.strategy.sampling.rule.SamplingRule",
@@ -41,7 +39,8 @@ public class XrayBuildStep {
                 "com.amazonaws.xray.entities.TraceID",
                 "com.amazonaws.xray.entities.Cause",
                 "com.amazonaws.xray.entities.SegmentImpl",
-                "com.fasterxml.jackson.databind.ser.std.ToStringSerializer"));
+                "com.fasterxml.jackson.databind.ser.std.ToStringSerializer").methods().fields()
+                .build());
 
         resource.produce(new NativeImageResourceBuildItem(
                 "com/amazonaws/xray/interceptors/DefaultOperationParameterWhitelist.json",

--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -99,7 +99,8 @@ public final class AmazonLambdaProcessor {
             final DotName name = info.name();
             final String lambda = name.toString();
             builder.addBeanClass(lambda);
-            reflectiveClassBuildItemBuildProducer.produce(new ReflectiveClassBuildItem(true, false, lambda));
+            reflectiveClassBuildItemBuildProducer
+                    .produce(ReflectiveClassBuildItem.builder(lambda).methods().build());
 
             String cdiName = null;
             AnnotationInstance named = info.classAnnotation(NAMED);
@@ -140,7 +141,8 @@ public final class AmazonLambdaProcessor {
         }
         additionalBeanBuildItemBuildProducer.produce(builder.build());
         reflectiveClassBuildItemBuildProducer
-                .produce(new ReflectiveClassBuildItem(true, true, true, FunctionError.class));
+                .produce(ReflectiveClassBuildItem.builder(FunctionError.class).methods().fields()
+                        .build());
         return ret;
     }
 
@@ -157,7 +159,7 @@ public final class AmazonLambdaProcessor {
         additionalBeanBuildItemBuildProducer.produce(builder.build());
 
         reflectiveClassBuildItemBuildProducer
-                .produce(new ReflectiveClassBuildItem(true, true, true, handlerClass));
+                .produce(ReflectiveClassBuildItem.builder(handlerClass).methods().fields().build());
 
         // TODO
         // This really isn't good enough.  We should recursively add reflection for all method and field types of the parameter
@@ -169,11 +171,13 @@ public final class AmazonLambdaProcessor {
                 Class<?>[] parameterTypes = method.getParameterTypes();
                 if (!parameterTypes[0].equals(Object.class)) {
                     reflectiveClassBuildItemBuildProducer
-                            .produce(new ReflectiveClassBuildItem(true, true, true, parameterTypes[0].getName()));
+                            .produce(ReflectiveClassBuildItem.builder(parameterTypes[0].getName())
+                                    .methods().fields().build());
                     reflectiveClassBuildItemBuildProducer
-                            .produce(new ReflectiveClassBuildItem(true, true, true, method.getReturnType().getName()));
-                    reflectiveClassBuildItemBuildProducer.produce(new ReflectiveClassBuildItem(true, true, true,
-                            DateTime.class));
+                            .produce(ReflectiveClassBuildItem.builder(method.getReturnType().getName())
+                                    .methods().fields().build());
+                    reflectiveClassBuildItemBuildProducer.produce(ReflectiveClassBuildItem.builder(DateTime.class)
+                            .methods().fields().build());
                     break;
                 }
             }
@@ -307,7 +311,8 @@ public final class AmazonLambdaProcessor {
             BuildProducer<ReflectiveClassBuildItem> registerForReflection,
             AmazonLambdaStaticRecorder recorder) {
         Set<Class<?>> classes = config.expectedExceptions.map(Set::copyOf).orElseGet(Set::of);
-        classes.stream().map(clazz -> new ReflectiveClassBuildItem(false, false, false, clazz))
+        classes.stream()
+                .map(clazz -> ReflectiveClassBuildItem.builder(clazz).constructors(false).build())
                 .forEach(registerForReflection::produce);
         recorder.setExpectedExceptionClasses(classes);
     }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -599,7 +599,8 @@ public class ArcProcessor {
             public void registerClientProxy(DotName beanClassName, String clientProxyName) {
                 if (reflectiveBeanClassesNames.contains(beanClassName)) {
                     // Fields should never be registered for client proxies
-                    reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, clientProxyName));
+                    reflectiveClasses
+                            .produce(ReflectiveClassBuildItem.builder(clientProxyName).methods().build());
                 }
             }
 
@@ -607,7 +608,8 @@ public class ArcProcessor {
             public void registerSubclass(DotName beanClassName, String subclassName) {
                 if (reflectiveBeanClassesNames.contains(beanClassName)) {
                     // Fields should never be registered for subclasses
-                    reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, subclassName));
+                    reflectiveClasses
+                            .produce(ReflectiveClassBuildItem.builder(subclassName).methods().build());
                 }
             }
 
@@ -638,12 +640,14 @@ public class ArcProcessor {
 
         // Register all qualifiers for reflection to support type-safe resolution at runtime in native image
         for (ClassInfo qualifier : beanProcessor.getBeanDeployment().getQualifiers()) {
-            reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, qualifier.name().toString()));
+            reflectiveClasses
+                    .produce(ReflectiveClassBuildItem.builder(qualifier.name().toString()).methods().build());
         }
 
         // Register all interceptor bindings for reflection so that AnnotationLiteral.equals() works in a native image
         for (ClassInfo binding : beanProcessor.getBeanDeployment().getInterceptorBindings()) {
-            reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, binding.name().toString()));
+            reflectiveClasses
+                    .produce(ReflectiveClassBuildItem.builder(binding.name().toString()).methods().build());
         }
 
         ArcContainer container = recorder.initContainer(shutdown,

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -128,7 +128,8 @@ public class ConfigBuildStep {
         for (Type type : customBeanTypes) {
             if (type.kind() != Kind.ARRAY) {
                 // Implicit converters are most likely used
-                reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, type.name().toString()));
+                reflectiveClass
+                        .produce(ReflectiveClassBuildItem.builder(type.name().toString()).methods().build());
             }
             DotName implClazz = type.kind() == Kind.ARRAY ? DotName.createSimple(ConfigBeanCreator.class.getName())
                     : type.name();
@@ -208,7 +209,7 @@ public class ConfigBuildStep {
             Type requiredType = item.getPropertyType();
             String propertyType = requiredType.name().toString();
             if (requiredType.kind() != Kind.PRIMITIVE) {
-                reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, propertyType));
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(propertyType).build());
             }
         }
 
@@ -222,7 +223,8 @@ public class ConfigBuildStep {
                 for (Type argumentType : argumentTypes) {
                     actualTypeArgumentNames.add(argumentType.name().toString());
                     if (argumentType.kind() != Kind.PRIMITIVE) {
-                        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, argumentType.name().toString()));
+                        reflectiveClass.produce(ReflectiveClassBuildItem.builder(argumentType.name().toString())
+                                .build());
                     }
                 }
 
@@ -385,7 +387,7 @@ public class ConfigBuildStep {
                 .toArray(String[]::new);
         if (valueTypes.length > 0) {
             producer.produce(
-                    ReflectiveClassBuildItem.builder(valueTypes).constructors(true).methods(false).fields(false).build());
+                    ReflectiveClassBuildItem.builder(valueTypes).build());
         }
     }
 

--- a/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroProcessor.java
+++ b/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroProcessor.java
@@ -45,7 +45,8 @@ public class AvroProcessor {
         for (AnnotationInstance annotation : annotations) {
             if (annotation.target().kind() == AnnotationTarget.Kind.CLASS) {
                 String className = annotation.target().asClass().name().toString();
-                reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, className));
+                reflectiveClass.produce(
+                        ReflectiveClassBuildItem.builder(className).methods().fields().build());
             }
         }
 

--- a/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
+++ b/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
@@ -53,17 +53,15 @@ class AwtProcessor {
 
     @BuildStep
     ReflectiveClassBuildItem setupReflectionClasses() {
-        return new ReflectiveClassBuildItem(false, false,
-                "sun.awt.X11.XToolkit",
+        return ReflectiveClassBuildItem.builder("sun.awt.X11.XToolkit",
                 "sun.awt.X11FontManager",
                 "sun.awt.X11GraphicsEnvironment",
-                "com.sun.imageio.plugins.common.I18N");
+                "com.sun.imageio.plugins.common.I18N").build();
     }
 
     @BuildStep
     ReflectiveClassBuildItem setupReflectionClassesWithMethods() {
-        return new ReflectiveClassBuildItem(true, false,
-                "sun.java2d.loops.SetDrawLineANY",
+        return ReflectiveClassBuildItem.builder("sun.java2d.loops.SetDrawLineANY",
                 "sun.java2d.loops.SetDrawPathANY",
                 "sun.java2d.loops.SetDrawPolygonsANY",
                 "sun.java2d.loops.SetDrawRectANY",
@@ -79,7 +77,7 @@ class AwtProcessor {
                 "javax.imageio.plugins.tiff.ExifTIFFTagSet",
                 "javax.imageio.plugins.tiff.FaxTIFFTagSet",
                 "javax.imageio.plugins.tiff.GeoTIFFTagSet",
-                "javax.imageio.plugins.tiff.TIFFTagSet");
+                "javax.imageio.plugins.tiff.TIFFTagSet").methods().build();
     }
 
     @BuildStep

--- a/extensions/caffeine/deployment/src/main/java/io/quarkus/caffeine/deployment/CaffeineProcessor.java
+++ b/extensions/caffeine/deployment/src/main/java/io/quarkus/caffeine/deployment/CaffeineProcessor.java
@@ -42,10 +42,10 @@ public class CaffeineProcessor {
         }
         if (!effectiveImplementorNames.isEmpty()) {
             //Do not force registering any Caffeine classes if we can avoid it: there's a significant chain reaction
-            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(CACHE_LOADER_CLASS_NAME).methods(true).build());
+            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(CACHE_LOADER_CLASS_NAME).methods().build());
 
             reflectiveClasses.produce(
-                    ReflectiveClassBuildItem.builder(effectiveImplementorNames.toArray(new String[0])).methods(true).build());
+                    ReflectiveClassBuildItem.builder(effectiveImplementorNames.toArray(new String[0])).methods().build());
         }
     }
 

--- a/extensions/csrf-reactive/deployment/src/main/java/io/quarkus/csrf/reactive/CsrfReactiveBuildStep.java
+++ b/extensions/csrf-reactive/deployment/src/main/java/io/quarkus/csrf/reactive/CsrfReactiveBuildStep.java
@@ -19,7 +19,8 @@ public class CsrfReactiveBuildStep {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClassesBuildItem) {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(CsrfRequestResponseReactiveFilter.class));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, CsrfRequestResponseReactiveFilter.class));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(CsrfRequestResponseReactiveFilter.class).methods().fields().build());
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(CsrfTokenParameterProvider.class));
         additionalIndexedClassesBuildItem
                 .produce(new AdditionalIndexedClassesBuildItem(CsrfRequestResponseReactiveFilter.class.getName()));

--- a/extensions/elasticsearch-rest-high-level-client/deployment/src/main/java/io/quarkus/elasticsearch/restclient/highlevel/deployment/ElasticsearchHighLevelClientProcessor.java
+++ b/extensions/elasticsearch-rest-high-level-client/deployment/src/main/java/io/quarkus/elasticsearch/restclient/highlevel/deployment/ElasticsearchHighLevelClientProcessor.java
@@ -21,9 +21,8 @@ class ElasticsearchHighLevelClientProcessor {
 
     @BuildStep
     public ReflectiveClassBuildItem registerForReflection() {
-        return new ReflectiveClassBuildItem(true, false,
-                "org.apache.logging.log4j.message.ReusableMessageFactory",
-                "org.apache.logging.log4j.message.DefaultFlowMessageFactory");
+        return ReflectiveClassBuildItem.builder("org.apache.logging.log4j.message.ReusableMessageFactory",
+                "org.apache.logging.log4j.message.DefaultFlowMessageFactory").methods().build();
     }
 
 }

--- a/extensions/elytron-security-common/deployment/src/main/java/io/quarkus/elytron/security/common/deployment/QuarkusSecurityCommonProcessor.java
+++ b/extensions/elytron-security-common/deployment/src/main/java/io/quarkus/elytron/security/common/deployment/QuarkusSecurityCommonProcessor.java
@@ -43,6 +43,6 @@ public class QuarkusSecurityCommonProcessor {
         String[] allClasses = {
                 "org.wildfly.security.password.impl.PasswordFactorySpiImpl",
         };
-        classes.produce(new ReflectiveClassBuildItem(true, false, allClasses));
+        classes.produce(ReflectiveClassBuildItem.builder(allClasses).methods().build());
     }
 }

--- a/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
+++ b/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
@@ -64,8 +64,11 @@ class ElytronSecurityLdapProcessor {
     void registerForReflection(BuildProducer<ReflectiveClassBuildItem> reflection) {
         // All JDK provided InitialContextFactory impls via the module descriptors:
         // com.sun.jndi.ldap.LdapCtxFactory, com.sun.jndi.dns.DnsContextFactory and com.sun.jndi.rmi.registry.RegistryContextFactory
-        reflection.produce(new ReflectiveClassBuildItem(true, true, QuarkusDirContextFactory.INITIAL_CONTEXT_FACTORY));
-        reflection.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jndi.dns.DnsContextFactory"));
-        reflection.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jndi.rmi.registry.RegistryContextFactory"));
+        reflection.produce(ReflectiveClassBuildItem.builder(QuarkusDirContextFactory.INITIAL_CONTEXT_FACTORY).methods()
+                .fields().build());
+        reflection.produce(
+                ReflectiveClassBuildItem.builder("com.sun.jndi.dns.DnsContextFactory").build());
+        reflection.produce(ReflectiveClassBuildItem.builder("com.sun.jndi.rmi.registry.RegistryContextFactory")
+                .build());
     }
 }

--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayCallbacksLocator.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayCallbacksLocator.java
@@ -93,7 +93,8 @@ class FlywayCallbacksLocator {
             final Class<?> clazzType = Class.forName(callback, false, Thread.currentThread().getContextClassLoader());
             final Callback instance = (Callback) clazzType.getConstructors()[0].newInstance();
             instances.add(instance);
-            reflectiveClassProducer.produce(new ReflectiveClassBuildItem(false, false, clazz.name().toString()));
+            reflectiveClassProducer
+                    .produce(ReflectiveClassBuildItem.builder(clazz.name().toString()).build());
         }
         return instances;
     }

--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
@@ -149,7 +149,8 @@ class FlywayProcessor {
                 continue;
             }
             javaMigrationClasses.add((Class<JavaMigration>) context.classProxy(javaMigration.name().toString()));
-            reflectiveClassProducer.produce(new ReflectiveClassBuildItem(false, false, javaMigration.name().toString()));
+            reflectiveClassProducer.produce(
+                    ReflectiveClassBuildItem.builder(javaMigration.name().toString()).build());
         }
     }
 

--- a/extensions/funqy/funqy-server-common/deployment/src/main/java/io/quarkus/funqy/deployment/FunctionScannerBuildStep.java
+++ b/extensions/funqy/funqy-server-common/deployment/src/main/java/io/quarkus/funqy/deployment/FunctionScannerBuildStep.java
@@ -108,7 +108,8 @@ public class FunctionScannerBuildStep {
         }
         Set<ClassInfo> withoutDefaultCtor = new HashSet<>();
         for (ClassInfo clazz : classes) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, clazz.name().toString()));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(clazz.name().toString()).methods()
+                    .fields().build());
             if (!clazz.hasNoArgsConstructor()) {
                 withoutDefaultCtor.add(clazz);
             }

--- a/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcCommonProcessor.java
+++ b/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcCommonProcessor.java
@@ -23,37 +23,45 @@ public class GrpcCommonProcessor {
         Collection<ClassInfo> messages = combinedIndex.getIndex()
                 .getAllKnownSubclasses(GrpcDotNames.GENERATED_MESSAGE_V3);
         for (ClassInfo message : messages) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, message.name().toString()));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(message.name().toString()).methods()
+                    .fields().build());
         }
 
         // We also need to include enums.
         Collection<ClassInfo> enums = combinedIndex.getIndex()
                 .getAllKnownSubclasses(GrpcDotNames.PROTOCOL_MESSAGE_ENUM);
         for (ClassInfo en : enums) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, en.name().toString()));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(en.name().toString()).methods()
+                    .fields().build());
         }
 
         Collection<ClassInfo> builders = combinedIndex.getIndex().getAllKnownSubclasses(GrpcDotNames.MESSAGE_BUILDER);
         for (ClassInfo builder : builders) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, builder.name().toString()));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(builder.name().toString()).methods()
+                    .fields().build());
         }
 
         Collection<ClassInfo> lbs = combinedIndex.getIndex().getAllKnownSubclasses(GrpcDotNames.LOAD_BALANCER_PROVIDER);
         for (ClassInfo lb : lbs) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, lb.name().toString()));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(lb.name().toString()).methods()
+                    .build());
         }
 
         Collection<ClassInfo> nrs = combinedIndex.getIndex().getAllKnownSubclasses(GrpcDotNames.NAME_RESOLVER_PROVIDER);
         for (ClassInfo nr : nrs) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, nr.name().toString()));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(nr.name().toString()).methods()
+                    .build());
         }
 
         // Built-In providers:
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, DnsNameResolverProvider.class));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, PickFirstLoadBalancerProvider.class));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false,
-                "io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, NettyChannelProvider.class));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(DnsNameResolverProvider.class).methods()
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(PickFirstLoadBalancerProvider.class)
+                .methods().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider")
+                .methods().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(NettyChannelProvider.class).methods()
+                .build());
     }
 
     @BuildStep

--- a/extensions/hal/deployment/src/main/java/io/quarkus/hal/deployment/HalProcessor.java
+++ b/extensions/hal/deployment/src/main/java/io/quarkus/hal/deployment/HalProcessor.java
@@ -20,7 +20,7 @@ public class HalProcessor {
 
     @BuildStep
     ReflectiveClassBuildItem registerReflection() {
-        return new ReflectiveClassBuildItem(true, true, HalLink.class);
+        return ReflectiveClassBuildItem.builder(HalLink.class).methods().fields().build();
     }
 
     @BuildStep

--- a/extensions/hibernate-envers/deployment/src/main/java/io/quarkus/hibernate/envers/deployment/HibernateEnversProcessor.java
+++ b/extensions/hibernate-envers/deployment/src/main/java/io/quarkus/hibernate/envers/deployment/HibernateEnversProcessor.java
@@ -34,13 +34,17 @@ public final class HibernateEnversProcessor {
     @BuildStep
     public void registerEnversReflections(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             HibernateEnversBuildTimeConfig buildTimeConfig) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, "org.hibernate.envers.DefaultRevisionEntity"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false,
-                "org.hibernate.envers.DefaultTrackingModifiedEntitiesRevisionEntity"));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("org.hibernate.envers.DefaultRevisionEntity").methods()
+                .build());
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder("org.hibernate.envers.DefaultTrackingModifiedEntitiesRevisionEntity")
+                        .methods().build());
 
         for (HibernateEnversBuildTimeConfigPersistenceUnit pu : buildTimeConfig.getAllPersistenceUnitConfigsAsMap().values()) {
-            pu.revisionListener.ifPresent(s -> reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, s)));
-            pu.auditStrategy.ifPresent(s -> reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, s)));
+            pu.revisionListener.ifPresent(
+                    s -> reflectiveClass.produce(ReflectiveClassBuildItem.builder(s).methods().fields().build()));
+            pu.auditStrategy.ifPresent(
+                    s -> reflectiveClass.produce(ReflectiveClassBuildItem.builder(s).methods().fields().build()));
         }
     }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -311,10 +311,10 @@ public final class HibernateOrmProcessor {
     public void enrollBeanValidationTypeSafeActivatorForReflection(Capabilities capabilities,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
         if (capabilities.isPresent(Capability.HIBERNATE_VALIDATOR)) {
-            reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true,
-                    "org.hibernate.boot.beanvalidation.TypeSafeActivator"));
-            reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false, false,
-                    BeanValidationIntegrator.BV_CHECK_CLASS));
+            reflectiveClasses.produce(ReflectiveClassBuildItem.builder("org.hibernate.boot.beanvalidation.TypeSafeActivator")
+                    .methods().fields().build());
+            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(BeanValidationIntegrator.BV_CHECK_CLASS)
+                    .constructors(false).build());
         }
     }
 
@@ -537,7 +537,8 @@ public final class HibernateOrmProcessor {
             for (DotName name : HibernateOrmAnnotations.HIBERNATE_MAPPING_ANNOTATIONS) {
                 annotationClassNames.add(name.toString());
             }
-            reflective.produce(new ReflectiveClassBuildItem(true, true, true, annotationClassNames.toArray(new String[0])));
+            reflective.produce(ReflectiveClassBuildItem.builder(annotationClassNames.toArray(new String[0]))
+                    .methods().fields().build());
             for (String annotationClassName : annotationClassNames) {
                 proxyDefinitions.produce(new NativeImageProxyDefinitionBuildItem(annotationClassName));
             }
@@ -818,7 +819,8 @@ public final class HibernateOrmProcessor {
                     .map(a -> a.target().asClass().name().toString())
                     .toArray(String[]::new);
 
-            reflective.produce(new ReflectiveClassBuildItem(false, false, true, metamodel));
+            reflective.produce(
+                    ReflectiveClassBuildItem.builder(metamodel).constructors(false).fields().build());
         }
     }
 
@@ -842,7 +844,8 @@ public final class HibernateOrmProcessor {
                 .forEach(classes::add);
 
         if (!classes.isEmpty()) {
-            reflective.produce(new ReflectiveClassBuildItem(false, true, false, classes.toArray(new String[0])));
+            reflective.produce(ReflectiveClassBuildItem.builder(classes.toArray(new String[0])).constructors(false)
+                    .methods().build());
         }
     }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateUserTypeProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateUserTypeProcessor.java
@@ -43,7 +43,8 @@ public final class HibernateUserTypeProcessor {
         }
 
         if (!userTypes.isEmpty()) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, userTypes.toArray(new String[] {})));
+            reflectiveClass.produce(
+                    ReflectiveClassBuildItem.builder(userTypes.toArray(new String[] {})).methods().fields().build());
         }
     }
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
@@ -105,20 +105,20 @@ public final class JpaJandexScavenger {
         Set<String> allModelClassNames = new HashSet<>(collector.entityTypes);
         allModelClassNames.addAll(collector.modelTypes);
         for (String className : allModelClassNames) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, className));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).methods().fields().build());
         }
 
         if (!collector.enumTypes.isEmpty()) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, "java.lang.Enum"));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder("java.lang.Enum").methods().build());
             for (String className : collector.enumTypes) {
-                reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, className));
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).methods().build());
             }
         }
 
         // for the java types we collected (usually from java.time but it could be from other types),
         // we just register them for reflection
         for (String javaType : collector.javaTypes) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, javaType));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(javaType).methods().build());
         }
 
         // Converters need to be in the list of model types in order for @Converter#autoApply to work,

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
@@ -34,7 +34,7 @@ class HibernateSearchOutboxPollingProcessor {
         String[] avroTypes = HibernateOrmMapperOutboxPollingClasses.avroTypes().toArray(String[]::new);
         additionalIndexedClasses.produce(new AdditionalIndexedClassesBuildItem(avroTypes));
         String[] hibernateOrmTypes = HibernateOrmMapperOutboxPollingClasses.hibernateOrmTypes().toArray(String[]::new);
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, hibernateOrmTypes));
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(hibernateOrmTypes).methods().fields().build());
         for (String className : hibernateOrmTypes) {
             additionalJpaModel.produce(new AdditionalJpaModelBuildItem(className));
         }

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -337,7 +337,7 @@ class HibernateSearchElasticsearchProcessor {
 
     private void registerReflectionForGson(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
         String[] reflectiveClasses = GsonClasses.typesRequiringReflection().toArray(String[]::new);
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, reflectiveClasses));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(reflectiveClasses).methods().fields().build());
     }
 
     @BuildStep

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -403,8 +403,8 @@ class HibernateValidatorProcessor {
         exceptionMapperProducer.produce(new ExceptionMapperBuildItem(ResteasyReactiveViolationExceptionMapper.class.getName(),
                 ValidationException.class.getName(), Priorities.USER + 1, true));
         reflectiveClassProducer.produce(
-                new ReflectiveClassBuildItem(true, true, ViolationReport.class,
-                        ViolationReport.Violation.class));
+                ReflectiveClassBuildItem.builder(ViolationReport.class,
+                        ViolationReport.Violation.class).methods().fields().build());
     }
 
     // We need to make sure that the standard process of obtaining a ValidationFactory is not followed,

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
@@ -133,8 +133,10 @@ class InfinispanClientProcessor {
 
             // We use caffeine for bounded near cache - so register that reflection if we have a bounded near cache
             if (properties.containsKey(ConfigurationProperties.NEAR_CACHE_MAX_ENTRIES)) {
-                reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.github.benmanes.caffeine.cache.SSMS"));
-                reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.github.benmanes.caffeine.cache.PSMS"));
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.github.benmanes.caffeine.cache.SSMS")
+                        .build());
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.github.benmanes.caffeine.cache.PSMS")
+                        .build());
             }
         }
 
@@ -205,21 +207,26 @@ class InfinispanClientProcessor {
         for (AnnotationInstance instance : listenerInstances) {
             AnnotationTarget target = instance.target();
             if (target.kind() == AnnotationTarget.Kind.CLASS) {
-                reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, target.asClass().name().toString()));
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(target.asClass().name().toString()).methods()
+                        .build());
             }
         }
 
         // This is required for netty to work properly
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "io.netty.channel.socket.nio.NioSocketChannel"));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("io.netty.channel.socket.nio.NioSocketChannel")
+                .build());
         // We use reflection to have continuous queries work
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false,
-                "org.infinispan.client.hotrod.event.impl.ContinuousQueryImpl$ClientEntryListener"));
+        reflectiveClass.produce(ReflectiveClassBuildItem
+                .builder("org.infinispan.client.hotrod.event.impl.ContinuousQueryImpl$ClientEntryListener").methods()
+                .build());
         // We use reflection to allow for near cache invalidations
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false,
-                "org.infinispan.client.hotrod.near.NearCacheService$InvalidatedNearCacheListener"));
+        reflectiveClass.produce(ReflectiveClassBuildItem
+                .builder("org.infinispan.client.hotrod.near.NearCacheService$InvalidatedNearCacheListener").methods()
+                .build());
         // This is required when a cache is clustered to tell us topology
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false,
-                "org.infinispan.client.hotrod.impl.consistenthash.SegmentConsistentHash"));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder("org.infinispan.client.hotrod.impl.consistenthash.SegmentConsistentHash")
+                        .build());
 
         return new InfinispanPropertiesBuildItem(properties);
     }

--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -124,14 +124,14 @@ public class JacksonProcessor {
                         "com.fasterxml.jackson.databind.ser.std.SqlTimeSerializer",
                         "com.fasterxml.jackson.databind.deser.std.DateDeserializers$SqlDateDeserializer",
                         "com.fasterxml.jackson.databind.deser.std.DateDeserializers$TimestampDeserializer",
-                        "com.fasterxml.jackson.annotation.SimpleObjectIdResolver").methods(true).build());
+                        "com.fasterxml.jackson.annotation.SimpleObjectIdResolver").methods().build());
 
         if (curateOutcomeBuildItem.getApplicationModel().getDependencies().stream().anyMatch(
                 x -> x.getGroupId().equals("com.fasterxml.jackson.module")
                         && x.getArtifactId().equals("jackson-module-jaxb-annotations"))) {
             reflectiveClass.produce(
                     ReflectiveClassBuildItem.builder("com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector")
-                            .methods(true).build());
+                            .methods().build());
         }
 
         IndexView index = combinedIndexBuildItem.getIndex();
@@ -207,7 +207,7 @@ public class JacksonProcessor {
         for (AnnotationInstance creatorInstance : index.getAnnotations(JSON_AUTO_DETECT)) {
             if (creatorInstance.target().kind() == CLASS) {
                 reflectiveClass.produce(ReflectiveClassBuildItem.builder(creatorInstance.target().asClass().name().toString())
-                        .methods(true).fields(true).build());
+                        .methods().fields().build());
             }
         }
 
@@ -221,7 +221,7 @@ public class JacksonProcessor {
             if (value != null) {
                 // Add the type-id-resolver class
                 reflectiveClass
-                        .produce(ReflectiveClassBuildItem.builder(value.asClass().name().toString()).methods(true).fields(true)
+                        .produce(ReflectiveClassBuildItem.builder(value.asClass().name().toString()).methods().fields()
                                 .build());
                 if (resolverInstance.target().kind() == CLASS) {
                     // Add the whole hierarchy of the annotated class
@@ -242,7 +242,7 @@ public class JacksonProcessor {
             AnnotationValue strategyValue = jsonNamingInstance.value("value");
             if (strategyValue != null) {
                 reflectiveClass.produce(ReflectiveClassBuildItem.builder(strategyValue.asClass().name().toString())
-                        .methods(true).fields(true).build());
+                        .methods().fields().build());
             }
         }
 
@@ -252,15 +252,15 @@ public class JacksonProcessor {
             AnnotationValue resolverValue = jsonIdentityInfoInstance.value("resolver");
             if (generatorValue != null) {
                 reflectiveClass.produce(ReflectiveClassBuildItem.builder(generatorValue.asClass().name().toString())
-                        .methods(true).fields(true).build());
+                        .methods().fields().build());
             }
             if (resolverValue != null) {
                 reflectiveClass.produce(ReflectiveClassBuildItem.builder(resolverValue.asClass().name().toString())
-                        .methods(true).fields(true).build());
+                        .methods().fields().build());
             } else {
                 // Registering since SimpleObjectIdResolver is the default value of @JsonIdentityInfo.resolver
                 reflectiveClass.produce(
-                        ReflectiveClassBuildItem.builder(SimpleObjectIdResolver.class).methods(true).fields(true).build());
+                        ReflectiveClassBuildItem.builder(SimpleObjectIdResolver.class).methods().fields().build());
             }
         }
 
@@ -394,7 +394,7 @@ public class JacksonProcessor {
             }
             ClassInfo mixinClassInfo = instance.target().asClass();
             String mixinClassName = mixinClassInfo.name().toString();
-            reflectiveClass.produce(ReflectiveClassBuildItem.builder(mixinClassName).methods(true).fields(true).build());
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(mixinClassName).methods().fields().build());
             try {
                 Type[] targetTypes = instance.value().asClassArray();
                 if ((targetTypes == null) || targetTypes.length == 0) {
@@ -404,7 +404,7 @@ public class JacksonProcessor {
                 for (Type targetType : targetTypes) {
                     String targetClassName = targetType.name().toString();
                     reflectiveClass
-                            .produce(ReflectiveClassBuildItem.builder(targetClassName).methods(true).fields(true).build());
+                            .produce(ReflectiveClassBuildItem.builder(targetClassName).methods().fields().build());
                     mixinsMap.put(Thread.currentThread().getContextClassLoader().loadClass(targetClassName),
                             mixinClass);
                 }

--- a/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
+++ b/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
@@ -56,7 +56,7 @@ public class JaegerProcessor {
                         "io.jaegertracing.internal.samplers.http.ProbabilisticSamplingStrategy",
                         "io.jaegertracing.internal.samplers.http.RateLimitingSamplingStrategy",
                         "io.jaegertracing.internal.samplers.http.SamplingStrategyResponse")
-                .fields(true)
+                .fields()
                 .build();
     }
 }

--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
@@ -204,7 +204,7 @@ public class JaxbProcessor {
                     .getAnnotations(jaxbRootAnnotation)) {
                 if (jaxbRootAnnotationInstance.target().kind() == Kind.CLASS) {
                     String className = jaxbRootAnnotationInstance.target().asClass().name().toString();
-                    reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, className));
+                    reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).methods().fields().build());
                     classesToBeBound.add(className);
                     jaxbRootAnnotationsDetected = true;
                 }
@@ -220,14 +220,15 @@ public class JaxbProcessor {
             if (xmlSchemaInstance.target().kind() == Kind.CLASS) {
                 String className = xmlSchemaInstance.target().asClass().name().toString();
 
-                reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, className));
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).build());
             }
         }
 
         // Register XML Java type adapters for reflection
         for (AnnotationInstance xmlJavaTypeAdapterInstance : index.getAnnotations(XML_JAVA_TYPE_ADAPTER)) {
             reflectiveClass.produce(
-                    new ReflectiveClassBuildItem(true, true, xmlJavaTypeAdapterInstance.value().asClass().name().toString()));
+                    ReflectiveClassBuildItem.builder(xmlJavaTypeAdapterInstance.value().asClass().name().toString())
+                            .methods().fields().build());
         }
 
         if (!index.getAnnotations(XML_ANY_ELEMENT).isEmpty()) {
@@ -378,7 +379,7 @@ public class JaxbProcessor {
                     classesToBeBound.add(clazz);
 
                     while (cl != Object.class) {
-                        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, cl));
+                        reflectiveClass.produce(ReflectiveClassBuildItem.builder(cl).methods().fields().build());
                         cl = cl.getSuperclass();
                     }
                 }

--- a/extensions/jaxp/deployment/src/main/java/io/quarkus/jaxp/deployment/JaxpProcessor.java
+++ b/extensions/jaxp/deployment/src/main/java/io/quarkus/jaxp/deployment/JaxpProcessor.java
@@ -13,20 +13,19 @@ class JaxpProcessor {
 
     @BuildStep
     void reflectiveClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false,
-                "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
-                "com.sun.org.apache.xerces.internal.jaxp.datatype.DatatypeFactoryImpl",
-                "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl",
-                "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
-                "com.sun.org.apache.xerces.internal.parsers.SAXParser",
-                "com.sun.org.apache.xml.internal.utils.FastStringBuffer"));
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder("com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
+                        "com.sun.org.apache.xerces.internal.jaxp.datatype.DatatypeFactoryImpl",
+                        "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl",
+                        "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+                        "com.sun.org.apache.xerces.internal.parsers.SAXParser",
+                        "com.sun.org.apache.xml.internal.utils.FastStringBuffer").build());
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false,
-                "com.sun.xml.internal.stream.XMLInputFactoryImpl",
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.sun.xml.internal.stream.XMLInputFactoryImpl",
                 "com.sun.xml.internal.stream.XMLOutputFactoryImpl",
                 "com.sun.org.apache.xpath.internal.functions.FuncNot",
                 "com.sun.org.apache.xerces.internal.impl.dv.xs.SchemaDVFactoryImpl",
-                "javax.xml.namespace.QName"));
+                "javax.xml.namespace.QName").methods().build());
     }
 
     @BuildStep

--- a/extensions/jdbc/jdbc-db2/deployment/src/main/java/io/quarkus/jdbc/db2/deployment/JDBCDB2Processor.java
+++ b/extensions/jdbc/jdbc-db2/deployment/src/main/java/io/quarkus/jdbc/db2/deployment/JDBCDB2Processor.java
@@ -60,7 +60,7 @@ public class JDBCDB2Processor {
         //any JDBC driver being configured explicitly through its configuration.
         //We register it for the sake of people not using Agroal,
         //for example when the driver is used with OpenTelemetry JDBC instrumentation.
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, DB2_DRIVER_CLASS));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(DB2_DRIVER_CLASS).build());
     }
 
     @BuildStep

--- a/extensions/jdbc/jdbc-derby/deployment/src/main/java/io/quarkus/jdbc/derby/deployment/JDBCDerbyProcessor.java
+++ b/extensions/jdbc/jdbc-derby/deployment/src/main/java/io/quarkus/jdbc/derby/deployment/JDBCDerbyProcessor.java
@@ -53,7 +53,8 @@ public class JDBCDerbyProcessor {
         //Not strictly necessary when using Agroal, as it also registers
         //any JDBC driver being configured explicitly through its configuration.
         //We register it for the sake of people not using Agroal.
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, org.apache.derby.jdbc.ClientDriver.class.getName()));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(org.apache.derby.jdbc.ClientDriver.class.getName())
+                .build());
 
         nativeImageResourceBundles.produce(new NativeImageResourceBundleBuildItem("org/apache/derby/loc/clientmessages"));
     }

--- a/extensions/jdbc/jdbc-h2/deployment/src/main/java/io/quarkus/jdbc/h2/deployment/H2JDBCReflections.java
+++ b/extensions/jdbc/jdbc-h2/deployment/src/main/java/io/quarkus/jdbc/h2/deployment/H2JDBCReflections.java
@@ -35,7 +35,7 @@ public final class H2JDBCReflections {
         //any JDBC driver being configured explicitly through its configuration.
         //We register it for the sake of people not using Agroal.
         final String driverName = "org.h2.Driver";
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, driverName));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(driverName).build());
     }
 
     @BuildStep

--- a/extensions/jdbc/jdbc-mariadb/deployment/src/main/java/io/quarkus/jdbc/mariadb/deployment/MariaDBJDBCReflections.java
+++ b/extensions/jdbc/jdbc-mariadb/deployment/src/main/java/io/quarkus/jdbc/mariadb/deployment/MariaDBJDBCReflections.java
@@ -11,10 +11,12 @@ public final class MariaDBJDBCReflections {
         //Not strictly necessary when using Agroal, as it also registers
         //any JDBC driver being configured explicitly through its configuration.
         //We register it for the sake of people not using Agroal.
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "org.mariadb.jdbc.Driver"));
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder("org.mariadb.jdbc.Driver").build());
 
         //MariaDB's connection process requires reflective read to all fields of Configuration and its Builder:
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, true,
-                "org.mariadb.jdbc.Configuration", "org.mariadb.jdbc.Configuration$Builder"));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder("org.mariadb.jdbc.Configuration", "org.mariadb.jdbc.Configuration$Builder")
+                        .fields().build());
     }
 }

--- a/extensions/jdbc/jdbc-mssql/deployment/src/main/java/io/quarkus/jdbc/mssql/deployment/MsSQLReflections.java
+++ b/extensions/jdbc/jdbc-mssql/deployment/src/main/java/io/quarkus/jdbc/mssql/deployment/MsSQLReflections.java
@@ -18,7 +18,7 @@ public final class MsSQLReflections {
         //any JDBC driver being configured explicitly through its configuration.
         //We register it for the sake of people not using Agroal.
         final String driverName = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, driverName));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(driverName).build());
     }
 
 }

--- a/extensions/jdbc/jdbc-mysql/deployment/src/main/java/io/quarkus/jdbc/mysql/deployment/MySQLJDBCReflections.java
+++ b/extensions/jdbc/jdbc-mysql/deployment/src/main/java/io/quarkus/jdbc/mysql/deployment/MySQLJDBCReflections.java
@@ -54,74 +54,115 @@ public final class MySQLJDBCReflections {
     @BuildStep
     void registerDriverForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, Driver.class.getName()));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(Driver.class.getName()).build());
         reflectiveClass.produce(
-                new ReflectiveClassBuildItem(false, false, FailoverDnsSrvConnectionUrl.class.getName()));
+                ReflectiveClassBuildItem.builder(FailoverDnsSrvConnectionUrl.class.getName())
+                        .build());
         reflectiveClass.produce(
-                new ReflectiveClassBuildItem(false, false, FailoverConnectionUrl.class.getName()));
+                ReflectiveClassBuildItem.builder(FailoverConnectionUrl.class.getName()).build());
         reflectiveClass
-                .produce(new ReflectiveClassBuildItem(false, false, SingleConnectionUrl.class.getName()));
+                .produce(ReflectiveClassBuildItem.builder(SingleConnectionUrl.class.getName())
+                        .build());
         reflectiveClass.produce(
-                new ReflectiveClassBuildItem(false, false, LoadBalanceConnectionUrl.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false,
-                LoadBalanceDnsSrvConnectionUrl.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false,
-                ReplicationDnsSrvConnectionUrl.class.getName()));
+                ReflectiveClassBuildItem.builder(LoadBalanceConnectionUrl.class.getName())
+                        .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(LoadBalanceDnsSrvConnectionUrl.class.getName())
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(ReplicationDnsSrvConnectionUrl.class.getName())
+                .build());
         reflectiveClass.produce(
-                new ReflectiveClassBuildItem(false, false, ReplicationConnectionUrl.class.getName()));
+                ReflectiveClassBuildItem.builder(ReplicationConnectionUrl.class.getName())
+                        .build());
         reflectiveClass.produce(
-                new ReflectiveClassBuildItem(false, false, XDevApiConnectionUrl.class.getName()));
+                ReflectiveClassBuildItem.builder(XDevApiConnectionUrl.class.getName()).build());
         reflectiveClass.produce(
-                new ReflectiveClassBuildItem(false, false, XDevApiDnsSrvConnectionUrl.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false,
-                com.mysql.cj.jdbc.ha.LoadBalancedAutoCommitInterceptor.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, StandardLogger.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, Wrapper.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, com.mysql.cj.jdbc.MysqlDataSource.class.getName()));
+                ReflectiveClassBuildItem.builder(XDevApiDnsSrvConnectionUrl.class.getName())
+                        .build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(com.mysql.cj.jdbc.ha.LoadBalancedAutoCommitInterceptor.class.getName())
+                        .build());
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder(StandardLogger.class.getName()).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(Wrapper.class.getName()).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(com.mysql.cj.jdbc.MysqlDataSource.class.getName())
+                .methods().build());
     }
 
     @BuildStep
     void registerSocketFactoryForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, NamedPipeSocketFactory.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, StandardSocketFactory.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, SocksProxySocketFactory.class.getName()));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(NamedPipeSocketFactory.class.getName()).build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(StandardSocketFactory.class.getName()).build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(SocksProxySocketFactory.class.getName()).build());
     }
 
     @BuildStep
     void registerExceptionsForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, CJCommunicationsException.class.getName()));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(CJCommunicationsException.class.getName())
+                .build());
         reflectiveClass
-                .produce(new ReflectiveClassBuildItem(false, false, CJConnectionFeatureNotAvailableException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, CJOperationNotSupportedException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, CJTimeoutException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, CJPacketTooBigException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, CJException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, AssertionFailedException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, CJOperationNotSupportedException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, ClosedOnExpiredPasswordException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, ConnectionIsClosedException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, DataConversionException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, DataReadException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, DataTruncationException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, DeadlockTimeoutRollbackMarker.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, FeatureNotAvailableException.class.getName()));
+                .produce(ReflectiveClassBuildItem.builder(CJConnectionFeatureNotAvailableException.class.getName())
+                        .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(CJOperationNotSupportedException.class.getName())
+                .build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(CJTimeoutException.class.getName()).build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(CJPacketTooBigException.class.getName()).build());
         reflectiveClass
-                .produce(new ReflectiveClassBuildItem(false, false, InvalidConnectionAttributeException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, NumberOutOfRange.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, OperationCancelledException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, PasswordExpiredException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, PropertyNotModifiableException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, RSAException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, SSLParamsException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, StatementIsClosedException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, StreamingNotifiable.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, UnableToConnectException.class.getName()));
+                .produce(ReflectiveClassBuildItem.builder(CJException.class.getName()).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(AssertionFailedException.class.getName())
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(CJOperationNotSupportedException.class.getName())
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(ClosedOnExpiredPasswordException.class.getName())
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(ConnectionIsClosedException.class.getName())
+                .build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(DataConversionException.class.getName()).build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(DataReadException.class.getName()).build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(DataTruncationException.class.getName()).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(DeadlockTimeoutRollbackMarker.class.getName())
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(FeatureNotAvailableException.class.getName())
+                .build());
         reflectiveClass
-                .produce(new ReflectiveClassBuildItem(false, false, UnsupportedConnectionStringException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, WrongArgumentException.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, "com.mysql.cj.jdbc.MysqlXAException"));
+                .produce(ReflectiveClassBuildItem.builder(InvalidConnectionAttributeException.class.getName())
+                        .build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(NumberOutOfRange.class.getName()).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(OperationCancelledException.class.getName())
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(PasswordExpiredException.class.getName())
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(PropertyNotModifiableException.class.getName())
+                .build());
         reflectiveClass
-                .produce(new ReflectiveClassBuildItem(false, false, StandardLoadBalanceExceptionChecker.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, NdbLoadBalanceExceptionChecker.class.getName()));
+                .produce(ReflectiveClassBuildItem.builder(RSAException.class.getName()).build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(SSLParamsException.class.getName()).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(StatementIsClosedException.class.getName())
+                .build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(StreamingNotifiable.class.getName()).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(UnableToConnectException.class.getName())
+                .build());
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder(UnsupportedConnectionStringException.class.getName())
+                        .build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(WrongArgumentException.class.getName()).build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder("com.mysql.cj.jdbc.MysqlXAException").methods().fields().build());
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder(StandardLoadBalanceExceptionChecker.class.getName())
+                        .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(NdbLoadBalanceExceptionChecker.class.getName())
+                .build());
     }
 }

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
@@ -47,23 +47,39 @@ public final class OracleMetadataOverrides {
     @BuildStep
     void build(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
         //This is to match the Oracle metadata (which we excluded so that we can apply fixes):
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, "oracle.jdbc.internal.ACProxyable"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.jdbc.driver.T4CDriverExtension"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.jdbc.driver.T2CDriverExtension"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.jdbc.driver.ShardingDriverExtension"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.net.ano.Ano"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.net.ano.AuthenticationService"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.net.ano.DataIntegrityService"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.net.ano.EncryptionService"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.net.ano.SupervisorService"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.jdbc.driver.Message11"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, true, "oracle.sql.TypeDescriptor"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.sql.TypeDescriptorFactory"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "oracle.sql.AnyDataFactory"));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.jdbc.internal.ACProxyable")
+                .methods().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.jdbc.driver.T4CDriverExtension")
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.jdbc.driver.T2CDriverExtension")
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.jdbc.driver.ShardingDriverExtension")
+                .build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder("oracle.net.ano.Ano").build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.net.ano.AuthenticationService")
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.net.ano.DataIntegrityService")
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.net.ano.EncryptionService")
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.net.ano.SupervisorService")
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.jdbc.driver.Message11")
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.sql.TypeDescriptor")
+                .fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.sql.TypeDescriptorFactory")
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.sql.AnyDataFactory")
+                .build());
         reflectiveClass
-                .produce(new ReflectiveClassBuildItem(true, false, false, "com.sun.rowset.providers.RIOptimisticProvider"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, "oracle.jdbc.logging.annotations.Supports"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, "oracle.jdbc.logging.annotations.Feature"));
+                .produce(ReflectiveClassBuildItem.builder("com.sun.rowset.providers.RIOptimisticProvider")
+                        .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.jdbc.logging.annotations.Supports")
+                .methods().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("oracle.jdbc.logging.annotations.Feature")
+                .methods().build());
     }
 
     @BuildStep

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleNativeImage.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleNativeImage.java
@@ -21,7 +21,7 @@ public final class OracleNativeImage {
         // "oracle.jdbc.OracleDriver" is what's listed in the serviceloader resource from Oracle,
         // but it delegates all use to "oracle.jdbc.driver.OracleDriver" - which is also what's recommended by the docs.
         final String driverName = "oracle.jdbc.driver.OracleDriver";
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, driverName));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(driverName).build());
 
         // for ldap style jdbc urls. e.g. jdbc:oracle:thin:@ldap://oid:5000/mydb1,cn=OracleContext,dc=myco,dc=com
         //
@@ -29,9 +29,12 @@ public final class OracleNativeImage {
         // available at build time need to be reflectively accessible via ServiceLoader for runtime consistency.
         // These are:
         // com.sun.jndi.ldap.LdapCtxFactory, com.sun.jndi.dns.DnsContextFactory and com.sun.jndi.rmi.registry.RegistryContextFactory
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jndi.ldap.LdapCtxFactory"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jndi.dns.DnsContextFactory"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "com.sun.jndi.rmi.registry.RegistryContextFactory"));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder("com.sun.jndi.ldap.LdapCtxFactory").build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder("com.sun.jndi.dns.DnsContextFactory").build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.sun.jndi.rmi.registry.RegistryContextFactory")
+                .build());
     }
 
 }

--- a/extensions/jdbc/jdbc-postgresql/deployment/src/main/java/io/quarkus/jdbc/postgresql/deployment/PostgreSQLJDBCReflections.java
+++ b/extensions/jdbc/jdbc-postgresql/deployment/src/main/java/io/quarkus/jdbc/postgresql/deployment/PostgreSQLJDBCReflections.java
@@ -18,10 +18,11 @@ public final class PostgreSQLJDBCReflections {
         //any JDBC driver being configured explicitly through its configuration.
         //We register it for the sake of other users.
         final String driverName = "org.postgresql.Driver";
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, driverName));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(driverName).build());
 
         // Needed when quarkus.datasource.jdbc.transactions=xa for the setting of the username and password
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, true, false, "org.postgresql.ds.common.BaseDataSource"));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("org.postgresql.ds.common.BaseDataSource").constructors(false)
+                .methods().build());
     }
 
 }

--- a/extensions/jsonb/deployment/src/main/java/io/quarkus/jsonb/deployment/JsonbProcessor.java
+++ b/extensions/jsonb/deployment/src/main/java/io/quarkus/jsonb/deployment/JsonbProcessor.java
@@ -63,8 +63,8 @@ public class JsonbProcessor {
             BuildProducer<ServiceProviderBuildItem> serviceProvider,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             CombinedIndexBuildItem combinedIndexBuildItem) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false,
-                JsonBindingProvider.class.getName()));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(JsonBindingProvider.class.getName()).build());
 
         resourceBundle.produce(new NativeImageResourceBundleBuildItem("yasson-messages"));
 
@@ -88,7 +88,8 @@ public class JsonbProcessor {
 
         // register String constructors for reflection as they may not have been properly registered by default
         // see https://github.com/quarkusio/quarkus/issues/10873
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, "java.lang.String"));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder("java.lang.String").build());
 
         // Necessary for Yasson versions using MethodHandles (2.0+)
         reflectiveMethod.produce(new ReflectiveMethodBuildItem("jdk.internal.misc.Unsafe", "putReference", Object.class,
@@ -101,7 +102,8 @@ public class JsonbProcessor {
             AnnotationValue value = instance.value();
             if (value != null) {
                 // the Deserializers are constructed internally by JSON-B using a no-args constructor
-                reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, value.asClass().toString()));
+                reflectiveClass.produce(
+                        ReflectiveClassBuildItem.builder(value.asClass().toString()).build());
             }
         }
     }

--- a/extensions/jsonp/deployment/src/main/java/io/quarkus/jsonp/deployment/JsonpProcessor.java
+++ b/extensions/jsonp/deployment/src/main/java/io/quarkus/jsonp/deployment/JsonpProcessor.java
@@ -14,6 +14,7 @@ public class JsonpProcessor {
     void build(BuildProducer<FeatureBuildItem> feature,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<NativeImageResourceBundleBuildItem> resourceBundle) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, JsonProviderImpl.class.getName()));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(JsonProviderImpl.class.getName()).build());
     }
 }

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
@@ -66,23 +66,31 @@ class KafkaStreamsProcessor {
     }
 
     private void registerCompulsoryClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, false, StreamsPartitionAssignor.class));
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(StreamsPartitionAssignor.class)
+                .build());
         if (QuarkusClassLoader.isClassPresentAtRuntime(DEFAULT_PARTITION_GROUPER)) {
             // Class DefaultPartitionGrouper deprecated in Kafka 2.8.x and removed in 3.0.0
             reflectiveClasses.produce(
-                    new ReflectiveClassBuildItem(true, false, false, DEFAULT_PARTITION_GROUPER));
+                    ReflectiveClassBuildItem.builder(DEFAULT_PARTITION_GROUPER)
+                            .build());
         }
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, false, DefaultProductionExceptionHandler.class));
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, false, FailOnInvalidTimestamp.class));
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, true,
-                org.apache.kafka.streams.processor.internals.assignment.HighAvailabilityTaskAssignor.class));
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, true,
-                org.apache.kafka.streams.processor.internals.assignment.StickyTaskAssignor.class));
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, true,
-                org.apache.kafka.streams.processor.internals.assignment.FallbackPriorTaskAssignor.class));
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(DefaultProductionExceptionHandler.class)
+                .build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(FailOnInvalidTimestamp.class)
+                .build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem
+                .builder(org.apache.kafka.streams.processor.internals.assignment.HighAvailabilityTaskAssignor.class)
+                .methods().fields().build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem
+                .builder(org.apache.kafka.streams.processor.internals.assignment.StickyTaskAssignor.class)
+                .methods().fields().build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem
+                .builder(org.apache.kafka.streams.processor.internals.assignment.FallbackPriorTaskAssignor.class)
+                .methods().fields().build());
         // See https://github.com/quarkusio/quarkus/issues/23404
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, true,
-                "org.apache.kafka.streams.processor.internals.StateDirectory$StateDirectoryProcessFile"));
+        reflectiveClasses.produce(ReflectiveClassBuildItem
+                .builder("org.apache.kafka.streams.processor.internals.StateDirectory$StateDirectoryProcessFile")
+                .methods().fields().build());
     }
 
     private void registerClassesThatClientMaySpecify(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
@@ -105,7 +113,8 @@ class KafkaStreamsProcessor {
     }
 
     private void registerDefaultExceptionHandler(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, false, LogAndFailExceptionHandler.class));
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(LogAndFailExceptionHandler.class)
+                .build());
     }
 
     private void registerDefaultSerdes(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
@@ -145,7 +154,8 @@ class KafkaStreamsProcessor {
     }
 
     private void registerClassName(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses, String defaultKeySerdeClass) {
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, false, defaultKeySerdeClass));
+        reflectiveClasses.produce(
+                ReflectiveClassBuildItem.builder(defaultKeySerdeClass).build());
     }
 
     private boolean allDefaultSerdesAreDefinedInProperties(String defaultKeySerdeClass, String defaultValueSerdeClass) {
@@ -153,7 +163,8 @@ class KafkaStreamsProcessor {
     }
 
     private void registerDefaultSerde(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, false, ByteArraySerde.class));
+        reflectiveClasses.produce(
+                ReflectiveClassBuildItem.builder(ByteArraySerde.class).build());
     }
 
     @BuildStep

--- a/extensions/keycloak-admin-client-reactive/deployment/src/main/java/io/quarkus/keycloak/admin/client/reactive/KeycloakAdminClientReactiveProcessor.java
+++ b/extensions/keycloak-admin-client-reactive/deployment/src/main/java/io/quarkus/keycloak/admin/client/reactive/KeycloakAdminClientReactiveProcessor.java
@@ -44,9 +44,7 @@ public class KeycloakAdminClientReactiveProcessor {
                 StringListMapDeserializer.class,
                 StringOrArrayDeserializer.class,
                 StringOrArraySerializer.class)
-                .constructors(true)
-                .methods(true)
-                .build());
+                .methods().build());
         reflectiveHierarchyProducer.produce(
                 new ReflectiveHierarchyIgnoreWarningBuildItem(new ReflectiveHierarchyIgnoreWarningBuildItem.DotNameExclusion(
                         DotName.createSimple(MultivaluedHashMap.class.getName()))));

--- a/extensions/keycloak-admin-client/deployment/src/main/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientProcessor.java
+++ b/extensions/keycloak-admin-client/deployment/src/main/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientProcessor.java
@@ -42,9 +42,7 @@ public class KeycloakAdminClientProcessor {
                 StringListMapDeserializer.class,
                 StringOrArrayDeserializer.class,
                 StringOrArraySerializer.class)
-                .constructors(true)
-                .methods(true)
-                .build();
+                .methods().build();
     }
 
     @Record(ExecutionTime.STATIC_INIT)

--- a/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakReflectionBuildStep.java
+++ b/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakReflectionBuildStep.java
@@ -41,8 +41,7 @@ public class KeycloakReflectionBuildStep {
 
     @BuildStep
     public void registerReflectionItems(BuildProducer<ReflectiveClassBuildItem> reflectiveItems) {
-        reflectiveItems.produce(new ReflectiveClassBuildItem(true, true,
-                JsonWebToken.class.getName(),
+        reflectiveItems.produce(ReflectiveClassBuildItem.builder(JsonWebToken.class.getName(),
                 TokenIntrospectionResponse.class.getName(),
                 JWSHeader.class.getName(),
                 AccessToken.class.getName(),
@@ -67,7 +66,7 @@ public class KeycloakReflectionBuildStep {
                 StringListMapDeserializer.class.getName(),
                 StringOrArrayDeserializer.class.getName(),
                 MTLSEndpointAliases.class.getName(),
-                OIDCConfigurationRepresentation.class.getName()));
+                OIDCConfigurationRepresentation.class.getName()).methods().fields().build());
     }
 
     @BuildStep

--- a/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinProcessor.java
+++ b/extensions/kotlin/deployment/src/main/java/io/quarkus/kotlin/deployment/KotlinProcessor.java
@@ -51,12 +51,16 @@ public class KotlinProcessor {
     void registerKotlinReflection(final BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<NativeImageResourcePatternsBuildItem> nativeResourcePatterns) {
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false,
-                "kotlin.reflect.jvm.internal.ReflectionFactoryImpl"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, "kotlin.KotlinVersion"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, false, "kotlin.KotlinVersion[]"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, false, "kotlin.KotlinVersion$Companion"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, false, "kotlin.KotlinVersion$Companion[]"));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("kotlin.reflect.jvm.internal.ReflectionFactoryImpl")
+                .build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder("kotlin.KotlinVersion").methods().fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("kotlin.KotlinVersion[]").constructors(false)
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("kotlin.KotlinVersion$Companion").constructors(false)
+                .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("kotlin.KotlinVersion$Companion[]").constructors(false)
+                .build());
 
         nativeResourcePatterns.produce(builder().includePatterns(
                 "META-INF/.*.kotlin_module$",

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
@@ -167,12 +167,12 @@ public class KubernetesClientProcessor {
 
         if (!withFieldsRegistration.isEmpty()) {
             reflectiveClasses.produce(ReflectiveClassBuildItem
-                    .builder(withFieldsRegistration.toArray(EMPTY_STRINGS_ARRAY)).weak(true).methods(true).fields(true)
+                    .builder(withFieldsRegistration.toArray(EMPTY_STRINGS_ARRAY)).weak(true).methods().fields()
                     .build());
         }
         if (!withoutFieldsRegistration.isEmpty()) {
             reflectiveClasses.produce(ReflectiveClassBuildItem
-                    .builder(withoutFieldsRegistration.toArray(EMPTY_STRINGS_ARRAY)).weak(true).methods(true).fields(false)
+                    .builder(withoutFieldsRegistration.toArray(EMPTY_STRINGS_ARRAY)).weak(true).methods()
                     .build());
         }
 
@@ -191,7 +191,7 @@ public class KubernetesClientProcessor {
                 .map(c -> c.name().toString())
                 .filter(s -> s.startsWith("io.fabric8.kubernetes"))
                 .toArray(String[]::new);
-        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(deserializerClasses).methods(true).build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(deserializerClasses).methods().build());
 
         final String[] serializerClasses = combinedIndexBuildItem.getIndex()
                 .getAllKnownSubclasses(DotName.createSimple("com.fasterxml.jackson.databind.JsonSerializer"))
@@ -199,19 +199,19 @@ public class KubernetesClientProcessor {
                 .map(c -> c.name().toString())
                 .filter(s -> s.startsWith("io.fabric8.kubernetes"))
                 .toArray(String[]::new);
-        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(serializerClasses).methods(true).build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(serializerClasses).methods().build());
 
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(KubernetesClientImpl.class, DefaultKubernetesClient.class, VersionInfo.class)
-                        .methods(true).fields(true).build());
+                        .methods().fields().build());
         reflectiveClasses.produce(ReflectiveClassBuildItem
-                .builder(AnyType.class, IntOrString.class, KubernetesDeserializer.class).methods(true).build());
+                .builder(AnyType.class, IntOrString.class, KubernetesDeserializer.class).methods().build());
 
         // exec credentials support
         reflectiveClasses
                 .produce(ReflectiveClassBuildItem.builder(Config.ExecCredential.class,
                         Config.ExecCredentialSpec.class,
-                        Config.ExecCredentialStatus.class).methods(true).fields(true).build());
+                        Config.ExecCredentialStatus.class).methods().fields().build());
 
         if (log.isDebugEnabled()) {
             final String watchedClassNames = watchedClasses

--- a/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerProcessor.java
+++ b/extensions/mailer/deployment/src/main/java/io/quarkus/mailer/deployment/MailerProcessor.java
@@ -73,11 +73,10 @@ public class MailerProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
 
         // We must register the auth provider used by the Vert.x mail clients
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true,
-                "io.vertx.ext.mail.impl.sasl.AuthCram",
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("io.vertx.ext.mail.impl.sasl.AuthCram",
                 "io.vertx.ext.mail.impl.sasl.AuthDigest",
                 "io.vertx.ext.mail.impl.sasl.AuthLogin",
-                "io.vertx.ext.mail.impl.sasl.AuthPlain"));
+                "io.vertx.ext.mail.impl.sasl.AuthPlain").methods().fields().build());
 
         // Register io.vertx.ext.mail.impl.sasl.NTLMEngineImpl to be initialized at runtime, it uses a static random.
         NativeImageConfigBuildItem.Builder builder = NativeImageConfigBuildItem.builder();

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
@@ -133,7 +133,7 @@ public class MicrometerProcessor {
                 .builder("org.HdrHistogram.Histogram",
                         "org.HdrHistogram.DoubleHistogram",
                         "org.HdrHistogram.ConcurrentHistogram")
-                .constructors(true).build());
+                .build());
 
         return UnremovableBeanBuildItem.beanTypes(METER_REGISTRY, METER_BINDER, METER_FILTER, NAMING_CONVENTION);
     }

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -161,13 +161,13 @@ public class MongoClientProcessor {
         reflectiveClassNames.addAll(commandListeners.getCommandListenerClassNames());
 
         List<ReflectiveClassBuildItem> reflectiveClass = reflectiveClassNames.stream()
-                .map(s -> ReflectiveClassBuildItem.builder(s).methods(true).build())
+                .map(s -> ReflectiveClassBuildItem.builder(s).methods().build())
                 .collect(Collectors.toCollection(ArrayList::new));
         // ChangeStreamDocument needs to be registered for reflection with its fields.
-        reflectiveClass.add(ReflectiveClassBuildItem.builder(ChangeStreamDocument.class).methods(true).fields(true).build());
-        reflectiveClass.add(ReflectiveClassBuildItem.builder(UpdateDescription.class).methods(true).build());
+        reflectiveClass.add(ReflectiveClassBuildItem.builder(ChangeStreamDocument.class).methods().fields().build());
+        reflectiveClass.add(ReflectiveClassBuildItem.builder(UpdateDescription.class).methods().build());
         // ObjectId is often used on identifier, so we also register it
-        reflectiveClass.add(ReflectiveClassBuildItem.builder(ObjectId.class).methods(true).fields(true).build());
+        reflectiveClass.add(ReflectiveClassBuildItem.builder(ObjectId.class).methods().fields().build());
         return reflectiveClass;
     }
 

--- a/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
+++ b/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
@@ -95,7 +95,7 @@ class NarayanaJtaProcessor {
         runtimeInit.produce(new RuntimeInitializedClassBuildItem(JTAActionStatusServiceXAResourceOrphanFilter.class.getName()));
         runtimeInit.produce(new RuntimeInitializedClassBuildItem(AtomicActionExpiryScanner.class.getName()));
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, JTAEnvironmentBean.class.getName(),
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(JTAEnvironmentBean.class.getName(),
                 UserTransactionImple.class.getName(),
                 CheckedActionFactoryImple.class.getName(),
                 TransactionManagerImple.class.getName(),
@@ -109,7 +109,7 @@ class NarayanaJtaProcessor {
                 JTATransactionLogXAResourceOrphanFilter.class.getName(),
                 JTANodeNameXAResourceOrphanFilter.class.getName(),
                 JTAActionStatusServiceXAResourceOrphanFilter.class.getName(),
-                ExpiredTransactionStatusManagerScanner.class.getName()));
+                ExpiredTransactionStatusManagerScanner.class.getName()).build());
 
         AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder();
         builder.addBeanClass(TransactionalInterceptorSupports.class);

--- a/extensions/narayana-stm/deployment/src/main/java/io/quarkus/narayana/stm/deployment/NarayanaSTMProcessor.java
+++ b/extensions/narayana-stm/deployment/src/main/java/io/quarkus/narayana/stm/deployment/NarayanaSTMProcessor.java
@@ -45,10 +45,9 @@ class NarayanaSTMProcessor {
     ReflectiveClassBuildItem registerFeature(BuildProducer<FeatureBuildItem> feature) {
         feature.produce(new FeatureBuildItem(Feature.NARAYANA_STM));
 
-        return new ReflectiveClassBuildItem(true, false,
-                ShadowNoFileLockStore.class.getName(),
+        return ReflectiveClassBuildItem.builder(ShadowNoFileLockStore.class.getName(),
                 CheckedActionFactoryImple.class.getName(),
-                Lock.class.getName());
+                Lock.class.getName()).methods().build();
     }
 
     // the software transactional memory implementation does not require a TSM
@@ -98,7 +97,7 @@ class NarayanaSTMProcessor {
 
         String[] classNames = proxies.toArray(new String[0]);
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, classNames));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(classNames).methods().fields().build());
 
         return new NativeImageProxyDefinitionBuildItem(classNames);
     }

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -85,12 +85,16 @@ class NettyProcessor {
             BuildProducer<SystemPropertyBuildItem> systemProperties,
             List<MinNettyAllocatorMaxOrderBuildItem> minMaxOrderBuildItems) {
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "io.netty.channel.socket.nio.NioSocketChannel"));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("io.netty.channel.socket.nio.NioSocketChannel")
+                .build());
         reflectiveClass
-                .produce(new ReflectiveClassBuildItem(false, false, "io.netty.channel.socket.nio.NioServerSocketChannel"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "io.netty.channel.socket.nio.NioDatagramChannel"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, "java.util.LinkedHashMap"));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, "sun.nio.ch.SelectorImpl"));
+                .produce(ReflectiveClassBuildItem.builder("io.netty.channel.socket.nio.NioServerSocketChannel")
+                        .build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("io.netty.channel.socket.nio.NioDatagramChannel")
+                .build());
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder("java.util.LinkedHashMap").build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("sun.nio.ch.SelectorImpl").methods().fields().build());
 
         String maxOrder = calculateMaxOrder(config.allocatorMaxOrder, minMaxOrderBuildItems, false);
 

--- a/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
+++ b/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
@@ -42,7 +42,8 @@ public class OidcClientFilterBuildStep {
             BuildProducer<RestClientAnnotationProviderBuildItem> restAnnotationProvider) {
 
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(OidcClientRequestFilter.class));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, OidcClientRequestFilter.class));
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder(OidcClientRequestFilter.class).methods().fields().build());
         final Set<String> namedFilterClientClasses = namedOidcClientFilterBuildItem.namedFilterClientClasses;
 
         // register default request filter provider against the rest of the clients (client != namedFilterClientClasses)
@@ -109,7 +110,8 @@ public class OidcClientFilterBuildStep {
                 namedFilterClientClasses.add(targetRestClient);
 
                 // register for reflection
-                reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, true, generatedProvider));
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(generatedProvider).methods()
+                        .fields().serialization(true).build());
 
                 // register named request filter provider against Rest client
                 restPredicateProvider.produce(new RestClientPredicateProviderBuildItem(generatedProvider,

--- a/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
@@ -75,6 +75,7 @@ public class OidcClientReactiveFilterBuildStep {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(OidcClientRequestReactiveFilter.class));
         additionalIndexedClassesBuildItem
                 .produce(new AdditionalIndexedClassesBuildItem(OidcClientRequestReactiveFilter.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, OidcClientRequestReactiveFilter.class));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(OidcClientRequestReactiveFilter.class).methods().fields().build());
     }
 }

--- a/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveBuildStep.java
+++ b/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveBuildStep.java
@@ -44,7 +44,8 @@ public class OidcTokenPropagationReactiveBuildStep {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClassesBuildItem) {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(AccessTokenRequestReactiveFilter.class));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, AccessTokenRequestReactiveFilter.class));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(AccessTokenRequestReactiveFilter.class).methods().fields().build());
         additionalIndexedClassesBuildItem
                 .produce(new AdditionalIndexedClassesBuildItem(AccessTokenRequestReactiveFilter.class.getName()));
 

--- a/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
+++ b/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
@@ -33,8 +33,10 @@ public class OidcTokenPropagationBuildStep {
             BuildProducer<RestClientAnnotationProviderBuildItem> restAnnotationProvider) {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(AccessTokenRequestFilter.class));
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(JsonWebTokenRequestFilter.class));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, AccessTokenRequestFilter.class));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, JsonWebTokenRequestFilter.class));
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder(AccessTokenRequestFilter.class).methods().fields().build());
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder(JsonWebTokenRequestFilter.class).methods().fields().build());
 
         if (config.registerFilter) {
             Class<?> filterClass = config.jsonWebToken ? JsonWebTokenRequestFilter.class : AccessTokenRequestFilter.class;

--- a/extensions/openshift-client/deployment/src/main/java/io/quarkus/openshift/client/deployment/OpenShiftClientProcessor.java
+++ b/extensions/openshift-client/deployment/src/main/java/io/quarkus/openshift/client/deployment/OpenShiftClientProcessor.java
@@ -41,7 +41,7 @@ public class OpenShiftClientProcessor {
                 .map(c -> c.name().toString())
                 .filter(s -> s.startsWith("io.fabric8.openshift"))
                 .toArray(String[]::new);
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, deserializerClasses));
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(deserializerClasses).methods().build());
 
         final String[] serializerClasses = combinedIndexBuildItem.getIndex()
                 .getAllKnownSubclasses(DotName.createSimple("com.fasterxml.jackson.databind.JsonSerializer"))
@@ -49,12 +49,14 @@ public class OpenShiftClientProcessor {
                 .map(c -> c.name().toString())
                 .filter(s -> s.startsWith("io.fabric8.openshift"))
                 .toArray(String[]::new);
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, serializerClasses));
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(serializerClasses).methods().build());
 
         reflectiveClasses
-                .produce(new ReflectiveClassBuildItem(true, true, OpenShiftClientImpl.class.getName()));
+                .produce(ReflectiveClassBuildItem.builder(OpenShiftClientImpl.class.getName()).methods().fields()
+                        .build());
         reflectiveClasses
-                .produce(new ReflectiveClassBuildItem(true, true, DefaultOpenShiftClient.class.getName()));
+                .produce(ReflectiveClassBuildItem.builder(DefaultOpenShiftClient.class.getName()).methods().fields()
+                        .build());
     }
 
     @BuildStep

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
@@ -94,7 +94,7 @@ public class OpenTelemetryProcessor {
         resource.produce(new NativeImageResourceBuildItem(
                 "META-INF/services/io.opentelemetry.context.ContextStorageProvider"));
         reflectiveClass
-                .produce(new ReflectiveClassBuildItem(true, true, QuarkusContextStorage.class));
+                .produce(ReflectiveClassBuildItem.builder(QuarkusContextStorage.class).methods().fields().build());
     }
 
     @BuildStep

--- a/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/deployment/KotlinPanacheResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache-kotlin/deployment/src/main/java/io/quarkus/hibernate/orm/panache/kotlin/deployment/KotlinPanacheResourceProcessor.java
@@ -137,7 +137,7 @@ public final class KotlinPanacheResourceProcessor {
             String name = classInfo.name().toString();
             if (modelClasses.add(name)) {
                 transformers.produce(new BytecodeTransformerBuildItem(name, entityEnhancer));
-                reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, name));
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(name).methods().fields().build());
             }
         }
 
@@ -179,7 +179,8 @@ public final class KotlinPanacheResourceProcessor {
         }
         for (Type parameterType : typeParameters) {
             // Register for reflection the type parameters of the repository: this should be the entity class and the ID class
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, parameterType.name().toString()));
+            reflectiveClass.produce(
+                    ReflectiveClassBuildItem.builder(parameterType.name().toString()).methods().fields().build());
         }
     }
 
@@ -201,7 +202,8 @@ public final class KotlinPanacheResourceProcessor {
 
         for (Type parameterType : typeParameters) {
             // Register for reflection the type parameters of the repository: this should be the entity class and the ID class
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, parameterType.name().toString()));
+            reflectiveClass.produce(
+                    ReflectiveClassBuildItem.builder(parameterType.name().toString()).methods().fields().build());
         }
     }
 

--- a/extensions/panache/mongodb-panache-common/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/BasePanacheMongoResourceProcessor.java
+++ b/extensions/panache/mongodb-panache-common/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/BasePanacheMongoResourceProcessor.java
@@ -279,7 +279,7 @@ public abstract class BasePanacheMongoResourceProcessor {
             transformers.produce(new BytecodeTransformerBuildItem(modelClass, entityEnhancer));
 
             //register for reflection entity classes
-            reflectiveClass.produce(ReflectiveClassBuildItem.builder(modelClass).fields(true).methods(true).build());
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(modelClass).fields().methods().build());
 
             // Register for building the property mapping cache
             propertyMappingClass.produce(new PropertyMappingClassBuildStep(modelClass));

--- a/extensions/panache/mongodb-panache-kotlin/deployment/src/main/java/io/quarkus/mongodb/panache/kotlin/deployment/KotlinPanacheMongoResourceProcessor.java
+++ b/extensions/panache/mongodb-panache-kotlin/deployment/src/main/java/io/quarkus/mongodb/panache/kotlin/deployment/KotlinPanacheMongoResourceProcessor.java
@@ -130,7 +130,7 @@ public class KotlinPanacheMongoResourceProcessor extends BasePanacheMongoResourc
             transformers.produce(new BytecodeTransformerBuildItem(modelClass, companionEnhancer));
 
             //register for reflection entity classes
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, modelClass));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(modelClass).methods().fields().build());
 
             // Register for building the property mapping cache
             propertyMappingClass.produce(new PropertyMappingClassBuildStep(modelClass));

--- a/extensions/picocli/deployment/src/main/java/io/quarkus/picocli/deployment/PicocliNativeImageProcessor.java
+++ b/extensions/picocli/deployment/src/main/java/io/quarkus/picocli/deployment/PicocliNativeImageProcessor.java
@@ -99,10 +99,12 @@ public class PicocliNativeImageProcessor {
                 nativeImageProxies
                         .produce(new NativeImageProxyDefinitionBuildItem(classInfo.name().toString()));
                 reflectiveClasses
-                        .produce(new ReflectiveClassBuildItem(false, true, false, classInfo.name().toString()));
+                        .produce(ReflectiveClassBuildItem.builder(classInfo.name().toString()).constructors(false).methods()
+                                .build());
             } else {
                 reflectiveClasses
-                        .produce(new ReflectiveClassBuildItem(true, true, false, classInfo.name().toString()));
+                        .produce(ReflectiveClassBuildItem.builder(classInfo.name().toString()).methods()
+                                .build());
             }
         });
         foundFields.forEach(fieldInfo -> reflectiveFields.produce(new ReflectiveFieldBuildItem(fieldInfo)));

--- a/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
+++ b/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
@@ -152,23 +152,34 @@ public class QuartzProcessor {
             QuartzJDBCDriverDialectBuildItem driverDialect) {
         List<ReflectiveClassBuildItem> reflectiveClasses = new ArrayList<>();
 
-        reflectiveClasses.add(new ReflectiveClassBuildItem(true, false, SimpleThreadPool.class.getName()));
-        reflectiveClasses.add(new ReflectiveClassBuildItem(true, false, SimpleInstanceIdGenerator.class.getName()));
-        reflectiveClasses.add(new ReflectiveClassBuildItem(false, false, CascadingClassLoadHelper.class.getName()));
-        reflectiveClasses.add(new ReflectiveClassBuildItem(true, true, config.storeType.clazz));
         reflectiveClasses
-                .add(new ReflectiveClassBuildItem(false, false, org.quartz.simpl.InitThreadContextClassLoadHelper.class));
+                .add(ReflectiveClassBuildItem.builder(SimpleThreadPool.class.getName()).methods().build());
+        reflectiveClasses.add(ReflectiveClassBuildItem.builder(SimpleInstanceIdGenerator.class.getName()).methods()
+                .build());
+        reflectiveClasses.add(ReflectiveClassBuildItem.builder(CascadingClassLoadHelper.class.getName())
+                .build());
+        reflectiveClasses.add(ReflectiveClassBuildItem.builder(config.storeType.clazz).methods().fields().build());
+        reflectiveClasses
+                .add(ReflectiveClassBuildItem.builder(org.quartz.simpl.InitThreadContextClassLoadHelper.class)
+                        .build());
 
         if (config.storeType.isDbStore()) {
-            reflectiveClasses.add(new ReflectiveClassBuildItem(true, false, JobStoreSupport.class.getName()));
-            reflectiveClasses.add(new ReflectiveClassBuildItem(true, true, Connection.class.getName()));
-            reflectiveClasses.add(new ReflectiveClassBuildItem(true, false, AbstractTrigger.class.getName()));
-            reflectiveClasses.add(new ReflectiveClassBuildItem(true, false, SimpleTriggerImpl.class.getName()));
-            reflectiveClasses.add(new ReflectiveClassBuildItem(true, false, driverDialect.getDriver().get()));
             reflectiveClasses
-                    .add(new ReflectiveClassBuildItem(true, true, "io.quarkus.quartz.runtime.QuartzSchedulerImpl$InvokerJob"));
+                    .add(ReflectiveClassBuildItem.builder(JobStoreSupport.class.getName()).methods().build());
             reflectiveClasses
-                    .add(new ReflectiveClassBuildItem(true, false, QuarkusQuartzConnectionPoolProvider.class.getName()));
+                    .add(ReflectiveClassBuildItem.builder(Connection.class.getName()).methods().fields().build());
+            reflectiveClasses
+                    .add(ReflectiveClassBuildItem.builder(AbstractTrigger.class.getName()).methods().build());
+            reflectiveClasses.add(
+                    ReflectiveClassBuildItem.builder(SimpleTriggerImpl.class.getName()).methods().build());
+            reflectiveClasses
+                    .add(ReflectiveClassBuildItem.builder(driverDialect.getDriver().get()).methods().build());
+            reflectiveClasses
+                    .add(ReflectiveClassBuildItem.builder("io.quarkus.quartz.runtime.QuartzSchedulerImpl$InvokerJob")
+                            .methods().fields().build());
+            reflectiveClasses
+                    .add(ReflectiveClassBuildItem.builder(QuarkusQuartzConnectionPoolProvider.class.getName()).methods()
+                            .build());
         }
 
         reflectiveClasses
@@ -192,7 +203,7 @@ public class QuartzProcessor {
             } catch (ClassNotFoundException e) {
                 throw new IllegalArgumentException(e);
             }
-            reflectiveClasses.add(new ReflectiveClassBuildItem(true, false, props.clazz));
+            reflectiveClasses.add(ReflectiveClassBuildItem.builder(props.clazz).methods().build());
         }
         return reflectiveClasses;
     }

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -1680,7 +1680,7 @@ public class QuteProcessor {
 
         for (String generatedType : generatedValueResolvers) {
             generatedResolvers.produce(new GeneratedValueResolverBuildItem(generatedType));
-            reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, generatedType));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(generatedType).build());
         }
 
         if (!templateGlobals.isEmpty()) {
@@ -1700,7 +1700,7 @@ public class QuteProcessor {
 
             for (String generatedType : globalGenerator.getGeneratedTypes()) {
                 generatedInitializers.produce(new GeneratedTemplateInitializerBuildItem(generatedType));
-                reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, generatedType));
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(generatedType).build());
             }
         }
     }

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
@@ -449,7 +449,8 @@ class ReactiveRoutesProcessor {
                             businessMethod.getBean(), businessMethod.getMethod(), classOutput, transformedAnnotations,
                             routeString, reflectiveHierarchy, produces.length > 0 ? produces[0] : null,
                             validatorAvailable, index);
-                    reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false, handlerClass));
+                    reflectiveClasses
+                            .produce(ReflectiveClassBuildItem.builder(handlerClass).build());
                     routeHandler = recorder.createHandler(handlerClass);
                     routeHandlers.put(routeString, routeHandler);
                 }
@@ -492,7 +493,7 @@ class ReactiveRoutesProcessor {
                             new String[0]),
                     filterMethod.getBean(), filterMethod.getMethod(), classOutput, transformedAnnotations,
                     filterMethod.getRouteFilter().toString(true), reflectiveHierarchy, null, validatorAvailable, index);
-            reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false, handlerClass));
+            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(handlerClass).build());
             Handler<RoutingContext> routingHandler = recorder.createHandler(handlerClass);
             AnnotationValue priorityValue = filterMethod.getRouteFilter().value();
             filterProducer.produce(new FilterBuildItem(routingHandler,

--- a/extensions/resteasy-classic/rest-client/deployment/src/main/java/io/quarkus/restclient/deployment/RestClientProcessor.java
+++ b/extensions/resteasy-classic/rest-client/deployment/src/main/java/io/quarkus/restclient/deployment/RestClientProcessor.java
@@ -140,7 +140,8 @@ class RestClientProcessor {
             resource.produce(new NativeImageResourceBuildItem(
                     "META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientListener"));
             reflectiveClass
-                    .produce(new ReflectiveClassBuildItem(true, true, "io.smallrye.opentracing.SmallRyeRestClientListener"));
+                    .produce(ReflectiveClassBuildItem.builder("io.smallrye.opentracing.SmallRyeRestClientListener")
+                            .methods().fields().build());
         }
     }
 
@@ -157,17 +158,17 @@ class RestClientProcessor {
 
         additionalBeans.produce(new AdditionalBeanBuildItem(RestClient.class));
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false,
-                DefaultResponseExceptionMapper.class.getName(),
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(DefaultResponseExceptionMapper.class.getName(),
                 AsyncInterceptorRxInvokerProvider.class.getName(),
                 ResteasyProviderFactoryImpl.class.getName(),
                 ProxyBuilderImpl.class.getName(),
                 ClientRequestFilter[].class.getName(),
                 ClientResponseFilter[].class.getName(),
-                jakarta.ws.rs.ext.ReaderInterceptor[].class.getName()));
+                jakarta.ws.rs.ext.ReaderInterceptor[].class.getName()).build());
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false,
-                ResteasyClientBuilder.class.getName(), NoopHostnameVerifier.class.getName()));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(ResteasyClientBuilder.class.getName(), NoopHostnameVerifier.class.getName())
+                        .methods().build());
     }
 
     @BuildStep
@@ -233,12 +234,13 @@ class RestClientProcessor {
             proxyDefinition.produce(new NativeImageProxyDefinitionBuildItem(iName, ResteasyClientProxy.class.getName()));
             proxyDefinition.produce(
                     new NativeImageProxyDefinitionBuildItem(iName, RestClientProxy.class.getName(), Closeable.class.getName()));
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, iName));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(iName).methods().build());
         }
 
         // Incoming headers
         // required for the non-arg constructor of DCHFImpl to be included in the native image
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, DefaultClientHeadersFactoryImpl.class.getName()));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(DefaultClientHeadersFactoryImpl.class.getName()).methods()
+                .build());
 
         // Register Interface return types for reflection
         for (Type returnType : returnTypes) {
@@ -491,7 +493,7 @@ class RestClientProcessor {
 
         // register the providers for reflection
         for (String providerToRegister : jaxrsProvidersToRegisterBuildItem.getProviders()) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, providerToRegister));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(providerToRegister).build());
         }
 
         // now we register all values of @RegisterProvider for constructor reflection
@@ -503,7 +505,8 @@ class RestClientProcessor {
         }
         for (AnnotationInstance annotationInstance : allInstances) {
             reflectiveClass
-                    .produce(new ReflectiveClassBuildItem(false, false, annotationInstance.value().asClass().toString()));
+                    .produce(ReflectiveClassBuildItem.builder(annotationInstance.value().asClass().toString())
+                            .build());
         }
 
         // Register @RegisterClientHeaders for reflection
@@ -511,17 +514,20 @@ class RestClientProcessor {
             AnnotationValue value = annotationInstance.value();
             if (value != null) {
                 reflectiveClass
-                        .produce(new ReflectiveClassBuildItem(false, false, annotationInstance.value().asClass().toString()));
+                        .produce(ReflectiveClassBuildItem.builder(annotationInstance.value().asClass().toString())
+                                .build());
             }
         }
 
         // now retain all un-annotated implementations of ClientRequestFilter and ClientResponseFilter
         // in case they are programmatically registered by applications
         for (ClassInfo info : index.getAllKnownImplementors(CLIENT_REQUEST_FILTER)) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, info.name().toString()));
+            reflectiveClass
+                    .produce(ReflectiveClassBuildItem.builder(info.name().toString()).build());
         }
         for (ClassInfo info : index.getAllKnownImplementors(CLIENT_RESPONSE_FILTER)) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, info.name().toString()));
+            reflectiveClass
+                    .produce(ReflectiveClassBuildItem.builder(info.name().toString()).build());
         }
     }
 

--- a/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -140,10 +140,9 @@ public class ResteasyCommonProcessor {
 
         staticInitConfigBuilder.produce(new StaticInitConfigBuilderBuildItem(ResteasyConfigBuilder.class));
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false,
-                ServletConfigSource.class,
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(ServletConfigSource.class,
                 ServletContextConfigSource.class,
-                FilterConfigSource.class));
+                FilterConfigSource.class).build());
     }
 
     @BuildStep
@@ -273,8 +272,9 @@ public class ResteasyCommonProcessor {
 
         if (providersToRegister.contains("org.jboss.resteasy.plugins.providers.jsonb.JsonBindingProvider")) {
             // This abstract one is also accessed directly via reflection
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true,
-                    "org.jboss.resteasy.plugins.providers.jsonb.AbstractJsonBindingProvider"));
+            reflectiveClass.produce(
+                    ReflectiveClassBuildItem.builder("org.jboss.resteasy.plugins.providers.jsonb.AbstractJsonBindingProvider")
+                            .methods().fields().build());
         }
 
         JaxrsProvidersToRegisterBuildItem result = new JaxrsProvidersToRegisterBuildItem(

--- a/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -304,7 +304,7 @@ public class ResteasyServerCommonProcessor {
                                 scannedResources.putIfAbsent(clazz.name(), clazz);
                             }
                         }
-                        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, className));
+                        reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).methods().fields().build());
 
                         if (!clazz.hasNoArgsConstructor()) {
                             withoutDefaultCtor.put(clazz.name(), clazz);
@@ -321,7 +321,7 @@ public class ResteasyServerCommonProcessor {
             final Collection<ClassInfo> implementors = index.getAllKnownImplementors(iface);
             for (final ClassInfo implementor : implementors) {
                 String className = implementor.name().toString();
-                reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, className));
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).methods().fields().build());
                 scannedResources.putIfAbsent(implementor.name(), implementor);
 
                 if (!implementor.hasNoArgsConstructor()) {
@@ -334,7 +334,7 @@ public class ResteasyServerCommonProcessor {
             final Collection<ClassInfo> implementors = index.getAllKnownSubclasses(cls);
             for (final ClassInfo implementor : implementors) {
                 String className = implementor.name().toString();
-                reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, className));
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).methods().fields().build());
                 if (!Modifier.isAbstract(implementor.flags())) {
                     scannedResources.putIfAbsent(implementor.name(), implementor);
                 }
@@ -356,7 +356,8 @@ public class ResteasyServerCommonProcessor {
         Set<DotName> subresources = findSubresources(beanArchiveIndexBuildItem.getIndex(), scannedResources);
         if (!subresources.isEmpty()) {
             for (DotName locator : subresources) {
-                reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, locator.toString()));
+                reflectiveClass
+                        .produce(ReflectiveClassBuildItem.builder(locator.toString()).methods().fields().build());
             }
             // Sub-resource locators are unremovable beans
             unremovableBeans.produce(
@@ -377,7 +378,8 @@ public class ResteasyServerCommonProcessor {
                 beanArchiveIndexBuildItem, additionalJaxRsResourceMethodAnnotations);
 
         for (ClassInfo implementation : index.getAllKnownImplementors(ResteasyDotNames.DYNAMIC_FEATURE)) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, implementation.name().toString()));
+            reflectiveClass.produce(
+                    ReflectiveClassBuildItem.builder(implementation.name().toString()).build());
         }
 
         Map<String, String> resteasyInitParameters = new HashMap<>();
@@ -643,10 +645,9 @@ public class ResteasyServerCommonProcessor {
         }
 
         // special case: our config providers
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, false,
-                ServletConfigSource.class,
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(ServletConfigSource.class,
                 ServletContextConfigSource.class,
-                FilterConfigSource.class));
+                FilterConfigSource.class).build());
     }
 
     private static void generateDefaultConstructors(BuildProducer<BytecodeTransformerBuildItem> transformers,
@@ -809,7 +810,8 @@ public class ResteasyServerCommonProcessor {
         for (AnnotationInstance annotation : index.getAnnotations(JSONB_ANNOTATION)) {
             if (annotation.target().kind() == AnnotationTarget.Kind.CLASS) {
                 reflectiveClass
-                        .produce(new ReflectiveClassBuildItem(true, true, annotation.target().asClass().name().toString()));
+                        .produce(ReflectiveClassBuildItem.builder(annotation.target().asClass().name().toString()).methods()
+                                .fields().build());
             }
         }
 
@@ -829,8 +831,10 @@ public class ResteasyServerCommonProcessor {
         }
 
         // In the case of a constraint violation, these elements might be returned as entities and will be serialized
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, ViolationReport.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, ResteasyConstraintViolation.class.getName()));
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder(ViolationReport.class.getName()).methods().fields().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(ResteasyConstraintViolation.class.getName()).methods()
+                .fields().build());
     }
 
     private static void scanMethods(DotName annotationType,

--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyServletProcessor.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyServletProcessor.java
@@ -106,12 +106,14 @@ public class ResteasyServletProcessor {
                         .addFilterServletNameMapping("default", DispatcherType.FORWARD)
                         .addFilterServletNameMapping("default", DispatcherType.INCLUDE).setAsyncSupported(true)
                         .build());
-                reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, ResteasyFilter.class.getName()));
+                reflectiveClass.produce(
+                        ReflectiveClassBuildItem.builder(ResteasyFilter.class.getName()).build());
             } else {
                 String mappingPath = getMappingPath(path);
                 servlet.produce(ServletBuildItem.builder(JAX_RS_SERVLET_NAME, ResteasyServlet.class.getName())
                         .setLoadOnStartup(1).addMapping(mappingPath).setAsyncSupported(true).build());
-                reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, HttpServlet30Dispatcher.class.getName()));
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(HttpServlet30Dispatcher.class.getName())
+                        .build());
             }
 
             for (Entry<String, String> initParameter : resteasyServerConfig.get().getInitParameters().entrySet()) {

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -226,7 +226,8 @@ public class JaxrsClientReactiveProcessor {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(StorkClientRequestFilter.class));
         additionalIndexedClassesBuildItem
                 .produce(new AdditionalIndexedClassesBuildItem(StorkClientRequestFilter.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, StorkClientRequestFilter.class));
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder(StorkClientRequestFilter.class).methods().fields().build());
     }
 
     @BuildStep
@@ -267,9 +268,10 @@ public class JaxrsClientReactiveProcessor {
         for (ParameterContainersBuildItem parameterContainersBuildItem : parameterContainersBuildItems) {
             scannedParameterContainers.addAll(parameterContainersBuildItem.getClassNames());
         }
-        reflectiveClassBuildItemBuildProducer.produce(new ReflectiveClassBuildItem(false, true,
-                scannedParameterContainers.stream().map(name -> name.toString()).collect(Collectors.toSet())
-                        .toArray(new String[0])));
+        reflectiveClassBuildItemBuildProducer.produce(ReflectiveClassBuildItem
+                .builder(scannedParameterContainers.stream().map(name -> name.toString()).collect(Collectors.toSet())
+                        .toArray(new String[0]))
+                .fields().build());
 
         if (resourceScanningResultBuildItem.isEmpty()
                 || resourceScanningResultBuildItem.get().getResult().getClientInterfaces().isEmpty()) {
@@ -392,7 +394,8 @@ public class JaxrsClientReactiveProcessor {
             reader.setMediaTypeStrings(Collections.singletonList(additionalReader.getMediaType()));
             recorder.registerReader(serialisers, additionalReader.getEntityClass(), reader);
             reflectiveClassBuildItemBuildProducer
-                    .produce(new ReflectiveClassBuildItem(true, false, false, readerClass));
+                    .produce(ReflectiveClassBuildItem.builder(readerClass)
+                            .build());
         }
 
         for (AdditionalReaderWriter.Entry entry : additionalWriters.get()) {
@@ -403,7 +406,8 @@ public class JaxrsClientReactiveProcessor {
             writer.setMediaTypeStrings(Collections.singletonList(entry.getMediaType()));
             recorder.registerWriter(serialisers, entry.getEntityClass(), writer);
             reflectiveClassBuildItemBuildProducer
-                    .produce(new ReflectiveClassBuildItem(true, false, false, writerClass));
+                    .produce(ReflectiveClassBuildItem.builder(writerClass)
+                            .build());
         }
 
         Map<String, RuntimeValue<MultipartResponseData>> responsesData = new HashMap<>();

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
@@ -123,7 +123,8 @@ public class ResteasyReactiveCommonProcessor {
                 .scanForApplicationClass(combinedIndexBuildItem.getComputingIndex(),
                         config.buildTimeConditionAware ? getExcludedClasses(buildTimeConditions) : Collections.emptySet());
         if (result.getSelectedAppClass() != null) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, result.getSelectedAppClass().name().toString()));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(result.getSelectedAppClass().name().toString())
+                    .build());
         }
         return new ApplicationResultBuildItem(result);
     }
@@ -302,7 +303,8 @@ public class ResteasyReactiveCommonProcessor {
         for (var i : serializers.getReaders()) {
             messageBodyReaderBuildItemBuildProducer.produce(new MessageBodyReaderBuildItem(i.getClassName(),
                     i.getHandledClassName(), i.getMediaTypeStrings(), i.getRuntimeType(), i.isBuiltin(), i.getPriority()));
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, i.getClassName()));
+            reflectiveClass.produce(
+                    ReflectiveClassBuildItem.builder(i.getClassName()).build());
         }
         for (var i : serializers.getWriters()) {
             messageBodyWriterBuildItemBuildProducer.produce(new MessageBodyWriterBuildItem(i.getClassName(),

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/SerializersUtil.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/SerializersUtil.java
@@ -60,7 +60,8 @@ public class SerializersUtil {
                 writer.setPriority(additionalWriter.getPriority());
             }
             recorder.registerWriter(serialisers, additionalWriter.getHandledClassName(), writer);
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, writerClassName));
+            reflectiveClass.produce(
+                    ReflectiveClassBuildItem.builder(writerClassName).build());
         }
 
         Map<String, MessageBodyReaderWriterOverrideData> readerOverrides = new HashMap<>();
@@ -90,7 +91,8 @@ public class SerializersUtil {
                 reader.setPriority(additionalReader.getPriority());
             }
             recorder.registerReader(serialisers, additionalReader.getHandledClassName(), reader);
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, readerClassName));
+            reflectiveClass.produce(
+                    ReflectiveClassBuildItem.builder(readerClassName).build());
         }
 
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
@@ -244,7 +244,8 @@ public class ResteasyReactiveJacksonProcessor {
                         }
                     }
                     reflectiveClassProducer.produce(
-                            new ReflectiveClassBuildItem(true, false, false, biFunctionType.name().toString()));
+                            ReflectiveClassBuildItem.builder(biFunctionType.name().toString())
+                                    .build());
                     recorder.recordCustomSerialization(getMethodId(instance.target().asMethod()),
                             biFunctionType.name().toString());
                 }
@@ -255,7 +256,7 @@ public class ResteasyReactiveJacksonProcessor {
             jacksonFeatures.add(JacksonFeatureBuildItem.Feature.CUSTOM_SERIALIZATION);
             String className = bi.getCustomSerializationProvider().getName();
             reflectiveClassProducer.produce(
-                    new ReflectiveClassBuildItem(true, false, false, className));
+                    ReflectiveClassBuildItem.builder(className).build());
             recorder.recordCustomSerialization(getMethodId(bi.getMethodInfo(), bi.getDeclaringClassInfo()), className);
         }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/common/deployment/KotlinSerializationCommonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/common/deployment/KotlinSerializationCommonProcessor.java
@@ -45,9 +45,11 @@ public class KotlinSerializationCommonProcessor {
             }
         }
         // the companion classes need to be registered for reflection so Kotlin can construct them and invoke methods reflectively
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, supportClassNames.toArray(EMPTY_ARRAY)));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(supportClassNames.toArray(EMPTY_ARRAY))
+                .methods().build());
         // the serializable classes need to be registered for reflection, so they can be constructed and also Kotlin can determine the companion field at runtime
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, true, serializableClassNames.toArray(EMPTY_ARRAY)));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(serializableClassNames.toArray(EMPTY_ARRAY))
+                .fields().build());
     }
 
     @BuildStep

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusMultipartReturnTypeHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusMultipartReturnTypeHandler.java
@@ -50,9 +50,11 @@ public class QuarkusMultipartReturnTypeHandler implements EndpointIndexer.Multip
                             applicationClassPredicate.test(className)),
                     index);
             reflectiveClassProducer.produce(
-                    new ReflectiveClassBuildItem(true, false, MultipartMessageBodyWriter.class.getName()));
-            reflectiveClassProducer.produce(new ReflectiveClassBuildItem(false, false, className));
-            reflectiveClassProducer.produce(new ReflectiveClassBuildItem(true, false, mapperClassName));
+                    ReflectiveClassBuildItem.builder(MultipartMessageBodyWriter.class.getName()).methods()
+                            .build());
+            reflectiveClassProducer.produce(ReflectiveClassBuildItem.builder(className).build());
+            reflectiveClassProducer
+                    .produce(ReflectiveClassBuildItem.builder(mapperClassName).methods().build());
             canHandle = true;
         }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveCDIProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveCDIProcessor.java
@@ -113,7 +113,8 @@ public class ResteasyReactiveCDIProcessor {
                 additionalProviders.addBeanClass(dynamicFeature.getClassName());
             } else {
                 reflectiveClassBuildItemBuildProducer
-                        .produce(new ReflectiveClassBuildItem(true, false, false, dynamicFeature.getClassName()));
+                        .produce(ReflectiveClassBuildItem.builder(dynamicFeature.getClassName())
+                                .build());
             }
         }
         for (JaxrsFeatureBuildItem feature : featureBuildItems) {
@@ -121,7 +122,8 @@ public class ResteasyReactiveCDIProcessor {
                 additionalProviders.addBeanClass(feature.getClassName());
             } else {
                 reflectiveClassBuildItemBuildProducer
-                        .produce(new ReflectiveClassBuildItem(true, false, false, feature.getClassName()));
+                        .produce(ReflectiveClassBuildItem.builder(feature.getClassName())
+                                .build());
             }
         }
         additionalBean.produce(additionalProviders.setUnremovable().setDefaultScope(DotNames.SINGLETON).build());

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -326,8 +326,8 @@ public class ResteasyReactiveProcessor {
                     classOutput,
                     Set.of(HTTP_SERVER_REQUEST, HTTP_SERVER_RESPONSE, ROUTING_CONTEXT), Set.of(Unremovable.class.getName()));
             reflectiveClass.produce(
-                    new ReflectiveClassBuildItem(true, false, false, generationResult.values().toArray(
-                            EMPTY_STRING_ARRAY)));
+                    ReflectiveClassBuildItem.builder(generationResult.values().toArray(
+                            EMPTY_STRING_ARRAY)).build());
             Map<String, String> classMappers;
             DotName classDotName = methodInfo.declaringClass().name();
             if (resultingMappers.containsKey(classDotName)) {
@@ -513,8 +513,9 @@ public class ResteasyReactiveProcessor {
                             ClassInfo classInfoWithSecurity = consumeStandardSecurityAnnotations(method,
                                     entry.getActualEndpointInfo(), index, c -> c);
                             if (classInfoWithSecurity != null) {
-                                reflectiveClassBuildItemBuildProducer.produce(new ReflectiveClassBuildItem(false, true, false,
-                                        entry.getActualEndpointInfo().name().toString()));
+                                reflectiveClassBuildItemBuildProducer.produce(
+                                        ReflectiveClassBuildItem.builder(entry.getActualEndpointInfo().name().toString())
+                                                .constructors(false).methods().build());
                             }
 
                             reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem.Builder()
@@ -546,14 +547,16 @@ public class ResteasyReactiveProcessor {
                                 }
                                 if (parameterType.name().equals(FILE)) {
                                     reflectiveClassBuildItemBuildProducer
-                                            .produce(new ReflectiveClassBuildItem(false, true, false,
-                                                    entry.getActualEndpointInfo().name().toString()));
+                                            .produce(ReflectiveClassBuildItem
+                                                    .builder(entry.getActualEndpointInfo().name().toString())
+                                                    .constructors(false).methods().build());
                                 }
                             }
 
                             if (filtersAccessResourceMethod) {
-                                reflectiveClassBuildItemBuildProducer.produce(new ReflectiveClassBuildItem(false, true, false,
-                                        entry.getActualEndpointInfo().name().toString()));
+                                reflectiveClassBuildItemBuildProducer.produce(
+                                        ReflectiveClassBuildItem.builder(entry.getActualEndpointInfo().name().toString())
+                                                .constructors(false).methods().build());
                             }
                         }
 
@@ -889,8 +892,9 @@ public class ResteasyReactiveProcessor {
             }
         }
         if (!dateTimeFormatterProviderClassNames.isEmpty()) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, false,
-                    dateTimeFormatterProviderClassNames.toArray(EMPTY_STRING_ARRAY)));
+            reflectiveClass
+                    .produce(ReflectiveClassBuildItem.builder(dateTimeFormatterProviderClassNames.toArray(EMPTY_STRING_ARRAY))
+                            .serialization(false).build());
         }
     }
 
@@ -999,13 +1003,15 @@ public class ResteasyReactiveProcessor {
             registerWriter(recorder, serialisers, builtinWriter.entityClass.getName(), builtinWriter.writerClass.getName(),
                     beanContainerBuildItem.getValue(),
                     builtinWriter.mediaType);
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, builtinWriter.writerClass.getName()));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(builtinWriter.writerClass.getName())
+                    .build());
         }
         for (Serialisers.BuiltinReader builtinReader : ServerSerialisers.BUILTIN_READERS) {
             registerReader(recorder, serialisers, builtinReader.entityClass.getName(), builtinReader.readerClass.getName(),
                     beanContainerBuildItem.getValue(),
                     builtinReader.mediaType, builtinReader.constraint);
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, builtinReader.readerClass.getName()));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(builtinReader.readerClass.getName())
+                    .build());
         }
 
         serverSerializersProducer.produce(new ServerSerialisersBuildItem(serialisers));
@@ -1062,8 +1068,8 @@ public class ResteasyReactiveProcessor {
         }
         if (serializersRequireResourceReflection) {
             producer.produce(ReflectiveClassBuildItem
-                    .builder(resourceClasses.stream().map(ResourceClass::getClassName).toArray(String[]::new)).fields(false)
-                    .constructors(false).methods(true).build());
+                    .builder(resourceClasses.stream().map(ResourceClass::getClassName).toArray(String[]::new))
+                    .constructors(false).methods().build());
         }
     }
 
@@ -1156,14 +1162,16 @@ public class ResteasyReactiveProcessor {
             String readerClass = additionalReader.getHandlerClass();
             registerReader(recorder, serialisers, additionalReader.getEntityClass(), readerClass,
                     beanContainerBuildItem.getValue(), additionalReader.getMediaType(), additionalReader.getConstraint());
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, readerClass));
+            reflectiveClass.produce(
+                    ReflectiveClassBuildItem.builder(readerClass).build());
         }
 
         for (AdditionalReaderWriter.Entry entry : additionalWriters.get()) {
             String writerClass = entry.getHandlerClass();
             registerWriter(recorder, serialisers, entry.getEntityClass(), writerClass,
                     beanContainerBuildItem.getValue(), entry.getMediaType());
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, writerClass));
+            reflectiveClass.produce(
+                    ReflectiveClassBuildItem.builder(writerClass).build());
         }
 
         BeanFactory<ResteasyReactiveInitialiser> initClassFactory = recorder.factory(QUARKUS_INIT_CLASS,

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
@@ -153,7 +153,8 @@ public class ResteasyReactiveScanningProcessor {
                 beanBuilder.addBeanClass(additionalExceptionMapper.getClassName());
             } else {
                 reflectiveClassBuildItemBuildProducer
-                        .produce(new ReflectiveClassBuildItem(true, false, false, additionalExceptionMapper.getClassName()));
+                        .produce(ReflectiveClassBuildItem.builder(additionalExceptionMapper.getClassName())
+                                .build());
             }
             int priority = Priorities.USER;
             if (additionalExceptionMapper.getPriority() != null) {
@@ -201,7 +202,8 @@ public class ResteasyReactiveScanningProcessor {
                 beanBuilder.addBeanClass(additionalParamConverter.getClassName());
             } else {
                 reflectiveClassBuildItemBuildProducer
-                        .produce(new ReflectiveClassBuildItem(true, false, false, additionalParamConverter.getClassName()));
+                        .produce(ReflectiveClassBuildItem.builder(additionalParamConverter.getClassName())
+                                .build());
             }
             int priority = Priorities.USER;
             if (additionalParamConverter.getPriority() != null) {
@@ -263,7 +265,8 @@ public class ResteasyReactiveScanningProcessor {
                 beanBuilder.addBeanClass(i.getClassName());
             } else {
                 reflectiveClassBuildItemBuildProducer
-                        .produce(new ReflectiveClassBuildItem(true, false, false, i.getClassName()));
+                        .produce(ReflectiveClassBuildItem.builder(i.getClassName())
+                                .build());
             }
             ResourceContextResolver resolver = new ResourceContextResolver();
             resolver.setClassName(i.getClassName());

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -159,8 +159,8 @@ class RestClientReactiveProcessor {
             resource.produce(new NativeImageResourceBuildItem(
                     "META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientListener"));
             reflectiveClass
-                    .produce(new ReflectiveClassBuildItem(true, false, false,
-                            "io.smallrye.opentracing.SmallRyeRestClientListener"));
+                    .produce(ReflectiveClassBuildItem.builder("io.smallrye.opentracing.SmallRyeRestClientListener")
+                            .build());
         }
     }
 
@@ -508,7 +508,8 @@ class RestClientReactiveProcessor {
                         + "' is allowed per REST Client interface. Offending class is '" + result.interfaceName + "'");
             }
             generatedProviders.put(result.interfaceName, result);
-            reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, false, false, result.generatedClassName));
+            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(result.generatedClassName)
+                    .serialization(false).build());
         }
     }
 
@@ -530,7 +531,8 @@ class RestClientReactiveProcessor {
                         + "Offending class is '" + result.interfaceName + "'");
             } else if (existing == null || existing.priority < result.priority) {
                 generatedProviders.put(result.interfaceName, result);
-                reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, false, false, result.generatedClassName));
+                reflectiveClasses.produce(ReflectiveClassBuildItem.builder(result.generatedClassName)
+                        .serialization(false).build());
             }
         }
     }

--- a/extensions/schema-registry/apicurio/avro/deployment/src/main/java/io/quarkus/apicurio/registry/avro/ApicurioRegistryAvroProcessor.java
+++ b/extensions/schema-registry/apicurio/avro/deployment/src/main/java/io/quarkus/apicurio/registry/avro/ApicurioRegistryAvroProcessor.java
@@ -18,28 +18,28 @@ public class ApicurioRegistryAvroProcessor {
     public void apicurioRegistryAvro(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport) {
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false,
-                "io.apicurio.registry.serde.avro.AvroKafkaDeserializer",
-                "io.apicurio.registry.serde.avro.AvroKafkaSerializer"));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("io.apicurio.registry.serde.avro.AvroKafkaDeserializer",
+                "io.apicurio.registry.serde.avro.AvroKafkaSerializer").methods().build());
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true,
-                "io.apicurio.registry.serde.strategy.SimpleTopicIdStrategy",
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("io.apicurio.registry.serde.strategy.SimpleTopicIdStrategy",
                 "io.apicurio.registry.serde.strategy.TopicIdStrategy",
                 "io.apicurio.registry.serde.avro.DefaultAvroDatumProvider",
                 "io.apicurio.registry.serde.avro.ReflectAvroDatumProvider",
                 "io.apicurio.registry.serde.avro.strategy.RecordIdStrategy",
-                "io.apicurio.registry.serde.avro.strategy.TopicRecordIdStrategy"));
+                "io.apicurio.registry.serde.avro.strategy.TopicRecordIdStrategy").methods().fields()
+                .build());
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true,
-                "io.apicurio.registry.serde.DefaultIdHandler",
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("io.apicurio.registry.serde.DefaultIdHandler",
                 "io.apicurio.registry.serde.Legacy4ByteIdHandler",
                 "io.apicurio.registry.serde.fallback.DefaultFallbackArtifactProvider",
-                "io.apicurio.registry.serde.headers.DefaultHeadersHandler"));
+                "io.apicurio.registry.serde.headers.DefaultHeadersHandler").methods().fields()
+                .build());
 
         String defaultSchemaResolver = "io.apicurio.registry.serde.DefaultSchemaResolver";
         if (QuarkusClassLoader.isClassPresentAtRuntime(defaultSchemaResolver)) {
             // Class not present after 2.2.0.Final
-            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, defaultSchemaResolver));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(defaultSchemaResolver).methods()
+                    .fields().build());
         }
     }
 

--- a/extensions/schema-registry/apicurio/common/deployment/src/main/java/io/quarkus/apicurio/registry/common/ApicurioRegistryClientProcessor.java
+++ b/extensions/schema-registry/apicurio/common/deployment/src/main/java/io/quarkus/apicurio/registry/common/ApicurioRegistryClientProcessor.java
@@ -18,17 +18,17 @@ public class ApicurioRegistryClientProcessor {
     @BuildStep
     public void apicurioRegistryClient(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true,
-                "io.apicurio.rest.client.auth.exception.NotAuthorizedException",
-                "io.apicurio.rest.client.auth.exception.ForbiddenException",
-                "io.apicurio.rest.client.auth.exception.AuthException",
-                "io.apicurio.rest.client.auth.exception.AuthErrorHandler",
-                "io.apicurio.rest.client.auth.request.TokenRequestsProvider",
-                "io.apicurio.rest.client.request.Request",
-                "io.apicurio.rest.client.auth.AccessTokenResponse",
-                "io.apicurio.rest.client.auth.Auth",
-                "io.apicurio.rest.client.auth.BasicAuth",
-                "io.apicurio.rest.client.auth.OidcAuth"));
+        reflectiveClass
+                .produce(ReflectiveClassBuildItem.builder("io.apicurio.rest.client.auth.exception.NotAuthorizedException",
+                        "io.apicurio.rest.client.auth.exception.ForbiddenException",
+                        "io.apicurio.rest.client.auth.exception.AuthException",
+                        "io.apicurio.rest.client.auth.exception.AuthErrorHandler",
+                        "io.apicurio.rest.client.auth.request.TokenRequestsProvider",
+                        "io.apicurio.rest.client.request.Request",
+                        "io.apicurio.rest.client.auth.AccessTokenResponse",
+                        "io.apicurio.rest.client.auth.Auth",
+                        "io.apicurio.rest.client.auth.BasicAuth",
+                        "io.apicurio.rest.client.auth.OidcAuth").methods().fields().build());
     }
 
     @BuildStep

--- a/extensions/schema-registry/confluent/avro/deployment/src/main/java/io/quarkus/confluent/registry/avro/ConfluentRegistryAvroProcessor.java
+++ b/extensions/schema-registry/confluent/avro/deployment/src/main/java/io/quarkus/confluent/registry/avro/ConfluentRegistryAvroProcessor.java
@@ -41,9 +41,8 @@ public class ConfluentRegistryAvroProcessor {
     public void confluentRegistryAvro(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport) {
         reflectiveClass
-                .produce(new ReflectiveClassBuildItem(true, false,
-                        "io.confluent.kafka.serializers.KafkaAvroDeserializer",
-                        "io.confluent.kafka.serializers.KafkaAvroSerializer"));
+                .produce(ReflectiveClassBuildItem.builder("io.confluent.kafka.serializers.KafkaAvroDeserializer",
+                        "io.confluent.kafka.serializers.KafkaAvroSerializer").methods().build());
     }
 
     @BuildStep

--- a/extensions/schema-registry/confluent/common/deployment/src/main/java/io/quarkus/confluent/registry/common/ConfluentRegistryClientProcessor.java
+++ b/extensions/schema-registry/confluent/common/deployment/src/main/java/io/quarkus/confluent/registry/common/ConfluentRegistryClientProcessor.java
@@ -24,37 +24,40 @@ public class ConfluentRegistryClientProcessor {
             String nullContextNameStrategy = "io.confluent.kafka.serializers.context.NullContextNameStrategy";
             if (QuarkusClassLoader.isClassPresentAtRuntime(nullContextNameStrategy)) {
                 // Class not present before v7.0.0
-                reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, nullContextNameStrategy));
+                reflectiveClass.produce(ReflectiveClassBuildItem.builder(nullContextNameStrategy)
+                        .build());
             }
 
             reflectiveClass
-                    .produce(new ReflectiveClassBuildItem(true, true, false,
-                            "io.confluent.kafka.serializers.subject.TopicNameStrategy",
+                    .produce(ReflectiveClassBuildItem.builder("io.confluent.kafka.serializers.subject.TopicNameStrategy",
                             "io.confluent.kafka.serializers.subject.TopicRecordNameStrategy",
-                            "io.confluent.kafka.serializers.subject.RecordNameStrategy"));
+                            "io.confluent.kafka.serializers.subject.RecordNameStrategy").methods()
+                            .build());
         }
 
         if (curateOutcomeBuildItem.getApplicationModel().getDependencies().stream().anyMatch(
                 x -> x.getGroupId().equals("io.confluent")
                         && x.getArtifactId().equals("kafka-schema-registry-client"))) {
             reflectiveClass
-                    .produce(new ReflectiveClassBuildItem(true, true, false,
-                            "io.confluent.kafka.schemaregistry.client.rest.entities.ErrorMessage",
-                            "io.confluent.kafka.schemaregistry.client.rest.entities.Schema",
-                            "io.confluent.kafka.schemaregistry.client.rest.entities.Config",
-                            "io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference",
-                            "io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString",
-                            "io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTypeConverter",
-                            "io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId",
-                            "io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion"));
+                    .produce(ReflectiveClassBuildItem
+                            .builder("io.confluent.kafka.schemaregistry.client.rest.entities.ErrorMessage",
+                                    "io.confluent.kafka.schemaregistry.client.rest.entities.Schema",
+                                    "io.confluent.kafka.schemaregistry.client.rest.entities.Config",
+                                    "io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference",
+                                    "io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString",
+                                    "io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTypeConverter",
+                                    "io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId",
+                                    "io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion")
+                            .methods().build());
 
             reflectiveClass
-                    .produce(new ReflectiveClassBuildItem(true, true, false,
+                    .produce(ReflectiveClassBuildItem.builder(
                             "io.confluent.kafka.schemaregistry.client.rest.entities.requests.CompatibilityCheckResponse",
                             "io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest",
                             "io.confluent.kafka.schemaregistry.client.rest.entities.requests.ModeUpdateRequest",
                             "io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest",
-                            "io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse"));
+                            "io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse")
+                            .methods().build());
 
             // Make this a weak registration since the class is only reachable when kafka-schema-registry-client v [5.2,7) is in the classpath
             reflectiveClass

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -144,7 +144,7 @@ public class SecurityProcessor {
             List<String> providerClasses = registerProvider(provider.getProviderName(), provider.getProviderConfig(),
                     additionalProviders);
             for (String className : providerClasses) {
-                classes.produce(new ReflectiveClassBuildItem(true, true, className));
+                classes.produce(ReflectiveClassBuildItem.builder(className).methods().fields().build());
                 log.debugf("Register JCA class: %s", className);
             }
         }
@@ -159,9 +159,11 @@ public class SecurityProcessor {
         Optional<BouncyCastleJsseProviderBuildItem> bouncyCastleJsseProvider = getOne(bouncyCastleJsseProviders);
         if (bouncyCastleJsseProvider.isPresent()) {
             reflection.produce(
-                    new ReflectiveClassBuildItem(true, true, SecurityProviderUtils.BOUNCYCASTLE_JSSE_PROVIDER_CLASS_NAME));
-            reflection.produce(new ReflectiveClassBuildItem(true, true, true,
-                    "org.bouncycastle.jsse.provider.DefaultSSLContextSpi$LazyManagers"));
+                    ReflectiveClassBuildItem.builder(SecurityProviderUtils.BOUNCYCASTLE_JSSE_PROVIDER_CLASS_NAME).methods()
+                            .fields().build());
+            reflection.produce(
+                    ReflectiveClassBuildItem.builder("org.bouncycastle.jsse.provider.DefaultSSLContextSpi$LazyManagers")
+                            .methods().fields().build());
             runtimeReInitialized
                     .produce(new RuntimeReinitializedClassBuildItem(
                             "org.bouncycastle.jsse.provider.DefaultSSLContextSpi$LazyManagers"));
@@ -179,14 +181,16 @@ public class SecurityProcessor {
     private static void prepareBouncyCastleProvider(CurateOutcomeBuildItem curateOutcomeBuildItem,
             BuildProducer<ReflectiveClassBuildItem> reflection,
             BuildProducer<RuntimeReinitializedClassBuildItem> runtimeReInitialized, boolean isFipsMode) {
-        reflection.produce(new ReflectiveClassBuildItem(true, true,
-                isFipsMode ? SecurityProviderUtils.BOUNCYCASTLE_FIPS_PROVIDER_CLASS_NAME
-                        : SecurityProviderUtils.BOUNCYCASTLE_PROVIDER_CLASS_NAME));
+        reflection
+                .produce(
+                        ReflectiveClassBuildItem
+                                .builder(isFipsMode ? SecurityProviderUtils.BOUNCYCASTLE_FIPS_PROVIDER_CLASS_NAME
+                                        : SecurityProviderUtils.BOUNCYCASTLE_PROVIDER_CLASS_NAME)
+                                .methods().fields().build());
 
         if (curateOutcomeBuildItem.getApplicationModel().getDependencies().stream().anyMatch(
                 x -> x.getGroupId().equals("org.bouncycastle") && x.getArtifactId().startsWith("bcprov-"))) {
-            reflection.produce(new ReflectiveClassBuildItem(true, true,
-                    "org.bouncycastle.jcajce.provider.symmetric.AES",
+            reflection.produce(ReflectiveClassBuildItem.builder("org.bouncycastle.jcajce.provider.symmetric.AES",
                     "org.bouncycastle.jcajce.provider.symmetric.AES$CBC",
                     "org.bouncycastle.crypto.paddings.PKCS7Padding",
                     "org.bouncycastle.jcajce.provider.asymmetric.ec.KeyFactorySpi",
@@ -198,19 +202,21 @@ public class SecurityProcessor {
                     "org.bouncycastle.jcajce.provider.asymmetric.rsa.KeyFactorySpi",
                     "org.bouncycastle.jcajce.provider.asymmetric.rsa.KeyPairGeneratorSpi",
                     "org.bouncycastle.jcajce.provider.asymmetric.rsa.PSSSignatureSpi",
-                    "org.bouncycastle.jcajce.provider.asymmetric.rsa.PSSSignatureSpi$SHA256withRSA"));
+                    "org.bouncycastle.jcajce.provider.asymmetric.rsa.PSSSignatureSpi$SHA256withRSA").methods().fields()
+                    .build());
         }
         runtimeReInitialized
                 .produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.crypto.CryptoServicesRegistrar"));
         if (!isFipsMode) {
-            reflection.produce(new ReflectiveClassBuildItem(true, true, true,
-                    "org.bouncycastle.jcajce.provider.drbg.DRBG$Default"));
+            reflection.produce(ReflectiveClassBuildItem.builder("org.bouncycastle.jcajce.provider.drbg.DRBG$Default")
+                    .methods().fields().build());
             runtimeReInitialized
                     .produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.jcajce.provider.drbg.DRBG$Default"));
             runtimeReInitialized
                     .produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.jcajce.provider.drbg.DRBG$NonceAndIV"));
         } else {
-            reflection.produce(new ReflectiveClassBuildItem(true, true, true, "org.bouncycastle.crypto.general.AES"));
+            reflection.produce(ReflectiveClassBuildItem.builder("org.bouncycastle.crypto.general.AES")
+                    .methods().fields().build());
             runtimeReInitialized.produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.crypto.general.AES"));
             runtimeReInitialized
                     .produce(new RuntimeReinitializedClassBuildItem(

--- a/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
+++ b/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
@@ -104,7 +104,8 @@ public class SmallRyeGraphQLClientProcessor {
             proxies.produce(new NativeImageProxyDefinitionBuildItem(apiClass.getName()));
 
             // register the api class and all classes that it references for reflection
-            reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, apiClassInfo.name().toString()));
+            reflectiveClass.produce(
+                    ReflectiveClassBuildItem.builder(apiClassInfo.name().toString()).build());
             for (MethodInfo method : apiClassInfo.methods()) {
                 reflectiveHierarchies.produce(new ReflectiveHierarchyBuildItem.Builder()
                         .type(method.returnType())
@@ -126,9 +127,9 @@ public class SmallRyeGraphQLClientProcessor {
             syntheticBeans.produce(bean);
         }
         // needed to be able to convert config values to URI (performed by the GraphQL client code)
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder("java.net.URI").methods(true).build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder("java.util.List").methods(true).build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder("java.util.Collection").methods(true).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("java.net.URI").methods().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("java.util.List").methods().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("java.util.Collection").methods().build());
     }
 
     /**

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -294,10 +294,12 @@ public class SmallRyeGraphQLProcessor {
         graphQLInitializedProducer.produce(new SmallRyeGraphQLInitializedBuildItem(initialized));
 
         // Make sure the complex object from the application can work in native mode
-        reflectiveClassProducer.produce(new ReflectiveClassBuildItem(true, true, getSchemaJavaClasses(schema)));
+        reflectiveClassProducer
+                .produce(ReflectiveClassBuildItem.builder(getSchemaJavaClasses(schema)).methods().fields().build());
 
         // Make sure the GraphQL Java classes needed for introspection can work in native mode
-        reflectiveClassProducer.produce(new ReflectiveClassBuildItem(true, true, getGraphQLJavaClasses()));
+        reflectiveClassProducer
+                .produce(ReflectiveClassBuildItem.builder(getGraphQLJavaClasses()).methods().fields().build());
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)

--- a/extensions/smallrye-jwt-build/deployment/src/main/java/io/quarkus/smallrye/jwt/build/deployment/SmallRyeJwtBuildProcessor.java
+++ b/extensions/smallrye-jwt-build/deployment/src/main/java/io/quarkus/smallrye/jwt/build/deployment/SmallRyeJwtBuildProcessor.java
@@ -22,9 +22,11 @@ class SmallRyeJwtBuildProcessor {
 
     @BuildStep
     void addClassesForReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, SignatureAlgorithm.class));
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, KeyEncryptionAlgorithm.class));
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, JwtProviderImpl.class));
+        reflectiveClasses
+                .produce(ReflectiveClassBuildItem.builder(SignatureAlgorithm.class).methods().fields().build());
+        reflectiveClasses
+                .produce(ReflectiveClassBuildItem.builder(KeyEncryptionAlgorithm.class).methods().fields().build());
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(JwtProviderImpl.class).methods().fields().build());
     }
 
     /**

--- a/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
+++ b/extensions/smallrye-jwt/deployment/src/main/java/io/quarkus/smallrye/jwt/deployment/SmallRyeJwtProcessor.java
@@ -100,8 +100,10 @@ class SmallRyeJwtProcessor {
         removable.addBeanClass(Claim.class);
         additionalBeans.produce(removable.build());
 
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, SignatureAlgorithm.class));
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, KeyEncryptionAlgorithm.class));
+        reflectiveClasses
+                .produce(ReflectiveClassBuildItem.builder(SignatureAlgorithm.class).methods().fields().build());
+        reflectiveClasses
+                .produce(ReflectiveClassBuildItem.builder(KeyEncryptionAlgorithm.class).methods().fields().build());
     }
 
     /**

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/SmallRyeMetricsProcessor.java
@@ -310,10 +310,12 @@ public class SmallRyeMetricsProcessor {
             SmallRyeMetricsRecorder metrics,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
         for (DotName metricsAnnotation : METRICS_ANNOTATIONS) {
-            reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false, metricsAnnotation.toString()));
+            reflectiveClasses.produce(
+                    ReflectiveClassBuildItem.builder(metricsAnnotation.toString()).build());
         }
 
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false, METRICS_BINDING.toString()));
+        reflectiveClasses
+                .produce(ReflectiveClassBuildItem.builder(METRICS_BINDING.toString()).build());
         metrics.createRegistries(beanContainerBuildItem.getValue());
     }
 

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -666,7 +666,8 @@ public class SmallRyeOpenApiProcessor {
 
                 AnnotationValue schemaNotClass = schema.value(OPENAPI_SCHEMA_NOT);
                 if (schemaNotClass != null) {
-                    reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, schemaNotClass.asString()));
+                    reflectiveClass.produce(
+                            ReflectiveClassBuildItem.builder(schemaNotClass.asString()).methods().fields().build());
                 }
 
                 produceReflectiveHierarchy(reflectiveHierarchy, schema.value(OPENAPI_SCHEMA_ONE_OF), source);

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
@@ -63,7 +63,7 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
 
     @BuildStep
     public void build(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, ProcessingState.class));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(ProcessingState.class).methods().fields().build());
     }
 
     @BuildStep
@@ -106,7 +106,8 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
             Capabilities capabilities) {
         if (hasStateStoreConfig(REDIS_STATE_STORE, ConfigProvider.getConfig())) {
             Optional<String> checkpointStateType = getConnectorProperty("checkpoint.state-type", ConfigProvider.getConfig());
-            checkpointStateType.ifPresent(s -> reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, s)));
+            checkpointStateType.ifPresent(
+                    s -> reflectiveClass.produce(ReflectiveClassBuildItem.builder(s).methods().fields().build()));
             if (capabilities.isPresent(Capability.REDIS_CLIENT)) {
                 additionalBean.produce(new AdditionalBeanBuildItem(RedisStateStore.Factory.class));
                 additionalBean.produce(new AdditionalBeanBuildItem(DatabindProcessingStateCodec.Factory.class));
@@ -725,7 +726,8 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
                 clazz = JacksonSerdeGenerator.generateDeserializer(generatedClass, type);
                 LOGGER.infof("Generating Jackson deserializer for type %s", type.name().toString());
                 // Deserializers are access by reflection.
-                reflection.produce(new ReflectiveClassBuildItem(true, true, false, clazz));
+                reflection.produce(
+                        ReflectiveClassBuildItem.builder(clazz).methods().build());
                 alreadyGeneratedSerializers.put(type.toString(), clazz);
             }
             result = Result.of(clazz);
@@ -751,7 +753,8 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
                 clazz = JacksonSerdeGenerator.generateSerializer(generatedClass, type);
                 LOGGER.infof("Generating Jackson serializer for type %s", type.name().toString());
                 // Serializers are access by reflection.
-                reflection.produce(new ReflectiveClassBuildItem(true, true, false, clazz));
+                reflection.produce(
+                        ReflectiveClassBuildItem.builder(clazz).methods().build());
                 alreadyGeneratedSerializers.put(type.toString(), clazz);
             }
             result = Result.of(clazz);
@@ -860,7 +863,8 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
     }
 
     void produceReflectiveClass(BuildProducer<ReflectiveClassBuildItem> reflectiveClass, Type type) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, type.name().toString()));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(type.name().toString()).methods().fields().build());
     }
 
     // visible for testing

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -251,7 +251,8 @@ public class SmallRyeReactiveMessagingProcessor {
                  * We could potentially lift this restriction with some extra CDI bean generation, but it's probably not worth
                  * it
                  */
-                reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, generatedInvokerName));
+                reflectiveClass
+                        .produce(ReflectiveClassBuildItem.builder(generatedInvokerName).build());
                 mediatorConfiguration
                         .setInvokerClass((Class<? extends Invoker>) recorderContext.classProxy(generatedInvokerName));
             } catch (IllegalArgumentException e) {

--- a/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ConfigurationPropertiesUtil.java
+++ b/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ConfigurationPropertiesUtil.java
@@ -164,7 +164,8 @@ final class ConfigurationPropertiesUtil {
         // We need to register for reflection in case an implicit converter is required.
         if (!ConfigBuildStep.isHandledByProducers(type)) {
             if (type.kind() != Type.Kind.ARRAY) {
-                reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, type.name().toString()));
+                reflectiveClasses
+                        .produce(ReflectiveClassBuildItem.builder(type.name().toString()).methods().build());
             }
         }
     }

--- a/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/YamlListObjectHandler.java
+++ b/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/YamlListObjectHandler.java
@@ -55,7 +55,8 @@ class YamlListObjectHandler {
         ClassInfo classInfo = validateType(member.type());
         validateClass(classInfo, member);
         // these need to be registered for reflection because SnakeYaml used reflection to instantiate them
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, true, classInfo.name().toString()));
+        reflectiveClasses
+                .produce(ReflectiveClassBuildItem.builder(classInfo.name().toString()).methods().fields().build());
 
         String wrapperClassName = classInfo.name().toString() + "_GeneratedListWrapper_" + configName;
 
@@ -79,7 +80,7 @@ class YamlListObjectHandler {
             setter.returnValue(null);
         }
         // we always generate getters and setters, so reflection is only needed on the methods
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, wrapperClassName));
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(wrapperClassName).methods().build());
 
         // generate an MP-Config converter which looks something like this
         // public class GeneratedInputsConverter extends io.quarkus.config.yaml.runtime.AbstractYamlObjectConverter<SomeClass_GeneratedListWrapper_fieldName> {

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
@@ -103,7 +103,7 @@ public class SpringDataJPAProcessor {
                 "org.springframework.data.domain.Sort",
                 "org.springframework.data.domain.Chunk",
                 "org.springframework.data.domain.PageRequest",
-                "org.springframework.data.domain.AbstractPageRequest").methods(true).fields(false).build());
+                "org.springframework.data.domain.AbstractPageRequest").methods().build());
     }
 
     @BuildStep
@@ -256,7 +256,7 @@ public class SpringDataJPAProcessor {
                 (className -> {
                     // the generated classes that implement interfaces for holding custom query results need
                     // to be registered for reflection here since this is the only point where the generated class is known
-                    reflectiveClasses.produce(ReflectiveClassBuildItem.builder(className).methods(true).fields(false).build());
+                    reflectiveClasses.produce(ReflectiveClassBuildItem.builder(className).methods().build());
                 }), JavaJpaTypeBundle.BUNDLE);
 
         Set<String> entities = new HashSet<>();

--- a/extensions/spring-web/core/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
+++ b/extensions/spring-web/core/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebProcessor.java
@@ -196,7 +196,8 @@ public class SpringWebProcessor {
             }
 
             if (!RESPONSE_ENTITY.equals(returnTypeDotName)) {
-                reflectiveClassProducer.produce(new ReflectiveClassBuildItem(true, true, returnTypeDotName.toString()));
+                reflectiveClassProducer.produce(
+                        ReflectiveClassBuildItem.builder(returnTypeDotName.toString()).methods().fields().build());
             }
 
             // we need to generate one JAX-RS ExceptionMapper per Exception type

--- a/extensions/spring-web/resteasy-classic/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebResteasyClassicProcessor.java
+++ b/extensions/spring-web/resteasy-classic/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebResteasyClassicProcessor.java
@@ -127,7 +127,8 @@ public class SpringWebResteasyClassicProcessor {
             }
         }));
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, SpringResourceBuilder.class.getName()));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(SpringResourceBuilder.class.getName())
+                .build());
     }
 
     /**

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -400,7 +400,8 @@ public class UndertowBuildStep {
         ObjectSubstitutionBuildItem.Holder holder = new ObjectSubstitutionBuildItem.Holder(ServletSecurityInfo.class,
                 ServletSecurityInfoProxy.class, ServletSecurityInfoSubstitution.class);
         substitutions.produce(new ObjectSubstitutionBuildItem(holder));
-        reflectiveClasses.accept(new ReflectiveClassBuildItem(false, false, DefaultServlet.class.getName()));
+        reflectiveClasses
+                .accept(ReflectiveClassBuildItem.builder(DefaultServlet.class.getName()).build());
 
         WebMetaData webMetaData = webMetadataBuildItem.getWebMetaData();
         final IndexView index = combinedIndexBuildItem.getIndex();
@@ -424,7 +425,8 @@ public class UndertowBuildStep {
         //add servlets
         if (webMetaData.getServlets() != null) {
             for (ServletMetaData servlet : webMetaData.getServlets()) {
-                reflectiveClasses.accept(new ReflectiveClassBuildItem(false, false, servlet.getServletClass()));
+                reflectiveClasses.accept(
+                        ReflectiveClassBuildItem.builder(servlet.getServletClass()).build());
                 RuntimeValue<ServletInfo> sref = recorder.registerServlet(deployment, servlet.getServletName(),
                         context.classProxy(servlet.getServletClass()),
                         servlet.isAsyncSupported(),
@@ -492,7 +494,8 @@ public class UndertowBuildStep {
         //filters
         if (webMetaData.getFilters() != null) {
             for (FilterMetaData filter : webMetaData.getFilters()) {
-                reflectiveClasses.accept(new ReflectiveClassBuildItem(false, false, filter.getFilterClass()));
+                reflectiveClasses
+                        .accept(ReflectiveClassBuildItem.builder(filter.getFilterClass()).build());
                 RuntimeValue<FilterInfo> sref = recorder.registerFilter(deployment,
                         filter.getFilterName(),
                         context.classProxy(filter.getFilterClass()),
@@ -571,7 +574,8 @@ public class UndertowBuildStep {
         //listeners
         if (webMetaData.getListeners() != null) {
             for (ListenerMetaData listener : webMetaData.getListeners()) {
-                reflectiveClasses.accept(new ReflectiveClassBuildItem(false, false, listener.getListenerClass()));
+                reflectiveClasses.accept(
+                        ReflectiveClassBuildItem.builder(listener.getListenerClass()).build());
                 recorder.registerListener(deployment, context.classProxy(listener.getListenerClass()), bc.getValue());
             }
         }
@@ -586,7 +590,8 @@ public class UndertowBuildStep {
         for (ServletBuildItem servlet : servlets) {
             String servletClass = servlet.getServletClass();
             if (servlet.getLoadOnStartup() == 0) {
-                reflectiveClasses.accept(new ReflectiveClassBuildItem(false, false, servlet.getServletClass()));
+                reflectiveClasses.accept(
+                        ReflectiveClassBuildItem.builder(servlet.getServletClass()).build());
             }
             RuntimeValue<ServletInfo> s = recorder.registerServlet(deployment, servlet.getName(),
                     context.classProxy(servletClass),
@@ -608,7 +613,7 @@ public class UndertowBuildStep {
 
         for (FilterBuildItem filter : filters) {
             String filterClass = filter.getFilterClass();
-            reflectiveClasses.accept(new ReflectiveClassBuildItem(false, false, filterClass));
+            reflectiveClasses.accept(ReflectiveClassBuildItem.builder(filterClass).build());
             RuntimeValue<FilterInfo> f = recorder.registerFilter(deployment, filter.getName(), context.classProxy(filterClass),
                     filter.isAsyncSupported(),
                     bc.getValue(), filter.getInstanceFactory());
@@ -633,7 +638,8 @@ public class UndertowBuildStep {
             recorder.addServletExtension(deployment, i.getValue());
         }
         for (ListenerBuildItem i : listeners) {
-            reflectiveClasses.accept(new ReflectiveClassBuildItem(false, false, i.getListenerClass()));
+            reflectiveClasses
+                    .accept(ReflectiveClassBuildItem.builder(i.getListenerClass()).build());
             recorder.registerListener(deployment, context.classProxy(i.getListenerClass()), bc.getValue());
         }
 

--- a/extensions/vertx-graphql/deployment/src/main/java/io/quarkus/vertx/graphql/deployment/VertxGraphqlProcessor.java
+++ b/extensions/vertx-graphql/deployment/src/main/java/io/quarkus/vertx/graphql/deployment/VertxGraphqlProcessor.java
@@ -42,8 +42,8 @@ class VertxGraphqlProcessor {
     List<ReflectiveClassBuildItem> registerForReflection() {
         return Arrays.asList(
                 //new ReflectiveClassBuildItem(true, true, GraphQLInputDeserializer.class.getName()),
-                new ReflectiveClassBuildItem(true, true, GraphQLBatch.class.getName()),
-                new ReflectiveClassBuildItem(true, true, GraphQLQuery.class.getName()));
+                ReflectiveClassBuildItem.builder(GraphQLBatch.class.getName()).methods().fields().build(),
+                ReflectiveClassBuildItem.builder(GraphQLQuery.class.getName()).methods().fields().build());
     }
 
     @BuildStep

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -394,7 +394,8 @@ class VertxHttpProcessor {
         boolean startVirtual = requireVirtual.isPresent() || httpBuildTimeConfig.virtual;
         if (startVirtual) {
             reflectiveClass
-                    .produce(new ReflectiveClassBuildItem(true, false, false, VirtualServerChannel.class));
+                    .produce(ReflectiveClassBuildItem.builder(VirtualServerChannel.class)
+                            .build());
         }
         boolean startSocket = (!startVirtual || launchMode.getLaunchMode() != LaunchMode.NORMAL)
                 && (requireVirtual.isEmpty() || !requireVirtual.get().isAlwaysVirtual());

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -74,8 +74,10 @@ class VertxCoreProcessor {
     @BuildStep
     NativeImageConfigBuildItem build(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResources) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, VertxLogDelegateFactory.class.getName()));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, LateBoundMDCProvider.class.getName()));
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(VertxLogDelegateFactory.class.getName()).methods().build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(LateBoundMDCProvider.class.getName()).methods().fields().build());
         nativeImageResources.produce(new NativeImageResourceBuildItem("META-INF/services/org.jboss.logmanager.MDCProvider"));
         return NativeImageConfigBuildItem.builder()
                 .addRuntimeInitializedClass("io.vertx.core.buffer.impl.VertxByteBufAllocator")
@@ -245,7 +247,7 @@ class VertxCoreProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
         for (ClassInfo ci : indexBuildItem.getIndex()
                 .getAllKnownSubclasses(DotName.createSimple(AbstractVerticle.class.getName()))) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, ci.toString()));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(ci.toString()).build());
         }
     }
 

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusCodecProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusCodecProcessor.java
@@ -120,7 +120,7 @@ public class EventBusCodecProcessor {
                 .forEach(new Consumer<String>() {
                     @Override
                     public void accept(String name) {
-                        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, name));
+                        reflectiveClass.produce(ReflectiveClassBuildItem.builder(name).methods().build());
                     }
                 });
     }

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -83,7 +83,7 @@ class VertxProcessor {
                     annotationProxy.builder(businessMethod.getConsumeEvent(), ConsumeEvent.class)
                             .withDefaultValue("value", businessMethod.getBean().getBeanClass().toString())
                             .build(classOutput));
-            reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, invokerClass));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(invokerClass).build());
         }
 
         Map<Class<?>, Class<?>> codecByClass = new HashMap<>();
@@ -171,7 +171,7 @@ class VertxProcessor {
         // Mutiny Verticles
         for (ClassInfo ci : indexBuildItem.getIndex()
                 .getAllKnownSubclasses(DotName.createSimple(io.smallrye.mutiny.vertx.core.AbstractVerticle.class.getName()))) {
-            reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, ci.toString()));
+            reflectiveClass.produce(ReflectiveClassBuildItem.builder(ci.toString()).build());
         }
     }
 

--- a/extensions/websockets/client/deployment/src/main/java/io/quarkus/websockets/client/deployment/WebsocketClientProcessor.java
+++ b/extensions/websockets/client/deployment/src/main/java/io/quarkus/websockets/client/deployment/WebsocketClientProcessor.java
@@ -120,12 +120,14 @@ public class WebsocketClientProcessor {
             annotated.add(i.className);
         }
         reflection.produce(
-                new ReflectiveClassBuildItem(true, false, annotated.toArray(new String[annotated.size()])));
+                ReflectiveClassBuildItem.builder(annotated.toArray(new String[annotated.size()])).methods()
+                        .build());
 
         registerCodersForReflection(reflection, index.getAnnotations(CLIENT_ENDPOINT));
 
         reflection.produce(
-                new ReflectiveClassBuildItem(true, true, ClientEndpointConfig.Configurator.class.getName()));
+                ReflectiveClassBuildItem.builder(ClientEndpointConfig.Configurator.class.getName()).methods().fields()
+                        .build());
 
         RuntimeValue<WebSocketDeploymentInfo> deploymentInfo = recorder.createDeploymentInfo(annotated, endpoints, config,
                 websocketConfig.maxFrameSize,
@@ -157,7 +159,8 @@ public class WebsocketClientProcessor {
     static void registerForReflection(BuildProducer<ReflectiveClassBuildItem> reflection, AnnotationValue types) {
         if (types != null && types.asClassArray() != null) {
             for (Type type : types.asClassArray()) {
-                reflection.produce(new ReflectiveClassBuildItem(true, false, type.name().toString()));
+                reflection
+                        .produce(ReflectiveClassBuildItem.builder(type.name().toString()).methods().build());
             }
         }
     }

--- a/integration-tests/test-extension/extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
+++ b/integration-tests/test-extension/extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
@@ -436,7 +436,7 @@ public final class TestProcessor {
             }
         }
         for (String className : providerClasses) {
-            classes.produce(new ReflectiveClassBuildItem(true, true, className));
+            classes.produce(ReflectiveClassBuildItem.builder(className).methods().fields().build());
             log.debugf("Register SUN.provider class: %s", className);
         }
     }
@@ -445,8 +445,8 @@ public final class TestProcessor {
     void registerFinalFieldReflectionObject(BuildProducer<ReflectiveClassBuildItem> classes) {
         ReflectiveClassBuildItem finalField = ReflectiveClassBuildItem
                 .builder(FinalFieldReflectionObject.class.getName())
-                .methods(true)
-                .fields(true)
+                .methods()
+                .fields()
                 .build();
         classes.produce(finalField);
     }


### PR DESCRIPTION
related to https://github.com/quarkusio/quarkus/pull/31222 and ReflectiveClassBuildItem construct methods have been marked for removal.