### PR TITLE
Fix ConfigMap volumes example at deploying-to-openshift.adoc

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -469,7 +469,7 @@ quarkus.openshift.secret-volumes.my-volume.secret-name=my-secret
 
 [source,properties]
 ----
-quarkus.openshift.config-map-volumes.my-volume.config-map-name=my-secret
+quarkus.openshift.config-map-volumes.my-volume.config-map-name=my-config-map
 ----
 
 ==== Persistent Volume Claims


### PR DESCRIPTION
quarkus.openshift.config-map-volumes.my-volume.config-map-name=my-secret replaced by quarkus.openshift.config-map-volumes.my-volume.config-map-name=my-config-map