### PR TITLE
Prevent splitting of cookie header values when using AWS Lambda

### DIFF
--- a/extensions/amazon-lambda-http/http-event-server/src/main/java/io/quarkus/amazon/lambda/runtime/MockHttpEventServer.java
+++ b/extensions/amazon-lambda-http/http-event-server/src/main/java/io/quarkus/amazon/lambda/runtime/MockHttpEventServer.java
@@ -128,6 +128,11 @@ public class MockHttpEventServer extends MockEventServer {
                         }
                     }
                 }
+                if (res.getCookies() != null) {
+                    for (String cookie : res.getCookies()) {
+                        response.headers().add("set-cookie", cookie);
+                    }
+                }
                 response.setStatusCode(res.getStatusCode());
                 String body = res.getBody();
                 if (body != null) {

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -108,6 +108,11 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
                         if (allForName == null || allForName.isEmpty()) {
                             continue;
                         }
+                        // Handle cookies separately to preserve commas in the header values
+                        if ("set-cookie".equals(name)) {
+                            responseBuilder.setCookies(allForName);
+                            continue;
+                        }
                         final StringBuilder sb = new StringBuilder();
                         for (Iterator<String> valueIterator = allForName.iterator(); valueIterator.hasNext();) {
                             sb.append(valueIterator.next());


### PR DESCRIPTION
This fixes #32037 by using the `cookies` property of the Lambda response object to set `Set-Cookie` header values. I also adjusted the `MockHttpEventServer`, so the cookies property is correctly picked up when using the dev server.

The underlying issue is that AWS API Gateway request and response objects contain a header property that contains keys for header names and string values for the header values. However, the string values are ambiguous since a comma within them can either just be a comma in the header value or split two values for separate header lines with the same header name.

Example:
```json
{"set-cookie": "a,b"}
```
may either mean
```
set-cookie: a
set-cookie: b
```
or
```
set-cookie: a,b
```

AWS API Gateway will always interpret the JSON in the first manner which breaks e.g. cookies used with OIDC. This PR uses the specialized `cookies` property of the API Gateway response object to avoid that issue.

This still is not a fix that handles all possible headers, but such a fix would probably require "downgrading" to payload version 1.0 of the AWS Api Gateway in order to use the `multiValueHeaders` property which would probably be a breaking change. After reading [this documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html), I do not see a robust way to receive or send headers while using payload format 2.0.

This fix still handles the common case of cookie headers, when commas in the expiration property will trigger the bug.

For the usage at our company we would also need a backport of this fix to Quarkus 2.x. I think this would generally be useful, since I don't see a way one could currently use Lambda deployment together with OIDC or any other technology that makes use of cookies with expirations without a fix such as this one.

I think this is my first pull request on github, so please feel free to point me to any mistakes I have made.

@patriot1burke, since you fixed the previous issue I had with quarkus and that one went in a similar direction, maybe you could have a look at this PR, too