### PR TITLE
Updating Upstream snippets to workaround Downstream-tooling incapacitates with multiple-snippet bars

### DIFF
--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -55,4 +55,8 @@
 // .
 :create-app-group-id: org.acme
 // .
+// Devtools snippet's attribute and context
+:upstream:
+:note-quarkus-cli-support: * _For more information about how to install the Quarkus CLI and use it, please refer to xref:cli-tooling.adoc[the Quarkus CLI guide]._
+// .
 include::_attributes-local.adoc[]

--- a/docs/src/main/asciidoc/_includes/devtools/build-native-container-parameters.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/build-native-container-parameters.adoc
@@ -1,21 +1,57 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[role="primary asciidoc-tabs-sync-cli"]
+ifdef::upstream[]
 .CLI
+endif::[]
+ifdef::downstream[]
+* Using Quarkus CLI:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 quarkus build --native -Dquarkus.native.container-build=true {build-additional-parameters}
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+
+ifdef::upstream[]
+
+endif::[]
+ifdef::downstream[]
+* {note-quarkus-cli-support}
+endif::[]
+****
+
+[role="secondary asciidoc-tabs-sync-maven"]
+ifdef::upstream[]
 .Maven
+endif::[]
+ifdef::downstream[]
+* Using Maven:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ./mvnw install -Dnative -Dquarkus.native.container-build=true {build-additional-parameters}
 ----
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+****
+
+[role="secondary asciidoc-tabs-sync-gradle"]
+ifdef::upstream[]
 .Gradle
+endif::[]
+ifdef::downstream[]
+* Using Gradle:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ./gradlew build -Dquarkus.package.type=native -Dquarkus.native.container-build=true {build-additional-parameters}
 ----
 endif::[]
+****

--- a/docs/src/main/asciidoc/_includes/devtools/build-native-container.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/build-native-container.adoc
@@ -1,5 +1,13 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[role="primary asciidoc-tabs-sync-cli"]
+ifdef::upstream[]
 .CLI
+endif::[]
+ifdef::downstream[]
+* Using Quarkus CLI:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ifdef::build-additional-parameters[]
 quarkus build --native --no-tests -Dquarkus.native.container-build=true {build-additional-parameters}
@@ -11,8 +19,25 @@ endif::[]
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+
+ifdef::upstream[]
+
+endif::[]
+ifdef::downstream[]
+* {note-quarkus-cli-support}
+endif::[]
+****
+
+[role="secondary asciidoc-tabs-sync-maven"]
+ifdef::upstream[]
 .Maven
+endif::[]
+ifdef::downstream[]
+* Using Maven:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ifdef::build-additional-parameters[]
 ./mvnw install -Dnative -DskipTests -Dquarkus.native.container-build=true {build-additional-parameters}
@@ -24,8 +49,18 @@ endif::[]
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+****
+
+[role="secondary asciidoc-tabs-sync-gradle"]
+ifdef::upstream[]
 .Gradle
+endif::[]
+ifdef::downstream[]
+* Using Gradle:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ifdef::build-additional-parameters[]
 ./gradlew build -Dquarkus.package.type=native -Dquarkus.native.container-build=true {build-additional-parameters}

--- a/docs/src/main/asciidoc/_includes/devtools/build-native.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/build-native.adoc
@@ -1,5 +1,13 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[role="primary asciidoc-tabs-sync-cli"]
+ifdef::upstream[]
 .CLI
+endif::[]
+ifdef::downstream[]
+* Using Quarkus CLI:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ifdef::build-additional-parameters[]
 quarkus build --native {build-additional-parameters}
@@ -10,8 +18,25 @@ endif::[]
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+
+ifdef::upstream[]
+
+endif::[]
+ifdef::downstream[]
+* {note-quarkus-cli-support}
+endif::[]
+****
+
+[role="secondary asciidoc-tabs-sync-maven"]
+ifdef::upstream[]
 .Maven
+endif::[]
+ifdef::downstream[]
+* Using Maven:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ifdef::build-additional-parameters[]
 ./mvnw install -Dnative {build-additional-parameters}
