### PR TITLE
The annotation @RestStreamElementType should override @Produces at class

### DIFF
--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -662,15 +662,16 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                 streamElementType = streamElementTypeInMethod;
             }
 
-            String[] produces = extractProducesConsumesValues(getAnnotationStore().getAnnotation(currentMethodInfo, PRODUCES),
-                    basicResourceClassInfo.getProduces());
+            String[] produces = extractProducesConsumesValues(getAnnotationStore().getAnnotation(currentMethodInfo, PRODUCES));
             if (((produces == null) || (produces.length == 0)) && (streamElementType != null)) {
                 // when @RestStreamElementType is used, we automatically determine SSE as the @Produces MediaType
-                produces = applyDefaultProducesAndAddCharsets(httpMethod, nonAsyncReturnType,
-                        new String[] { MediaType.SERVER_SENT_EVENTS });
-            } else {
-                produces = applyDefaultProducesAndAddCharsets(httpMethod, nonAsyncReturnType, produces);
+                produces = new String[] { MediaType.SERVER_SENT_EVENTS };
+            } else if (produces == null || produces.length == 0) {
+                // use the @Produces annotation at class level if exists
+                produces = basicResourceClassInfo.getProduces();
             }
+
+            produces = applyDefaultProducesAndAddCharsets(httpMethod, nonAsyncReturnType, produces);
 
             boolean returnsMultipart = false;
             if (produces != null && produces.length == 1) {


### PR DESCRIPTION
According to [the documentation](https://quarkus.io/guides/resteasy-reactive#server-sent-event-sse-support), when using the annotation @RestStreamElementType and there is no @Produces annotation set at method level, then RR is automatically using the media type `SERVER_SENT_EVENTS`.

However, when there is no @Produces annotation set at method level, but it exists at class level, then the class level @Produces annotation will be used which is wrong.

These changes address the mentioned issue above, so if there is no @Produces annotation set at method level, then RR will always use the media type `SERVER_SENT_EVENTS` regardless if the annotation @Produces is present at class level. 

Fix https://github.com/quarkusio/quarkus/issues/32012