### PR TITLE
Logging with Panache: fix LocalVariablesSorter usage

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingWithPanacheProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingWithPanacheProcessor.java
@@ -137,7 +137,7 @@ public class LoggingWithPanacheProcessor {
                         locals = new int[numArgs];
                         for (int i = numArgs - 1; i >= 0; i--) {
                             locals[i] = newLocal(argTypes[i]);
-                            super.visitVarInsn(argTypes[i].getOpcode(Opcodes.ISTORE), locals[i]);
+                            visitor.visitVarInsn(argTypes[i].getOpcode(Opcodes.ISTORE), locals[i]);
                         }
                     }
 
@@ -162,7 +162,7 @@ public class LoggingWithPanacheProcessor {
                         // stack: [logger arg1 arg2 arg3]      locals: {l1 = arg4}
                         // stack: [logger arg1 arg2 arg3 arg4] locals: {}
                         for (int i = 0; i < numArgs; i++) {
-                            super.visitVarInsn(argTypes[i].getOpcode(Opcodes.ILOAD), locals[i]);
+                            visitor.visitVarInsn(argTypes[i].getOpcode(Opcodes.ILOAD), locals[i]);
                         }
                     }
 

--- a/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingBean.java
+++ b/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingBean.java
@@ -40,4 +40,12 @@ public class LoggingBean implements LoggingInterface {
         Log.error("Hello Error", error);
     }
 
+    // https://github.com/quarkusio/quarkus/issues/32663
+    public void reproduceStackDisciplineIssue() {
+        String result;
+        String now = "now";
+
+        Log.infov("{0} {1}", "number", 42);
+        Log.info("string " + now);
+    }
 }

--- a/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingWithPanacheTest.java
+++ b/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingWithPanacheTest.java
@@ -40,7 +40,9 @@ public class LoggingWithPanacheTest {
                         "[ERROR] four: foo | bar | baz | quux",
                         "[WARN] foo | bar | baz | quux: io.quarkus.logging.NoStackTraceTestException",
                         "[ERROR] Hello Error: io.quarkus.logging.NoStackTraceTestException",
-                        "[INFO] Hi!");
+                        "[INFO] Hi!",
+                        "[INFO] number 42",
+                        "[INFO] string now");
             });
 
     @Inject
@@ -50,5 +52,7 @@ public class LoggingWithPanacheTest {
     public void test() {
         bean.doSomething();
         new LoggingEntity().something();
+
+        bean.reproduceStackDisciplineIssue();
     }
 }


### PR DESCRIPTION
The `LocalVariablesSorter` utility from ASM is prone to misuse [1], which is exactly what happened in the Logging with Panache bytecode transformation. As a result, the transformed bytecode didn't obey the JVM stack discipline, leading to verification errors or possibly incorrect log messages.

With this commit, instructions that refer to the newly allocated local variables are emitted directly through the original `MethodVisitor`, bypassing the `LocalVariablesSorter`. Therefore, local variable slot numbers in these instructions are not transformed and will not refer to wrong local variables.

[1] https://stackoverflow.com/questions/50140365/asm-strange-localvar-index-using-newlocal-from-localvariablesorter

Fixes #32663