### PR TITLE
Add rule to mark Bearer token issues as security issues

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -226,6 +226,10 @@ triage:
         - extensions/security/
         - extensions/elytron
         - integration-tests/elytron
+    - id: bearer-token
+      labels: [area/security, area/oidc]
+      title: "bearer"
+      notify: [sberyozkin, pedroigor]
     - id: metrics
       labels: [area/metrics, area/smallrye]
       title: "metrics"


### PR DESCRIPTION
Done because https://github.com/quarkusio/quarkus/issues/32701 was left as `needs-triage`