### PR TITLE
Restore the ability to use @TestReactiveTransaction on a test class

### DIFF
--- a/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/TestReactiveTransactionTest.java
+++ b/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/TestReactiveTransactionTest.java
@@ -6,21 +6,17 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.hibernate.reactive.panache.Panache;
 import io.quarkus.test.TestReactiveTransaction;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.vertx.RunOnVertxContext;
 import io.quarkus.test.vertx.UniAsserter;
 
 @QuarkusTest
+@TestReactiveTransaction
 public class TestReactiveTransactionTest {
 
-    @RunOnVertxContext
-    @TestReactiveTransaction
     @Test
     public void testTestTransaction(UniAsserter asserter) {
         asserter.assertNotNull(() -> Panache.currentTransaction());
     }
 
-    @RunOnVertxContext
-    @TestReactiveTransaction
     @BeforeEach
     public void beforeEach(UniAsserter asserter) {
         asserter.assertNotNull(() -> Panache.currentTransaction());

--- a/test-framework/vertx/src/main/java/io/quarkus/test/vertx/RunOnVertxContextTestMethodInvoker.java
+++ b/test-framework/vertx/src/main/java/io/quarkus/test/vertx/RunOnVertxContextTestMethodInvoker.java
@@ -99,7 +99,8 @@ public class RunOnVertxContextTestMethodInvoker implements TestMethodInvoker {
         }
         if (runOnVertxContext == null) {
             // Use duplicated context if @TestReactiveTransaction is present
-            return m.isAnnotationPresent(TestReactiveTransaction.class);
+            return m.isAnnotationPresent(TestReactiveTransaction.class)
+                    || m.getDeclaringClass().isAnnotationPresent(TestReactiveTransaction.class);
         } else {
             return runOnVertxContext.duplicateContext();
         }


### PR DESCRIPTION
Fixes: #32650