### PR TITLE
Dev UI: Allow multiple pages for menu items

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -324,19 +324,28 @@ public class BuildTimeContentProcessor {
 
         // Sections Menu
         Page extensions = Page.webComponentPageBuilder().internal()
+                .namespace("devui-extensions")
                 .title("Extensions")
                 .icon("font-awesome-solid:puzzle-piece")
                 .componentLink("qwc-extensions.js").build();
 
         Page configuration = Page.webComponentPageBuilder().internal()
+                .namespace("devui-configuration")
                 .title("Configuration")
                 .icon("font-awesome-solid:sliders")
                 .componentLink("qwc-configuration.js").build();
+
+        Page configurationSourceEditor = Page.webComponentPageBuilder().internal()
+                .namespace("devui-configuration")
+                .title("Config Editor")
+                .icon("font-awesome-solid:code")
+                .componentLink("qwc-configuration-editor.js").build();
 
         internalBuildTimeData.addBuildTimeData("allConfiguration",
                 getAllConfig(configDescriptionBuildItems, devServicesLauncherConfig));
 
         Page continuousTesting = Page.webComponentPageBuilder().internal()
+                .namespace("devui-continuous-testing")
                 .title("Continuous Testing")
                 .icon("font-awesome-solid:flask-vial")
                 .componentLink("qwc-continuous-testing.js").build();
@@ -344,6 +353,7 @@ public class BuildTimeContentProcessor {
         internalBuildTimeData.addBuildTimeData("continuousTesting", "TODO: Continuous Testing");
 
         Page devServices = Page.webComponentPageBuilder().internal()
+                .namespace("devui-dev-services")
                 .title("Dev services")
                 .icon("font-awesome-solid:wand-magic-sparkles")
                 .componentLink("qwc-dev-services.js").build();
@@ -351,15 +361,24 @@ public class BuildTimeContentProcessor {
         internalBuildTimeData.addBuildTimeData("devServices", devServiceDescriptions);
 
         Page buildSteps = Page.webComponentPageBuilder().internal()
-                .title("Build information")
+                .namespace("devui-build-information")
+                .title("Build Steps")
                 .icon("font-awesome-solid:hammer")
-                .componentLink("qwc-build-information.js").build();
-
+                .componentLink("qwc-build-steps.js").build();
         internalBuildTimeData.addBuildTimeData("buildSteps", "TODO: Build Steps");
+
+        Page buildItems = Page.webComponentPageBuilder().internal()
+                .namespace("devui-build-information")
+                .title("Build Items")
+                .icon("font-awesome-solid:trowel")
+                .componentLink("qwc-build-items.js").build();
+        internalBuildTimeData.addBuildTimeData("buildItems", "TODO: Build Items");
 
         // Add default menu items
         @SuppressWarnings("unchecked")
-        List<Page> sectionMenu = new ArrayList(List.of(extensions, configuration, continuousTesting, devServices, buildSteps));
+        List<Page> sectionMenu = new ArrayList(
+                List.of(extensions, configuration, configurationSourceEditor, continuousTesting, devServices,
+                        buildSteps, buildItems));
 
         // Add any Menus from extensions
         for (Extension e : extensionsBuildItem.getSectionMenuExtensions()) {

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/jsonrpc.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/controller/jsonrpc.js
@@ -87,7 +87,6 @@ export class JsonRpc {
     _extensionName;
     _logTraffic;
     
-    
     /**
      * 
      * @param {type} host the component using this.
@@ -102,19 +101,26 @@ export class JsonRpc {
      * @returns {Proxy}
      */
     constructor(host, logTraffic=true, serviceIdentifier=null) {
-        var page = RouterController.pageForComponent(host.tagName.toLowerCase());
         
-        if (page){
-            if(page.namespace){
-                // For pages
-                this._setExtensionName(page.namespace, serviceIdentifier);
-            }else{
-                // For Menu items
-                this._setExtensionName(page.id, serviceIdentifier);
+        // First check if host is a String
+        if (typeof host === 'string' || host instanceof String){
+            this._setExtensionName(host, serviceIdentifier);
+        }else {
+        
+            var page = RouterController.componentMap.get(host.tagName.toLowerCase());
+
+            if (page){
+                // Internal Menu
+                if(page.internal){
+                    this._setExtensionName(page.id, serviceIdentifier);
+                }else {
+                    // For pages
+                    this._setExtensionName(page.namespace, serviceIdentifier);
+                }
+            } else {
+                // For cards and logs
+                this._setExtensionName(host.getAttribute("namespace"), serviceIdentifier);
             }
-        } else {
-            // For cards and logs
-            this._setExtensionName(host.getAttribute("namespace"), serviceIdentifier);
         }
         
         this._logTraffic = logTraffic;

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-build-items.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-build-items.js
@@ -1,0 +1,29 @@
+import { LitElement, html, css} from 'lit';
+import { buildItems } from 'devui-data';
+
+/**
+ * This component shows the Build Items
+ */
+export class QwcBuildItems extends LitElement {
+  static styles = css`
+        .todo {
+            padding-left: 10px;
+            height: 100%;
+        }`;
+
+  static properties = {
+    _items: {state: true}
+  };
+  
+  constructor() {
+    super();
+    this._items = buildItems;
+  }
+
+  render() {
+    if(this._items){
+      return html`<div class="todo">${this._items}</div>`;
+    }
+  }
+}
+customElements.define('qwc-build-items', QwcBuildItems);

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-build-steps.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-build-steps.js
@@ -2,9 +2,9 @@ import { LitElement, html, css} from 'lit';
 import { buildSteps } from 'devui-data';
 
 /**
- * This component shows the Build Information Page
+ * This component shows the Build Steps
  */
-export class QwcBuildInformation extends LitElement {
+export class QwcBuildSteps extends LitElement {
   static styles = css`
         .todo {
             padding-left: 10px;
@@ -26,4 +26,4 @@ export class QwcBuildInformation extends LitElement {
     }
   }
 }
-customElements.define('qwc-build-information', QwcBuildInformation);
+customElements.define('qwc-build-steps', QwcBuildSteps);

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration-editor.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration-editor.js
@@ -1,0 +1,23 @@
+import { LitElement, html, css } from 'lit';
+
+/**
+ * This component allows users to change the configuration in an online editor
+ */
+export class QwcConfigurationEditor extends LitElement {
+
+    static styles = css`
+    `;
+
+    static properties = {        
+    };
+
+    constructor() {
+        super();
+    }
+
+    render() {
+        return html`<span>TODO: Configuration properties editor</span>`;
+    }
+}
+
+customElements.define('qwc-configuration-editor', QwcConfigurationEditor);

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-data-qute-page.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-data-qute-page.js
@@ -6,6 +6,7 @@ import { RouterController } from 'router-controller';
  * This component renders build time data using qute
  */
 export class QwcDataQutePage extends LitElement {
+    routerController = new RouterController(this);
     
     static styles = css``;
 
@@ -15,7 +16,7 @@ export class QwcDataQutePage extends LitElement {
 
     connectedCallback() {
         super.connectedCallback();
-        var page = RouterController.currentPage();
+        var page = this.routerController.getCurrentPage();
         if(page && page.metadata){
             this._htmlFragment = page.metadata.htmlFragment;
         }

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-data-raw-page.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-data-raw-page.js
@@ -9,6 +9,7 @@ import '@vanillawc/wc-codemirror/mode/javascript/javascript.js';
  * This component renders build time data in raw json format
  */
 export class QwcDataRawPage extends observeState(LitElement) {
+    routerController = new RouterController(this);
     
     static styles = css`
         .codeBlock {
@@ -37,7 +38,7 @@ export class QwcDataRawPage extends observeState(LitElement) {
     connectedCallback() {
         super.connectedCallback();
         
-        var page = RouterController.currentPage();
+        var page = this.routerController.getCurrentPage();
         if(page && page.metadata){
             this._buildTimeDataKey = page.metadata.buildTimeDataKey;
 

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-data-table-page.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-data-table-page.js
@@ -7,6 +7,7 @@ import '@vaadin/grid/vaadin-grid-sort-column.js';
  * This component renders build time data in a table
  */
 export class QwcDataTablePage extends LitElement {
+    routerController = new RouterController(this);
     
     static styles = css`
         .datatable {
@@ -23,7 +24,7 @@ export class QwcDataTablePage extends LitElement {
 
     connectedCallback() {
         super.connectedCallback();
-        var page = RouterController.currentPage();
+        var page = this.routerController.getCurrentPage();
         if(page && page.metadata){
             this._buildTimeDataKey = page.metadata.buildTimeDataKey;
 

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -10,7 +10,8 @@ import 'qwc/qwc-extension-link.js';
  * This component create cards of all the extensions
  */
 export class QwcExtensions extends observeState(LitElement) {
-
+    routerController = new RouterController(this);
+    
     static styles = css`
         .grid {
             display: flex;
@@ -40,14 +41,6 @@ export class QwcExtensions extends observeState(LitElement) {
         }
     `;
 
-    constructor() {
-        super();
-        // TODO: Change this to use state
-        window.addEventListener('vaadin-router-location-changed', (event) => {
-            var pageDetails = RouterController.parseLocationChangedEvent(event);
-        });
-    }
-
     render() {
         return html`<div class="grid">
             ${devuiState.cards.active.map(extension => this._renderActive(extension))}            
@@ -59,7 +52,7 @@ export class QwcExtensions extends observeState(LitElement) {
         extension.cardPages.forEach(page => {   
             if(page.embed){ // we need to register with the router
                 import(page.componentRef);
-                RouterController.addExtensionRoute(page);
+                this.routerController.addRouteForExtension(page);
             }
         });
         

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-external-page.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-external-page.js
@@ -13,6 +13,7 @@ import '@vaadin/icon';
  * This component loads an external page
  */
 export class QwcExternalPage extends observeState(LitElement)  {
+    routerController = new RouterController(this);
     
     static styles = css`
         .codeBlock {
@@ -38,7 +39,7 @@ export class QwcExternalPage extends observeState(LitElement)  {
 
     connectedCallback() {
         super.connectedCallback();
-        var metadata = RouterController.currentMetaData();
+        var metadata = this.routerController.getCurrentMetaData();
         if(metadata){
             this._externalUrl = metadata.externalUrl;
             if(metadata.mimeType){

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-header.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-header.js
@@ -13,6 +13,7 @@ import '@vaadin/tabs';
 export class QwcHeader extends observeState(LitElement) {
     
     storageControl = new StorageController(this);
+    routerController = new RouterController(this);
     
     static styles = css`
         
@@ -225,17 +226,14 @@ export class QwcHeader extends observeState(LitElement) {
     }
 
     _updateHeader(event){
-        var pageDetails = RouterController.parseLocationChangedEvent(event);
-        
-        this._title = pageDetails.title;
-        var subMenu = pageDetails.subMenu;
-
+        this._title = this.routerController.getCurrentTitle();
+        var subMenu = this.routerController.getCurrentSubMenu();
         if(subMenu){
             this._rightSideNav = html`<vaadin-tabs selected="${subMenu.index}">
-                                        ${subMenu.links.map(link =>
-                                            html`<vaadin-tab><a href="${link.path}">${link.name}</a></vaadin-tab>`
-                                        )}
-                                    </vaadin-tabs>`;
+                                    ${subMenu.links.map(link =>
+                                        html`<vaadin-tab><a title="${link.path}" href="${link.path}">${link.name}</a></vaadin-tab>`
+                                    )}
+                                </vaadin-tabs>`;
         }else{
             this._rightSideNav = html`<div class="app-info">${devuiState.applicationInfo.applicationName} ${devuiState.applicationInfo.applicationVersion}</div>`; // default
         }

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/AbstractPageBuildItem.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/AbstractPageBuildItem.java
@@ -1,6 +1,9 @@
 package io.quarkus.devui.spi.page;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import io.quarkus.devui.spi.AbstractDevUIBuildItem;
@@ -11,15 +14,38 @@ import io.quarkus.devui.spi.AbstractDevUIBuildItem;
 public abstract class AbstractPageBuildItem extends AbstractDevUIBuildItem {
 
     protected final Map<String, Object> buildTimeData;
+    protected final List<PageBuilder> pageBuilders;
 
     public AbstractPageBuildItem() {
         super();
         this.buildTimeData = new HashMap<>();
+        this.pageBuilders = new ArrayList<>();
+    }
+
+    public AbstractPageBuildItem(PageBuilder... pageBuilder) {
+        super();
+        this.buildTimeData = new HashMap<>();
+        this.pageBuilders = Arrays.asList(pageBuilder);
     }
 
     public AbstractPageBuildItem(String customIdentifier) {
         super(customIdentifier);
         this.buildTimeData = new HashMap<>();
+        this.pageBuilders = new ArrayList<>();
+    }
+
+    public AbstractPageBuildItem(String customIdentifier, PageBuilder... pageBuilder) {
+        super(customIdentifier);
+        this.buildTimeData = new HashMap<>();
+        this.pageBuilders = Arrays.asList(pageBuilder);
+    }
+
+    public void addPage(PageBuilder page) {
+        this.pageBuilders.add(page);
+    }
+
+    public List<PageBuilder> getPages() {
+        return this.pageBuilders;
     }
 
     public void addBuildTimeData(String fieldName, Object fieldData) {

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/CardPageBuildItem.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/CardPageBuildItem.java
@@ -1,7 +1,5 @@
 package io.quarkus.devui.spi.page;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -10,26 +8,16 @@ import java.util.Optional;
  */
 public final class CardPageBuildItem extends AbstractPageBuildItem {
 
-    private final List<PageBuilder> pageBuilders;
     private Optional<Card> optionalCard = Optional.empty();
 
     public CardPageBuildItem() {
         super();
-        this.pageBuilders = new ArrayList<>();
-    }
-
-    public void addPage(PageBuilder page) {
-        this.pageBuilders.add(page);
     }
 
     public void setCustomCard(String cardComponent) {
         if (cardComponent != null) {
             this.optionalCard = Optional.of(new Card(cardComponent));
         }
-    }
-
-    public List<PageBuilder> getPages() {
-        return this.pageBuilders;
     }
 
     public Optional<Card> getOptionalCard() {

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/FooterPageBuildItem.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/FooterPageBuildItem.java
@@ -1,27 +1,19 @@
 package io.quarkus.devui.spi.page;
 
-import java.util.Arrays;
-import java.util.List;
-
 /**
  * Add a footer tab to the Dev UI.
  */
 public final class FooterPageBuildItem extends AbstractPageBuildItem {
 
-    private final List<PageBuilder> pageBuilders;
+    public FooterPageBuildItem() {
+        super();
+    }
 
     public FooterPageBuildItem(PageBuilder... pageBuilder) {
-        super();
-        this.pageBuilders = Arrays.asList(pageBuilder);
+        super(pageBuilder);
     }
 
     public FooterPageBuildItem(String customIdentifier, PageBuilder... pageBuilder) {
-        super(customIdentifier);
-        this.pageBuilders = Arrays.asList(pageBuilder);
+        super(customIdentifier, pageBuilder);
     }
-
-    public List<PageBuilder> getPages() {
-        return this.pageBuilders;
-    }
-
 }

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/MenuPageBuildItem.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/MenuPageBuildItem.java
@@ -1,27 +1,19 @@
 package io.quarkus.devui.spi.page;
 
-import java.util.Arrays;
-import java.util.List;
-
 /**
  * Add a menu (or section) to the Dev UI.
  */
 public final class MenuPageBuildItem extends AbstractPageBuildItem {
 
-    private final List<PageBuilder> pageBuilders;
+    public MenuPageBuildItem() {
+        super();
+    }
 
     public MenuPageBuildItem(PageBuilder... pageBuilder) {
-        super();
-        this.pageBuilders = Arrays.asList(pageBuilder);
+        super(pageBuilder);
     }
 
     public MenuPageBuildItem(String customIdentifier, PageBuilder... pageBuilder) {
-        super(customIdentifier);
-        this.pageBuilders = Arrays.asList(pageBuilder);
+        super(customIdentifier, pageBuilder);
     }
-
-    public List<PageBuilder> getPages() {
-        return this.pageBuilders;
-    }
-
 }

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/Page.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/Page.java
@@ -25,6 +25,8 @@ public class Page {
 
     private String namespace = null; // The namespace can be the extension path or, if internal, qwc
 
+    private String extensionId = null; // If this originates from an extension, then id. For internal this will be null;
+
     protected Page(String icon,
             String title,
             String staticLabel,
@@ -35,7 +37,8 @@ public class Page {
             Map<String, String> metadata,
             boolean embed,
             boolean internalComponent,
-            String namespace) {
+            String namespace,
+            String extensionId) {
 
         this.icon = icon;
         this.title = title;
@@ -48,11 +51,12 @@ public class Page {
         this.embed = embed;
         this.internalComponent = internalComponent;
         this.namespace = namespace;
+        this.extensionId = extensionId;
     }
 
     public String getId() {
         String id = this.title.toLowerCase().replaceAll(SPACE, DASH);
-        if (this.namespace != null) {
+        if (!this.isInternal() && this.namespace != null) {
             id = this.namespace + SLASH + id;
         }
         return id;
@@ -102,6 +106,14 @@ public class Page {
 
     public boolean isEmbed() {
         return embed;
+    }
+
+    public boolean isInternal() {
+        return this.internalComponent && this.extensionId == null;
+    }
+
+    public String getExtensionId() {
+        return extensionId;
     }
 
     public Map<String, String> getMetadata() {

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/PageBuilder.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/PageBuilder.java
@@ -23,6 +23,7 @@ public abstract class PageBuilder<T> {
     protected boolean embed = true; // default
     protected boolean internalComponent = false; // default
     protected String namespace = null;
+    protected String extensionId = null;
     protected Class preprocessor = null;
 
     @SuppressWarnings("unchecked")
@@ -77,11 +78,9 @@ public abstract class PageBuilder<T> {
 
     @SuppressWarnings("unchecked")
     public T extension(String extension) {
+        this.extensionId = extension.toLowerCase().replaceAll(SPACE, DASH);
         this.metadata.put("extensionName", extension);
-        this.metadata.put("extensionId", extension.toLowerCase().replaceAll(SPACE, DASH));
-        //if (this.namespace == null) {
-        //    this.namespace = extension.toLowerCase().replaceAll(SPACE, DASH);
-        //}
+        this.metadata.put("extensionId", extensionId); // TODO: Remove ?
         return (T) this;
     }
 
@@ -115,7 +114,7 @@ public abstract class PageBuilder<T> {
 
         Page page = new Page(icon, title, staticLabel, dynamicLabel, streamingLabel, componentName, componentLink, metadata,
                 embed,
-                internalComponent, namespace);
+                internalComponent, namespace, extensionId);
 
         return page;
     }

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/QuteDataPageBuilder.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/QuteDataPageBuilder.java
@@ -30,7 +30,7 @@ public class QuteDataPageBuilder extends PageBuilder<QuteDataPageBuilder> {
     }
 
     public String getTemplatePath() {
-        return "/dev-ui/" + super.namespace + "/" + this.templateLink;
+        return "/dev-ui/" + this.templateLink;
     }
 
 }


### PR DESCRIPTION
This PR changes the Dev UI so that the Menu Items (like configure etc) can also take part in the Sub Menu in the top right corner, that was prev only used for extensions.

It also:
- fix #32184
- clean up the router-controller

See below the configure menu now has multiple pages in the sub-menu

![menuitem-multiplepages](https://user-images.githubusercontent.com/6836179/228393318-7432d17f-1855-4128-aee9-df2919f78cc1.gif)

