### PR TITLE
Undertow ignore root _static directory

### DIFF
--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/ResourceManagerTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/ResourceManagerTestCase.java
@@ -34,6 +34,12 @@ public class ResourceManagerTestCase {
 
     @Test
     public void testServlet() {
+        RestAssured.when().get(" ").then() // space
+                .statusCode(200)
+                .body(is("[foo, index.html]"));
+        RestAssured.when().get("").then() // empty
+                .statusCode(200)
+                .body(is("[foo, index.html]"));
         RestAssured.when().get("/").then()
                 .statusCode(200)
                 .body(is("[foo, index.html]"));

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/KnownPathResourceManager.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/KnownPathResourceManager.java
@@ -135,7 +135,7 @@ public class KnownPathResourceManager implements ResourceManager {
 
             for (var s : List.of(fileSet, dirSet)) {
                 for (String i : s) {
-                    if (i.equals(slashPath)) {
+                    if (i.equals(slashPath) || "_static".equalsIgnoreCase(i)) {
                         continue;
                     }
                     if (i.startsWith(slashPath)) {


### PR DESCRIPTION
Fix #32724: Undertow ignore root _static directory

@stuartwdouglas is probably not going to like this fix but this is the only thing that makes it work for me.