### PR TITLE
Fix guide oidc trust-store config parameter name

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -721,8 +721,8 @@ quarkus.oidc.client.tls.key-store-password=${key-store-password}
 #quarkus.oidc.client.tls.key-store-alias-password=keyAliasPassword
 
 # Truststore configuration
-quarkus.oidc.client.tls.trust-store-file=client-truststore.jks
-quarkus.oidc.client.tls.trust-store-password=${trust-store-password}
+quarkus.oidc-client.tls.trust-store-file=client-truststore.jks
+quarkus.oidc-client.tls.trust-store-password=${trust-store-password}
 # Add more truststore properties if needed:
 #quarkus.oidc.client.tls.trust-store-alias=certAlias
 ----


### PR DESCRIPTION
Fix error on parameter names.

I got these erros using the config names that are on [Quarkus OIDC Guide](https://quarkus.io/guides/security-openid-connect-client-reference#mutual-tls):
```
WARN  [io.qu.config] (Quarkus Main Thread)  Unrecognized configuration key "quarkus.oidc.client.tls.trust-store-password" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
WARN  [io.qu.config] (Quarkus Main Thread)  Unrecognized configuration key "quarkus.oidc.client.tls.trust-store-file" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
```