### PR TITLE
Upgrade Caffeine 3.1.5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -142,7 +142,7 @@
         <junit-pioneer.version>1.5.0</junit-pioneer.version>
         <infinispan.version>14.0.7.Final</infinispan.version>
         <infinispan.protostream.version>4.6.1.Final</infinispan.protostream.version>
-        <caffeine.version>3.1.1</caffeine.version>
+        <caffeine.version>3.1.5</caffeine.version>
         <netty.version>4.1.87.Final</netty.version>
         <brotli4j.version>1.11.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>


### PR DESCRIPTION
Caffeine right now has 3.1.1-SNAPSHOT accidentally in the pom.xml which has been fixed in later Caffeine

![image](https://user-images.githubusercontent.com/4399574/226997231-04f7eba3-6863-44e7-8ce3-166ff42472c1.png)