### PR TITLE
Fix on RestPathAnnotationProcessor to ensure that the correct url template is computed for metrics

### DIFF
--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagWithInterfaceResourceTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/UriTagWithInterfaceResourceTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.micrometer.deployment.binder;
+
+import static io.restassured.RestAssured.when;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.micrometer.test.Util;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.restassured.RestAssured;
+import io.vertx.core.http.impl.HttpServerRequestInternal;
+
+class UriTagWithInterfaceResourceTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
+            .overrideConfigKey("quarkus.micrometer.binder.http-server.enabled", "true")
+            .overrideConfigKey("quarkus.micrometer.binder.vertx.enabled", "true")
+            .overrideConfigKey("quarkus.redis.devservices.enabled", "false")
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Util.class,
+                            InterfaceResourceReturningUrlTemplate.class,
+                            InterfaceResourceReturningUrlTemplateImpl.class));
+
+    @Inject
+    MeterRegistry registry;
+
+    @Test
+    void testRequestUris() throws Exception {
+        RestAssured.basePath = "/";
+
+        when().get("/class/path/method/path/test").then()
+                .statusCode(200)
+                .body(Matchers.is("/class/path/method/path/{param}"));
+
+        Util.waitForMeters(registry.find("http.server.requests").timers(), 1);
+
+        System.out.println("Server paths\n" + Util.listMeters(registry, "http.server.requests"));
+
+        Assertions.assertEquals(1,
+                registry.find("http.server.requests").tag("uri", "/class/path/method/path/{param}").timers().size(),
+                Util.foundServerRequests(registry, "Servlet path (/servlet) should be returned by JAX-RS."));
+    }
+
+    @Path("/class/path")
+    public interface InterfaceResourceReturningUrlTemplate {
+
+        @Path("method/path/{param}")
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        String getTemplatizedPath(@PathParam("param") String param);
+
+    }
+
+    public static class InterfaceResourceReturningUrlTemplateImpl implements InterfaceResourceReturningUrlTemplate {
+
+        private final CurrentVertxRequest request;
+
+        public InterfaceResourceReturningUrlTemplateImpl(CurrentVertxRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public String getTemplatizedPath(String param) {
+            return ((HttpServerRequestInternal) request.getCurrent().request()).context().getLocal("UrlPathTemplate");
+        }
+    }
+
+}

--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/RestPathAnnotationProcessor.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/RestPathAnnotationProcessor.java
@@ -114,9 +114,9 @@ public class RestPathAnnotationProcessor {
                 } else {
                     // Fallback: look for @Path on interfaces
                     getAllClassInterfaces(index, List.of(classInfo), new ArrayList<>()).stream()
-                            .filter(interfaceClassInfo -> interfaceClassInfo.hasAnnotation(REST_PATH))
+                            .filter(interfaceClassInfo -> interfaceClassInfo.hasDeclaredAnnotation(REST_PATH))
                             .findFirst()
-                            .map(interfaceClassInfo -> interfaceClassInfo.annotation(REST_PATH).value())
+                            .map(interfaceClassInfo -> interfaceClassInfo.declaredAnnotation(REST_PATH).value())
                             .ifPresent(annotationValue -> stringBuilder.insert(0, slashify(annotationValue.asString())));
                 }
 


### PR DESCRIPTION
This is a proposition to fix a bug on the metric system. When using quarkus-micrometer, the metrics contain information on the time taken by a request. One of the tag is the uri and currently the uri is incorrect.
For example we get:
```text
# HELP http_server_requests_seconds  
# TYPE http_server_requests_seconds summary
http_server_requests_seconds_count{method="GET",outcome="SUCCESS",status="200",uri="/{firstname}/{firstname}",} 1.0
http_server_requests_seconds_sum{method="GET",outcome="SUCCESS",status="200",uri="/{firstname}/{firstname}",} 0.1192732
```
instead of:
```# HELP http_server_requests_seconds  
# TYPE http_server_requests_seconds summary
http_server_requests_seconds_count{method="GET",outcome="SUCCESS",status="200",uri="/hello/{firstname}",} 1.0
http_server_requests_seconds_sum{method="GET",outcome="SUCCESS",status="200",uri="/hello/{firstname}",} 0.1192732
```

Here is a reproducer: https://github.com/souchel/quarkus-metrics-reproducer