### PR TITLE
Upgrade the reference Oracle RDBMS container used across integration tests

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -94,7 +94,7 @@
         <db2.image>docker.io/ibmcom/db2:11.5.7.0a</db2.image>
         <mssql.image>mcr.microsoft.com/mssql/server:2019-latest</mssql.image>
         <mysql.image>docker.io/mysql:8.0</mysql.image>
-        <oracle.image>docker.io/gvenzl/oracle-xe:21-slim-faststart</oracle.image>
+        <oracle.image>docker.io/gvenzl/oracle-free:23.2.0-faststart</oracle.image>
         <mongo.image>docker.io/mongo:4.4</mongo.image>
 
         <!-- Align various dependencies that are not really part of the bom-->

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -29,7 +29,11 @@ public class OracleDevServicesProcessor {
 
     private static final Logger LOG = Logger.getLogger(OracleDevServicesProcessor.class);
 
-    public static final String IMAGE = "gvenzl/oracle-xe";
+    /**
+     * This is the container name as defined by the Testcontainer's OracleContainer:
+     * does not necessarily match the container name that Quarkus will default to use.
+     */
+    public static final String ORIGINAL_IMAGE_NAME = "gvenzl/oracle-xe";
     public static final int PORT = 1521;
 
     @BuildStep
@@ -91,7 +95,7 @@ public class OracleDevServicesProcessor {
                 boolean useSharedNetwork) {
             super(DockerImageName
                     .parse(imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("oracle")))
-                    .asCompatibleSubstituteFor(OracleDevServicesProcessor.IMAGE));
+                    .asCompatibleSubstituteFor(OracleDevServicesProcessor.ORIGINAL_IMAGE_NAME));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
         }

--- a/extensions/reactive-oracle-client/deployment/pom.xml
+++ b/extensions/reactive-oracle-client/deployment/pom.xml
@@ -15,7 +15,7 @@
     <name>Quarkus - Reactive Oracle Client - Deployment</name>
 
     <properties>
-        <reactive-oracledb.url>vertx-reactive:oracle:thin:@localhost:1521:XE</reactive-oracledb.url>
+        <reactive-oracledb.url>vertx-reactive:oracle:thin:@localhost:1521/FREEPDB1</reactive-oracledb.url>
     </properties>
 
     <dependencies>
@@ -131,7 +131,7 @@
                 </property>
             </activation>
             <properties>
-                <reactive-oracledb.url>vertx-reactive:oracle:thin:@localhost:1521:XE</reactive-oracledb.url>
+                <reactive-oracledb.url>vertx-reactive:oracle:thin:@localhost:1521/FREEPDB1</reactive-oracledb.url>
             </properties>
             <build>
                 <plugins>

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/ReactiveOracleReloadTest.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/ReactiveOracleReloadTest.java
@@ -16,7 +16,7 @@ public class ReactiveOracleReloadTest {
                     .add(new StringAsset("quarkus.datasource.db-kind=oracle\n" +
                             "quarkus.datasource.username=SYSTEM\n" +
                             "quarkus.datasource.password=hibernate_orm_test\n" +
-                            "quarkus.datasource.reactive.url=vertx-reactive:oracle:thin:@localhost:2115:XE"),
+                            "quarkus.datasource.reactive.url=vertx-reactive:oracle:thin:@localhost:2115/FREEPDB1"),
                             "application.properties"));
 
     @Test

--- a/extensions/reactive-oracle-client/deployment/src/test/resources/application-credentials-with-erroneous-url.properties
+++ b/extensions/reactive-oracle-client/deployment/src/test/resources/application-credentials-with-erroneous-url.properties
@@ -1,3 +1,3 @@
 quarkus.datasource.db-kind=oracle
 quarkus.datasource.credentials-provider=custom
-quarkus.datasource.reactive.url=vertx-reactive:oracle:thin:@test:12345:XE
+quarkus.datasource.reactive.url=vertx-reactive:oracle:thin:@test:12345/FREEPDB1

--- a/extensions/reactive-oracle-client/deployment/src/test/resources/application-multiple-datasources-with-erroneous-url.properties
+++ b/extensions/reactive-oracle-client/deployment/src/test/resources/application-multiple-datasources-with-erroneous-url.properties
@@ -1,9 +1,9 @@
 quarkus.datasource.db-kind=oracle
 quarkus.datasource.username=SYSTEM
 quarkus.datasource.password=hibernate_orm_test
