### PR TITLE
Introduce a first version of the `/q/info` endpoint

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -210,6 +210,7 @@
         <aesh.version>2.7</aesh.version>
         <aesh-readline.version>2.4</aesh-readline.version>
         <jansi.version>2.4.0</jansi.version> <!-- Keep in sync with aesh-readline and dekorate -->
+        <jgit.version>6.5.0.202303070854-r</jgit.version>
         <!-- these two artifacts needs to be compatible together -->
         <strimzi-oauth.version>0.12.0</strimzi-oauth.version>
         <strimzi-oauth.nimbus.version>9.31</strimzi-oauth.nimbus.version>
@@ -2867,6 +2868,27 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-opentelemetry</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-info-deployment-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-info-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-info-runtime-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-info</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -6087,6 +6109,12 @@
                 <groupId>org.hdrhistogram</groupId>
                 <artifactId>HdrHistogram</artifactId>
                 <version>${hdrhistogram.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jgit</groupId>
+                <artifactId>org.eclipse.jgit</artifactId>
+                <version>${jgit.version}</version>
             </dependency>
 
             <!-- Quarkus build related dependencies -->

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -904,6 +904,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-info</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-jackson</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -914,6 +914,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-info-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/extensions/info/deployment-spi/pom.xml
+++ b/extensions/info/deployment-spi/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-info-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-info-deployment-spi</artifactId>
+    <name>Quarkus - Info - SPI</name>
+    <description>Artifact that provides BuildItems specific to Info extension</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-info-runtime-spi</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions/info/deployment-spi/src/main/java/io/quarkus/info/deployment/spi/InfoBuildTimeContributorBuildItem.java
+++ b/extensions/info/deployment-spi/src/main/java/io/quarkus/info/deployment/spi/InfoBuildTimeContributorBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.info.deployment.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.info.runtime.spi.InfoContributor;
+
+/**
+ * Allows for extensions to include their own {@link InfoContributor} implementations that result in inclusion of properties in
+ * the info endpoint
+ */
+public final class InfoBuildTimeContributorBuildItem extends MultiBuildItem {
+
+    private final InfoContributor infoContributor;
+
+    public InfoBuildTimeContributorBuildItem(InfoContributor infoContributor) {
+        this.infoContributor = infoContributor;
+    }
+
+    public InfoContributor getInfoContributor() {
+        return infoContributor;
+    }
+}

--- a/extensions/info/deployment-spi/src/main/java/io/quarkus/info/deployment/spi/InfoBuildTimeValuesBuildItem.java
+++ b/extensions/info/deployment-spi/src/main/java/io/quarkus/info/deployment/spi/InfoBuildTimeValuesBuildItem.java
@@ -1,0 +1,27 @@
+package io.quarkus.info.deployment.spi;
+
+import java.util.Map;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Allows for extensions to include their properties into the info endpoint
+ */
+public final class InfoBuildTimeValuesBuildItem extends MultiBuildItem {
+
+    private final String name;
+    private final Map<String, Object> value;
+
+    public InfoBuildTimeValuesBuildItem(String name, Map<String, Object> value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, Object> getValue() {
+        return value;
+    }
+}

--- a/extensions/info/deployment/pom.xml
+++ b/extensions/info/deployment/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-info-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-info-deployment</artifactId>
+    <name>Quarkus - Info - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-info-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-info</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/BuildInInfoEndpointEnabled.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/BuildInInfoEndpointEnabled.java
@@ -1,0 +1,18 @@
+
+package io.quarkus.info.deployment;
+
+import java.util.function.BooleanSupplier;
+
+public class BuildInInfoEndpointEnabled implements BooleanSupplier {
+
+    private final InfoBuildTimeConfig config;
+
+    BuildInInfoEndpointEnabled(InfoBuildTimeConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        return config.enabled() && config.build().enabled();
+    }
+}

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/GitInInfoEndpointEnabled.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/GitInInfoEndpointEnabled.java
@@ -1,0 +1,18 @@
+
+package io.quarkus.info.deployment;
+
+import java.util.function.BooleanSupplier;
+
+public class GitInInfoEndpointEnabled implements BooleanSupplier {
+
+    private final InfoBuildTimeConfig config;
+
+    GitInInfoEndpointEnabled(InfoBuildTimeConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        return config.enabled() && config.git().enabled();
+    }
+}

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoBuildTimeConfig.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoBuildTimeConfig.java
@@ -1,0 +1,88 @@
+package io.quarkus.info.deployment;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithParentName;
+
+@ConfigMapping(prefix = "quarkus.info")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface InfoBuildTimeConfig {
+
+    /**
+     * Whether the info endpoint will be enabled
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * The path under which the info endpoint will be located
+     */
+    @WithDefault("info")
+    String path();
+
+    /**
+     * Git related configuration
+     */
+    Git git();
+
+    /**
+     * Build related configuration
+     */
+    Build build();
+
+    /**
+     * Build related configuration
+     */
+    Os os();
+
+    /**
+     * Build related configuration
+     */
+    Java java();
+
+    interface Git {
+
+        /**
+         * Whether git info will be included in the info endpoint
+         */
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface Build {
+
+        /**
+         * Whether build info will be included in the info endpoint
+         */
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
+         * Additional properties to be added to the build section
+         */
+        @WithParentName
+        Map<String, String> additionalProperties();
+    }
+
+    interface Os {
+
+        /**
+         * Whether os info will be included in the info endpoint
+         */
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface Java {
+
+        /**
+         * Whether java info will be included in the info endpoint
+         */
+        @WithDefault("true")
+        boolean enabled();
+    }
+}

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoEndpointEnabled.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoEndpointEnabled.java
@@ -1,0 +1,18 @@
+
+package io.quarkus.info.deployment;
+
+import java.util.function.BooleanSupplier;
+
+public class InfoEndpointEnabled implements BooleanSupplier {
+
+    private final InfoBuildTimeConfig config;
+
+    InfoEndpointEnabled(InfoBuildTimeConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        return config.enabled();
+    }
+}

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
@@ -1,0 +1,142 @@
+package io.quarkus.info.deployment;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+import java.io.File;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.RepositoryBuilder;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.jboss.logging.Logger;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.info.deployment.spi.InfoBuildTimeContributorBuildItem;
+import io.quarkus.info.deployment.spi.InfoBuildTimeValuesBuildItem;
+import io.quarkus.info.runtime.InfoRecorder;
+import io.quarkus.info.runtime.spi.InfoContributor;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.RouteBuildItem;
+
+public class InfoProcessor {
+
+    private static final Logger log = Logger.getLogger(InfoProcessor.class);
+
+    @BuildStep(onlyIf = GitInInfoEndpointEnabled.class)
+    InfoBuildTimeValuesBuildItem gitInfo(CurateOutcomeBuildItem curateOutcomeBuildItem,
+            OutputTargetBuildItem outputTargetBuildItem) {
+        File projectRoot = highestKnownProjectDirectory(curateOutcomeBuildItem, outputTargetBuildItem);
+        if (projectRoot == null) {
+            log.debug("Unable to determine project directory");
+            return null;
+        }
+        RepositoryBuilder repositoryBuilder = new RepositoryBuilder().findGitDir(projectRoot);
+        if (repositoryBuilder.getGitDir() == null) {
+            log.debug("Project is not checked in to git");
+            return null;
+        }
+        try (Repository repository = repositoryBuilder.build()) {
+
+            RevCommit latestCommit = new Git(repository).log().setMaxCount(1).call().iterator().next();
+
+            PersonIdent authorIdent = latestCommit.getAuthorIdent();
+            Date authorDate = authorIdent.getWhen();
+            TimeZone authorTimeZone = authorIdent.getTimeZone();
+
+            Map<String, Object> data = new LinkedHashMap<>();
+            data.put("branch", repository.getBranch());
+            data.put("commit", Map.of(
+                    "id", latestCommit.getName(),
+                    "time",
+                    ISO_OFFSET_DATE_TIME.format(
+                            OffsetDateTime.ofInstant(authorDate.toInstant(), authorTimeZone.toZoneId()))));
+            return new InfoBuildTimeValuesBuildItem("git", data);
+        } catch (Exception e) {
+            log.debug("Unable to determine git information", e);
+            return null;
+        }
+    }
+
+    private File highestKnownProjectDirectory(CurateOutcomeBuildItem curateOutcomeBuildItem,
+            OutputTargetBuildItem outputTargetBuildItem) {
+        ApplicationModel applicationModel = curateOutcomeBuildItem.getApplicationModel();
+        WorkspaceModule workspaceModule = applicationModel.getAppArtifact().getWorkspaceModule();
+        if (workspaceModule != null) {
+            // in this case we know the precise project root
+            return workspaceModule.getModuleDir();
+        }
+        // in this case we will simply use the build directory and let jgit go up the file system to determine the git directory - if any
+        return outputTargetBuildItem.getOutputDirectory().toFile();
+    }
+
+    @BuildStep(onlyIf = BuildInInfoEndpointEnabled.class)
+    InfoBuildTimeValuesBuildItem buildInfo(CurateOutcomeBuildItem curateOutcomeBuildItem, InfoBuildTimeConfig config) {
+        ApplicationModel applicationModel = curateOutcomeBuildItem.getApplicationModel();
+        ResolvedDependency appArtifact = applicationModel.getAppArtifact();
+        Map<String, Object> buildData = new LinkedHashMap<>();
+        buildData.put("group", appArtifact.getGroupId());
+        buildData.put("artifact", appArtifact.getArtifactId());
+        buildData.put("version", appArtifact.getVersion());
+        buildData.put("time", ISO_OFFSET_DATE_TIME.format(OffsetDateTime.now())); // TODO: what is the proper notion of build time?
+        return new InfoBuildTimeValuesBuildItem("build", finalBuildData(buildData, config.build()));
+    }
+
+    private Map<String, Object> finalBuildData(Map<String, Object> buildData, InfoBuildTimeConfig.Build buildConfig) {
+        if (buildConfig.additionalProperties().isEmpty()) {
+            return buildData;
+        }
+        Map<String, Object> result = new LinkedHashMap<>(buildData);
+        result.putAll(buildConfig.additionalProperties());
+        return result;
+    }
+
+    @BuildStep(onlyIf = OsInInfoEndpointEnabled.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    InfoBuildTimeContributorBuildItem osInfo(InfoRecorder recorder) {
+        return new InfoBuildTimeContributorBuildItem(recorder.osInfoContributor());
+    }
+
+    @BuildStep(onlyIf = JavaInInfoEndpointEnabled.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    InfoBuildTimeContributorBuildItem javaInfo(InfoRecorder recorder) {
+        return new InfoBuildTimeContributorBuildItem(recorder.javaInfoContributor());
+    }
+
+    @BuildStep(onlyIf = InfoEndpointEnabled.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    RouteBuildItem defineRoute(InfoBuildTimeConfig buildTimeConfig,
+            List<InfoBuildTimeValuesBuildItem> buildTimeValues,
+            List<InfoBuildTimeContributorBuildItem> contributors,
+            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
+            InfoRecorder recorder) {
+        Map<String, Object> buildTimeInfo = buildTimeValues.stream().collect(
+                Collectors.toMap(InfoBuildTimeValuesBuildItem::getName, InfoBuildTimeValuesBuildItem::getValue, (x, y) -> y,
+                        LinkedHashMap::new));
+        List<InfoContributor> infoContributors = contributors.stream()
+                .map(InfoBuildTimeContributorBuildItem::getInfoContributor)
+                .collect(Collectors.toList());
+        return nonApplicationRootPathBuildItem.routeBuilder()
+                .management()
+                .route(buildTimeConfig.path())
+                .routeConfigKey("quarkus.info.path")
+                .handler(recorder.handler(buildTimeInfo, infoContributors))
+                .displayOnNotFoundPage()
+                .blockingRoute()
+                .build();
+    }
+}

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/JavaInInfoEndpointEnabled.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/JavaInInfoEndpointEnabled.java
@@ -1,0 +1,18 @@
+
+package io.quarkus.info.deployment;
+
+import java.util.function.BooleanSupplier;
+
+public class JavaInInfoEndpointEnabled implements BooleanSupplier {
+
+    private final InfoBuildTimeConfig config;
+
+    JavaInInfoEndpointEnabled(InfoBuildTimeConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        return config.enabled() && config.java().enabled();
+    }
+}

--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/OsInInfoEndpointEnabled.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/OsInInfoEndpointEnabled.java
@@ -1,0 +1,18 @@
+
+package io.quarkus.info.deployment;
+
+import java.util.function.BooleanSupplier;
+
+public class OsInInfoEndpointEnabled implements BooleanSupplier {
+
+    private final InfoBuildTimeConfig config;
+
+    OsInInfoEndpointEnabled(InfoBuildTimeConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        return config.enabled() && config.os().enabled();
+    }
+}

--- a/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/CustomDataInfoTest.java
+++ b/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/CustomDataInfoTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.info.deployment;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.info.deployment.spi.InfoBuildTimeContributorBuildItem;
+import io.quarkus.info.deployment.spi.InfoBuildTimeValuesBuildItem;
+import io.quarkus.info.runtime.spi.InfoContributor;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CustomDataInfoTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TestInfoContributor.class))
+            .addBuildChainCustomizer(buildCustomizer());
+
+    protected static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+            // This represents the extension.
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(context -> {
+                    context.produce(new InfoBuildTimeContributorBuildItem(new TestInfoContributor()));
+                    context.produce(new InfoBuildTimeValuesBuildItem("test2", Map.of("key", "value")));
+                })
+                        .produces(InfoBuildTimeContributorBuildItem.class)
+                        .produces(InfoBuildTimeValuesBuildItem.class)
+                        .build();
+            }
+        };
+    }
+
+    @Test
+    public void test() {
+        when().get("/q/info")
+                .then()
+                .statusCode(200)
+                .body("os", is(notNullValue()))
+                .body("os.name", is(notNullValue()))
+                .body("java", is(notNullValue()))
+                .body("java.version", is(notNullValue()))
+                .body("build", is(notNullValue()))
+                .body("build.time", is(notNullValue()))
+                .body("git", is(notNullValue()))
+                .body("git.branch", is(notNullValue()))
+                .body("test", is(notNullValue()))
+                .body("test.foo", is("bar"))
+                .body("test2", is(notNullValue()))
+                .body("test2.key", is("value"));
+
+    }
+
+    public static class TestInfoContributor implements InfoContributor {
+
+        @Override
+        public String name() {
+            return "test";
+        }
+
+        @Override
+        public Map<String, Object> data() {
+            return Map.of("foo", "bar");
+        }
+    }
+}

--- a/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/DisabledGitAndBuildTest.java
+++ b/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/DisabledGitAndBuildTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.info.deployment;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DisabledGitAndBuildTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.info.git.enabled", "false")
+            .overrideConfigKey("quarkus.info.build.enabled", "false");
+
+    @Test
+    public void test() {
+        when().get("/q/info")
+                .then()
+                .statusCode(200)
+                .body("os", is(notNullValue()))
+                .body("java", is(notNullValue()))
+                .body("build", is(nullValue()))
+                .body("git", is(nullValue()));
+
+    }
+}

