### PR TITLE
Only substitute OctetKeyPair* classes when on the classpath

### DIFF
--- a/extensions/smallrye-jwt-build/runtime/src/main/java/io/quarkus/smallrye/jwt/build/runtime/graalvm/Substitutions.java
+++ b/extensions/smallrye-jwt-build/runtime/src/main/java/io/quarkus/smallrye/jwt/build/runtime/graalvm/Substitutions.java
@@ -5,25 +5,34 @@ import java.util.function.BooleanSupplier;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
-@TargetClass(className = "org.jose4j.jwk.OctetKeyPairJsonWebKey", onlyWith = JavaVersionLessThan17.class)
+@TargetClass(className = "org.jose4j.jwk.OctetKeyPairJsonWebKey", onlyWith = JavaVersionLessThan17andOctetKeyPairOnClasspath.class)
 final class Target_org_jose4j_jwk_OctetKeyPairJsonWebKey {
     @Substitute
     public Target_org_jose4j_jwk_OctetKeyPairJsonWebKey(java.security.PublicKey publicKey) {
+        throw new UnsupportedOperationException(
+                "OctetKeyPairJsonWebKey depends on EdECPrivateKeySpec which is not available in Java < 15");
     }
 
     @Substitute
     Target_org_jose4j_jwk_OctetKeyPairUtil subtypeKeyUtil() {
-        return null;
+        throw new UnsupportedOperationException(
+                "OctetKeyPairJsonWebKey depends on EdECPrivateKeySpec which is not available in Java < 15");
     }
 }
 
-@TargetClass(className = "org.jose4j.keys.OctetKeyPairUtil", onlyWith = JavaVersionLessThan17.class)
+@TargetClass(className = "org.jose4j.keys.OctetKeyPairUtil", onlyWith = JavaVersionLessThan17andOctetKeyPairOnClasspath.class)
 final class Target_org_jose4j_jwk_OctetKeyPairUtil {
 }
 
-class JavaVersionLessThan17 implements BooleanSupplier {
+class JavaVersionLessThan17andOctetKeyPairOnClasspath implements BooleanSupplier {
     @Override
     public boolean getAsBoolean() {
-        return Runtime.version().version().get(0) < 17;
+        try {
+            Class.forName("org.jose4j.jwk.OctetKeyPairJsonWebKey");
+            Class.forName("org.jose4j.jwk.OctetKeyPairUtil");
+            return Runtime.version().version().get(0) < 17;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Under certain configurations (e.g. in https://github.com/quarkusio/quarkus/issues/31930) the substitution fails with:

```
Error: Substitution target for io.quarkus.smallrye.jwt.build.runtime.graalvm.Target_org_jose4j_jwk_OctetKeyPairJsonWebKey is not loaded. Use field `onlyWith` in the `TargetClass` annotation to make substitution only active when needed.
com.oracle.svm.core.util.UserError$UserException: Substitution target for io.quarkus.smallrye.jwt.build.runtime.graalvm.Target_org_jose4j_jwk_OctetKeyPairJsonWebKey is not loaded. Use field `onlyWith` in the `TargetClass` annotation to make substitution only active when needed.
```

which indicates that the class being substituted cannot be located on the classpath.

Closes https://github.com/quarkusio/quarkus/issues/31930