### PR TITLE
Bump dekorate from 3.5.0 to 3.5.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -161,7 +161,7 @@
         <kotlin.version>1.8.10</kotlin.version>
         <kotlin.coroutine.version>1.6.4</kotlin.coroutine.version>
         <kotlin-serialization.version>1.5.0</kotlin-serialization.version>
-        <dekorate.version>3.5.0</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
+        <dekorate.version>3.5.2</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>
         <jboss-logmanager.version>1.1.1</jboss-logmanager.version>

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
@@ -43,10 +43,12 @@ import io.dekorate.kubernetes.decorator.AddImagePullSecretDecorator;
 import io.dekorate.kubernetes.decorator.AddInitContainerDecorator;
 import io.dekorate.kubernetes.decorator.AddLabelDecorator;
 import io.dekorate.kubernetes.decorator.AddLivenessProbeDecorator;
+import io.dekorate.kubernetes.decorator.AddMetadataToTemplateDecorator;
 import io.dekorate.kubernetes.decorator.AddMountDecorator;
 import io.dekorate.kubernetes.decorator.AddPvcVolumeDecorator;
 import io.dekorate.kubernetes.decorator.AddReadinessProbeDecorator;
 import io.dekorate.kubernetes.decorator.AddSecretVolumeDecorator;
+import io.dekorate.kubernetes.decorator.AddSelectorToDeploymentSpecDecorator;
 import io.dekorate.kubernetes.decorator.AddStartupProbeDecorator;
 import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
 import io.dekorate.kubernetes.decorator.ApplyArgsDecorator;
@@ -433,6 +435,10 @@ public class KubernetesCommonHelper {
             PlatformConfiguration config, List<KubernetesLabelBuildItem> labels) {
 
         List<DecoratorBuildItem> result = new ArrayList<>();
+
+        result.add(new DecoratorBuildItem(target, new AddMetadataToTemplateDecorator()));
+        result.add(new DecoratorBuildItem(target, new AddSelectorToDeploymentSpecDecorator()));
+
         labels.forEach(l -> {
             result.add(new DecoratorBuildItem(l.getTarget(),
                     new AddLabelDecorator(name, l.getKey(), l.getValue())));


### PR DESCRIPTION
Release changes: https://github.com/dekorateio/dekorate/releases/tag/3.5.1 and https://github.com/dekorateio/dekorate/releases/tag/3.5.2
Relates: https://github.com/quarkusio/quarkus/pull/31986
Fix: https://github.com/quarkusio/quarkus/issues/31968