### PR TITLE
Add the .quarkus directory to project .gitignore

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/base/..gitignore
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/base/..gitignore
@@ -30,3 +30,6 @@ nb-configuration.xml
 
 # Local environment
 .env
+
+# Plugin directory
+/.quarkus/cli/plugins/


### PR DESCRIPTION
Local plugins will be installed in .quarkus/cli/plugins. I'm not sure it's a good idea to get it committed to the repository given it might contain local paths.

@iocanel I created this PR to not forget to ping you about this. I'm not sure if it's a good idea and if you had in mind that project plugins would be things that are installed globally for all project participants? I have my doubts here as it might be very easy to end up with local paths there.

/cc @aloubyansky as I'm not sure if ignoring the whole `.quarkus` directory is a good idea.