### PR TITLE
Dev UI 2 - Hide the RESTEasy Reactive score on the home page

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/devui/ResteasyReactiveDevUIProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/devui/ResteasyReactiveDevUIProcessor.java
@@ -34,7 +34,8 @@ public class ResteasyReactiveDevUIProcessor {
                 .icon("font-awesome-solid:arrow-right-arrow-left"));
 
         // Custom Card
-        cardPageBuildItem.setCustomCard("qwc-resteasy-reactive-card.js");
+        // For now, we don't display the score as it might be confusing for people using blocking
+        //cardPageBuildItem.setCustomCard("qwc-resteasy-reactive-card.js");
 
         cardPageProducer.produce(cardPageBuildItem);
     }


### PR DESCRIPTION
Until we fix the fact that blocking endpoints are reported as something bad, better hide the score as it might be interpreted like "I upgraded to Quarkus 3, I need to move to reactive endpoints".

Per discussion with Phillip.