### PR TITLE
Simplify MutinyInfrastructure

### DIFF
--- a/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
+++ b/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
@@ -1,7 +1,6 @@
 package io.quarkus.mutiny.deployment;
 
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
 
 import org.jboss.threads.ContextHandler;
 
@@ -21,9 +20,8 @@ public class MutinyProcessor {
             MutinyInfrastructure recorder,
             ShutdownContextBuildItem shutdownContext,
             Optional<ContextHandlerBuildItem> contextHandler) {
-        ExecutorService executor = executorBuildItem.getExecutorProxy();
         ContextHandler<Object> handler = contextHandler.map(ContextHandlerBuildItem::contextHandler).orElse(null);
-        recorder.configureMutinyInfrastructure(executor, shutdownContext, handler);
+        recorder.configureMutinyInfrastructure(executorBuildItem.getExecutorProxy(), shutdownContext, handler);
     }
 
     @BuildStep

--- a/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
+++ b/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/MutinyInfrastructure.java
@@ -1,17 +1,6 @@
 package io.quarkus.mutiny.runtime;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.RunnableScheduledFuture;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
@@ -21,135 +10,17 @@ import org.jboss.threads.ContextHandler;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
-import io.smallrye.mutiny.infrastructure.MutinyScheduler;
 
 @Recorder
 public class MutinyInfrastructure {
 
     public static final String VERTX_EVENT_LOOP_THREAD_PREFIX = "vert.x-eventloop-thread-";
 
-    public void configureMutinyInfrastructure(ExecutorService executor, ShutdownContext shutdownContext,
+    public void configureMutinyInfrastructure(ScheduledExecutorService executor, ShutdownContext shutdownContext,
             ContextHandler<Object> contextHandler) {
         // Mutiny leaks a ScheduledExecutorService if we don't do this
         Infrastructure.getDefaultWorkerPool().shutdown();
-
-        // Since executor is not a ScheduledExecutorService and Mutiny needs one for scheduling we have to adapt one around the provided executor
-        MutinyScheduler mutinyScheduler = new MutinyScheduler(executor) {
-            @Override
-            protected <V> RunnableScheduledFuture<V> decorateTask(Runnable runnable, RunnableScheduledFuture<V> task) {
-                Object context = (contextHandler != null) ? contextHandler.captureContext() : null;
-                return super.decorateTask(runnable, new ContextualRunnableScheduledFuture<>(contextHandler, context, task));
-            }
-
-            @Override
-            protected <V> RunnableScheduledFuture<V> decorateTask(Callable<V> callable, RunnableScheduledFuture<V> task) {
-                Object context = (contextHandler != null) ? contextHandler.captureContext() : null;
-                return super.decorateTask(callable, new ContextualRunnableScheduledFuture<>(contextHandler, context, task));
-            }
-        };
-        Infrastructure.setDefaultExecutor(new ScheduledExecutorService() {
-
-            @Override
-            public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-                return mutinyScheduler.schedule(command, delay, unit);
-            }
-
-            @Override
-            public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-                return mutinyScheduler.schedule(callable, delay, unit);
-            }
-
-            @Override
-            public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
-                return mutinyScheduler.scheduleAtFixedRate(command, initialDelay, period, unit);
-            }
-
-            @Override
-            public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
-                return mutinyScheduler.scheduleWithFixedDelay(command, initialDelay, delay, unit);
-            }
-
-            @Override
-            public void shutdown() {
-                mutinyScheduler.shutdown(); // ...but do not shut `executor` down
-            }
-
-            @Override
-            public List<Runnable> shutdownNow() {
-                return mutinyScheduler.shutdownNow();
-            }
-
-            @Override
-            public boolean isShutdown() {
-                return mutinyScheduler.isShutdown();
-            }
-
-            @Override
-            public boolean isTerminated() {
-                return mutinyScheduler.isTerminated();
-            }
-
-            @Override
-            public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-                return mutinyScheduler.awaitTermination(timeout, unit);
-            }
-
-            @Override
-            public <T> Future<T> submit(Callable<T> task) {
-                return executor.submit(task);
-            }
-
-            @Override
-            public <T> Future<T> submit(Runnable task, T result) {
-                return executor.submit(task, result);
-            }
-
-            @Override
-            public Future<?> submit(Runnable task) {
-                return executor.submit(task);
-            }
-
-            @Override
-            public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-                return executor.invokeAll(tasks);
-            }
-
-            @Override
-            public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-                    throws InterruptedException {
-                return executor.invokeAll(tasks, timeout, unit);
-            }
-
-            @Override
-            public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-                return executor.invokeAny(tasks);
-            }
-
-            @Override
-            public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-                    throws InterruptedException, ExecutionException, TimeoutException {
-                return executor.invokeAny(tasks, timeout, unit);
-            }
-
-            @Override
-            public void execute(Runnable command) {
-                try {
-                    executor.execute(command);
-                } catch (RejectedExecutionException rejected) {
-                    // Ignore submission failures on application shutdown
-                    if (!executor.isShutdown() && !executor.isTerminated()) {
-                        throw rejected;
-                    }
-                }
-            }
-        });
-
-        shutdownContext.addLastShutdownTask(new Runnable() {
-            @Override
-            public void run() {
-                mutinyScheduler.shutdown();
-            }
-        });
+        Infrastructure.setDefaultExecutor(executor);
     }
 
     public void configureDroppedExceptionHandler() {


### PR DESCRIPTION
- there is no need to wrap the default executor service anymore - the ScheduledExecutorService is implemented