### PR TITLE
Integrate Stork 2.1.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -70,7 +70,7 @@
         <smallrye-reactive-types-converter.version>3.0.0</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.2.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.4.0</smallrye-reactive-messaging.version>
-        <smallrye-stork.version>2.0.1</smallrye-stork.version>
+        <smallrye-stork.version>2.1.0</smallrye-stork.version>
         <jakarta.activation.version>2.1.1</jakarta.activation.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkWithPathIntegrationTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkWithPathIntegrationTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.rest.client.reactive.stork;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.HelloClient2;
+import io.quarkus.rest.client.reactive.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.stork.api.NoSuchServiceDefinitionException;
+
+public class StorkWithPathIntegrationTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HelloClient2.class, HelloResource.class))
+            .withConfigurationResource("stork-application-with-path.properties");
+
+    @RestClient
+    HelloClient2 client;
+
+    @Test
+    void shouldDetermineUrlViaStork() {
+        String greeting = RestClientBuilder.newBuilder().baseUri(URI.create("stork://hello-service"))
+                .build(HelloClient2.class)
+                .echo("black and white bird");
+        assertThat(greeting).isEqualTo("hello, black and white bird");
+    }
+
+    @Test
+    void shouldDetermineUrlViaStorkWhenUsingTarget() throws URISyntaxException {
+        String greeting = ClientBuilder.newClient().target("stork://hello-service").request().get(String.class);
+        assertThat(greeting).isEqualTo("Hello");
+
+        greeting = ClientBuilder.newClient().target(new URI("stork://hello-service")).request().get(String.class);
+        assertThat(greeting).isEqualTo("Hello");
+
+        greeting = ClientBuilder.newClient().target(UriBuilder.fromUri("stork://hello-service/")).request()
+                .get(String.class);
+        assertThat(greeting).isEqualTo("Hello");
+    }
+
+    @Test
+    void shouldDetermineUrlViaStorkCDI() {
+        String greeting = client.echo("big bird");
+        assertThat(greeting).isEqualTo("hello, big bird");
+    }
+
+    @Test
+    @Timeout(20)
+    void shouldFailOnUnknownService() {
+        HelloClient2 client2 = RestClientBuilder.newBuilder()
+                .baseUri(URI.create("stork://nonexistent-service"))
+                .build(HelloClient2.class);
+        assertThatThrownBy(() -> client2.echo("foo")).isInstanceOf(NoSuchServiceDefinitionException.class);
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/stork-application-with-path.properties
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/stork-application-with-path.properties
@@ -1,0 +1,5 @@
+quarkus.stork.hello-service.service-discovery.type=static
+quarkus.stork.hello-service.service-discovery.address-list=${quarkus.http.host}:${quarkus.http.test-port}/hello
+quarkus.stork.hello-service.load-balancer.type=least-response-time
+
+hello2/mp-rest/url=stork://hello-service

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/StorkClientRequestFilter.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/StorkClientRequestFilter.java
@@ -2,6 +2,7 @@ package org.jboss.resteasy.reactive.client.impl;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Optional;
 
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.Priorities;
@@ -59,9 +60,29 @@ public class StorkClientRequestFilter implements ResteasyReactiveClientRequestFi
                                     port = 80;
                                 }
                             }
+                            // Service instance can also contain an optional path.
+                            Optional<String> path = instance.getPath();
+                            String actualPath = uri.getPath();
+                            if (path.isPresent()) {
+                                var p = path.get();
+                                if (!p.startsWith("/")) {
+                                    p = "/" + p;
+                                }
+                                if (actualPath == null) {
+                                    actualPath = p;
+                                } else {
+                                    // Append both.
+                                    if (actualPath.startsWith("/") || p.endsWith("/")) {
+                                        actualPath = p + actualPath;
+                                    } else {
+                                        actualPath = p + "/" + actualPath;
+                                    }
+                                }
+                            }
+
                             URI newUri = new URI(scheme,
                                     uri.getUserInfo(), host, port,
-                                    uri.getPath(), uri.getQuery(), uri.getFragment());
+                                    actualPath, uri.getQuery(), uri.getFragment());
                             requestContext.setUri(newUri);
                             if (measureTime && instance.gatherStatistics()) {
                                 requestContext.setCallStatsCollector(instance);

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -67,7 +67,7 @@
         <rest-assured.version>5.3.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.14.2</jackson-bom.version>
-        <smallrye-stork.version>2.0.1</smallrye-stork.version>
+        <smallrye-stork.version>2.1.0</smallrye-stork.version>
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
         <yasson.version>3.0.2</yasson.version>
         <jakarta.json.bind-api.version>3.0.0</jakarta.json.bind-api.version>


### PR DESCRIPTION
The main new feature is the ability for a ServiceInstance to provide a `path`. This path can be used to discover HTTP services running behind an API gateway or having URLs using a specific path (AWS, for example).

Also fixes https://github.com/quarkusio/quarkus/issues/32111.
