### PR TITLE
Throw the exception if OIDC client fails to acquire the token

### DIFF
--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/AbstractOidcClientRequestFilter.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/AbstractOidcClientRequestFilter.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientRequestFilter;
 import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.Response;
 
 import org.jboss.logging.Logger;
 
@@ -26,10 +25,11 @@ public class AbstractOidcClientRequestFilter extends AbstractTokensProducer impl
             final String accessToken = getAccessToken();
             requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, BEARER_SCHEME_WITH_SPACE + accessToken);
         } catch (DisabledOidcClientException ex) {
-            requestContext.abortWith(Response.status(500).build());
+            LOG.debug("Client is disabled, aborting the request");
+            throw ex;
         } catch (Exception ex) {
-            LOG.debugf("Access token is not available, aborting the request with HTTP 401 error: %s", ex.getMessage());
-            requestContext.abortWith(Response.status(401).build());
+            LOG.debugf("Access token is not available, cause: %s, aborting the request", ex.getMessage());
+            throw (ex instanceof RuntimeException) ? (RuntimeException) ex : new RuntimeException(ex);
         }
     }
 

--- a/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/AbstractOidcClientRequestReactiveFilter.java
+++ b/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/AbstractOidcClientRequestReactiveFilter.java
@@ -3,7 +3,6 @@ package io.quarkus.oidc.client.reactive.filter.runtime;
 import java.util.function.Consumer;
 
 import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.Response;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
@@ -40,13 +39,11 @@ public class AbstractOidcClientRequestReactiveFilter extends AbstractTokensProdu
             @Override
             public void accept(Throwable t) {
                 if (t instanceof DisabledOidcClientException) {
-                    LOG.debug("Client is disabled");
-                    requestContext.abortWith(Response.status(Response.Status.INTERNAL_SERVER_ERROR).build());
+                    LOG.debug("Client is disabled, aborting the request");
                 } else {
-                    LOG.debugf("Access token is not available, aborting the request with HTTP 401 error: %s", t.getMessage());
-                    requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
+                    LOG.debugf("Access token is not available, cause: %s, aborting the request", t.getMessage());
                 }
-                requestContext.resume();
+                requestContext.resume((t instanceof RuntimeException) ? t : new RuntimeException(t));
             }
         });
     }

--- a/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.keycloak;
 
