### PR TITLE
CVE-2023-24815: Increase vertx version from 4.3.7 to 4.3.8

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -119,7 +119,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.1.0.Final</wildfly-elytron.version>
         <jboss-threads.version>3.5.0.Final</jboss-threads.version>
-        <vertx.version>4.3.7</vertx.version>
+        <vertx.version>4.3.8</vertx.version>
 
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>


### PR DESCRIPTION
Since 9th February is known a medium vulnerability in the vertx-web module version 4.3.7 - see [CVE-2023-24815](https://github.com/advisories/GHSA-53jx-vvf9-4x38). The fix has been already released within the version 4.3.8.