### PR TITLE
ArC AnnotationsTransformer - add more specific builders

### DIFF
--- a/docs/src/main/asciidoc/cdi-integration.adoc
+++ b/docs/src/main/asciidoc/cdi-integration.adoc
@@ -157,14 +157,32 @@ For example, classes from the _runtime module_ of a Quarkus extension are not in
 _Solution_: Use the `AdditionalBeanBuildItem` as described in <<additional_bean_build_item>>. 
 
 [[annotations_transformer_build_item]]
-== Use Case - I Need To Transform Metadata
+== Use Case - I Need To Transform Annotation Metadata
 
-In some cases, it's useful to be able to modify the metadata.
+In some cases, it's useful to be able to modify the annotation metadata.
 Quarkus provides a powerful alternative to https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html#process_annotated_type[`jakarta.enterprise.inject.spi.ProcessAnnotatedType`, window="_blank"].
 With an `AnnotationsTransformerBuildItem` it's possible to override the annotations that exist on bean classes.
 
+NOTE: Keep in mind that annotation transformers must be produced _before_ the bean discovery starts.
+
 For example, you might want to add an interceptor binding to a specific bean class.
-Here is how to do it: 
+You can use a convenient builder-like API to create a transformer instance:
+
+Builder Example
+[source,java]
+----
+@BuildStep
+AnnotationsTransformerBuildItem transform() {
+   return new AnnotationsTransformerBuildItem(AnnotationsTransformer.appliedToClass() <1>
+        .whenClass(c -> c.name().toString().equals("org.acme.Bar")) <2>
+        .thenTransform(t -> t.add(MyInterceptorBinding.class))); <3>
+}
+----
+<1> The transformer is only applied to classes.
+<2> Only apply the transformation if the class name equals to `org.acme.Bar`.
+<3> Add the `@MyInterceptorBinding` annotation.
+
+The example above can be rewritten with an anonymous class:
 
 .`AnnotationsTransformerBuildItem` Example
 [source,java]
