### PR TITLE
Switch Hibernate Search extension to @ConfigMapping

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
@@ -61,6 +61,7 @@ final public class Constants {
     public static final String ANNOTATION_CONFIG_DOC_MAP_KEY = "io.quarkus.runtime.annotations.ConfigDocMapKey";
     public static final String ANNOTATION_CONFIG_DOC_SECTION = "io.quarkus.runtime.annotations.ConfigDocSection";
     public static final String ANNOTATION_CONFIG_DOC_ENUM_VALUE = "io.quarkus.runtime.annotations.ConfigDocEnumValue";
+    public static final String ANNOTATION_CONFIG_DOC_DEFAULT = "io.quarkus.runtime.annotations.ConfigDocDefault";
 
     public static final String ANNOTATION_CONFIG_WITH_NAME = "io.smallrye.config.WithName";
     public static final String ANNOTATION_CONFIG_WITH_DEFAULT = "io.smallrye.config.WithDefault";

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
@@ -64,6 +64,7 @@ final public class Constants {
     public static final String ANNOTATION_CONFIG_DOC_DEFAULT = "io.quarkus.runtime.annotations.ConfigDocDefault";
 
     public static final String ANNOTATION_CONFIG_WITH_NAME = "io.smallrye.config.WithName";
+    public static final String ANNOTATION_CONFIG_WITH_PARENT_NAME = "io.smallrye.config.WithParentName";
     public static final String ANNOTATION_CONFIG_WITH_DEFAULT = "io.smallrye.config.WithDefault";
 
     public static final Set<String> SUPPORTED_ANNOTATIONS_TYPES = Set.of(ANNOTATION_BUILD_STEP, ANNOTATION_CONFIG_GROUP,

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemFinder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemFinder.java
@@ -7,6 +7,7 @@ import static io.quarkus.annotation.processor.Constants.ANNOTATION_CONFIG_DOC_SE
 import static io.quarkus.annotation.processor.Constants.ANNOTATION_CONFIG_ITEM;
 import static io.quarkus.annotation.processor.Constants.ANNOTATION_CONFIG_WITH_DEFAULT;
 import static io.quarkus.annotation.processor.Constants.ANNOTATION_CONFIG_WITH_NAME;
+import static io.quarkus.annotation.processor.Constants.ANNOTATION_CONFIG_WITH_PARENT_NAME;
 import static io.quarkus.annotation.processor.Constants.ANNOTATION_CONVERT_WITH;
 import static io.quarkus.annotation.processor.Constants.ANNOTATION_DEFAULT_CONVERTER;
 import static io.quarkus.annotation.processor.Constants.DOT;
@@ -226,10 +227,11 @@ class ConfigDocItemFinder {
                 // Mappings
                 if (annotationName.equals(ANNOTATION_CONFIG_WITH_NAME)) {
                     name = parentName + DOT + annotationMirror.getElementValues().values().iterator().next().getValue();
+                } else if (annotationName.equals(ANNOTATION_CONFIG_WITH_PARENT_NAME)) {
+                    name = parentName;
                 } else if (annotationName.equals(ANNOTATION_CONFIG_DOC_DEFAULT)) {
-                    defaultValue = annotationMirror.getElementValues().values().iterator().next().getValue().toString();
-                } else if (annotationName.equals(ANNOTATION_CONFIG_WITH_DEFAULT)
-                        && defaultValue == null) {
+                    defaultValueDoc = annotationMirror.getElementValues().values().iterator().next().getValue().toString();
+                } else if (annotationName.equals(ANNOTATION_CONFIG_WITH_DEFAULT)) {
                     defaultValue = annotationMirror.getElementValues().values().iterator().next().getValue().toString();
                 }
             }
@@ -244,12 +246,8 @@ class ConfigDocItemFinder {
             if (name == null) {
                 name = parentName + DOT + hyphenatedFieldName;
             }
-
             if (NO_DEFAULT.equals(defaultValue)) {
                 defaultValue = EMPTY;
-            }
-            if (EMPTY.equals(defaultValue)) {
-                defaultValue = defaultValueDoc;
             }
 
             if (isConfigGroup(type)) {
@@ -321,10 +319,14 @@ class ConfigDocItemFinder {
 
                             type = simpleTypeToString(realTypeMirror);
                             if (isEnumType(realTypeMirror)) {
-                                if (useHyphenateEnumValue) {
-                                    defaultValue = Arrays.stream(defaultValue.split(COMMA))
-                                            .map(defaultEnumValue -> hyphenateEnumValue(defaultEnumValue.trim()))
-                                            .collect(Collectors.joining(COMMA));
+                                if (defaultValueDoc.isBlank()) {
+                                    if (useHyphenateEnumValue) {
+                                        defaultValue = Arrays.stream(defaultValue.split(COMMA))
+                                                .map(defaultEnumValue -> hyphenateEnumValue(defaultEnumValue.trim()))
+                                                .collect(Collectors.joining(COMMA));
+                                    }
+                                } else {
+                                    defaultValue = defaultValueDoc;
                                 }
                                 acceptedValues = extractEnumValues(realTypeMirror, useHyphenateEnumValue,
                                         clazz.getQualifiedName().toString());
@@ -333,15 +335,18 @@ class ConfigDocItemFinder {
                         }
                     } else {
                         type = simpleTypeToString(declaredType);
-                        if (isEnumType(declaredType)) {
-                            if (useHyphenateEnumValue) {
+
+                        if (defaultValueDoc.isBlank()) {
+                            if (isEnumType(declaredType)) {
                                 defaultValue = hyphenateEnumValue(defaultValue);
+                                acceptedValues = extractEnumValues(declaredType, useHyphenateEnumValue,
+                                        clazz.getQualifiedName().toString());
+                                configDocKey.setEnum(true);
+                            } else if (isDurationType(declaredType) && !defaultValue.isEmpty()) {
+                                defaultValue = DocGeneratorUtil.normalizeDurationValue(defaultValue);
                             }
-                            acceptedValues = extractEnumValues(declaredType, useHyphenateEnumValue,
-                                    clazz.getQualifiedName().toString());
-                            configDocKey.setEnum(true);
-                        } else if (isDurationType(declaredType) && !defaultValue.isEmpty()) {
-                            defaultValue = DocGeneratorUtil.normalizeDurationValue(defaultValue);
+                        } else {
+                            defaultValue = defaultValueDoc;
                         }
                     }
                 }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemFinder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemFinder.java
@@ -1,5 +1,6 @@
 package io.quarkus.annotation.processor.generate_doc;
 
+import static io.quarkus.annotation.processor.Constants.ANNOTATION_CONFIG_DOC_DEFAULT;
 import static io.quarkus.annotation.processor.Constants.ANNOTATION_CONFIG_DOC_ENUM_VALUE;
 import static io.quarkus.annotation.processor.Constants.ANNOTATION_CONFIG_DOC_MAP_KEY;
 import static io.quarkus.annotation.processor.Constants.ANNOTATION_CONFIG_DOC_SECTION;
@@ -223,14 +224,13 @@ class ConfigDocItemFinder {
                 }
 
                 // Mappings
-                for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : annotationMirror
-                        .getElementValues().entrySet()) {
-                    Object value = entry.getValue().getValue();
-                    if (annotationName.equals(ANNOTATION_CONFIG_WITH_NAME)) {
-                        name = parentName + DOT + value;
-                    } else if (annotationName.equals(ANNOTATION_CONFIG_WITH_DEFAULT)) {
-                        defaultValue = value.toString();
-                    }
+                if (annotationName.equals(ANNOTATION_CONFIG_WITH_NAME)) {
+                    name = parentName + DOT + annotationMirror.getElementValues().values().iterator().next().getValue();
+                } else if (annotationName.equals(ANNOTATION_CONFIG_DOC_DEFAULT)) {
+                    defaultValue = annotationMirror.getElementValues().values().iterator().next().getValue().toString();
+                } else if (annotationName.equals(ANNOTATION_CONFIG_WITH_DEFAULT)
+                        && defaultValue == null) {
+                    defaultValue = annotationMirror.getElementValues().values().iterator().next().getValue().toString();
                 }
             }
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigDocDefault.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigDocDefault.java
@@ -1,0 +1,25 @@
+package io.quarkus.runtime.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import io.smallrye.config.ConfigMapping;
+
+/**
+ * Specifies a default value for the documentation.
+ * <p>
+ * Replaces defaultValueForDocumentation for the {@link ConfigMapping} approach.
+ */
+@Documented
+@Retention(SOURCE)
+@Target({ FIELD, PARAMETER, METHOD })
+public @interface ConfigDocDefault {
+
+    String value();
+}

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
@@ -80,7 +80,7 @@ class HibernateSearchOutboxPollingProcessor {
         if (puConfig == null) {
             return false;
         }
-        Optional<String> configuredStrategy = puConfig.coordination.strategy;
+        Optional<String> configuredStrategy = puConfig.coordination().strategy();
         return configuredStrategy.isPresent()
                 && configuredStrategy.get().equals(HibernateOrmMapperOutboxPollingSettings.COORDINATION_STRATEGY_NAME);
     }

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRecorder.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRecorder.java
@@ -20,8 +20,8 @@ public class HibernateSearchOutboxPollingRecorder {
             HibernateSearchOutboxPollingRuntimeConfig runtimeConfig, String persistenceUnitName) {
         HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit puConfig = PersistenceUnitUtil
                 .isDefaultPersistenceUnit(persistenceUnitName)
-                        ? runtimeConfig.defaultPersistenceUnit
-                        : runtimeConfig.persistenceUnits.get(persistenceUnitName);
+                        ? runtimeConfig.defaultPersistenceUnit()
+                        : runtimeConfig.persistenceUnits().get(persistenceUnitName);
         return new RuntimeInitListener(puConfig);
     }
 
@@ -40,9 +40,9 @@ public class HibernateSearchOutboxPollingRecorder {
                 return;
             }
 
-            contributeCoordinationRuntimeProperties(propertyCollector, null, runtimeConfig.coordination.defaults);
+            contributeCoordinationRuntimeProperties(propertyCollector, null, runtimeConfig.coordination().defaults());
 
-            for (Entry<String, AgentsConfig> tenantEntry : runtimeConfig.coordination.tenants.entrySet()) {
+            for (Entry<String, AgentsConfig> tenantEntry : runtimeConfig.coordination().tenants().entrySet()) {
                 contributeCoordinationRuntimeProperties(propertyCollector, tenantEntry.getKey(), tenantEntry.getValue());
             }
         }
@@ -51,41 +51,41 @@ public class HibernateSearchOutboxPollingRecorder {
                 AgentsConfig agentsConfig) {
             addCoordinationConfig(propertyCollector, tenantId,
                     HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.EVENT_PROCESSOR_ENABLED,
-                    agentsConfig.eventProcessor.enabled);
+                    agentsConfig.eventProcessor().enabled());
             addCoordinationConfig(propertyCollector, tenantId,
                     HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.EVENT_PROCESSOR_SHARDS_TOTAL_COUNT,
-                    agentsConfig.eventProcessor.shards.totalCount);
+                    agentsConfig.eventProcessor().shards().totalCount());
             addCoordinationConfig(propertyCollector, tenantId,
                     HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.EVENT_PROCESSOR_SHARDS_ASSIGNED,
-                    agentsConfig.eventProcessor.shards.assigned);
+                    agentsConfig.eventProcessor().shards().assigned());
             addCoordinationConfig(propertyCollector, tenantId,
                     HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.EVENT_PROCESSOR_POLLING_INTERVAL,
-                    agentsConfig.eventProcessor.pollingInterval.toMillis());
+                    agentsConfig.eventProcessor().pollingInterval().toMillis());
             addCoordinationConfig(propertyCollector, tenantId,
                     HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.EVENT_PROCESSOR_PULSE_INTERVAL,
-                    agentsConfig.eventProcessor.pulseInterval.toMillis());
+                    agentsConfig.eventProcessor().pulseInterval().toMillis());
             addCoordinationConfig(propertyCollector, tenantId,
                     HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.EVENT_PROCESSOR_PULSE_EXPIRATION,
-                    agentsConfig.eventProcessor.pulseExpiration.toMillis());
+                    agentsConfig.eventProcessor().pulseExpiration().toMillis());
             addCoordinationConfig(propertyCollector, tenantId,
                     HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.EVENT_PROCESSOR_BATCH_SIZE,
-                    agentsConfig.eventProcessor.batchSize);
+                    agentsConfig.eventProcessor().batchSize());
             addCoordinationConfig(propertyCollector, tenantId,
                     HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.EVENT_PROCESSOR_TRANSACTION_TIMEOUT,
-                    agentsConfig.eventProcessor.transactionTimeout, Optional::isPresent, d -> d.get().toSeconds());
+                    agentsConfig.eventProcessor().transactionTimeout(), Optional::isPresent, d -> d.get().toSeconds());
             addCoordinationConfig(propertyCollector, tenantId,
                     HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.EVENT_PROCESSOR_RETRY_DELAY,
-                    agentsConfig.eventProcessor.retryDelay.toSeconds());
+                    agentsConfig.eventProcessor().retryDelay().toSeconds());
 
             addCoordinationConfig(propertyCollector, tenantId,
                     HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.MASS_INDEXER_POLLING_INTERVAL,
-                    agentsConfig.massIndexer.pollingInterval.toMillis());
+                    agentsConfig.massIndexer().pollingInterval().toMillis());
             addCoordinationConfig(propertyCollector, tenantId,
                     HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.MASS_INDEXER_PULSE_INTERVAL,
-                    agentsConfig.massIndexer.pulseInterval.toMillis());
+                    agentsConfig.massIndexer().pulseInterval().toMillis());
             addCoordinationConfig(propertyCollector, tenantId,
                     HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.MASS_INDEXER_PULSE_EXPIRATION,
-                    agentsConfig.massIndexer.pulseExpiration.toMillis());
+                    agentsConfig.massIndexer().pulseExpiration().toMillis());
         }
 
     }

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfig.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfig.java
@@ -4,25 +4,27 @@ import java.util.Map;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithParentName;
 
