### PR TITLE
Fix HttpRootPathBuildItem.Builder.orderedRoute()

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpRootPathBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpRootPathBuildItem.java
@@ -127,7 +127,7 @@ public final class HttpRootPathBuildItem extends SimpleBuildItem {
                 this.routerType = RouteType.ABSOLUTE_ROUTE;
             }
 
-            BasicRoute basicRoute = new BasicRoute(this.path, -1);
+            BasicRoute basicRoute = new BasicRoute(this.path, order);
 
             super.routeFunction = basicRoute;
             return this;


### PR DESCRIPTION
- the order value is not used

It seems that [`SmallRyeGraphQLProcessor#buildExecutionEndpoint()`](https://github.com/quarkusio/quarkus/blob/88dc0232d09bf4850fd3be099fdffd27875e3dfb/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java#L361) is the only usage in the quarkus repo...