### PR TITLE
Remove the session cookie if ID token verification failed

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -321,8 +321,13 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
                                             if (!expired) {
                                                 LOG.errorf("ID token verification failure: %s", t.getCause());
-                                                return Uni.createFrom()
-                                                        .failure(new AuthenticationCompletionException(t.getCause()));
+                                                return removeSessionCookie(context, configContext.oidcConfig)
+                                                        .replaceWith(Uni.createFrom()
+                                                                .failure(t
+                                                                        .getCause() instanceof AuthenticationCompletionException
+                                                                                ? t.getCause()
+                                                                                : new AuthenticationCompletionException(
+                                                                                        t.getCause())));
                                             }
                                             // Token has expired, try to refresh
                                             if (session.getRefreshToken() == null) {

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -564,6 +564,22 @@ public class CodeFlowTest {
             page = webClient.getPage("http://localhost:8081/web-app");
 
             assertEquals("alice", page.getBody().asNormalizedText());
+
+            Cookie sessionCookie = getSessionCookie(webClient, null);
+            assertNotNull(sessionCookie);
+            webClient.getCookieManager().clearCookies();
+            webClient.getCookieManager().addCookie(new Cookie(sessionCookie.getDomain(), sessionCookie.getName(),
+                    "1|2|3"));
+            sessionCookie = getSessionCookie(webClient, null);
+            assertEquals("1|2|3", sessionCookie.getValue());
+
+            try {
+                webClient.getPage("http://localhost:8081/web-app");
+                fail("401 status error is expected");
+            } catch (FailingHttpStatusCodeException ex) {
+                assertEquals(401, ex.getStatusCode());
+                assertNull(getSessionCookie(webClient, null));
+            }
             webClient.getCookieManager().clearCookies();
         }
     }


### PR DESCRIPTION
Fixes #31717

If the ID token verification fails then the session cookie has to be cleared - currently 401 is immediately returned and the user gets stuck. 

Note this exception is caused by `AuthenticationCompletionException` meaning no redirect to OIDC provider will be happening, user just gets `401`. In some cases when no session cookie exists for example, we'd throw `AuthenticationFailedException` leading to `302` and redirect to the provider. In this case though if for example the signature verification has failed then it means something gone badly wrong somewhere and just redirecting to the provider ro reauthenticate would be a problem, it may make some serious underlying security issue unnoticed.
So I think we should continue returning 401 in such cases but indeed get rid of the session cookie - for example, the application, if it wants, can catch the exception and offer a user an option to access a secured Quarkus page again which will cause the expected redirect back to the OIDC provider etc