### PR TITLE
Allow for other ObjectMapper-s to be built / used

### DIFF
--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -313,6 +313,33 @@ public class CustomJsonbConfig {
 }
 ----
 
+== Other data formats
+
+Jackson supports other data formats as well -- YAML, JavaProps, Toml, CBOR, Smile.
+With Quarkus you can easily configure such `ObjectMapper` instantiation -- either via configuration property or overriding default `MapperBuilder` CDI bean.
+
+[source,properties]
+----
+quarkus.jackson.mapper-builder-type=yaml
+----
+
+[source,java]
+----
+@ApplicationScoped
+public class Config {
+    @Singleton
+    @Produces
+    public MapperBuilder mapperBuilder() {
+        return YAMLMapper.builder();
+    }
+}
+----
+
+[NOTE]
+====
+This change of type will change the type of default `ObjectMapper` bean - from plain JSON to your configured type. Which also affects REST services, etc.
+====
+
 
 == Creating a frontend
 

--- a/extensions/jackson/deployment/pom.xml
+++ b/extensions/jackson/deployment/pom.xml
@@ -39,6 +39,31 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-properties</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-toml</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-cbor</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-smile</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderCborTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderCborTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.jackson.deployment;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JacksonMapperBuilderCborTest extends JacksonMapperBuilderTypeTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.jackson.mapper-builder-type", "cbor");
+
+    @Override
+    ObjectMapper explicitObjectMapper() {
+        return CBORMapper.builder().build();
+    }
+}

--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderJsonTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderJsonTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.jackson.deployment;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JacksonMapperBuilderJsonTest extends JacksonMapperBuilderTypeTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.jackson.mapper-builder-type", "json");
+
+    @Override
+    ObjectMapper explicitObjectMapper() {
+        return JsonMapper.builder().build();
+    }
+}

--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderPropsTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderPropsTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.jackson.deployment;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JacksonMapperBuilderPropsTest extends JacksonMapperBuilderTypeTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.jackson.mapper-builder-type", "javaprops");
+
+    @Override
+    ObjectMapper explicitObjectMapper() {
+        return JavaPropsMapper.builder().build();
+    }
+}

--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderSmileTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderSmileTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.jackson.deployment;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JacksonMapperBuilderSmileTest extends JacksonMapperBuilderTypeTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.jackson.mapper-builder-type", "smile");
+
+    @Override
+    ObjectMapper explicitObjectMapper() {
+        return SmileMapper.builder().build();
+    }
+}

--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderTomlTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderTomlTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.jackson.deployment;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.toml.TomlMapper;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JacksonMapperBuilderTomlTest extends JacksonMapperBuilderTypeTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.jackson.mapper-builder-type", "toml");
+
+    @Override
+    ObjectMapper explicitObjectMapper() {
+        return TomlMapper.builder().build();
+    }
+}

--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderTypeTestBase.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderTypeTestBase.java
@@ -1,0 +1,44 @@
+package io.quarkus.jackson.deployment;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public abstract class JacksonMapperBuilderTypeTestBase {
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    abstract ObjectMapper explicitObjectMapper();
+
+    @Test
+    public void testType() throws Exception {
+        byte[] bytes = objectMapper.writeValueAsBytes(new Pojo("foobar"));
+        ObjectMapper om = explicitObjectMapper();
+        Pojo pojo = om.readValue(bytes, Pojo.class);
+        Assertions.assertEquals("foobar", pojo.getS());
+    }
+
+    public static class Pojo {
+        private String s;
+
+        public Pojo() {
+        }
+
+        public Pojo(String s) {
+            this.s = s;
+        }
+
+        public String getS() {
+            return s;
+        }
+
+        public void setS(String s) {
+            this.s = s;
+        }
+    }
+
+}

--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderYamlTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonMapperBuilderYamlTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.jackson.deployment;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JacksonMapperBuilderYamlTest extends JacksonMapperBuilderTypeTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.jackson.mapper-builder-type", "yaml");
+
+    @Override
+    ObjectMapper explicitObjectMapper() {
+        return YAMLMapper.builder().build();
+    }
+}

