### PR TITLE
Rework sequence handling in import scripts in codestarts, guides and tests

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/hibernate-orm-codestart/base/src/main/resources/import.sql
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/hibernate-orm-codestart/base/src/main/resources/import.sql
@@ -1,5 +1,6 @@
 -- This file allow to write SQL commands that will be emitted in test and dev.
 -- The commands are commented as their support depends of the database
--- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-1');
--- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-2');
--- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-3');
+-- insert into myentity (id, field) values(1, 'field-1');
+-- insert into myentity (id, field) values(2, 'field-2');
+-- insert into myentity (id, field) values(3, 'field-3');
+-- alter sequence myentity_seq restart with 4;

--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -160,9 +160,10 @@ In the same directory, create an `import.sql` file, which inserts a few fruits, 
 
 [source, text]
 ----
-INSERT INTO fruit(id, name) VALUES (nextval('hibernate_sequence'), 'Cherry');
-INSERT INTO fruit(id, name) VALUES (nextval('hibernate_sequence'), 'Apple');
-INSERT INTO fruit(id, name) VALUES (nextval('hibernate_sequence'), 'Banana');
+INSERT INTO fruit(id, name) VALUES (1, 'Cherry');
+INSERT INTO fruit(id, name) VALUES (2, 'Apple');
+INSERT INTO fruit(id, name) VALUES (3, 'Banana');
+ALTER SEQUENCE fruit_seq RESTART WITH 4;
 ----
 
 In a terminal, launch the application in dev mode using: `./mvnw quarkus:dev`.

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -612,7 +612,8 @@ To make it easier to showcase some capabilities of Hibernate ORM with Panache on
 
 [source,sql]
 ----
-INSERT INTO person (id, birth, name, status) VALUES (nextval('hibernate_sequence'), '1995-09-12', 'Emily Brown', 0);
+INSERT INTO person (id, birth, name, status) VALUES (1, '1995-09-12', 'Emily Brown', 0);
+ALTER SEQUENCE person_seq RESTART WITH 2;
 ----
 
 NOTE: If you would like to initialize the DB when you start the Quarkus app in your production environment, add `quarkus.hibernate-orm.database.generation=drop-and-create` to the Quarkus startup options in addition to `import.sql`.

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -645,22 +645,24 @@ Let's create a `src/main/resources/import.sql` file with the following content:
 
 [source,sql]
 ----
-INSERT INTO author(id, firstname, lastname) VALUES (nextval('hibernate_sequence'), 'John', 'Irving');
-INSERT INTO author(id, firstname, lastname) VALUES (nextval('hibernate_sequence'), 'Paul', 'Auster');
+INSERT INTO author(id, firstname, lastname) VALUES (1, 'John', 'Irving');
+INSERT INTO author(id, firstname, lastname) VALUES (2, 'Paul', 'Auster');
+ALTER SEQUENCE author_seq RESTART WITH 3;
 
-INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'The World According to Garp', 1);
-INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'The Hotel New Hampshire', 1);
-INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'The Cider House Rules', 1);
-INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'A Prayer for Owen Meany', 1);
-INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'Last Night in Twisted River', 1);
-INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'In One Person', 1);
-INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'Avenue of Mysteries', 1);
-INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'The New York Trilogy', 2);
-INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'Mr. Vertigo', 2);
-INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'The Brooklyn Follies', 2);
-INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'Invisible', 2);
-INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'Sunset Park', 2);
-INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), '4 3 2 1', 2);
+INSERT INTO book(id, title, author_id) VALUES (1, 'The World According to Garp', 1);
+INSERT INTO book(id, title, author_id) VALUES (2, 'The Hotel New Hampshire', 1);
+INSERT INTO book(id, title, author_id) VALUES (3, 'The Cider House Rules', 1);
+INSERT INTO book(id, title, author_id) VALUES (4, 'A Prayer for Owen Meany', 1);
+INSERT INTO book(id, title, author_id) VALUES (5, 'Last Night in Twisted River', 1);
+INSERT INTO book(id, title, author_id) VALUES (6, 'In One Person', 1);
+INSERT INTO book(id, title, author_id) VALUES (7, 'Avenue of Mysteries', 1);
+INSERT INTO book(id, title, author_id) VALUES (8, 'The New York Trilogy', 2);
+INSERT INTO book(id, title, author_id) VALUES (9, 'Mr. Vertigo', 2);
+INSERT INTO book(id, title, author_id) VALUES (10, 'The Brooklyn Follies', 2);
+INSERT INTO book(id, title, author_id) VALUES (11, 'Invisible', 2);
+INSERT INTO book(id, title, author_id) VALUES (12, 'Sunset Park', 2);
+INSERT INTO book(id, title, author_id) VALUES (13, '4 3 2 1', 2);
+ALTER SEQUENCE book_seq RESTART WITH 14;
 ----
 
 == Time to play with your application

