### PR TITLE
Remove quarkus.hibernate-orm.database.generation=drop-and-create from Hibernate ORM codestart

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/hibernate-orm-codestart/base/src/main/resources/application.yml
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/hibernate-orm-codestart/base/src/main/resources/application.yml
@@ -1,4 +1,0 @@
-quarkus:
-  hibernate-orm:
-    database:
-      generation: drop-and-create


### PR DESCRIPTION
1. It's not necessary: if you're using dev services, this will be set implicitly in dev mode and test mode.
2. It's incorrect and dangerous: this setting should be applied to the dev and test profile explicitly, otherwise it will lead to dropping the whole database content in production...

I think this should be backported to 2.16 as it's really not a good practice and we don't want to encourage people to do this.