### PR TITLE
Disable flaky OpenTelemetry Jdbc instrumentation test

### DIFF
--- a/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleOpenTelemetryJdbcInstrumentationTest.java
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/src/test/java/io/quarkus/it/opentelemetry/OracleOpenTelemetryJdbcInstrumentationTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.opentelemetry;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.QuarkusTestResource;
@@ -7,6 +8,7 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(value = OracleLifecycleManager.class, restrictToAnnotatedClass = true)
+@Disabled("flaky test")
 public class OracleOpenTelemetryJdbcInstrumentationTest extends OpenTelemetryJdbcInstrumentationTest {
 
     @Test


### PR DESCRIPTION
This test fails from time to time (see #32708 for example)

Similar to: #32559