@@ -23,8 +48,18 @@ endif::[]
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+****
+
+[role="secondary asciidoc-tabs-sync-gradle"]
+ifdef::upstream[]
 .Gradle
+endif::[]
+ifdef::downstream[]
+* Using Gradle:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ifdef::build-additional-parameters[]
 ./gradlew build -Dquarkus.package.type=native {build-additional-parameters}
@@ -34,3 +69,4 @@ ifndef::build-additional-parameters[]
 endif::[]
 ----
 endif::[]
+****

--- a/docs/src/main/asciidoc/_includes/devtools/build.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/build.adoc
@@ -1,5 +1,13 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[role="primary asciidoc-tabs-sync-cli"]
+ifdef::upstream[]
 .CLI
+endif::[]
+ifdef::downstream[]
+* Using Quarkus CLI:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ifdef::build-additional-parameters[]
 quarkus build {build-additional-parameters}
@@ -10,8 +18,25 @@ endif::[]
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+
+ifdef::upstream[]
+
+endif::[]
+ifdef::downstream[]
+* {note-quarkus-cli-support}
+endif::[]
+****
+
+[role="secondary asciidoc-tabs-sync-maven"]
+ifdef::upstream[]
 .Maven
+endif::[]
+ifdef::downstream[]
+* Using Maven:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ifdef::build-additional-parameters[]
 ./mvnw install {build-additional-parameters}
@@ -23,8 +48,18 @@ endif::[]
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+****
+
+[role="secondary asciidoc-tabs-sync-gradle"]
+ifdef::upstream[]
 .Gradle
+endif::[]
+ifdef::downstream[]
+* Using Gradle:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ifdef::build-additional-parameters[]
 ./gradlew build {build-additional-parameters}
@@ -34,3 +69,4 @@ ifndef::build-additional-parameters[]
 endif::[]
 ----
 endif::[]
+****

--- a/docs/src/main/asciidoc/_includes/devtools/create-app.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/create-app.adoc
@@ -1,5 +1,11 @@
 [role="primary asciidoc-tabs-sync-cli"]
+ifdef::upstream[]
 .CLI
+endif::[]
+ifdef::downstream[]
+* Using Quarkus CLI:
++
+endif::[]
 ****
 [source,bash,subs=attributes+]
 ----
@@ -56,7 +62,13 @@ _For more information about how to install the Quarkus CLI and use it, please re
 ****
 
 [role="secondary asciidoc-tabs-sync-maven"]
+ifdef::upstream[]
 .Maven
+endif::[]
+ifdef::downstream[]
+* Using Maven:
++
+endif::[]
 ****
 [source,bash,subs=attributes+]
 ----

--- a/docs/src/main/asciidoc/_includes/devtools/create-cli.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/create-cli.adoc
@@ -1,5 +1,11 @@
 [role="primary asciidoc-tabs-sync-cli"]
+ifdef::upstream[]
 .CLI
+endif::[]
+ifdef::downstream[]
+* Using Quarkus CLI:
++
+endif::[]
 ****
 [source,bash,subs=attributes+]
 ----
@@ -50,13 +56,19 @@ cd {create-cli-artifact-id}
 endif::[]
 ----
 
-To create a Gradle project, add the `--gradle` or `--gradle-kotlin-dsl` option.
+* To create a Gradle project, add the `--gradle` or `--gradle-kotlin-dsl` option.
 
-_For more information about how to install the Quarkus CLI and use it, please refer to xref:cli-tooling.adoc[the Quarkus CLI guide]._
+* _{note-quarkus-cli-support}_
 ****
 
 [role="secondary asciidoc-tabs-sync-maven"]
+ifdef::upstream[]
 .Maven
+endif::[]
+ifdef::downstream[]
+* Using Maven:
++
+endif::[]
 ****
 [source,bash,subs=attributes+]
 ----

--- a/docs/src/main/asciidoc/_includes/devtools/dev-parameters.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/dev-parameters.adoc
@@ -1,21 +1,57 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[role="primary asciidoc-tabs-sync-cli"]
+ifdef::upstream[]
 .CLI
