### PR TITLE
Bump OTel to 1.24+1.25

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -36,8 +36,8 @@
         <opentracing-jdbc.version>0.2.4</opentracing-jdbc.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
         <opentracing-mongo.version>0.1.5</opentracing-mongo.version>
-        <opentelemetry.version>1.23.1</opentelemetry.version>
-        <opentelemetry-alpha.version>1.23.0-alpha</opentelemetry-alpha.version>
+        <opentelemetry.version>1.25.0</opentelemetry.version>
+        <opentelemetry-alpha.version>1.25.0-alpha</opentelemetry-alpha.version>
         <jaeger.version>1.8.1</jaeger.version>
         <quarkus-http.version>5.0.2.Final</quarkus-http.version>
         <micrometer.version>1.10.5</micrometer.version><!-- keep in sync with hdrhistogram -->
@@ -68,7 +68,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.0</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.3.0</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>4.4.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>4.5.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.1.0</smallrye-stork.version>
         <jakarta.activation.version>2.1.1</jakarta.activation.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
@@ -3269,7 +3269,7 @@
                 <artifactId>router</artifactId>
                 <version>${vaadin-router.version}</version>
                 <scope>runtime</scope>
-            </dependency>    
+            </dependency>
             <dependency>
                 <groupId>org.mvnpm</groupId>
                 <artifactId>path-to-regexp</artifactId>
@@ -3645,7 +3645,7 @@
                 <version>${dedupe-mixin.version}</version>
                 <scope>runtime</scope>
             </dependency>
-            
+
             <!-- Lit -->
             <dependency>
                 <groupId>org.mvnpm</groupId>
@@ -3689,7 +3689,7 @@
                 <version>${lit-state.version}</version>
                 <scope>runtime</scope>
             </dependency>
-            
+
             <!-- Apache echarts -->
             <dependency>
                 <groupId>org.mvnpm</groupId>
@@ -3697,7 +3697,7 @@
                 <version>${echarts.version}</version>
                 <scope>runtime</scope>
             </dependency>
-            
+
             <!-- Code editor -->
             <dependency>
                 <groupId>org.mvnpm.at.vanillawc</groupId>
@@ -3705,7 +3705,7 @@
                 <version>${wc-codemirror.version}</version>
                 <scope>runtime</scope>
             </dependency>
-            
+
             <!-- Polyfill for importmaps -->
             <dependency>
                 <groupId>org.mvnpm</groupId>

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxClientOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxClientOpenTelemetryTest.java
@@ -9,6 +9,8 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_URL;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_NAME;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_PORT;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_PEER_NAME;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_PEER_PORT;
 import static io.quarkus.opentelemetry.deployment.common.TestSpanExporter.getSpanByKindAndParentId;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.util.stream.Collectors.toSet;
