### PR TITLE
Correcting Resteasy Reactive docs

### DIFF
--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -889,7 +889,7 @@ public class GetTokenReactiveClientHeadersFactory extends ReactiveClientHeadersF
     @Override
     public Uni<MultivaluedMap<String, String>> getHeaders(
             MultivaluedMap<String, String> incomingHeaders,
-            MultivaluedMap<String, String> clientOutgoingHeaders);
+            MultivaluedMap<String, String> clientOutgoingHeaders) {
         return Uni.createFrom().item(() -> {
             MultivaluedHashMap<String, String> newHeaders = new MultivaluedHashMap<>();
             // perform blocking call


### PR DESCRIPTION
I discovered a small mistake in the Rest Client Reactive documentation.

In the code that explains how to use `ReactiveClientHeadersFactory` it was a `;` instead of `{`.
I assume this came out of a migration from an interface to an abstract class.