### PR TITLE
Support multi-stage Dockerfiles

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-{java.version}:1.14
+FROM registry.access.redhat.com/ubi8/openjdk-{java.version}:1.15
 
 ENV LANGUAGE='en_US:en'
 

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.multistage.jvm.dockerignore
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.multistage.jvm.dockerignore
@@ -1,0 +1,12 @@
+*
+!pom.xml
+!mvnw
+!.mvn/*
+!gradle.properties
+!build.gradle
+!settings.gradle
+!build.gradle.kts
+!settings.gradle.kts
+!src
+!gradlew
+!gradle/*

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.multistage.native-micro.dockerignore
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.multistage.native-micro.dockerignore
@@ -1,0 +1,12 @@
+*
+!pom.xml
+!mvnw
+!.mvn/*
+!gradle.properties
+!build.gradle
+!settings.gradle
+!build.gradle.kts
+!settings.gradle.kts
+!src
+!gradlew
+!gradle/*

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.multistage.native.dockerignore
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.multistage.native.dockerignore
@@ -1,0 +1,12 @@
+*
+!pom.xml
+!mvnw
+!.mvn/*
+!gradle.properties
+!build.gradle
+!settings.gradle
+!build.gradle.kts
+!settings.gradle.kts
+!src
+!gradlew
+!gradle/*

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.multistage.jvm
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.multistage.jvm
@@ -1,0 +1,39 @@
+####
+# This Multistage Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.multistage.jvm -t quarkus/{project.artifact-id} .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/{project.artifact-id}
+#
+###
+
+## Stage 1 : build with Maven builder image
+FROM {dockerfile.builder.from} AS build
+ARG MAVEN_BUILD_EXTRA_ARGS=
+COPY --chown=quarkus:quarkus src mvnw pom.xml /code/
+COPY --chown=quarkus:quarkus .mvn/ /code/.mvn/
+USER quarkus
+WORKDIR /code
+RUN ./mvnw -B -ntp org.apache.maven.plugins:maven-dependency-plugin:3.5.0:go-offline
+RUN ./mvnw -ntp package -DskipTests $MAVEN_BUILD_EXTRA_ARGS
+
+## Stage 2 : create the Docker final image
+FROM registry.access.redhat.com/ubi8/openjdk-{java.version}:1.15
+
+ENV LANGUAGE='en_US:en'
+
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --from=build --chown=185 /code/{buildtool.build-dir}/quarkus-app/lib/ /deployments/lib/
+COPY --from=build --chown=185 /code/{buildtool.build-dir}/quarkus-app/*.jar /deployments/
+COPY --from=build --chown=185 /code/{buildtool.build-dir}/quarkus-app/app/ /deployments/app/
+COPY --from=build --chown=185 /code/{buildtool.build-dir}/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+USER 185
+
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.multistage.native
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.multistage.native
@@ -1,0 +1,36 @@
+####
+# This Multistage Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode.
+#
+# Build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.multistage.native -t quarkus/{project.artifact-id} .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/{project.artifact-id}
+#
+###
+
+## Stage 1 : build with Maven builder image
+FROM {dockerfile.builder.from} AS build
+ARG MAVEN_BUILD_EXTRA_ARGS=
+COPY --chown=quarkus:quarkus src mvnw pom.xml /code/
+COPY --chown=quarkus:quarkus .mvn/ /code/.mvn/
+USER quarkus
+WORKDIR /code
+RUN ./mvnw -B -ntp org.apache.maven.plugins:maven-dependency-plugin:3.5.0:go-offline
+RUN ./mvnw -ntp package -Pnative -DskipTests $MAVEN_BUILD_EXTRA_ARGS
+
+## Stage 2 : create the Docker final image
+FROM {dockerfile.native.from}
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+
+COPY --from=build --chown=1001:root /code/{buildtool.build-dir}/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.multistage.native-micro
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/src/main/docker/Dockerfile.tpl.qute.multistage.native-micro
@@ -1,0 +1,39 @@
+####
+# This Multistage Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode.
+# It uses a micro base image, tuned for Quarkus native executables.
+# It reduces the size of the resulting container image.
+# Check https://quarkus.io/guides/quarkus-runtime-base-image for further information about this image.
+#
+# Build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.multistage.native-micro -t quarkus/{project.artifact-id} .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/{project.artifact-id}
+#
+###
+
+## Stage 1 : build with Maven builder image
+FROM {dockerfile.builder.from} AS build
+ARG MAVEN_BUILD_EXTRA_ARGS=
+COPY --chown=quarkus:quarkus src mvnw pom.xml /code/
+COPY --chown=quarkus:quarkus .mvn/ /code/.mvn/
+USER quarkus
+WORKDIR /code
+RUN ./mvnw -B -ntp org.apache.maven.plugins:maven-dependency-plugin:3.5.0:go-offline
+RUN ./mvnw -ntp package -Pnative -DskipTests $MAVEN_BUILD_EXTRA_ARGS
+
+## Stage 2 : create the Docker final image
+FROM {dockerfile.native-micro.from}
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+
+COPY --from=build --chown=1001:root /code/{buildtool.build-dir}/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/codestart.yml
@@ -8,3 +8,5 @@ language:
           from: registry.access.redhat.com/ubi8/ubi-minimal:8.6
         native-micro:
           from: quay.io/quarkus/quarkus-micro-image:2.0
+        builder:
+          from: quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17


### PR DESCRIPTION
This introduces three new `Dockerfile` files (and their respective `.dockerignore`s) to the generated projects to support [multi-staged builds](https://docs.docker.com/build/building/multi-stage/):

- `src/main/docker/Dockerfile.multistage.jvm`
- `src/main/docker/Dockerfile.multistage.native`
- `src/main/docker/Dockerfile.multistage.native-micro`

This is required in some CI environments

- Fixes #15905