### PR TITLE
Make generate no-args constructor package private

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -1040,7 +1040,7 @@ public final class Beans {
                         String superName,
                         String[] interfaces) {
                     super.visit(version, access, name, signature, superName, interfaces);
-                    MethodVisitor mv = visitMethod(Modifier.PUBLIC | Opcodes.ACC_SYNTHETIC, Methods.INIT, "()V", null,
+                    MethodVisitor mv = visitMethod(Opcodes.ACC_SYNTHETIC, Methods.INIT, "()V", null,
                             null);
                     mv.visitCode();
                     mv.visitVarInsn(Opcodes.ALOAD, 0);


### PR DESCRIPTION
The idea here is that hopefully it convince code coverage tools to ignore it

Relates to: #32254