### PR TITLE
Add missing static import in config interceptor doc

### DIFF
--- a/docs/src/main/asciidoc/config-extending-support.adoc
+++ b/docs/src/main/asciidoc/config-extending-support.adoc
@@ -368,6 +368,8 @@ The `ConfigSourceInterceptorFactory` may initialize an interceptor with access t
 ----
 package org.acme.config;
 
+import static io.smallrye.config.SecretKeys.doLocked;
+
 import jakarta.annotation.Priority;
 
 import io.smallrye.config.ConfigSourceInterceptor;


### PR DESCRIPTION
Would be nice to have an explanation of that the doLocked actually does but I do not know, just used it as the example was using it.