### PR TITLE
Bump to newer version of wildfly-common

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -115,7 +115,7 @@
         <jboss-logging-annotations.version>2.2.1.Final</jboss-logging-annotations.version>
         <slf4j.version>2.0.6</slf4j.version>
         <slf4j-jboss-logmanager.version>2.0.0.Final</slf4j-jboss-logmanager.version>
-        <wildfly-common.version>1.5.4.Final-format-001</wildfly-common.version>
+        <wildfly-common.version>1.5.4.Final-format-002</wildfly-common.version>
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.1.0.Final</wildfly-elytron.version>
         <jboss-threads.version>3.5.0.Final</jboss-threads.version>


### PR DESCRIPTION
It seems like we forgot to do it after the release. 
Maven Central contains an even newer version (`1.6.0.Final`), so I'll let @dmlloyd decide

Fixes: #23769