### PR TITLE
Qute - fix validation of expressions with the "cdi" namespace

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/inject/NamedBeanIterableReturnTypeTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/inject/NamedBeanIterableReturnTypeTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
@@ -26,6 +27,7 @@ public class NamedBeanIterableReturnTypeTest {
                                     "{@java.lang.String field}"
                                             + "{#if cdi:validation.hasViolations(field)}"
                                             + "{#each cdi:validation.getViolations(field)}{it}{/each}"
+                                            + "{#each cdi:violations}:{it.toUpperCase}{/each}"
                                             + "{/if}"),
                             "templates/validate.html"));
 
@@ -34,7 +36,7 @@ public class NamedBeanIterableReturnTypeTest {
 
     @Test
     public void testResult() {
-        assertEquals("Foo!", validate.data("field", "foo").render());
+        assertEquals("Foo!:BAR:BAZ", validate.data("field", "foo").render());
     }
 
     @ApplicationScoped
@@ -47,6 +49,12 @@ public class NamedBeanIterableReturnTypeTest {
 
         public List<String> getViolations(String field) {
             return List.of("Foo!");
+        }
+
+        @Named("violations")
+        @Produces
+        public List<String> getViolations() {
+            return List.of("bar", "baz");
         }
     }
 


### PR DESCRIPTION
- if a bean that has iterable in its set of bean types is used as an iterable in a loop section then the hints are not processed correctly