+import java.util.function.Function;
+
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -23,6 +25,10 @@ public class FrontendResource {
     @RestClient
     ProtectedResourceServiceNamedFilter protectedResourceServiceNamedFilter;
 
+    @Inject
+    @RestClient
+    MisconfiguredClientFilter misconfiguredClientFilter;
+
     @GET
     @Path("userNameCustomFilter")
     @Produces("text/plain")
@@ -42,5 +48,20 @@ public class FrontendResource {
     @Produces("text/plain")
     public Uni<String> userNameNamedFilter() {
         return protectedResourceServiceNamedFilter.getUserName();
+    }
+
+    @GET
+    @Path("userNameMisconfiguredClientFilter")
+    @Produces("text/plain")
+    public Uni<String> userNameMisconfiguredClientFilter() {
+        return misconfiguredClientFilter.getUserName().onFailure(Throwable.class)
+                .recoverWithItem(new Function<Throwable, String>() {
+
+                    @Override
+                    public String apply(Throwable t) {
+                        return t.getMessage();
+                    }
+
+                });
     }
 }

--- a/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/MisconfiguredClientFilter.java
+++ b/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/MisconfiguredClientFilter.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.oidc.client.filter.OidcClientFilter;
+import io.smallrye.mutiny.Uni;
+
+@RegisterRestClient
+@OidcClientFilter("misconfigured-client")
+@Path("/")
+public interface MisconfiguredClientFilter {
+
+    @GET
+    @Produces("text/plain")
+    @Path("userNameReactive")
+    Uni<String> getUserName();
+}

--- a/integration-tests/oidc-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-reactive/src/main/resources/application.properties
@@ -17,9 +17,17 @@ quarkus.oidc-client.named-client.grant.type=password
 quarkus.oidc-client.named-client.grant-options.password.username=jdoe
 quarkus.oidc-client.named-client.grant-options.password.password=jdoe
 
+quarkus.oidc-client.misconfigured-client.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc-client.misconfigured-client.client-id=${quarkus.oidc.client-id}
+quarkus.oidc-client.misconfigured-client.credentials.secret=${quarkus.oidc.credentials.secret}
+quarkus.oidc-client.misconfigured-client.grant.type=password
+quarkus.oidc-client.misconfigured-client.grant-options.password.username=jdoe
+quarkus.oidc-client.misconfigured-client.grant-options.password.password=bob
+
 io.quarkus.it.keycloak.ProtectedResourceServiceCustomFilter/mp-rest/url=http://localhost:8081/protected
 io.quarkus.it.keycloak.ProtectedResourceServiceReactiveFilter/mp-rest/url=http://localhost:8081/protected
 io.quarkus.it.keycloak.ProtectedResourceServiceNamedFilter/mp-rest/url=http://localhost:8081/protected
+io.quarkus.it.keycloak.MisconfiguredClientFilter/mp-rest/url=http://localhost:8081/protected
 
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=TRACE

--- a/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -2,6 +2,7 @@ package io.quarkus.it.keycloak;
 
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -42,6 +43,15 @@ public class OidcClientTest {
                 .then()
                 .statusCode(200)
                 .body(equalTo("jdoe"));
+    }
+
+    @Test
+    public void testGetUserNameMisconfiguredClientFilter() {
+        RestAssured.given().header("Accept", "text/plain")
+                .when().get("/frontend/userNameMisconfiguredClientFilter")
+                .then()
+                .statusCode(200)
+                .body(containsString("invalid_grant"));
     }
 
     @Test

--- a/integration-tests/oidc-client/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -3,6 +3,7 @@ package io.quarkus.it.keycloak;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -30,6 +31,10 @@ public class FrontendResource {
     ProtectedResourceServiceNonDefaultOidcClient protectedResourceServiceNonDefaultOidcClient;
 
     @Inject
+    @RestClient
+    MisconfiguredClientFilter misconfiguredClientFilter;
+
+    @Inject
     ManagedExecutor managedExecutor;
 
     private Object lock = new Object();
@@ -45,6 +50,17 @@ public class FrontendResource {
     @Path("userNonDefaultOidcClient")
     public String userNameNonDefaultOidcClient() {
         return protectedResourceServiceNonDefaultOidcClient.getUserName();
+    }
+
+    @GET
+    @Path("userNameMisconfiguredClientFilter")
+    @Produces("text/plain")
+    public String userNameMisconfiguredClientFilter() {
+        try {
+            return misconfiguredClientFilter.getUserName();
+        } catch (Throwable t) {
+            return t.getMessage();
+        }
     }
 
     @GET

--- a/integration-tests/oidc-client/src/main/java/io/quarkus/it/keycloak/MisconfiguredClientFilter.java
+++ b/integration-tests/oidc-client/src/main/java/io/quarkus/it/keycloak/MisconfiguredClientFilter.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.oidc.client.filter.OidcClientFilter;
+
+@RegisterRestClient
+@OidcClientFilter("misconfigured-client")
+@Path("/")
+public interface MisconfiguredClientFilter {
+
+    @GET
+    String getUserName();
+}

--- a/integration-tests/oidc-client/src/main/resources/application.properties
+++ b/integration-tests/oidc-client/src/main/resources/application.properties
@@ -16,6 +16,14 @@ quarkus.oidc-client.named.grant.type=password
 quarkus.oidc-client.named.grant-options.password.username=alice
 quarkus.oidc-client.named.grant-options.password.password=alice
 
+quarkus.oidc-client.misconfigured-client.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc-client.misconfigured-client.client-id=${quarkus.oidc.client-id}
+quarkus.oidc-client.misconfigured-client.credentials.secret=${quarkus.oidc.credentials.secret}
+quarkus.oidc-client.misconfigured-client.grant.type=password
+quarkus.oidc-client.misconfigured-client.grant-options.password.username=jdoe
+quarkus.oidc-client.misconfigured-client.grant-options.password.password=bob
+quarkus.oidc-client.misconfigured-client.early-tokens-acquisition=false
+
 quarkus.oidc-client.non-default-client.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.non-default-client.client-id=${quarkus.oidc.client-id}
 quarkus.oidc-client.non-default-client.credentials.secret=${quarkus.oidc.credentials.secret}
@@ -28,6 +36,7 @@ io.quarkus.it.keycloak.ProtectedResourceServiceOidcClient/mp-rest/url=http://loc
 io.quarkus.it.keycloak.ProtectedResourceServiceNamedOidcClient/mp-rest/url=http://localhost:8081/protected
 io.quarkus.it.keycloak.ProtectedResourceServiceNoOidcClient/mp-rest/url=http://localhost:8081/protected
 io.quarkus.it.keycloak.ProtectedResourceServiceNonDefaultOidcClient/mp-rest/url=http://localhost:8081/protected
+io.quarkus.it.keycloak.MisconfiguredClientFilter/mp-rest/url=http://localhost:8081/protected
 
 quarkus.tls.trust-all=true
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE

--- a/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -2,6 +2,7 @@ package io.quarkus.it.keycloak;
 
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -34,6 +35,15 @@ public class OidcClientTest {
                 .then()
                 .statusCode(200)
                 .body(equalTo("alice"));
+    }
+
+    @Test
+    public void testGetUserNameMisconfiguredClientFilter() {
+        RestAssured.given().header("Accept", "text/plain")
+                .when().get("/frontend/userNameMisconfiguredClientFilter")
+                .then()
+                .statusCode(200)
+                .body(containsString("invalid_grant"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #32480.

Hi @geoand 

Here I have updated both the Resteasy reactive and classic OIDC client filters to report an exception when OIDC client filter fails to acquire the token, since having this token is a precondition for the main target be invoked, instead of aborting the request with 401/500 - as it is in fact misleading - the client can think this is coming from the target server.

I've added 2 tests, one for the OIDC Resteasy classic client filter - the test passes, and another for the OIDC Resteasy reactive client filter - this one fails, the exception reported from the filter is ignored and the call to the test endpoint (from `FrontendResource` to `ProtectedResource`) goes ahead.
 
Can you have a look please when you'll have time ? I was not sure how to resume the suspended thread when throwing the exception, I decided to do it in the `finally` block, but I also tried to avoid resuming  at all and putting the resume call at the very top of the `Consumer<Throwable>` code  

Thanks