### PR TITLE
Enhance MS Azure content doc portal search results

### DIFF
--- a/docs/src/main/asciidoc/azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/azure-functions-http.adoc
@@ -7,7 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 :extension-status: preview
 include::_attributes.adoc[]
 :categories: cloud
-:summary: This guide explains how you can deploy Vert.x Web, Servlet, or RESTEasy microservices as an Azure Function.
+:summary: Deploy Vert.x Web, Servlet, or RESTEasy microservices as a Microsoft Azure Function.
 
 The `quarkus-azure-functions-http` extension allows you to write microservices with RESTEasy Reactive (our Jakarta REST implementation),
 Undertow (servlet), Reactive Routes, or xref:funqy-http.adoc[Funqy HTTP] and make these microservices deployable to the Azure Functions runtime.

--- a/docs/src/main/asciidoc/azure-functions.adoc
+++ b/docs/src/main/asciidoc/azure-functions.adoc
@@ -7,7 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 :extension-status: preview
 include::_attributes.adoc[]
 :categories: cloud
-:summary: This guide explains how you can integrate Quarkus with any Azure Functions you write.
+:summary: Integrate Quarkus with the Microsoft Azure functions that you have written.
 
 The `quarkus-azure-functions` extension is a simple integration point between Azure Functions
 and Quarkus.  It interacts with Azure Functions runtime to bootstrap quarkus and turns any

--- a/docs/src/main/asciidoc/deploying-to-azure-cloud.adoc
+++ b/docs/src/main/asciidoc/deploying-to-azure-cloud.adoc
@@ -6,7 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Deploying to Microsoft Azure Cloud
 include::_attributes.adoc[]
 :categories: cloud
-:summary: This guide explains how to deploy a Quarkus application to Microsoft Azure Cloud.
+:summary: Deploy a Quarkus application to the Microsoft Azure cloud platform.
 
 This guide covers:
 
@@ -30,7 +30,7 @@ Make sure you have the getting-started application at hand, or clone the Git rep
 
 == Change Quarkus HTTP Port
 
-If you correctly followed the xref:building-native-image.adoc[building native image guide], you should have a local container image named `quarkus-quickstart/getting-started`. 
+If you correctly followed the xref:building-native-image.adoc[building native image guide], you should have a local container image named `quarkus-quickstart/getting-started`.
 
 While Quarkus by default runs on port 8080, most Azure services expect web applications to be running on port 80. Before we continue, go back to your quickstart code and open the file `src/main/docker/Dockerfile.native`.
 
@@ -124,7 +124,7 @@ $ az acr repository list -n <registry-name>
 
 == Deploy to Azure Container Instances
 
-The simplest way to start this container in the cloud is with the Azure Container Instances service. It simply creates a container on Azure infrastructure. 
+The simplest way to start this container in the cloud is with the Azure Container Instances service. It simply creates a container on Azure infrastructure.
 
 There are different approaches for using ACI. Check the documentation for details. The quickest way to get a container up and running goes as it follows.
 

--- a/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
@@ -7,7 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 :extension-status: preview
 include::_attributes.adoc[]
 :categories: cloud
-:summary: This guide explains Funqy's Azure Functions HTTP binding.
+:summary: Use Funqy HTTP binding with Microsoft Azure Functions to deploy your serverless Quarkus applications.
 
 You can use xref:funqy-http.adoc[Funqy HTTP] on Azure Functions.  This allows you to invoke on multiple Funqy functions
 using HTTP deployed as one Azure Function.


### PR DESCRIPTION
This PR enhances the search results on the [Quarkus doc landing page](https://quarkus.io/guides/) relating to Microsoft Azure content. 

![image](https://user-images.githubusercontent.com/92924207/228305745-b97056e4-d741-45df-b672-d6a37afb7412.png)

When you search for Microsoft, only 3 guides are returned. This fix ensures that all 4 guides relating to Microsoft Azure deployment/integration with Quarkus are returned when a reader does a quick search using the string 'Microsoft'. 