-quarkus.datasource.reactive.url=vertx-reactive:oracle:thin:@test:12345:XE
+quarkus.datasource.reactive.url=vertx-reactive:oracle:thin:@test:12345/FREEPDB1
 
 quarkus.datasource."hibernate".db-kind=oracle
 quarkus.datasource."hibernate".username=SYSTEM
 quarkus.datasource."hibernate".password=hibernate_orm_test
-quarkus.datasource."hibernate".reactive.url=vertx-reactive:oracle:thin:@test:55555:XE
+quarkus.datasource."hibernate".reactive.url=vertx-reactive:oracle:thin:@test:55555/FREEPDB1

--- a/integration-tests/jpa-oracle/README.md
+++ b/integration-tests/jpa-oracle/README.md
@@ -22,7 +22,7 @@ Authentication parameters might need to be changed in the Quarkus configuration 
 ### Starting Oracle via docker
 
 ```
-docker run --memory-swappiness=0 --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test docker.io/gvenzl/oracle-xe:21-slim-faststart
+docker run --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test docker.io/gvenzl/oracle-free:23.2.0-faststart
 ```
 
 This will start a local instance with the configuration matching the parameters used by the integration tests of this module.

--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -14,7 +14,7 @@
     <description>Module that contains JPA related tests running with the Oracle database</description>
 
     <properties>
-        <oracledb.url>jdbc:oracle:thin:@localhost:1521/XE</oracledb.url>
+        <oracledb.url>jdbc:oracle:thin:@localhost:1521/FREEPDB1</oracledb.url>
     </properties>
 
     <dependencies>
@@ -187,7 +187,7 @@
                 </property>
             </activation>
             <properties>
-                <oracledb.url>jdbc:oracle:thin:@localhost:1521/XE</oracledb.url>
+                <oracledb.url>jdbc:oracle:thin:@localhost:1521/FREEPDB1</oracledb.url>
             </properties>
             <build>
                 <plugins>

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleLifecycleManager.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleLifecycleManager.java
@@ -10,7 +10,7 @@ public class OracleLifecycleManager implements QuarkusTestResourceLifecycleManag
     @Override
     public Map<String, String> start() {
         Map<String, String> properties = new HashMap<>();
-        properties.put("quarkus.datasource.oracle.jdbc.url", "jdbc:oracle:thin:@localhost:1521/XE");
+        properties.put("quarkus.datasource.oracle.jdbc.url", "jdbc:oracle:thin:@localhost:1521/FREEPDB1");
         properties.put("quarkus.datasource.oracle.password", "quarkus");
         properties.put("quarkus.datasource.oracle.username", "SYSTEM");
         properties.put("quarkus.hibernate-orm.oracle.database.generation", "drop-and-create");

--- a/integration-tests/reactive-oracle-client/README.md
+++ b/integration-tests/reactive-oracle-client/README.md
@@ -23,7 +23,7 @@ Authentication parameters might need to be changed in the Quarkus configuration 
 ### Starting Oracle via docker
 
 ```
-docker run --memory-swappiness=0 --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test docker.io/gvenzl/oracle-xe:21-slim-faststart
+docker run --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test docker.io/gvenzl/oracle-free:23.2.0-faststart
 ```
 
 This will start a local instance with the configuration matching the parameters used by the integration tests of this module.

--- a/integration-tests/reactive-oracle-client/pom.xml
+++ b/integration-tests/reactive-oracle-client/pom.xml
@@ -15,7 +15,7 @@
     <name>Quarkus - Integration Tests - Reactive Oracle Client</name>
 
     <properties>
-        <reactive-oracledb.url>vertx-reactive:oracle:thin:@localhost:1521:XE</reactive-oracledb.url>
+        <reactive-oracledb.url>vertx-reactive:oracle:thin:@localhost:1521/FREEPDB1</reactive-oracledb.url>
     </properties>
 
     <dependencies>
@@ -152,7 +152,7 @@
                 </property>
             </activation>
             <properties>
-                <reactive-oracledb.url>vertx-reactive:oracle:thin:@localhost:1521:XE</reactive-oracledb.url>
+                <reactive-oracledb.url>vertx-reactive:oracle:thin:@localhost:1521/FREEPDB1</reactive-oracledb.url>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
Oracle RDBMs container images are now available for Oracle version 23.2