### PR TITLE
Support config reactive datasource with list of database urls for fault tolerance and load balance

### DIFF
--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -688,6 +688,23 @@ In `application.properties` add:
 quarkus.datasource.reactive.url=mysql:///quarkus_test?host=/var/run/mysqld/mysqld.sock
 ----
 
+== Load-balancing connections
+
+The reactive PostgreSQL and MariaDB/MySQL clients support defining several connections.
+
+A typical configuration with several connections would look like:
+
+[source,properties]
+----
+quarkus.datasource.reactive.url=postgresql://host1:5432/default,postgresql://host2:5432/default,postgresql://host3:5432/default
+----
+This can also be written with indexed property syntax:
+----
+quarkus.datasource.reactive.url[0]=postgresql://host1:5432/default
+quarkus.datasource.reactive.url[1]=postgresql://host2:5432/default
+quarkus.datasource.reactive.url[2]=postgresql://host3:5432/default
+----
+
 == Pooled Connection `idle-timeout`
 
 Reactive datasources can be configured with an `idle-timeout` (in milliseconds).

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.reactive.datasource.runtime;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -23,10 +24,14 @@ public class DataSourceReactiveRuntimeConfig {
     public boolean cachePreparedStatements = false;
 
     /**
-     * The datasource URL.
+     * The datasource URLs.
+     * <p>
+     * If multiple values are set, this datasource will create a pool with a list of servers instead of a single server.
+     * The pool uses a round-robin load balancing when a connection is created to select different servers.
+     * Note: some driver may not support multiple values here.
      */
     @ConfigItem
-    public Optional<String> url = Optional.empty();
+    public Optional<List<String>> url = Optional.empty();
 
     /**
      * The datasource pool maximum size.

--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
@@ -9,6 +9,7 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemTrustOpt
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxKeyCertOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOptions;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -119,7 +120,12 @@ public class DB2PoolRecorder {
         DB2ConnectOptions connectOptions;
 
         if (dataSourceReactiveRuntimeConfig.url.isPresent()) {
-            String url = dataSourceReactiveRuntimeConfig.url.get();
+            List<String> urls = dataSourceReactiveRuntimeConfig.url.get();
+            if (urls.size() > 1) {
+                log.warn("The Reactive DB2 client does not support multiple URLs. The first one will be used, and " +
+                        "others will be ignored.");
+            }
+            String url = urls.get(0);
             // clean up the URL to make migrations easier
             if (url.matches("^vertx-reactive:db2://.*$")) {
                 url = url.substring("vertx-reactive:".length());

--- a/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
+++ b/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
@@ -9,6 +9,7 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemTrustOpt
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxKeyCertOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOptions;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -118,7 +119,12 @@ public class MSSQLPoolRecorder {
             DataSourceReactiveMSSQLConfig dataSourceReactiveMSSQLConfig) {
         MSSQLConnectOptions mssqlConnectOptions;
         if (dataSourceReactiveRuntimeConfig.url.isPresent()) {
-            String url = dataSourceReactiveRuntimeConfig.url.get();
+            List<String> urls = dataSourceReactiveRuntimeConfig.url.get();
+            if (urls.size() > 1) {
+                log.warn("The Reactive MSSQL client does not support multiple URLs. The first one will be used, and " +
+                        "others will be ignored.");
+            }
+            String url = urls.get(0);
             // clean up the URL to make migrations easier
             if (url.startsWith("vertx-reactive:sqlserver://")) {
                 url = url.substring("vertx-reactive:".length());

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/LocalhostMySQLPoolCreator.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/LocalhostMySQLPoolCreator.java
@@ -9,7 +9,7 @@ public class LocalhostMySQLPoolCreator implements MySQLPoolCreator {
 
     @Override
     public MySQLPool create(Input input) {
-        return MySQLPool.pool(input.vertx(), input.mySQLConnectOptions().setHost("localhost").setPort(3308),
+        return MySQLPool.pool(input.vertx(), input.mySQLConnectOptionsList().get(0).setHost("localhost").setPort(3308),
                 input.poolOptions());
     }
 }

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MultipleDataSourcesAndMySQLPoolCreatorsTest.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MultipleDataSourcesAndMySQLPoolCreatorsTest.java
@@ -85,8 +85,8 @@ public class MultipleDataSourcesAndMySQLPoolCreatorsTest {
 
         @Override
         public MySQLPool create(Input input) {
-            assertEquals(12345, input.mySQLConnectOptions().getPort()); // validate that the bean has been called for the proper datasource
-            return MySQLPool.pool(input.vertx(), input.mySQLConnectOptions().setHost("localhost").setPort(3308),
+            assertEquals(12345, input.mySQLConnectOptionsList().get(0).getPort()); // validate that the bean has been called for the proper datasource
+            return MySQLPool.pool(input.vertx(), input.mySQLConnectOptionsList().get(0).setHost("localhost").setPort(3308),
                     input.poolOptions());
         }
     }
@@ -97,8 +97,8 @@ public class MultipleDataSourcesAndMySQLPoolCreatorsTest {
 
         @Override
         public MySQLPool create(Input input) {
-            assertEquals(55555, input.mySQLConnectOptions().getPort()); // validate that the bean has been called for the proper datasource
-            return MySQLPool.pool(input.vertx(), input.mySQLConnectOptions().setHost("localhost").setPort(3308),
+            assertEquals(55555, input.mySQLConnectOptionsList().get(0).getPort()); // validate that the bean has been called for the proper datasource
+            return MySQLPool.pool(input.vertx(), input.mySQLConnectOptionsList().get(0).setHost("localhost").setPort(3308),
                     input.poolOptions());
         }
     }

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MultipleMySQLPoolCreatorsForSameDatasourceTest.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MultipleMySQLPoolCreatorsForSameDatasourceTest.java
@@ -33,7 +33,7 @@ public class MultipleMySQLPoolCreatorsForSameDatasourceTest {
 
         @Override
         public MySQLPool create(Input input) {
-            return MySQLPool.pool(input.vertx(), input.mySQLConnectOptions(), input.poolOptions());
+            return MySQLPool.pool(input.vertx(), input.mySQLConnectOptionsList(), input.poolOptions());
         }
     }
 

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MySQLPoolLoadBalanceTest.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MySQLPoolLoadBalanceTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.reactive.mysql.client;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class MySQLPoolLoadBalanceTest {
+
+    @RegisterExtension
+    public static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DevModeResource.class)
+                    .add(new StringAsset("quarkus.datasource.db-kind=mysql\n" +
+                            "quarkus.datasource.reactive.url=vertx-reactive:mysql://localhost:6033/load_balance_test," +
+                            "vertx-reactive:mysql://localhost:6034/load_balance_test," +
+                            "vertx-reactive:mysql://localhost:6035/load_balance_test"),
+                            "application.properties"));
+
+    @Test
+    public void testLoadBalance() {
+        RestAssured
+                .get("/dev/error")
+                .then()
+                .statusCode(200)
+                .body(Matchers.anyOf(Matchers.endsWith(":6033"), Matchers.endsWith(":6034"), Matchers.endsWith(":6035")));
+    }
+}

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/MySQLPoolCreator.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/MySQLPoolCreator.java
@@ -1,5 +1,7 @@
 package io.quarkus.reactive.mysql.client;
 
+import java.util.List;
+
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.vertx.core.Vertx;
 import io.vertx.mysqlclient.MySQLConnectOptions;
@@ -25,6 +27,6 @@ public interface MySQLPoolCreator {
 
         PoolOptions poolOptions();
 
-        MySQLConnectOptions mySQLConnectOptions();
+        List<MySQLConnectOptions> mySQLConnectOptionsList();
     }
 }

--- a/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/runtime/OraclePoolRecorder.java
+++ b/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/runtime/OraclePoolRecorder.java
@@ -3,6 +3,7 @@ package io.quarkus.reactive.oracle.client.runtime;
 import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -112,7 +113,12 @@ public class OraclePoolRecorder {
             DataSourceReactiveOracleConfig dataSourceReactiveOracleConfig) {
         OracleConnectOptions oracleConnectOptions;
         if (dataSourceReactiveRuntimeConfig.url.isPresent()) {
-            String url = dataSourceReactiveRuntimeConfig.url.get();
+            List<String> urls = dataSourceReactiveRuntimeConfig.url.get();
+            if (urls.size() > 1) {
+                log.warn("The Reactive Oracle client does not support multiple URLs. The first one will be used, and " +
+                        "others will be ignored.");
+            }
+            String url = urls.get(0);
             // clean up the URL to make migrations easier
             if (url.startsWith("vertx-reactive:oracle:")) {
                 url = url.substring("vertx-reactive:".length());

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/LocalhostPgPoolCreator.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/LocalhostPgPoolCreator.java
@@ -9,6 +9,7 @@ public class LocalhostPgPoolCreator implements PgPoolCreator {
 
     @Override
     public PgPool create(Input input) {
-        return PgPool.pool(input.vertx(), input.pgConnectOptions().setHost("localhost").setPort(5431), input.poolOptions());
+        return PgPool.pool(input.vertx(), input.pgConnectOptionsList().get(0).setHost("localhost").setPort(5431),
+                input.poolOptions());
     }
 }

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultipleDataSourcesAndPgPoolCreatorsTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultipleDataSourcesAndPgPoolCreatorsTest.java
@@ -85,8 +85,9 @@ public class MultipleDataSourcesAndPgPoolCreatorsTest {
 
         @Override
         public PgPool create(Input input) {
-            assertEquals(10, input.pgConnectOptions().getPipeliningLimit()); // validate that the bean has been called for the proper datasource
-            return PgPool.pool(input.vertx(), input.pgConnectOptions().setHost("localhost").setPort(5431), input.poolOptions());
+            assertEquals(10, input.pgConnectOptionsList().get(0).getPipeliningLimit()); // validate that the bean has been called for the proper datasource
+            return PgPool.pool(input.vertx(), input.pgConnectOptionsList().get(0).setHost("localhost").setPort(5431),
+                    input.poolOptions());
         }
     }
 
@@ -96,8 +97,9 @@ public class MultipleDataSourcesAndPgPoolCreatorsTest {
 
         @Override
         public PgPool create(Input input) {
-            assertEquals(7, input.pgConnectOptions().getPipeliningLimit()); // validate that the bean has been called for the proper datasource
-            return PgPool.pool(input.vertx(), input.pgConnectOptions().setHost("localhost").setPort(5431), input.poolOptions());
+            assertEquals(7, input.pgConnectOptionsList().get(0).getPipeliningLimit()); // validate that the bean has been called for the proper datasource
+            return PgPool.pool(input.vertx(), input.pgConnectOptionsList().get(0).setHost("localhost").setPort(5431),
+                    input.poolOptions());
         }
     }
 }

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultiplePgPoolCreatorsForSameDatasourceTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MultiplePgPoolCreatorsForSameDatasourceTest.java
@@ -33,7 +33,7 @@ public class MultiplePgPoolCreatorsForSameDatasourceTest {
 
         @Override
         public PgPool create(Input input) {
-            return PgPool.pool(input.vertx(), input.pgConnectOptions(), input.poolOptions());
+            return PgPool.pool(input.vertx(), input.pgConnectOptionsList(), input.poolOptions());
         }
     }
 

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/PgPoolLoadBalanceTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/PgPoolLoadBalanceTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.reactive.pg.client;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class PgPoolLoadBalanceTest {
+
+    @RegisterExtension
+    public static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DevModeResource.class)
+                    .add(new StringAsset("quarkus.datasource.db-kind=postgresql\n" +
+                            "quarkus.datasource.reactive.url=vertx-reactive:postgresql://localhost:5342/load_balance_test," +
+                            "vertx-reactive:postgresql://localhost:5343/load_balance_test," +
+                            "vertx-reactive:postgresql://localhost:5344/load_balance_test"),
+                            "application.properties"));
+
+    @Test
+    public void testLoadBalance() {
+        RestAssured
+                .get("/dev/error")
+                .then()
+                .statusCode(200)
+                .body(Matchers.anyOf(Matchers.endsWith(":5342"), Matchers.endsWith(":5343"), Matchers.endsWith(":5344")));
+    }
+}

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/PgPoolCreator.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/PgPoolCreator.java
@@ -1,5 +1,7 @@
 package io.quarkus.reactive.pg.client;
 
+import java.util.List;
+
 import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.vertx.core.Vertx;
 import io.vertx.pgclient.PgConnectOptions;
@@ -25,6 +27,6 @@ public interface PgPoolCreator {
 
         PoolOptions poolOptions();
 
-        PgConnectOptions pgConnectOptions();
+        List<PgConnectOptions> pgConnectOptionsList();
     }
 }


### PR DESCRIPTION
Add support to config load balance urls for reactive datasources in application.properties, for example:
```
quarkus.datasource.reactive.url=mysql://host1:3306/dbname,mysql://host2:3306/dbname,mysql://host3:3306/dbname
```
or
```
quarkus.datasource.reactive.url[0]=mysql://host1:3306/dbname
quarkus.datasource.reactive.url[1]=mysql://host2:3306/dbname
quarkus.datasource.reactive.url[2]=mysql://host3:3306/dbname
```
The original PR is https://github.com/quarkusio/quarkus/pull/31852, which only update reactive mysql client. As @tsegismont suggested, I replaced public Optional<String> url with public Optional<List<String>> urls in DataSourceReactiveRuntimeConfig, and all of reactive database client were updated accordingly.

There is one exception: Vert.x oracle client already have build-in load balance support, and there is no such function like OraclePool.pool(Vertx vertx, List<OracleConnectOptions> databases, PoolOptions options). So only the first url is valid and others is discarded even if you config more urls.

The original PR title maybe improperly and misleading, so I create this one.