--- a/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/DisabledInfoTest.java
+++ b/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/DisabledInfoTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.info.deployment;
+
+import static io.restassured.RestAssured.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DisabledInfoTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.info.enabled", "false");
+
+    @Test
+    public void test() {
+        when().get("/q/info")
+                .then()
+                .statusCode(404);
+
+    }
+}

--- a/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/EnabledInfoOnManagementInterfaceTest.java
+++ b/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/EnabledInfoOnManagementInterfaceTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.info.deployment;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class EnabledInfoOnManagementInterfaceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.management.enabled", "true");
+
+    @Test
+    public void test() {
+        when().get("/q/info")
+                .then()
+                .statusCode(404);
+
+        when().get("http://0.0.0.0:9001/q/info")
+                .then()
+                .statusCode(200)
+                .body("os", is(notNullValue()))
+                .body("os.name", is(notNullValue()))
+                .body("java", is(notNullValue()))
+                .body("java.version", is(notNullValue()))
+                .body("build", is(notNullValue()))
+                .body("build.time", is(notNullValue()))
+                .body("git", is(notNullValue()))
+                .body("git.branch", is(notNullValue()));
+
+    }
+}

--- a/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/EnabledInfoTest.java
+++ b/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/EnabledInfoTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.info.deployment;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class EnabledInfoTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication();
+
+    @Test
+    public void test() {
+        when().get("/q/info")
+                .then()
+                .statusCode(200)
+                .body("os", is(notNullValue()))
+                .body("os.name", is(notNullValue()))
+                .body("java", is(notNullValue()))
+                .body("java.version", is(notNullValue()))
+                .body("build", is(notNullValue()))
+                .body("build.time", is(notNullValue()))
+                .body("git", is(notNullValue()))
+                .body("git.branch", is(notNullValue()));
+
+    }
+}

