### PR TITLE
Fixes and improvements for image build and deploy mojo and tasks

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/BuildToolDelegatingCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/BuildToolDelegatingCommand.java
@@ -123,7 +123,8 @@ public class BuildToolDelegatingCommand implements Callable<Integer> {
 
     public void prepareMaven(BuildToolContext context) {
         BuildSystemRunner runner = getRunner(context);
-        BuildSystemRunner.BuildCommandArgs compileArgs = runner.prepareAction("compiler:compile", context.getBuildOptions(),
+        BuildSystemRunner.BuildCommandArgs compileArgs = runner.prepareAction("resources:resources",
+                context.getBuildOptions(),
                 context.getRunModeOption(),
                 context.getParams());
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/deploy/Kind.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/deploy/Kind.java
@@ -3,7 +3,7 @@ package io.quarkus.cli.deploy;
 import io.quarkus.cli.BuildToolContext;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "kind", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on minikube.", description = "%n"
+@CommandLine.Command(name = "kind", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Perform the deploy action on kind.", description = "%n"
         + "The command will deploy the application on kind.", footer = "%n"
                 + "For example (using default values), it will create a Deployment named '<project.artifactId>' using the image with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>' and will deploy it to the target cluster.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Kind extends BaseKubernetesDeployCommand {

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/JBangCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/JBangCommand.java
@@ -49,4 +49,11 @@ public class JBangCommand implements PluginCommand {
     public OutputOptionMixin getOutput() {
         return output;
     }
+
+    @Override
+    public void useArguments(List<String> arguments) {
+        this.arguments.clear();
+        this.arguments.add(location);
+        this.arguments.addAll(arguments);
+    }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/JarCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/JarCommand.java
@@ -13,7 +13,7 @@ public class JarCommand implements PluginCommand {
     private JBangSupport jbang;
     private String name;
     private Path location; //May be path, url or CAGTV
-    private List<String> arguments = new ArrayList<>();
+    private final List<String> arguments = new ArrayList<>();
 
     private OutputOptionMixin output;
     private Path workingDirectory;
@@ -25,7 +25,6 @@ public class JarCommand implements PluginCommand {
         this.jbang = new JBangSupport(output.isCliTest(), output, workingDirectory);
         this.name = name;
         this.location = location;
-        this.arguments = new ArrayList<>();
         this.output = output;
         this.workingDirectory = workingDirectory;
         arguments.add(location.toAbsolutePath().toString());
@@ -39,6 +38,13 @@ public class JarCommand implements PluginCommand {
     @Override
     public List<String> getArguments() {
         return arguments;
+    }
+
+    @Override
+    public void useArguments(List<String> arguments) {
+        this.arguments.clear();
+        this.arguments.add(location.toAbsolutePath().toString());
+        this.arguments.addAll(arguments);
     }
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCommand.java
@@ -17,6 +17,8 @@ public interface PluginCommand extends Callable<Integer> {
 
     OutputOptionMixin getOutput();
 
+    void useArguments(List<String> arguments);
+
     default Path getWorkingDirectory() {
         return Paths.get(System.getProperty("user.dir"));
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCommandFactory.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCommandFactory.java
@@ -60,7 +60,7 @@ public class PluginCommandFactory {
                             }
                             if (value instanceof String[]) {
                                 String[] array = (String[]) value;
-                                command.getArguments().addAll(Arrays.asList(array));
+                                command.useArguments(Arrays.asList(array));
                             }
                             return value;
                         }

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/ShellCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/ShellCommand.java
@@ -42,6 +42,12 @@ public class ShellCommand implements PluginCommand, Callable<Integer> {
         return arguments;
     }
 
+    @Override
+    public void useArguments(List<String> arguments) {
+        this.arguments.clear();
+        this.arguments.addAll(arguments);
+    }
+
     public OutputOptionMixin getOutput() {
         return output;
     }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
@@ -126,11 +126,5 @@ public abstract class Deploy extends QuarkusBuildTask {
                 .or(() -> imageBuild ? Arrays.stream(getDeployer().requiresOneOf).findFirst() : Optional.empty());
     }
 
-    private void abort(String message, Object... args) {
-        getProject().getLogger().warn(message, args);
-        getProject().getTasks().stream().filter(t -> t != this).forEach(t -> {
-            t.setEnabled(false);
-        });
-        throw new StopExecutionException();
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/Deploy.java
@@ -47,11 +47,6 @@ public abstract class Deploy extends QuarkusBuildTask {
         }
     }
 
-    @Inject
-    public Deploy() {
-        super("Deploy");
-    }
-
     @Input
     Optional<String> deployer = Optional.empty();
     boolean imageBuild = false;
@@ -73,8 +68,9 @@ public abstract class Deploy extends QuarkusBuildTask {
         this.imageBuild = true;
     }
 
-    public Deploy(String description) {
-        super(description);
+    @Inject
+    public Deploy() {
+        super("Deploy");
         extension().forcedPropertiesProperty().convention(
                 getProject().provider(() -> {
                     Map<String, String> props = new HashMap<>();

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageBuild.java
@@ -22,12 +22,6 @@ public abstract class ImageBuild extends ImageTask {
         super("Perform an image build");
         MapProperty<String, String> forcedProperties = extension().forcedPropertiesProperty();
         forcedProperties.put(QUARKUS_CONTAINER_IMAGE_BUILD, "true");
-        forcedProperties.put(QUARKUS_CONTAINER_IMAGE_BUILDER, getProject().provider(() -> builder().orElseThrow().name()));
-    }
-
-    public Optional<Builder> builder() {
-        return builder
-                .or(() -> builderFromSystemProperties())
-                .or(() -> availableBuilders().stream().findFirst());
+        forcedProperties.put(QUARKUS_CONTAINER_IMAGE_BUILDER, getProject().provider(() -> builder().name()));
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageTask.java
@@ -37,8 +37,10 @@ public abstract class ImageTask extends QuarkusBuildTask {
         super(description);
     }
 
-    Optional<Builder> builder() {
-        return builderFromSystemProperties();
+    public Builder builder() {
+        return builderFromSystemProperties()
+                .or(() -> availableBuilders().stream().findFirst())
+                .orElse(Builder.docker);
     }
 
     Optional<Builder> builderFromSystemProperties() {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageTask.java
@@ -80,12 +80,4 @@ public abstract class ImageTask extends QuarkusBuildTask {
             abort("Aborting.");
         }
     }
-
-    void abort(String message, Object... args) {
-        getProject().getLogger().warn(message, args);
-        getProject().getTasks().stream().filter(t -> t != this).forEach(t -> {
-            t.setEnabled(false);
-        });
-        throw new StopExecutionException();
-    }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/AbstractDeploymentMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/AbstractDeploymentMojo.java
@@ -1,7 +1,6 @@
 package io.quarkus.maven;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -9,42 +8,12 @@ import java.util.stream.Collectors;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 
-import io.quarkus.deployment.util.DeploymentUtil;
-import io.quarkus.maven.dependency.ArtifactDependency;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.runtime.LaunchMode;
 
 public class AbstractDeploymentMojo extends BuildMojo {
-
-    public enum Deployer {
-
-        kubernetes("quarkus-kubernetes", "quarkus-container-image-docker", "quarkus-container-image-jib",
-                "quarkus-container-image-buildpack"),
-        minikube("quarkus-minikube", "quarkus-container-image-docker", "quarkus-container-image-jib",
-                "quarkus-container-image-buildpack"),
-        kind("quarkus-kind", "quarkus-container-image-docker", "quarkus-container-image-jib",
-                "quarkus-container-image-buildpack"),
-        knative("quarkus-kubernetes", "quarkus-container-image-docker", "quarkus-container-image-jib",
-                "quarkus-container-image-buildpack"),
-        openshift("quarkus-openshift");
-
-        private final String extension;
-        private final String[] requiresOneOf;
-
-        Deployer(String extension, String... requiresOneOf) {
-            this.extension = extension;
-            this.requiresOneOf = requiresOneOf;
-        }
-
-        public String getExtension() {
-            return extension;
-        }
-
-        public String[] getRequiresOneOf() {
-            return requiresOneOf;
-        }
-    }
 
     Optional<String> deployer = Optional.empty();
 
@@ -71,90 +40,28 @@ public class AbstractDeploymentMojo extends BuildMojo {
         }
     }
 
-    public Optional<String> getImageBuilder() {
-        return Optional.ofNullable(imageBuilder);
+    public Deployer getDeployer() {
+        return Deployer.getDeployer(mavenProject())
+                .orElse(Deployer.kubernetes);
     }
 
-    public Deployer getDeployer() {
-        return deployer
-                .or(() -> DeploymentUtil.getEnabledDeployer())
-                .or(() -> getProjectDeployers().stream().findFirst())
-                .map(Deployer::valueOf)
-                .orElse(Deployer.kubernetes);
+    public Optional<String> getImageBuilder() {
+        return Optional.ofNullable(imageBuilder);
     }
 
     @Override
     protected List<Dependency> forcedDependencies(LaunchMode mode) {
         List<Dependency> dependencies = new ArrayList<>();
+        MavenProject project = mavenProject();
         Deployer deployer = getDeployer();
-        String containerImageBuilderArtifactId = containerImageBuilderArtifactId(imageBuilder);
-        getDeploymentExtension(deployer).ifPresent(d -> dependencies.add(d));
-        getContainerImageExtension(containerImageBuilderArtifactId).or(() -> getFirstContainerImageExtension(deployer))
-                .ifPresent(d -> dependencies.add(d));
-        return dependencies;
-    }
-
-    protected Optional<ArtifactDependency> getDeploymentExtension(Deployer deployer) {
-        return mavenProject().getDependencyManagement().getDependencies().stream()
-                .filter(d -> "io.quarkus".equals(d.getGroupId()) && deployer.getExtension().equals(d.getArtifactId()))
-                .map(d -> new ArtifactDependency(d.getGroupId(), d.getArtifactId(), null,
-                        io.quarkus.maven.dependency.ArtifactCoords.TYPE_JAR,
-                        d.getVersion()))
-                .findFirst();
-    }
-
-    public Set<String> getProjectDeployers() {
-        return mavenProject().getDependencies().stream()
-                .filter(d -> "io.quarkus".equals(d.getGroupId()) && Arrays.stream(Deployer.values()).map(Deployer::getExtension).anyMatch(e -> d.getArtifactId().equals(e)))
-                .map(d -> d.getArtifactId().replaceAll("^quarkus\\-", ""))
-                .collect(Collectors.toSet());
-    }
-
-    /**
-     * Get the first {@link ArtifactDependency} that is requires by the specified {@link Deployer}.
-     * The depndency is looked up in the project.
-     *
-     * @param deployer The deployer
-     * @return a {@link Optional} containing the {@link ArtifactDependency} or empty if none is found.
-     */
-    protected Optional<ArtifactDependency> getFirstContainerImageExtension(Deployer deployer) {
-        return getContainerImageExtension(Arrays.stream(deployer.requiresOneOf).findFirst());
-    }
-
-    /**
-     * Get the first {@link ArtifactDependency} that matches the specified artifactId.
-     * The depndency is looked up in the project (by artifactId).
-     *
-     * @param artifactId The artifactId to use for the lookup.
-     * @return a {@link Optional} containing the {@link ArtifactDependency} or empty if none is found.
-     */
-    protected Optional<ArtifactDependency> getContainerImageExtension(String artifactId) {
-        return getContainerImageExtension(Optional.ofNullable(artifactId));
-    }
-
-    /**
-     * Get the first {@link ArtifactDependency} that matches the specified artifactId.
-     * The depndency is looked up in the project (by artifactId).
-     *
-     * @param artifactId the {@link Optional} artifactId to use for the lookup.
-     * @return a {@link Optional} containing the {@link ArtifactDependency} or empty if none is found.
-     */
-    protected Optional<ArtifactDependency> getContainerImageExtension(Optional<String> artifactId) {
-        return artifactId.flatMap(a -> {
-            return mavenProject().getDependencyManagement().getDependencies().stream()
-                    .filter(d -> "io.quarkus".equals(d.getGroupId()) && a.equals(d.getArtifactId()))
-                    .map(d -> new ArtifactDependency(d.getGroupId(), d.getArtifactId(), null,
-                            io.quarkus.maven.dependency.ArtifactCoords.TYPE_JAR,
-                            d.getVersion()))
-                    .findFirst();
-
-        });
-    }
-
-    protected static String containerImageBuilderArtifactId(String builder) {
-        if (builder == null || builder.isEmpty()) {
-            return null;
+        deployer.getExtensionArtifact(project).ifPresent(d -> dependencies.add(d));
+        if (this.imageBuild || this.imageBuilder != null) {
+            Set<ImageBuilder> projectBuilders = ImageBuilder.getProjecBuilder(project).stream().map(ImageBuilder::valueOf)
+                    .collect(Collectors.toSet());
+            Optional<ImageBuilder> imageBuilder = ImageBuilder.getBuilder(this.imageBuilder, projectBuilders);
+            imageBuilder.filter(b -> !projectBuilders.contains(b)).flatMap(b -> b.getExtensionArtifact(project))
+                    .ifPresent(d -> dependencies.add(d));
         }
-        return "quarkus-container-image-" + builder;
+        return dependencies;
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/AbstractImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/AbstractImageMojo.java
@@ -2,12 +2,10 @@ package io.quarkus.maven;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import io.quarkus.maven.dependency.ArtifactDependency;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.runtime.LaunchMode;
 
@@ -16,22 +14,19 @@ import io.quarkus.runtime.LaunchMode;
  */
 public class AbstractImageMojo extends BuildMojo {
 
-    public enum Builder {
-        docker,
-        jib,
-        buildpack,
-        openshift
-    }
-
-    @Parameter(defaultValue = "docker", property = "quarkus.container-image.builder")
-    Builder builder = Builder.docker;
+    @Parameter(property = "quarkus.container-image.builder")
+    String builderName;
 
     @Parameter(property = "quarkus.container-image.dry-run")
     boolean dryRun;
 
+    public ImageBuilder getBuilder() {
+        return ImageBuilder.getBuilder(builderName, mavenProject()).orElse(ImageBuilder.docker);
+    }
+
     @Override
     protected boolean beforeExecute() throws MojoExecutionException {
-        systemProperties.put("quarkus.container-image.builder", builder.name());
+        systemProperties.put("quarkus.container-image.builder", getBuilder().name());
         return super.beforeExecute();
     }
 
@@ -52,20 +47,7 @@ public class AbstractImageMojo extends BuildMojo {
     @Override
     protected List<Dependency> forcedDependencies(LaunchMode mode) {
         List<Dependency> dependencies = new ArrayList<>();
-        getContainerImageExtension(builder).ifPresent(d -> dependencies.add(d));
+        getBuilder().getExtensionArtifact(mavenProject()).ifPresent(d -> dependencies.add(d));
         return dependencies;
-    }
-
-    protected Optional<ArtifactDependency> getContainerImageExtension(Builder builder) {
-        return getExtension("quarkus-container-image-" + builder.name());
-    }
-
-    protected Optional<ArtifactDependency> getExtension(String artifactId) {
-        return mavenProject().getDependencyManagement().getDependencies().stream()
-                .filter(d -> "io.quarkus".equals(d.getGroupId()) && artifactId.equals(d.getArtifactId()))
-                .map(d -> new ArtifactDependency(d.getGroupId(), d.getArtifactId(), null,
-                        io.quarkus.maven.dependency.ArtifactCoords.TYPE_JAR,
-                        d.getVersion()))
-                .findFirst();
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/Deployer.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/Deployer.java
@@ -1,0 +1,89 @@
+package io.quarkus.maven;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.maven.project.MavenProject;
+
+import io.quarkus.deployment.util.DeploymentUtil;
+import io.quarkus.maven.dependency.ArtifactDependency;
+
+public enum Deployer {
+
+    kubernetes("quarkus-kubernetes", "quarkus-container-image-docker", "quarkus-container-image-jib",
+            "quarkus-container-image-buildpack"),
+    minikube("quarkus-minikube", "quarkus-container-image-docker", "quarkus-container-image-jib",
+            "quarkus-container-image-buildpack"),
+    kind("quarkus-kind", "quarkus-container-image-docker", "quarkus-container-image-jib",
+            "quarkus-container-image-buildpack"),
+    knative("quarkus-kubernetes", "quarkus-container-image-docker", "quarkus-container-image-jib",
+            "quarkus-container-image-buildpack"),
+    openshift("quarkus-openshift");
+
+    private final String extension;
+    private final String[] requiresOneOf;
+
+    Deployer(String extension, String... requiresOneOf) {
+        this.extension = extension;
+        this.requiresOneOf = requiresOneOf;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public String[] getRequiresOneOf() {
+        return requiresOneOf;
+    }
+
+    static final String QUARKUS_GROUP_ID = "io.quarkus";
+    static final String QUARKUS_PREFIX = "quarkus-";
+
+    /**
+     * Get the {@link ArtifactDependency} matching the builder.
+     *
+     * @param project the target project
+     * @return the dependency wrapped in {@link Optional}.
+     */
+    public Optional<ArtifactDependency> getExtensionArtifact(MavenProject project) {
+        String artifactId = QUARKUS_PREFIX + name();
+        return project.getDependencyManagement().getDependencies().stream()
+                .filter(d -> QUARKUS_GROUP_ID.equals(d.getGroupId()) && artifactId.equals(d.getArtifactId()))
+                .map(d -> new ArtifactDependency(d.getGroupId(), d.getArtifactId(), null,
+                        io.quarkus.maven.dependency.ArtifactCoords.TYPE_JAR,
+                        d.getVersion()))
+                .findFirst();
+    }
+
+    /**
+     * Get the deployer by name or the first one found in the project.
+     *
+     * @project the project to search for deployer extensions
+     * @return the {@link Optional} builder matching the name, project.
+     */
+    public static Optional<Deployer> getDeployer(MavenProject project) {
+        return DeploymentUtil.getEnabledDeployer()
+                .or(() -> getProjecDeployer(project).stream().findFirst()).map(Deployer::valueOf);
+    }
+
+    /**
+     * Get teh deployer extensions found in the project.
+     *
+     * @param the project to search for extensions
+     * @return A set with the discovered extenions.
+     */
+    public static Set<String> getProjecDeployer(MavenProject project) {
+        return project.getDependencies().stream()
+                .filter(d -> QUARKUS_GROUP_ID.equals(d.getGroupId()))
+                .map(d -> strip(d.getArtifactId()))
+                .filter(n -> Arrays.stream(Deployer.values()).anyMatch(e -> e.equals(n)))
+                .collect(Collectors.toSet());
+    }
+
+    private static final String strip(String s) {
+        return s.replaceAll("^" + Pattern.quote(QUARKUS_PREFIX), "");
+    }
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/ImageBuilder.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/ImageBuilder.java
@@ -1,0 +1,85 @@
+package io.quarkus.maven;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.maven.project.MavenProject;
+
+import io.quarkus.maven.dependency.ArtifactDependency;
+
+public enum ImageBuilder {
+
+    docker,
+    jib,
+    buildpack,
+    openshift;
+
+    static final String QUARKUS_PREFIX = "quarkus-";
+    static final String QUARKUS_CONTAINER_IMAGE_PREFIX = "quarkus-container-image-";
+
+    /**
+     * Get the {@link ArtifactDependency} matching the builder.
+     *
+     * @param project the target project
+     * @return the dependency wrapped in {@link Optional}.
+     */
+    public Optional<ArtifactDependency> getExtensionArtifact(MavenProject project) {
+        String artifactId = QUARKUS_CONTAINER_IMAGE_PREFIX + name();
+        return project.getDependencyManagement().getDependencies().stream()
+                .filter(d -> "io.quarkus".equals(d.getGroupId()) && artifactId.equals(d.getArtifactId()))
+                .map(d -> new ArtifactDependency(d.getGroupId(), d.getArtifactId(), null,
+                        io.quarkus.maven.dependency.ArtifactCoords.TYPE_JAR,
+                        d.getVersion()))
+                .findFirst();
+    }
+
+    /**
+     * Get the image builder by name or the first one found in the project.
+     *
+     * @param name the name of the builder.
+     * @project the project to search for container image builder extensions
+     * @return the {@link Optional} builder matching the name, project.
+     */
+    public static Optional<ImageBuilder> getBuilder(String name, MavenProject project) {
+        return Optional.ofNullable(name)
+                .filter(n -> Arrays.stream(ImageBuilder.values()).map(ImageBuilder::name).anyMatch(i -> i.equals(n)))
+                .or(() -> getProjecBuilder(project).stream().findFirst()).map(ImageBuilder::valueOf);
+    }
+
+    /**
+     * Get the image builder by name or the first one found in the project.
+     *
+     * @param name the name of the builder.
+     * @projectBuilder the collection of builders found in the project.
+     * @return the {@link Optional} builder matching the name, project.
+     */
+    public static Optional<ImageBuilder> getBuilder(String name, Collection<ImageBuilder> projectBuilders) {
+        return Optional.ofNullable(name)
+                .filter(n -> Arrays.stream(ImageBuilder.values()).map(ImageBuilder::name).anyMatch(i -> i.equals(n)))
+                .map(ImageBuilder::valueOf)
+                .or(() -> projectBuilders.stream().findFirst());
+    }
+
+    /**
+     * Get teh image builder extensions found in the project.
+     *
+     * @param the project to search for extensions
+     * @return A set with the discovered extenions.
+     */
+    public static Set<String> getProjecBuilder(MavenProject project) {
+        return project.getDependencies().stream()
+                .filter(d -> "io.quarkus".equals(d.getGroupId()))
+                .map(d -> strip(d.getArtifactId()))
+                .filter(n -> Arrays.stream(ImageBuilder.values()).anyMatch(e -> e.equals(n)))
+                .collect(Collectors.toSet());
+    }
+
+    private static final String strip(String s) {
+        return s.replaceAll("^" + Pattern.quote(QUARKUS_CONTAINER_IMAGE_PREFIX), "")
+                .replaceAll("^" + Pattern.quote(QUARKUS_PREFIX), "");
+    }
+}


### PR DESCRIPTION
Resolves: #32226

Also addresses a ton of issues spotted with I was on it:

- Deploy tasks was competely broken
- Both image build & deploy tasks/mojo didn't recognize `quarkus-openshift` as a container image extension.
- Both deploy tasks/mojo were getting confused by the presence of image builders in the project.
- A lot of code dublication.