### PR TITLE
Gradle integration tests: tackle (Windows) CI issues

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -430,7 +430,7 @@ jobs:
       MAVEN_OPTS: -Xmx1g
     # Skip main in forks
     if: "needs.calculate-test-jobs.outputs.run_gradle == 'true' && (github.repository == 'quarkusio/quarkus' || !endsWith(github.ref, '/main'))"
-    timeout-minutes: 80
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -65,7 +65,7 @@
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
         <proposed-maven-version>3.8.8</proposed-maven-version>
         <maven-wrapper.version>3.2.0</maven-wrapper.version>
-        <gradle-wrapper.version>8.0.2</gradle-wrapper.version>
+        <gradle-wrapper.version>8.1</gradle-wrapper.version>
         <quarkus-gradle-plugin.version>${project.version}</quarkus-gradle-plugin.version>
         <quarkus-maven-plugin.version>${project.version}</quarkus-maven-plugin.version>
         <maven-plugin-plugin.version>3.8.1</maven-plugin-plugin.version>

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -233,9 +233,8 @@ public class QuarkusPlugin implements Plugin<Project> {
 
         tasks.register(BUILD_NATIVE_TASK_NAME, DefaultTask.class, task -> {
             task.finalizedBy(quarkusBuild);
-            task.doFirst(t -> project.getLogger()
+            task.doFirst(t -> t.getLogger()
                     .warn("The 'buildNative' task has been deprecated in favor of 'build -Dquarkus.package.type=native'"));
-
         });
 
         configureBuildNativeTask(project);

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
@@ -62,6 +62,11 @@ public abstract class QuarkusTask extends DefaultTask {
 
         customizations.forEach(a -> a.execute(forkOptions));
 
+        String quarkusWorkerMaxHeap = System.getProperty("quarkus.gradle-worker.max-heap");
+        if (quarkusWorkerMaxHeap != null && forkOptions.getAllJvmArgs().stream().noneMatch(arg -> arg.startsWith("-Xmx"))) {
+            forkOptions.jvmArgs("-Xmx" + quarkusWorkerMaxHeap);
+        }
+
         // Pass all environment variables
         forkOptions.environment(System.getenv());
 

--- a/devtools/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/devtools/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=47a5bfed9ef814f90f8debcbbb315e8e7c654109acd224595ea39fca95c5d4da
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
+# https://gradle.org/release-checksums/
+distributionSha256Sum=2cbafcd2c47a101cb2165f636b4677fac0b954949c9429c1c988da399defe6a9
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -77,7 +77,7 @@
         <plexus-utils.version>3.5.1</plexus-utils.version>
         <smallrye-common.version>2.1.0</smallrye-common.version>
         <smallrye-beanbag.version>1.1.0</smallrye-beanbag.version>
-        <gradle-tooling.version>8.0.2</gradle-tooling.version>
+        <gradle-tooling.version>8.1</gradle-tooling.version>
         <quarkus-fs-util.version>0.0.9</quarkus-fs-util.version>
         <org-crac.version>0.1.3</org-crac.version>
         <formatter-maven-plugin.version>2.22.0</formatter-maven-plugin.version>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/gradle-wrapper/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/gradle-wrapper/codestart.yml
@@ -6,7 +6,7 @@ language:
   base:
     data:
       gradle:
-        version: 8.0.2
+        version: 8.1
     shared-data:
       buildtool:
         cli: ./gradlew

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -388,7 +388,7 @@
         "supported-maven-versions": "[3.6.2,)",
         "proposed-maven-version": "3.8.8",
         "maven-wrapper-version": "3.2.0",
-        "gradle-wrapper-version": "8.0.2"
+        "gradle-wrapper-version": "8.1"
       }
     },
     "codestarts-artifacts": [

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -42,7 +42,7 @@
         <!-- These properties are used by CreateProjectMojo to add the Maven Wrapper -->
         <proposed-maven-version>3.8.8</proposed-maven-version>
         <maven-wrapper.version>3.2.0</maven-wrapper.version>
-        <gradle-wrapper.version>8.0.2</gradle-wrapper.version>
+        <gradle-wrapper.version>8.1</gradle-wrapper.version>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->

--- a/integration-tests/gradle/gradle.properties
+++ b/integration-tests/gradle/gradle.properties
@@ -2,3 +2,6 @@ version=999-SNAPSHOT
 
 # Idle timeout in milliseconds
 org.gradle.daemon.idletimeout=10000
+
+# Override Java default heap size calculation for the Quarkus Gradle plugin worker processes, important for CI
+systemProp.quarkus.gradle-worker.max-heap=256m

--- a/integration-tests/gradle/gradle.properties
+++ b/integration-tests/gradle/gradle.properties
@@ -1,7 +1,7 @@
 version=999-SNAPSHOT
 
 # Idle timeout in milliseconds
-org.gradle.daemon.idletimeout=10000
+systemProp.org.gradle.daemon.idletimeout=10000
 
 # Override Java default heap size calculation for the Quarkus Gradle plugin worker processes, important for CI
 systemProp.quarkus.gradle-worker.max-heap=256m

--- a/integration-tests/gradle/gradle.properties
+++ b/integration-tests/gradle/gradle.properties
@@ -5,3 +5,8 @@ systemProp.org.gradle.daemon.idletimeout=10000
 
 # Override Java default heap size calculation for the Quarkus Gradle plugin worker processes, important for CI
 systemProp.quarkus.gradle-worker.max-heap=256m
+
+# Use the miniumu Java heap sizes for a Gradle daemon, important for CI
+org.gradle.jvmargs=-Xms128m -Xmx256m \
+  -Dfile.encoding=UTF-8 \
+  -Duser.language=en -Duser.country=US -Duser.variant=

--- a/integration-tests/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/integration-tests/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=47a5bfed9ef814f90f8debcbbb315e8e7c654109acd224595ea39fca95c5d4da
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
+# https://gradle.org/release-checksums/
+distributionSha256Sum=2cbafcd2c47a101cb2165f636b4677fac0b954949c9429c1c988da399defe6a9
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/integration-tests/gradle/pom.xml
+++ b/integration-tests/gradle/pom.xml
@@ -430,13 +430,13 @@
             </build>
         </profile>
         <profile>
-            <id>jdk19-workarounds</id>
+            <id>jdk20-workarounds</id>
             <activation>
-                <jdk>[19,)</jdk>
+                <jdk>[20,)</jdk>
             </activation>
             <properties>
                 <!-- auto-exclude tests that are known to fail on JDK 19 or above (tagged via @Tag("failsOnJDK19")) -->
-                <excludedGroups>failsOnJDK19</excludedGroups>
+                <excludedGroups>failsOnJDK20</excludedGroups>
             </properties>
         </profile>
     </profiles>

--- a/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/src/main/java/org/acme/Config.java
+++ b/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/src/main/java/org/acme/Config.java
@@ -1,8 +1,8 @@
 package org.acme;
 
-import io.quarkus.arc.config.ConfigProperties;
+import io.smallrye.config.ConfigMapping;
 
-@ConfigProperties(prefix = "example")
-public class Config {
-    public String message;
+@ConfigMapping(prefix = "example")
+public interface Config {
+    public String message();
 }

--- a/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/src/main/java/org/acme/ExampleResource.java
+++ b/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/src/main/java/org/acme/ExampleResource.java
@@ -15,6 +15,6 @@ public class ExampleResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
-        return config.message;
+        return config.message();
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/BuildConfigurationTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/BuildConfigurationTest.java
@@ -101,8 +101,6 @@ public class BuildConfigurationTest extends QuarkusGradleWrapperTestBase {
     private void verifyBuild(String override) throws IOException, InterruptedException, URISyntaxException {
         File rootDir = getProjectDir(ROOT_PROJECT_NAME);
         BuildResult buildResult = runGradleWrapper(rootDir, "clean", "quarkusBuild",
-                // Package type is not included in the Gradle cache inputs, see https://github.com/quarkusio/quarkus/issues/30852
-                "--no-build-cache",
                 override != null ? "-Dquarkus.package.type=" + override : "-Dfoo=bar");
         soft.assertThat(buildResult.unsuccessfulTasks()).isEmpty();
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/FastJarFormatWorksTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/FastJarFormatWorksTest.java
@@ -22,9 +22,7 @@ public class FastJarFormatWorksTest extends QuarkusGradleWrapperTestBase {
 
         final File projectDir = getProjectDir("test-that-fast-jar-format-works");
 
-        BuildResult result = runGradleWrapper(projectDir, "clean", "build");
-        result.getTasks().forEach((k, v) -> System.err.println("   " + k + " --> " + v));
-        System.err.println(result.getOutput());
+        runGradleWrapper(projectDir, "clean", "build");
 
         final Path quarkusApp = projectDir.toPath().resolve("build").resolve("quarkus-app");
         assertThat(quarkusApp).exists();

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcMultiModuleQuarkusBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcMultiModuleQuarkusBuildTest.java
@@ -35,7 +35,7 @@ public class GrpcMultiModuleQuarkusBuildTest extends QuarkusGradleWrapperTestBas
         final Path protoDirectory = new File(projectDir, "application/src/main/proto/").toPath();
         Files.copy(projectDir.toPath().resolve("invalid.proto"), protoDirectory.resolve("invalid.proto"));
         try {
-            final BuildResult buildResult = runGradleWrapper(projectDir, ":application:quarkusBuild", "--info");
+            final BuildResult buildResult = runGradleWrapper(true, projectDir, ":application:quarkusBuild", "--info");
             assertTrue(buildResult.getOutput().contains("invalid.proto:5:1: Missing field number."));
         } finally {
             Files.delete(protoDirectory.resolve("invalid.proto"));

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/JandexMultiModuleTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/JandexMultiModuleTest.java
@@ -10,11 +10,14 @@ public class JandexMultiModuleTest extends QuarkusGradleWrapperTestBase {
 
     @Test
     public void testBasicMultiModuleBuildKordamp() throws Exception {
+        // Kordamp Jandex plugin's not compatible w/ the Gradle configuration cache
+        gradleConfigurationCache(false);
         jandexTest("jandex-basic-multi-module-project-kordamp", ":common:jandex");
     }
 
     @Test
     public void testBasicMultiModuleBuildJandex() throws Exception {
+        gradleConfigurationCache(true);
         jandexTest("jandex-basic-multi-module-project-vlsi", ":common:processJandexIndex");
     }
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleDevToolsTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleDevToolsTestBase.java
@@ -29,6 +29,7 @@ public class QuarkusGradleDevToolsTestBase extends QuarkusGradleWrapperTestBase 
 
     @Override
     protected void setupTestCommand() {
+        gradleNoWatchFs(false);
         for (Map.Entry<?, ?> prop : devToolsProps.entrySet()) {
             setSystemProperty(prop.getKey().toString(), prop.getValue().toString());
         }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
@@ -39,13 +39,18 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
         File logOutput = new File(projectDir, "command-output.log");
 
         System.out.println("$ " + String.join(" ", command));
-        Process p = new ProcessBuilder()
+        ProcessBuilder pb = new ProcessBuilder()
                 .directory(projectDir)
                 .command(command)
                 .redirectInput(ProcessBuilder.Redirect.INHERIT)
-                .redirectError(logOutput)
                 .redirectOutput(logOutput)
-                .start();
+                // Should prevent "fragmented" output (parts of stdout and stderr interleaved)
+                .redirectErrorStream(true);
+        if (System.getenv("JAVA_HOME") == null) {
+            // This helps running the tests in IntelliJ w/o configuring an explicit JAVA_HOME env var.
+            pb.environment().put("JAVA_HOME", System.getProperty("java.home"));
+        }
+        Process p = pb.start();
 
         //long timeout for native tests
         //that may also need to download docker

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
@@ -21,10 +21,28 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
 
     private Map<String, String> systemProps;
 
+    private boolean configurationCacheEnable = true;
+    private boolean noWatchFs = true;
+
     protected void setupTestCommand() {
 
     }
 
+    /**
+     * Gradle's configuration cache is enabled by default for all tests. This option can be used to disable the
+     * configuration test.
+     */
+    protected void gradleConfigurationCache(boolean configurationCacheEnable) {
+        this.configurationCacheEnable = configurationCacheEnable;
+    }
+
+    /**
+     * Gradle is run by default with {@code --no-watch-fs} to reduce I/O load during tests. Some tests might run into issues
+     * with this option.
+     */
+    protected void gradleNoWatchFs(boolean noWatchFs) {
+        this.noWatchFs = noWatchFs;
+    }
 
     public BuildResult runGradleWrapper(File projectDir, String... args) throws IOException, InterruptedException {
         return runGradleWrapper(false, projectDir, args);
@@ -37,9 +55,13 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
         command.add(getGradleWrapperCommand());
         addSystemProperties(command);
         command.add("-Dorg.gradle.console=plain");
-        command.add("-Dorg.gradle.daemon=false");
-        command.add("--configuration-cache");
+        if (configurationCacheEnable) {
+            command.add("--configuration-cache");
+        }
         command.add("--stacktrace");
+        if (noWatchFs) {
+            command.add("--no-watch-fs");
+        }
         command.add("--info");
         command.add("--daemon");
         command.addAll(Arrays.asList(args));

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/BasicKotlinApplicationModuleDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/BasicKotlinApplicationModuleDevModeTest.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 
 import com.google.common.collect.ImmutableMap;
 
-@org.junit.jupiter.api.Tag("failsOnJDK19")
+@org.junit.jupiter.api.Tag("failsOnJDK20")
 public class BasicKotlinApplicationModuleDevModeTest extends QuarkusDevGradleTestBase {
 
     @Override

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/MultiModuleKotlinProjectDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/MultiModuleKotlinProjectDevModeTest.java
@@ -2,12 +2,9 @@ package io.quarkus.gradle.devmode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Disabled;
-
 import com.google.common.collect.ImmutableMap;
 
-@Disabled
-@org.junit.jupiter.api.Tag("failsOnJDK19")
+@org.junit.jupiter.api.Tag("failsOnJDK20")
 public class MultiModuleKotlinProjectDevModeTest extends QuarkusDevGradleTestBase {
 
     @Override

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/MultiSourceProjectDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/MultiSourceProjectDevModeTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 
-@org.junit.jupiter.api.Tag("failsOnJDK19")
+@org.junit.jupiter.api.Tag("failsOnJDK20")
 public class MultiSourceProjectDevModeTest extends QuarkusDevGradleTestBase {
 
     @Override

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
@@ -27,6 +27,11 @@ public abstract class QuarkusDevGradleTestBase extends QuarkusGradleWrapperTestB
     private Future<?> quarkusDev;
     protected File projectDir;
 
+    @Override
+    protected void setupTestCommand() {
+        gradleNoWatchFs(false);
+    }
+
     @Test
     public void main() throws Exception {
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
@@ -7,6 +7,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -122,7 +123,7 @@ public abstract class QuarkusDevGradleTestBase extends QuarkusGradleWrapperTestB
     }
 
     protected String getHttpResponse(String path) {
-        return getHttpResponse(path, 1, TimeUnit.MINUTES);
+        return getHttpResponse(path, devModeTimeoutSeconds(), TimeUnit.SECONDS);
     }
 
     protected String getHttpResponse(String path, long timeout, TimeUnit tu) {
@@ -146,7 +147,16 @@ public abstract class QuarkusDevGradleTestBase extends QuarkusGradleWrapperTestB
     }
 
     protected void assertUpdatedResponseContains(String path, String value) {
-        assertUpdatedResponseContains(path, value, 1, TimeUnit.MINUTES);
+        assertUpdatedResponseContains(path, value, devModeTimeoutSeconds(), TimeUnit.SECONDS);
+    }
+
+    protected int devModeTimeoutSeconds() {
+        // It's a wild guess, but maybe Windows is just slower - at least: a successful Gradle-CI-jobs on Windows is
+        // 2.5x slower than the same Gradle-CI-job on Linux.
+        if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("windows")) {
+            return 90;
+        }
+        return 60;
     }
 
     protected void assertUpdatedResponseContains(String path, String value, long waitAtMost, TimeUnit timeUnit) {

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/extension/ExtensionUnitTestTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/extension/ExtensionUnitTestTest.java
@@ -13,6 +13,8 @@ public class ExtensionUnitTestTest extends QuarkusGradleWrapperTestBase {
 
     @Test
     public void shouldRunTestWithSuccess() throws Exception {
+        gradleConfigurationCache(false);
+
         File projectDir = getProjectDir("extensions/simple-extension");
 
         BuildResult buildResult = runGradleWrapper(projectDir, "clean", ":deployment:test", "--no-build-cache");


### PR DESCRIPTION
The major issue was (very likely) that in the `Gradle Tests - JDK 11 Windows` CI job (at least) the Quarkus process running in dev-mode somehow "survived". The observed pattern is that one dev-mode test ran successfully and all following dev-mode tests failed with test timeout exceptions (awaitability). Adding some code to collect the `List` of child `ProcessHandle`s before calling `ProcessHandle.destroy()` plus a (potentially over-cautious) `ProcessHandle.destroyForcibly()` seems to solve the Gradle-Windows-CI issue. A couple of CI runs did not fail.

This change adds "process dumps" (not really useful w/ Windows :( ) from before and after the test run to the failed test outputs.

Additional mandatory / related changes (in separate commits for review purposes):
* Minor configuration-cache related fix for `buildNative`
* Fix test-project "test resources vs main resources": The test-project for `TestResourcesVsMainResourcesTest` did not work with "recent Quarkus versions", see `integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/src/main/java/org/acme/Config.java` (was still using `io.quarkus.arc.config.ConfigProperties`, failed to compile, but the IT didn't fail.)
* Add a system property to forcefully limit the heap size of Quarkus' Gradle worker processes
* Fix property for the Gradle Daemon idle timeout
* Limit heap size for Gradle daemons, force some code related system properties
* Increase CI timeout for Gradle jobs from 80 to 120 minutes (Windows job takes about 70 minutes to succeed)
* Allow running Gradle ITs in IntelliJ (JAVA_HOME's not set by default)
* Fail Gradle ITs that expect no error (and vice versa) according to Gradle exit code
* Programmatically disable some Gradle features in ITs