--- a/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/NoGitProjectInfoTest.java
+++ b/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/NoGitProjectInfoTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.info.deployment;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.test.QuarkusUnitTest;
+
+@EnabledOnOs(OS.LINUX) // as this test deals with temp files that are created manually, let's avoid dealing with other OSes
+public class NoGitProjectInfoTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .addBootstrapCustomizer(new Consumer<QuarkusBootstrap.Builder>() {
+                @Override
+                public void accept(QuarkusBootstrap.Builder builder) {
+                    // needed to ensure that the workspace is not populated
+                    builder.setLocalProjectDiscovery(false);
+                    // needed to avoid bootstrap failing because of the previous property
+                    builder.setDisableClasspathCache(true);
+                    try {
+                        // needed to ensure that the output directory is outside the source tree
+                        Path tempDirectory = Files.createTempDirectory(Path.of("/tmp"), "info-test");
+                        tempDirectory.toFile().deleteOnExit();
+                        builder.setTargetDirectory(tempDirectory);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }
+            });
+
+    @Test
+    public void test() {
+        when().get("/q/info")
+                .then()
+                .statusCode(200)
+                .body("os", is(notNullValue()))
+                .body("os.name", is(notNullValue()))
+                .body("java", is(notNullValue()))
+                .body("java.version", is(notNullValue()))
+                .body("build", is(notNullValue()))
+                .body("build.time", is(notNullValue()))
+                .body("git", is(nullValue()));
+
+    }
+}

