### PR TITLE
Allow ConfigMappings with default visibility

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -173,8 +173,6 @@ public final class RunTimeConfigurationGenerator {
     static final MethodDescriptor CU_ADD_SOURCE_FACTORY_PROVIDER = MethodDescriptor.ofMethod(ConfigUtils.class,
             "addSourceFactoryProvider",
             void.class, SmallRyeConfigBuilder.class, ConfigSourceFactoryProvider.class);
-    static final MethodDescriptor CU_WITH_MAPPING = MethodDescriptor.ofMethod(ConfigUtils.class, "addMapping",
-            void.class, SmallRyeConfigBuilder.class, String.class, String.class);
 
     static final MethodDescriptor RCS_NEW = MethodDescriptor.ofConstructor(RuntimeConfigSource.class, String.class);
     static final MethodDescriptor RCSP_NEW = MethodDescriptor.ofConstructor(RuntimeConfigSourceProvider.class, String.class);

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -75,6 +75,7 @@ import io.quarkus.runtime.configuration.ConfigDiagnostic;
 import io.quarkus.runtime.configuration.ConfigRecorder;
 import io.quarkus.runtime.configuration.DefaultsConfigSource;
 import io.quarkus.runtime.configuration.DisableableConfigSource;
+import io.quarkus.runtime.configuration.MappingsConfigBuilder;
 import io.quarkus.runtime.configuration.QuarkusConfigValue;
 import io.quarkus.runtime.configuration.RuntimeOverrideConfigSource;
 import io.smallrye.config.ConfigMappings.ConfigClassWithPrefix;
@@ -90,10 +91,6 @@ public class ConfigGenerationBuildStep {
     private static final MethodDescriptor WITH_SOURCES = MethodDescriptor.ofMethod(
             SmallRyeConfigBuilder.class, "withSources",
             SmallRyeConfigBuilder.class, ConfigSource[].class);
-
-    private static final MethodDescriptor WITH_MAPPING = MethodDescriptor.ofMethod(
-            SmallRyeConfigBuilder.class, "withMapping",
-            SmallRyeConfigBuilder.class, Class.class, String.class);
 
     @BuildStep
     void staticInitSources(
@@ -553,23 +550,25 @@ public class ConfigGenerationBuildStep {
                 .classOutput(new GeneratedClassGizmoAdaptor(generatedClass, true))
                 .className(className)
                 .interfaces(ConfigBuilder.class)
+                .superClass(MappingsConfigBuilder.class)
                 .setFinal(true)
                 .build()) {
 
             MethodCreator method = classCreator.getMethodCreator(CONFIG_BUILDER);
             ResultHandle configBuilder = method.getMethodParam(0);
 
+            MethodDescriptor addMapping = MethodDescriptor.ofMethod(MappingsConfigBuilder.class, "addMapping", void.class,
+                    SmallRyeConfigBuilder.class, String.class, String.class);
+
             for (ConfigClassWithPrefix mapping : mappings) {
-                method.invokeVirtualMethod(WITH_MAPPING, configBuilder,
-                        method.loadClass(mapping.getKlass()),
+                method.invokeStaticMethod(addMapping, configBuilder, method.load(mapping.getKlass().getName()),
                         method.load(mapping.getPrefix()));
             }
 
             method.returnValue(configBuilder);
         }
 
-        reflectiveClass
-                .produce(ReflectiveClassBuildItem.builder(className).build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).build());
     }
 
     private static Set<String> discoverService(

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
@@ -244,15 +244,6 @@ public final class ConfigUtils {
         builder.withSources(provider.getConfigSourceFactory(Thread.currentThread().getContextClassLoader()));
     }
 
-    public static void addMapping(SmallRyeConfigBuilder builder, String mappingClass, String prefix) {
-        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-        try {
-            builder.withMapping(contextClassLoader.loadClass(mappingClass), prefix);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public static List<String> getProfiles() {
         return ConfigProvider.getConfig().unwrap(SmallRyeConfig.class).getProfiles();
     }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/MappingsConfigBuilder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/MappingsConfigBuilder.java
@@ -1,0 +1,18 @@
+package io.quarkus.runtime.configuration;
+
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+/**
+ * To support mappings that are not public
+ */
+public abstract class MappingsConfigBuilder implements ConfigBuilder {
+    protected static void addMapping(SmallRyeConfigBuilder builder, String mappingClass, String prefix) {
+        // TODO - Ideally should use the classloader passed to Config, but the method is not public. Requires a change in SmallRye Config.
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            builder.withMapping(contextClassLoader.loadClass(mappingClass), prefix);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
- Fixes #31554

This allows having ConfigMappings with default visibility again, broken with https://github.com/quarkusio/quarkus/pull/30964. Bean Validation still requires the visibility to be public (it never supported default visibility). This has to be fixed in SmallRye Config.