### PR TITLE
Remove unwanted (and unnecessary) build-order dependency from test

### DIFF
--- a/independent-projects/extension-maven-plugin/src/test/resources/fake-extension-runtime-with-missing-dependencies/pom.xml
+++ b/independent-projects/extension-maven-plugin/src/test/resources/fake-extension-runtime-with-missing-dependencies/pom.xml
@@ -17,7 +17,9 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-core</artifactId>
-      <version>${project.version}</version>
+      <!-- The version in this dependency is arbitrary, but needs to be 'real' (downloadable from maven).
+      It should not be a snapshot build, to avoid introducing a build-order dependency into this test. -->
+      <version>2.12.0.Final</version>
     </dependency>
 
     <!-- Mirror of the deployment artifact's dependencies would be here, but is deliberately missing -->

--- a/independent-projects/extension-maven-plugin/src/test/resources/fake-extension-runtime/pom.xml
+++ b/independent-projects/extension-maven-plugin/src/test/resources/fake-extension-runtime/pom.xml
@@ -19,7 +19,7 @@
   </properties>
 
   <!-- The versions in these dependencies are arbitrary, but need to match
-  in the runtime and deployment poms. -->
+  in the runtime and deployment poms. They should not be a snapshot build, to avoid introducing a build-order dependency into this test. -->
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Resolves #31528.

One of the sample projects in the extension mojo test has a dependency on `quarkus-core`. This is good for realism, but there's no need for the dependency to be a snapshot dependency. Having the snapshot dependency introduces a requirement the product be built before tests are run. We do that in our CI, but the early access JVM build does not.  

To reproduce the issue (and confirm the fix):

```
rm -rf ~/.m2/repository/io/quarkus/quarkus-core/999-SNAPSHOT 
mvn -f independent-projects/extension-maven-plugin verify   
```