@@ -79,6 +81,8 @@ public class VertxClientOpenTelemetryTest {
         assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
         assertEquals(uri.toString() + "hello", client.getAttributes().get(HTTP_URL));
+        assertEquals(uri.getHost(), client.getAttributes().get(NET_PEER_NAME));
+        assertEquals(uri.getPort(), client.getAttributes().get(NET_PEER_PORT));
 
         SpanData server = getSpanByKindAndParentId(spans, SERVER, client.getSpanId());
         assertEquals(SERVER, server.getKind());
@@ -111,6 +115,8 @@ public class VertxClientOpenTelemetryTest {
         assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
         assertEquals(uri.toString() + "hello/naruto", client.getAttributes().get(HTTP_URL));
+        assertEquals(uri.getHost(), client.getAttributes().get(NET_PEER_NAME));
+        assertEquals(uri.getPort(), client.getAttributes().get(NET_PEER_PORT));
 
         SpanData server = getSpanByKindAndParentId(spans, SERVER, client.getSpanId());
         assertEquals(SERVER, server.getKind());

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxOpenTelemetryTest.java
@@ -4,15 +4,14 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_CLIENT_IP;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_FLAVOR;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_METHOD;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_ROUTE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_SCHEME;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_TARGET;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_USER_AGENT;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_NAME;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_PORT;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.USER_AGENT_ORIGINAL;
 import static io.quarkus.opentelemetry.deployment.common.TestSpanExporter.getSpanByKindAndParentId;
 import static io.restassured.RestAssured.given;
 import static io.vertx.core.http.HttpMethod.GET;
@@ -90,7 +89,6 @@ public class VertxOpenTelemetryTest {
 
         SpanData server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
         assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
-        assertEquals("1.1", server.getAttributes().get(HTTP_FLAVOR));
         assertEquals("/tracer", server.getAttributes().get(HTTP_TARGET));
         assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
         assertEquals("localhost", server.getAttributes().get(NET_HOST_NAME));
@@ -100,7 +98,7 @@ public class VertxOpenTelemetryTest {
                 W3CBaggagePropagator.getInstance()));
         assertThat(idGenerator, instanceOf(IdGenerator.random().getClass()));
         assertThat(sampler.getDescription(), stringContainsInOrder("ParentBased", "AlwaysOnSampler"));
-        assertNotNull(server.getAttributes().get(HTTP_USER_AGENT));
+        assertNotNull(server.getAttributes().get(USER_AGENT_ORIGINAL));
 
         SpanData internal = getSpanByKindAndParentId(spans, INTERNAL, server.getSpanId());
         assertEquals("io.quarkus.vertx.opentelemetry", internal.getName());
@@ -118,13 +116,12 @@ public class VertxOpenTelemetryTest {
         final SpanData server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
         assertEquals("GET /tracer", server.getName());
         assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
-        assertEquals("1.1", server.getAttributes().get(HTTP_FLAVOR));
         assertEquals("/tracer?id=1", server.getAttributes().get(HTTP_TARGET));
         assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
         assertEquals("localhost", server.getAttributes().get(NET_HOST_NAME));
         assertEquals("8081", server.getAttributes().get(NET_HOST_PORT).toString());
         assertEquals("127.0.0.1", server.getAttributes().get(HTTP_CLIENT_IP));
-        assertNotNull(server.getAttributes().get(HTTP_USER_AGENT));
+        assertNotNull(server.getAttributes().get(USER_AGENT_ORIGINAL));
 
         SpanData internal = getSpanByKindAndParentId(spans, INTERNAL, server.getSpanId());
         assertEquals("io.quarkus.vertx.opentelemetry", internal.getName());

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/EventBusInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/EventBusInstrumenterVertxTracer.java
@@ -110,21 +110,6 @@ public class EventBusInstrumenterVertxTracer implements InstrumenterVertxTracer<
         }
 
         @Override
-        public String getProtocol(final Message message) {
-            return null;
-        }
-
-        @Override
-        public String getProtocolVersion(final Message message) {
-            return "4.0";
-        }
-
-        @Override
-        public String getUrl(final Message message) {
-            return null;
-        }
-
-        @Override
         public String getConversationId(final Message message) {
             return message.replyAddress();
         }

--- a/integration-tests/opentelemetry-reactive-messaging/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
+++ b/integration-tests/opentelemetry-reactive-messaging/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
@@ -119,14 +119,13 @@ public class OpenTelemetryTestCase {
         Assertions.assertFalse((Boolean) spanData.get("parent_remote"));
 
         Assertions.assertEquals("GET", spanData.get("attr_http.method"));
-        Assertions.assertEquals("1.1", spanData.get("attr_http.flavor"));
         Assertions.assertEquals("/direct", spanData.get("attr_http.target"));
         assertEquals(url.getHost(), spanData.get("attr_net.host.name"));
         assertEquals(url.getPort(), Integer.valueOf((String) spanData.get("attr_net.host.port")));
         Assertions.assertEquals("http", spanData.get("attr_http.scheme"));
         Assertions.assertEquals("200", spanData.get("attr_http.status_code"));
         Assertions.assertNotNull(spanData.get("attr_http.client_ip"));
-        Assertions.assertNotNull(spanData.get("attr_http.user_agent"));
+        Assertions.assertNotNull(spanData.get("attr_user_agent.original"));
     }
 
     private static void verifyProducer(Map<String, Object> spanData,

--- a/integration-tests/opentelemetry-spi/src/test/java/io/quarkus/it/opentelemetry/spi/OTelSpiTest.java
+++ b/integration-tests/opentelemetry-spi/src/test/java/io/quarkus/it/opentelemetry/spi/OTelSpiTest.java
@@ -68,14 +68,13 @@ public class OTelSpiTest {
         assertFalse((Boolean) spanData.get("parent_remote"));
 
         assertEquals("GET", spanData.get("attr_http.method"));
-        assertEquals("1.1", spanData.get("attr_http.flavor"));
         assertEquals("/direct", spanData.get("attr_http.target"));
         assertEquals(deepPathUrl.getHost(), spanData.get("attr_net.host.name"));
         assertEquals(deepPathUrl.getPort(), Integer.valueOf((String) spanData.get("attr_net.host.port")));
         assertEquals("http", spanData.get("attr_http.scheme"));
         assertEquals("200", spanData.get("attr_http.status_code"));
         assertNotNull(spanData.get("attr_http.client_ip"));
-        assertNotNull(spanData.get("attr_http.user_agent"));
+        assertNotNull(spanData.get("attr_user_agent.original"));
     }
 
     @Test

--- a/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTest.java
+++ b/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTest.java
@@ -94,14 +94,13 @@ public class OpenTelemetryTest {
         assertFalse((Boolean) spanData.get("parent_remote"));
 
         assertEquals("GET", spanData.get("attr_http.method"));
-        assertEquals("1.1", spanData.get("attr_http.flavor"));
         assertEquals("/direct", spanData.get("attr_http.target"));
         assertEquals(deepPathUrl.getHost(), spanData.get("attr_net.host.name"));
         assertEquals(deepPathUrl.getPort(), Integer.valueOf((String) spanData.get("attr_net.host.port")));
         assertEquals("http", spanData.get("attr_http.scheme"));
         assertEquals("200", spanData.get("attr_http.status_code"));
         assertNotNull(spanData.get("attr_http.client_ip"));
-        assertNotNull(spanData.get("attr_http.user_agent"));
+        assertNotNull(spanData.get("attr_user_agent.original"));
     }
 
     @Test
@@ -129,7 +128,6 @@ public class OpenTelemetryTest {
         assertFalse((Boolean) server.get("parent_valid"));
         assertFalse((Boolean) server.get("parent_remote"));
         assertEquals("GET", server.get("attr_http.method"));
-        assertEquals("1.1", server.get("attr_http.flavor"));
         assertEquals("/nopath", server.get("attr_http.target"));
         assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
         assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
@@ -137,7 +135,7 @@ public class OpenTelemetryTest {
         assertEquals("/nopath", server.get("attr_http.route"));
         assertEquals("200", server.get("attr_http.status_code"));
         assertNotNull(server.get("attr_http.client_ip"));
-        assertNotNull(server.get("attr_http.user_agent"));
+        assertNotNull(server.get("attr_user_agent.original"));
 
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, server.get("spanId"));
         assertEquals(CLIENT.toString(), client.get("kind"));
@@ -161,7 +159,6 @@ public class OpenTelemetryTest {
         assertTrue((Boolean) clientServer.get("parent_valid"));
         assertTrue((Boolean) clientServer.get("parent_remote"));
         assertEquals("GET", clientServer.get("attr_http.method"));
-        assertEquals("1.1", clientServer.get("attr_http.flavor"));
         assertEquals("/", clientServer.get("attr_http.target"));
         assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
         assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
@@ -169,7 +166,7 @@ public class OpenTelemetryTest {
         assertNull(clientServer.get("attr_http.route"));
         assertEquals("200", clientServer.get("attr_http.status_code"));
         assertNotNull(clientServer.get("attr_http.client_ip"));
-        assertNotNull(clientServer.get("attr_http.user_agent"));
+        assertNotNull(clientServer.get("attr_user_agent.original"));
         assertEquals(clientServer.get("parentSpanId"), client.get("spanId"));
     }
 
@@ -198,7 +195,6 @@ public class OpenTelemetryTest {
         assertFalse((Boolean) server.get("parent_valid"));
         assertFalse((Boolean) server.get("parent_remote"));
         assertEquals("GET", server.get("attr_http.method"));
-        assertEquals("1.1", server.get("attr_http.flavor"));
         assertEquals("/slashpath", server.get("attr_http.target"));
         assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
         assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
@@ -206,7 +202,7 @@ public class OpenTelemetryTest {
         assertEquals("/slashpath", server.get("attr_http.route"));
         assertEquals("200", server.get("attr_http.status_code"));
         assertNotNull(server.get("attr_http.client_ip"));
-        assertNotNull(server.get("attr_http.user_agent"));
+        assertNotNull(server.get("attr_user_agent.original"));
 
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, server.get("spanId"));
         assertEquals(CLIENT.toString(), client.get("kind"));
@@ -229,7 +225,6 @@ public class OpenTelemetryTest {
         assertTrue((Boolean) clientServer.get("parent_valid"));
         assertTrue((Boolean) clientServer.get("parent_remote"));
         assertEquals("GET", clientServer.get("attr_http.method"));
-        assertEquals("1.1", clientServer.get("attr_http.flavor"));
         assertEquals("/", clientServer.get("attr_http.target"));
         assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
         assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
@@ -237,7 +232,7 @@ public class OpenTelemetryTest {
         assertNull(clientServer.get("attr_http.route"));
         assertEquals("200", clientServer.get("attr_http.status_code"));
         assertNotNull(clientServer.get("attr_http.client_ip"));
-        assertNotNull(clientServer.get("attr_http.user_agent"));
+        assertNotNull(clientServer.get("attr_user_agent.original"));
         assertEquals(clientServer.get("parentSpanId"), client.get("spanId"));
     }
 
@@ -266,14 +261,13 @@ public class OpenTelemetryTest {
         assertFalse((Boolean) server.get("parent_valid"));
         assertFalse((Boolean) server.get("parent_remote"));
         assertEquals("GET", server.get("attr_http.method"));
-        assertEquals("1.1", server.get("attr_http.flavor"));
         assertEquals("/chained", server.get("attr_http.target"));
         assertEquals(deepPathUrl.getHost(), server.get("attr_net.host.name"));
         assertEquals(deepPathUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
         assertEquals("http", server.get("attr_http.scheme"));
         assertEquals("200", server.get("attr_http.status_code"));
         assertNotNull(server.get("attr_http.client_ip"));
-        assertNotNull(server.get("attr_http.user_agent"));
+        assertNotNull(server.get("attr_user_agent.original"));
 
         // CDI call
         Map<String, Object> cdi = getSpanByKindAndParentId(spans, INTERNAL, server.get("spanId"));
@@ -322,14 +316,13 @@ public class OpenTelemetryTest {
         assertTrue((Boolean) spanData.get("parent_valid"));
 
         assertEquals("GET", spanData.get("attr_http.method"));
-        assertEquals("1.1", spanData.get("attr_http.flavor"));
         assertEquals("/direct", spanData.get("attr_http.target"));
         assertEquals(deepPathUrl.getHost(), spanData.get("attr_net.host.name"));
         assertEquals(deepPathUrl.getPort(), Integer.valueOf((String) spanData.get("attr_net.host.port")));
         assertEquals("http", spanData.get("attr_http.scheme"));
         assertEquals("200", spanData.get("attr_http.status_code"));
         assertNotNull(spanData.get("attr_http.client_ip"));
-        assertNotNull(spanData.get("attr_http.user_agent"));
+        assertNotNull(spanData.get("attr_user_agent.original"));
     }
 
     @Test
@@ -358,14 +351,13 @@ public class OpenTelemetryTest {
         assertFalse((Boolean) spanData.get("parent_remote"));
 
         assertEquals("GET", spanData.get("attr_http.method"));
-        assertEquals("1.1", spanData.get("attr_http.flavor"));
         assertEquals("/deep/path", spanData.get("attr_http.target"));
         assertEquals(deepPathUrl.getHost(), spanData.get("attr_net.host.name"));
         assertEquals(deepPathUrl.getPort(), Integer.valueOf((String) spanData.get("attr_net.host.port")));
         assertEquals("http", spanData.get("attr_http.scheme"));
         assertEquals("200", spanData.get("attr_http.status_code"));
         assertNotNull(spanData.get("attr_http.client_ip"));
-        assertNotNull(spanData.get("attr_http.user_agent"));
+        assertNotNull(spanData.get("attr_user_agent.original"));
     }
 
     @Test
@@ -394,7 +386,6 @@ public class OpenTelemetryTest {
         assertFalse((Boolean) spanData.get("parent_remote"));
 
         assertEquals("GET", spanData.get("attr_http.method"));
-        assertEquals("1.1", spanData.get("attr_http.flavor"));
         assertEquals("/param/12345", spanData.get("attr_http.target"));
         assertEquals(pathParamUrl.getHost(), spanData.get("attr_net.host.name"));
         assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) spanData.get("attr_net.host.port")));
@@ -402,7 +393,7 @@ public class OpenTelemetryTest {
         assertEquals("/param/{paramId}", spanData.get("attr_http.route"));
         assertEquals("200", spanData.get("attr_http.status_code"));
         assertNotNull(spanData.get("attr_http.client_ip"));
-        assertNotNull(spanData.get("attr_http.user_agent"));
+        assertNotNull(spanData.get("attr_user_agent.original"));
     }
 
     @Test
@@ -429,7 +420,6 @@ public class OpenTelemetryTest {
         assertFalse((Boolean) server.get("parent_valid"));
         assertFalse((Boolean) server.get("parent_remote"));
         assertEquals("GET", server.get("attr_http.method"));
-        assertEquals("1.1", server.get("attr_http.flavor"));
         assertEquals("/client/ping/one", server.get("attr_http.target"));
         assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
         assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
@@ -437,7 +427,7 @@ public class OpenTelemetryTest {
         assertEquals("/client/ping/{message}", server.get("attr_http.route"));
         assertEquals("200", server.get("attr_http.status_code"));
         assertNotNull(server.get("attr_http.client_ip"));
-        assertNotNull(server.get("attr_http.user_agent"));
+        assertNotNull(server.get("attr_user_agent.original"));
 
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, server.get("spanId"));
         assertEquals("GET", client.get("name"));
@@ -458,7 +448,6 @@ public class OpenTelemetryTest {
         assertTrue((Boolean) clientServer.get("parent_valid"));
         assertTrue((Boolean) clientServer.get("parent_remote"));
         assertEquals("GET", clientServer.get("attr_http.method"));
-        assertEquals("1.1", clientServer.get("attr_http.flavor"));
         assertEquals("/client/pong/one", clientServer.get("attr_http.target"));
         assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
         assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
@@ -466,7 +455,7 @@ public class OpenTelemetryTest {
         assertEquals("/client/pong/{message}", clientServer.get("attr_http.route"));
         assertEquals("200", clientServer.get("attr_http.status_code"));
         assertNotNull(clientServer.get("attr_http.client_ip"));
-        assertNotNull(clientServer.get("attr_http.user_agent"));
+        assertNotNull(clientServer.get("attr_user_agent.original"));
         assertEquals(clientServer.get("parentSpanId"), client.get("spanId"));
     }
 
@@ -494,7 +483,6 @@ public class OpenTelemetryTest {
         assertFalse((Boolean) server.get("parent_valid"));
         assertFalse((Boolean) server.get("parent_remote"));
         assertEquals("GET", server.get("attr_http.method"));
-        assertEquals("1.1", server.get("attr_http.flavor"));
         assertEquals("/client/async-ping/one", server.get("attr_http.target"));
         assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
         assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
@@ -502,7 +490,7 @@ public class OpenTelemetryTest {
         assertEquals("/client/async-ping/{message}", server.get("attr_http.route"));
         assertEquals("200", server.get("attr_http.status_code"));
         assertNotNull(server.get("attr_http.client_ip"));
-        assertNotNull(server.get("attr_http.user_agent"));
+        assertNotNull(server.get("attr_user_agent.original"));
 
         Map<String, Object> client = getSpanByKindAndParentId(spans, CLIENT, server.get("spanId"));
         assertEquals("GET", client.get("name"));
@@ -523,7 +511,6 @@ public class OpenTelemetryTest {
         assertTrue((Boolean) clientServer.get("parent_valid"));
         assertTrue((Boolean) clientServer.get("parent_remote"));
         assertEquals("GET", clientServer.get("attr_http.method"));
-        assertEquals("1.1", clientServer.get("attr_http.flavor"));
         assertEquals("/client/pong/one", clientServer.get("attr_http.target"));
         assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
         assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
@@ -531,7 +518,7 @@ public class OpenTelemetryTest {
         assertEquals("/client/pong/{message}", clientServer.get("attr_http.route"));
         assertEquals("200", clientServer.get("attr_http.status_code"));
         assertNotNull(clientServer.get("attr_http.client_ip"));
-        assertNotNull(clientServer.get("attr_http.user_agent"));
+        assertNotNull(clientServer.get("attr_user_agent.original"));
     }
 
     @Test
@@ -560,14 +547,13 @@ public class OpenTelemetryTest {
         assertFalse((Boolean) spanData.get("parent_remote"));
 
         assertEquals("GET", spanData.get("attr_http.method"));
-        assertEquals("1.1", spanData.get("attr_http.flavor"));
         assertEquals("/template/path/something", spanData.get("attr_http.target"));
         assertEquals(deepPathUrl.getHost(), spanData.get("attr_net.host.name"));
         assertEquals(deepPathUrl.getPort(), Integer.valueOf((String) spanData.get("attr_net.host.port")));
         assertEquals("http", spanData.get("attr_http.scheme"));
         assertEquals("200", spanData.get("attr_http.status_code"));
         assertNotNull(spanData.get("attr_http.client_ip"));
-        assertNotNull(spanData.get("attr_http.user_agent"));
+        assertNotNull(spanData.get("attr_user_agent.original"));
     }
 
     @Test

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
@@ -150,12 +150,11 @@ public class BasicTest {
         Assertions.assertFalse((Boolean) initialServerSpan.get("parent_remote"));
 
         Assertions.assertEquals("POST", initialServerSpan.get("attr_http.method"));
-        Assertions.assertEquals("1.1", initialServerSpan.get("attr_http.flavor"));
         Assertions.assertEquals("/call-hello-client-trace", initialServerSpan.get("attr_http.target"));
         Assertions.assertEquals("http", initialServerSpan.get("attr_http.scheme"));
         Assertions.assertEquals("200", initialServerSpan.get("attr_http.status_code"));
         Assertions.assertNotNull(initialServerSpan.get("attr_http.client_ip"));
-        Assertions.assertNotNull(initialServerSpan.get("attr_http.user_agent"));
+        Assertions.assertNotNull(initialServerSpan.get("attr_user_agent.original"));
 
         spans = getClientSpans("POST", "http://localhost:8081/hello?count=3");
         Assertions.assertEquals(1, spans.size());
@@ -207,7 +206,6 @@ public class BasicTest {
         Assertions.assertTrue((Boolean) serverSpanClientSide.get("parent_remote"));
 
         Assertions.assertEquals("POST", serverSpanClientSide.get("attr_http.method"));
-        Assertions.assertEquals("1.1", serverSpanClientSide.get("attr_http.flavor"));
         Assertions.assertEquals("/hello?count=3", serverSpanClientSide.get("attr_http.target"));
         Assertions.assertEquals("http", serverSpanClientSide.get("attr_http.scheme"));
         Assertions.assertEquals("200", serverSpanClientSide.get("attr_http.status_code"));


### PR DESCRIPTION
aws.contrib dependencies are no longer needed.
Includes upgrade to 1.24 + 1.25.
Requires SR Reactive Messaging. 
