### PR TITLE
Remove Java 19 from Early Access JDK Build

### DIFF
--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -43,9 +43,7 @@ jobs:
             github.event_name == 'workflow_dispatch'
             && format( '{{ "include": [{{ "version": "{0}", "dist": "{1}" }}] }}',
                 github.event.inputs.jdkVersion, github.event.inputs.jdkDistribution )
-            || '{ "include": [{ "version": 19, "dist": "jdk.java.net" },
-                { "version": 20, "dist": "jdk.java.net" },
-                { "version": 21, "dist": "jdk.java.net" }] }'
+            || '{ "include": [{ "version": 20, "dist": "jdk.java.net" }, { "version": 21, "dist": "jdk.java.net" }] }'
           )
         }}
     if: "github.repository == 'quarkusio/quarkus' || github.event_name == 'workflow_dispatch'"


### PR DESCRIPTION
19 reached GA 6 months ago and even 20 has now reached GA.
19 is covered in the regular CI (not for everything but at least for the "JVM Tests").
20 cannot be added to regular CI yet because Gradle is lacking support for it (and we don't use toolchains): https://docs.gradle.org/current/userguide/compatibility.html#java