### PR TITLE
ArC: fix known-compatible bean archives check

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/KnownCompatibleBeanArchives.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/KnownCompatibleBeanArchives.java
@@ -2,6 +2,7 @@ package io.quarkus.arc.deployment;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import io.quarkus.deployment.ApplicationArchive;
@@ -17,6 +18,25 @@ final class KnownCompatibleBeanArchives {
             this.groupId = groupId;
             this.artifactId = artifactId;
             this.classifier = classifier;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Key)) {
+                return false;
+            }
+            Key key = (Key) o;
+            return Objects.equals(groupId, key.groupId)
+                    && Objects.equals(artifactId, key.artifactId)
+                    && Objects.equals(classifier, key.classifier);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(groupId, artifactId, classifier);
         }
     }
 


### PR DESCRIPTION
The known-compatible bean archives are stored in a `HashSet`, so the class must define `equals()` and `hashCode()`.

Follow-up on #31856 