### PR TITLE
Remove lock icon for runtime config overrides

### DIFF
--- a/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/config.html
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/config.html
@@ -419,8 +419,6 @@ function clearConfigFilter(){
                         <td class="filterableConfigKey">
                             {#if item.configPhase?? && (item.configPhase == "BUILD_AND_RUN_TIME_FIXED" || item.configPhase == "BUILD_TIME")}
                             <i class="fas fa-lock" data-toggle="tooltip" data-placement="top" title="Fixed at build time (not overridable at runtime)"></i>
-                            {#else}
-                            <i class="fas fa-lock-open text-white" data-placement="top" title="Overridable at runtime"></i>
                             {/if}
                             
                             {item.configValue.name}

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration.js
@@ -65,11 +65,11 @@ export class QwcConfiguration extends LitElement {
       }
       
       .lock-icon {
-        color: var(--lumo-error-color-50pct);
+        color: var(--lumo-contrast-60pct);
         font-size: small;
       }
       .unlock-icon {
-        color: var(--lumo-success-color-50pct);
+        color: var(--lumo-contrast-60pct);
         font-size: small;
       }
     `;
@@ -156,12 +156,6 @@ export class QwcConfiguration extends LitElement {
             return html`
                 <vaadin-icon theme="small" class="lock-icon" id="icon-lock-${prop.name}" icon="font-awesome-solid:lock"></vaadin-icon>
                 <vaadin-tooltip for="icon-lock-${prop.name}" text="Fixed at build time (not overridable at runtime)"
-                                position="top-start"></vaadin-tooltip>
-            `
-        } else {
-            return html`
-                <vaadin-icon theme="small" class="unlock-icon" id="icon-lock-${prop.name}" icon="font-awesome-solid:lock-open"></vaadin-icon>
-                <vaadin-tooltip for="icon-lock-${prop.name}" text="Overridable at runtime"
                                 position="top-start"></vaadin-tooltip>
             `
         }


### PR DESCRIPTION
- Remove the lock icon from the fixed property icon in the qwc-configuration.js file
- Remove the lock icon for config values that are overridable at runtime in the config.html file
- Fixes #32229

![image](https://user-images.githubusercontent.com/54133/228597673-633143cc-5dc3-421d-a748-73e3d57e2449.png)
