### PR TITLE
K8s moved its registry

### DIFF
--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/DevServicesKubernetesProcessor.java
@@ -343,7 +343,8 @@ public class DevServicesKubernetesProcessor {
                 return getKubernetesClientConfigFromKubeConfig(
                         KubeConfigUtils.parseKubeConfig(KubeConfigUtils.replaceServerInKubeconfig(containerAddress.getUrl(),
                                 getFileContentFromContainer(KIND_KUBECONFIG))));
-            } else if (image.contains("k8s.gcr.io/kube-apiserver")) {
+            } else if (image.contains("k8s.gcr.io/kube-apiserver") ||
+                    image.contains("registry.k8s.io/kube-apiserver")) {
                 return getKubernetesClientConfigFromKubeConfig(getKubeconfigFromApiContainer(containerAddress.getUrl()));
             }
 


### PR DESCRIPTION
old registry k8s.grc.io will be phased out use registry.k8s.io instead

fixes #32041