### PR TITLE
Re-use current ApplicationModel for JaCoCo reports when testing Gradle projects

### DIFF
--- a/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
+++ b/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
@@ -16,7 +16,6 @@ import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
 import org.jboss.jandex.ClassInfo;
 
 import io.quarkus.bootstrap.model.ApplicationModel;
-import io.quarkus.bootstrap.utils.BuildToolHelper;
 import io.quarkus.bootstrap.workspace.SourceDir;
 import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.IsTest;
@@ -105,17 +104,7 @@ public class JacocoProcessor {
             info.classFiles = classes;
 
             Set<String> sources = new HashSet<>();
-            ApplicationModel model;
-            if (BuildToolHelper.isMavenProject(targetdir.toPath())) {
-                model = curateOutcomeBuildItem.getApplicationModel();
-            } else if (BuildToolHelper.isGradleProject(targetdir.toPath())) {
-                //this seems counter productive, but we want the dev mode model and not the test model
-                //as the test model will include the test classes that we don't want in the report
-                model = BuildToolHelper.enableGradleAppModelForDevMode(targetdir.toPath());
-            } else {
-                throw new RuntimeException("Cannot determine project type generating Jacoco report");
-            }
-
+            final ApplicationModel model = curateOutcomeBuildItem.getApplicationModel();
             if (model.getApplicationModule() != null) {
                 addProjectModule(model.getAppArtifact(), config, info, includes, excludes, classes, sources);
             }


### PR DESCRIPTION
Fix #32079

This change could potentially re-introduce an issue fixed in https://github.com/quarkusio/quarkus/commit/beb0db6e72621e2d28d8ddec11670bdaa395f27c, although at the time the impl was a bit different. Unfortunately, the reproducer in the issue fixed by that commit isn't available any more to test this change.

However, I think we should be consistent with Maven here, which re-uses the current ApplicationModel (resolved for test mode). If we do get reports about a regression, we'll probably get new reproducers or info and we could look into applying dependency classifier-based filters.