### PR TITLE
Various Quarkus Update fixes and enhancements

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Update.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Update.java
@@ -15,7 +15,7 @@ public class Update extends BaseBuildCommand implements Callable<Integer> {
     @CommandLine.ArgGroup(order = 0, heading = "%nTarget Quarkus version:%n", multiplicity = "0..1")
     TargetQuarkusVersionGroup targetQuarkusVersion = new TargetQuarkusVersionGroup();
 
-    @CommandLine.ArgGroup(order = 1, heading = "%nRewrite:%n")
+    @CommandLine.ArgGroup(order = 1, heading = "%nRewrite:%n", exclusive = false)
     RewriteGroup rewrite = new RewriteGroup();
 
     @CommandLine.Option(order = 2, names = { "--per-module" }, description = "Display information per project module.")

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -163,7 +163,7 @@ public class GradleRunner implements BuildSystemRunner {
             args.add(targetQuarkusVersion.platformVersion);
         }
         if (!StringUtil.isNullOrEmpty(targetQuarkusVersion.streamId)) {
-            args.add("--streamId");
+            args.add("--stream");
             args.add(targetQuarkusVersion.streamId);
         }
         if (rewrite.pluginVersion != null) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
@@ -10,7 +10,6 @@ import org.gradle.api.tasks.options.Option;
 
 import io.quarkus.devtools.commands.UpdateProject;
 import io.quarkus.devtools.project.QuarkusProject;
-import io.quarkus.devtools.project.update.QuarkusUpdateCommand;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.registry.RegistryResolutionException;
 import io.quarkus.registry.catalog.ExtensionCatalog;
@@ -27,7 +26,7 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
     private String targetStreamId;
     private String targetPlatformVersion;
 
-    private String rewritePluginVersion = QuarkusUpdateCommand.DEFAULT_GRADLE_REWRITE_PLUGIN_VERSION;
+    private String rewritePluginVersion = null;
 
     private String rewriteUpdateRecipesVersion = null;
 
@@ -66,6 +65,7 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
     }
 
     @Input
+    @Optional
     public String getRewritePluginVersion() {
         return rewritePluginVersion;
     }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
@@ -29,7 +29,7 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
 
     private String rewritePluginVersion = QuarkusUpdateCommand.DEFAULT_GRADLE_REWRITE_PLUGIN_VERSION;
 
-    private String rewriteUpdateRecipesVersion;
+    private String rewriteUpdateRecipesVersion = null;
 
     @Input
     @Optional
@@ -93,7 +93,7 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
         return targetStreamId;
     }
 
-    @Option(description = "A target stream id, for example:  2.0", option = "streamId")
+    @Option(description = "A target stream, for example:  2.0", option = "stream")
     public void setStreamId(String targetStreamId) {
         this.targetStreamId = targetStreamId;
     }
