### PR TITLE
Add `.sdkmanrc` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,5 @@ nbactions.xml
 nb-configuration.xml
 .cache
 /lsp/
-.sdkmanrc
 .envrc
 .jekyll-cache

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=11.0.18-tem

--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,8 @@
                              General recap: Anything that is directly set in <configuration> cannot be redefined via '-D...'!
                              See also: https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/issues/213 -->
                         <configuration>
+                            <!-- these metadata file can't affect the build -->
+                            <excludePathsMatching>\.sdkmanrc</excludePathsMatching>
                             <!-- pointless to attempt incremental build if something like mvnw was changed
                                  (and also potentially wrong, given that independent-projects might not be built) -->
                             <skipIfPathMatches>\.github[/\\].*|\.mvn[/\\].*|mvnw.*</skipIfPathMatches>


### PR DESCRIPTION
This makes it very easy for sdkman users to get
a proper JDK set for the project by issuing:

`sdk env`