### PR TITLE
Change link to new Dev UI

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/base/src/main/resources/META-INF/resources/index.tpl.qute.html
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/base/src/main/resources/META-INF/resources/index.tpl.qute.html
@@ -250,7 +250,7 @@
                 <div class="left-column">
                     <h1>You just made a Quarkus application.</h1>
                     <p>This page is served by Quarkus.</p>
-                    <a href="/q/dev/" class="cta-button">Visit the Dev UI</a>
+                    <a href="/q/dev-ui/" class="cta-button">Visit the Dev UI</a>
                     <p>This page: <code>src/main/resources/META-INF/resources/index.html</code></p>
                     <p>App configuration: <code>src/main/resources/{config.file-name}</code></p>
                     <p>Static assets: <code>src/main/resources/META-INF/resources/</code></p>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateRESTEasyJavaCustom/src_main_resources_META-INF_resources_index.html
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateRESTEasyJavaCustom/src_main_resources_META-INF_resources_index.html
@@ -250,7 +250,7 @@
                 <div class="left-column">
                     <h1>You just made a Quarkus application.</h1>
                     <p>This page is served by Quarkus.</p>
-                    <a href="/q/dev/" class="cta-button">Visit the Dev UI</a>
+                    <a href="/q/dev-ui/" class="cta-button">Visit the Dev UI</a>
                     <p>This page: <code>src/main/resources/META-INF/resources/index.html</code></p>
                     <p>App configuration: <code>src/main/resources/application.properties</code></p>
                     <p>Static assets: <code>src/main/resources/META-INF/resources/</code></p>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/verifyIndexExtensionList/src_main_resources_META-INF_resources_index.html
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/verifyIndexExtensionList/src_main_resources_META-INF_resources_index.html
@@ -250,7 +250,7 @@
                 <div class="left-column">
                     <h1>You just made a Quarkus application.</h1>
                     <p>This page is served by Quarkus.</p>
-                    <a href="/q/dev/" class="cta-button">Visit the Dev UI</a>
+                    <a href="/q/dev-ui/" class="cta-button">Visit the Dev UI</a>
                     <p>This page: <code>src/main/resources/META-INF/resources/index.html</code></p>
                     <p>App configuration: <code>src/main/resources/application.properties</code></p>
                     <p>Static assets: <code>src/main/resources/META-INF/resources/</code></p>

--- a/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/app/src/main/resources/META-INF/resources/index.html
@@ -250,7 +250,7 @@
                 <div class="left-column">
                     <h1>You just made a Quarkus application.</h1>
                     <p>This page is served by Quarkus.</p>
-                    <a href="/q/dev/" class="cta-button">Visit the Dev UI</a>
+                    <a href="/q/dev-ui/" class="cta-button">Visit the Dev UI</a>
                     <p>This page: <code>src/main/resources/META-INF/resources/index.html</code></p>
                     <p>App configuration: <code>src/main/resources/application.properties</code></p>
                     <p>Static assets: <code>src/main/resources/META-INF/resources/</code></p>


### PR DESCRIPTION
- Because `/q/dev` is being redirected to `/q/dev-ui` in https://github.com/quarkusio/quarkus/pull/32151, it's better to change the links to point to the correct URL
- This also ensures that if the beforementioned PR is not merged until 3.0.0.Final people access the new Dev UI directly