--- a/extensions/info/pom.xml
+++ b/extensions/info/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-info-parent</artifactId>
+    <name>Quarkus - Info</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>deployment-spi</module>
+        <module>runtime</module>
+        <module>runtime-spi</module>
+    </modules>
+
+</project>

--- a/extensions/info/runtime-spi/pom.xml
+++ b/extensions/info/runtime-spi/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-info-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-info-runtime-spi</artifactId>
+    <name>Quarkus - Info - Runtime SPI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/info/runtime-spi/src/main/java/io/quarkus/info/runtime/spi/InfoContributor.java
+++ b/extensions/info/runtime-spi/src/main/java/io/quarkus/info/runtime/spi/InfoContributor.java
@@ -1,0 +1,20 @@
+package io.quarkus.info.runtime.spi;
+
+import java.util.Map;
+
+/**
+ * SPI used by extensions to contribute properties to the info endpoint.
+ * This is meant to be called when the application is started and provide properties that do not change.
+ */
+public interface InfoContributor {
+
+    /**
+     * The top level property under which the {@code data} will be added
+     */
+    String name();
+
+    /**
+     * Properties to add under {@code name}
+     */
+    Map<String, Object> data();
+}

--- a/extensions/info/runtime/pom.xml
+++ b/extensions/info/runtime/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-info-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-info</artifactId>
+    <name>Quarkus - Info - Runtime</name>
+    <description>Expose the info endpoint</description>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-info-runtime-spi</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/info/runtime/src/main/java/io/quarkus/info/runtime/InfoRecorder.java
+++ b/extensions/info/runtime/src/main/java/io/quarkus/info/runtime/InfoRecorder.java
@@ -1,0 +1,50 @@
+package io.quarkus.info.runtime;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.info.runtime.spi.InfoContributor;
+import io.quarkus.runtime.annotations.Recorder;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+@Recorder
+public class InfoRecorder {
+
+    public Handler<RoutingContext> handler(Map<String, Object> buildTimeInfo, List<InfoContributor> knownContributors) {
+        return new InfoHandler(buildTimeInfo, knownContributors);
+    }
+
+    public OsInfoContributor osInfoContributor() {
+        return new OsInfoContributor();
+    }
+
+    public JavaInfoContributor javaInfoContributor() {
+        return new JavaInfoContributor();
+    }
+
+    private static class InfoHandler implements Handler<RoutingContext> {
+        private final Map<String, Object> finalBuildInfo;
+
+        public InfoHandler(Map<String, Object> buildTimeInfo, List<InfoContributor> knownContributors) {
+            this.finalBuildInfo = new HashMap<>(buildTimeInfo);
+            for (InfoContributor contributor : knownContributors) {
+                //TODO: we might want this to be done lazily
+                // also, do we want to merge information or simply replace like we are doing here?
+                finalBuildInfo.put(contributor.name(), contributor.data());
+            }
+        }
+
+        @Override
+        public void handle(RoutingContext ctx) {
+            HttpServerResponse resp = ctx.response();
+            resp.headers().set(HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8");
+            JsonObject jsonObject = new JsonObject(finalBuildInfo);
+            ctx.json(jsonObject);
+        }
+    }
+}

--- a/extensions/info/runtime/src/main/java/io/quarkus/info/runtime/JavaInfoContributor.java
+++ b/extensions/info/runtime/src/main/java/io/quarkus/info/runtime/JavaInfoContributor.java
@@ -1,0 +1,22 @@
+package io.quarkus.info.runtime;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.quarkus.info.runtime.spi.InfoContributor;
+
+public class JavaInfoContributor implements InfoContributor {
+
+    @Override
+    public String name() {
+        return "java";
+    }
+
+    @Override
+    public Map<String, Object> data() {
+        //TODO: should we add more information like 'java.runtime.*' and 'java.vm.*' ?
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("version", System.getProperty("java.version"));
+        return result;
+    }
+}

--- a/extensions/info/runtime/src/main/java/io/quarkus/info/runtime/OsInfoContributor.java
+++ b/extensions/info/runtime/src/main/java/io/quarkus/info/runtime/OsInfoContributor.java
@@ -1,0 +1,22 @@
+package io.quarkus.info.runtime;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.quarkus.info.runtime.spi.InfoContributor;
+
+public class OsInfoContributor implements InfoContributor {
+    @Override
+    public String name() {
+        return "os";
+    }
+
+    @Override
+    public Map<String, Object> data() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("name", System.getProperty("os.name"));
+        result.put("version", System.getProperty("os.version"));
+        result.put("arch", System.getProperty("os.arch"));
+        return result;
+    }
+}

