### PR TITLE
ArC: fix spying on intercepted beans

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodsProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodsProcessor.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.spi.Contextual;
@@ -371,8 +370,8 @@ public class InterceptedStaticMethodsProcessor {
 
     private ResultHandle createForwardingFunction(MethodCreator init, ClassInfo target, MethodInfo method) {
         // Forwarding function
-        // Function<InvocationContext, Object> forward = ctx -> Foo.interceptMe_original((java.lang.String)ctx.getParameters()[0])
-        FunctionCreator func = init.createFunction(Function.class);
+        // BiFunction<Object, InvocationContext, Object> forward = (ignored, ctx) -> Foo.interceptMe_original((java.lang.String)ctx.getParameters()[0])
+        FunctionCreator func = init.createFunction(BiFunction.class);
         BytecodeCreator funcBytecode = func.getBytecode();
         List<Type> paramTypes = method.parameterTypes();
         ResultHandle[] paramHandles;
@@ -382,7 +381,7 @@ public class InterceptedStaticMethodsProcessor {
             params = new String[0];
         } else {
             paramHandles = new ResultHandle[paramTypes.size()];
-            ResultHandle ctxHandle = funcBytecode.getMethodParam(0);
+            ResultHandle ctxHandle = funcBytecode.getMethodParam(1);
             ResultHandle ctxParamsHandle = funcBytecode.invokeInterfaceMethod(
                     MethodDescriptor.ofMethod(InvocationContext.class, "getParameters", Object[].class),
                     ctxHandle);

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -55,6 +55,7 @@
         <version.junit5>5.9.2</version.junit5>
         <version.kotlin>1.8.10</version.kotlin>
         <version.kotlin-coroutines>1.6.4</version.kotlin-coroutines>
+        <version.mockito>5.2.0</version.mockito>
         <!-- TCK versions -->
         <version.arquillian>1.7.0.Alpha14</version.arquillian>
         <version.atinject-tck>2.0.1</version.atinject-tck>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -35,31 +35,32 @@
     </scm>
 
     <properties>
-        <angus-activation.version>1.0.0</angus-activation.version>
-        <expressly.version>5.0.0</expressly.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
-        <!-- Versions -->
+
+        <!-- specification versions -->
         <version.cdi>4.0.1</version.cdi>
+        <version.jakarta-annotation>2.1.1</version.jakarta-annotation>
+        <version.jpa>3.0.0</version.jpa>
         <version.jta>2.0.1</version.jta>
+        <!-- main versions -->
+        <version.gizmo>1.6.0.Final</version.gizmo>
         <version.jandex>3.0.5</version.jandex>
+        <version.jboss-logging>3.5.0.Final</version.jboss-logging>
+        <version.mutiny>2.1.0</version.mutiny>
+        <!-- test versions -->
+        <version.assertj>3.24.2</version.assertj>
         <version.junit5>5.9.2</version.junit5>
         <version.kotlin>1.8.10</version.kotlin>
         <version.kotlin-coroutines>1.6.4</version.kotlin-coroutines>
-        <version.maven>3.8.8</version.maven>
-        <version.assertj>3.24.2</version.assertj>
-        <version.jboss-logging>3.5.0.Final</version.jboss-logging>
-        <version.jakarta-annotation>2.1.1</version.jakarta-annotation>
-        <version.gizmo>1.6.0.Final</version.gizmo>
-        <version.jpa>3.0.0</version.jpa>
-        <version.mutiny>2.1.0</version.mutiny>
+        <!-- TCK versions -->
         <version.arquillian>1.7.0.Alpha14</version.arquillian>
         <version.atinject-tck>2.0.1</version.atinject-tck>
         <version.cdi-tck>4.0.9</version.cdi-tck>
         <version.junit4>4.13.2</version.junit4>
-
+        <!-- Maven plugin versions -->
         <version.compiler.plugin>3.11.0</version.compiler.plugin>
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.0.0</version.surefire.plugin>
@@ -139,27 +140,6 @@
                 <type>pom</type>
             </dependency>
 
-
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-plugin-api</artifactId>
-                <version>${version.maven}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.maven.plugin-tools</groupId>
-                <artifactId>maven-plugin-annotations</artifactId>
-                <version>${version.maven}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-core</artifactId>
-                <version>${version.maven}</version>
-                <scope>provided</scope>
-            </dependency>
 
             <dependency>
                 <groupId>org.jboss.logging</groupId>

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.context.spi.Context;
@@ -231,8 +231,7 @@ public final class MethodDescriptors {
             String.class);
 
     public static final MethodDescriptor INTERCEPTED_METHOD_METADATA_CONSTRUCTOR = MethodDescriptor.ofConstructor(
-            InterceptedMethodMetadata.class,
-            List.class, Method.class, Set.class, Function.class);
+            InterceptedMethodMetadata.class, List.class, Method.class, Set.class, BiFunction.class);
 
     public static final MethodDescriptor CREATIONAL_CTX_HAS_DEPENDENT_INSTANCES = MethodDescriptor.ofMethod(
             CreationalContextImpl.class,

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundInvokeInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundInvokeInvocationContext.java
@@ -71,7 +71,7 @@ class AroundInvokeInvocationContext extends AbstractInvocationContext {
                         .invoke(new NextAroundInvokeInvocationContext(currentPosition + 1, parameters));
             } else {
                 // Invoke the target method
-                return metadata.aroundInvokeForward.apply(this);
+                return metadata.aroundInvokeForward.apply(target, this);
             }
         } catch (InvocationTargetException e) {
             Throwable cause = e.getCause();

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedMethodMetadata.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedMethodMetadata.java
@@ -4,7 +4,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import jakarta.interceptor.InvocationContext;
 
@@ -16,10 +16,10 @@ public class InterceptedMethodMetadata {
     public final List<InterceptorInvocation> chain;
     public final Method method;
     public final Set<Annotation> bindings;
-    public final Function<InvocationContext, Object> aroundInvokeForward;
+    public final BiFunction<Object, InvocationContext, Object> aroundInvokeForward;
 
     public InterceptedMethodMetadata(List<InterceptorInvocation> chain, Method method, Set<Annotation> bindings,
-            Function<InvocationContext, Object> aroundInvokeForward) {
+            BiFunction<Object, InvocationContext, Object> aroundInvokeForward) {
         this.chain = chain;
         this.method = method;
         this.bindings = bindings;

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -36,6 +36,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${version.mockito}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
         </dependency>

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/mocking/SpyOnInterceptedBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/mocking/SpyOnInterceptedBeanTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.arc.test.mocking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class SpyOnInterceptedBeanTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        MyBean bean = Arc.container().instance(MyBean.class).get();
+
+        MyBean spy = Mockito.spy(bean);
+        Mockito.when(spy.getValue()).thenReturn("quux");
+
+        assertEquals("intercepted: intercepted: quux42", spy.doSomething(42));
+        Mockito.verify(spy).doSomething(Mockito.anyInt());
+        Mockito.verify(spy).doSomethingElse();
+        Mockito.verify(spy).getValue();
+    }
+
+    @Singleton
+    static class MyBean {
+        @MyInterceptorBinding
+        String doSomething(int param) {
+            return doSomethingElse() + param;
+        }
+
+        @MyInterceptorBinding
+        String doSomethingElse() {
+            return getValue();
+        }
+
+        String getValue() {
+            return "foobar";
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    public @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    public static class MyInterceptor {
+        @AroundInvoke
+        Object aroundInvoke(InvocationContext ctx) throws Exception {
+            return "intercepted: " + ctx.proceed();
+        }
+    }
+}


### PR DESCRIPTION
When instantiating a `Subclass` for a bean with intercepted methods,
all `InterceptedMethodMetadata` for all intercepted methods are also
instantiated. These metadata used to hold a `Function` instance that
takes an `InvocationContext` and calls the original method after all
interceptors have executed. The `Function` instance used to remember
the `this` instance on which the method should be invoked.

This is incompatible with the way how Mockito implements spying on
objects. To create a spy, Mockito takes an object, obtains its class,
creates a subclass, and creates a copy of the original object, except
it's an instance of the subclass. When calling an intercepted method
on the spy object, the `Function` instance mentioned above diverts
the ultimate method call to the object it remembered, instead of
using the target object stored in the `InvocationContext`.

This commit changes the `InterceptedMethodMetadata` to no longer hold
a `Function`; it holds a `BiFunction` instead. The `BiFunction` is
completely stateless. Instead, the caller of the `BiFunction` must
pass not only the `InvocationContext`, but also the target object.

This way, if an intercepted object is spied upon, all intercepted
methods are eventually called correctly on the spy, instead of the
original instance.

Fixes #32300