### PR TITLE
Add SmallRye Config Jasypt to Quarkus BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -3864,6 +3864,11 @@
                 <version>${smallrye-config.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.smallrye.config</groupId>
+                <artifactId>smallrye-config-jasypt</artifactId>
+                <version>${smallrye-config.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-health</artifactId>
                 <version>${smallrye-health.version}</version>


### PR DESCRIPTION
https://quarkus.io/version/main/guides/config-reference#secret-keys-expressions points to https://smallrye.io/smallrye-config/Main/config/secret-keys/ and I think it is weird to manage SmallRye Config Jasypt myself if other dependencies like Crypto are managed for me.