--- a/extensions/info/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/info/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,11 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "Info"
+metadata:
+  keywords:
+  - "info"
+  categories:
+  - "miscellaneous"
+  status: "experimental"
+  config:
+  - "quarkus.info."

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -52,6 +52,7 @@
         <module>micrometer</module>
         <module>micrometer-registry-prometheus</module>
         <module>opentelemetry</module>
+        <module>info</module>
 
         <!-- REST services -->
         <module>resteasy-classic</module>

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -135,6 +135,8 @@ public class QuarkusUnitTest
 
     private List<Object> testMethodInvokers;
 
+    private List<Consumer<QuarkusBootstrap.Builder>> bootstrapCustomizers = new ArrayList<>();
+
     public QuarkusUnitTest setExpectedException(Class<? extends Throwable> expectedException) {
         return setExpectedException(expectedException, false);
     }
@@ -325,6 +327,15 @@ public class QuarkusUnitTest
      */
     public QuarkusUnitTest setAllowTestClassOutsideDeployment(boolean allowTestClassOutsideDeployment) {
         this.allowTestClassOutsideDeployment = allowTestClassOutsideDeployment;
+        return this;
+    }
+
+    /**
+     * An advanced option that allows tests to customize the {@link QuarkusBootstrap.Builder} that will be used to create the
+     * {@link CuratedApplication}
+     */
+    public QuarkusUnitTest addBootstrapCustomizer(Consumer<QuarkusBootstrap.Builder> consumer) {
+        this.bootstrapCustomizers.add(consumer);
         return this;
     }
 
