### PR TITLE
Improve container runtime detection

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -42,8 +42,7 @@ public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRu
 
     @Override
     public void setup(boolean processInheritIODisabled) {
-        if (containerRuntime == ContainerRuntimeUtil.ContainerRuntime.DOCKER
-                || containerRuntime == ContainerRuntimeUtil.ContainerRuntime.PODMAN) {
+        if (containerRuntime != ContainerRuntimeUtil.ContainerRuntime.UNAVAILABLE) {
             log.infof("Using %s to run the native image builder", containerRuntime.getExecutableName());
             // we pull the docker image in order to give users an indication of which step the process is at
             // it's not strictly necessary we do this, however if we don't the subsequent version command

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -1,8 +1,6 @@
 package io.quarkus.deployment.pkg.steps;
 
 import static io.quarkus.deployment.pkg.steps.LinuxIDUtil.getLinuxID;
-import static io.quarkus.runtime.util.ContainerRuntimeUtil.ContainerRuntime.DOCKER;
-import static io.quarkus.runtime.util.ContainerRuntimeUtil.ContainerRuntime.PODMAN;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -21,14 +19,14 @@ public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContai
         super(nativeConfig);
         if (SystemUtils.IS_OS_LINUX) {
             final ArrayList<String> containerRuntimeArgs = new ArrayList<>(Arrays.asList(baseContainerRuntimeArgs));
-            if (containerRuntime == DOCKER && containerRuntime.isRootless()) {
+            if (containerRuntime.isDocker() && containerRuntime.isRootless()) {
                 Collections.addAll(containerRuntimeArgs, "--user", String.valueOf(0));
             } else {
                 String uid = getLinuxID("-ur");
                 String gid = getLinuxID("-gr");
                 if (uid != null && gid != null && !uid.isEmpty() && !gid.isEmpty()) {
                     Collections.addAll(containerRuntimeArgs, "--user", uid + ":" + gid);
-                    if (containerRuntime == PODMAN && containerRuntime.isRootless()) {
+                    if (containerRuntime.isPodman() && containerRuntime.isRootless()) {
                         // Needed to avoid AccessDeniedExceptions
                         containerRuntimeArgs.add("--userns=keep-id");
                     }
@@ -47,7 +45,7 @@ public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContai
         }
 
         final String selinuxBindOption;
-        if (SystemUtils.IS_OS_MAC && containerRuntime == PODMAN) {
+        if (SystemUtils.IS_OS_MAC && containerRuntime.isPodman()) {
             selinuxBindOption = "";
         } else {
             selinuxBindOption = ":z";

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
@@ -126,8 +126,7 @@ public class UpxCompressionBuildStep {
             String gid = getLinuxID("-gr");
             if (uid != null && gid != null && !uid.isEmpty() && !gid.isEmpty()) {
                 Collections.addAll(commandLine, "--user", uid + ":" + gid);
-                if (containerRuntime == ContainerRuntimeUtil.ContainerRuntime.PODMAN
-                        && containerRuntime.isRootless()) {
+                if (containerRuntime.isPodman() && containerRuntime.isRootless()) {
                     // Needed to avoid AccessDeniedExceptions
                     commandLine.add("--userns=keep-id");
                 }


### PR DESCRIPTION
Fully resolve the container runtime once and for all. It costs us one more call when the rootless info is not needed but I prefer things to be resolved entirely once, rather than using patterns that are a bit brittle.

Fixes #32246

@Karm any chance you could have a look at this? I /think/ it's the last rabbit hole. It's probably worth having a look at the result, rather than the diff as the diff is not very readable. Things should be much simpler to follow.