+endif::[]
+ifdef::downstream[]
+* Using Quarkus CLI:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 quarkus dev {dev-additional-parameters}
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+
+ifdef::upstream[]
+
+endif::[]
+ifdef::downstream[]
+* {note-quarkus-cli-support}
+endif::[]
+****
+
+[role="secondary asciidoc-tabs-sync-maven"]
+ifdef::upstream[]
 .Maven
+endif::[]
+ifdef::downstream[]
+* Using Maven:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ./mvnw quarkus:dev {dev-additional-parameters}
 ----
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+****
+
+[role="secondary asciidoc-tabs-sync-gradle"]
+ifdef::upstream[]
 .Gradle
+endif::[]
+ifdef::downstream[]
+* Using Gradle:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ./gradlew --console=plain quarkusDev {dev-additional-parameters}
 ----
 endif::[]
+****

--- a/docs/src/main/asciidoc/_includes/devtools/dev.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/dev.adoc
@@ -1,5 +1,13 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[role="primary asciidoc-tabs-sync-cli"]
+ifdef::upstream[]
 .CLI
+endif::[]
+ifdef::downstream[]
+* Using Quarkus CLI:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ifdef::dev-additional-parameters[]
 quarkus dev {dev-additional-parameters}
@@ -10,8 +18,25 @@ endif::[]
 ----
 ifdef::devtools-wrapped[+]
 ifndef::devtools-no-maven[]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+
+ifdef::upstream[]
+
+endif::[]
+ifdef::downstream[]
+* {note-quarkus-cli-support}
+endif::[]
+****
+
+[role="secondary asciidoc-tabs-sync-maven"]
+ifdef::upstream[]
 .Maven
+endif::[]
+ifdef::downstream[]
+* Using Maven:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ifdef::dev-additional-parameters[]
 ./mvnw quarkus:dev {dev-additional-parameters}
@@ -23,8 +48,18 @@ endif::[]
 endif::[]
 ifdef::devtools-wrapped[+]
 ifndef::devtools-no-gradle[]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+****
+
+[role="secondary asciidoc-tabs-sync-gradle"]
+ifdef::upstream[]
 .Gradle
+endif::[]
+ifdef::downstream[]
+* Using Gradle:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ifdef::dev-additional-parameters[]
 ./gradlew --console=plain quarkusDev {dev-additional-parameters}
@@ -34,3 +69,4 @@ ifndef::dev-additional-parameters[]
 endif::[]
 ----
 endif::[]
+****

--- a/docs/src/main/asciidoc/_includes/devtools/extension-add.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/extension-add.adoc
@@ -1,21 +1,57 @@
-[source,bash,subs=attributes+,role="primary asciidoc-tabs-sync-cli"]
+[role="primary asciidoc-tabs-sync-cli"]
+ifdef::upstream[]
 .CLI
+endif::[]
+ifdef::downstream[]
+* Using Quarkus CLI:
++
+endif::[]
+****
+[source,bash,subs=attributes+]
 ----
 quarkus extension add '{add-extension-extensions}'
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source,bash,subs=attributes+,role="secondary asciidoc-tabs-sync-maven"]
+
+ifdef::upstream[]
+
+endif::[]
+ifdef::downstream[]
+* {note-quarkus-cli-support}
+endif::[]
+****
+
+[role="secondary asciidoc-tabs-sync-maven"]
+ifdef::upstream[]
 .Maven
+endif::[]
+ifdef::downstream[]
+* Using Maven:
++
+endif::[]
+****
+[source,bash,subs=attributes+]
 ----
 ./mvnw quarkus:add-extension -Dextensions='{add-extension-extensions}'
 ----
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]
-[source,bash,subs=attributes+,role="secondary asciidoc-tabs-sync-gradle"]
+****
+
+[role="secondary asciidoc-tabs-sync-gradle"]
+ifdef::upstream[]
 .Gradle
+endif::[]
+ifdef::downstream[]
+* Using Gradle:
++
+endif::[]
+****
+[source,bash,subs=attributes+]
 ----
 ./gradlew addExtension --extensions='{add-extension-extensions}'
 ----
 endif::[]
+****

