### PR TITLE
Pass method arguments to permissions on RESTEasy Reactive endpoints

### DIFF
--- a/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
+++ b/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
@@ -591,13 +591,7 @@ However this option comes with a price, as the `LibraryPermission` must be insta
 <2> Here, the first `Library` parameter is `migrate`, therefore we marked `library` parameter explicitly via `PermissionsAllowed#params`.
 Please note that both Permission constructor and annotated method must have parameter `library`, otherwise validation will fail.
 
-CAUTION: If you would like to pass method parameters to a custom `Permission` constructor from RESTEasy Reactive endpoints,
-make sure you have `@PermissionsAllowed` annotation set not on the JAX-RS resource method itself, but on the injected CDI
-bean to which this method will delegate to. Setting `@PermissionsAllowed` on the JAX-RS resource method will not work
-because RESTEasy Reactive performs the security checks before the deserialization.
-These limitations are demonstrated in the example below.
-
-.Example of endpoint limitations when it comes to passing annotated method arguments to the Permission constructor
+.Example of resource secured with the `LibraryPermission`
 
 [source,java]
 ----
@@ -610,7 +604,7 @@ public class LibraryResource {
     @PermissionsAllowed(value = "tv:write", permission = LibraryPermission.class)
     @PUT
     @Path("/id/{id}")
-    public Library updateLibrary(@PathParam("id") Integer id, Library library) { <1>
+    public Library updateLibrary(@PathParam("id") Integer id, Library library) {
         ...
     }
 
@@ -618,15 +612,11 @@ public class LibraryResource {
     @Path("/service-way/id/{id}")
     public Library updateLibrarySvc(@PathParam("id") Integer id, Library library) {
         String newDescription = "new description " + id;
-        return libraryService.updateLibrary(newDescription, library); <2>
+        return libraryService.updateLibrary(newDescription, library);
     }
 
 }
 ----
-<1> In the RESTEasy Reactive, the endpoint argument `library` won't ever be passed to the `LibraryPermission`, because it is not available.
-Instead, Quarkus will pass `null` for the argument `library`.
-That gives you option to reuse your custom Permission when the method argument (like `library`) is optional.
-<2> Argument `library` will be passed to the `LibraryPermission` constructor as the `LibraryService#updateLibrary` method is not an endpoint.
 
 Similarly to the `CRUDResource` example, we can use permission to role mapping and grant user with role `admin` right to
 update `MediaLibrary`:

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/CustomPermissionWithExtraArgs.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/CustomPermissionWithExtraArgs.java
@@ -1,0 +1,51 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import java.security.Permission;
+import java.util.Objects;
+
+public class CustomPermissionWithExtraArgs extends Permission {
+
+    private final String permName;
+    private final String goodbye;
+    private final String toWhom;
+    private final int day;
+    private final String place;
+
+    public CustomPermissionWithExtraArgs(String permName, String goodbye, String toWhom, int day, String place) {
+        super(permName);
+        this.permName = permName;
+        this.goodbye = goodbye;
+        this.toWhom = toWhom;
+        this.day = day;
+        this.place = place;
+    }
+
+    @Override
+    public boolean implies(Permission permission) {
+        if (permission instanceof CustomPermissionWithExtraArgs) {
+            return permission.equals(this);
+        }
+        return false;
+    }
+
+    @Override
+    public String getActions() {
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        CustomPermissionWithExtraArgs that = (CustomPermissionWithExtraArgs) o;
+        return day == that.day && Objects.equals(permName, that.permName) && Objects.equals(goodbye, that.goodbye)
+                && Objects.equals(toWhom, that.toWhom) && Objects.equals(place, that.place);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(permName, goodbye, toWhom, day, place);
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/LazyAuthPermissionsAllowedTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/LazyAuthPermissionsAllowedTestCase.java
@@ -14,7 +14,7 @@ public class LazyAuthPermissionsAllowedTestCase extends AbstractPermissionsAllow
             .withApplicationRoot((jar) -> jar
                     .addClasses(PermissionsAllowedResource.class, TestIdentityProvider.class, TestIdentityController.class,
                             NonBlockingPermissionsAllowedResource.class, CustomPermission.class,
-                            PermissionsIdentityAugmentor.class)
+                            PermissionsIdentityAugmentor.class, CustomPermissionWithExtraArgs.class)
                     .addAsResource(new StringAsset("quarkus.http.auth.proactive=false\n"),
                             "application.properties"));
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/NonBlockingPermissionsAllowedResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/NonBlockingPermissionsAllowedResource.java
@@ -7,6 +7,10 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 
+import org.jboss.resteasy.reactive.RestCookie;
+import org.jboss.resteasy.reactive.RestHeader;
+import org.jboss.resteasy.reactive.RestPath;
+
 import io.quarkus.security.PermissionsAllowed;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.smallrye.mutiny.Uni;
@@ -44,5 +48,14 @@ public class NonBlockingPermissionsAllowedResource {
     @GET
     public Uni<String> greetings(@QueryParam("greeting") String greeting) {
         return Uni.createFrom().item(greeting);
+    }
+
+    @PermissionsAllowed(value = "farewell", permission = CustomPermissionWithExtraArgs.class)
+    @Path("/custom-perm-with-args/{goodbye}")
+    @POST
+    public Uni<String> farewell(@RestPath String goodbye, @RestHeader("toWhom") String toWhom, @RestCookie int day,
+            String place) {
+        String farewell = String.join(" ", new String[] { goodbye, toWhom, Integer.toString(day), place });
+        return Uni.createFrom().item(farewell);
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/PermissionsAllowedResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/PermissionsAllowedResource.java
@@ -6,6 +6,10 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 
+import org.jboss.resteasy.reactive.RestCookie;
+import org.jboss.resteasy.reactive.RestHeader;
+import org.jboss.resteasy.reactive.RestPath;
+
 import io.quarkus.security.PermissionsAllowed;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.smallrye.common.annotation.NonBlocking;
@@ -45,4 +49,12 @@ public class PermissionsAllowedResource {
         return greeting;
     }
 
+    @PermissionsAllowed(value = "farewell", permission = CustomPermissionWithExtraArgs.class, params = { "goodbye", "toWhom",
+            "day", "place" })
+    @Path("/custom-perm-with-args/{goodbye}")
+    @POST
+    public String farewell(@RestPath String goodbye, @RestHeader("toWhom") String toWhom, @RestCookie int day, String place) {
+        String farewell = String.join(" ", new String[] { goodbye, toWhom, Integer.toString(day), place });
+        return farewell;
+    }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/PermissionsIdentityAugmentor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/PermissionsIdentityAugmentor.java
@@ -30,10 +30,12 @@ public class PermissionsIdentityAugmentor implements SecurityIdentityAugmentor {
         switch (identity.getPrincipal().getName()) {
             case "admin":
                 builder.addPermissionChecker(new PermissionCheckBuilder().addPermission("update").addPermission("create")
-                        .addPermission("read", "resource-admin").addCustomPermission().build());
+                        .addPermission("read", "resource-admin").addCustomPermission()
+                        .addCustomPermission("farewell", "so long", "Nelson", 3, "Ostrava").build());
                 break;
             case "user":
                 builder.addPermissionChecker(new PermissionCheckBuilder().addPermission("update").addPermission("get-identity")
+                        .addCustomPermission("farewell", "so long", "Nelson", 3, "Prague")
                         .addPermission("read", "resource-admin").build());
                 break;
             case "viewer":
@@ -59,6 +61,11 @@ public class PermissionsIdentityAugmentor implements SecurityIdentityAugmentor {
 
         PermissionCheckBuilder addCustomPermission() {
             permissionSet.add(new CustomPermission("ignored"));
+            return this;
+        }
+
+        PermissionCheckBuilder addCustomPermission(String permName, String goodbye, String toWhom, int day, String place) {
+            permissionSet.add(new CustomPermissionWithExtraArgs(permName, goodbye, toWhom, day, place));
             return this;
         }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/ProactiveAuthPermissionsAllowedTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/ProactiveAuthPermissionsAllowedTestCase.java
@@ -13,6 +13,6 @@ public class ProactiveAuthPermissionsAllowedTestCase extends AbstractPermissions
             .withApplicationRoot((jar) -> jar
                     .addClasses(PermissionsAllowedResource.class, TestIdentityProvider.class, TestIdentityController.class,
                             NonBlockingPermissionsAllowedResource.class, CustomPermission.class,
-                            PermissionsIdentityAugmentor.class));
+                            PermissionsIdentityAugmentor.class, CustomPermissionWithExtraArgs.class));
 
 }

--- a/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/SecurityCheck.java
+++ b/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/SecurityCheck.java
@@ -24,4 +24,18 @@ public interface SecurityCheck {
     default boolean isPermitAll() {
         return false;
     }
+
+    /**
+     * Security checks may be performed before the secured method is actually invoked.
+     * This happens to make sure they are run before serialization and fully asynchronous checks work as expected.
+     * However, if the security checks requires arguments of invoked method, it is possible to postpone this check
+     * to the moment when arguments are available.
+     *
+     * IMPORTANT: in order to avoid security risks, all requests with postponed security checks must be authenticated
+     *
+     * @return true if the security check needs method parameters to work correctly
+     */
+    default boolean requiresMethodArguments() {
+        return false;
+    }
 }

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/PermissionSecurityCheck.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/check/PermissionSecurityCheck.java
@@ -65,6 +65,11 @@ public abstract class PermissionSecurityCheck<T> implements SecurityCheck {
         return checkPermissions(identity, getPermissions(parameters), 0);
     }
 
+    @Override
+    public boolean requiresMethodArguments() {
+        return useComputedPermissions;
+    }
+
     private static void throwException(SecurityIdentity identity) {
         if (identity.isAnonymous()) {
             throw new UnauthorizedException();


### PR DESCRIPTION
closes: #32030

Allows security checks to be performed by CDI interceptor rather than `ServerRestHandler` as long as request is authenticated. Requirement of authentication mitigate some security risks as DoS and but also tells us we have identity available so it don't need to be created on worker thread in cases when endpoint returns something in a synchronous manner and proactive auth is disabled. As far as permission check is concerned, it changes nothing as only authenticated user may hold permissions.