### PR TITLE
Upgrade Oracle DB container images to use the slim-faststart variant

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -94,7 +94,7 @@
         <db2.image>docker.io/ibmcom/db2:11.5.7.0a</db2.image>
         <mssql.image>mcr.microsoft.com/mssql/server:2019-latest</mssql.image>
         <mysql.image>docker.io/mysql:8.0</mysql.image>
-        <oracle.image>docker.io/gvenzl/oracle-free:23.2.0-faststart</oracle.image>
+        <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
         <mongo.image>docker.io/mongo:4.4</mongo.image>
 
         <!-- Align various dependencies that are not really part of the bom-->

--- a/integration-tests/jpa-oracle/README.md
+++ b/integration-tests/jpa-oracle/README.md
@@ -22,7 +22,7 @@ Authentication parameters might need to be changed in the Quarkus configuration 
 ### Starting Oracle via docker
 
 ```
-docker run --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test docker.io/gvenzl/oracle-free:23.2.0-faststart
+docker run --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test docker.io/gvenzl/oracle-free:23-slim-faststart
 ```
 
 This will start a local instance with the configuration matching the parameters used by the integration tests of this module.

--- a/integration-tests/reactive-oracle-client/README.md
+++ b/integration-tests/reactive-oracle-client/README.md
@@ -23,7 +23,7 @@ Authentication parameters might need to be changed in the Quarkus configuration 
 ### Starting Oracle via docker
 
 ```
-docker run --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test docker.io/gvenzl/oracle-free:23.2.0-faststart
+docker run --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test docker.io/gvenzl/oracle-free:23-slim-faststart
 ```
 
 This will start a local instance with the configuration matching the parameters used by the integration tests of this module.


### PR DESCRIPTION
These more suitable images (for Quarkus purposes) were just released last night.