@@ -187,8 +205,6 @@ AnnotationsTransformerBuildItem transform() {
 ----
 <1> The transformer is only applied to classes.
 <2> If the class name equals to `org.acme.Bar` then add `@MyInterceptorBinding`. Don't forget to invoke `Transformation#done()`.
-
-NOTE: Keep in mind that annotation transformers must be produced _before_ the bean discovery starts.
 
 Build steps can query the transformed annotations for a given annotation target via the `TransformedAnnotationsBuildItem`.
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationsTransformer.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationsTransformer.java
@@ -6,13 +6,17 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.MethodInfo;
 
 /**
  * Allows a build-time extension to override the annotations that exist on bean classes.
@@ -35,6 +39,10 @@ public interface AnnotationsTransformer extends BuildExtension {
     }
 
     /**
+     * The transformation context is used to perform the transformation. In particular,
+     * {@link TransformationContext#transform()}
+     * returns a new transformation object that can be used to alter annotation metadata. Note that the transformation is not
+     * applied until the {@link Transformation#done()} method is invoked.
      *
      * @param transformationContext
      */
@@ -43,9 +51,36 @@ public interface AnnotationsTransformer extends BuildExtension {
     /**
      *
      * @return a new builder instance
+     * @see #appliedToMethod()
+     * @see #appliedToField()
+     * @see #appliedToClass()
      */
     static Builder builder() {
         return new Builder();
+    }
+
+    /**
+     *
+     * @return a new builder to transform methods
+     */
+    static MethodTransformerBuilder appliedToMethod() {
+        return new MethodTransformerBuilder();
+    }
+
+    /**
+     *
+     * @return a new builder to transform fields
+     */
+    static FieldTransformerBuilder appliedToField() {
+        return new FieldTransformerBuilder();
+    }
+
+    /**
+     *
+     * @return a new builder to transform class
+     */
+    static ClassTransformerBuilder appliedToClass() {
+        return new ClassTransformerBuilder();
     }
 
     /**
@@ -53,9 +88,16 @@ public interface AnnotationsTransformer extends BuildExtension {
      */
     interface TransformationContext extends BuildContext {
 
+        /**
+         * Returns the annotated class, method or field.
+         *
+         * @return the annotation target
+         */
         AnnotationTarget getTarget();
 
         /**
+         * Returns the current set of annotations.
+         * <p>
          * The initial set of annotations instances corresponds to {@link org.jboss.jandex.ClassInfo#classAnnotations()},
          * {@link org.jboss.jandex.FieldInfo#annotations()} and {@link org.jboss.jandex.MethodInfo#annotations()} respectively.
          *
@@ -85,17 +127,11 @@ public interface AnnotationsTransformer extends BuildExtension {
     }
 
     /**
-     * A convenient builder.
+     * A common {@link AnnotationsTransformer} builder.
      */
-    static final class Builder {
+    public final static class Builder extends AbstractBuilder<Builder> {
 
-        private int priority;
-        private Predicate<Kind> appliesTo;
-        private Predicate<TransformationContext> predicate;
-
-        private Builder() {
-            this.priority = DEFAULT_PRIORITY;
-        }
+        protected Predicate<Kind> appliesTo;
 
         /**
          *
@@ -118,14 +154,100 @@ public interface AnnotationsTransformer extends BuildExtension {
             return this;
         }
 
+        @Override
+        public boolean test(Kind kind) {
+            return appliesTo == null || appliesTo.test(kind);
+        }
+
+    }
+
+    public final static class MethodTransformerBuilder extends AbstractBuilder<MethodTransformerBuilder> {
+
+        /**
+         * The method must meet the given condition.
+         *
+         * @param condition
+         * @return self
+         */
+        public MethodTransformerBuilder whenMethod(Predicate<MethodInfo> condition) {
+            return when(wrap(condition, MethodTransformerBuilder::extract));
+        }
+
+        @Override
+        public boolean test(Kind kind) {
+            return kind == Kind.METHOD;
+        }
+
+        private static MethodInfo extract(TransformationContext ctx) {
+            return ctx.getTarget().asMethod();
+        }
+
+    }
+
+    public final static class FieldTransformerBuilder extends AbstractBuilder<FieldTransformerBuilder> {
+
+        /**
+         * The field must meet the given condition.
+         *
+         * @param condition
+         * @return self
+         */
+        public FieldTransformerBuilder whenField(Predicate<FieldInfo> condition) {
+            return when(wrap(condition, FieldTransformerBuilder::extract));
+        }
+
+        @Override
+        public boolean test(Kind kind) {
+            return kind == Kind.FIELD;
+        }
+
+        private static FieldInfo extract(TransformationContext ctx) {
+            return ctx.getTarget().asField();
+        }
+
+    }
+
+    public final static class ClassTransformerBuilder extends AbstractBuilder<ClassTransformerBuilder> {
+
+        /**
+         * The class must meet the given condition.
+         *
+         * @param condition
+         * @return self
+         */
+        public ClassTransformerBuilder whenClass(Predicate<ClassInfo> condition) {
+            return when(wrap(condition, ClassTransformerBuilder::extract));
+        }
+
+        @Override
+        public boolean test(Kind kind) {
+            return kind == Kind.CLASS;
+        }
+
+        private static ClassInfo extract(TransformationContext ctx) {
+            return ctx.getTarget().asClass();
+        }
+
+    }
+
+    public abstract static class AbstractBuilder<THIS extends AbstractBuilder<THIS>>
+            implements Predicate<Kind> {
+
+        protected int priority;
+        protected Predicate<TransformationContext> predicate;
+
+        private AbstractBuilder() {
+            this.priority = DEFAULT_PRIORITY;
+        }
+
         /**
          *
          * @param priority
          * @return self
          */
-        public Builder priority(int priority) {
+        public THIS priority(int priority) {
             this.priority = priority;
-            return this;
+            return self();
         }
 
         /**
@@ -134,7 +256,7 @@ public interface AnnotationsTransformer extends BuildExtension {
          * @param annotationNames
          * @return self
          */
-        public Builder whenContainsAll(List<DotName> annotationNames) {
+        public THIS whenContainsAll(List<DotName> annotationNames) {
             return when(context -> {
                 for (DotName annotationName : annotationNames) {
                     if (!Annotations.contains(context.getAnnotations(), annotationName)) {
@@ -151,7 +273,7 @@ public interface AnnotationsTransformer extends BuildExtension {
          * @param annotationNames
          * @return self
          */
-        public Builder whenContainsAll(DotName... annotationNames) {
+        public THIS whenContainsAll(DotName... annotationNames) {
             return whenContainsAll(List.of(annotationNames));
         }
 
@@ -162,7 +284,7 @@ public interface AnnotationsTransformer extends BuildExtension {
          * @return self
          */
         @SafeVarargs
-        public final Builder whenContainsAll(Class<? extends Annotation>... annotationNames) {
+        public final THIS whenContainsAll(Class<? extends Annotation>... annotationNames) {
             return whenContainsAll(
                     Arrays.stream(annotationNames).map(a -> DotName.createSimple(a.getName())).collect(Collectors.toList()));
         }
@@ -173,7 +295,7 @@ public interface AnnotationsTransformer extends BuildExtension {
          * @param annotationNames
          * @return self
          */
-        public Builder whenContainsAny(List<DotName> annotationNames) {
+        public THIS whenContainsAny(List<DotName> annotationNames) {
             return when(context -> Annotations.containsAny(context.getAnnotations(), annotationNames));
         }
 
@@ -183,7 +305,7 @@ public interface AnnotationsTransformer extends BuildExtension {
          * @param annotationNames
          * @return self
          */
-        public Builder whenContainsAny(DotName... annotationNames) {
+        public THIS whenContainsAny(DotName... annotationNames) {
             return whenContainsAny(List.of(annotationNames));
         }
 
@@ -194,7 +316,7 @@ public interface AnnotationsTransformer extends BuildExtension {
          * @return self
          */
         @SafeVarargs
-        public final Builder whenContainsAny(Class<? extends Annotation>... annotationNames) {
+        public final THIS whenContainsAny(Class<? extends Annotation>... annotationNames) {
             return whenContainsAny(
                     Arrays.stream(annotationNames).map(a -> DotName.createSimple(a.getName())).collect(Collectors.toList()));
         }
@@ -205,7 +327,7 @@ public interface AnnotationsTransformer extends BuildExtension {
          * @param annotationNames
          * @return self
          */
-        public Builder whenContainsNone(List<DotName> annotationNames) {
+        public THIS whenContainsNone(List<DotName> annotationNames) {
             return when(context -> !Annotations.containsAny(context.getAnnotations(), annotationNames));
         }
 
@@ -215,7 +337,7 @@ public interface AnnotationsTransformer extends BuildExtension {
          * @param annotationNames
          * @return self
          */
-        public Builder whenContainsNone(DotName... annotationNames) {
+        public THIS whenContainsNone(DotName... annotationNames) {
             return whenContainsNone(List.of(annotationNames));
         }
 
@@ -226,7 +348,7 @@ public interface AnnotationsTransformer extends BuildExtension {
          * @return self
          */
         @SafeVarargs
-        public final Builder whenContainsNone(Class<? extends Annotation>... annotationNames) {
+        public final THIS whenContainsNone(Class<? extends Annotation>... annotationNames) {
             return whenContainsNone(
                     Arrays.stream(annotationNames).map(a -> DotName.createSimple(a.getName())).collect(Collectors.toList()));
         }
@@ -238,23 +360,49 @@ public interface AnnotationsTransformer extends BuildExtension {
          * @param predicate
          * @return self
          */
-        public Builder when(Predicate<TransformationContext> when) {
+        public THIS when(Predicate<TransformationContext> when) {
             if (predicate == null) {
                 predicate = when;
             } else {
                 predicate = predicate.and(when);
             }
-            return this;
+            return self();
         }
 
         /**
-         * The given transformation logic is only performed if all conditions added via {@link #when(Predicate)} are met.
+         * If all conditions are met then apply the transformation logic.
+         * <p>
+         * Unlike in {@link #transform(Consumer)} the transformation is automatically applied, i.e. a {@link Transformation}
+         * is created and the {@link Transformation#done()} method is called automatically.
          *
          * @param consumer
          * @return a new annotation transformer
          */
+        public AnnotationsTransformer thenTransform(Consumer<Transformation> consumer) {
+            Consumer<Transformation> transform = Objects.requireNonNull(consumer);
+            return transform(new Consumer<TransformationContext>() {
+
+                @Override
+                public void accept(TransformationContext context) {
+                    Transformation transformation = context.transform();
+                    transform.accept(transformation);
+                    transformation.done();
+                }
+            });
+
+        }
+
+        /**
+         * The transformation logic is performed only if all conditions are met.
+         * <p>
+         * This method should be used if you need to access the transformation context directly. Otherwise, the
+         * {@link #thenTransform(Consumer)} is more convenient.
+         *
+         * @param consumer
+         * @return a new annotation transformer
+         * @see #thenTransform(Consumer)
+         */
         public AnnotationsTransformer transform(Consumer<TransformationContext> consumer) {
-            Predicate<Kind> appliesTo = this.appliesTo;
             int priority = this.priority;
             Consumer<TransformationContext> transform = Objects.requireNonNull(consumer);
             Predicate<TransformationContext> predicate = this.predicate;
@@ -267,7 +415,7 @@ public interface AnnotationsTransformer extends BuildExtension {
 
                 @Override
                 public boolean appliesTo(Kind kind) {
-                    return appliesTo != null ? appliesTo.test(kind) : true;
+                    return test(kind);
                 }
 
                 @Override
@@ -277,6 +425,22 @@ public interface AnnotationsTransformer extends BuildExtension {
                     }
                 }
 
+            };
+        }
+
+        @SuppressWarnings("unchecked")
+        protected THIS self() {
+            return (THIS) this;
+        }
+
+        protected <TARGET> Predicate<TransformationContext> wrap(Predicate<TARGET> condition,
+                Function<TransformationContext, TARGET> extractor) {
+            return new Predicate<TransformationContext>() {
+
+                @Override
+                public boolean test(TransformationContext ctx) {
+                    return condition.test(extractor.apply(ctx));
+                }
             };
         }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Transformation.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Transformation.java
@@ -6,6 +6,13 @@ import java.util.function.Consumer;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 
+/**
+ * Represents a transformation of an annotation target.
+ * <p>
+ * The transformation is not applied until the {@link Transformation#done()} method is invoked.
+ *
+ * @see AnnotationsTransformer
+ */
 public final class Transformation extends AbstractAnnotationsTransformation<Transformation, Collection<AnnotationInstance>> {
 
     public Transformation(Collection<AnnotationInstance> annotations, AnnotationTarget target,

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/annotations/AbstractTransformerBuilderTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/annotations/AbstractTransformerBuilderTest.java
@@ -1,0 +1,86 @@
+package io.quarkus.arc.test.buildextension.annotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.AbstractList;
+
+import jakarta.enterprise.context.Dependent;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InstanceHandle;
+
+public abstract class AbstractTransformerBuilderTest {
+
+    @Test
+    public void testVetoed() {
+        ArcContainer arc = Arc.container();
+        assertTrue(arc.instance(Seven.class).isAvailable());
+        // One is vetoed
+        assertFalse(arc.instance(One.class).isAvailable());
+        assertEquals(Integer.valueOf(7), Integer.valueOf(arc.instance(Seven.class).get().size()));
+
+        // Scope annotation and @Inject are added by transformer
+        InstanceHandle<IWantToBeABean> iwant = arc.instance(IWantToBeABean.class);
+        assertTrue(iwant.isAvailable());
+        assertEquals(Integer.valueOf(7), Integer.valueOf(iwant.get().size()));
+
+        assertEquals(Integer.valueOf(7), arc.select(int.class).get());
+    }
+
+    // => add @Dependent here
+    static class IWantToBeABean {
+
+        // => add @Inject here
+        Seven seven;
+
+        // => add @Produces here
+        public int size() {
+            return seven.size();
+        }
+
+        // => do not add @Produces here
+        @Simple
+        public int anotherSize() {
+            return seven.size();
+        }
+
+    }
+
+    @Dependent
+    static class Seven extends AbstractList<Integer> {
+
+        @Override
+        public Integer get(int index) {
+            return Integer.valueOf(7);
+        }
+
+        @Simple
+        @Override
+        public int size() {
+            return 7;
+        }
+
+    }
+
+    // => add @Vetoed here
+    @Dependent
+    static class One extends AbstractList<Integer> {
+
+        @Override
+        public Integer get(int index) {
+            return Integer.valueOf(1);
+        }
+
+        @Override
+        public int size() {
+            return 1;
+        }
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/annotations/AnnotationsTransformerSpecificBuildersTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/annotations/AnnotationsTransformerSpecificBuildersTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.arc.test.buildextension.annotations;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.Vetoed;
+import jakarta.inject.Inject;
+
+import org.jboss.jandex.PrimitiveType;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.processor.AnnotationsTransformer;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class AnnotationsTransformerSpecificBuildersTest extends AbstractTransformerBuilderTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Seven.class, One.class, IWantToBeABean.class)
+            .annotationsTransformers(
+                    AnnotationsTransformer.appliedToClass()
+                            .whenContainsAny(Dependent.class)
+                            .whenClass(c -> c.name().toString().equals(One.class.getName()))
+                            .thenTransform(t ->
+                            // Veto bean class One
+                            t.add(Vetoed.class)),
+
+                    AnnotationsTransformer.appliedToClass()
+                            .whenClass(c -> c.name().local()
+                                    .equals(IWantToBeABean.class.getSimpleName()))
+                            .transform(context -> context.transform().add(Dependent.class).done()),
+                    AnnotationsTransformer.appliedToField()
+                            .whenField(f -> f.name().equals("seven"))
+                            .thenTransform(t -> t.add(Inject.class)),
+
+                    // Add @Produces to a method that returns int and is not annoated with @Simple
+                    AnnotationsTransformer.appliedToMethod()
+                            .whenContainsNone(Simple.class)
+                            .whenMethod(m -> m.returnType().name().equals(PrimitiveType.INT.name()))
+                            .thenTransform(t -> t.add(Produces.class)))
+            .build();
+
+}


### PR DESCRIPTION
- and add the convenient doTransform() method that applies transformation automatically
- also mention the builders in the docs

Compare:

```java
    @BuildStep
    AnnotationsTransformerBuildItem addInterceptorBindingToProcessors() {
        return new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
            @Override
            public boolean appliesTo(AnnotationTarget.Kind kind) {
                return kind == AnnotationTarget.Kind.METHOD;
            }

            @Override
            public void transform(TransformationContext transformationContext) {
                MethodInfo method = transformationContext.getTarget().asMethod();
                if (method.declaringClass().interfaceNames().contains(DotName.createSimple(Processor.class))
                        && method.name().equals("doWork")
                        && method.parametersCount() == 0) {
                    transformationContext.transform().add(AnnotationInstance.builder(Logged.class).build()).done();
                }
            }
        });
    }
```

and now:

```java
    @BuildStep
    AnnotationsTransformerBuildItem addInterceptorBindingToProcessors() {
        return new AnnotationsTransformerBuildItem(AnnotationsTransformer.appliedToMethod()
           .whenMethod(m -> m.declaringClass().interfaceNames().contains(DotName.createSimple(Processor.class))
                        && m.name().equals("doWork")
                        && m.parametersCount() == 0))
           .thenTransform(t -> t.add(Logged.class))
        );
    } 
```