### PR TITLE
Avoid calling after construct callbacks twice when using @Nested tests

### DIFF
--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/WithSpiesTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/WithSpiesTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.is;
 import jakarta.inject.Named;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -79,5 +80,21 @@ class WithSpiesTest {
                 .then()
                 .statusCode(200)
                 .body(is("1/2"));
+    }
+
+    @Nested
+    class WithNested {
+        @Test
+        @DisplayName("Verify default Greeting values are returned from Spied objects")
+        public void testGreet() {
+            given()
+                    .when().get("/greeting")
+                    .then()
+                    .statusCode(200)
+                    .body(is("HELLO"));
+            Mockito.verify(capitalizerService, Mockito.times(1)).capitalize(Mockito.eq("hello"));
+            Mockito.verify(messageService, Mockito.times(1)).getMessage();
+            Mockito.verify(suffixService, Mockito.times(1)).getSuffix();
+        }
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -765,9 +765,6 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             }
 
             invokeAfterConstructCallbacks(Object.class, actualTestInstance);
-            for (Object outerInstance : outerInstances) {
-                invokeAfterConstructCallbacks(Object.class, outerInstance);
-            }
         } catch (Exception e) {
             throw new TestInstantiationException("Failed to create test instance",
                     e instanceof InvocationTargetException ? e.getCause() : e);


### PR DESCRIPTION
The creation of test instances is done recursively, JUnit will call the method `initTestState` for every class.  So we don't need to call the method `invokeAfterConstructCallbacks` for outer instances.

I've added a test that reproduces the issue and as stated in the issue description, the test was flaky. After this fix, the test is consistently working fine. 

Fix https://github.com/quarkusio/quarkus/issues/32383