### PR TITLE
Do not print stack-trace in LogStreamBroadcaster.recordHistory

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/logstream/LogStreamBroadcaster.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/logstream/LogStreamBroadcaster.java
@@ -34,7 +34,6 @@ public class LogStreamBroadcaster {
                 }
                 history.add(message);
             } catch (InterruptedException ex) {
-                ex.printStackTrace();
                 Thread.currentThread().interrupt();
             }
         }


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/32203