### PR TITLE
Possible IT test for testing the case where the Mongo has _id & id fields

### DIFF
--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/duplicateids/TestDuplicateIdEntity.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/duplicateids/TestDuplicateIdEntity.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.mongodb.panache.duplicateids;
+
+import org.bson.codecs.pojo.annotations.BsonProperty;
+import org.bson.types.ObjectId;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntityBase;
+
+public class TestDuplicateIdEntity extends PanacheMongoEntityBase {
+
+    @BsonProperty(value = "_id")
+    public ObjectId objectId;
+
+    public String id;
+
+    public TestDuplicateIdEntity() {
+    }
+
+    public TestDuplicateIdEntity(String id) {
+        this.id = id;
+    }
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/duplicateids/TestDuplicateIdRepository.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/duplicateids/TestDuplicateIdRepository.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.mongodb.panache.duplicateids;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoRepository;
+
+@ApplicationScoped
+public class TestDuplicateIdRepository implements ReactivePanacheMongoRepository<TestDuplicateIdEntity> {
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/duplicateids/TestResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/duplicateids/TestResource.java
@@ -1,0 +1,107 @@
+package io.quarkus.it.mongodb.panache.duplicateids;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Assertions;
+
+@Path("/testDuplicateId")
+public class TestResource {
+
+    @Inject
+    TestDuplicateIdRepository testDuplicateIdRepository;
+
+    @GET
+    @Path("imperative/entity")
+    public Response TestDuplicateIdEntity() {
+        List<TestDuplicateIdEntity> entities = getTestImperativeEntities();
+
+        // insert all
+        Assertions.assertEquals(0, TestDuplicateIdEntity.count());
+        TestDuplicateIdEntity.persist(entities);
+        Assertions.assertEquals(10, TestDuplicateIdEntity.count());
+
+        // Verify that the _id is set
+        verifyIdsSet(entities);
+
+        // varargs
+        TestDuplicateIdEntity entity11 = new TestDuplicateIdEntity("id11");
+        TestDuplicateIdEntity entity12 = new TestDuplicateIdEntity("id11");
+        TestDuplicateIdEntity.persist(entity11, entity12);
+        Assertions.assertEquals(12, TestDuplicateIdEntity.count());
+        entity11.id = "id11Updated";
+        entity12.id = "id12Updated";
+        TestDuplicateIdEntity.update(entity11, entity12);
+        entity11.delete();
+        entity12.delete();
+        Assertions.assertEquals(10, TestDuplicateIdEntity.count());
+        TestDuplicateIdEntity.persistOrUpdate(entity11, entity12);
+        Assertions.assertEquals(12, TestDuplicateIdEntity.count());
+        entity11.id = "id11Updated";
+        entity12.id = "id12Updated";
+        TestDuplicateIdEntity.persistOrUpdate(entity11, entity12);
+        entity11.delete();
+        entity12.delete();
+        Assertions.assertEquals(10, TestDuplicateIdEntity.count());
+
+        return Response.ok().build();
+    }
+
+    private void verifyIdsSet(List<TestDuplicateIdEntity> entities) {
+        for (TestDuplicateIdEntity testDuplicateIdEntity : entities) {
+
+            // This is the key...must not be null.  Field is _id in Mongo.
+            Assertions.assertNotNull(testDuplicateIdEntity.objectId);
+            Assertions.assertNotNull(testDuplicateIdEntity.id);
+        }
+    }
+
+    @GET
+    @Path("imperative/repository")
+    public Response testImperativeRepository() {
+        List<TestDuplicateIdEntity> entities = getTestImperativeEntities();
+
+        // insert all
+        Assertions.assertEquals(0, testDuplicateIdRepository.count());
+        testDuplicateIdRepository.persist(entities);
+        Assertions.assertEquals(10, testDuplicateIdRepository.count());
+
+        // Verify that the _id is set
+        verifyIdsSet(entities);
+
+        // varargs
+        TestDuplicateIdEntity entity11 = new TestDuplicateIdEntity("id11");
+        TestDuplicateIdEntity entity12 = new TestDuplicateIdEntity("id12");
+        testDuplicateIdRepository.persist(entity11, entity12);
+        Assertions.assertEquals(12, testDuplicateIdRepository.count());
+        entity11.id = "id11Updated";
+        entity12.id = "id12Updated";
+        testDuplicateIdRepository.update(entity11, entity12);
+        entity11.delete();
+        entity12.delete();
+        Assertions.assertEquals(10, testDuplicateIdRepository.count());
+        testDuplicateIdRepository.persistOrUpdate(entity11, entity12);
+        Assertions.assertEquals(12, testDuplicateIdRepository.count());
+        entity11.id = "id11Updated";
+        entity12.id = "id12Updated";
+        testDuplicateIdRepository.persistOrUpdate(entity11, entity12);
+        entity11.delete();
+        entity12.delete();
+        Assertions.assertEquals(10, testDuplicateIdRepository.count());
+
+        return Response.ok().build();
+    }
+
+    private List<TestDuplicateIdEntity> getTestImperativeEntities() {
+        List<TestDuplicateIdEntity> entities = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            entities.add(new TestDuplicateIdEntity("id" + i));
+        }
+        return entities;
+    }
+}

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheDuplicateIdTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheDuplicateIdTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.mongodb.panache;
+
+import static io.restassured.RestAssured.get;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.mongodb.MongoReplicaSetTestResource;
+
+@QuarkusTest
+@QuarkusTestResource(MongoReplicaSetTestResource.class)
+//@DisabledOnOs(OS.WINDOWS)
+class MongodbPanacheDuplicateIdTest {
+
+    @Test
+    public void testMoreEntityFunctionalities() {
+        get("/testDuplicateId/imperative/entity").then().statusCode(200);
+    }
+
+    @Test
+    public void testMoreRepositoryFunctionalities() {
+        get("/testDuplicateId/imperative/repository").then().statusCode(200);
+    }
+}


### PR DESCRIPTION
Branch contains possible IT test for testing the case where the Mongo record has both an _id & id field.  

Also contains my change in MongoClients to allow this to work, however all the PojoCodec Conventions should be configurable.  

Note I could not successfully run a complete build with all tests as I run on Windows it appears that IT tests are disabled on Windows.