### PR TITLE
Dev UI Resteasy reactive: no endpoint and card

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/qwc-resteasy-reactive-card.js
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/qwc-resteasy-reactive-card.js
@@ -20,9 +20,14 @@ export class QwcResteasyReactiveCard extends QwcHotReloadElement {
         .extensionLink:hover {
             filter: brightness(80%);
         }
+        a, a:link, a:visited, a:hover, a:active{
+            color: var(--lumo-primary-color);
+        }
     `;
     
     static properties = {
+        description: {attribute: true},
+        guide: {attribute: true},
         _pages: {state: false},
         _latestScores: {state: true},
     };
@@ -43,14 +48,20 @@ export class QwcResteasyReactiveCard extends QwcHotReloadElement {
     render() {
         
         if(this._latestScores){
-            return html`<div class="graph" @click=${this.hotReload}>
-                <echarts-gauge-grade 
-                            percentage="${this._latestScores.score}"
-                            percentageFontSize="14"
-                            sectionColors="--lumo-error-color,--lumo-warning-color,--lumo-success-color">
-                        </echarts-gauge-grade>
-            </div>
+            if(this._latestScores.endpoints){
+                return html`<div class="graph" @click=${this.hotReload}>
+                                <echarts-gauge-grade 
+                                    percentage="${this._latestScores.score}"
+                                    percentageFontSize="14"
+                                    sectionColors="--lumo-error-color,--lumo-warning-color,--lumo-success-color">
+                                </echarts-gauge-grade>
+                            </div>
             ${this._renderPagesLinks()}`;
+            }else{
+                return html`${this.description}
+                            <p>No endpoints detected. 
+                            <a href="${this.guide}" target="_blank">Learn how you can add Endpoints</a></p>`;
+            }
         }
     }
     

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/qwc-resteasy-reactive-card.js
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/qwc-resteasy-reactive-card.js
@@ -1,18 +1,22 @@
 import { QwcHotReloadElement, html, css} from 'qwc-hot-reload-element';
 import { pages } from 'build-time-data';
 import { JsonRpc } from 'jsonrpc';
-import 'echarts-gauge-grade';
 import '@vaadin/icon';
+import 'qwc/qwc-extension-link.js';
 
 export class QwcResteasyReactiveCard extends QwcHotReloadElement {
     jsonRpc = new JsonRpc(this);
     
     static styles = css`
-        .graph {
-            height: 200px;
+        .score {
+            font-size: 4em;
+            text-align: center;
+            color: var(--lumo-primary-text-color);
+            text-shadow: 2px 1px 0 var(--lumo-contrast-10pct);
         }
+    
         .extensionLink {
-            color: var(--lumo-contrast);
+            color: var(--lumo-contrast) !important;
             font-size: small;
             cursor: pointer;
             text-decoration: none;
@@ -26,8 +30,10 @@ export class QwcResteasyReactiveCard extends QwcHotReloadElement {
     `;
     
     static properties = {
+        extensionName: {attribute: true},
         description: {attribute: true},
         guide: {attribute: true},
+        namespace: {attribute: true},
         _pages: {state: false},
         _latestScores: {state: true},
     };
@@ -49,12 +55,8 @@ export class QwcResteasyReactiveCard extends QwcHotReloadElement {
         
         if(this._latestScores){
             if(this._latestScores.endpoints){
-                return html`<div class="graph" @click=${this.hotReload}>
-                                <echarts-gauge-grade 
-                                    percentage="${this._latestScores.score}"
-                                    percentageFontSize="14"
-                                    sectionColors="--lumo-error-color,--lumo-warning-color,--lumo-success-color">
-                                </echarts-gauge-grade>
+                return html`<div class="score" @click=${this.hotReload}>
+                                ${this._latestScores.score} %
                             </div>
             ${this._renderPagesLinks()}`;
             }else{
@@ -66,10 +68,21 @@ export class QwcResteasyReactiveCard extends QwcHotReloadElement {
     }
     
     _renderPagesLinks(){
-        return html`<a class="extensionLink" href="${this._pages[0].id}">
-                <vaadin-icon class="icon" icon="${this._pages[0].icon}"></vaadin-icon>
-                ${this._pages[0].title}
-            </a>`;
+        return html`${this._pages.map(page => html`
+                            <qwc-extension-link slot="link"
+                                namespace="${this.namespace}"
+                                extensionName="${this.name}"
+                                iconName="${page.icon}"
+                                displayName="${page.title}"
+                                staticLabel="${page.staticLabel}"
+                                dynamicLabel="${page.dynamicLabel}"
+                                streamingLabel="${page.streamingLabel}"
+                                path="${page.id}"
+                                ?embed=${page.embed}
+                                externalUrl="${page.metadata.externalUrl}"
+                                webcomponent="${page.componentLink}" >
+                            </qwc-extension-link>
+                        `)}`;
     }
     
     hotReload(){

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/qwc-resteasy-reactive-endpoint-scores.js
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/qwc-resteasy-reactive-endpoint-scores.js
@@ -94,9 +94,13 @@ export class QwcResteasyReactiveEndpointScores extends QwcHotReloadElement {
 
     render() {
         if(this._latestScores){
-            return html`${this._latestScores.endpoints.map(endpoint=>{
-                return html`${this._renderEndpoint(endpoint)}`;
-            })}`;
+            if(this._latestScores.endpoints){
+                return html`${this._latestScores.endpoints.map(endpoint=>{
+                    return html`${this._renderEndpoint(endpoint)}`;
+                })}`;
+            }else{
+                return html`<p>No endpoints detected</p>`;
+            }
         }
     }
 

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -91,11 +91,11 @@ export class QwcExtensions extends observeState(LitElement) {
 
     _renderCustomCardContent(extension){
         import(extension.card.componentRef);
-        
         let customCardCode = `<${extension.card.componentName} 
                                 class="card-content"
                                 slot="content"
                                 description="${extension.description}"
+                                guide="${extension.guide}"
                                 namespace="${extension.namespace}">
 
                              </${extension.card.componentName}>`;

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -94,6 +94,7 @@ export class QwcExtensions extends observeState(LitElement) {
         let customCardCode = `<${extension.card.componentName} 
                                 class="card-content"
                                 slot="content"
+                                extensionName="${extension.name}"
                                 description="${extension.description}"
                                 guide="${extension.guide}"
                                 namespace="${extension.namespace}">


### PR DESCRIPTION
This PR contains 2 commits

1) Fix #32216

![resteasy-reactive-no-endpoint](https://user-images.githubusercontent.com/6836179/228724518-e1f629bc-9648-4384-954d-80bd3b9934a4.png)

2) Fix #32228 - Replace the gauge on the card with just the score %.

![resteasy-reactive-card](https://user-images.githubusercontent.com/6836179/228724745-11a9251a-6b05-4cee-b3fe-736a5f8cbe42.png)


cc @maxandersen @gsmet @geoand  @FroMage 