### PR TITLE
Initial setup of gradle enterprise build scans

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -48,6 +48,8 @@ env:
   DB_USER: hibernate_orm_test
   DB_PASSWORD: hibernate_orm_test
   DB_NAME: hibernate_orm_test
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  PULL_REQUEST_NUMBER: ${{ github.event.number }}
 jobs:
   # This is a hack to work around a GitHub API limitation:
   # when the PR is coming from another fork, the pull_requests field of the

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ nb-configuration.xml
 /lsp/
 .envrc
 .jekyll-cache
+.mvn/.gradle-enterprise

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,12 @@
+ <extensions>
+    <extension>
+        <groupId>com.gradle</groupId>
+        <artifactId>gradle-enterprise-maven-extension</artifactId>
+        <version>1.17</version>
+    </extension>
+    <extension>
+        <groupId>com.gradle</groupId>
+        <artifactId>common-custom-user-data-maven-extension</artifactId>
+        <version>1.11.1</version>
+    </extension>
+</extensions> 

--- a/.mvn/gradle-enterprise-custom-user-data.groovy
+++ b/.mvn/gradle-enterprise-custom-user-data.groovy
@@ -1,0 +1,31 @@
+
+
+// Add mvn command line
+def mvnCommand = ''
+if (System.env.MAVEN_CMD_LINE_ARGS) {
+    mvnCommand = "mvn ${System.env.MAVEN_CMD_LINE_ARGS}".toString()
+    buildScan.value('mvn command line', mvnCommand)
+}
+
+//Add github action information
+if (System.env.GITHUB_ACTIONS) {
+    buildScan.value('gh-job-name', System.env.GITHUB_JOB)
+    buildScan.value('gh-event-name', System.env.GITHUB_EVENT_NAME)
+    buildScan.value('gh-ref-name', System.env.GITHUB_REF_NAME)
+    buildScan.value('gh-actor', System.env.GITHUB_ACTOR)
+    buildScan.value('gh-workflow', System.env.GITHUB_WORKFLOW)
+    
+   
+    def prnumber = System.env.PULL_REQUEST_NUMBER
+    if (prnumber != null) {
+        buildScan.value('gh-pr', prnumber)
+        buildScan.tag('pr-' + prnumber)
+    }
+
+    buildScan.buildScanPublished {  publishedBuildScan ->
+        new File(System.env.GITHUB_STEP_SUMMARY).withWriterAppend { out ->
+            out.println("\n[Build scan for '${mavenCommand}' in ${jobName}](${publishedBuildScan.buildScanUri})\n")
+        }
+    }
+}
+

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -1,0 +1,28 @@
+<gradleEnterprise>
+    <server>
+      <url>https://ge.quarkus.io</url>
+      <allowUntrusted>false</allowUntrusted>
+     </server>
+    <buildScan>
+        <!-- adjust conditions ?
+        mvn gradle-enterprise:provision-access-key 
+        https://docs.gradle.com/enterprise/maven-extension/#publishing_based_on_criteria
+         -->
+        <publish>ALWAYS</publish>
+        <obfuscation>
+          <!-- Don't share ip addresses-->
+          <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
+        </obfuscation>
+        <capture>
+          <goalInputFiles>true</goalInputFiles>
+        </capture>
+        <!-- https://docs.gradle.com/enterprise/maven-extension/#manual_access_key_configuration -->
+        <backgroundBuildScanUpload>#{env['CI'] == null}</backgroundBuildScanUpload>
+        <publishIfAuthenticated>true</publishIfAuthenticated>
+    </buildScan>
+    <buildCache>
+        <local><enabled>false</enabled></local>
+        <remote><enabled>false</enabled></remote>
+    </buildCache>
+</gradleEnterprise>
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -503,6 +503,21 @@ CI is using a slightly different GIB config than locally:
 
 For more details see the `Get GIB arguments` step in `.github/workflows/ci-actions-incremental.yml`.
 
+##### Gradle Enterprise build cache
+
+Quarkus has a Gradle Enterprise setup at https://ge.quarkus.io that can be used to analyze the build performance of the Quarkus project.
+
+Locally you can use `-Dgradle.cache.local.enabled=true` to enable the local Gradle Enterprise cache. This can speed up the build significantly. It is still considered experimental but can be used for local development.
+
+If you have a need or interest to report build times, you will need to get an API key for the GE instance. It is mainly relevant for those working on optimizing the Quarkus build. Ping on quarkus-dev mailing list or on Zulip if you need one.
+
+When you have the account setup you run `mvn gradle-enterprise:provision-access-key` and login - from then on build time info will be sent to the GE instance.
+You can alternatively also generate an API key from the GE UI and then use an environment variable like this:
+
+```
+export GRADLE_ENTERPRISE_ACCESS_KEY=ge.quarkus.io=a_secret_key
+```
+
 ## Release your own version
 
 You might want to release your own patched version of Quarkus to an internal repository.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Project Chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg?style=for-the-badge&logo=zulip)](https://quarkusio.zulipchat.com/)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?style=for-the-badge&logo=gitpod&logoColor=white)](https://gitpod.io/#https://github.com/quarkusio/quarkus/-/tree/main/)
 [![Supported JVM Versions](https://img.shields.io/badge/JVM-11--17--19-brightgreen.svg?style=for-the-badge&logo=openjdk)](https://github.com/quarkusio/quarkus/actions/runs/113853915/)
+[![Gradle Enterprise](https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?style=for-the-badge&logo=gradle)](https://ge.quarkus.io/scans)
 
 # Quarkus - Supersonic Subatomic Java
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -82,6 +82,32 @@
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>
+
+                <plugin>
+                <!-- config to avoid unbind-executions confuses gradle enterprise caching-->
+                <groupId>com.gradle</groupId>
+                <artifactId>gradle-enterprise-maven-extension</artifactId>
+                <configuration>
+                    <gradleEnterprise>
+                    <plugins>
+                        <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <inputs>
+                            <fileSets>
+                            <fileSet>
+                                <name>specs</name>
+                                <paths>
+                                <path>${project.basedir}/disable-unbind-executions</path>
+                                </paths>
+                                <normalization>RELATIVE_PATH</normalization>
+                            </fileSet>
+                            </fileSets>
+                        </inputs>
+                        </plugin>
+                    </plugins>
+                    </gradleEnterprise>
+                </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This is thesetup of gradle build scan that will publish to https://ge.quarkus.io only if you have an account and configured an access key.

To get that key setup run: `mvn gradle-enterprise:provision-access-key`

ping @maxandersen for account info if you need it :)

This PR is not touching/enabling any of this unless you have a key setup (i.e. GRADLE_ENTERPRISE_ACCEESS_KEY env variable). 