### PR TITLE
Add Gradle project update

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
@@ -10,6 +10,7 @@ import org.gradle.api.tasks.options.Option;
 
 import io.quarkus.devtools.commands.UpdateProject;
 import io.quarkus.devtools.project.QuarkusProject;
+import io.quarkus.devtools.project.update.QuarkusUpdateCommand;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.registry.RegistryResolutionException;
 import io.quarkus.registry.catalog.ExtensionCatalog;
@@ -18,8 +19,41 @@ import io.quarkus.registry.catalog.PlatformStreamCoords;
 public abstract class QuarkusUpdate extends QuarkusPlatformTask {
 
     private boolean perModule = false;
+
+    private boolean noRewrite;
+
+    private boolean rewriteDryRun;
+
     private String targetStreamId;
     private String targetPlatformVersion;
+
+    private String rewritePluginVersion = QuarkusUpdateCommand.DEFAULT_GRADLE_REWRITE_PLUGIN_VERSION;
+
+    private String rewriteUpdateRecipesVersion;
+
+    @Input
+    @Optional
+    public Boolean getNoRewrite() {
+        return noRewrite;
+    }
+
+    @Option(description = "Disable the rewrite feature.", option = "noRewrite")
+    public QuarkusUpdate setNoRewrite(Boolean noRewrite) {
+        this.noRewrite = noRewrite;
+        return this;
+    }
+
+    @Input
+    @Optional
+    public Boolean getRewriteDryRun() {
+        return rewriteDryRun;
+    }
+
+    @Option(description = "Rewrite in dry-mode.", option = "rewriteDryRun")
+    public QuarkusUpdate setRewriteDryRun(Boolean rewriteDryRun) {
+        this.rewriteDryRun = rewriteDryRun;
+        return this;
+    }
 
     @Input
     public boolean getPerModule() {
@@ -29,6 +63,28 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
     @Option(description = "Log project's state per module.", option = "perModule")
     public void setPerModule(boolean perModule) {
         this.perModule = perModule;
+    }
+
+    @Input
+    public String getRewritePluginVersion() {
+        return rewritePluginVersion;
+    }
+
+    @Option(description = "The OpenRewrite plugin version", option = "rewritePluginVersion")
+    public void setRewritePluginVersion(String rewritePluginVersion) {
+        this.rewritePluginVersion = rewritePluginVersion;
+    }
+
+    @Input
+    @Optional
+    public String getRewriteUpdateRecipesVersion() {
+        return rewriteUpdateRecipesVersion;
+    }
+
+    @Option(description = " The io.quarkus:quarkus-update-recipes version. This artifact contains the base recipes used by this tool to update a project.", option = "updateRecipesVersion")
+    public QuarkusUpdate setRewriteUpdateRecipesVersion(String rewriteUpdateRecipesVersion) {
+        this.rewriteUpdateRecipesVersion = rewriteUpdateRecipesVersion;
+        return this;
     }
 
     @Input
@@ -61,7 +117,6 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
     public void logUpdates() {
 
         getProject().getLogger().warn(getName() + " is experimental, its options and output might change in future versions");
-
         final QuarkusProject quarkusProject = getQuarkusProject(false);
         final ExtensionCatalog targetCatalog;
         try {
@@ -86,15 +141,16 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
 
         final UpdateProject invoker = new UpdateProject(quarkusProject);
         invoker.latestCatalog(targetCatalog);
+        invoker.rewritePluginVersion(rewritePluginVersion);
         invoker.targetPlatformVersion(targetPlatformVersion);
+        invoker.rewriteDryRun(rewriteDryRun);
+        invoker.noRewrite(noRewrite);
         invoker.perModule(perModule);
-        // This is currently not supported with gradle
-        invoker.noRewrite(true);
         invoker.appModel(extension().getApplicationModel());
         try {
             invoker.execute();
         } catch (Exception e) {
-            throw new GradleException("Failed to resolve recommended updates", e);
+            throw new GradleException("Failed to apply recommended updates", e);
         }
     }
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -65,7 +65,7 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
     private Boolean rewriteDryRun;
 
     /**
-     * "The io.quarkus:quarkus-update-recipes version. This artifact contains the base recipes used by this tool to update a
+     * The io.quarkus:quarkus-update-recipes version. This artifact contains the base recipes used by this tool to update a
      * project.
      */
     @Parameter(property = "updateRecipesVersion", required = false)

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -29,6 +29,7 @@ import io.quarkus.devtools.project.state.TopExtensionDependency;
 import io.quarkus.devtools.project.update.QuarkusUpdateCommand;
 import io.quarkus.devtools.project.update.QuarkusUpdateException;
 import io.quarkus.devtools.project.update.QuarkusUpdates;
+import io.quarkus.devtools.project.update.QuarkusUpdatesRepository;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.platform.tools.ToolsConstants;
@@ -45,7 +46,6 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
     public static final String REMOVE = "Remove:";
     public static final String UPDATE = "Update:";
     public static final String ITEM_FORMAT = "%-7s %s";
-    public static final String DEFAULT_UPDATE_RECIPES_VERSION = "LATEST";
 
     @Override
     public QuarkusCommandOutcome execute(QuarkusCommandInvocation invocation) throws QuarkusCommandException {
@@ -72,12 +72,13 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
 
             if (!noRewrite) {
                 QuarkusUpdates.ProjectUpdateRequest request = new QuarkusUpdates.ProjectUpdateRequest(
+                        quarkusProject.getExtensionManager().getBuildTool(),
                         projectQuarkusPlatformBom.getVersion(), targetPlatformVersion);
                 Path recipe = null;
                 try {
                     recipe = Files.createTempFile("quarkus-project-recipe-", ".yaml");
                     final String updateRecipesVersion = invocation.getValue(UpdateProject.REWRITE_UPDATE_RECIPES_VERSION,
-                            DEFAULT_UPDATE_RECIPES_VERSION);
+                            QuarkusUpdatesRepository.DEFAULT_UPDATE_RECIPES_VERSION);
                     QuarkusUpdates.createRecipe(recipe,
                             QuarkusProjectHelper.artifactResolver(), updateRecipesVersion, request);
                     final String rewritePluginVersion = invocation.getValue(UpdateProject.REWRITE_PLUGIN_VERSION);
@@ -92,7 +93,7 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
                 } catch (IOException e) {
                     throw new QuarkusCommandException("Error while generating the project update script", e);
                 } catch (QuarkusUpdateException e) {
-                    throw new QuarkusCommandException("Error while running the project update scrip", e);
+                    throw new QuarkusCommandException("Error while running the project update script", e);
                 } finally {
                     if (recipe != null) {
                         try {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/QuarkusUpdates.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/QuarkusUpdates.java
@@ -20,9 +20,20 @@ public final class QuarkusUpdates {
                 request.currentVersion,
                 request.targetVersion);
         QuarkusUpdateRecipe recipe = new QuarkusUpdateRecipe()
-                .buildTool(request.buildTool)
-                .addOperation(new UpdatePropertyOperation("quarkus.platform.version", request.targetVersion))
-                .addOperation(new UpdatePropertyOperation("quarkus.version", request.targetVersion));
+                .buildTool(request.buildTool);
+
+        switch (request.buildTool) {
+            case MAVEN:
+                recipe.addOperation(new UpdatePropertyOperation("quarkus.platform.version", request.targetVersion))
+                        .addOperation(new UpdatePropertyOperation("quarkus.version", request.targetVersion));
+                break;
+            case GRADLE:
+            case GRADLE_KOTLIN_DSL:
+                recipe.addOperation(new UpdatePropertyOperation("quarkusPlatformVersion", request.targetVersion))
+                        .addOperation(new UpdatePropertyOperation("quarkusPluginVersion", request.targetVersion));
+                break;
+        }
+
         for (String s : recipes) {
             recipe.addRecipes(QuarkusUpdateRecipeIO.readRecipesYaml(s));
         }
@@ -31,11 +42,16 @@ public final class QuarkusUpdates {
 
     public static class ProjectUpdateRequest {
 
-        public BuildTool buildTool = BuildTool.MAVEN;
+        public BuildTool buildTool;
         public String currentVersion;
         public String targetVersion;
 
         public ProjectUpdateRequest(String currentVersion, String targetVersion) {
+            this(BuildTool.MAVEN, currentVersion, targetVersion);
+        }
+
+        public ProjectUpdateRequest(BuildTool buildTool, String currentVersion, String targetVersion) {
+            this.buildTool = buildTool;
             this.currentVersion = currentVersion;
             this.targetVersion = targetVersion;
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/QuarkusUpdatesRepository.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/QuarkusUpdatesRepository.java
@@ -21,6 +21,7 @@ public final class QuarkusUpdatesRepository {
     }
 
     private static final String QUARKUS_RECIPE_GA = "io.quarkus:quarkus-update-recipes";
+    public static final String DEFAULT_UPDATE_RECIPES_VERSION = "LATEST";
 
     public static List<String> fetchRecipes(MavenArtifactResolver artifactResolver, String recipeVersion, String currentVersion,
             String targetVersion) {

--- a/independent-projects/tools/devtools-common/src/main/resources/openrewrite-init.gradle
+++ b/independent-projects/tools/devtools-common/src/main/resources/openrewrite-init.gradle
@@ -1,0 +1,44 @@
+// Script used to run Open Rewrite without having to modify the build.
+// Based on https://docs.openrewrite.org/tutorials/running-rewrite-on-a-gradle-project-without-modifying-the-build
+
+initscript {
+    repositories {
+        maven { url "https://plugins.gradle.org/m2" }
+    }
+
+    dependencies {
+        classpath("org.openrewrite:plugin:{pluginVersion}")
+    }
+}
+
+addListener(new BuildInfoPluginListener())
+
+allprojects {
+    project.afterEvaluate {
+        if (!project.plugins.hasPlugin(org.openrewrite.gradle.RewritePlugin)) {
+            project.plugins.apply(org.openrewrite.gradle.RewritePlugin)
+        }
+    }
+    dependencies {
+      rewrite("org.openrewrite:rewrite-java")
+    }
+    rewrite {
+      configFile = project.getRootProject().file("{rewriteFile}")
+      activeRecipe("{activeRecipe}")
+      plainTextMask({plainTextMask})
+    }
+}
+
+class BuildInfoPluginListener extends BuildAdapter {
+
+    def void projectsLoaded(Gradle gradle) {
+        Project root = gradle.getRootProject()
+        if (!"buildSrc".equals(root.name)) {
+            root.allprojects {
+                apply {
+                    apply plugin: org.openrewrite.gradle.RewritePlugin
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #29000, #29410

Gradle Kotlin is not supported, we would need an init script for it, but it's not yet provided by OpenRewrite.

```
~/D/test-update> qss update -S 3.0

> Task :quarkusUpdate
quarkusUpdate is experimental, its options and output might change in future versions
Instructions to update this project from '2.16.5.Final' to '3.0.0.CR1':

Recommended Quarkus platform BOM updates:
Update: io.quarkus.platform:quarkus-bom:pom:2.16.5.Final -> 3.0.0.CR1




 ------------------------------------------------------------------------
Executing:
/Users/ia3andy/Downloads/test-update/gradlew --console plain --stacktrace --init-script /var/folders/j8/sj85tl7d2pq_vnhbpj4t5lwm0000gn/T/openrewrite-init8614588297482456797gradle rewriteRun

Starting a Gradle Daemon, 1 busy and 2 stopped Daemons could not be reused, use --status for details
> Task :processResources
> Task :quarkusGenerateCode
> Task :quarkusGenerateCodeDev
> Task :compileJava
> Task :classes
> Task :quarkusGenerateCodeTests
> Task :compileTestJava
> Task :processTestResources NO-SOURCE
> Task :testClasses
> Task :compileIntegrationTestJava NO-SOURCE
> Task :processIntegrationTestResources NO-SOURCE
> Task :integrationTestClasses UP-TO-DATE
> Task :compileNativeTestJava
> Task :compileQuarkusGeneratedSourcesJava NO-SOURCE
> Task :compileQuarkusTestGeneratedSourcesJava NO-SOURCE
> Task :rewriteResolveDependencies

> Task :rewriteRun
Validating active recipes
Parsing sources from project test-update
All sources parsed, running active recipes: io.quarkus.openrewrite.Quarkus
Changes have been made to src/main/java/org/acme/GreetingResource.java by:
    io.quarkus.openrewrite.Quarkus
        org.openrewrite.java.migrate.jakarta.JavaxWsToJakartaWs
            org.openrewrite.java.ChangePackage: {oldPackageName=javax.ws, newPackageName=jakarta.ws, recursive=true}
Changes have been made to gradle.properties by:
    io.quarkus.openrewrite.Quarkus
        org.openrewrite.gradle.AddProperty: {key=quarkusPlatformVersion, value=3.0.0.CR1, overwrite=true}
        org.openrewrite.gradle.AddProperty: {key=quarkusPluginVersion, value=3.0.0.CR1, overwrite=true}
Please review and commit the results.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.5.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 24s
9 actionable tasks: 9 executed
Recipe validation error in oldArtifactId: is required
Recipe validation error in oldGroupId: is required
Recipe validation error in oldArtifactId: is required
Recipe validation error in oldGroupId: is required
Recipe validation error in oldArtifactId: is required
Recipe validation error in oldGroupId: is required
Recipe validation error in oldArtifactId: is required
Recipe validation error in oldGroupId: is required
Recipe validation errors detected as part of one or more activeRecipe(s). Execution will continue regardless.




BUILD SUCCESSFUL in 28s
1 actionable task: 1 executed
```