### PR TITLE
Arc CDI TCK related fixes, focused around behavior gated behind strict mode

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -637,9 +637,9 @@ public class ArcProcessor {
             reflectiveClasses
                     .produce(ReflectiveClassBuildItem.builder(binding.name().toString()).methods().build());
         }
-
         ArcContainer container = recorder.initContainer(shutdown,
-                currentContextFactory.isPresent() ? currentContextFactory.get().getFactory() : null);
+                currentContextFactory.isPresent() ? currentContextFactory.get().getFactory() : null,
+                config.strictCompatibility);
         BeanContainer beanContainer = recorder.initBeanContainer(container,
                 beanContainerListenerBuildItems.stream().map(BeanContainerListenerBuildItem::getBeanContainerListener)
                         .collect(Collectors.toList()));

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
@@ -40,9 +40,11 @@ public class ArcRecorder {
      */
     public static volatile Map<String, Function<SyntheticCreationalContext<?>, ?>> syntheticBeanProviders;
 
-    public ArcContainer initContainer(ShutdownContext shutdown, RuntimeValue<CurrentContextFactory> currentContextFactory)
+    public ArcContainer initContainer(ShutdownContext shutdown, RuntimeValue<CurrentContextFactory> currentContextFactory,
+            boolean strictCompatibility)
             throws Exception {
-        ArcContainer container = Arc.initialize(currentContextFactory != null ? currentContextFactory.getValue() : null);
+        ArcContainer container = Arc.initialize(currentContextFactory != null ? currentContextFactory.getValue() : null,
+                strictCompatibility);
         shutdown.addShutdownTask(new Runnable() {
             @Override
             public void run() {

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
@@ -15,6 +15,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.ArcInitConfig;
 import io.quarkus.arc.CurrentContextFactory;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableBean.Kind;
@@ -43,8 +44,9 @@ public class ArcRecorder {
     public ArcContainer initContainer(ShutdownContext shutdown, RuntimeValue<CurrentContextFactory> currentContextFactory,
             boolean strictCompatibility)
             throws Exception {
-        ArcContainer container = Arc.initialize(currentContextFactory != null ? currentContextFactory.getValue() : null,
-                strictCompatibility);
+        ArcContainer container = Arc.initialize(ArcInitConfig.builder()
+                .setCurrentContextFactory(currentContextFactory != null ? currentContextFactory.getValue() : null)
+                .setStrictCompatibility(strictCompatibility).build());
         shutdown.addShutdownTask(new Runnable() {
             @Override
             public void run() {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -264,7 +264,7 @@ public class BeanDeployment {
         List<InjectionPointInfo> injectionPoints = new ArrayList<>();
         this.beans.addAll(
                 findBeans(initBeanDefiningAnnotations(beanDefiningAnnotations.values(), stereotypes.keySet()), observers,
-                        injectionPoints, jtaCapabilities, strictCompatibility));
+                        injectionPoints, jtaCapabilities));
         // Note that we use unmodifiable views because the underlying collections may change in the next phase
         // E.g. synthetic beans are added and unused interceptors removed
         buildContextPut(Key.BEANS.asString(), Collections.unmodifiableList(beans));
@@ -892,7 +892,7 @@ public class BeanDeployment {
     }
 
     private List<BeanInfo> findBeans(Collection<DotName> beanDefiningAnnotations, List<ObserverInfo> observers,
-            List<InjectionPointInfo> injectionPoints, boolean jtaCapabilities, boolean strictCompatibility) {
+            List<InjectionPointInfo> injectionPoints, boolean jtaCapabilities) {
 
         Set<ClassInfo> beanClasses = new HashSet<>();
         Set<MethodInfo> producerMethods = new HashSet<>();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -1038,10 +1038,10 @@ public class BeanDeployment {
                     if (annotationStore.hasAnnotation(method, DotNames.OBSERVES)) {
                         syncObserverMethods.computeIfAbsent(method, ignored -> new HashSet<>())
                                 .add(beanClass);
+                        // add only concrete classes
                         if (!Modifier.isAbstract(beanClass.flags())) {
                             // do not register classes with observers and no bean def. annotation as beans in strict mode
                             if (!strictCompatibility) {
-                                // add only concrete classes
                                 beanClasses.add(beanClass);
                                 if (!hasBeanDefiningAnnotation) {
                                     LOGGER.debugf(
@@ -1053,10 +1053,10 @@ public class BeanDeployment {
                     } else if (annotationStore.hasAnnotation(method, DotNames.OBSERVES_ASYNC)) {
                         asyncObserverMethods.computeIfAbsent(method, ignored -> new HashSet<>())
                                 .add(beanClass);
+                        // add only concrete classes
                         if (!Modifier.isAbstract(beanClass.flags())) {
                             // do not register classes with observers and no bean def. annotation as beans in strict mode
                             if (!strictCompatibility) {
-                                // add only concrete classes
                                 beanClasses.add(beanClass);
                                 if (!hasBeanDefiningAnnotation) {
                                     LOGGER.debugf(
@@ -1080,12 +1080,19 @@ public class BeanDeployment {
                     if (annotationStore.hasAnnotation(field, DotNames.INJECT)) {
                         throw new DefinitionException("Injected field cannot be annotated with @Produces: " + field);
                     }
+                    // Do not register classes with producers and no bean def. annotation as beans in strict mode
                     // Producer fields are not inherited
-                    producerFields.add(field);
-                    if (!hasBeanDefiningAnnotation) {
-                        LOGGER.debugf("Producer field found but %s has no bean defining annotation - using @Dependent",
-                                beanClass);
-                        beanClasses.add(beanClass);
+                    if (strictCompatibility) {
+                        if (hasBeanDefiningAnnotation) {
+                            producerFields.add(field);
+                        }
+                    } else {
+                        producerFields.add(field);
+                        if (!hasBeanDefiningAnnotation) {
+                            LOGGER.debugf("Producer field found but %s has no bean defining annotation - using @Dependent",
+                                    beanClass);
+                            beanClasses.add(beanClass);
+                        }
                     }
                 } else {
                     // Verify that non-producer fields are not annotated with stereotypes

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -23,7 +23,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.enterprise.context.spi.Contextual;
 import jakarta.enterprise.event.Reception;
 import jakarta.enterprise.event.TransactionPhase;
@@ -414,8 +413,8 @@ public class ObserverGenerator extends AbstractGenerator {
                 ResultHandle context = notify.invokeInterfaceMethod(MethodDescriptors.ARC_CONTAINER_GET_ACTIVE_CONTEXT,
                         container,
                         scope);
-                notify.ifNull(context).trueBranch().throwException(ContextNotActiveException.class,
-                        "Context not active: " + observer.getDeclaringBean().getScope().getDotName());
+                // if the context isn't active, don't notify the observer
+                notify.ifNull(context).trueBranch().returnVoid();
                 notify.assign(declaringProviderInstanceHandle,
                         notify.invokeInterfaceMethod(MethodDescriptors.CONTEXT_GET_IF_PRESENT, context,
                                 declaringProviderHandle));

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Arc.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Arc.java
@@ -19,7 +19,7 @@ public final class Arc {
      * @return {@link ArcContainer} instance with default configuration
      */
     public static ArcContainer initialize() {
-        return initialize(ArcInitConfig.INSTANCE);
+        return initialize(ArcInitConfig.DEFAULT);
     }
 
     /**

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Arc.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Arc.java
@@ -12,27 +12,37 @@ public final class Arc {
 
     private static final AtomicReference<ArcContainerImpl> INSTANCE = new AtomicReference<>();
 
+    /**
+     * Initializes {@link ArcContainer} with default settings.
+     * This is equal to using {@code Arc#initialize(ArcInitConfig.INSTANCE)}
+     *
+     * @return {@link ArcContainer} instance with default configuration
+     */
     public static ArcContainer initialize() {
-        return initialize(null);
+        return initialize(ArcInitConfig.INSTANCE);
     }
 
     /**
+     * Deprecated, will be removed in future iterations.
+     * Users are encouraged to use {@link #initialize(ArcInitConfig)} instead.
      *
      * @param currentContextFactory
      * @return the initialized container
      */
+    @Deprecated(since = "3.0", forRemoval = true)
     public static ArcContainer initialize(CurrentContextFactory currentContextFactory) {
-        return initialize(currentContextFactory, false);
+        return initialize(ArcInitConfig.builder().setCurrentContextFactory(currentContextFactory).build());
     }
 
-    public static ArcContainer initialize(CurrentContextFactory currentContextFactory, boolean strictMode) {
+    public static ArcContainer initialize(ArcInitConfig arcInitConfig) {
         ArcContainerImpl container = INSTANCE.get();
         if (container == null) {
             synchronized (INSTANCE) {
                 container = INSTANCE.get();
                 if (container == null) {
                     // Set the container instance first because Arc.container() can be used within ArcContainerImpl.init()
-                    container = new ArcContainerImpl(currentContextFactory, strictMode);
+                    container = new ArcContainerImpl(arcInitConfig.getCurrentContextFactory(),
+                            arcInitConfig.isStrictCompatibility());
                     INSTANCE.set(container);
                     container.init();
                 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Arc.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Arc.java
@@ -22,13 +22,17 @@ public final class Arc {
      * @return the initialized container
      */
     public static ArcContainer initialize(CurrentContextFactory currentContextFactory) {
+        return initialize(currentContextFactory, false);
+    }
+
+    public static ArcContainer initialize(CurrentContextFactory currentContextFactory, boolean strictMode) {
         ArcContainerImpl container = INSTANCE.get();
         if (container == null) {
             synchronized (INSTANCE) {
                 container = INSTANCE.get();
                 if (container == null) {
                     // Set the container instance first because Arc.container() can be used within ArcContainerImpl.init()
-                    container = new ArcContainerImpl(currentContextFactory);
+                    container = new ArcContainerImpl(currentContextFactory, strictMode);
                     INSTANCE.set(container);
                     container.init();
                 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
@@ -233,4 +233,12 @@ public interface ArcContainer {
      * @see CurrentContext
      */
     CurrentContextFactory getCurrentContextFactory();
+
+    /**
+     * Indicates whether container runs in strict compatibility mode.
+     * Default value is false.
+     *
+     * @return true is strict mode is enabled, false otherwise.
+     */
+    boolean strictCompatibility();
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcInitConfig.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcInitConfig.java
@@ -10,7 +10,7 @@ public final class ArcInitConfig {
     /**
      * Basic instance without any configuration, all values are default
      */
-    public static final ArcInitConfig INSTANCE = builder().build();
+    public static final ArcInitConfig DEFAULT = builder().build();
 
     /**
      * Obtains a builder for {@link ArcInitConfig}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcInitConfig.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcInitConfig.java
@@ -1,0 +1,64 @@
+package io.quarkus.arc;
+
+/**
+ * A configuration object used while initializing Arc, see {@link Arc#initialize()} methods.
+ * Consolidates all configuration objects needed for Arc to initialize, values are initialized to their defaults.
+ *
+ */
+public final class ArcInitConfig {
+
+    /**
+     * Basic instance without any configuration, all values are default
+     */
+    public static final ArcInitConfig INSTANCE = builder().build();
+
+    /**
+     * Obtains a builder for {@link ArcInitConfig}
+     *
+     * @return new instance of the builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private ArcInitConfig(Builder builder) {
+        this.currentContextFactory = builder.currentContextFactory;
+        this.strictCompatibility = builder.strictCompatibility;
+    }
+
+    private final boolean strictCompatibility;
+    private final CurrentContextFactory currentContextFactory;
+
+    public boolean isStrictCompatibility() {
+        return strictCompatibility;
+    }
+
+    public CurrentContextFactory getCurrentContextFactory() {
+        return currentContextFactory;
+    }
+
+    public static class Builder {
+        private boolean strictCompatibility;
+        private CurrentContextFactory currentContextFactory;
+
+        private Builder() {
+            // init all values with their defaults
+            this.strictCompatibility = false;
+            this.currentContextFactory = null;
+        }
+
+        public Builder setStrictCompatibility(boolean strictCompatibility) {
+            this.strictCompatibility = strictCompatibility;
+            return this;
+        }
+
+        public Builder setCurrentContextFactory(CurrentContextFactory currentContextFactory) {
+            this.currentContextFactory = currentContextFactory;
+            return this;
+        }
+
+        public ArcInitConfig build() {
+            return new ArcInitConfig(this);
+        }
+    }
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableObserverMethod.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableObserverMethod.java
@@ -38,7 +38,7 @@ public interface InjectableObserverMethod<T> extends ObserverMethod<T> {
 
     @Override
     default Bean<?> getDeclaringBean() {
-        return Arc.container().bean(getDeclaringBeanIdentifier());
+        return getDeclaringBeanIdentifier() != null ? Arc.container().bean(getDeclaringBeanIdentifier()) : null;
     }
 
     default void notify(T event) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -98,7 +98,10 @@ public class ArcContainerImpl implements ArcContainer {
 
     private final CurrentContextFactory currentContextFactory;
 
-    public ArcContainerImpl(CurrentContextFactory currentContextFactory) {
+    private final boolean strictMode;
+
+    public ArcContainerImpl(CurrentContextFactory currentContextFactory, boolean strictMode) {
+        this.strictMode = strictMode;
         id = String.valueOf(ID_GENERATOR.incrementAndGet());
         running = new AtomicBoolean(true);
         List<InjectableBean<?>> beans = new ArrayList<>();
@@ -361,6 +364,11 @@ public class ArcContainerImpl implements ArcContainer {
     @Override
     public CurrentContextFactory getCurrentContextFactory() {
         return currentContextFactory;
+    }
+
+    @Override
+    public boolean strictCompatibility() {
+        return strictMode;
     }
 
     @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventImpl.java
@@ -22,13 +22,11 @@ import java.util.concurrent.Executor;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.NotificationOptions;
 import jakarta.enterprise.event.ObserverException;
 import jakarta.enterprise.event.TransactionPhase;
 import jakarta.enterprise.inject.Any;
-import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.EventContext;
 import jakarta.enterprise.inject.spi.EventMetadata;
 import jakarta.enterprise.inject.spi.InjectionPoint;
@@ -168,7 +166,8 @@ class EventImpl<T> implements Event<T> {
 
     static <T> Notifier<T> createNotifier(Class<?> runtimeType, Type eventType, Set<Annotation> qualifiers,
             ArcContainerImpl container, InjectionPoint injectionPoint) {
-        return createNotifier(runtimeType, eventType, qualifiers, container, true, injectionPoint);
+        return createNotifier(runtimeType, eventType, qualifiers, container, !Arc.container().strictCompatibility(),
+                injectionPoint);
     }
 
     static <T> Notifier<T> createNotifier(Class<?> runtimeType, Type eventType, Set<Annotation> qualifiers,
@@ -317,8 +316,9 @@ class EventImpl<T> implements Event<T> {
                     }
                 }
 
-                // Non-tx observers notifications; only activate req. context in non-strict mode
-                if (activateRequestContext && !Arc.container().strictCompatibility()) {
+                // Non-tx observers notifications
+                // req. context is activated if not in strict mode and not for lifecycle events such as init/shutdown
+                if (activateRequestContext) {
                     ManagedContext requestContext = Arc.container().requestContext();
                     if (requestContext.isActive()) {
                         notifyObservers(event, exceptionHandler, predicate);
@@ -341,12 +341,6 @@ class EventImpl<T> implements Event<T> {
                 Predicate<ObserverMethod<? super T>> predicate) {
             EventContext eventContext = new EventContextImpl<>(event, eventMetadata);
             for (ObserverMethod<? super T> observerMethod : observerMethods) {
-                Bean<?> declaringBean = observerMethod.getDeclaringBean();
-                // don't notify observers on beans with inactive context
-                if (declaringBean != null && !declaringBean.getScope().equals(Dependent.class)
-                        && Arc.container().getActiveContext(declaringBean.getScope()) == null) {
-                    continue;
-                }
                 if (predicate.test(observerMethod)) {
                     try {
                         observerMethod.notify(eventContext);

--- a/independent-projects/arc/tcks/arquillian/src/main/java/io/quarkus/arc/arquillian/ArcDeployableContainer.java
+++ b/independent-projects/arc/tcks/arquillian/src/main/java/io/quarkus/arc/arquillian/ArcDeployableContainer.java
@@ -21,6 +21,7 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptor;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.ArcInitConfig;
 import io.quarkus.arc.InjectableInstance;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.arquillian.utils.ClassLoading;
@@ -82,7 +83,7 @@ public class ArcDeployableContainer implements DeployableContainer<ArcContainerC
             Thread.currentThread().setContextClassLoader(deploymentClassLoader);
 
             // passing strict mode here allows it to be visible in runtime
-            ArcContainer arcContainer = Arc.initialize(null, true);
+            ArcContainer arcContainer = Arc.initialize(ArcInitConfig.builder().setStrictCompatibility(true).build());
             runningArc.set(arcContainer);
             arcContainer.beanManager().getEvent().fire(new Startup());
 

--- a/independent-projects/arc/tcks/arquillian/src/main/java/io/quarkus/arc/arquillian/ArcDeployableContainer.java
+++ b/independent-projects/arc/tcks/arquillian/src/main/java/io/quarkus/arc/arquillian/ArcDeployableContainer.java
@@ -81,7 +81,8 @@ public class ArcDeployableContainer implements DeployableContainer<ArcContainerC
 
             Thread.currentThread().setContextClassLoader(deploymentClassLoader);
 
-            ArcContainer arcContainer = Arc.initialize();
+            // passing strict mode here allows it to be visible in runtime
+            ArcContainer arcContainer = Arc.initialize(null, true);
             runningArc.set(arcContainer);
             arcContainer.beanManager().getEvent().fire(new Startup());
 

--- a/independent-projects/arc/tcks/cdi-tck-porting-pkg/src/main/java/io/quarkus/arc/tck/porting/ContextsImpl.java
+++ b/independent-projects/arc/tcks/cdi-tck-porting-pkg/src/main/java/io/quarkus/arc/tck/porting/ContextsImpl.java
@@ -14,13 +14,18 @@ import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.ManagedContext;
 
 public class ContextsImpl implements Contexts<Context> {
+
+    private InjectableContext.ContextState savedState;
+
     @Override
     public void setActive(Context context) {
-        ((ManagedContext) context).activate();
+        ((ManagedContext) context).activate(savedState);
+        savedState = null;
     }
 
     @Override
     public void setInactive(Context context) {
+        savedState = ((ManagedContext) context).getState();
         ((ManagedContext) context).deactivate();
     }
 

--- a/independent-projects/arc/tcks/cdi-tck-porting-pkg/src/main/java/io/quarkus/arc/tck/porting/ContextsImpl.java
+++ b/independent-projects/arc/tcks/cdi-tck-porting-pkg/src/main/java/io/quarkus/arc/tck/porting/ContextsImpl.java
@@ -1,8 +1,8 @@
 package io.quarkus.arc.tck.porting;
 
 import java.lang.annotation.Annotation;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.spi.Context;
@@ -17,8 +17,8 @@ import io.quarkus.arc.ManagedContext;
 
 public class ContextsImpl implements Contexts<Context> {
 
-    // volatile is just a precaution in case some (future) TCK test attempts to use this in between multiple threads
-    private volatile Map<Context, InjectableContext.ContextState> contextStateMap = new HashMap();
+    // ConcurrentHashMap is just future-proofing, could be implemented with plain map too
+    private final Map<Context, InjectableContext.ContextState> contextStateMap = new ConcurrentHashMap<>();
 
     @Override
     public void setActive(Context context) {

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -188,12 +188,6 @@
                     <exclude name="testScopeTypeDeclaredInheritedIsBlockedByIntermediateScopeTypeNotMarkedInherited"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.event.observer.conditional.ConditionalObserverTest">
-                <methods>
-                    <exclude name="testObserverMethodInvokedOnReturnedInstanceFromContext"/>
-                    <exclude name="testConditionalObserverMethodNotInvokedIfNoActiveContext"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.interceptors.tests.order.aroundInvoke.AroundInvokeOrderTest">
                 <methods>
                     <exclude name="testInvocationOrder"/>
@@ -407,11 +401,6 @@
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptorTypeParamInitializerTest">
                 <methods>
                     <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.event.observer.ObserverNotificationTest">
-                <methods>
-                    <exclude name="testObserverMethodNotInvokedIfNoActiveContext"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.context.dependent.DependentContextTest">

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -85,31 +85,6 @@
                     <exclude name="testDeploymentFails"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.producer.method.definition.ProducerMethodDefinitionTest">
-                <methods>
-                    <exclude name="testStereotypeSpecifiesScope"/>
-                    <exclude name="testDefaultBindingType"/>
-                    <exclude name="testDefaultNamedMethod"/>
-                    <exclude name="testStaticMethod"/>
-                    <exclude name="testApiTypeForPrimitiveReturn"/>
-                    <exclude name="testApiTypeForClassReturn"/>
-                    <exclude name="testTypeVariableReturnType"/>
-                    <exclude name="testApiTypeForInterfaceReturn"/>
-                    <exclude name="testProducerOnNonBean"/>
-                    <exclude name="testStaticDisposerMethod"/>
-                    <exclude name="testParameterizedReturnType"/>
-                    <exclude name="testBindingType"/>
-                    <exclude name="testNonStaticDisposerMethodWithStaticProducer"/>
-                    <exclude name="testStaticDisposerMethodWithNonStaticProducer"/>
-                    <exclude name="testNamedMethod"/>
-                    <exclude name="testNonDependentProducerReturnsNullValue"/>
-                    <exclude name="testNonStaticProducerMethodNotInherited"/>
-                    <exclude name="testDependentProducerReturnsNullValue"/>
-                    <exclude name="testBindingTypesAppliedToProducerMethodParameters"/>
-                    <exclude name="testScopeType"/>
-                    <exclude name="testApiTypeForArrayTypeReturn"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.lookup.circular.CircularDependencyTest">
                 <methods>
                     <exclude name="testCircularInjectionOnTwoNormalBeans"/>
@@ -148,11 +123,6 @@
             <class name="org.jboss.cdi.tck.interceptors.tests.bindings.broken.InvalidTransitiveInterceptorBindingAnnotationsTest">
                 <methods>
                     <exclude name="testInterceptorBindingsWithConflictingAnnotationMembersNotOk"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.event.broken.observer.beanNotManaged.ObserverMethodOnIncorrectBeanTest">
-                <methods>
-                    <exclude name="testObserverMethodNotOnManagedOrSessionBeanFails"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.BeanTypeParamConstructorTest">


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/issues/28558

This PR tackles tests that we earlier discover needed some `strictMode` behavior (in that Arc is too permissive compared to spec).
It also makes sure we can determine whether we are in strict compat. mode even in runtime.


I know @mkouba mentioned we could also introduce some abstraction for all parameters going into `Arc.initialize(...)` method. I can take a look at that tomorrow even though I am not wholly sold on doing that just yet because there are only two parameters and I am not aware of any more we need ATM. But like I said, I will still happily do that if requested :)