### PR TITLE
Upgrade spring extensions to spring 6

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -178,10 +178,10 @@
         <okio.version>1.17.2</okio.version><!-- keep in sync with okhttp -->
         <hibernate-quarkus-local-cache.version>0.2.0</hibernate-quarkus-local-cache.version>
         <flapdoodle.mongo.version>4.6.2</flapdoodle.mongo.version>
-        <quarkus-spring-api.version>5.2.SP7</quarkus-spring-api.version>
-        <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>
-        <quarkus-spring-security-api.version>5.4.Final</quarkus-spring-security-api.version>
-        <quarkus-spring-boot-api.version>2.1.SP1</quarkus-spring-boot-api.version>
+        <quarkus-spring-api.version>6.0.Final-SNAPSHOT</quarkus-spring-api.version>
+        <quarkus-spring-data-api.version>3.0.Final-SNAPSHOT</quarkus-spring-data-api.version>
+        <quarkus-spring-security-api.version>6.0.Final-SNAPSHOT</quarkus-spring-security-api.version>
+        <quarkus-spring-boot-api.version>3.0.Final-SNAPSHOT</quarkus-spring-boot-api.version>
         <mockito.version>5.2.0</mockito.version>
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.10.1</antlr.version><!-- needs to align with same property in build-parent/pom.xml -->

--- a/docs/src/main/asciidoc/spring-data-rest.adoc
+++ b/docs/src/main/asciidoc/spring-data-rest.adoc
@@ -323,17 +323,17 @@ The former is used by default, but it is highly recommended to specify which one
 ==== Exposing many entities
 
 If a database contains many entities, it might not be a great idea to return them all at once.
-`PagingAndSortingRepository` allows the `spring-data-rest` extension to access data in chunks.
+`JpaRepository` allows the `spring-data-rest` extension to access data in chunks.
 
-Replace the `CrudRepository` with `PagingAndSortingRepository` in the `FruitsRepository`:
+Replace the `CrudRepository` with `JpaRepository` in the `FruitsRepository`:
 
 [source,java]
 ----
 package org.acme.spring.data.rest;
 
-import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.JpaRepository;
 
