### PR TITLE
Make SDKMAN releases minor for maintenance and preview releases

### DIFF
--- a/devtools/cli/distribution/jreleaser-maintenance.yml
+++ b/devtools/cli/distribution/jreleaser-maintenance.yml
@@ -56,6 +56,7 @@ packagers:
     connectTimeout: 20
     readTimeout: 60
     candidate: quarkus
+    command: MINOR
   chocolatey:
     active: ALWAYS
     continueOnError: true

--- a/devtools/cli/distribution/jreleaser-preview.yml
+++ b/devtools/cli/distribution/jreleaser-preview.yml
@@ -56,6 +56,7 @@ packagers:
     connectTimeout: 20
     readTimeout: 60
     candidate: quarkus
+    command: MINOR
 
 announce:
   sdkman:


### PR DESCRIPTION
Minor in SDKMAN terms means that the version is not made the default version.