### PR TITLE
Reinitialize BouncyCastle DRBG URLSeededEntropySourceProvider at runtime

### DIFF
--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -214,6 +214,11 @@ public class SecurityProcessor {
                     .produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.jcajce.provider.drbg.DRBG$Default"));
             runtimeReInitialized
                     .produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.jcajce.provider.drbg.DRBG$NonceAndIV"));
+            // URLSeededEntropySourceProvider.seedStream may contain a reference to a 'FileInputStream' which includes
+            // references to FileDescriptors which aren't allowed in the image heap
+            runtimeReInitialized
+                    .produce(new RuntimeReinitializedClassBuildItem(
+                            "org.bouncycastle.jcajce.provider.drbg.DRBG$URLSeededEntropySourceProvider"));
         } else {
             reflection.produce(ReflectiveClassBuildItem.builder("org.bouncycastle.crypto.general.AES")
                     .methods().fields().build());


### PR DESCRIPTION
@jerboaa, As it happens a few of DRBG classes are already runtime reinitialized, so I've added one more class. I'm pretty sure I tried, when I was adding those initial classes, just runtime initialize them, but only the runtime reinitialization worked.
Can you please check if this PR fixes the problem ?