-public interface FruitsRepository extends PagingAndSortingRepository<Fruit, Long> {
+public interface FruitsRepository extends JpaRepository<Fruit, Long> {
 }
 ----
 
@@ -394,7 +394,7 @@ public interface FruitsRepository extends CrudRepository<Fruit, Long> {
 It is important to annotate the correct method in order to customize its REST endpoint:
 
 |===
-|REST operation |CrudRepository |PagingAndSortingRepository and JpaRepository
+|REST operation |CrudRepository |JpaRepository
 
 |Get by ID
 |`Optional<T> findById(ID id)`

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/SpringDataJPAProcessor.java
@@ -27,6 +27,8 @@ import org.springframework.data.domain.Auditable;
 import org.springframework.data.domain.Persistable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.ListPagingAndSortingRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.QueryByExampleExecutor;
@@ -80,7 +82,9 @@ public class SpringDataJPAProcessor {
         additionalIndexedClasses.produce(new AdditionalIndexedClassesBuildItem(
                 Repository.class.getName(),
                 CrudRepository.class.getName(),
+                ListCrudRepository.class.getName(),
                 PagingAndSortingRepository.class.getName(),
+                ListPagingAndSortingRepository.class.getName(),
                 JpaRepository.class.getName(),
                 QueryByExampleExecutor.class.getName()));
     }

--- a/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/SpringDataRestProcessor.java
+++ b/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/SpringDataRestProcessor.java
@@ -16,6 +16,8 @@ import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Type;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.ListPagingAndSortingRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
@@ -46,14 +48,21 @@ class SpringDataRestProcessor {
 
     private static final DotName CRUD_REPOSITORY_INTERFACE = DotName.createSimple(CrudRepository.class.getName());
 
+    private static final DotName LIST_CRUD_REPOSITORY_INTERFACE = DotName.createSimple(ListCrudRepository.class.getName());
+
     private static final DotName PAGING_AND_SORTING_REPOSITORY_INTERFACE = DotName
             .createSimple(PagingAndSortingRepository.class.getName());
+
+    private static final DotName LIST_PAGING_AND_SORTING_REPOSITORY_INTERFACE = DotName
+            .createSimple(ListPagingAndSortingRepository.class.getName());
 
     private static final DotName JPA_REPOSITORY_INTERFACE = DotName.createSimple(JpaRepository.class.getName());
 
     private static final List<DotName> EXCLUDED_INTERFACES = Arrays.asList(
             CRUD_REPOSITORY_INTERFACE,
+            LIST_CRUD_REPOSITORY_INTERFACE,
             PAGING_AND_SORTING_REPOSITORY_INTERFACE,
+            LIST_PAGING_AND_SORTING_REPOSITORY_INTERFACE,
             JPA_REPOSITORY_INTERFACE);
 
     @BuildStep

--- a/extensions/spring-data-rest/deployment/src/test/java/io/quarkus/spring/data/rest/paged/DefaultRecordsRepository.java
+++ b/extensions/spring-data-rest/deployment/src/test/java/io/quarkus/spring/data/rest/paged/DefaultRecordsRepository.java
@@ -1,6 +1,6 @@
 package io.quarkus.spring.data.rest.paged;
 
-import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface DefaultRecordsRepository extends PagingAndSortingRepository<Record, Long> {
+public interface DefaultRecordsRepository extends JpaRepository<Record, Long> {
 }

--- a/extensions/spring-web/core/common-runtime/src/main/java/io/quarkus/spring/web/runtime/common/ResponseEntityConverter.java
+++ b/extensions/spring-web/core/common-runtime/src/main/java/io/quarkus/spring/web/runtime/common/ResponseEntityConverter.java
@@ -18,7 +18,7 @@ public class ResponseEntityConverter {
 
     @SuppressWarnings("rawtypes")
     public static Response toResponse(ResponseEntity responseEntity, MediaType defaultMediaType) {
-        Response.ResponseBuilder responseBuilder = Response.status(responseEntity.getStatusCodeValue())
+        Response.ResponseBuilder responseBuilder = Response.status(responseEntity.getStatusCode().value())
                 .entity(responseEntity.getBody());
         var jaxRsHeaders = toJaxRsHeaders(responseEntity.getHeaders());
         if (!jaxRsHeaders.containsKey(HttpHeaders.CONTENT_TYPE) && (defaultMediaType != null)) {

--- a/extensions/spring-web/core/common-runtime/src/main/java/io/quarkus/spring/web/runtime/common/ResponseStatusExceptionMapper.java
+++ b/extensions/spring-web/core/common-runtime/src/main/java/io/quarkus/spring/web/runtime/common/ResponseStatusExceptionMapper.java
@@ -14,8 +14,8 @@ public class ResponseStatusExceptionMapper implements ExceptionMapper<ResponseSt
 
     @Override
     public Response toResponse(ResponseStatusException exception) {
-        Response.ResponseBuilder responseBuilder = Response.status(exception.getStatus().value());
-        addHeaders(responseBuilder, exception.getResponseHeaders());
+        Response.ResponseBuilder responseBuilder = Response.status(exception.getStatusCode().value());
+        addHeaders(responseBuilder, exception.getHeaders());
         return responseBuilder.entity(exception.getMessage())
                 .type(MediaType.TEXT_PLAIN).build();
     }

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/SongRepository.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/SongRepository.java
@@ -3,11 +3,11 @@ package io.quarkus.it.spring.data.jpa;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 
-public interface SongRepository extends PagingAndSortingRepository<Song, Long> {
+public interface SongRepository extends JpaRepository<Song, Long> {
 
     @Query(value = "SELECT s FROM Song s JOIN s.likes l WHERE l.id = :personId")
     List<Song> findPersonLikedSongs(@Param("personId") Long personId);

--- a/integration-tests/spring-data-rest/src/main/java/io/quarkus/it/spring/data/rest/BooksRepository.java
+++ b/integration-tests/spring-data-rest/src/main/java/io/quarkus/it/spring/data/rest/BooksRepository.java
@@ -1,6 +1,6 @@
 package io.quarkus.it.spring.data.rest;
 
-import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BooksRepository extends PagingAndSortingRepository<Book, Long> {
+public interface BooksRepository extends JpaRepository<Book, Long> {
 }

--- a/integration-tests/spring-data-rest/src/main/resources/application.properties
+++ b/integration-tests/spring-data-rest/src/main/resources/application.properties
@@ -4,3 +4,5 @@ quarkus.datasource.jdbc.max-size=8
 quarkus.hibernate-orm.database.generation=drop-and-create
 #quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.sql-load-script=import.sql
+# Bean validation asserts in tests
+quarkus.default-locale=en-US


### PR DESCRIPTION
Fixes #32027

Depends on SNAPSHOT version of quarkus-spring-api-* repos.

Breaking changes:

- spring 6 uses Java 17 bytecode, so the Quarkus spring-* extensions will only work with JDK17+ (meaning Quarkus release build would need to use JDK17 and modules would need to be excluded from JDK11 CI build)
- spring-data PagingAndSortingRepository no longer extends CrudRepository ([diagrams](https://stackoverflow.com/questions/14014086/what-is-difference-between-crudrepository-and-jparepository-interfaces-in-spring/74512964#74512964)) , users need to extend JpaRepository to have CRUD+paging features. New ListCrudRepository/ListPagingAndSortingRepository interfaces are not directly supported.
- spring-web splited the enums HttpStatus / HttpStatusCode, which requires a change in runtime ResponseStatusExceptionMapper/ResponseEntityConverter.

Also fix a failing spring-data-rest test when running on systems with non-english locale.