### PR TITLE
Make it possible to test Google OIDC from DevUI

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -68,4 +68,6 @@ public final class OidcConstants {
     public static final String BACK_CHANNEL_LOGOUT_SID_CLAIM = "sid";
     public static final String FRONT_CHANNEL_LOGOUT_SID_PARAM = "sid";
     public static final String ID_TOKEN_SID_CLAIM = "sid";
+
+    public static final String OPENID_SCOPE = "openid";
 }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevConsoleProcessor.java
@@ -18,6 +18,7 @@ public abstract class AbstractDevConsoleProcessor {
     protected static final String TOKEN_PATH_CONFIG_KEY = CONFIG_PREFIX + "token-path";
     protected static final String END_SESSION_PATH_CONFIG_KEY = CONFIG_PREFIX + "end-session-path";
     protected static final String POST_LOGOUT_URI_PARAM_CONFIG_KEY = CONFIG_PREFIX + "logout.post-logout-uri-param";
+    protected static final String SCOPES_KEY = CONFIG_PREFIX + "authentication.scopes";
 
     protected void produceDevConsoleTemplateItems(Capabilities capabilities,
             BuildProducer<DevConsoleTemplateInfoBuildItem> devConsoleTemplate,
@@ -66,6 +67,9 @@ public abstract class AbstractDevConsoleProcessor {
                 new DevConsoleRuntimeTemplateInfoBuildItem("postLogoutUriParam",
                         new OidcConfigPropertySupplier(POST_LOGOUT_URI_PARAM_CONFIG_KEY), this.getClass(),
                         curateOutcomeBuildItem));
+        devConsoleRuntimeInfo.produce(
+                new DevConsoleRuntimeTemplateInfoBuildItem("scopes",
+                        new OidcConfigPropertySupplier(SCOPES_KEY), this.getClass(), curateOutcomeBuildItem));
 
     }
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
@@ -101,7 +101,8 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
                     metadata != null ? metadata.getString("authorization_endpoint") : null,
                     metadata != null ? metadata.getString("token_endpoint") : null,
                     metadata != null ? metadata.getString("end_session_endpoint") : null,
-                    metadata != null ? metadata.containsKey("introspection_endpoint") : false);
+                    metadata != null ? metadata.containsKey("introspection_endpoint")
+                            || metadata.containsKey("userinfo_endpoint") : false);
 
             produceDevConsoleRouteItems(devConsoleRoute,
                     new OidcTestServiceHandler(vertxInstance, oidcConfig.devui.webClientTimeout),

--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -10,7 +10,7 @@ OpenId Connect Dev Console
 
 var port = {config:property('quarkus.http.port')};
 
-{#if info:oidcApplicationType is 'service'}
+{#if info:oidcApplicationType is 'service' || info:oidcApplicationType is 'hybrid'}
     var devRoot = '{devRootAppend}';
     var encodedDevRoot = devRoot.replaceAll("/", "%2F");
 
@@ -40,7 +40,7 @@ var port = {config:property('quarkus.http.port')};
             $('.loginError').hide();
             $('.implicitLoggedIn').show();
             var search = window.location.search;
-            var code = search.match(/code=([^&]+)/)[1];
+            var code = decodeURIComponent(search.match(/code=([^&]+)/)[1]);
             var state = search.match(/state=([^&]+)/)[1];
             exchangeCodeForTokens(code, state);
         }else if(errorInUrl()){
@@ -103,6 +103,7 @@ var port = {config:property('quarkus.http.port')};
       var address;
       var state;
       var clientId = getClientId();
+      var scopes = '{info:scopes??}';
       {#if info:keycloakAdminUrl?? && info:keycloakRealms??}
           address = '{info:keycloakAdminUrl??}' + "/realms/" + $('#keycloakRealm').val() + "/protocol/openid-connect/auth";
           state = makeid() + "_" + $('#keycloakRealm').val() + "_" + clientId;
@@ -114,14 +115,14 @@ var port = {config:property('quarkus.http.port')};
         window.location.href = address
           + "?client_id=" + clientId
           + "&redirect_uri=" + "http%3A%2F%2Flocalhost%3A" + port + encodedDevRoot + "%2Fio.quarkus.quarkus-oidc%2Fprovider"
-          + "&scope=openid&response_type=token id_token&response_mode=query&prompt=login"
+          + "&scope=" + scopes + "&response_type=token id_token&response_mode=query&prompt=login"
           + "&nonce=" + makeid()
           + "&state=" + state;
       {#else}
         window.location.href = address
           + "?client_id=" + clientId
           + "&redirect_uri=" + "http%3A%2F%2Flocalhost%3A" + port + encodedDevRoot + "%2Fio.quarkus.quarkus-oidc%2Fprovider"
-          + "&scope=openid&response_type=code&response_mode=query&prompt=login"
+          + "&scope=" + scopes + "&response_type=code&response_mode=query&prompt=login"
           + "&nonce=" + makeid()
           + "&state=" + state;
       {/if}    

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -533,7 +533,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                 : Collections.emptyList();
                         List<String> scopes = new ArrayList<>(oidcConfigScopes.size() + 1);
                         if (configContext.oidcConfig.getAuthentication().addOpenidScope.orElse(true)) {
-                            scopes.add("openid");
+                            scopes.add(OidcConstants.OPENID_SCOPE);
                         }
                         scopes.addAll(oidcConfigScopes);
                         codeFlowParams.append(AMP).append(OidcConstants.TOKEN_SCOPE).append(EQ)

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfigPropertySupplier.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfigPropertySupplier.java
@@ -1,15 +1,18 @@
 package io.quarkus.oidc.runtime;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
+import io.quarkus.oidc.common.runtime.OidcConstants;
 
 public class OidcConfigPropertySupplier implements Supplier<String> {
     private static final String AUTH_SERVER_URL_CONFIG_KEY = "quarkus.oidc.auth-server-url";
     private static final String END_SESSION_PATH_KEY = "quarkus.oidc.end-session-path";
+    private static final String SCOPES_KEY = "quarkus.oidc.authentication.scopes";
     private String oidcConfigProperty;
     private String defaultValue;
     private boolean urlProperty;
@@ -40,6 +43,13 @@ public class OidcConfigPropertySupplier implements Supplier<String> {
                 return checkUrlProperty(value);
             }
             return defaultValue;
+        } else if (SCOPES_KEY.equals(oidcConfigProperty)) {
+            Optional<List<String>> scopes = ConfigProvider.getConfig().getOptionalValues(oidcConfigProperty, String.class);
+            if (scopes.isPresent()) {
+                return OidcCommonUtils.urlEncode(String.join(" ", scopes.get()));
+            } else {
+                return OidcConstants.OPENID_SCOPE;
+            }
         } else {
             return checkUrlProperty(ConfigProvider.getConfig().getOptionalValue(oidcConfigProperty, String.class));
         }


### PR DESCRIPTION
This PR does a few minor updates which will allow testing Google OIDC provider directly from the OIDC DevUI:
* Google authorization code (probably always) includes a `/` character which is returned to DevUi as `%2F`, and currently it is not decoded and the authorization code flow fails so the `code` in now decoded in `provider.html`
* Google access token (as opposed to ID token) is binary, and OIDC DevUI passes the ID token to SwaggerUI if it thinks that the binary token can not be introspected - but now Quarkus OIDC can also verify the binary tokens indirectly via the `UserInfo` acquisition, so `OidcDevConsoleProcessor` now also checks if the discovered metadata contains a user info endpoint to give a hint to DevUI that the binary token can be verified, and thus DevUI should pass the access token to Swagger UI (instead of ID token)
* DevUI only passes `openid` scope when requesting an authorization code, which with Google, is not enough to get the user name, so `OidcConfigPropertySupplier` which is used by DevUI to fetch runtime-init configuration values has been updated to return an encoded list of scopes if they are configured

Additionally, I updated `provider.html` to recognize `hybrid` OIDC applications, which is convenient for testing for example Google directly against Quarkus web-app but also from DevUI where Quarkus can accept bearer tokens.

With these updates and some related configuration (both in Quarkus and Google Cloud Console) one will be able to login to Google, use both ID and access tokens it returns from DevUI. It is already possible to do it with Auth0/Okta as well