### PR TITLE
Bump smallrye-jwt version to 4.2.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -64,7 +64,7 @@
         <smallrye-graphql.version>2.1.2</smallrye-graphql.version>
         <smallrye-opentracing.version>3.0.3</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>6.2.1</smallrye-fault-tolerance.version>
-        <smallrye-jwt.version>4.2.0</smallrye-jwt.version>
+        <smallrye-jwt.version>4.2.1</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.1.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.0</smallrye-reactive-types-converter.version>

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -1032,6 +1032,8 @@ include::{generated-dir}/config/quarkus-smallrye-jwt.adoc[opts=optional, levelof
 |mp.jwt.decrypt.key.location|none|Config property allows for an external or internal location of Private Decryption Key to be specified.
 |mp.jwt.verify.issuer|none|Config property specifies the value of the `iss` (issuer) claim of the JWT that the server will accept as valid.
 |mp.jwt.verify.audiences|none|Comma separated list of the audiences that a token `aud` claim may contain.
+|mp.jwt.verify.clock.skew|`60`|Clock skew in seconds used during the token expiration and age verification. An expired token is accepted if the current time is within the number of seconds specified by this property after the token expiration time. The default value is 60 seconds.
+|mp.jwt.verify.token.age|`none`|Number of seconds that must not elapse since the token `iat` (issued at) time.
 |mp.jwt.token.header|`Authorization`|Set this property if another header such as `Cookie` is used to pass the token.
 |mp.jwt.token.cookie|none|Name of the cookie containing a token. This property will be effective only if `mp.jwt.token.header` is set to `Cookie`.
 |===
@@ -1062,7 +1064,7 @@ SmallRye JWT provides more properties which can be used to customize the token p
 |smallrye.jwt.claims.groups|none| This property can be used to set a default groups claim value when the current token has no standard or custom groups claim available.
 |smallrye.jwt.jwks.refresh-interval|60|JWK cache refresh interval in minutes. It will be ignored unless the `mp.jwt.verify.publickey.location` points to the HTTP or HTTPS URL based JWK set and no HTTP `Cache-Control` response header with a positive `max-age` parameter value is returned from a JWK HTTPS endpoint.
 |smallrye.jwt.jwks.forced-refresh-interval|30|Forced JWK cache refresh interval in minutes which is used to restrict the frequency of the forced refresh attempts which may happen when the token verification fails due to the cache having no JWK key with a `kid` property matching the current token's `kid` header. It will be ignored unless the `mp.jwt.verify.publickey.location` points to the HTTP or HTTPS URL based JWK set.
-|smallrye.jwt.expiration.grace|60|Expiration grace in seconds. By default, an expired token will still be accepted if the current time is no more than 1 min after the token expiry time.
+|smallrye.jwt.expiration.grace|0|Expiration grace in seconds. By default an expired token will still be accepted if the current time is no more than 1 min after the token expiry time. This property is deprecated. Use `mp.jwt.verify.clock.skew` instead.
 |smallrye.jwt.verify.aud|none|Comma separated list of the audiences that a token `aud` claim may contain. This property is deprecated - use `mp.jwt.verify.audiences`.
 |smallrye.jwt.required.claims|none|Comma separated list of the claims that a token must contain.
 |smallrye.jwt.decrypt.key.location|none|Config property allows for an external or internal location of Private Decryption Key to be specified. This property is deprecated - use 'mp.jwt.decrypt.key.location'.


### PR DESCRIPTION
Incorporates PR from @Skyllarr to support a standard `mp.jwt.verify.clock.skew` property.
I also updated the doc to mention `mp.jwt.verify.token.age` which is supported (and TCK tested) since 4.2.0