### PR TITLE
Remove now unnecessary logging configuration for k8s config

### DIFF
--- a/extensions/kubernetes-config/deployment/src/main/java/io/quarkus/kubernetes/config/deployment/KubernetesConfigProcessor.java
+++ b/extensions/kubernetes-config/deployment/src/main/java/io/quarkus/kubernetes/config/deployment/KubernetesConfigProcessor.java
@@ -2,13 +2,10 @@ package io.quarkus.kubernetes.config.deployment;
 
 import java.util.List;
 
-import org.jboss.logmanager.Level;
-
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.LogCategoryBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationSourceValueBuildItem;
 import io.quarkus.kubernetes.client.runtime.KubernetesClientBuildConfig;
 import io.quarkus.kubernetes.config.runtime.KubernetesConfigBuildTimeConfig;
@@ -70,13 +67,5 @@ public class KubernetesConfigProcessor {
         }
 
         recorder.warnAboutSecrets(config, buildTimeConfig);
-    }
-
-    // done in order to ensure that http logs aren't shown by default which happens because of the interplay between
-    // not yet setup logging (as the bootstrap config runs before logging is set up) and the configuration
-    // of the okhttp3.logging.HttpLoggingInterceptor by io.fabric8.kubernetes.client.utils.HttpClientUtils
-    @BuildStep
-    public void produceLoggingCategories(BuildProducer<LogCategoryBuildItem> categories) {
-        categories.produce(new LogCategoryBuildItem("okhttp3.OkHttpClient", Level.WARN));
     }
 }


### PR DESCRIPTION
The Kubernetes Client has moved to using Vert.x in Quarkus instead of OkHttp, so there is no longer any reason to configure OkHttp logging