### PR TITLE
Avoid instantiating JPAConfig just to destroy it when static init fails

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -117,7 +117,6 @@ import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationSt
 import io.quarkus.hibernate.orm.deployment.spi.DatabaseKindDialectBuildItem;
 import io.quarkus.hibernate.orm.runtime.HibernateOrmRecorder;
 import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
-import io.quarkus.hibernate.orm.runtime.JPAConfig;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.orm.runtime.RequestScopedSessionHolder;
 import io.quarkus.hibernate.orm.runtime.RequestScopedStatelessSessionHolder;
@@ -589,7 +588,6 @@ public final class HibernateOrmProcessor {
         }
 
         List<Class<?>> unremovableClasses = new ArrayList<>();
-        unremovableClasses.add(JPAConfig.class);
         if (capabilities.isPresent(Capability.TRANSACTIONS)) {
             unremovableClasses.add(TransactionManager.class);
             unremovableClasses.add(TransactionSessions.class);

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/boot/StaticInitFailureTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/boot/StaticInitFailureTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.hibernate.orm.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import org.hibernate.annotations.SQLDeleteAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Checks that a failure during static init is correctly propagated and doesn't trigger other, cascading failures.
+ */
+public class StaticInitFailureTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addClass(EntityWithIncorrectMapping.class))
+            .withConfigurationResource("application.properties")
+            // Expect only one error: the one we triggered
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+            // In particular we don't want a log telling us JPAConfig could not be created
+            // because HibernateOrmRuntimeConfig is not initialized yet.
+            // JPAConfig should not be created in the first place!
+            // See https://github.com/quarkusio/quarkus/issues/32188#issuecomment-1488037517
+            .assertLogRecords(records -> assertThat(records).extracting(LogRecord::getMessage).isEmpty())
+            .assertException(throwable -> assertThat(throwable)
+                    .hasNoSuppressedExceptions()
+                    .rootCause()
+                    .hasMessageContaining("@SQLDeleteAll")
+                    .hasNoSuppressedExceptions());
+
+    @Test
+    public void test() {
+        Assertions.fail("Startup should have failed");
+    }
+
+    @Entity(name = "myentity")
+    @SQLDeleteAll(sql = "foo") // Triggers a failure because this annotation shouldn't be applied to entities
+    public static class EntityWithIncorrectMapping {
+        private long id;
+
+        public EntityWithIncorrectMapping() {
+        }
+
+        @Id
+        @GeneratedValue
+        public long getId() {
+            return id;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+    }
+
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
@@ -93,6 +93,10 @@ public class HibernateOrmRecorder {
         };
     }
 
+    public Supplier<JPAConfig> jpaConfigSupplier(HibernateOrmRuntimeConfig config) {
+        return () -> new JPAConfig(config);
+    }
+
     public void startAllPersistenceUnits(BeanContainer beanContainer) {
         beanContainer.beanInstance(JPAConfig.class).startAll();
     }


### PR DESCRIPTION
This avoids cascading failures when something else fails during static init, see [here](https://github.com/quarkusio/quarkus/issues/32188#issuecomment-1488037517) for an example. I checked that these changes avoid cascading failures using the reproducer from that issue, ~~but gave up on an automated test (can't seem to reproduce the cascading failures in JVM mode).~~ => Actually I managed to reproduce it in the end

(Note that #32188 still has to be fixed, this PR is only tangentially related)