### PR TITLE
Rename `InitalizationTaskCompletedBuildItem` to `InitTaskCompletedBuildItem`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/InitTaskBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/InitTaskBuildItem.java
@@ -8,9 +8,9 @@ import java.util.Optional;
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
- * Represents an initalization task for the application.
+ * Represents an initialization task for the application.
  * Often extension perform some sort of initialization as part of the application startup.
- * There are cases where we we want to externalize the initialization (e.g. in a pipeline).
+ * There are cases where we want to externalize the initialization (e.g. in a pipeline).
  *
  * Often the task is run using the same artifact as the application but using a different command or
  * arguments. In the later case it might be deseriable to pass additional environment variable to both the

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/InitTaskCompletedBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/InitTaskCompletedBuildItem.java
@@ -7,13 +7,13 @@ import io.quarkus.builder.item.MultiBuildItem;
  * Similar to {@link ServiceStartBuildItem} but focused on initialization tasks (e.g. db migrations etc) that are run during
  * runtime just before the application startups.
  * <p>
- * The build item is used, so that we can track when all intialization tasks have been completed.
+ * The build item is used, so that we can track when all initialization tasks have been completed.
  */
-public final class InitalizationTaskCompletedBuildItem extends MultiBuildItem {
+public final class InitTaskCompletedBuildItem extends MultiBuildItem {
 
     private final String name;
 
-    public InitalizationTaskCompletedBuildItem(String name) {
+    public InitTaskCompletedBuildItem(String name) {
         this.name = name;
     }
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/init/InitializtionTaskProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/init/InitializtionTaskProcessor.java
@@ -7,11 +7,12 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.InitalizationTaskCompletedBuildItem;
+import io.quarkus.deployment.builditem.InitTaskCompletedBuildItem;
 import io.quarkus.runtime.init.InitializationTaskRecorder;
 
 /**
- * A processor that is used to track all {@link InitalizationTaskCompletedBuildItem} in order to exit once they are completed if
+ * A processor that is used to track all {@link io.quarkus.deployment.builditem.InitTaskCompletedBuildItem} in order to exit
+ * once they are completed if
  * needed.
  */
 public class InitializtionTaskProcessor {
@@ -20,7 +21,7 @@ public class InitializtionTaskProcessor {
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void startApplicationInitializer(InitializationTaskRecorder recorder,
-            List<InitalizationTaskCompletedBuildItem> initalizationCompletedBuildItems) {
+            List<InitTaskCompletedBuildItem> initTaskCompletedBuildItems) {
         recorder.exitIfNeeded();
     }
 }

--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
@@ -51,7 +51,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.InitTaskBuildItem;
-import io.quarkus.deployment.builditem.InitalizationTaskCompletedBuildItem;
+import io.quarkus.deployment.builditem.InitTaskCompletedBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -208,7 +208,7 @@ class FlywayProcessor {
     public ServiceStartBuildItem startActions(FlywayRecorder recorder,
             FlywayRuntimeConfig config,
             BuildProducer<JdbcDataSourceSchemaReadyBuildItem> schemaReadyBuildItem,
-            BuildProducer<InitalizationTaskCompletedBuildItem> initializationCompleteBuildItem,
+            BuildProducer<InitTaskCompletedBuildItem> initializationCompleteBuildItem,
             MigrationStateBuildItem migrationsBuildItem) {
 
         recorder.doStartActions();
@@ -216,7 +216,7 @@ class FlywayProcessor {
         // once we are done running the migrations, we produce a build item indicating that the
         // schema is "ready"
         schemaReadyBuildItem.produce(new JdbcDataSourceSchemaReadyBuildItem(migrationsBuildItem.hasMigrations));
-        initializationCompleteBuildItem.produce(new InitalizationTaskCompletedBuildItem("flyway"));
+        initializationCompleteBuildItem.produce(new InitTaskCompletedBuildItem("flyway"));
         return new ServiceStartBuildItem("flyway");
     }
 

--- a/extensions/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
+++ b/extensions/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
@@ -33,7 +33,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.InitTaskBuildItem;
-import io.quarkus.deployment.builditem.InitalizationTaskCompletedBuildItem;
+import io.quarkus.deployment.builditem.InitTaskCompletedBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -246,10 +246,10 @@ class LiquibaseMongodbProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
     ServiceStartBuildItem startLiquibase(LiquibaseMongodbRecorder recorder,
-            BuildProducer<InitalizationTaskCompletedBuildItem> initializationCompleteBuildItem) {
+            BuildProducer<InitTaskCompletedBuildItem> initializationCompleteBuildItem) {
         // will actually run the actions at runtime
         recorder.doStartActions();
-        initializationCompleteBuildItem.produce(new InitalizationTaskCompletedBuildItem("liquibase-mongodb"));
+        initializationCompleteBuildItem.produce(new InitTaskCompletedBuildItem("liquibase-mongodb"));
         return new ServiceStartBuildItem("liquibase-mongodb");
     }
 

--- a/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
+++ b/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
@@ -44,7 +44,7 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.InitTaskBuildItem;
-import io.quarkus.deployment.builditem.InitalizationTaskCompletedBuildItem;
+import io.quarkus.deployment.builditem.InitTaskCompletedBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
@@ -301,14 +301,14 @@ class LiquibaseProcessor {
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
     ServiceStartBuildItem startLiquibase(LiquibaseRecorder recorder,
             List<JdbcDataSourceBuildItem> jdbcDataSourceBuildItems,
-            BuildProducer<InitalizationTaskCompletedBuildItem> initializationCompleteBuildItem,
+            BuildProducer<InitTaskCompletedBuildItem> initializationCompleteBuildItem,
             BuildProducer<JdbcDataSourceSchemaReadyBuildItem> schemaReadyBuildItem) {
 
         recorder.doStartActions();
         // once we are done running the migrations, we produce a build item indicating that the
         // schema is "ready"
         schemaReadyBuildItem.produce(new JdbcDataSourceSchemaReadyBuildItem(getDataSourceNames(jdbcDataSourceBuildItems)));
-        initializationCompleteBuildItem.produce(new InitalizationTaskCompletedBuildItem("liquibase"));
+        initializationCompleteBuildItem.produce(new InitTaskCompletedBuildItem("liquibase"));
 
         return new ServiceStartBuildItem("liquibase");
     }


### PR DESCRIPTION
- Because the original class name has a typo (missing the `i`) and it matches the intent with the existing `InitTaskBuildItem`