--- a/extensions/hibernate-orm/deployment/src/test/resources/import-custom-table-name.sql
+++ b/extensions/hibernate-orm/deployment/src/test/resources/import-custom-table-name.sql
@@ -1,3 +1,3 @@
 INSERT INTO MyEntityTable(id, name) VALUES(1, 'default sql load script entity');
 INSERT INTO MyEntityTable(id, name) VALUES(2, 'import.sql load script entity');
-alter sequence myEntitySeq restart with 3;
+ALTER SEQUENCE myEntitySeq RESTART WITH 3;

--- a/extensions/hibernate-orm/deployment/src/test/resources/import.sql
+++ b/extensions/hibernate-orm/deployment/src/test/resources/import.sql
@@ -1,3 +1,3 @@
 INSERT INTO MyEntity(id, name) VALUES(1, 'default sql load script entity');
 INSERT INTO MyEntity(id, name) VALUES(2, 'import.sql load script entity');
-alter sequence myEntitySeq restart with 3;
+ALTER SEQUENCE myEntitySeq RESTART WITH 3;

--- a/integration-tests/cache/src/main/resources/import.sql
+++ b/integration-tests/cache/src/main/resources/import.sql
@@ -1,2 +1,3 @@
-INSERT INTO tree(id, name) VALUES (nextval('Tree_SEQ'), 'Oak');
-INSERT INTO tree(id, name) VALUES (nextval('Tree_SEQ'), 'Chestnut');
+INSERT INTO tree(id, name) VALUES (1, 'Oak');
+INSERT INTO tree(id, name) VALUES (2, 'Chestnut');
+ALTER SEQUENCE tree_seq RESTART WITH 3;

--- a/integration-tests/devtools/src/test/resources/__snapshots__/HibernateOrmCodestartIT/testContent/src_main_resources_import.sql
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/HibernateOrmCodestartIT/testContent/src_main_resources_import.sql
@@ -1,5 +1,6 @@
 -- This file allow to write SQL commands that will be emitted in test and dev.
 -- The commands are commented as their support depends of the database
--- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-1');
--- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-2');
--- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-3');
+-- insert into myentity (id, field) values(1, 'field-1');
+-- insert into myentity (id, field) values(2, 'field-2');
+-- insert into myentity (id, field) values(3, 'field-3');
+-- alter sequence myentity_seq restart with 4;

--- a/integration-tests/devtools/src/test/resources/__snapshots__/HibernateOrmPanacheCodestartIT/testContent/src_main_resources_import.sql
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/HibernateOrmPanacheCodestartIT/testContent/src_main_resources_import.sql
@@ -1,5 +1,6 @@
 -- This file allow to write SQL commands that will be emitted in test and dev.
 -- The commands are commented as their support depends of the database
--- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-1');
--- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-2');
--- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-3');
+-- insert into myentity (id, field) values(1, 'field-1');
+-- insert into myentity (id, field) values(2, 'field-2');
+-- insert into myentity (id, field) values(3, 'field-3');
+-- alter sequence myentity_seq restart with 4;

--- a/integration-tests/devtools/src/test/resources/__snapshots__/HibernateOrmPanacheKotlinCodestartIT/testContent/src_main_resources_import.sql
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/HibernateOrmPanacheKotlinCodestartIT/testContent/src_main_resources_import.sql
@@ -1,5 +1,6 @@
 -- This file allow to write SQL commands that will be emitted in test and dev.
 -- The commands are commented as their support depends of the database
--- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-1');
--- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-2');
--- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-3');
+-- insert into myentity (id, field) values(1, 'field-1');
+-- insert into myentity (id, field) values(2, 'field-2');
+-- insert into myentity (id, field) values(3, 'field-3');
+-- alter sequence myentity_seq restart with 4;


### PR DESCRIPTION
* to be more consistent
* to adapt to Hibernate ORM 6 changes

Fixes #31521

Goes together with https://github.com/quarkusio/quarkus-quickstarts/pull/1255