--- a/docs/src/main/asciidoc/_includes/devtools/extension-list.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/extension-list.adoc
@@ -1,21 +1,57 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[role="primary asciidoc-tabs-sync-cli"]
+ifdef::upstream[]
 .CLI
+endif::[]
+ifdef::downstream[]
+* Using Quarkus CLI:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 quarkus extension
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+
+ifdef::upstream[]
+
+endif::[]
+ifdef::downstream[]
+* {note-quarkus-cli-support}
+endif::[]
+****
+
+[role="secondary asciidoc-tabs-sync-maven"]
+ifdef::upstream[]
 .Maven
+endif::[]
+ifdef::downstream[]
+* Using Maven:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ./mvnw quarkus:list-extensions
 ----
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+****
+
+[role="secondary asciidoc-tabs-sync-gradle"]
+ifdef::upstream[]
 .Gradle
+endif::[]
+ifdef::downstream[]
+* Using Gradle:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ./gradlew listExtensions
 ----
 endif::[]
+****

--- a/docs/src/main/asciidoc/_includes/devtools/maven-opts.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/maven-opts.adoc
@@ -1,13 +1,39 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[role="primary asciidoc-tabs-sync-cli"]
+ifdef::upstream[]
 .CLI
+endif::[]
+ifdef::downstream[]
+* Using Quarkus CLI:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 MAVEN_OPTS='--enable-preview' quarkus build
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+
+ifdef::upstream[]
+
+endif::[]
+ifdef::downstream[]
+* {note-quarkus-cli-support}
+endif::[]
+****
+
+[role="secondary asciidoc-tabs-sync-maven"]
+ifdef::upstream[]
 .Maven
+endif::[]
+ifdef::downstream[]
+* Using Maven:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 MAVEN_OPTS='--enable-preview' ./mvnw install
 ----
 endif::[]
+****

--- a/docs/src/main/asciidoc/_includes/devtools/test.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/test.adoc
@@ -1,15 +1,34 @@
 ifndef::devtools-no-maven[]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+[role="secondary asciidoc-tabs-sync-maven"]
+ifdef::upstream[]
 .Maven
+endif::[]
+ifdef::downstream[]
+* Using Maven:
++
+endif::[]
+****
+[source, bash, subs=attributes+]
 ----
 ./mvnw test
 ----
 endif::[]
 ifdef::devtools-wrapped[+]
 ifndef::devtools-no-gradle[]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+****
+
+[role="secondary asciidoc-tabs-sync-gradle"]
+ifdef::upstream[]
 .Gradle
+endif::[]
+ifdef::downstream[]
+* Using Gradle:
++
+endif::[]
+[source, bash, subs=attributes+]
+****
 ----
 ./gradlew test
 ----
 endif::[]
+****

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -14,10 +14,10 @@ include::{includes}/prerequisites.adoc[]
 
 == Architecture
 
-In this example, we build a very simple web application with a single page:
+In this example, we build a simple web application with a single page:
 
 * `/index.html`
-
++
 This page is protected and can only be accessed by authenticated users.
 
 == Solution


### PR DESCRIPTION
The cause of this PR is to solve issues caused by Downstream obsolete tooling that doesn't support advanced features.

This solution uses **ifdef** and **ifndef**  to display correct content triggered by the presence/absence of the **upstream** context attribute. In the downstream repo, this attribute will be called **downstream**.

The intention here is to keep Upstream functionality untouched and recreate the snippers so that they can be reused for downstream efforts in the shape of **tabs-as-list**. 

**Description:**
I am adding one attribute, context, and _if_ condition to recreate G. Smet's brilliant snippets for multiple-option bars so that they display in a usable way in the downstream repo, too, since this advanced asciidoc is not supported there thanks to publication tool limitations.

The attribute, context, the if-condition combo was needed because of the fact that attributes cant transcend asciidoc markup elements (out of the box). However, the solution I created here is more elegant than the pure attribute one since I added just two rows of code to our upstream-attributes-docs file.

This results in completely the same Upstream output as G. Smet proposed, but now these files render properly in Downstream as a "good-looking" bullet-item list with some additional top-notch level styling.