### PR TITLE
Fix ConfigMap volumes example at deploying-to-kubernetes.adoc

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -547,7 +547,7 @@ quarkus.kubernetes.secret-volumes.my-volume.secret-name=my-secret
 
 [source,properties]
 ----
-quarkus.kubernetes.config-map-volumes.my-volume.config-map-name=my-secret
+quarkus.kubernetes.config-map-volumes.my-volume.config-map-name=my-config-map
 ----
 
 ==== Passing application configuration


### PR DESCRIPTION
quarkus.kubernetes.config-map-volumes.my-volume.config-map-name=my-secret replaced by quarkus.kubernetes.config-map-volumes.my-volume.config-map-name=my-config-map