### PR TITLE
Prevent NPE for UserInfo String and Boolean properties

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractJsonObjectResponse.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractJsonObjectResponse.java
@@ -29,11 +29,11 @@ public class AbstractJsonObjectResponse {
     }
 
     public String getString(String name) {
-        return json.getString(name);
+        return contains(name) ? json.getString(name) : null;
     }
 
     public Boolean getBoolean(String name) {
-        return json.getBoolean(name);
+        return contains(name) ? json.getBoolean(name) : null;
     }
 
     public Long getLong(String name) {

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/UserInfoTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/UserInfoTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.oidc.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.UserInfo;
+
+public class UserInfoTest {
+    UserInfo userInfo = new UserInfo(
+            "{"
+                    + "\"name\": \"alice\","
+                    + "\"admin\": true"
+                    + "}");
+
+    @Test
+    public void testGetString() {
+        assertEquals("alice", userInfo.getString("name"));
+        assertNull(userInfo.getString("names"));
+    }
+
+    @Test
+    public void testGetBoolean() {
+        assertTrue(userInfo.getBoolean("admin"));
+        assertNull(userInfo.getBoolean("admins"));
+    }
+}


### PR DESCRIPTION
Minor update to OIDC UserInfo throwing NPE if a string or boolean property with a given name does not exist 