### PR TITLE
Avoid null pointer exception when building containers

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/worker/BuildWorker.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/worker/BuildWorker.java
@@ -59,7 +59,7 @@ public abstract class BuildWorker extends QuarkusWorker<BuildWorkerParams> {
                     LOGGER.warn("AugmentResult.results = null");
                 } else {
                     LOGGER.info("AugmentResult.results = {}", results.stream().map(ArtifactResult::getPath)
-                            .map(Object::toString).collect(Collectors.joining("\n    ", "\n    ", "")));
+                            .map(r -> r == null ? "null" : r.toString()).collect(Collectors.joining("\n    ", "\n    ", "")));
                 }
                 JarResult jar = result.getJar();
                 LOGGER.info("AugmentResult:");


### PR DESCRIPTION
ArtifactResultBuildItem#path is set to `null` for Artifact results of type `native-container` and `jar-container`

Follow up to #31166 (cc @snazy) 
Closes #32418