### PR TITLE
Make header computation in Reactive REST Client more capable

### DIFF
--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -820,7 +820,7 @@ public interface ExtensionsService {
 
 <1> There can be only one `ClientHeadersFactory` per class. With it, you can not only add custom headers, but you can also transform existing ones. See the `RequestUUIDHeaderFactory` class below for an example of the factory.
 <2> `@ClientHeaderParam` can be used on the client interface and on methods. It can specify a constant header value...
-<3> ... and a name of a method that should compute the value of the header. It can either be a static method or a default method in this interface
+<3> ... and a name of a method that should compute the value of the header. It can either be a static method or a default method in this interface. The method can take either no parameters, a single String parameter or a single `io.quarkus.rest.client.reactive.ComputedParamContext` parameter (which is very useful for code that needs to compute headers based on method parameters and naturally complements `@io.quarkus.rest.client.reactive.NotBody`).
 <4> ... as well as a value from your application's configuration
 <5> ... or as a normal Jakarta REST `@HeaderParam` annotated argument
 

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -197,6 +198,8 @@ public class JaxrsClientReactiveProcessor {
     private static final DotName PATH = DotName.createSimple(Path.class.getName());
     private static final DotName BUFFER = DotName.createSimple(Buffer.class.getName());
 
+    private static final DotName NOT_BODY = DotName.createSimple("io.quarkus.rest.client.reactive.NotBody");
+
     private static final Set<DotName> ASYNC_RETURN_TYPES = Set.of(COMPLETION_STAGE, UNI, MULTI);
     public static final DotName BYTE = DotName.createSimple(Byte.class.getName());
     public static final MethodDescriptor MULTIPART_RESPONSE_DATA_ADD_FILLER = MethodDescriptor
@@ -300,6 +303,12 @@ public class JaxrsClientReactiveProcessor {
                 .setHasRuntimeConverters(false)
                 .setDefaultProduces(defaultProducesType)
                 .setSmartDefaultProduces(disableSmartDefaultProduces.isEmpty())
+                .setSkipMethodParameter(new Predicate<Map<DotName, AnnotationInstance>>() {
+                    @Override
+                    public boolean test(Map<DotName, AnnotationInstance> anns) {
+                        return anns.containsKey(NOT_BODY);
+                    }
+                })
                 .setResourceMethodCallback(new Consumer<>() {
                     @Override
                     public void accept(EndpointIndexer.ResourceMethodCallbackData entry) {

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/BasicRestClientTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/BasicRestClientTest.java
@@ -40,6 +40,11 @@ public class BasicRestClientTest {
     }
 
     @Test
+    void shouldIgnoreNonBodyParams() {
+        assertThat(testBean.helloViaInjectedClientIgnoreParams("wor1d")).isEqualTo("hello, wor1d");
+    }
+
+    @Test
     void shouldHaveApplicationScopeByDefault() {
         BeanManager beanManager = Arc.container().beanManager();
         Set<Bean<?>> beans = beanManager.getBeans(HelloClient2.class, RestClient.LITERAL);

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/HelloClient2.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/HelloClient2.java
@@ -17,6 +17,11 @@ public interface HelloClient2 {
     @Path("/")
     String echo(String name);
 
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Path("/")
+    String echoIgnoreParams(String name, @NotBody String ignored, @NotBody String ignored2);
+
     @GET
     String bug18977();
 

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/TestBean.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/TestBean.java
@@ -25,6 +25,10 @@ public class TestBean {
         return client2.echo(name);
     }
 
+    String helloViaInjectedClientIgnoreParams(String name) {
+        return client2.echoIgnoreParams(name, "whatever", "whatever2");
+    }
+
     String helloViaBuiltClient(String name) {
         HelloClient helloClient = RestClientBuilder.newBuilder()
                 .baseUrl(url)

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/registerclientheaders/ComputedHeader.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/registerclientheaders/ComputedHeader.java
@@ -1,9 +1,15 @@
 package io.quarkus.rest.client.reactive.registerclientheaders;
 
+import io.quarkus.rest.client.reactive.ComputedParamContext;
+
 public final class ComputedHeader {
 
     public static String get() {
         return "From " + ComputedHeader.class.getName();
+    }
+
+    public static String contentType(ComputedParamContext context) {
+        return "application/json;param=" + context.methodParameters().get(1).value();
     }
 
 }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/registerclientheaders/MultipleHeadersBindingClient.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/registerclientheaders/MultipleHeadersBindingClient.java
@@ -9,16 +9,18 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
+import io.quarkus.rest.client.reactive.NotBody;
 import io.quarkus.rest.client.reactive.TestJacksonBasicMessageBodyReader;
 
 @RegisterRestClient
 @RegisterClientHeaders(MyHeadersFactory.class)
 @ClientHeaderParam(name = "my-header", value = "constant-header-value")
 @ClientHeaderParam(name = "computed-header", value = "{io.quarkus.rest.client.reactive.registerclientheaders.ComputedHeader.get}")
+@ClientHeaderParam(name = "Content-Type", value = "{io.quarkus.rest.client.reactive.registerclientheaders.ComputedHeader.contentType}")
 @RegisterProvider(TestJacksonBasicMessageBodyReader.class)
 public interface MultipleHeadersBindingClient {
     @GET
     @Path("/describe-request")
     @ClientHeaderParam(name = "header-from-properties", value = "${header.value}")
-    RequestData call(@HeaderParam("jaxrs-style-header") String headerValue);
+    RequestData call(@HeaderParam("jaxrs-style-header") String headerValue, @NotBody String usedForComputingContentType);
 }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/registerclientheaders/RegisterClientHeadersTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/registerclientheaders/RegisterClientHeadersTest.java
@@ -70,13 +70,15 @@ public class RegisterClientHeadersTest {
     @Test
     public void shouldSetHeadersFromMultipleBindings() {
         String headerValue = "my-header-value";
-        Map<String, List<String>> headers = multipleHeadersBindingClient.call(headerValue).getHeaders();
+        Map<String, List<String>> headers = multipleHeadersBindingClient.call(headerValue, "test").getHeaders();
         // Verify: @RegisterClientHeaders(MyHeadersFactory.class)
         assertThat(headers.get("foo")).containsExactly("bar");
         // Verify: @ClientHeaderParam(name = "my-header", value = "constant-header-value")
         assertThat(headers.get("my-header")).containsExactly("constant-header-value");
         // Verify: @ClientHeaderParam(name = "computed-header", value = "{...ComputedHeader.get}")
         assertThat(headers.get("computed-header")).containsExactly("From " + ComputedHeader.class.getName());
+        // Verify: @ClientHeaderParam(name = "Content-Type", value = "{...ComputedHeader.contentType}")
+        assertThat(headers.get("Content-Type")).containsExactly("application/json;param=test");
         // Verify: @ClientHeaderParam(name = "header-from-properties", value = "${header.value}")
         assertThat(headers.get("header-from-properties")).containsExactly("from property file");
         // Verify: @HeaderParam("jaxrs-style-header")

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/ComputedParamContext.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/ComputedParamContext.java
@@ -1,0 +1,23 @@
+package io.quarkus.rest.client.reactive;
+
+import java.util.List;
+
+/**
+ * Allows methods that are meant to compute a value for a Rest Client method to have access to the
+ * context on which they are invoked
+ */
+public interface ComputedParamContext {
+    /**
+     * The name of the parameter whose value is being computed
+     */
+    String name();
+
+    /**
+     * Information about the method parameters of the REST Client method for which the computed value is needed
+     */
+    List<MethodParameter> methodParameters();
+
+    interface MethodParameter {
+        Object value();
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/NotBody.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/NotBody.java
@@ -1,0 +1,17 @@
+package io.quarkus.rest.client.reactive;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The sole purpose of this annotation is to allow REST Client methods to contain multiple non-annotated Jakarta REST parameters
+ * which would normally not be allowed because all the parameters would be considered to represent the body of the request.
+ */
+@Target({ ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface NotBody {
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ComputedParamContextImpl.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ComputedParamContextImpl.java
@@ -1,0 +1,65 @@
+package io.quarkus.rest.client.reactive.runtime;
+
+import static org.jboss.resteasy.reactive.client.impl.RestClientRequestContext.INVOKED_METHOD_PARAMETERS_PROP;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+
+import io.quarkus.rest.client.reactive.ComputedParamContext;
+
+@SuppressWarnings("unused")
+public class ComputedParamContextImpl implements ComputedParamContext {
+
+    private final String name;
+    private final List<MethodParameter> parameters;
+
+    public ComputedParamContextImpl(String name, ClientRequestContext context) {
+        this.name = name;
+        this.parameters = createParameters(context);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<MethodParameter> createParameters(ClientRequestContext context) {
+        Object property = context.getProperty(INVOKED_METHOD_PARAMETERS_PROP);
+        if (property == null) {
+            throw new IllegalStateException(
+                    "property " + INVOKED_METHOD_PARAMETERS_PROP + " should have been part of the client context");
+        }
+        List<Object> methodParameterValues = (List<Object>) property;
+        if (methodParameterValues.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<MethodParameter> result = new ArrayList<>(methodParameterValues.size());
+        for (Object value : methodParameterValues) {
+            result.add(new MethodParameterImpl(value));
+        }
+        return result;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public List<MethodParameter> methodParameters() {
+        return parameters;
+    }
+
+    private static class MethodParameterImpl implements MethodParameter {
+
+        private final Object value;
+
+        private MethodParameterImpl(Object value) {
+            this.value = value;
+        }
+
+        @Override
+        public Object value() {
+            return value;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ConfigUtils.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ConfigUtils.java
@@ -19,6 +19,7 @@ public class ConfigUtils {
      * @param required whether the expression is required to be present in the configuration
      * @return null if the resulting expression is empty, otherwise the interpolated expression
      */
+    @SuppressWarnings("unused")
     public static String interpolate(String expression, boolean required) {
         StringBuilder sb = new StringBuilder(expression);
         int idx;

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ExtendedHeaderFiller.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ExtendedHeaderFiller.java
@@ -1,0 +1,16 @@
+package io.quarkus.rest.client.reactive.runtime;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
+
+import io.quarkus.rest.client.reactive.HeaderFiller;
+
+public interface ExtendedHeaderFiller extends HeaderFiller {
+
+    void addHeaders(MultivaluedMap<String, String> headers, ResteasyReactiveClientRequestContext requestContext);
+
+    default void addHeaders(MultivaluedMap<String, String> headers) {
+        throw new IllegalStateException("should not be used");
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/MicroProfileRestClientRequestFilter.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/MicroProfileRestClientRequestFilter.java
@@ -44,7 +44,12 @@ public class MicroProfileRestClientRequestFilter implements ResteasyReactiveClie
         // add headers from MP annotations
         if (headerFiller != null) {
             // add headers to a mutable headers collection
-            headerFiller.addHeaders(headers);
+            if (headerFiller instanceof ExtendedHeaderFiller) {
+                ((ExtendedHeaderFiller) headerFiller).addHeaders(headers, requestContext);
+            } else {
+                headerFiller.addHeaders(headers);
+            }
+
         }
 
         MultivaluedMap<String, String> incomingHeaders = MicroProfileRestClientRequestFilter.EMPTY_MAP;

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
@@ -55,7 +55,8 @@ import io.vertx.core.http.HttpClientResponse;
  */
 public class RestClientRequestContext extends AbstractResteasyReactiveContext<RestClientRequestContext, ClientRestHandler> {
 
-    private static final String MP_INVOKED_METHOD_PROP = "org.eclipse.microprofile.rest.client.invokedMethod";
+    public static final String INVOKED_METHOD_PROP = "org.eclipse.microprofile.rest.client.invokedMethod";
+    public static final String INVOKED_METHOD_PARAMETERS_PROP = "io.quarkus.rest.client.invokedMethodParameters";
     private static final String TMP_FILE_PATH_KEY = "tmp_file_path";
 
     private final HttpClient httpClient;
@@ -157,7 +158,7 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
     }
 
     public Method getInvokedMethod() {
-        Object o = properties.get(MP_INVOKED_METHOD_PROP);
+        Object o = properties.get(INVOKED_METHOD_PROP);
         if (o instanceof Method) {
             return (Method) o;
         }
@@ -170,7 +171,7 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
         if (res instanceof WebApplicationException) {
             var webApplicationException = (WebApplicationException) res;
             var message = webApplicationException.getMessage();
-            var invokedMethodObject = properties.get(MP_INVOKED_METHOD_PROP);
+            var invokedMethodObject = properties.get(INVOKED_METHOD_PROP);
             if ((invokedMethodObject instanceof Method) && !disableContextualErrorMessages) {
                 var invokedMethod = (Method) invokedMethodObject;
                 message = "Received: '" + message + "' when invoking: Rest Client method: '"

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ParameterType.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ParameterType.java
@@ -9,6 +9,7 @@ public enum ParameterType {
     MULTI_PART_FORM,
     MULTI_PART_DATA_INPUT,
     BODY,
+    SKIPPED,
     MATRIX,
     CONTEXT,
     ASYNC_RESPONSE,


### PR DESCRIPTION
By passing contextual information to the method that is tasked
with computing the header value, the feature is now a lot
more useful.