### PR TITLE
Disable validation of JAXBContext by default

### DIFF
--- a/extensions/jaxb/deployment/pom.xml
+++ b/extensions/jaxb/deployment/pom.xml
@@ -52,6 +52,13 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Duser.language=en</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/ConflictingModelClassesMarshalerOnlyTest.java
+++ b/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/ConflictingModelClassesMarshalerOnlyTest.java
@@ -26,6 +26,7 @@ public class ConflictingModelClassesMarshalerOnlyTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-enable-validation.properties")
             .withApplicationRoot((jar) -> jar
                     .addClasses(
                             io.quarkus.jaxb.deployment.one.Model.class,

--- a/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/ConflictingModelClassesTest.java
+++ b/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/ConflictingModelClassesTest.java
@@ -25,6 +25,7 @@ public class ConflictingModelClassesTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-enable-validation.properties")
             .withApplicationRoot((jar) -> jar
                     .addClasses(
                             io.quarkus.jaxb.deployment.one.Model.class,

--- a/extensions/jaxb/deployment/src/test/resources/application-enable-validation.properties
+++ b/extensions/jaxb/deployment/src/test/resources/application-enable-validation.properties
@@ -1,0 +1,1 @@
+quarkus.jaxb.validate-jaxb-context=true

--- a/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbConfig.java
+++ b/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbConfig.java
@@ -13,7 +13,7 @@ public class JaxbConfig {
     /**
      * If enabled, it will validate the default JAXB context at build time.
      */
-    @ConfigItem(defaultValue = "true")
+    @ConfigItem(defaultValue = "false")
     public boolean validateJaxbContext;
 
     /**


### PR DESCRIPTION
Since the validation of the JAXBContext is causing lots of troubles to users, we're going to disable it by default.  

Relates to https://github.com/quarkusio/quarkus/pull/31043#issuecomment-1482430997