### PR TITLE
Switch Hibernate Validator extension to @ConfigMapping

### DIFF
--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorBuildTimeConfig.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorBuildTimeConfig.java
@@ -4,36 +4,39 @@ import java.util.Optional;
 
 import org.hibernate.validator.messageinterpolation.ExpressionLanguageFeatureLevel;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
+@ConfigMapping(prefix = "quarkus.hibernate-validator")
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class HibernateValidatorBuildTimeConfig {
+public interface HibernateValidatorBuildTimeConfig {
 
     /**
      * Enable the fail fast mode. When fail fast is enabled the validation
      * will stop on the first constraint violation detected.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean failFast;
+    @WithDefault("false")
+    boolean failFast();
 
     /**
      * Method validation.
      */
     @ConfigDocSection
-    public HibernateValidatorMethodBuildTimeConfig methodValidation;
+    HibernateValidatorMethodBuildTimeConfig methodValidation();
 
     /**
      * Expression Language.
      */
     @ConfigDocSection
-    public HibernateValidatorExpressionLanguageBuildTimeConfig expressionLanguage;
+    HibernateValidatorExpressionLanguageBuildTimeConfig expressionLanguage();
 
     @ConfigGroup
-    public static class HibernateValidatorMethodBuildTimeConfig {
+    public interface HibernateValidatorMethodBuildTimeConfig {
 
         /**
          * Define whether overriding methods that override constraints should throw a {@code ConstraintDefinitionException}.
@@ -47,8 +50,8 @@ public class HibernateValidatorBuildTimeConfig {
          * This would pose a strengthening of preconditions to be fulfilled by the caller."
          * </pre>
          */
-        @ConfigItem(defaultValue = "false")
-        public boolean allowOverridingParameterConstraints;
+        @WithDefault("false")
+        boolean allowOverridingParameterConstraints();
 
         /**
          * Define whether parallel methods that define constraints should throw a {@code ConstraintDefinitionException}. The
@@ -63,8 +66,8 @@ public class HibernateValidatorBuildTimeConfig {
          * This again is to avoid an unexpected strengthening of preconditions to be fulfilled by the caller."
          * </pre>
          */
-        @ConfigItem(defaultValue = "false")
-        public boolean allowParameterConstraintsOnParallelMethods;
+        @WithDefault("false")
+        boolean allowParameterConstraintsOnParallelMethods();
 
         /**
          * Define whether more than one constraint on a return value may be marked for cascading validation are allowed.
@@ -79,12 +82,12 @@ public class HibernateValidatorBuildTimeConfig {
          * overridden method of the super type or interface."
          * </pre>
          */
-        @ConfigItem(defaultValue = "false")
-        public boolean allowMultipleCascadedValidationOnReturnValues;
+        @WithDefault("false")
+        boolean allowMultipleCascadedValidationOnReturnValues();
     }
 
     @ConfigGroup
-    public static class HibernateValidatorExpressionLanguageBuildTimeConfig {
+    public interface HibernateValidatorExpressionLanguageBuildTimeConfig {
 
         /**
          * Configure the Expression Language feature level for constraints, allowing the selection of
@@ -97,7 +100,7 @@ public class HibernateValidatorBuildTimeConfig {
          * created programmatically in validator implementations.
          * The feature level for those can only be configured directly in the validator implementation.
          */
-        @ConfigItem(defaultValueDocumentation = "bean-properties")
-        public Optional<ExpressionLanguageFeatureLevel> constraintExpressionFeatureLevel;
+        @ConfigDocDefault("bean-properties")
+        Optional<ExpressionLanguageFeatureLevel> constraintExpressionFeatureLevel();
     }
 }

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
@@ -82,9 +82,9 @@ public class HibernateValidatorRecorder {
                         .defaultLocale(localesBuildTimeConfig.defaultLocale)
                         .beanMetaDataClassNormalizer(new ArcProxyBeanMetaDataClassNormalizer());
 
-                if (hibernateValidatorBuildTimeConfig.expressionLanguage.constraintExpressionFeatureLevel.isPresent()) {
+                if (hibernateValidatorBuildTimeConfig.expressionLanguage().constraintExpressionFeatureLevel().isPresent()) {
                     configuration.constraintExpressionLanguageFeatureLevel(
-                            hibernateValidatorBuildTimeConfig.expressionLanguage.constraintExpressionFeatureLevel.get());
+                            hibernateValidatorBuildTimeConfig.expressionLanguage().constraintExpressionFeatureLevel().get());
                 }
 
                 InstanceHandle<ConstraintValidatorFactory> configuredConstraintValidatorFactory = Arc.container()
@@ -127,13 +127,13 @@ public class HibernateValidatorRecorder {
 
                 // Hibernate Validator-specific configuration
 
-                configuration.failFast(hibernateValidatorBuildTimeConfig.failFast);
+                configuration.failFast(hibernateValidatorBuildTimeConfig.failFast());
                 configuration.allowOverridingMethodAlterParameterConstraint(
-                        hibernateValidatorBuildTimeConfig.methodValidation.allowOverridingParameterConstraints);
+                        hibernateValidatorBuildTimeConfig.methodValidation().allowOverridingParameterConstraints());
                 configuration.allowParallelMethodsDefineParameterConstraints(
-                        hibernateValidatorBuildTimeConfig.methodValidation.allowParameterConstraintsOnParallelMethods);
+                        hibernateValidatorBuildTimeConfig.methodValidation().allowParameterConstraintsOnParallelMethods());
                 configuration.allowMultipleCascadedValidationOnReturnValues(
-                        hibernateValidatorBuildTimeConfig.methodValidation.allowMultipleCascadedValidationOnReturnValues);
+                        hibernateValidatorBuildTimeConfig.methodValidation().allowMultipleCascadedValidationOnReturnValues());
 
                 InstanceHandle<ScriptEvaluatorFactory> configuredScriptEvaluatorFactory = Arc.container()
                         .instance(ScriptEvaluatorFactory.class);


### PR DESCRIPTION
Following https://github.com/quarkusio/quarkus/pull/32586, we can switch HV to `@ConfigMapping`.