### PR TITLE
Gradle: ability to disable worker process isolation, pass all envs+sys-props

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildTask.java
@@ -163,9 +163,7 @@ abstract class QuarkusBuildTask extends QuarkusTask {
                             .collect(Collectors.joining("\n    ", "\n    ", "")));
         }
 
-        WorkQueue workQueue = getWorkerExecutor()
-                .processIsolation(processWorkerSpec -> configureProcessWorkerSpec(processWorkerSpec, effectiveConfig,
-                        extension().buildForkOptions));
+        WorkQueue workQueue = workQueue(effectiveConfig, () -> extension().buildForkOptions);
 
         workQueue.submit(BuildWorker.class, params -> {
             params.getBuildSystemProperties().putAll(effectiveConfig.configMap());

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -104,9 +104,7 @@ public abstract class QuarkusGenerateCode extends QuarkusTask {
         getLogger().debug("Will trigger preparing sources for source directory: {} buildDir: {}",
                 sourcesDirectories, getProject().getBuildDir().getAbsolutePath());
 
-        WorkQueue workQueue = getWorkerExecutor()
-                .processIsolation(processWorkerSpec -> configureProcessWorkerSpec(processWorkerSpec, effectiveConfig,
-                        extension().codeGenForkOptions));
+        WorkQueue workQueue = workQueue(effectiveConfig, () -> extension().codeGenForkOptions);
 
         workQueue.submit(CodeGenWorker.class, params -> {
             params.getBuildSystemProperties().putAll(effectiveConfig.configMap());


### PR DESCRIPTION
* Gradle workers for Quarkus use _process_ isaolation by default. This can make debugging "tricky". This change changes this to _class loader_ isolation, if the `org.gradle.debug` or the `quarkus.gradle-worker.no-process` property is set to `true`.
* Also ensure that all environment variables and system properties are passed to the worker processes.

See also #32465