### PR TITLE
Openshift project and image group alignment

### DIFF
--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/util/ImageUtil.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/util/ImageUtil.java
@@ -15,12 +15,12 @@ public final class ImageUtil {
      * Create an image from the individual parts.
      *
      * @param registry The registry.
-     * @param repository The repository.
+     * @param repository The group.
      * @param name The name.
      * @param tag The tag.
      * @return The image.
      */
-    public static String getImage(Optional<String> registry, String repository, String name, String tag) {
+    public static String getImage(Optional<String> registry, String group, String name, String tag) {
         if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("Docker image name cannot be null!");
         }
@@ -29,10 +29,42 @@ public final class ImageUtil {
         }
         StringBuilder sb = new StringBuilder();
         registry.ifPresent(r -> sb.append(r).append(SLASH));
-        sb.append(repository).append(SLASH);
+        sb.append(group).append(SLASH);
 
         sb.append(name).append(COLN).append(tag);
         return sb.toString();
+    }
+
+    /**
+     * Return the image registry.
+     *
+     * @param image The docker image.
+     * @return The image registry.
+     */
+    public static Optional<String> getRegistry(String image) {
+        String[] parts = image.split(SLASH);
+        if (parts.length <= 2) {
+            //name:tag
+            //group/name:tag
+            return Optional.empty();
+        }
+        return Optional.ofNullable(parts[0]);
+    }
+
+    /**
+     * Return the image group.
+     *
+     * @param image The docker image.
+     * @return The image group.
+     */
+    public static String getGroup(String image) {
+        String[] parts = image.split(SLASH);
+        if (parts.length <= 2) {
+            //name:tag
+            //group/name:tag
+            return parts[0];
+        }
+        return parts[1];
     }
 
     /**
@@ -72,7 +104,7 @@ public final class ImageUtil {
         }
 
         if (tagged.contains(COLN)) {
-            return tagged.substring(0, tagged.indexOf(COLN));
+            return tagged.substring(0, tagged.lastIndexOf(COLN));
         }
         return tagged;
     }
@@ -85,7 +117,7 @@ public final class ImageUtil {
      */
     public static String getTag(String image) {
         if (image.contains(COLN)) {
-            return image.substring(image.indexOf(COLN) + 1);
+            return image.substring(image.lastIndexOf(COLN) + 1);
         }
         return image;
     }

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/DeploymentDecoratorBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/DeploymentDecoratorBuildItem.java
@@ -1,0 +1,54 @@
+
+package io.quarkus.kubernetes.spi;
+
+import java.util.Optional;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * A build item that wraps around Decorator objects.
+ * The purpose of those build items is to perform modification on the resources to be deployed.
+ * Note: The changes will not be reflected in the generated files, the resources will be modified directly on deployment.
+ * This is the main difference between this and {@link DeploymentDecoratorBuildItem}.
+ */
+public final class DeploymentDecoratorBuildItem extends MultiBuildItem {
+
+    /**
+     * The group the decorator will be applied to.
+     */
+    private final String group;
+
+    /**
+     * The decorator
+     */
+    private final Object decorator;
+
+    public DeploymentDecoratorBuildItem(Object decorator) {
+        this(null, decorator);
+    }
+
+    public DeploymentDecoratorBuildItem(String group, Object decorator) {
+        this.group = group;
+        this.decorator = decorator;
+    }
+
+    public String getGroup() {
+        return this.group;
+    }
+
+    public Object getDecorator() {
+        return this.decorator;
+    }
+
+    public boolean matches(Class type) {
+        return type.isInstance(decorator);
+
+    }
+
+    public <D> Optional<D> getDecorator(Class<D> type) {
+        if (matches(type)) {
+            return Optional.<D> of((D) decorator);
+        }
+        return Optional.empty();
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
@@ -36,6 +36,8 @@ public final class Constants {
     static final String S2I = "s2i";
     static final String DEFAULT_S2I_IMAGE_NAME = "s2i-java"; //refers to the Dekorate default image.
 
+    static final String OPENSHIFT_INTERNAL_REGISTRY = "image-registry.openshift-image-registry.svc:5000";
+
     static final String KNATIVE = "knative";
     static final String KNATIVE_SERVICE = "Service";
     static final String KNATIVE_SERVICE_GROUP = "serving.knative.dev";

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/DeploymentDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/DeploymentDecorator.java
@@ -1,0 +1,35 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Optional;
+
+import io.fabric8.kubernetes.client.Config;
+
+public interface DeploymentDecorator<D extends DeploymentDecorator<D>> {
+
+    /**
+     * Check if the decoratora has been applied.
+     *
+     * @return true if it has.
+     */
+    public boolean isApplied();
+
+    /**
+     * An optional message to display when applying the Decrator.
+     * As this decorator is not affecting files, its usually a good idea
+     * to log a message so that the user know what changed during deployment.
+     * This method is meant to be used for that purpose.
+     *
+     * @return an {@link Optional} message.
+     */
+    default Optional<String> getMessage() {
+        return Optional.empty();
+    }
+
+    /**
+     * Return an instance of the decroator that is aware of the kubernetes config.
+     *
+     * @param config The kubernetes config.
+     * @return an instance of the decorator.
+     */
+    public D withDeploymentContext(Config config);
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/DeploymentDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/DeploymentDecorator.java
@@ -7,14 +7,13 @@ import io.fabric8.kubernetes.client.Config;
 public interface DeploymentDecorator<D extends DeploymentDecorator<D>> {
 
     /**
-     * Check if the decoratora has been applied.
-     *
-     * @return true if it has.
+     * Check if the decorator has been applied.
+     * @return true if the decorator has been applied.
      */
     public boolean isApplied();
 
     /**
-     * An optional message to display when applying the Decrator.
+     * An optional message to display when applying the decorator.
      * As this decorator is not affecting files, its usually a good idea
      * to log a message so that the user know what changed during deployment.
      * This method is meant to be used for that purpose.

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -79,6 +79,12 @@ public class OpenshiftConfig implements PlatformConfiguration {
     Optional<String> partOf;
 
     /**
+     * When this property is set to true, on deployment time the name of the project will be set as image group.
+     */
+    @ConfigItem(defaultValue = "true")
+    boolean projectAsImageGroup;
+
+    /**
      * The name of the application. This value will be used for naming Kubernetes
      * resources like: 'Deployment', 'Service' and so on...
      */

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
@@ -5,6 +5,7 @@ import static io.quarkus.kubernetes.deployment.Constants.DEFAULT_S2I_IMAGE_NAME;
 import static io.quarkus.kubernetes.deployment.Constants.LIVENESS_PROBE;
 import static io.quarkus.kubernetes.deployment.Constants.OPENSHIFT;
 import static io.quarkus.kubernetes.deployment.Constants.OPENSHIFT_APP_RUNTIME;
+import static io.quarkus.kubernetes.deployment.Constants.OPENSHIFT_INTERNAL_REGISTRY;
 import static io.quarkus.kubernetes.deployment.Constants.QUARKUS;
 import static io.quarkus.kubernetes.deployment.Constants.READINESS_PROBE;
 import static io.quarkus.kubernetes.deployment.Constants.ROUTE;
@@ -76,7 +77,6 @@ import io.quarkus.kubernetes.spi.KubernetesServiceAccountBuildItem;
 public class OpenshiftProcessor {
 
     private static final int OPENSHIFT_PRIORITY = DEFAULT_PRIORITY;
-    private static final String OPENSHIFT_INTERNAL_REGISTRY = "image-registry.openshift-image-registry.svc:5000";
     private static final String DOCKERIO_REGISTRY = "docker.io";
     private static final String OPENSHIFT_V3_APP = "app";
     private static final String ANY = null;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProjectToImageGroupDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProjectToImageGroupDecorator.java
@@ -1,0 +1,63 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Optional;
+
+import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
+import io.fabric8.kubernetes.api.model.ContainerFluent;
+import io.fabric8.kubernetes.client.Config;
+import io.quarkus.container.image.deployment.util.ImageUtil;
+
+public class OpenshiftProjectToImageGroupDecorator extends ApplicationContainerDecorator<ContainerFluent<?>>
+        implements DeploymentDecorator<OpenshiftProjectToImageGroupDecorator> {
+
+    private static final String OPENSHIFT_INTERNAL_REGISTRY = "image-registry.openshift-image-registry.svc:5000";
+
+    private final String name;
+    private final String namespace;
+
+    private Optional<String> message;
+
+    public OpenshiftProjectToImageGroupDecorator(String name) {
+        this(name, ANY);
+    }
+
+    public OpenshiftProjectToImageGroupDecorator(String name, String namespace) {
+        super(ANY, ANY);
+        this.name = name;
+        this.namespace = namespace;
+    }
+
+    @Override
+    public void andThenVisit(ContainerFluent<?> container) {
+        if (namespace == null || namespace.isEmpty()) {
+            return;
+        }
+        String image = container.getImage();
+        Optional<String> registry = ImageUtil.getRegistry(image);
+        String group = ImageUtil.getGroup(image);
+        if (!group.equals(namespace)
+                && name.equals(ImageUtil.getName(image))
+                && registry.map(r -> r.equals(OPENSHIFT_INTERNAL_REGISTRY)).orElse(false)) {
+
+            String newImage = ImageUtil.getImage(registry, namespace, name, ImageUtil.getTag(image));
+            container.withImage(newImage);
+            message = Optional.of("Changed image to: " + newImage
+                    + " so that it matches the internal registry of Openshift. This feature can be disabled using the flag `quarkus.openshift.project-as-image-group`.");
+        }
+    }
+
+    @Override
+    public boolean isApplied() {
+        return message.isPresent();
+    }
+
+    @Override
+    public Optional<String> getMessage() {
+        return message;
+    }
+
+    @Override
+    public OpenshiftProjectToImageGroupDecorator withDeploymentContext(Config config) {
+        return new OpenshiftProjectToImageGroupDecorator(name, config.getNamespace());
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProjectToImageGroupDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProjectToImageGroupDecorator.java
@@ -1,5 +1,7 @@
 package io.quarkus.kubernetes.deployment;
 
+import static io.quarkus.kubernetes.deployment.Constants.OPENSHIFT_INTERNAL_REGISTRY;
+
 import java.util.Optional;
 
 import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
@@ -9,8 +11,6 @@ import io.quarkus.container.image.deployment.util.ImageUtil;
 
 public class OpenshiftProjectToImageGroupDecorator extends ApplicationContainerDecorator<ContainerFluent<?>>
         implements DeploymentDecorator<OpenshiftProjectToImageGroupDecorator> {
-
-    private static final String OPENSHIFT_INTERNAL_REGISTRY = "image-registry.openshift-image-registry.svc:5000";
 
     private final String name;
     private final String namespace;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProjectToImageGroupRequestBuildItem.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProjectToImageGroupRequestBuildItem.java
@@ -1,0 +1,6 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class OpenshiftProjectToImageGroupRequestBuildItem extends SimpleBuildItem {
+}


### PR DESCRIPTION
The current pull request does the following:

- Introduce decorator build items for deployment time
- Use deployment decorators to change image group so that it matches Openshift project when needed.
- Minor fixes in ImageUtil
  - fix handling of ':'
  - add getGroup()
  - add getRegistry()

