### PR TITLE
Save creation of hashset and array to create an immutable set

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InjectionPointImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InjectionPointImpl.java
@@ -37,7 +37,7 @@ public class InjectionPointImpl implements InjectionPoint {
             InjectableBean<?> bean, Set<Annotation> annotations, Member javaMember,
             int position, boolean isTransient) {
         this.requiredType = requiredType;
-        this.qualifiers = Set.copyOf(qualifiers);
+        this.qualifiers = CollectionHelpers.toImmutableSmallSet(qualifiers);
         this.bean = bean;
         if (javaMember instanceof Executable) {
             this.annotated = new InjectionPointImpl.AnnotatedParameterImpl<>(injectionPointType, annotations, position,


### PR DESCRIPTION
Some tests reported an allocation spike there, see:

![image](https://user-images.githubusercontent.com/13125299/228940149-96848414-5399-4da2-a650-d9abfe30c22f.png)

due to 

https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/util/Set.java#L727

Using the function introduced by @Sanne seems a good idea