### PR TITLE
Use local lookup policy for generated image stream resources

### DIFF
--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/util/ImageUtil.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/util/ImageUtil.java
@@ -15,12 +15,12 @@ public final class ImageUtil {
      * Create an image from the individual parts.
      *
      * @param registry The registry.
-     * @param repository The repository.
+     * @param repository The group.
      * @param name The name.
      * @param tag The tag.
      * @return The image.
      */
-    public static String getImage(Optional<String> registry, String repository, String name, String tag) {
+    public static String getImage(Optional<String> registry, String group, String name, String tag) {
         if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("Docker image name cannot be null!");
         }
@@ -29,10 +29,42 @@ public final class ImageUtil {
         }
         StringBuilder sb = new StringBuilder();
         registry.ifPresent(r -> sb.append(r).append(SLASH));
-        sb.append(repository).append(SLASH);
+        sb.append(group).append(SLASH);
 
         sb.append(name).append(COLN).append(tag);
         return sb.toString();
+    }
+
+    /**
+     * Return the image registry.
+     *
+     * @param image The docker image.
+     * @return The image registry.
+     */
+    public static Optional<String> getRegistry(String image) {
+        String[] parts = image.split(SLASH);
+        if (parts.length <= 2) {
+            //name:tag
+            //group/name:tag
+            return Optional.empty();
+        }
+        return Optional.ofNullable(parts[0]);
+    }
+
+    /**
+     * Return the image group.
+     *
+     * @param image The docker image.
+     * @return The image group.
+     */
+    public static String getGroup(String image) {
+        String[] parts = image.split(SLASH);
+        if (parts.length <= 2) {
+            //name:tag
+            //group/name:tag
+            return parts[0];
+        }
+        return parts[1];
     }
 
     /**
@@ -72,7 +104,7 @@ public final class ImageUtil {
         }
 
         if (tagged.contains(COLN)) {
-            return tagged.substring(0, tagged.indexOf(COLN));
+            return tagged.substring(0, tagged.lastIndexOf(COLN));
         }
         return tagged;
     }
@@ -85,7 +117,7 @@ public final class ImageUtil {
      */
     public static String getTag(String image) {
         if (image.contains(COLN)) {
-            return image.substring(image.indexOf(COLN) + 1);
+            return image.substring(image.lastIndexOf(COLN) + 1);
         }
         return image;
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
@@ -36,6 +36,8 @@ public final class Constants {
     static final String S2I = "s2i";
     static final String DEFAULT_S2I_IMAGE_NAME = "s2i-java"; //refers to the Dekorate default image.
 
+    static final String OPENSHIFT_INTERNAL_REGISTRY = "image-registry.openshift-image-registry.svc:5000";
+
     static final String KNATIVE = "knative";
     static final String KNATIVE_SERVICE = "Service";
     static final String KNATIVE_SERVICE_GROUP = "serving.knative.dev";

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnableImageStreamLocalLookupPolicyDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnableImageStreamLocalLookupPolicyDecorator.java
@@ -1,0 +1,23 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.openshift.api.model.ImageStreamSpecFluent;
+
+public class EnableImageStreamLocalLookupPolicyDecorator extends NamedResourceDecorator<ImageStreamSpecFluent<?>> {
+
+    public EnableImageStreamLocalLookupPolicyDecorator() {
+        super("ImageStream", ANY);
+    }
+
+    public EnableImageStreamLocalLookupPolicyDecorator(String name) {
+        super("ImageStream", name);
+    }
+
+    @Override
+    public void andThenVisit(ImageStreamSpecFluent<?> spec, ObjectMeta meta) {
+        spec.withNewLookupPolicy()
+                .withLocal()
+                .endLookupPolicy();
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithCustomNameTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithCustomNameTest.java
@@ -77,8 +77,7 @@ public class OpenshiftWithCustomNameTest {
                             assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                                 assertThat(container.getImage())
                                         .isEqualTo(
-                                                "image-registry.openshift-image-registry.svc:5000/testme/" + CUSTOM_NAME
-                                                        + ":0.1-SNAPSHOT");
+                                                "testme/" + CUSTOM_NAME + ":0.1-SNAPSHOT");
                             });
                         });
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithDeploymentResourceTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithDeploymentResourceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.openshift.api.model.ImageStream;
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
@@ -76,13 +77,22 @@ public class OpenshiftWithDeploymentResourceTest {
                         assertThat(t.getSpec()).satisfies(podSpec -> {
                             assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                                 assertThat(container.getImage())
-                                        .isEqualTo(
-                                                "image-registry.openshift-image-registry.svc:5000/testme/openshift-with-deployment-resource:0.1-SNAPSHOT");
+                                        .isEqualTo("testme/openshift-with-deployment-resource:0.1-SNAPSHOT");
                             });
                         });
                     });
                 });
             });
         });
+
+        assertThat(kubernetesList).filteredOn(r -> r instanceof ImageStream && r.getMetadata().getName().equals(NAME))
+                .singleElement().satisfies(r -> {
+                    assertThat(r).isInstanceOfSatisfying(ImageStream.class, i -> {
+                        assertThat(i.getSpec()).satisfies(spec -> {
+                            assertThat(spec.getLookupPolicy().getLocal()).isEqualTo(true);
+                        });
+                    });
+                });
+
     }
 }


### PR DESCRIPTION
When using kubernetes resources in Openshift we run into the issue of needing to now the project name upfront.
This is because the project name influences the image repository.

A solution to this issue is described here: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.8/html/images/using-imagestreams-with-kube-resources

The pull request applies the first of the two approaches described (using local lookup policy for images). 