### PR TITLE
Use list with an empty string by default in generated Role/ClusterRole

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
@@ -104,6 +104,7 @@ public class KubernetesCommonHelper {
     private static final String[] PROMETHEUS_ANNOTATION_TARGETS = { "Service",
             "Deployment", "DeploymentConfig" };
     private static final String DEFAULT_ROLE_NAME_VIEW = "view";
+    private static final List<String> LIST_WITH_EMPTY = List.of("");
 
     public static Optional<Project> createProject(ApplicationInfoBuildItem app,
             Optional<CustomProjectRootBuildItem> customProjectRoot, OutputTargetBuildItem outputTarget,
@@ -1011,7 +1012,7 @@ public class KubernetesCommonHelper {
         return policyRules.values()
                 .stream()
                 .map(it -> new PolicyRuleBuilder()
-                        .withApiGroups(it.apiGroups.orElse(null))
+                        .withApiGroups(it.apiGroups.orElse(LIST_WITH_EMPTY))
                         .withNonResourceURLs(it.nonResourceUrls.orElse(null))
                         .withResourceNames(it.resourceNames.orElse(null))
                         .withResources(it.resources.orElse(null))

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithRbacFullTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithRbacFullTest.java
@@ -61,6 +61,7 @@ public class KubernetesWithRbacFullTest {
         Role podWriterRole = getRoleByName(kubernetesList, "pod-writer");
         assertEquals(APP_NAMESPACE, podWriterRole.getMetadata().getNamespace());
         assertThat(podWriterRole.getRules()).satisfiesOnlyOnce(r -> {
+            assertThat(r.getApiGroups()).containsExactly("");
             assertThat(r.getResources()).containsExactly("pods");
             assertThat(r.getVerbs()).containsExactly("update");
         });
@@ -69,6 +70,7 @@ public class KubernetesWithRbacFullTest {
         Role podReaderRole = getRoleByName(kubernetesList, "pod-reader");
         assertEquals("projectb", podReaderRole.getMetadata().getNamespace());
         assertThat(podReaderRole.getRules()).satisfiesOnlyOnce(r -> {
+            assertThat(r.getApiGroups()).containsExactly("");
             assertThat(r.getResources()).containsExactly("pods");
             assertThat(r.getVerbs()).containsExactly("get", "watch", "list");
         });
@@ -76,6 +78,7 @@ public class KubernetesWithRbacFullTest {
         // secret-reader assertions
         ClusterRole secretReaderRole = getClusterRoleByName(kubernetesList, "secret-reader");
         assertThat(secretReaderRole.getRules()).satisfiesOnlyOnce(r -> {
+            assertThat(r.getApiGroups()).containsExactly("");
             assertThat(r.getResources()).containsExactly("secrets");
             assertThat(r.getVerbs()).containsExactly("get", "watch", "list");
         });


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/32519