### PR TITLE
Support @PartFilename on InputStream and Multi<Byte> fields

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartForm.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartForm.java
@@ -50,7 +50,11 @@ public class QuarkusMultipartForm implements Iterable<QuarkusMultipartFormDataPa
     }
 
     public QuarkusMultipartForm entity(String name, Object entity, String mediaType, Class<?> type) {
-        pojos.add(new PojoFieldData(name, entity, mediaType, type, parts.size()));
+        return entity(name, null, entity, mediaType, type);
+    }
+
+    public QuarkusMultipartForm entity(String name, String filename, Object entity, String mediaType, Class<?> type) {
+        pojos.add(new PojoFieldData(name, filename, entity, mediaType, type, parts.size()));
         parts.add(null); // make place for ^
         return this;
     }
@@ -132,19 +136,22 @@ public class QuarkusMultipartForm implements Iterable<QuarkusMultipartFormDataPa
                     break;
                 }
             }
-            parts.set(pojo.position, new QuarkusMultipartFormDataPart(pojo.name, value, pojo.mediaType, pojo.type));
+            parts.set(pojo.position,
+                    new QuarkusMultipartFormDataPart(pojo.name, pojo.filename, value, pojo.mediaType, pojo.type));
         }
     }
 
     public static class PojoFieldData {
         private final String name;
+        private final String filename;
         private final Object entity;
         private final String mediaType;
         private final Class<?> type;
         private final int position;
 
-        public PojoFieldData(String name, Object entity, String mediaType, Class<?> type, int position) {
+        public PojoFieldData(String name, String filename, Object entity, String mediaType, Class<?> type, int position) {
             this.name = name;
+            this.filename = filename;
             this.entity = entity;
             this.mediaType = mediaType;
             this.type = type;

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartFormDataPart.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartFormDataPart.java
@@ -20,7 +20,12 @@ public class QuarkusMultipartFormDataPart {
     private final Multi<Byte> multiByteContent;
 
     public QuarkusMultipartFormDataPart(String name, Buffer content, String mediaType, Class<?> type) {
+        this(name, null, content, mediaType, type);
+    }
+
+    public QuarkusMultipartFormDataPart(String name, String filename, Buffer content, String mediaType, Class<?> type) {
         this.name = name;
+        this.filename = filename;
         this.content = content;
         this.mediaType = mediaType;
         this.type = type;
@@ -37,7 +42,6 @@ public class QuarkusMultipartFormDataPart {
         }
         this.isObject = true;
         this.value = null;
-        this.filename = null;
         this.pathname = null;
         this.text = false;
     }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartFormUpload.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartFormUpload.java
@@ -68,8 +68,12 @@ public class QuarkusMultipartFormUpload implements ReadStream<Buffer>, Runnable 
             if (formDataPart.isAttribute()) {
                 encoder.addBodyAttribute(formDataPart.name(), formDataPart.value());
             } else if (formDataPart.isObject()) {
-                MemoryFileUpload data = new MemoryFileUpload(formDataPart.name(), "", formDataPart.mediaType(),
-                        formDataPart.isText() ? null : "binary", null, formDataPart.content().length());
+                MemoryFileUpload data = new MemoryFileUpload(formDataPart.name(),
+                        formDataPart.filename() != null ? formDataPart.filename() : "",
+                        formDataPart.mediaType(),
+                        formDataPart.isText() ? null : "binary",
+                        null,
+                        formDataPart.content().length());
                 data.setContent(formDataPart.content().getByteBuf());
                 encoder.addBodyHttpData(data);
             } else if (formDataPart.multiByteContent() != null) {


### PR DESCRIPTION
This pull request fixes the support of the annotation @PartFilename on InputStream and Multi<Byte> types. Also, it extends the coverage we had to also verify these types and byte[].

Fix https://github.com/quarkusio/quarkus/issues/32032