### PR TITLE
Disable flaky OpenTelemetry Jdbc instrumentation test

### DIFF
--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgresOpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgresOpenTelemetryJdbcInstrumentationTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.opentelemetry;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.QuarkusTestResource;
@@ -7,6 +8,7 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(value = PostgreSqlLifecycleManager.class, restrictToAnnotatedClass = true)
+@Disabled("flaky test")
 public class PostgresOpenTelemetryJdbcInstrumentationTest extends OpenTelemetryJdbcInstrumentationTest {
 
     @Test


### PR DESCRIPTION
This fails from time to time ([here](https://github.com/quarkusio/quarkus/pull/32432#issuecomment-1504685572) is the latest example) so let's disable it for now