### PR TITLE
Qute build steps - refactoring and performance improvements

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -88,8 +88,7 @@ import io.quarkus.qute.Resolver;
 import io.quarkus.qute.deployment.QuteProcessor.JavaMemberLookupConfig;
 import io.quarkus.qute.deployment.QuteProcessor.MatchResult;
 import io.quarkus.qute.deployment.TemplatesAnalysisBuildItem.TemplateAnalysis;
-import io.quarkus.qute.deployment.Types.AssignableInfo;
-import io.quarkus.qute.deployment.Types.HierarchyIndexer;
+import io.quarkus.qute.deployment.Types.AssignabilityCheck;
 import io.quarkus.qute.generator.Descriptors;
 import io.quarkus.qute.generator.ValueResolverGenerator;
 import io.quarkus.qute.i18n.Localized;
@@ -455,8 +454,7 @@ public class MessageBundleProcessor {
 
         JavaMemberLookupConfig lookupConfig = new QuteProcessor.FixedJavaMemberLookupConfig(index,
                 QuteProcessor.initDefaultMembersFilter(), false);
-        Map<DotName, AssignableInfo> assignableCache = new HashMap<>();
-        HierarchyIndexer hierarchyIndexer = new HierarchyIndexer(index);
+        AssignabilityCheck assignabilityCheck = new AssignabilityCheck(index);
 
         // bundle name -> (key -> method)
         Map<String, Map<String, MethodInfo>> bundleToMethods = new HashMap<>();
@@ -576,10 +574,10 @@ public class MessageBundleProcessor {
                                             implicitClassToMembersUsed, templateIdToPathFun, generatedIdsToMatches,
                                             extensionMethodExcludes, checkedTemplate, lookupConfig, namedBeans,
                                             namespaceTemplateData, regularExtensionMethods, namespaceExtensionMethods,
-                                            assignableCache, hierarchyIndexer);
+                                            assignabilityCheck);
                                     MatchResult match = results.get(param.toOriginalString());
-                                    if (match != null && !match.isEmpty() && !Types.isAssignableFrom(match.type(),
-                                            methodParams.get(idx), index, assignableCache)) {
+                                    if (match != null && !match.isEmpty() && !assignabilityCheck.isAssignableFrom(match.type(),
+                                            methodParams.get(idx))) {
                                         incorrectExpressions
                                                 .produce(new IncorrectExpressionBuildItem(expression.toOriginalString(),
                                                         "Message bundle method " + method.declaringClass().name() + "#" +

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/TypesTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/TypesTest.java
@@ -7,8 +7,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.jboss.jandex.ArrayType;
 import org.jboss.jandex.ClassType;
@@ -20,7 +18,7 @@ import org.jboss.jandex.PrimitiveType.Primitive;
 import org.jboss.jandex.Type;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.qute.deployment.Types.AssignableInfo;
+import io.quarkus.qute.deployment.Types.AssignabilityCheck;
 
 public class TypesTest {
 
@@ -37,28 +35,28 @@ public class TypesTest {
         Type booleanType = Types.box(Primitive.BOOLEAN);
         ArrayType byteArrayType = ArrayType.create(PrimitiveType.BYTE, 1);
         ArrayType intArrayType = ArrayType.create(PrimitiveType.INT, 1);
-        Map<DotName, AssignableInfo> cache = new HashMap<>();
+        AssignabilityCheck assignabilityCheck = new AssignabilityCheck(index);
 
         // byte[] is not assignable from String
-        assertFalse(Types.isAssignableFrom(byteArrayType, stringType, index, cache));
+        assertFalse(assignabilityCheck.isAssignableFrom(byteArrayType, stringType));
         // CharSequence is assignable from String
-        assertTrue(Types.isAssignableFrom(charSequenceType, stringType, index, cache));
+        assertTrue(assignabilityCheck.isAssignableFrom(charSequenceType, stringType));
         // String is not assignable from CharSequence
-        assertFalse(Types.isAssignableFrom(stringType, charSequenceType, index, cache));
+        assertFalse(assignabilityCheck.isAssignableFrom(stringType, charSequenceType));
         // String is not assignable from byte[]
-        assertFalse(Types.isAssignableFrom(stringType, byteArrayType, index, cache));
+        assertFalse(assignabilityCheck.isAssignableFrom(stringType, byteArrayType));
         // Object is assignable from any type
-        assertTrue(Types.isAssignableFrom(ClassType.OBJECT_TYPE, stringType, index, cache));
+        assertTrue(assignabilityCheck.isAssignableFrom(ClassType.OBJECT_TYPE, stringType));
         // boolean is assignable from Boolean
-        assertTrue(Types.isAssignableFrom(PrimitiveType.BOOLEAN, booleanType, index, cache));
+        assertTrue(assignabilityCheck.isAssignableFrom(PrimitiveType.BOOLEAN, booleanType));
         // boolean is not assignable from double
-        assertFalse(Types.isAssignableFrom(PrimitiveType.BOOLEAN, PrimitiveType.DOUBLE, index, cache));
+        assertFalse(assignabilityCheck.isAssignableFrom(PrimitiveType.BOOLEAN, PrimitiveType.DOUBLE));
         // Serializable is assignable from BigDecimal
-        assertTrue(Types.isAssignableFrom(serializableType, bigDecimalType, index, cache));
+        assertTrue(assignabilityCheck.isAssignableFrom(serializableType, bigDecimalType));
         // Number is assignable from BigDecimal
-        assertTrue(Types.isAssignableFrom(numberType, bigDecimalType, index, cache));
+        assertTrue(assignabilityCheck.isAssignableFrom(numberType, bigDecimalType));
         // byte[] is not assignable from int[]
-        assertFalse(Types.isAssignableFrom(byteArrayType, intArrayType, index, cache));
+        assertFalse(assignabilityCheck.isAssignableFrom(byteArrayType, intArrayType));
     }
 
     private static Index index(Class<?>... classes) throws IOException {


### PR DESCRIPTION
- replace the assignability cache and HierarchyIndexer with AssignabilityCheck and check supertypes instead of subtypes; this works better with computing index and allows the check to cache the misses
- match extension method name first (before checking the assignability of the first parameter)
- dev mode - do not regenerate the value resolvers for non-application classes during hot reload

I can observe ~50% speedup of the `QuteProcessor#validateExpressions` build step (100ms -> 45ms in prod build, 250ms -> 140ms in the dev mode) in a test app that has roughly 400 qute output expressions to validate.