### PR TITLE
Fix Quarkus Update fetch latest

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Update.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Update.java
@@ -15,7 +15,7 @@ public class Update extends BaseBuildCommand implements Callable<Integer> {
     @CommandLine.ArgGroup(order = 0, heading = "%nTarget Quarkus version:%n", multiplicity = "0..1")
     TargetQuarkusVersionGroup targetQuarkusVersion = new TargetQuarkusVersionGroup();
 
-    @CommandLine.ArgGroup(order = 1, heading = "%nRewrite:%n")
+    @CommandLine.ArgGroup(order = 1, heading = "%nRewrite:%n", exclusive = false)
     RewriteGroup rewrite = new RewriteGroup();
 
     @CommandLine.Option(order = 2, names = { "--per-module" }, description = "Display information per project module.")

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -163,7 +163,7 @@ public class GradleRunner implements BuildSystemRunner {
             args.add(targetQuarkusVersion.platformVersion);
         }
         if (!StringUtil.isNullOrEmpty(targetQuarkusVersion.streamId)) {
-            args.add("--streamId");
+            args.add("--stream");
             args.add(targetQuarkusVersion.streamId);
         }
         if (rewrite.pluginVersion != null) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
@@ -29,7 +29,7 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
 
     private String rewritePluginVersion = QuarkusUpdateCommand.DEFAULT_GRADLE_REWRITE_PLUGIN_VERSION;
 
-    private String rewriteUpdateRecipesVersion;
+    private String rewriteUpdateRecipesVersion = null;
 
     @Input
     @Optional
@@ -93,7 +93,7 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
         return targetStreamId;
     }
 
-    @Option(description = "A target stream id, for example:  2.0", option = "streamId")
+    @Option(description = "A target stream, for example:  2.0", option = "stream")
     public void setStreamId(String targetStreamId) {
         this.targetStreamId = targetStreamId;
     }
@@ -141,7 +141,12 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
 
         final UpdateProject invoker = new UpdateProject(quarkusProject);
         invoker.latestCatalog(targetCatalog);
-        invoker.rewritePluginVersion(rewritePluginVersion);
+        if (rewriteUpdateRecipesVersion != null) {
+            invoker.rewriteUpdateRecipesVersion(rewriteUpdateRecipesVersion);
+        }
+        if (rewritePluginVersion != null) {
+            invoker.rewritePluginVersion(rewritePluginVersion);
+        }
         invoker.targetPlatformVersion(targetPlatformVersion);
         invoker.rewriteDryRun(rewriteDryRun);
         invoker.noRewrite(noRewrite);

--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -15,6 +15,7 @@ import io.quarkus.devtools.commands.UpdateProject;
 import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
 import io.quarkus.devtools.project.QuarkusProject;
+import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devtools.project.update.QuarkusUpdateCommand;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.registry.RegistryResolutionException;
@@ -91,7 +92,7 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
 
     @Override
     protected void processProjectState(QuarkusProject quarkusProject) throws MojoExecutionException {
-
+        QuarkusProjectHelper.setArtifactResolver(artifactResolver());
         final ExtensionCatalog targetCatalog;
         try {
             if (platformVersion != null) {
@@ -120,7 +121,7 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
             invoker.rewritePluginVersion(rewritePluginVersion);
         }
         if (rewriteUpdateRecipesVersion != null) {
-            invoker.rewritePluginVersion(rewriteUpdateRecipesVersion);
+            invoker.rewriteUpdateRecipesVersion(rewriteUpdateRecipesVersion);
         }
         invoker.rewriteDryRun(rewriteDryRun);
         invoker.noRewrite(noRewrite);

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -83,6 +83,8 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
                             QuarkusProjectHelper.artifactResolver(), updateRecipesVersion, request);
                     final String rewritePluginVersion = invocation.getValue(UpdateProject.REWRITE_PLUGIN_VERSION);
                     final boolean rewriteDryRun = invocation.getValue(UpdateProject.REWRITE_DRY_RUN, false);
+                    invocation.log().warn(
+                            "The update feature does not yet handle updates of the extension versions. If needed, update your extensions manually.");
                     QuarkusUpdateCommand.handle(
                             invocation.log(),
                             quarkusProject.getExtensionManager().getBuildTool(),


### PR DESCRIPTION
- Fixes #32288 by adding `QuarkusProjectHelper.setArtifactResolver(artifactResolver());` in UpdateMojo
- Rename `streamId`to `stream` in Gradle update
- Fix connection problem with `updateRecipesVersion`
- Add warning log about extensions versions update