--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonYamlTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonYamlTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.jackson.deployment;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.MapperBuilder;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JacksonYamlTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Config.class));
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Test
+    public void testYaml() throws Exception {
+        byte[] bytes = objectMapper.writeValueAsBytes(new Pojo("foobar"));
+        YAMLMapper ym = new YAMLMapper();
+        Pojo pojo = ym.readValue(bytes, Pojo.class);
+        Assertions.assertEquals("foobar", pojo.getS());
+    }
+
+    @ApplicationScoped
+    public static class Config {
+        @SuppressWarnings("rawtypes")
+        @Singleton
+        @Produces
+        public MapperBuilder yamlBuilder() {
+            return YAMLMapper.builder();
+        }
+    }
+
+    public static class Pojo {
+        private String s;
+
+        public Pojo() {
+        }
+
+        public Pojo(String s) {
+            this.s = s;
+        }
+
+        public String getS() {
+            return s;
+        }
+
+        public void setS(String s) {
+            this.s = s;
+        }
+    }
+
+}

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/MapperBuilderType.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/MapperBuilderType.java
@@ -1,0 +1,70 @@
+package io.quarkus.jackson;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.MapperBuilder;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+/**
+ * Currently supported {@link ObjectMapper} {@link com.fasterxml.jackson.databind.cfg.MapperBuilder} types.
+ */
+@SuppressWarnings("rawtypes")
+public enum MapperBuilderType {
+    JSON(
+            "com.fasterxml.jackson.databind.json.JsonMapper",
+            "com.fasterxml.jackson.core:jackson-databind",
+            JsonMapper::builder),
+    YAML(
+            "com.fasterxml.jackson.dataformat.yaml.YAMLMapper",
+            "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"),
+    JAVAPROPS(
+            "com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper",
+            "com.fasterxml.jackson.dataformat:jackson-dataformat-properties"),
+    TOML(
+            "com.fasterxml.jackson.dataformat.toml.TomlMapper",
+            "com.fasterxml.jackson.dataformat:jackson-dataformat-toml"),
+    CBOR(
+            "com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper",
+            "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor"),
+    SMILE(
+            "com.fasterxml.jackson.dataformat.smile.databind.SmileMapper",
+            "com.fasterxml.jackson.dataformat:jackson-dataformat-smile");
+
+    private final String mapperClass;
+    private final String dependency;
+    private final Supplier<MapperBuilder> supplier;
+
+    MapperBuilderType(String mapperClass, String dependency) {
+        this(mapperClass, dependency, null);
+    }
+
+    MapperBuilderType(String mapperClass, String dependency, Supplier<MapperBuilder> supplier) {
+        this.mapperClass = mapperClass;
+        this.dependency = dependency;
+        this.supplier = supplier;
+    }
+
+    public String getMapperClass() {
+        return mapperClass;
+    }
+
+    public String getDependency() {
+        return dependency;
+    }
+
+    public Supplier<MapperBuilder> getSupplier() {
+        return Objects.requireNonNullElseGet(supplier, () -> () -> {
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            try {
+                Class<?> clazz = cl.loadClass(mapperClass);
+                Method builder = clazz.getMethod("builder");
+                return (MapperBuilder) builder.invoke(null);
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        });
+    }
+}

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
@@ -4,8 +4,8 @@ import java.time.ZoneId;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
+import io.quarkus.jackson.MapperBuilderType;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -74,4 +74,13 @@ public class JacksonBuildTimeConfig {
      */
     @ConfigItem
     public Optional<String> propertyNamingStrategy;
+
+    /**
+     * If set, this will create a {@link com.fasterxml.jackson.databind.cfg.MapperBuilder} bean of the configured type.
+     * This builder bean will then be used to create an {@link com.fasterxml.jackson.databind.ObjectMapper} bean.
+     * Make sure you have the required dependencies on the classpath.
+     * e.g. for YAML, make sure that YAMLMapper is available
+     */
+    @ConfigItem
+    public Optional<MapperBuilderType> mapperBuilderType;
 }

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/MapperBuilderRecorder.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/MapperBuilderRecorder.java
@@ -1,0 +1,19 @@
+package io.quarkus.jackson.runtime;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.MapperBuilder;
+
+import io.quarkus.jackson.MapperBuilderType;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class MapperBuilderRecorder {
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public Supplier<MapperBuilder> supplier(Optional<MapperBuilderType> ot) {
+        return ot.map(MapperBuilderType::getSupplier).orElse(() -> new MapperBuilder(new ObjectMapper()) {
+        });
+    }
+}


### PR DESCRIPTION
This easily enables other ObjectMapper types to be used -- if needed.
The default is exactly the same as before.
Note: when used with REST, be aware that it might not be JSON anymore