### PR TITLE
Fix OpenTelemetryJdbcInstrumentationTest flaky test

### DIFF
--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/main/resources/application.properties
@@ -40,3 +40,7 @@ quarkus.hibernate-orm.db2.database.generation=none
 quarkus.datasource.db2.db-kind=db2
 quarkus.datasource.db2.jdbc.max-size=1
 quarkus.datasource.db2.jdbc.telemetry=true
+
+# speed up build
+quarkus.otel.bsp.schedule.delay=100
+quarkus.otel.bsp.export.timeout=5s

--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgresOpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/PostgresOpenTelemetryJdbcInstrumentationTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.it.opentelemetry;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.QuarkusTestResource;
@@ -8,7 +7,6 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(value = PostgreSqlLifecycleManager.class, restrictToAnnotatedClass = true)
-@Disabled("flaky test")
 public class PostgresOpenTelemetryJdbcInstrumentationTest extends OpenTelemetryJdbcInstrumentationTest {
 
     @Test


### PR DESCRIPTION
Addresses https://github.com/quarkusio/quarkus/pull/32570#issuecomment-1511230019

OpenTelemetry JDBC instrumentation tests are flaky as assertion of 'insert' trace is done as soon as there are any traces detected. We should wait till insert trace arrives too in all cases. When running on strong workstations, traces arrive quickly, however in CI things takes longer sometimes.