@@ -141,7 +141,12 @@ public abstract class QuarkusUpdate extends QuarkusPlatformTask {
 
         final UpdateProject invoker = new UpdateProject(quarkusProject);
         invoker.latestCatalog(targetCatalog);
-        invoker.rewritePluginVersion(rewritePluginVersion);
+        if (rewriteUpdateRecipesVersion != null) {
+            invoker.rewriteUpdateRecipesVersion(rewriteUpdateRecipesVersion);
+        }
+        if (rewritePluginVersion != null) {
+            invoker.rewritePluginVersion(rewritePluginVersion);
+        }
         invoker.targetPlatformVersion(targetPlatformVersion);
         invoker.rewriteDryRun(rewriteDryRun);
         invoker.noRewrite(noRewrite);

--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -16,7 +16,6 @@ import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
-import io.quarkus.devtools.project.update.QuarkusUpdateCommand;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.registry.RegistryResolutionException;
 import io.quarkus.registry.catalog.ExtensionCatalog;
@@ -50,7 +49,7 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
     /**
      * The OpenRewrite plugin version
      */
-    @Parameter(property = "rewritePluginVersion", required = true, defaultValue = QuarkusUpdateCommand.DEFAULT_MAVEN_REWRITE_PLUGIN_VERSION)
+    @Parameter(property = "rewritePluginVersion", required = false)
     private String rewritePluginVersion;
 
     /**

--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -15,6 +15,7 @@ import io.quarkus.devtools.commands.UpdateProject;
 import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
 import io.quarkus.devtools.project.QuarkusProject;
+import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devtools.project.update.QuarkusUpdateCommand;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.registry.RegistryResolutionException;
@@ -91,7 +92,7 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
 
     @Override
     protected void processProjectState(QuarkusProject quarkusProject) throws MojoExecutionException {
-
+        QuarkusProjectHelper.setArtifactResolver(artifactResolver());
         final ExtensionCatalog targetCatalog;
         try {
             if (platformVersion != null) {
@@ -120,7 +121,7 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
             invoker.rewritePluginVersion(rewritePluginVersion);
         }
         if (rewriteUpdateRecipesVersion != null) {
-            invoker.rewritePluginVersion(rewriteUpdateRecipesVersion);
+            invoker.rewriteUpdateRecipesVersion(rewriteUpdateRecipesVersion);
         }
         invoker.rewriteDryRun(rewriteDryRun);
         invoker.noRewrite(noRewrite);

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -20,6 +20,7 @@ import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
 import io.quarkus.devtools.commands.handlers.ProjectInfoCommandHandler.PlatformInfo;
 import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.devtools.project.state.ExtensionProvider;
@@ -71,23 +72,26 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
             final boolean noRewrite = invocation.getValue(UpdateProject.NO_REWRITE, false);
 
             if (!noRewrite) {
+                final BuildTool buildTool = quarkusProject.getExtensionManager().getBuildTool();
                 QuarkusUpdates.ProjectUpdateRequest request = new QuarkusUpdates.ProjectUpdateRequest(
-                        quarkusProject.getExtensionManager().getBuildTool(),
+                        buildTool,
                         projectQuarkusPlatformBom.getVersion(), targetPlatformVersion);
                 Path recipe = null;
                 try {
                     recipe = Files.createTempFile("quarkus-project-recipe-", ".yaml");
                     final String updateRecipesVersion = invocation.getValue(UpdateProject.REWRITE_UPDATE_RECIPES_VERSION,
                             QuarkusUpdatesRepository.DEFAULT_UPDATE_RECIPES_VERSION);
-                    QuarkusUpdates.createRecipe(recipe,
-                            QuarkusProjectHelper.artifactResolver(), updateRecipesVersion, request);
-                    final String rewritePluginVersion = invocation.getValue(UpdateProject.REWRITE_PLUGIN_VERSION);
+                    final QuarkusUpdatesRepository.FetchResult fetchResult = QuarkusUpdates.createRecipe(invocation.log(),
+                            recipe,
+                            QuarkusProjectHelper.artifactResolver(), buildTool, updateRecipesVersion, request);
+                    final String rewritePluginVersion = invocation.getValue(UpdateProject.REWRITE_PLUGIN_VERSION,
+                            fetchResult.getRewritePluginVersion());
                     final boolean rewriteDryRun = invocation.getValue(UpdateProject.REWRITE_DRY_RUN, false);
                     invocation.log().warn(
                             "The update feature does not yet handle updates of the extension versions. If needed, update your extensions manually.");
                     QuarkusUpdateCommand.handle(
                             invocation.log(),
-                            quarkusProject.getExtensionManager().getBuildTool(),
+                            buildTool,
                             quarkusProject.getProjectDirPath(),
                             rewritePluginVersion,
                             recipe,

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -83,6 +83,8 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
                             QuarkusProjectHelper.artifactResolver(), updateRecipesVersion, request);
                     final String rewritePluginVersion = invocation.getValue(UpdateProject.REWRITE_PLUGIN_VERSION);
                     final boolean rewriteDryRun = invocation.getValue(UpdateProject.REWRITE_DRY_RUN, false);
+                    invocation.log().warn(
+                            "The update feature does not yet handle updates of the extension versions. If needed, update your extensions manually.");
                     QuarkusUpdateCommand.handle(
                             invocation.log(),
                             quarkusProject.getExtensionManager().getBuildTool(),

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/QuarkusUpdateCommand.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/QuarkusUpdateCommand.java
@@ -24,9 +24,6 @@ public class QuarkusUpdateCommand {
 
     public static final String MAVEN_REWRITE_PLUGIN_GROUP = "org.openrewrite.maven";
     public static final String MAVEN_REWRITE_PLUGIN_ARTIFACT = "rewrite-maven-plugin";
-    public static final String DEFAULT_MAVEN_REWRITE_PLUGIN_VERSION = "4.41.0";
-    public static final String DEFAULT_GRADLE_REWRITE_PLUGIN_VERSION = "5.38.0";
-
     public static Set<String> ADDITIONAL_SOURCE_FILES_SET = Set.of("**/META-INF/services/**",
             "**/*.txt",
             "**/*.adoc",

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/QuarkusUpdates.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/QuarkusUpdates.java
@@ -2,10 +2,11 @@ package io.quarkus.devtools.project.update;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
 
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.devtools.project.update.QuarkusUpdatesRepository.FetchResult;
 import io.quarkus.devtools.project.update.operations.UpdatePropertyOperation;
 
 public final class QuarkusUpdates {
@@ -13,10 +14,11 @@ public final class QuarkusUpdates {
     private QuarkusUpdates() {
     }
 
-    public static void createRecipe(Path target, MavenArtifactResolver artifactResolver, String updateRecipesVersion,
+    public static FetchResult createRecipe(MessageWriter log, Path target, MavenArtifactResolver artifactResolver,
+            BuildTool buildTool, String updateRecipesVersion,
             ProjectUpdateRequest request)
             throws IOException {
-        final List<String> recipes = QuarkusUpdatesRepository.fetchRecipes(artifactResolver, updateRecipesVersion,
+        final FetchResult result = QuarkusUpdatesRepository.fetchRecipes(log, artifactResolver, buildTool, updateRecipesVersion,
                 request.currentVersion,
                 request.targetVersion);
         QuarkusUpdateRecipe recipe = new QuarkusUpdateRecipe()
@@ -34,10 +36,11 @@ public final class QuarkusUpdates {
                 break;
         }
 
-        for (String s : recipes) {
+        for (String s : result.getRecipes()) {
             recipe.addRecipes(QuarkusUpdateRecipeIO.readRecipesYaml(s));
         }
         QuarkusUpdateRecipeIO.write(target, recipe);
+        return result;
     }
 
     public static class ProjectUpdateRequest {


### PR DESCRIPTION
Maybe superseding #32525 

- All from #32525 
- Use plugin versions from the quarkus-updates artifact 
- Print a nice log after resolution

```
Resolved io.quarkus:quarkus-updates-recipes:0.0.6 with 1 recipe(s) to update from 2.16.6.Final to 3.0.0.CR2 (initially made for OpenRewrite gradle plugin 5.38.0)
```