### PR TITLE
AWT related .so libs needed in container

### DIFF
--- a/integration-tests/awt/src/main/docker/Dockerfile.native
+++ b/integration-tests/awt/src/main/docker/Dockerfile.native
@@ -6,6 +6,8 @@ WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
+# Shared objects to be dynamically loaded at runtime as needed
+COPY --chown=1001:root target/*.so /work/
 COPY --chown=1001:root target/*-runner /work/application
 # Permissions fix for Windows
 RUN chmod "ugo+x" /work/application


### PR DESCRIPTION
| Tested | Status |
|-|-|
|./mvnw clean verify -f integration-tests/pom.xml -pl awt -Dnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true -Dquarkus.native.builder-image=quay.io/karmkarm/ubi-quarkus-mandrel-builder-image:23.0-java20| :green_circle: |
|./mvnw clean verify -f integration-tests/pom.xml -pl awt -Dnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17| :green_circle: |

With older Graal, without any additional .so files, the Dockerfile copy silently does nothing.