### PR TITLE
Update version detection scheme for native

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -18,6 +18,20 @@ public class GraalVMTest {
 
     @Test
     public void testGraalVMVersionDetected() {
+        // Version detection after: https://github.com/oracle/graal/pull/6302 (3 lines of version output)
+        assertVersion(org.graalvm.home.Version.create(23, 0, 0), MANDREL,
+                Version.of(Stream.of(("native-image 17.0.6 2023-01-17\n"
+                        + "OpenJDK Runtime Environment Mandrel-23.0.0-dev (build 17.0.6+10)\n"
+                        + "OpenJDK 64-Bit Server VM Mandrel-23.0.0-dev (build 17.0.6+10, mixed mode)").split("\\n"))));
+        assertVersion(org.graalvm.home.Version.create(23, 0, 0), MANDREL,
+                Version.of(Stream.of(("native-image 17.0.6 2023-01-17\n"
+                        + "GraalVM Runtime Environment Mandrel-23.0.0-dev (build 17.0.6+10)\n"
+                        + "Substrate VM Mandrel-23.0.0-dev (build 17.0.6+10, serial gc)").split("\\n"))));
+        assertVersion(org.graalvm.home.Version.create(23, 0), ORACLE,
+                Version.of(Stream.of(("native-image 20 2023-03-21\n"
+                        + "GraalVM Runtime Environment GraalVM CE (build 20+34-jvmci-23.0-b10)\n"
+                        + "Substrate VM GraalVM CE (build 20+34, serial gc)").split("\\n"))));
+        // Older version parsing
         assertVersion(org.graalvm.home.Version.create(20, 1), ORACLE,
                 Version.of(Stream.of("GraalVM Version 20.1.0 (Java Version 11.0.7)")));
         assertVersion(org.graalvm.home.Version.create(20, 1, 0, 1), MANDREL, Version
@@ -41,12 +55,12 @@ public class GraalVMTest {
     }
 
     static void assertVersion(org.graalvm.home.Version graalVmVersion, Distribution distro, Version version) {
+        assertThat(version.isDetected()).isEqualTo(true);
         assertThat(graalVmVersion.compareTo(version.version)).isEqualTo(0);
         assertThat(version.distribution).isEqualTo(distro);
         if (distro == MANDREL) {
             assertThat(version.isMandrel()).isTrue();
         }
-        assertThat(version.isDetected()).isEqualTo(true);
     }
 
     @Test


### PR DESCRIPTION
A new version scheme got pushed in upstream GraalVM. The new version output will look similar to `java --version` output going forward. Quarkus needs to update the version detection scheme to account for that.

For GraalVM CE the version is being deduced from the `jvmci` build level (a.k.a `java.runtime.version` property). Example:
```
$ bin/java -XshowSettings:properties --version 2>&1 | grep java.runtime.version
    java.runtime.version = 20+34-jvmci-23.0-b10
```

For Mandrel, we use the vendor version which we have appropriately set for Mandrel builds. Example: `Mandrel-23.1.0-dev`

This patch works for `native-image --version` outputs of GraalVM CE:

```
$ native-image --version
native-image 20 2023-03-21
GraalVM Runtime Environment GraalVM CE (build 20+34-jvmci-23.0-b10)
Substrate VM GraalVM CE (build 20+34, serial gc)
```

and Mandrel:

```
$ native-image --version
native-image 17.0.6 2023-01-17
OpenJDK Runtime Environment Mandrel-23.1.0-dev (build 17.0.6+10)
OpenJDK 64-Bit Server VM Mandrel-23.1.0-dev (build 17.0.6+10, mixed mode)
```

Testing: 
- [x] Example `smallrye-metrics` integration test which [fails currently in CI](https://github.com/graalvm/mandrel/actions/runs/4613968709/jobs/8156830248#step:11:1278) which isn't clear, though, whether or not it's because of the version detection. Anyway, it passes with mandrel/graal ce builds with this patch.
- [x] Ran `jaxb` integration-test with `quarkus.native.debug.enabled=true` and observed that `-H:+TrackNodeSourcePosition` got added to the `native-image` invocation (that's only for `>= 23.0`). It also doesn't do the the `objcopy --strip-debug` invocation via Quarkus (as that's done upstream for `>= 23.0`).
- [x] Added test cases in `GraalVMTest.java`