### PR TITLE
Clarify diagnostic of Resteasy reactive for blocking methods

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/util/ScoreSystem.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/util/ScoreSystem.java
@@ -87,7 +87,7 @@ public class ScoreSystem {
         }
 
         public static Diagnostic ExecutionNonBlocking = new Diagnostic("Dispatched on the IO thread", 100);
-        public static Diagnostic ExecutionBlocking = new Diagnostic("Needs a worker thread dispatch", 0);
+        public static Diagnostic ExecutionBlocking = new Diagnostic("Relies on a blocking worker thread", 0);
 
         public static Diagnostic ResourceSingleton = new Diagnostic("Single resource instance for all requests", 100);
         public static Diagnostic ResourcePerRequest = new Diagnostic("New resource instance for every request", 0);


### PR DESCRIPTION
With the current message "Needs a worker thread dispatch" in the Dev UI, dumb me was confused and thought "why does RestEasy Reactive want me to add a worker thread dispatch? Do I need an explicit `@Blocking` annotation?".

When in fact the problem is that the endpoint *already* uses a worker thread dispatch, not that it needs anything new.

So I think this new wording, "Relies on a blocking worker thread", might be less confusing?