### PR TITLE
Fix OTel exporter headers config

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -108,22 +108,26 @@ endpoint will be traced without any required code changes.
 
 === Create the configuration
 
-There are no mandatory configurations for the extension to work. If you need to change any of the default property values, here is an example on how to configure the default OTLP gRPC Exporter within the application, using the `src/main/resources/application.properties` file:
+There are no mandatory configurations for the extension to work.
+
+If you need to change any of the default property values, here is an example on how to configure the default OTLP gRPC Exporter within the application, using the `src/main/resources/application.properties` file:
 
 [source,properties]
 ----
 quarkus.application.name=myservice // <1>
 quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4317 // <2>
-quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n  // <3>
+quarkus.otel.exporter.otlp.traces.headers=authorization=Bearer my_secret // <3>
+quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n  // <4>
 
 # Alternative to the console log
-quarkus.http.access-log.pattern="...traceId=%{X,traceId} spanId=%{X,spanId}" // <4>
+quarkus.http.access-log.pattern="...traceId=%{X,traceId} spanId=%{X,spanId}" // <5>
 ----
 
 <1> All spans created from the application will include an OpenTelemetry `Resource` indicating the span was created by the `myservice` application. If not set, it will default to the artifact id.
 <2> gRPC endpoint to send spans. If not set, it will default to `http://localhost:4317`.
-<3> Add tracing information into log messages.
-<4> You can also only put the trace info into the access log. In this case you must omit the info in the console log format.
+<3> Optional gRPC headers commonly used for authentication
+<4> Add tracing information into log messages.
+<5> You can also only put the trace info into the access log. In this case you must omit the info in the console log format.
 
 [NOTE]
 ====

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/OtelConfigRelocateConfigSourceInterceptor.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/OtelConfigRelocateConfigSourceInterceptor.java
@@ -55,6 +55,8 @@ public class OtelConfigRelocateConfigSourceInterceptor extends RelocateConfigSou
                 "quarkus.otel.traces.suppress-non-application-uris");
         relocations.put("quarkus.opentelemetry.tracer.include-static-resources",
                 "quarkus.otel.traces.include-static-resources");
+        relocations.put("quarkus.opentelemetry.tracer.exporter.otlp.headers",
+                "quarkus.otel.exporter.otlp.traces.headers");
         return Collections.unmodifiableMap(relocations);
     }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterRuntimeConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterRuntimeConfig.java
@@ -1,7 +1,5 @@
 package io.quarkus.opentelemetry.runtime.config.runtime.exporter;
 
-import java.time.Duration;
-import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -25,64 +23,7 @@ public class OtlpExporterRuntimeConfig {
     public OtlpExporterTracesConfig traces;
     // TODO metrics();
     // TODO logs();
-
-    //    /**
-    //     * Sets the certificate chain to use for verifying servers when TLS is enabled. The {@code byte[]}
-    //     * should contain an X.509 certificate collection in PEM format. If not set, TLS connections will
-    //     * use the system default trusted certificates.
-    //     */
-    //    @ConfigItem()
-    //    public Optional<byte[]> certificate;
-
-    //    /**
-    //     * Sets ths client key and the certificate chain to use for verifying client when TLS is enabled.
-    //     * The key must be PKCS8, and both must be in PEM format.
-    //     */
-    //    @ConfigItem()
-    //    public Optional<ClientTlsConfig> client;
-
-    /**
-     * Add header to request. Optional.
-     */
-    @ConfigItem()
-    public Map<String, String> headers;
-
-    /**
-     * Sets the method used to compress payloads. If unset, compression is disabled. Currently
-     * supported compression methods include "gzip" and "none".
-     */
-    @ConfigItem()
-    public Optional<OtelConnectionRuntimeConfig.CompressionType> compression;
-
-    /**
-     * Sets the maximum time to wait for the collector to process an exported batch of spans. If
-     * unset, defaults to {@value OtelConnectionRuntimeConfig.Constants#DEFAULT_TIMEOUT_SECS}s.
-     */
-    @ConfigItem(defaultValue = OtelConnectionRuntimeConfig.Constants.DEFAULT_TIMEOUT_SECS)
-    public Duration timeout;
-
-    /**
-     * OTLP defines the encoding of telemetry data and the protocol used to exchange data between the client and the server.
-     * Depending on the exporter, the available protocols will be different.
-     */
-    @ConfigItem()
-    public Optional<String> protocol;
-
-    //    @ConfigGroup
-    //    public class ClientTlsConfig {
-    //
-    //        /**
-    //         * Key
-    //         */
-    //        @ConfigItem()
-    //        public byte[] key;
-    //
-    //        /**
-    //         * Certificate
-    //         */
-    //        @ConfigItem()
-    //        public byte[] certificate;
-    //    }
+    // TODO additional global exporter configuration
 
     /**
      * From <a href=

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterTracesConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterTracesConfig.java
@@ -53,11 +53,9 @@ public class OtlpExporterTracesConfig extends OtelConnectionRuntimeConfig {
     /**
      * Key-value pairs to be used as headers associated with gRPC requests.
      * The format is similar to the {@code OTEL_EXPORTER_OTLP_HEADERS} environment variable,
-     * a list of key-value pairs separated by the "=" character.
-     * See <a href=
-     * "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables">
-     * Specifying headers</a> for more details.
+     * a list of key-value pairs separated by the "=" character. i.e.: key1=value1,key2=value2
      */
+    @ConfigItem(defaultValue = "${quarkus.opentelemetry.tracer.exporter.otlp.headers}")
     public Map<String, String> headers;
 
     /**


### PR DESCRIPTION
Mapping between the old and the new header config was missing.
Improved the documentation.
Removed future properties to avoid entropy. These global properties will make sense when we support metrics and log exports. 