-@ConfigRoot(name = "hibernate-search-orm", phase = ConfigPhase.RUN_TIME)
-public class HibernateSearchOutboxPollingRuntimeConfig {
+@ConfigMapping(prefix = "quarkus.hibernate-search-orm")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface HibernateSearchOutboxPollingRuntimeConfig {
 
     /**
      * Configuration for the default persistence unit.
      */
-    @ConfigItem(name = ConfigItem.PARENT)
-    public HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit defaultPersistenceUnit;
+    @WithParentName
+    HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit defaultPersistenceUnit();
 
     /**
      * Configuration for additional named persistence units.
      */
     @ConfigDocSection
     @ConfigDocMapKey("persistence-unit-name")
-    @ConfigItem(name = ConfigItem.PARENT)
-    public Map<String, HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit> persistenceUnits;
+    @WithParentName
+    Map<String, HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit> persistenceUnits();
 
 }

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit.java
@@ -9,55 +9,53 @@ import java.util.OptionalInt;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithParentName;
 
 @ConfigGroup
-class HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
+public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
 
     /**
      * Configuration for coordination between threads or application instances.
      */
-    @ConfigItem
-    CoordinationConfig coordination;
+    CoordinationConfig coordination();
 
     @ConfigGroup
-    static class CoordinationConfig {
+    public interface CoordinationConfig {
 
         /**
          * Default config
          */
         @ConfigDocSection
-        @ConfigItem(name = ConfigItem.PARENT)
-        AgentsConfig defaults;
+        @WithParentName
+        AgentsConfig defaults();
 
         /**
          * Per-tenant config
          */
         @ConfigDocSection
         @ConfigDocMapKey("tenant-id")
-        Map<String, AgentsConfig> tenants;
+        Map<String, AgentsConfig> tenants();
 
     }
 
     @ConfigGroup
-    static class AgentsConfig {
+    public interface AgentsConfig {
 
         /**
          * Configuration for the event processor agent.
          */
-        @ConfigItem
-        EventProcessorConfig eventProcessor;
+        EventProcessorConfig eventProcessor();
 
         /**
          * Configuration for the mass indexer agent.
          */
-        @ConfigItem
-        MassIndexerConfig massIndexer;
+        MassIndexerConfig massIndexer();
 
     }
 
     @ConfigGroup
-    static class EventProcessorConfig {
+    public interface EventProcessorConfig {
 
         // @formatter:off
         /**
@@ -74,14 +72,13 @@ class HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem(defaultValue = "true")
-        boolean enabled;
+        @WithDefault("true")
+        boolean enabled();
 
         /**
          * Configuration related to shards.
          */
-        @ConfigItem
-        EventProcessorShardsConfig shards;
+        EventProcessorShardsConfig shards();
 
         // @formatter:off
         /**
@@ -97,8 +94,8 @@ class HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem(defaultValue = "0.100S")
-        Duration pollingInterval;
+        @WithDefault("0.100S")
+        Duration pollingInterval();
 
         // @formatter:off
         /**
@@ -127,8 +124,8 @@ class HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem(defaultValue = "2S")
-        Duration pulseInterval;
+        @WithDefault("2S")
+        Duration pulseInterval();
 
         // @formatter:off
         /**
@@ -154,8 +151,8 @@ class HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem(defaultValue = "30S")
-        Duration pulseExpiration;
+        @WithDefault("30S")
+        Duration pulseExpiration();
 
         // @formatter:off
         /**
@@ -172,8 +169,8 @@ class HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem(defaultValue = "50")
-        int batchSize;
+        @WithDefault("50")
+        int batchSize();
 
         // @formatter:off
         /**
@@ -191,8 +188,7 @@ class HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem
-        Optional<Duration> transactionTimeout;
+        Optional<Duration> transactionTimeout();
 
         // @formatter:off
         /**
@@ -207,13 +203,13 @@ class HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem(defaultValue = "30S")
-        Duration retryDelay;
+        @WithDefault("30S")
+        Duration retryDelay();
 
     }
 
     @ConfigGroup
-    static class EventProcessorShardsConfig {
+    public interface EventProcessorShardsConfig {
 
         // @formatter:off
         /**
@@ -232,8 +228,7 @@ class HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem
-        OptionalInt totalCount;
+        OptionalInt totalCount();
 
         // @formatter:off
         /**
@@ -257,13 +252,12 @@ class HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem
-        Optional<List<Integer>> assigned;
+        Optional<List<Integer>> assigned();
 
     }
 
     @ConfigGroup
-    static class MassIndexerConfig {
+    public interface MassIndexerConfig {
 
         // @formatter:off
         /**
@@ -285,8 +279,8 @@ class HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem(defaultValue = "0.100S")
-        Duration pollingInterval;
+        @WithDefault("0.100S")
+        Duration pollingInterval();
 
         // @formatter:off
         /**
@@ -313,8 +307,8 @@ class HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem(defaultValue = "2S")
-        Duration pulseInterval;
+        @WithDefault("2S")
+        Duration pulseInterval();
 
         // @formatter:off
         /**
@@ -340,8 +334,8 @@ class HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem(defaultValue = "30S")
-        Duration pulseExpiration;
+        @WithDefault("30S")
+        Duration pulseExpiration();
 
     }
 

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchEnabled.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchEnabled.java
@@ -18,7 +18,7 @@ public class HibernateSearchEnabled implements BooleanSupplier {
 
     @Override
     public boolean getAsBoolean() {
-        return config.enabled;
+        return config.enabled();
     }
 
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
@@ -6,12 +6,15 @@ import java.util.TreeMap;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithParentName;
 
-@ConfigRoot(name = "hibernate-search-orm", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class HibernateSearchElasticsearchBuildTimeConfig {
+@ConfigMapping(prefix = "quarkus.hibernate-search-orm")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface HibernateSearchElasticsearchBuildTimeConfig {
 
     /**
      * Whether Hibernate Search is enabled **during the build**.
@@ -22,30 +25,50 @@ public class HibernateSearchElasticsearchBuildTimeConfig {
      *
      * @asciidoclet
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enabled;
+    @WithDefault("true")
+    boolean enabled();
 
     /**
      * Configuration for the default persistence unit.
      */
-    @ConfigItem(name = ConfigItem.PARENT)
-    public HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit defaultPersistenceUnit;
+    @WithParentName
+    HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit defaultPersistenceUnit();
 
     /**
      * Configuration for additional named persistence units.
      */
     @ConfigDocSection
     @ConfigDocMapKey("persistence-unit-name")
-    @ConfigItem(name = ConfigItem.PARENT)
-    Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> persistenceUnits;
+    @WithParentName
+    Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> persistenceUnits();
 
-    public Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> getAllPersistenceUnitConfigsAsMap() {
+    default Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> getAllPersistenceUnitConfigsAsMap() {
         Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> map = new TreeMap<>();
+        HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit defaultPersistenceUnit = defaultPersistenceUnit();
+
         if (defaultPersistenceUnit != null) {
             map.put(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, defaultPersistenceUnit);
         }
-        map.putAll(persistenceUnits);
+        map.putAll(persistenceUnits());
         return map;
     }
 
+    default HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit getPersistenceUnitConfig(String persistenceUnitName) {
+        if (persistenceUnitName == null) {
+            throw new IllegalArgumentException("Persistence unit name may not be null");
+        }
+
+        if (PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME.equals(persistenceUnitName)) {
+            return defaultPersistenceUnit();
+        }
+
+        HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit persistenceUnitConfig = persistenceUnits()
+                .get(persistenceUnitName);
+
+        if (persistenceUnitConfig == null) {
+            throw new IllegalStateException("No persistence unit config exists for name " + persistenceUnitName);
+        }
+
+        return persistenceUnitConfig;
+    }
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
@@ -9,24 +9,26 @@ import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
+import io.smallrye.config.WithParentName;
 
 @ConfigGroup
-public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
+public interface HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
 
     /**
      * Default backend
      */
-    @ConfigItem(name = "elasticsearch")
     @ConfigDocSection
-    public ElasticsearchBackendBuildTimeConfig defaultBackend;
+    @WithName("elasticsearch")
+    ElasticsearchBackendBuildTimeConfig defaultBackend();
 
     /**
      * Named backends
      */
-    @ConfigItem(name = "elasticsearch")
     @ConfigDocSection
-    ElasticsearchNamedBackendsBuildTimeConfig namedBackends;
+    @WithName("elasticsearch")
+    ElasticsearchNamedBackendsBuildTimeConfig namedBackends();
 
     /**
      * A xref:hibernate-search-orm-elasticsearch.adoc#bean-reference-note-anchor[bean reference] to a component
@@ -45,39 +47,37 @@ public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
      *
      * @asciidoclet
      */
-    @ConfigItem
-    public Optional<String> backgroundFailureHandler;
+    Optional<String> backgroundFailureHandler();
 
     /**
      * Configuration for coordination between threads or application instances.
      */
-    @ConfigItem
-    public CoordinationConfig coordination;
+    CoordinationConfig coordination();
 
-    public Map<String, ElasticsearchBackendBuildTimeConfig> getAllBackendConfigsAsMap() {
+    default Map<String, ElasticsearchBackendBuildTimeConfig> getAllBackendConfigsAsMap() {
         Map<String, ElasticsearchBackendBuildTimeConfig> map = new LinkedHashMap<>();
-        if (defaultBackend != null) {
-            map.put(null, defaultBackend);
+        if (defaultBackend() != null) {
+            map.put(null, defaultBackend());
         }
-        if (namedBackends != null) {
-            map.putAll(namedBackends.backends);
+        if (namedBackends() != null) {
+            map.putAll(namedBackends().backends());
         }
         return map;
     }
 
     @ConfigGroup
-    public static class ElasticsearchNamedBackendsBuildTimeConfig {
+    public interface ElasticsearchNamedBackendsBuildTimeConfig {
 
         /**
          * Named backends
          */
         @ConfigDocMapKey("backend-name")
-        public Map<String, ElasticsearchBackendBuildTimeConfig> backends;
+        public Map<String, ElasticsearchBackendBuildTimeConfig> backends();
 
     }
 
     @ConfigGroup
-    public static class ElasticsearchBackendBuildTimeConfig {
+    public interface ElasticsearchBackendBuildTimeConfig {
         /**
          * The version of Elasticsearch used in the cluster.
          *
@@ -92,47 +92,42 @@ public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
          *
          * @asciidoclet
          */
-        @ConfigItem
-        public Optional<ElasticsearchVersion> version;
+        Optional<ElasticsearchVersion> version();
 
         /**
          * Configuration for the index layout.
          */
-        @ConfigItem
-        public LayoutConfig layout;
+        LayoutConfig layout();
 
         /**
          * The default configuration for the Elasticsearch indexes.
          */
-        @ConfigItem(name = ConfigItem.PARENT)
-        public ElasticsearchIndexBuildTimeConfig indexDefaults;
+        @WithParentName
+        ElasticsearchIndexBuildTimeConfig indexDefaults();
 
         /**
          * Per-index specific configuration.
          */
-        @ConfigItem
         @ConfigDocMapKey("index-name")
-        public Map<String, ElasticsearchIndexBuildTimeConfig> indexes;
+        Map<String, ElasticsearchIndexBuildTimeConfig> indexes();
     }
 
     @ConfigGroup
-    public static class ElasticsearchIndexBuildTimeConfig {
+    public interface ElasticsearchIndexBuildTimeConfig {
         /**
          * Configuration for automatic creation and validation of the Elasticsearch schema:
          * indexes, their mapping, their settings.
          */
-        @ConfigItem
-        public SchemaManagementConfig schemaManagement;
+        SchemaManagementConfig schemaManagement();
 
         /**
          * Configuration for full-text analysis.
          */
-        @ConfigItem
-        public AnalysisConfig analysis;
+        AnalysisConfig analysis();
     }
 
     @ConfigGroup
-    public static class SchemaManagementConfig {
+    public interface SchemaManagementConfig {
 
         // @formatter:off
         /**
@@ -149,8 +144,7 @@ public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem
-        public Optional<String> settingsFile;
+        Optional<String> settingsFile();
 
         // @formatter:off
         /**
@@ -166,13 +160,12 @@ public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem
-        public Optional<String> mappingFile;
+        Optional<String> mappingFile();
 
     }
 
     @ConfigGroup
-    public static class AnalysisConfig {
+    public interface AnalysisConfig {
         /**
          * A xref:hibernate-search-orm-elasticsearch.adoc#bean-reference-note-anchor[bean reference] to the component
          * used to configure full text analysis (e.g. analyzers, normalizers).
@@ -192,12 +185,11 @@ public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
          *
          * @asciidoclet
          */
-        @ConfigItem
-        public Optional<String> configurer;
+        Optional<String> configurer();
     }
 
     @ConfigGroup
-    public static class LayoutConfig {
+    public interface LayoutConfig {
         /**
          * A xref:hibernate-search-orm-elasticsearch.adoc#bean-reference-note-anchor[bean reference] to the component
          * used to configure layout (e.g. index names, index aliases).
@@ -229,12 +221,11 @@ public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
          *
          * @asciidoclet
          */
-        @ConfigItem
-        public Optional<String> strategy;
+        Optional<String> strategy();
     }
 
     @ConfigGroup
-    public static class CoordinationConfig {
+    public interface CoordinationConfig {
 
         /**
          * The strategy to use for coordinating between threads or even separate instances of the application,
@@ -244,8 +235,8 @@ public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
          *
          * @asciidoclet
          */
-        @ConfigItem(defaultValue = "none")
-        public Optional<String> strategy;
+        @WithDefault("none")
+        Optional<String> strategy();
     }
 
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
@@ -6,10 +6,10 @@ import java.util.Optional;
 
 import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 import io.smallrye.config.WithParentName;
 
@@ -235,7 +235,7 @@ public interface HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
          *
          * @asciidoclet
          */
-        @WithDefault("none")
+        @ConfigDocDefault("none")
         Optional<String> strategy();
     }
 

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -7,33 +7,35 @@ import java.util.TreeMap;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithParentName;
 
-@ConfigRoot(name = "hibernate-search-orm", phase = ConfigPhase.RUN_TIME)
-public class HibernateSearchElasticsearchRuntimeConfig {
+@ConfigMapping(prefix = "quarkus.hibernate-search-orm")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface HibernateSearchElasticsearchRuntimeConfig {
 
     /**
      * Configuration for the default persistence unit.
      */
-    @ConfigItem(name = ConfigItem.PARENT)
-    public HibernateSearchElasticsearchRuntimeConfigPersistenceUnit defaultPersistenceUnit;
+    @WithParentName
+    HibernateSearchElasticsearchRuntimeConfigPersistenceUnit defaultPersistenceUnit();
 
     /**
      * Configuration for additional named persistence units.
      */
     @ConfigDocSection
     @ConfigDocMapKey("persistence-unit-name")
-    @ConfigItem(name = ConfigItem.PARENT)
-    public Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> persistenceUnits;
+    @WithParentName
+    Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> persistenceUnits();
 
-    public Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> getAllPersistenceUnitConfigsAsMap() {
+    default Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> getAllPersistenceUnitConfigsAsMap() {
         Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> map = new TreeMap<>();
-        if (defaultPersistenceUnit != null) {
-            map.put(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, defaultPersistenceUnit);
+        if (defaultPersistenceUnit() != null) {
+            map.put(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, defaultPersistenceUnit());
         }
-        map.putAll(persistenceUnits);
+        map.putAll(persistenceUnits());
         return map;
     }
 

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
@@ -14,13 +14,16 @@ import org.hibernate.search.mapper.orm.schema.management.SchemaManagementStrateg
 import org.hibernate.search.mapper.orm.search.loading.EntityLoadingCacheLookupStrategy;
 import org.hibernate.search.util.common.SearchException;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
+import io.smallrye.config.WithParentName;
 
 @ConfigGroup
-public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
+public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
 
     /**
      * Whether Hibernate Search should be active for this persistence unit at runtime.
@@ -34,108 +37,103 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
      *
      * @asciidoclet
      */
-    @ConfigItem(defaultValueDocumentation = "'true' if Hibernate Search is enabled; 'false' otherwise")
-    public Optional<Boolean> active;
+    @ConfigDocDefault("'true' if Hibernate Search is enabled; 'false' otherwise")
+    Optional<Boolean> active();
 
     /**
      * Default backend
      */
-    @ConfigItem(name = "elasticsearch")
+    @WithName("elasticsearch")
     @ConfigDocSection
-    ElasticsearchBackendRuntimeConfig defaultBackend;
+    ElasticsearchBackendRuntimeConfig defaultBackend();
 
     /**
      * Named backends
      */
-    @ConfigItem(name = "elasticsearch")
+    @WithName("elasticsearch")
     @ConfigDocSection
-    ElasticsearchNamedBackendsRuntimeConfig namedBackends;
+    ElasticsearchNamedBackendsRuntimeConfig namedBackends();
 
     /**
      * Configuration for automatic creation and validation of the Elasticsearch schema:
      * indexes, their mapping, their settings.
      */
-    @ConfigItem
-    SchemaManagementConfig schemaManagement;
+    SchemaManagementConfig schemaManagement();
 
     /**
      * Configuration for how entities are loaded by a search query.
      */
-    @ConfigItem(name = "query.loading")
-    SearchQueryLoadingConfig queryLoading;
+    @WithName("query.loading")
+    SearchQueryLoadingConfig queryLoading();
 
     /**
      * Configuration for the automatic indexing.
      */
-    @ConfigItem
-    AutomaticIndexingConfig automaticIndexing;
+    AutomaticIndexingConfig automaticIndexing();
 
     /**
      * Configuration for multi-tenancy.
      */
-    @ConfigItem
-    MultiTenancyConfig multiTenancy;
+    MultiTenancyConfig multiTenancy();
 
-    Map<String, ElasticsearchBackendRuntimeConfig> getAllBackendConfigsAsMap() {
+    default Map<String, ElasticsearchBackendRuntimeConfig> getAllBackendConfigsAsMap() {
         Map<String, ElasticsearchBackendRuntimeConfig> map = new LinkedHashMap<>();
-        if (defaultBackend != null) {
-            map.put(null, defaultBackend);
+        if (defaultBackend() != null) {
+            map.put(null, defaultBackend());
         }
-        if (namedBackends != null) {
-            map.putAll(namedBackends.backends);
+        if (namedBackends() != null) {
+            map.putAll(namedBackends().backends());
         }
         return map;
     }
 
     @ConfigGroup
-    public static class ElasticsearchNamedBackendsRuntimeConfig {
+    public interface ElasticsearchNamedBackendsRuntimeConfig {
 
         /**
          * Named backends
          */
         @ConfigDocMapKey("backend-name")
-        public Map<String, ElasticsearchBackendRuntimeConfig> backends;
+        Map<String, ElasticsearchBackendRuntimeConfig> backends();
 
     }
 
     @ConfigGroup
-    public static class ElasticsearchBackendRuntimeConfig {
+    public interface ElasticsearchBackendRuntimeConfig {
         /**
          * The list of hosts of the Elasticsearch servers.
          */
-        @ConfigItem(defaultValue = "localhost:9200")
-        List<String> hosts;
+        @WithDefault("localhost:9200")
+        List<String> hosts();
 
         /**
          * The protocol to use when contacting Elasticsearch servers.
          * Set to "https" to enable SSL/TLS.
          */
-        @ConfigItem(defaultValue = "http")
-        ElasticsearchClientProtocol protocol;
+        @WithDefault("http")
+        ElasticsearchClientProtocol protocol();
 
         /**
          * The username used for authentication.
          */
-        @ConfigItem
-        Optional<String> username;
+        Optional<String> username();
 
         /**
          * The password used for authentication.
          */
-        @ConfigItem
-        Optional<String> password;
+        Optional<String> password();
 
         /**
          * The timeout when establishing a connection to an Elasticsearch server.
          */
-        @ConfigItem(defaultValue = "1S")
-        Duration connectionTimeout;
+        @WithDefault("1S")
+        Duration connectionTimeout();
 
         /**
          * The timeout when reading responses from an Elasticsearch server.
          */
-        @ConfigItem(defaultValue = "30S")
-        Duration readTimeout;
+        @WithDefault("30S")
+        Duration readTimeout();
 
         /**
          * The timeout when executing a request to an Elasticsearch server.
@@ -145,32 +143,29 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          *
          * @asciidoclet
          */
-        @ConfigItem
-        Optional<Duration> requestTimeout;
+        Optional<Duration> requestTimeout();
 
         /**
          * The maximum number of connections to all the Elasticsearch servers.
          */
-        @ConfigItem(defaultValue = "20")
-        int maxConnections;
+        @WithDefault("20")
+        int maxConnections();
 
         /**
          * The maximum number of connections per Elasticsearch server.
          */
-        @ConfigItem(defaultValue = "10")
-        int maxConnectionsPerRoute;
+        @WithDefault("10")
+        int maxConnectionsPerRoute();
 
         /**
          * Configuration for the automatic discovery of new Elasticsearch nodes.
          */
-        @ConfigItem
-        DiscoveryConfig discovery;
+        DiscoveryConfig discovery();
 
         /**
          * Configuration for the thread pool assigned to the backend.
          */
-        @ConfigItem
-        ThreadPoolConfig threadPool;
+        ThreadPoolConfig threadPool();
 
         /**
          * Whether Hibernate Search should check the version of the Elasticsearch cluster on startup.
@@ -179,21 +174,21 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          *
          * @asciidoclet
          */
-        @ConfigItem(name = "version-check.enabled", defaultValue = "true")
-        public boolean versionCheck;
+        @WithName("version-check.enabled")
+        @WithDefault("true")
+        boolean versionCheck();
 
         /**
          * The default configuration for the Elasticsearch indexes.
          */
-        @ConfigItem(name = ConfigItem.PARENT)
-        ElasticsearchIndexRuntimeConfig indexDefaults;
+        @WithParentName
+        ElasticsearchIndexRuntimeConfig indexDefaults();
 
         /**
          * Per-index specific configuration.
          */
-        @ConfigItem
         @ConfigDocMapKey("index-name")
-        Map<String, ElasticsearchIndexRuntimeConfig> indexes;
+        Map<String, ElasticsearchIndexRuntimeConfig> indexes();
     }
 
     public enum ElasticsearchClientProtocol {
@@ -231,45 +226,42 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public static class ElasticsearchIndexRuntimeConfig {
+    public interface ElasticsearchIndexRuntimeConfig {
         /**
          * Configuration for the schema management of the indexes.
          */
-        @ConfigItem
-        ElasticsearchIndexSchemaManagementConfig schemaManagement;
+        ElasticsearchIndexSchemaManagementConfig schemaManagement();
 
         /**
          * Configuration for the indexing process that creates, updates and deletes documents.
          */
-        @ConfigItem
-        ElasticsearchIndexIndexingConfig indexing;
+        ElasticsearchIndexIndexingConfig indexing();
     }
 
     @ConfigGroup
-    public static class DiscoveryConfig {
+    public interface DiscoveryConfig {
 
         /**
          * Defines if automatic discovery is enabled.
          */
-        @ConfigItem
-        boolean enabled;
+        @WithDefault("false")
+        Boolean enabled();
 
         /**
          * Refresh interval of the node list.
          */
-        @ConfigItem(defaultValue = "10S")
-        Duration refreshInterval;
+        @WithDefault("10S")
+        Duration refreshInterval();
 
     }
 
     @ConfigGroup
-    public static class AutomaticIndexingConfig {
+    public interface AutomaticIndexingConfig {
 
         /**
          * Configuration for synchronization with the index when indexing automatically.
          */
-        @ConfigItem
-        AutomaticIndexingSynchronizationConfig synchronization;
+        AutomaticIndexingSynchronizationConfig synchronization();
 
         /**
          * Whether to check if dirty properties are relevant to indexing before actually reindexing an entity.
@@ -279,12 +271,12 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          *
          * @asciidoclet
          */
-        @ConfigItem(defaultValue = "true")
-        boolean enableDirtyCheck;
+        @WithDefault("true")
+        boolean enableDirtyCheck();
     }
 
     @ConfigGroup
-    public static class AutomaticIndexingSynchronizationConfig {
+    public interface AutomaticIndexingSynchronizationConfig {
 
         // @formatter:off
         /**
@@ -357,38 +349,37 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem(defaultValueDocumentation = "write-sync")
-        Optional<String> strategy;
+        @ConfigDocDefault("write-sync")
+        Optional<String> strategy();
     }
 
     @ConfigGroup
-    public static class SearchQueryLoadingConfig {
+    public interface SearchQueryLoadingConfig {
 
         /**
          * Configuration for cache lookup when loading entities during the execution of a search query.
          */
-        @ConfigItem
-        SearchQueryLoadingCacheLookupConfig cacheLookup;
+        SearchQueryLoadingCacheLookupConfig cacheLookup();
 
         /**
          * The fetch size to use when loading entities during the execution of a search query.
          */
-        @ConfigItem(defaultValue = "100")
-        int fetchSize;
+        @WithDefault("100")
+        int fetchSize();
     }
 
     @ConfigGroup
-    public static class SearchQueryLoadingCacheLookupConfig {
+    interface SearchQueryLoadingCacheLookupConfig {
 
         /**
          * The strategy to use when loading entities during the execution of a search query.
          */
-        @ConfigItem(defaultValue = "skip")
-        EntityLoadingCacheLookupStrategy strategy;
+        @WithDefault("skip")
+        EntityLoadingCacheLookupStrategy strategy();
     }
 
     @ConfigGroup
-    public static class SchemaManagementConfig {
+    public interface SchemaManagementConfig {
 
         // @formatter:off
         /**
@@ -451,13 +442,14 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem(defaultValue = "create-or-validate", defaultValueDocumentation = "drop-and-create-and-drop when using Dev Services; create-or-validate otherwise")
-        SchemaManagementStrategyName strategy;
+        @WithDefault("create-or-validate")
+        @ConfigDocDefault("drop-and-create-and-drop when using Dev Services; create-or-validate otherwise")
+        SchemaManagementStrategyName strategy();
 
     }
 
     @ConfigGroup
-    public static class ThreadPoolConfig {
+    public interface ThreadPoolConfig {
         /**
          * The size of the thread pool assigned to the backend.
          *
@@ -477,14 +469,13 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // We can't set an actual default value here: see comment on this class.
-        @ConfigItem
-        OptionalInt size;
+        OptionalInt size();
     }
 
     // We can't set actual default values in this section,
     // otherwise "quarkus.hibernate-search-orm.elasticsearch.index-defaults" will be ignored.
     @ConfigGroup
-    public static class ElasticsearchIndexSchemaManagementConfig {
+    public interface ElasticsearchIndexSchemaManagementConfig {
         /**
          * The minimal https://www.elastic.co/guide/en/elasticsearch/reference/7.17/cluster-health.html[Elasticsearch cluster
          * status] required on startup.
@@ -492,21 +483,21 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // We can't set an actual default value here: see comment on this class.
-        @ConfigItem(defaultValueDocumentation = "yellow")
-        Optional<IndexStatus> requiredStatus;
+        @ConfigDocDefault("yellow")
+        Optional<IndexStatus> requiredStatus();
 
         /**
          * How long we should wait for the status before failing the bootstrap.
          */
         // We can't set an actual default value here: see comment on this class.
-        @ConfigItem(defaultValueDocumentation = "10S")
-        Optional<Duration> requiredStatusWaitTimeout;
+        @ConfigDocDefault("10S")
+        Optional<Duration> requiredStatusWaitTimeout();
     }
 
     // We can't set actual default values in this section,
     // otherwise "quarkus.hibernate-search-orm.elasticsearch.index-defaults" will be ignored.
     @ConfigGroup
-    public static class ElasticsearchIndexIndexingConfig {
+    public interface ElasticsearchIndexIndexingConfig {
         /**
          * The number of indexing queues assigned to each index.
          *
@@ -520,8 +511,8 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // We can't set an actual default value here: see comment on this class.
-        @ConfigItem(defaultValueDocumentation = "10")
-        OptionalInt queueCount;
+        @ConfigDocDefault("10")
+        OptionalInt queueCount();
 
         /**
          * The size of indexing queues.
@@ -534,8 +525,8 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // We can't set an actual default value here: see comment on this class.
-        @ConfigItem(defaultValueDocumentation = "1000")
-        OptionalInt queueSize;
+        @ConfigDocDefault("1000")
+        OptionalInt queueSize();
 
         /**
          * The maximum size of bulk requests created when processing indexing queues.
@@ -553,12 +544,12 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // We can't set an actual default value here: see comment on this class.
-        @ConfigItem(defaultValueDocumentation = "100")
-        OptionalInt maxBulkSize;
+        @ConfigDocDefault("100")
+        OptionalInt maxBulkSize();
     }
 
     @ConfigGroup
-    public static class MultiTenancyConfig {
+    public interface MultiTenancyConfig {
 
         /**
          * An exhaustive list of all tenant identifiers that may be used by the application when multi-tenancy is enabled.
@@ -568,8 +559,7 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          *
          * @asciidoclet
          */
-        @ConfigItem
-        Optional<List<String>> tenantIds;
+        Optional<List<String>> tenantIds();
 
     }
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/dev/HibernateSearchElasticsearchDevRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/dev/HibernateSearchElasticsearchDevRecorder.java
@@ -29,7 +29,7 @@ public class HibernateSearchElasticsearchDevRecorder {
         Set<String> activePersistenceUnitNames = persistenceUnitNames.stream()
                 .filter(name -> {
                     var puConfig = puConfigs.get(name);
-                    return puConfig == null || puConfig.active.orElse(true);
+                    return puConfig == null || puConfig.active().orElse(true);
                 })
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         HibernateSearchElasticsearchDevController.get().setActivePersistenceUnitNames(activePersistenceUnitNames);


### PR DESCRIPTION
This is some preliminary work in order to fix https://github.com/quarkusio/quarkus/issues/32209 .

The Hibernate Search extension config uses patterns that are used in a lot of extensions and are well tested.

Creating as draft as I spotted two issues related to config and I would like @radcortez to have a look.

1. The doc generation is broken when you don't have `@ConfigGroup`: `target/asciidoc/generated/config/quarkus-hibernate-search-orm-elasticsearch.adoc` is mostly empty and is incorrect as config groups are not handled. If the solution is to put back the `@ConfigGroup` annotations, I can do it.
2. I think we have a bug somewhere as I checked what I did several times and I can't figure out what I did wrong with `active` that would explain this behavior.

Reproducing the issue is easy:
- build the tree
- run `mvn -f extensions/hibernate-search-orm-elasticsearch clean install -Dstart-containers -Dtest-containers`
- you should get the following errors:
```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ConfigEnabledFalseAndActiveTrueTest.lambda$static$1:22 
Expecting actual throwable to be an instance of:
  io.quarkus.runtime.configuration.ConfigurationException
but was:
  io.smallrye.config.ConfigValidationException: Configuration validation failed:
	quarkus.hibernate-search-orm.active does not map to any root
	at io.smallrye.config.ConfigMappingProvider.mapConfigurationInternal(ConfigMappingProvider.java:975)
	at io.smallrye.config.ConfigMappingProvider.lambda$mapConfiguration$3(ConfigMappingProvider.java:931)
	at io.smallrye.config.SecretKeys.doUnlocked(SecretKeys.java:28)
	...(51 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
[ERROR] Errors: 
[ERROR]   ConfigActiveFalseAndIndexedEntityTest » Runtime io.smallrye.config.ConfigValidationException: Configuration validation failed:
	quarkus.hibernate-search-orm.active does not map to any root
[INFO] 
[ERROR] Tests run: 25, Failures: 1, Errors: 1, Skipped: 0
```

`active` is in this interface: `HibernateSearchElasticsearchRuntimeConfigPersistenceUnit`
