### PR TITLE
Encrypt OIDC session cookie value by default

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-concept.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-concept.adoc
@@ -371,7 +371,7 @@ Note that some endpoints do not require the access token. An access token is onl
 If the ID, access and refresh tokens are JWT tokens then combining all of them (if the strategy is the default `keep-all-tokens`) or only ID and refresh tokens (if the strategy is `id-refresh-token`) may produce a session cookie value larger than 4KB and the browsers may not be able to keep this cookie.
 In such cases, you can use `quarkus.oidc.token-state-manager.split-tokens=true` to have a unique session token per each of these tokens.
 
-You can also configure the default `TokenStateManager` to encrypt the tokens before storing them as cookie values which may be necessary if the tokens contain sensitive claim values.
+Note that `TokenStateManager` will encrypt the tokens before storing them in the session cookie.
 For example, here is how you configure it to split the tokens and encrypt them:
 
 [source, properties]
@@ -381,12 +381,14 @@ quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
 quarkus.oidc.application-type=web-app
 quarkus.oidc.token-state-manager.split-tokens=true
-quarkus.oidc.token-state-manager.encryption-required=true
 quarkus.oidc.token-state-manager.encryption-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 ----
 
-The token encryption secret must be 32 characters long. Note that you only have to set `quarkus.oidc.token-state-manager.encryption-secret` if you prefer not to use
-`quarkus.oidc.credentials.secret` for encrypting the tokens or if `quarkus.oidc.credentials.secret` length is less than 32 characters.
+The token encryption secret must be at least 32 characters long. If this key is not configured then either `quarkus.oidc.credentials.secret` or `quarkus.oidc.credentials.jwt.secret` will be hashed to create an encryption key.
+
+`quarkus.oidc.token-state-manager.encryption-secret` should be configured if Quarkus authenticates to OpenId Connect Provider using either mTLS or `private_key_jwt` (where a private RSA or EC key is used to sign a JWT token) authentication methods, otherwise a random key will be generated which will be problematic if the Quarkus application is running in the cloud with multiple pods managing the requests.
+
+If you need you can disable encrypting the tokens in the session cookie with `quarkus.oidc.token-state-manager.encryption-required=false`.
 
 Register your own `io.quarkus.oidc.TokenStateManager' implementation as an `@ApplicationScoped` CDI bean if you need to customize the way the tokens are associated with the session cookie. For example, you may want to keep the tokens in a database and have only a database pointer stored in a session cookie. Note though that it may present some challenges in making the tokens available across multiple microservices nodes.
 

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -280,6 +280,10 @@ public class OidcCommonUtils {
         return creds.secret.orElse(creds.clientSecret.value.orElseGet(fromCredentialsProvider(creds.clientSecret.provider)));
     }
 
+    public static String jwtSecret(Credentials creds) {
+        return creds.jwt.secret.orElseGet(fromCredentialsProvider(creds.jwt.secretProvider));
+    }
+
     public static Secret.Method clientSecretMethod(Credentials creds) {
         return creds.clientSecret.method.orElseGet(() -> Secret.Method.BASIC);
     }
@@ -304,7 +308,7 @@ public class OidcCommonUtils {
     public static Key clientJwtKey(Credentials creds) {
         if (creds.jwt.secret.isPresent() || creds.jwt.secretProvider.key.isPresent()) {
             return KeyUtils
-                    .createSecretKeyFromSecret(creds.jwt.secret.orElseGet(fromCredentialsProvider(creds.jwt.secretProvider)));
+                    .createSecretKeyFromSecret(jwtSecret(creds));
         } else {
             Key key = null;
             try {

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
@@ -97,7 +97,7 @@ public class CodeFlowDevModeTestCase {
 
             assertEquals("alice", page.getBody().asNormalizedText());
 
-            assertEquals("custom", page.getWebClient().getCookieManager().getCookie("q_session").getValue().split("\\|")[3]);
+            assertEquals("custom", page.getWebClient().getCookieManager().getCookie("q_session").getValue().split("\\|")[1]);
 
             webClient.getOptions().setRedirectEnabled(false);
             WebResponse webResponse = webClient

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -374,8 +374,8 @@ public class OidcTenantConfig extends OidcCommonConfig {
         /**
          * Requires that the tokens are encrypted before being stored in the cookies.
          */
-        @ConfigItem(defaultValueDocumentation = "false")
-        public Optional<Boolean> encryptionRequired = Optional.empty();
+        @ConfigItem(defaultValue = "true")
+        public boolean encryptionRequired = true;
 
         /**
          * Secret which will be used to encrypt the tokens.
@@ -385,12 +385,12 @@ public class OidcTenantConfig extends OidcCommonConfig {
         @ConfigItem
         public Optional<String> encryptionSecret = Optional.empty();
 
-        public Optional<Boolean> isEncryptionRequired() {
+        public boolean isEncryptionRequired() {
             return encryptionRequired;
         }
 
         public void setEncryptionRequired(boolean encryptionRequired) {
-            this.encryptionRequired = Optional.of(encryptionRequired);
+            this.encryptionRequired = encryptionRequired;
         }
 
         public Optional<String> getEncryptionSecret() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -287,10 +287,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                         if (isBackChannelLogoutPendingAndValid(configContext, identity)
                                                 || isFrontChannelLogoutValid(context, configContext,
                                                         identity)) {
-                                            return OidcUtils
-                                                    .removeSessionCookie(context, configContext.oidcConfig,
-                                                            sessionCookie.getName(),
-                                                            resolver.getTokenStateManager())
+                                            return removeSessionCookie(context, configContext.oidcConfig)
                                                     .map(new Function<Void, Void>() {
                                                         @Override
                                                         public Void apply(Void t) {
@@ -742,7 +739,9 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                             LOG.debugf("Starting the final redirect");
                                             return tInner;
                                         }
-                                        LOG.errorf("ID token verification has failed: %s", tInner.getMessage());
+                                        String message = tInner.getCause() != null ? tInner.getCause().getMessage()
+                                                : tInner.getMessage();
+                                        LOG.errorf("ID token verification has failed: %s", message);
                                         return new AuthenticationCompletionException(tInner);
                                     }
                                 });

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
@@ -21,14 +21,19 @@ public class DefaultTokenStateManager implements TokenStateManager {
     @Override
     public Uni<String> createTokenState(RoutingContext routingContext, OidcTenantConfig oidcConfig,
             AuthorizationCodeTokens tokens, OidcRequestContext<String> requestContext) {
+
+        boolean encryptAll = !oidcConfig.tokenStateManager.splitTokens;
+
         StringBuilder sb = new StringBuilder();
-        sb.append(encryptToken(tokens.getIdToken(), routingContext, oidcConfig));
+        sb.append(encryptAll ? tokens.getIdToken() : encryptToken(tokens.getIdToken(), routingContext, oidcConfig));
         if (oidcConfig.tokenStateManager.strategy == OidcTenantConfig.TokenStateManager.Strategy.KEEP_ALL_TOKENS) {
             if (!oidcConfig.tokenStateManager.splitTokens) {
                 sb.append(CodeAuthenticationMechanism.COOKIE_DELIM)
-                        .append(encryptToken(tokens.getAccessToken(), routingContext, oidcConfig))
+                        .append(encryptAll ? tokens.getAccessToken()
+                                : encryptToken(tokens.getAccessToken(), routingContext, oidcConfig))
                         .append(CodeAuthenticationMechanism.COOKIE_DELIM)
-                        .append(encryptToken(tokens.getRefreshToken(), routingContext, oidcConfig));
+                        .append(encryptAll ? tokens.getRefreshToken()
+                                : encryptToken(tokens.getRefreshToken(), routingContext, oidcConfig));
             } else {
                 CodeAuthenticationMechanism.createCookie(routingContext,
                         oidcConfig,
@@ -48,7 +53,8 @@ public class DefaultTokenStateManager implements TokenStateManager {
                 sb.append(CodeAuthenticationMechanism.COOKIE_DELIM)
                         .append("")
                         .append(CodeAuthenticationMechanism.COOKIE_DELIM)
-                        .append(encryptToken(tokens.getRefreshToken(), routingContext, oidcConfig));
+                        .append(encryptAll ? tokens.getRefreshToken()
+                                : encryptToken(tokens.getRefreshToken(), routingContext, oidcConfig));
             } else {
                 if (tokens.getRefreshToken() != null) {
                     CodeAuthenticationMechanism.createCookie(routingContext,
@@ -59,21 +65,26 @@ public class DefaultTokenStateManager implements TokenStateManager {
                 }
             }
         }
-        return Uni.createFrom().item(sb.toString());
+        String state = encryptAll ? encryptToken(sb.toString(), routingContext, oidcConfig) : sb.toString();
+        return Uni.createFrom().item(state);
     }
 
     @Override
     public Uni<AuthorizationCodeTokens> getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState,
             OidcRequestContext<AuthorizationCodeTokens> requestContext) {
+        boolean decryptAll = !oidcConfig.tokenStateManager.splitTokens;
+
+        tokenState = decryptAll ? decryptToken(tokenState, routingContext, oidcConfig) : tokenState;
+
         String[] tokens = CodeAuthenticationMechanism.COOKIE_PATTERN.split(tokenState);
-        String idToken = decryptToken(tokens[0], routingContext, oidcConfig);
+        String idToken = decryptAll ? tokens[0] : decryptToken(tokens[0], routingContext, oidcConfig);
 
         String accessToken = null;
         String refreshToken = null;
         if (oidcConfig.tokenStateManager.strategy == OidcTenantConfig.TokenStateManager.Strategy.KEEP_ALL_TOKENS) {
             if (!oidcConfig.tokenStateManager.splitTokens) {
-                accessToken = decryptToken(tokens[1], routingContext, oidcConfig);
-                refreshToken = decryptToken(tokens[2], routingContext, oidcConfig);
+                accessToken = decryptAll ? tokens[1] : decryptToken(tokens[1], routingContext, oidcConfig);
+                refreshToken = decryptAll ? tokens[2] : decryptToken(tokens[2], routingContext, oidcConfig);
             } else {
                 Cookie atCookie = getAccessTokenCookie(routingContext, oidcConfig);
                 if (atCookie != null) {
@@ -86,7 +97,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
             }
         } else if (oidcConfig.tokenStateManager.strategy == OidcTenantConfig.TokenStateManager.Strategy.ID_REFRESH_TOKENS) {
             if (!oidcConfig.tokenStateManager.splitTokens) {
-                refreshToken = decryptToken(tokens[2], routingContext, oidcConfig);
+                refreshToken = decryptAll ? tokens[2] : decryptToken(tokens[2], routingContext, oidcConfig);
             } else {
                 Cookie rtCookie = getRefreshTokenCookie(routingContext, oidcConfig);
                 if (rtCookie != null) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
@@ -129,7 +129,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
     }
 
     private String encryptToken(String token, RoutingContext context, OidcTenantConfig oidcConfig) {
-        if (oidcConfig.tokenStateManager.encryptionRequired.orElse(false)) {
+        if (oidcConfig.tokenStateManager.encryptionRequired) {
             TenantConfigContext configContext = context.get(TenantConfigContext.class.getName());
             try {
                 return OidcUtils.encryptString(token, configContext.getTokenEncSecretKey());
@@ -141,7 +141,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
     }
 
     private String decryptToken(String token, RoutingContext context, OidcTenantConfig oidcConfig) {
-        if (oidcConfig.tokenStateManager.encryptionRequired.orElse(false)) {
+        if (oidcConfig.tokenStateManager.encryptionRequired) {
             TenantConfigContext configContext = context.get(TenantConfigContext.class.getName());
             try {
                 return OidcUtils.decryptString(token, configContext.getTokenEncSecretKey());

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -455,7 +455,7 @@ public final class OidcUtils {
 
     public static String encryptString(String jweString, SecretKey key) throws Exception {
         JsonWebEncryption jwe = new JsonWebEncryption();
-        jwe.setAlgorithmHeaderValue(KeyEncryptionAlgorithm.A256KW.getAlgorithm());
+        jwe.setAlgorithmHeaderValue(KeyEncryptionAlgorithm.A256GCMKW.getAlgorithm());
         jwe.setEncryptionMethodHeaderParameter(ContentEncryptionAlgorithm.A256GCM.getAlgorithm());
         jwe.setKey(key);
         jwe.setPlaintext(jweString);
@@ -467,7 +467,7 @@ public final class OidcUtils {
     }
 
     public static String decryptString(String jweString, Key key) throws Exception {
-        return decryptString(jweString, key, KeyEncryptionAlgorithm.A256KW);
+        return decryptString(jweString, key, KeyEncryptionAlgorithm.A256GCMKW);
     }
 
     public static String decryptString(String jweString, Key key, KeyEncryptionAlgorithm algorithm) throws JoseException {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -70,6 +70,9 @@ public class TenantConfigContext {
         if (config.tokenStateManager.encryptionRequired) {
             String encSecret = config.tokenStateManager.encryptionSecret
                     .orElse(OidcCommonUtils.clientSecret(config.credentials));
+            if (encSecret == null) {
+                encSecret = OidcCommonUtils.jwtSecret(config.credentials);
+            }
             try {
                 if (encSecret == null) {
                     LOG.warn("Secret key for encrypting tokens is missing, auto-generating it");

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -1,12 +1,20 @@
 package io.quarkus.oidc.runtime;
 
-import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.smallrye.jwt.util.KeyUtils;
 
 public class TenantConfigContext {
+    private static final Logger LOG = Logger.getLogger(TenantConfigContext.class);
 
     /**
      * OIDC Provider
@@ -39,8 +47,8 @@ public class TenantConfigContext {
         this.oidcConfig = config;
         this.ready = ready;
 
-        pkceSecretKey = createPkceSecretKey(config);
-        tokenEncSecretKey = createTokenEncSecretKey(config);
+        pkceSecretKey = provider != null && provider.client != null ? createPkceSecretKey(config) : null;
+        tokenEncSecretKey = provider != null && provider.client != null ? createTokenEncSecretKey(config) : null;
     }
 
     private static SecretKey createPkceSecretKey(OidcTenantConfig config) {
@@ -59,16 +67,24 @@ public class TenantConfigContext {
     }
 
     private static SecretKey createTokenEncSecretKey(OidcTenantConfig config) {
-        if (config.tokenStateManager.encryptionRequired.orElse(false)) {
+        if (config.tokenStateManager.encryptionRequired) {
             String encSecret = config.tokenStateManager.encryptionSecret
                     .orElse(OidcCommonUtils.clientSecret(config.credentials));
-            if (encSecret == null) {
-                throw new RuntimeException("Secret key for encrypting tokens is missing");
+            try {
+                if (encSecret == null) {
+                    LOG.warn("Secret key for encrypting tokens is missing, auto-generating it");
+                    KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+                    keyGenerator.init(256);
+                    return keyGenerator.generateKey();
+                }
+                byte[] secretBytes = encSecret.getBytes(StandardCharsets.UTF_8);
+                if (secretBytes.length < 32) {
+                    LOG.warn("Secret key for encrypting tokens should be 32 characters long");
+                }
+                return new SecretKeySpec(OidcUtils.getSha256Digest(secretBytes), "AES");
+            } catch (Exception ex) {
+                throw new OIDCException(ex);
             }
-            if (encSecret.length() != 32) {
-                throw new RuntimeException("Secret key for encrypting tokens must be 32 characters long");
-            }
-            return KeyUtils.createSecretKeyFromSecret(encSecret);
         }
         return null;
     }

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -10,6 +10,7 @@ quarkus.oidc.authentication.cookie-domain=localhost
 quarkus.oidc.authentication.extra-params.max-age=60
 quarkus.oidc.application-type=web-app
 quarkus.oidc.authentication.cookie-suffix=test
+quarkus.oidc.token-state-manager.encryption-required=false
 
 # OIDC client configuration
 quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
@@ -145,7 +146,6 @@ quarkus.oidc.tenant-split-tokens.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-split-tokens.client-id=quarkus-app
 quarkus.oidc.tenant-split-tokens.credentials.secret=secret
 quarkus.oidc.tenant-split-tokens.token-state-manager.split-tokens=true
-quarkus.oidc.tenant-split-tokens.token-state-manager.encryption-required=true
 quarkus.oidc.tenant-split-tokens.token-state-manager.encryption-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 quarkus.oidc.tenant-split-tokens.application-type=web-app
 

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -17,6 +17,9 @@ import java.util.Base64;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -275,7 +278,15 @@ public class CodeFlowTest {
 
             Cookie sessionCookie = getSessionCookie(webClient, "tenant-https_test");
             assertNotNull(sessionCookie);
-            JsonObject idToken = OidcUtils.decodeJwtContent(sessionCookie.getValue().split("\\|")[0]);
+
+            String encryptedIdToken = sessionCookie.getValue().split("\\|")[0];
+
+            SecretKey key = new SecretKeySpec(OidcUtils
+                    .getSha256Digest("secret".getBytes(StandardCharsets.UTF_8)),
+                    "AES");
+            String encodedIdToken = OidcUtils.decryptString(encryptedIdToken, key);
+
+            JsonObject idToken = OidcUtils.decodeJwtContent(encodedIdToken);
             String expiresAt = idToken.getInteger("exp").toString();
             page = webClient.getPage(endpointLocationWithoutQueryUri.toURL());
             String response = page.getBody().asNormalizedText();
@@ -850,7 +861,7 @@ public class CodeFlowTest {
             assertEquals("tenant-idtoken-only:no refresh", page.getBody().asNormalizedText());
 
             Cookie idTokenCookie = getSessionCookie(page.getWebClient(), "tenant-idtoken-only");
-            checkSingleTokenCookie(idTokenCookie, "ID");
+            checkSingleTokenCookie(idTokenCookie, "ID", "secret");
 
             assertNull(getSessionAtCookie(webClient, "tenant-idtoken-only"));
             assertNull(getSessionRtCookie(webClient, "tenant-idtoken-only"));
@@ -860,7 +871,7 @@ public class CodeFlowTest {
     }
 
     @Test
-    public void testDefaultSessionManagerIdRefreshTokens() throws IOException, InterruptedException {
+    public void testDefaultSessionManagerIdRefreshTokens() throws Exception {
         try (final WebClient webClient = createWebClient()) {
             HtmlPage page = webClient.getPage("http://localhost:8081/web-app/tenant-id-refresh-token");
             assertNotNull(getStateCookie(webClient, "tenant-id-refresh-token"));
@@ -881,11 +892,16 @@ public class CodeFlowTest {
             assertEquals("tenant-id-refresh-token:RT injected", page.getBody().asNormalizedText());
 
             Cookie idTokenCookie = getSessionCookie(page.getWebClient(), "tenant-id-refresh-token");
+
+            SecretKey key = new SecretKeySpec(OidcUtils
+                    .getSha256Digest("secret".getBytes(StandardCharsets.UTF_8)),
+                    "AES");
+
             String[] parts = idTokenCookie.getValue().split("\\|");
             assertEquals(3, parts.length);
-            assertEquals("ID", OidcUtils.decodeJwtContent(parts[0]).getString("typ"));
+            assertEquals("ID", OidcUtils.decodeJwtContent(OidcUtils.decryptString(parts[0], key)).getString("typ"));
             assertEquals("", parts[1]);
-            assertEquals("Refresh", OidcUtils.decodeJwtContent(parts[2]).getString("typ"));
+            assertEquals("Refresh", OidcUtils.decodeJwtContent(OidcUtils.decryptString(parts[2], key)).getString("typ"));
 
             assertNull(getSessionAtCookie(webClient, "tenant-id-refresh-token"));
             assertNull(getSessionRtCookie(webClient, "tenant-id-refresh-token"));
@@ -916,14 +932,15 @@ public class CodeFlowTest {
             page = webClient.getPage("http://localhost:8081/web-app/refresh/tenant-split-tokens");
             assertEquals("tenant-split-tokens:RT injected", page.getBody().asNormalizedText());
 
+            final String decryptSecret = "eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU";
             Cookie idTokenCookie = getSessionCookie(page.getWebClient(), "tenant-split-tokens");
-            checkSingleTokenCookie(idTokenCookie, "ID", true);
+            checkSingleTokenCookie(idTokenCookie, "ID", decryptSecret);
 
             Cookie atTokenCookie = getSessionAtCookie(page.getWebClient(), "tenant-split-tokens");
-            checkSingleTokenCookie(atTokenCookie, "Bearer", true);
+            checkSingleTokenCookie(atTokenCookie, "Bearer", decryptSecret);
 
             Cookie rtTokenCookie = getSessionRtCookie(page.getWebClient(), "tenant-split-tokens");
-            checkSingleTokenCookie(rtTokenCookie, "Refresh", true);
+            checkSingleTokenCookie(rtTokenCookie, "Refresh", decryptSecret);
 
             // verify all the cookies are cleared after the session timeout
             webClient.getOptions().setRedirectEnabled(false);
@@ -972,12 +989,12 @@ public class CodeFlowTest {
             assertEquals("tenant-split-id-refresh-token:RT injected", page.getBody().asNormalizedText());
 
             Cookie idTokenCookie = getSessionCookie(page.getWebClient(), "tenant-split-id-refresh-token");
-            checkSingleTokenCookie(idTokenCookie, "ID");
+            checkSingleTokenCookie(idTokenCookie, "ID", "secret");
 
             assertNull(getSessionAtCookie(page.getWebClient(), "tenant-split-id-refresh-token"));
 
             Cookie rtTokenCookie = getSessionRtCookie(page.getWebClient(), "tenant-split-id-refresh-token");
-            checkSingleTokenCookie(rtTokenCookie, "Refresh");
+            checkSingleTokenCookie(rtTokenCookie, "Refresh", "secret");
 
             // verify all the cookies are cleared after the session timeout
             webClient.getOptions().setRedirectEnabled(false);
@@ -1005,26 +1022,30 @@ public class CodeFlowTest {
     }
 
     private void checkSingleTokenCookie(Cookie tokenCookie, String type) {
-        checkSingleTokenCookie(tokenCookie, type, false);
+        checkSingleTokenCookie(tokenCookie, type, null);
 
     }
 
-    private void checkSingleTokenCookie(Cookie tokenCookie, String type, boolean decrypt) {
+    private void checkSingleTokenCookie(Cookie tokenCookie, String type, String decryptSecret) {
         String[] cookieParts = tokenCookie.getValue().split("\\|");
         assertEquals(1, cookieParts.length);
         String token = cookieParts[0];
         String[] tokenParts = token.split("\\.");
-        if (decrypt) {
+        if (decryptSecret != null) {
             assertEquals(5, tokenParts.length);
             try {
-                token = OidcUtils.decryptString(token, KeyUtils.createSecretKeyFromSecret("eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU"));
+                SecretKey key = new SecretKeySpec(OidcUtils
+                        .getSha256Digest(decryptSecret.getBytes(StandardCharsets.UTF_8)),
+                        "AES");
+                token = OidcUtils.decryptString(token, key);
                 tokenParts = token.split("\\.");
             } catch (Exception ex) {
                 fail("Token decryption has failed");
             }
         }
         assertEquals(3, tokenParts.length);
-        assertEquals(type, OidcUtils.decodeJwtContent(token).getString("typ"));
+        JsonObject json = OidcUtils.decodeJwtContent(token);
+        assertEquals(type, json.getString("typ"));
     }
 
     @Test

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -139,6 +139,7 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     config.setJwksPath(jwksUri);
                     config.getToken().setIssuer("any");
                     config.tokenStateManager.setSplitTokens(true);
+                    config.tokenStateManager.setEncryptionRequired(false);
                     config.getAuthentication().setSessionAgeExtension(Duration.ofMinutes(1));
                     config.getAuthentication().setIdTokenRequired(false);
                     return config;

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -36,7 +36,7 @@ quarkus.oidc.code-flow-encrypted-id-token-pem.token.decryption-key-location=priv
 
 quarkus.oidc.code-flow-form-post.auth-server-url=${keycloak.url}/realms/quarkus-form-post/
 quarkus.oidc.code-flow-form-post.client-id=quarkus-web-app
-quarkus.oidc.code-flow-form-post.credentials.secret=secret
+quarkus.oidc.code-flow-form-post.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 quarkus.oidc.code-flow-form-post.application-type=web-app
 quarkus.oidc.code-flow-form-post.authentication.response-mode=form_post
 quarkus.oidc.code-flow-form-post.discovery-enabled=false

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -266,13 +266,16 @@ public class CodeFlowAuthorizationTest {
     private JsonObject decryptIdToken(WebClient webClient, String tenantId) throws Exception {
         Cookie sessionCookie = getSessionCookie(webClient, tenantId);
         assertNotNull(sessionCookie);
-        String encryptedIdToken = sessionCookie.getValue().split("\\|")[0];
 
         SecretKey key = new SecretKeySpec(OidcUtils
                 .getSha256Digest("AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
                         .getBytes(StandardCharsets.UTF_8)),
                 "AES");
-        String encodedIdToken = OidcUtils.decryptString(encryptedIdToken, key);
+
+        String decryptedSessionCookie = OidcUtils.decryptString(sessionCookie.getValue(), key);
+
+        String encodedIdToken = decryptedSessionCookie.split("\\|")[0];
+
         return OidcUtils.decodeJwtContent(encodedIdToken);
     }
 

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -13,7 +13,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -154,7 +158,7 @@ public class CodeFlowAuthorizationTest {
     }
 
     @Test
-    public void testCodeFlowFormPostAndFrontChannelLogout() throws IOException {
+    public void testCodeFlowFormPostAndFrontChannelLogout() throws Exception {
         defineCodeFlowLogoutStub();
         try (final WebClient webClient = createWebClient()) {
             webClient.getOptions().setRedirectEnabled(true);
@@ -174,9 +178,7 @@ public class CodeFlowAuthorizationTest {
             assertEquals("alice", page.getBody().asNormalizedText());
 
             // Session is still active
-            Cookie sessionCookie = getSessionCookie(webClient, "code-flow-form-post");
-            assertNotNull(sessionCookie);
-            JsonObject idTokenClaims = OidcUtils.decodeJwtContent(sessionCookie.getValue().split("\\|")[0]);
+            JsonObject idTokenClaims = decryptIdToken(webClient, "code-flow-form-post");
 
             webClient.getOptions().setRedirectEnabled(false);
 
@@ -238,7 +240,7 @@ public class CodeFlowAuthorizationTest {
         }
     }
 
-    private void doTestCodeFlowUserInfo(String tenantId, long internalIdTokenLifetime) throws IOException {
+    private void doTestCodeFlowUserInfo(String tenantId, long internalIdTokenLifetime) throws Exception {
         try (final WebClient webClient = createWebClient()) {
             webClient.getOptions().setRedirectEnabled(true);
             HtmlPage page = webClient.getPage("http://localhost:8081/" + tenantId);
@@ -251,9 +253,7 @@ public class CodeFlowAuthorizationTest {
 
             assertEquals("alice:alice:alice, cache size: 1", page.getBody().asNormalizedText());
 
-            Cookie sessionCookie = getSessionCookie(webClient, tenantId);
-            assertNotNull(sessionCookie);
-            JsonObject idTokenClaims = OidcUtils.decodeJwtContent(sessionCookie.getValue().split("\\|")[0]);
+            JsonObject idTokenClaims = decryptIdToken(webClient, tenantId);
             assertNull(idTokenClaims.getJsonObject(OidcUtils.USER_INFO_ATTRIBUTE));
             long issuedAt = idTokenClaims.getLong("iat");
             long expiresAt = idTokenClaims.getLong("exp");
@@ -261,6 +261,19 @@ public class CodeFlowAuthorizationTest {
 
             webClient.getCookieManager().clearCookies();
         }
+    }
+
+    private JsonObject decryptIdToken(WebClient webClient, String tenantId) throws Exception {
+        Cookie sessionCookie = getSessionCookie(webClient, tenantId);
+        assertNotNull(sessionCookie);
+        String encryptedIdToken = sessionCookie.getValue().split("\\|")[0];
+
+        SecretKey key = new SecretKeySpec(OidcUtils
+                .getSha256Digest("AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
+                        .getBytes(StandardCharsets.UTF_8)),
+                "AES");
+        String encodedIdToken = OidcUtils.decryptString(encryptedIdToken, key);
+        return OidcUtils.decodeJwtContent(encodedIdToken);
     }
 
     private void doTestCodeFlowUserInfoCashedInIdToken() throws Exception {
@@ -276,9 +289,7 @@ public class CodeFlowAuthorizationTest {
 
             assertEquals("alice:alice:alice, cache size: 0", page.getBody().asNormalizedText());
 
-            Cookie sessionCookie = getSessionCookie(webClient, "code-flow-user-info-github-cached-in-idtoken");
-            assertNotNull(sessionCookie);
-            JsonObject idTokenClaims = OidcUtils.decodeJwtContent(sessionCookie.getValue().split("\\|")[0]);
+            JsonObject idTokenClaims = decryptIdToken(webClient, "code-flow-user-info-github-cached-in-idtoken");
             assertNotNull(idTokenClaims.getJsonObject(OidcUtils.USER_INFO_ATTRIBUTE));
 
             // refresh


### PR DESCRIPTION
This PR does the following:
- Enables the optional encryption of ID/access/refresh tokens in the session cookie - it is already supported but currently it is not enabled by default
- Tunes the code which creates the encryption key - the main change - if the encryption key is not available then a warning is displayed and a new secret key is generated, and if the key is less than 32 chars - the warning is displayed - this is done to avoid breaking the currently running applications over secure 1 way TLS and mTLS in partucular
- The key is now additionally hashed (similarly to how it is done in FormAutentication)
- Also, it strengthens the key encryption algorithm to AESGCM Key wrap, the content encryption algo remains AES GCM
- Optimizes the way the tokens are encrypted, right now it is quite sub-optimal, where up to 3 JWE encryptions will be done and 3 cipher texts saved in the session cookie - instead, now only a single encryption is done on all the 3 tokens concatenated together. For example, now, instead of `q_session=encrypted_id_token|encrypted_access_token|encrypted_refresh_token` you will see `q_session=encrypted(id_token_access_token_refresh_token)` 
- Fixed tests, only disabled the encryption in 2 cases to make it a bit easier to test
- Minor doc updates

Users are not expected to be affected in anyway in the majority of cases, it is only 2 cases where they will likely want to make sure an encryption key is configured instead of relying on the default key creation: when Quarkus authenticates to OpenId Connect provider with mTLS or a JWT token signed with a private asymmetric key - in both cases, if the encryption key is not configured, there is no fallback to the client secret, so a key will be generated in memory - which won't work well if multiple pods are managing the requests. It won't be a problem for simple application using such mechanisms. The migration note will be added, and we can look at the CLI option to help users create correct secret keys when necessary.

Users can also always disable the token encryption.

The encryption key will also be expected to be properly provisioned, with the Config system or CredentialsProvider or other SPI