### PR TITLE
Bump the lowest supported Maven version to 3.6.3

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -60,7 +60,7 @@
         <!--
         Supported Maven versions, interpreted as a version range (Also defined in quarkus-enforcer-rules)
          -->
-        <supported-maven-versions>[3.6.2,)</supported-maven-versions>
+        <supported-maven-versions>[3.6.3,)</supported-maven-versions>
 
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
         <proposed-maven-version>3.8.8</proposed-maven-version>


### PR DESCRIPTION
Due to a recent change https://github.com/quarkusio/quarkus/pull/31969 that broke integration with Maven versions lower than 3.6.3.

Fix https://github.com/quarkusio/quarkus/issues/32081