@@ -631,6 +642,10 @@ public class QuarkusUnitTest
                                             .addBannedElement(ClassPathElement.fromPath(testLocation, true)).build());
                 }
                 builder.addClassLoaderEventListeners(this.classLoadListeners);
+
+                for (Consumer<QuarkusBootstrap.Builder> bootstrapCustomizer : bootstrapCustomizers) {
+                    bootstrapCustomizer.accept(builder);
+                }
                 curatedApplication = builder.build().bootstrap();
 
                 StartupActionImpl startupAction = new AugmentActionImpl(curatedApplication, customizers, classLoadListeners)


### PR DESCRIPTION
An example output of `http://localhost:8080/q/info` is:

```json
{

    "git": {
        "commit": {
            "id": "2230e915f9e2854ec55a9155ec1d9b3e92dc2c17",
            "time": "2023-03-01T21:57:22Z"
        },
        "branch": "development"
    },
    "java": {
        "version": "17.0.6"
    },
    "os": {
        "arch": "amd64",
        "name": "Linux",
        "version": "5.19.0-35-generic"
    },
    "build": {
        "version": "1.0.0-SNAPSHOT",
        "group": "org.acme",
        "time": "2023-03-27T17:48:21.797654785+03:00",
        "artifact": "getting-started"
    }

}
```

Questions that need to be answered:

* Do we want to call it `quarkus-info` which is super generic or something else?
* Are we okay with having this first version which does not allow user code to contribute entries?
* The API is pretty primitive for now, do we want to improve it? For the moment, I think it's fine because it solves the main use case and also the API is not publicly exposed

Things that need to be done: 

- [ ] Add documentation
- [x] Add tests

Closes: #29995