### PR TITLE
Rename guides mentioning MicroProfile to SmallRye to avoid redirects

### DIFF
--- a/extensions/smallrye-graphql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/smallrye-graphql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,7 +10,7 @@ metadata:
   - "web"
   categories:
   - "web"
-  guide: "https://quarkus.io/guides/microprofile-graphql"
+  guide: "https://quarkus.io/guides/smallrye-graphql"
   status: "stable"
   config:
   - "mp.graphql."

--- a/extensions/smallrye-health/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/smallrye-health/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,7 +9,7 @@ metadata:
   - "health"
   - "microprofile-health"
   - "microprofile-health-check"
-  guide: "https://quarkus.io/guides/microprofile-health"
+  guide: "https://quarkus.io/guides/smallrye-health"
   categories:
   - "cloud"
   status: "stable"

--- a/extensions/smallrye-metrics/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/smallrye-metrics/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,7 +9,7 @@ metadata:
   - "metric"
   - "prometheus"
   - "monitoring"
-  guide: "https://quarkus.io/guides/microprofile-metrics"
+  guide: "https://quarkus.io/guides/smallrye-metrics"
   categories:
   - "observability"
   status: "deprecated"


### PR DESCRIPTION
It was also surprising to me to see microprofile mentioned in the quarkus CLI.