### PR TITLE
Add missing mp-health and mp-fault-tolerance apis in bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -46,9 +46,11 @@
         <hdrhistogram.version>2.1.12</hdrhistogram.version><!-- keep in sync with micrometer -->
         <google-auth.version>0.22.0</google-auth.version>
         <microprofile-config-api.version>3.0.2</microprofile-config-api.version>
+        <microprofile-health-api.version>4.0</microprofile-health-api.version>
         <microprofile-metrics-api.version>4.0.1</microprofile-metrics-api.version>
         <microprofile-context-propagation.version>1.3</microprofile-context-propagation.version>
         <microprofile-opentracing-api.version>3.0</microprofile-opentracing-api.version>
+        <microprofile-fault-tolerance-api.version>4.0.2</microprofile-fault-tolerance-api.version>
         <microprofile-reactive-streams-operators.version>3.0</microprofile-reactive-streams-operators.version>
         <microprofile-rest-client.version>3.0.1</microprofile-rest-client.version>
         <microprofile-jwt.version>2.1</microprofile-jwt.version>
@@ -4372,6 +4374,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.microprofile.health</groupId>
+                <artifactId>microprofile-health-api</artifactId>
+                <version>${microprofile-health-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.eclipse.microprofile.metrics</groupId>
                 <artifactId>microprofile-metrics-api</artifactId>
                 <version>${microprofile-metrics-api.version}</version>
@@ -4397,6 +4404,11 @@
                         <artifactId>org.osgi.annotation.versioning</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+                <artifactId>microprofile-fault-tolerance-api</artifactId>
+                <version>${microprofile-fault-tolerance-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.rest.client</groupId>


### PR DESCRIPTION
Some context: we are using [maven-dependency-plugin:analyze-only](https://maven.apache.org/plugins/maven-dependency-plugin/analyze-only-mojo.html) to check for used but undeclared dependencies.
This has allowed us to make sure our internal bill-of-materials (which imports the quarkus-bom) is "complete" and that we don't compile on transitive dependencies, without seeing them clearly in pull-request diffs of a pom.xml.
However today it's a manual step when upgrading Quarkus versions to find the corresponding mp-health/mp-fault-tolerance versions, as auto-update bots are not smart enough to bundle all compatible versions.