### PR TITLE
Bump Gradle from 8.0.2 to 8.1

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -65,7 +65,7 @@
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
         <proposed-maven-version>3.8.8</proposed-maven-version>
         <maven-wrapper.version>3.2.0</maven-wrapper.version>
-        <gradle-wrapper.version>8.0.2</gradle-wrapper.version>
+        <gradle-wrapper.version>8.1</gradle-wrapper.version>
         <quarkus-gradle-plugin.version>${project.version}</quarkus-gradle-plugin.version>
         <quarkus-maven-plugin.version>${project.version}</quarkus-maven-plugin.version>
         <maven-plugin-plugin.version>3.8.1</maven-plugin-plugin.version>

--- a/devtools/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/devtools/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=47a5bfed9ef814f90f8debcbbb315e8e7c654109acd224595ea39fca95c5d4da
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
+# https://gradle.org/release-checksums/
+distributionSha256Sum=2cbafcd2c47a101cb2165f636b4677fac0b954949c9429c1c988da399defe6a9
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -77,7 +77,7 @@
         <plexus-utils.version>3.5.1</plexus-utils.version>
         <smallrye-common.version>2.1.0</smallrye-common.version>
         <smallrye-beanbag.version>1.1.0</smallrye-beanbag.version>
-        <gradle-tooling.version>8.0.2</gradle-tooling.version>
+        <gradle-tooling.version>8.1</gradle-tooling.version>
         <quarkus-fs-util.version>0.0.9</quarkus-fs-util.version>
         <org-crac.version>0.1.3</org-crac.version>
         <formatter-maven-plugin.version>2.22.0</formatter-maven-plugin.version>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/gradle-wrapper/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/gradle-wrapper/codestart.yml
@@ -6,7 +6,7 @@ language:
   base:
     data:
       gradle:
-        version: 8.0.2
+        version: 8.1
     shared-data:
       buildtool:
         cli: ./gradlew

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -388,7 +388,7 @@
         "supported-maven-versions": "[3.6.2,)",
         "proposed-maven-version": "3.8.8",
         "maven-wrapper-version": "3.2.0",
-        "gradle-wrapper-version": "8.0.2"
+        "gradle-wrapper-version": "8.1"
       }
     },
     "codestarts-artifacts": [

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -42,7 +42,7 @@
         <!-- These properties are used by CreateProjectMojo to add the Maven Wrapper -->
         <proposed-maven-version>3.8.8</proposed-maven-version>
         <maven-wrapper.version>3.2.0</maven-wrapper.version>
-        <gradle-wrapper.version>8.0.2</gradle-wrapper.version>
+        <gradle-wrapper.version>8.1</gradle-wrapper.version>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->

--- a/integration-tests/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/integration-tests/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=47a5bfed9ef814f90f8debcbbb315e8e7c654109acd224595ea39fca95c5d4da
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
+# https://gradle.org/release-checksums/
+distributionSha256Sum=2cbafcd2c47a101cb2165f636b4677fac0b954949c9429c1c988da399defe6a9
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Two successful CI runs from #32571 with this commit:
* https://github.com/snazy/quarkus/actions/runs/4691494225
* https://github.com/snazy/quarkus/actions/runs/4696898982