### PR TITLE
Fix NPE when OIDC TenantConfigResolver returns null

### DIFF
--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
@@ -124,6 +124,18 @@ public class CodeFlowDevModeTestCase {
 
             assertEquals("tenant-config-resolver:alice", page.getBody().asNormalizedText());
             webClient.getCookieManager().clearCookies();
+            try {
+                webClient.getPage("http://localhost:8080/protected/tenant/null-tenant");
+                fail("401 status error is expected");
+            } catch (FailingHttpStatusCodeException ex) {
+                assertEquals(401, ex.getStatusCode());
+            }
+            try {
+                webClient.getPage("http://localhost:8080/protected/tenant/unknown-tenant");
+                fail("401 status error is expected");
+            } catch (FailingHttpStatusCodeException ex) {
+                assertEquals(401, ex.getStatusCode());
+            }
         }
     }
 

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantConfigResolver.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantConfigResolver.java
@@ -22,6 +22,9 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
             config.setApplicationType(ApplicationType.WEB_APP);
             return Uni.createFrom().item(config);
         }
+        if (context.request().path().endsWith("/null-tenant")) {
+            return null;
+        }
         return Uni.createFrom().nullItem();
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -185,7 +185,12 @@ public class DefaultTenantConfigResolver {
         if (tenantConfigResolver.isResolvable()) {
             Uni<OidcTenantConfig> oidcConfig = context.get(CURRENT_DYNAMIC_TENANT_CONFIG);
             if (oidcConfig == null) {
-                oidcConfig = tenantConfigResolver.get().resolve(context, blockingRequestContext).memoize().indefinitely();
+                oidcConfig = tenantConfigResolver.get().resolve(context, blockingRequestContext);
+                if (oidcConfig == null) {
+                    //shouldn't happen, but guard against it anyway
+                    oidcConfig = Uni.createFrom().nullItem();
+                }
+                oidcConfig = oidcConfig.memoize().indefinitely();
                 if (oidcConfig == null) {
                     //shouldn't happen, but guard against it anyway
                     oidcConfig = Uni.createFrom().nullItem();


### PR DESCRIPTION
Fixes #32449.

If a custom OIDC `TenantConfigResolver` returns `null`, as opposed to `Uni.createFrom().nullitem()`, Uni `memoize` function will throw NPE, leading, in the linked issue, to `500`. So this PR only adds a null check before calling `memoize`, and updates the test to confirm that returning both `null` and `Uni.createFrom().nullitem()` lead to 401 when the current URL can not be used to resolve a valid tenant