### PR TITLE
Deprecations cleanup - Jandex, OpenTelemetry, SRye reactive messaging

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -1935,7 +1935,7 @@ public class BytecodeRecorderImpl implements RecorderContext {
 
     static String componentType(MethodInfo method) {
         ArrayType arrayType = method.returnType().asArrayType();
-        return arrayType.component().name().toString();
+        return arrayType.constituent().name().toString();
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ReflectiveHierarchyStep.java
@@ -160,7 +160,7 @@ public class ReflectiveHierarchyStep {
             }
         } else if (type instanceof ArrayType) {
             visits.addLast(() -> addReflectiveHierarchy(combinedIndexBuildItem, reflectiveHierarchyBuildItem, source,
-                    type.asArrayType().component(),
+                    type.asArrayType().constituent(),
                     processedReflectiveHierarchies,
                     unindexedClasses, finalFieldsWritable, reflectiveClass, visits));
         } else if (type instanceof ParameterizedType) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/RegisterForReflectionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/RegisterForReflectionBuildStep.java
@@ -210,7 +210,7 @@ public class RegisterForReflectionBuildStep {
             ClassLoader classLoader, Set<DotName> processedReflectiveHierarchies, boolean methods,
             ReflectiveHierarchyBuildItem.Builder builder, Type type) {
         if (type.kind().equals(Kind.ARRAY)) {
-            type = type.asArrayType().component();
+            type = type.asArrayType().constituent();
         }
         if (type.kind() != Kind.PRIMITIVE && !processedReflectiveHierarchies.contains(type.name())) {
             registerClassDependencies(reflectiveClassHierarchy, classLoader, processedReflectiveHierarchies,

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/AsmUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/AsmUtil.java
@@ -222,7 +222,7 @@ public class AsmUtil {
                 for (int i = 0; i < arrayType.dimensions(); i++) {
                     sb.append('[');
                 }
-                toSignature(sb, arrayType.component(), typeArgMapper, erased);
+                toSignature(sb, arrayType.constituent(), typeArgMapper, erased);
                 break;
             case CLASS:
                 sb.append('L').append(type.asClassType().name().toString('/')).append(';');

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/JandexUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/JandexUtil.java
@@ -233,7 +233,7 @@ public final class JandexUtil {
     private static boolean containsTypeParameters(Type type) {
         switch (type.kind()) {
             case ARRAY:
-                return containsTypeParameters(type.asArrayType().component());
+                return containsTypeParameters(type.asArrayType().constituent());
             case PARAMETERIZED_TYPE:
                 ParameterizedType parameterizedType = type.asParameterizedType();
                 if (parameterizedType.owner() != null
@@ -259,7 +259,7 @@ public final class JandexUtil {
         switch (type.kind()) {
             case ARRAY:
                 ArrayType arrayType = type.asArrayType();
-                return ArrayType.create(mapGenerics(arrayType.component(), mapping), arrayType.dimensions());
+                return ArrayType.create(mapGenerics(arrayType.constituent(), mapping), arrayType.dimensions());
             case CLASS:
                 return type;
             case PARAMETERIZED_TYPE:

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -177,7 +177,7 @@ Alternatively, your application can inject a `Multi` in your bean and subscribe 
 [source, java]
 ----
 import io.smallrye.mutiny.Multi;
-import io.smallrye.reactive.messaging.annotations.Channel;
+import org.eclipse.microprofile.reactive.messaging.Channel;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;

--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -447,10 +447,10 @@ The instrumentation documented in this section has been tested with Quarkus and 
 
 === CDI
 
-Annotating a method in any CDI aware bean with the `io.opentelemetry.extension.annotations.WithSpan`
+Annotating a method in any CDI aware bean with the `io.opentelemetry.instrumentation.annotations.WithSpan`
 annotation will create a new Span and establish any required relationships with the current Trace context.
 
-Method parameters can be annotated with the `io.opentelemetry.extension.annotations.SpanAttribute` annotation to
+Method parameters can be annotated with the `io.opentelemetry.instrumentation.annotations.SpanAttribute` annotation to
 indicate which method parameters should be part of the Trace.
 
 Example:

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -956,7 +956,7 @@ import org.jboss.resteasy.reactive.RestStreamElementType;
 
 import io.smallrye.mutiny.Multi;
 
-import io.smallrye.reactive.messaging.annotations.Channel;
+import org.eclipse.microprofile.reactive.messaging.Channel;
 
 @Path("escoffier")
 public class Endpoint {
@@ -995,7 +995,7 @@ import org.jboss.resteasy.reactive.RestStreamElementType;
 
 import io.smallrye.mutiny.Multi;
 
-import io.smallrye.reactive.messaging.annotations.Channel;
+import org.eclipse.microprofile.reactive.messaging.Channel;
 
 @Path("escoffier")
 public class Endpoint {

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/Name.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/Name.java
@@ -52,7 +52,7 @@ public class Name implements Comparable<Name> {
             case PARAMETERIZED_TYPE:
                 return createSimple(type.asParameterizedType());
             case ARRAY:
-                Type component = type.asArrayType().component();
+                Type component = type.asArrayType().constituent();
                 if (component.kind() == Kind.CLASS) {
                     return createSimple(type.toString());
                 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
@@ -497,7 +497,7 @@ public final class JpaJandexScavenger {
                 }
                 break;
             case ARRAY:
-                collectEmbeddedTypes(embeddedTypes, indexType.asArrayType().component());
+                collectEmbeddedTypes(embeddedTypes, indexType.asArrayType().constituent());
                 break;
             default:
                 // do nothing

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/test/HibernateSearchOutboxPollingClassesTest.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/test/HibernateSearchOutboxPollingClassesTest.java
@@ -145,7 +145,7 @@ public class HibernateSearchOutboxPollingClassesTest {
                 collectModelClassesRecursively(index, type.name(), classes);
                 break;
             case ARRAY:
-                collectModelClassesRecursively(index, type.asArrayType().component(), classes);
+                collectModelClassesRecursively(index, type.asArrayType().constituent(), classes);
                 break;
             case TYPE_VARIABLE:
                 for (Type bound : type.asTypeVariable().bounds()) {

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -699,7 +699,7 @@ class HibernateValidatorProcessor {
             case PARAMETERIZED_TYPE:
                 return type.name();
             case ARRAY:
-                return getClassName(type.asArrayType().component());
+                return getClassName(type.asArrayType().constituent());
             default:
                 return null;
         }

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GrpcOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GrpcOpenTelemetryTest.java
@@ -32,7 +32,7 @@ import io.grpc.stub.StreamObserver;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.grpc.GrpcService;

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -2458,7 +2458,7 @@ public class JaxrsClientReactiveProcessor {
             ResultHandle paramArray;
             String componentType = null;
             if (type.kind() == Type.Kind.ARRAY) {
-                componentType = type.asArrayType().component().name().toString();
+                componentType = type.asArrayType().constituent().name().toString();
                 paramArray = notNullParam.checkCast(queryParamHandle, Object[].class);
             } else if (isCollection(type, index)) {
                 if (type.kind() == PARAMETERIZED_TYPE) {

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/MicroProfileRestClientEnricher.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/MicroProfileRestClientEnricher.java
@@ -869,7 +869,7 @@ class MicroProfileRestClientEnricher implements JaxrsClientReactiveEnricher {
     }
 
     private static boolean isStringArray(Type returnType) {
-        return returnType.kind() == Type.Kind.ARRAY && returnType.asArrayType().component().name().equals(STRING);
+        return returnType.kind() == Type.Kind.ARRAY && returnType.asArrayType().constituent().name().equals(STRING);
     }
 
     private static boolean isComputedParamContext(Type type) {

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/PermissionSecurityChecks.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/PermissionSecurityChecks.java
@@ -720,7 +720,7 @@ interface PermissionSecurityChecks {
 
             private static boolean secondParamIsNotStringArr(MethodInfo constructor) {
                 return constructor.parametersCount() < 2 || constructor.parameterType(1).kind() != Type.Kind.ARRAY
-                        || !constructor.parameterType(1).asArrayType().component().name().equals(STRING);
+                        || !constructor.parameterType(1).asArrayType().constituent().name().equals(STRING);
             }
 
             private static boolean isStringPermission(PermissionKey permissionKey) {

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/devmode/HttpFrontend.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/devmode/HttpFrontend.java
@@ -5,11 +5,11 @@ import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
+import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import io.smallrye.reactive.messaging.annotations.Channel;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.Router;
 

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/ProcessorSignatureTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/ProcessorSignatureTest.java
@@ -13,6 +13,8 @@ import java.util.concurrent.Executors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
@@ -26,8 +28,6 @@ import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.smallrye.reactive.messaging.annotations.Channel;
-import io.smallrye.reactive.messaging.annotations.Emitter;
 
 @SuppressWarnings("unused")
 public class ProcessorSignatureTest {

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/SubscriberSignatureTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/SubscriberSignatureTest.java
@@ -13,6 +13,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.Test;
@@ -21,8 +23,6 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.smallrye.reactive.messaging.annotations.Channel;
-import io.smallrye.reactive.messaging.annotations.Emitter;
 
 @SuppressWarnings("unused")
 public class SubscriberSignatureTest {

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/TransformerSignatureTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/TransformerSignatureTest.java
@@ -12,6 +12,8 @@ import java.util.concurrent.Executors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
@@ -23,8 +25,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.reactivestreams.Publisher;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.smallrye.reactive.messaging.annotations.Channel;
-import io.smallrye.reactive.messaging.annotations.Emitter;
 
 @SuppressWarnings("unused")
 public class TransformerSignatureTest {

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/AbstractMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/AbstractMethodsAdder.java
@@ -298,7 +298,7 @@ public abstract class AbstractMethodsAdder {
             return t;
         }
         if (t.kind() == Type.Kind.ARRAY) {
-            return verifyQueryResultType(t.asArrayType().component(), index);
+            return verifyQueryResultType(t.asArrayType().constituent(), index);
         } else if (t.kind() == Type.Kind.PARAMETERIZED_TYPE) {
             final List<Type> types = t.asParameterizedType().arguments();
             if (types.size() == 1) {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
@@ -144,7 +144,7 @@ public class HttpSecurityProcessor {
     }
 
     private static boolean isStringArray(Type type) {
-        return type.kind() == Type.Kind.ARRAY && isString(type.asArrayType().component());
+        return type.kind() == Type.Kind.ARRAY && isString(type.asArrayType().constituent());
     }
 
     private static boolean isString(Type type) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralGenerator.java
@@ -174,7 +174,7 @@ public class AnnotationLiteralGenerator extends AbstractGenerator {
     private static boolean returnsClassOrClassArray(MethodInfo annotationMember) {
         boolean returnsClass = DotNames.CLASS.equals(annotationMember.returnType().name());
         boolean returnsClassArray = annotationMember.returnType().kind() == Type.Kind.ARRAY
-                && DotNames.CLASS.equals(annotationMember.returnType().asArrayType().component().name());
+                && DotNames.CLASS.equals(annotationMember.returnType().asArrayType().constituent().name());
         return returnsClass || returnsClassArray;
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralProcessor.java
@@ -355,7 +355,7 @@ public class AnnotationLiteralProcessor {
 
     private static DotName componentTypeName(MethodInfo method) {
         ArrayType arrayType = method.returnType().asArrayType();
-        return arrayType.component().name();
+        return arrayType.constituent().name();
     }
 
     private static String generateAnnotationLiteralClassName(DotName annotationName) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolverImpl.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolverImpl.java
@@ -145,7 +145,7 @@ class BeanResolverImpl implements BeanResolver {
         if (ARRAY.equals(requiredType.kind())) {
             if (ARRAY.equals(beanType.kind())) {
                 // Array types are considered to match only if their element types are identical
-                return matchesNoBoxing(requiredType.asArrayType().component(), beanType.asArrayType().component());
+                return matchesNoBoxing(requiredType.asArrayType().constituent(), beanType.asArrayType().constituent());
             }
         } else if (CLASS.equals(requiredType.kind())) {
             if (CLASS.equals(beanType.kind())) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
@@ -339,7 +339,7 @@ public class InjectionPointInfo {
             return ParameterizedType.create(parameterizedType.name(), typeParams, parameterizedType.owner());
         } else if (type.kind() == org.jboss.jandex.Type.Kind.ARRAY) {
             ArrayType arrayType = type.asArrayType();
-            Type component = arrayType.component();
+            Type component = arrayType.constituent();
             if (component.kind() == org.jboss.jandex.Type.Kind.TYPE_VARIABLE
                     || component.kind() == org.jboss.jandex.Type.Kind.PARAMETERIZED_TYPE) {
                 component = resolveType(component, beanClass, beanDeployment, resolvedTypeVariables);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -523,7 +523,7 @@ final class Methods {
                     }
                     DotName typeName = type.name();
                     if (type.kind() == Kind.ARRAY) {
-                        Type componentType = type.asArrayType().component();
+                        Type componentType = type.asArrayType().constituent();
                         if (componentType.kind() == Kind.PRIMITIVE) {
                             continue;
                         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
@@ -197,7 +197,7 @@ public final class Types {
                 arrayHandle = doLoadClass(creator, array.name().toString(), tccl);
             } else {
                 // E.g. List<String>[] -> new GenericArrayTypeImpl(new ParameterizedTypeImpl(List.class, String.class))
-                Type componentType = type.asArrayType().component();
+                Type componentType = type.asArrayType().constituent();
                 AssignableResultHandle componentTypeHandle = creator.createVariable(Object.class);
                 getTypeHandle(componentTypeHandle, creator, componentType, tccl, cache, typeVariables);
                 arrayHandle = creator.newInstance(
@@ -349,9 +349,9 @@ public final class Types {
     }
 
     static Type getArrayElementType(ArrayType array) {
-        Type elementType = array.component();
+        Type elementType = array.constituent();
         while (elementType.kind() == Kind.ARRAY) {
-            elementType = elementType.asArrayType().component();
+            elementType = elementType.asArrayType().constituent();
         }
         return elementType;
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ArrayTypeImpl.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ArrayTypeImpl.java
@@ -13,8 +13,8 @@ class ArrayTypeImpl extends TypeImpl<org.jboss.jandex.ArrayType> implements Arra
     public Type componentType() {
         int dimensions = jandexType.dimensions();
         org.jboss.jandex.Type componentType = dimensions == 1
-                ? jandexType.component()
-                : org.jboss.jandex.ArrayType.create(jandexType.component(), dimensions - 1);
+                ? jandexType.constituent()
+                : org.jboss.jandex.ArrayType.create(jandexType.constituent(), dimensions - 1);
         return fromJandexType(jandexIndex, annotationOverlays, componentType);
     }
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/TypesImpl.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/TypesImpl.java
@@ -135,15 +135,15 @@ class TypesImpl implements Types {
 
     @Override
     public WildcardType wildcardWithUpperBound(Type upperBound) {
-        org.jboss.jandex.WildcardType jandexType = org.jboss.jandex.WildcardType.create(((TypeImpl<?>) upperBound).jandexType,
-                true);
+        org.jboss.jandex.WildcardType jandexType = org.jboss.jandex.WildcardType
+                .createUpperBound(((TypeImpl<?>) upperBound).jandexType);
         return new WildcardTypeImpl(jandexIndex, annotationOverlays, jandexType);
     }
 
     @Override
     public WildcardType wildcardWithLowerBound(Type lowerBound) {
-        org.jboss.jandex.WildcardType jandexType = org.jboss.jandex.WildcardType.create(((TypeImpl<?>) lowerBound).jandexType,
-                false);
+        org.jboss.jandex.WildcardType jandexType = org.jboss.jandex.WildcardType
+                .createLowerBound(((TypeImpl<?>) lowerBound).jandexType);
         return new WildcardTypeImpl(jandexIndex, annotationOverlays, jandexType);
     }
 

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
@@ -328,7 +328,7 @@ public class ExtensionMethodGenerator {
                         // Last param is varargs
                         Type varargsParam = params.get(lastIdx).type;
                         ResultHandle componentType = tryCatch
-                                .loadClass(varargsParam.asArrayType().component().name().toString());
+                                .loadClass(varargsParam.asArrayType().constituent().name().toString());
                         ResultHandle varargsResults = tryCatch.invokeVirtualMethod(
                                 Descriptors.EVALUATED_PARAMS_GET_VARARGS_RESULTS,
                                 evaluatedParamsHandle, tryCatch.load(evaluated.size()), componentType);
@@ -579,7 +579,7 @@ public class ExtensionMethodGenerator {
                                 // Last param is varargs
                                 Type varargsParam = params.get(lastIdx).type;
                                 ResultHandle componentType = tryCatch
-                                        .loadClass(varargsParam.asArrayType().component().name().toString());
+                                        .loadClass(varargsParam.asArrayType().constituent().name().toString());
                                 ResultHandle varargsResults = tryCatch.invokeVirtualMethod(
                                         Descriptors.EVALUATED_PARAMS_GET_VARARGS_RESULTS,
                                         whenEvaluatedParams, tryCatch.load(evaluated.size()), componentType);

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
@@ -703,7 +703,7 @@ public class ValueResolverGenerator {
             // Then we need to create an array for the last argument
             Type varargsParam = parameterTypes.get(parameterTypes.size() - 1);
             ResultHandle componentType = tryCatch
-                    .loadClass(varargsParam.asArrayType().component().name().toString());
+                    .loadClass(varargsParam.asArrayType().constituent().name().toString());
             ResultHandle varargsResults = tryCatch.invokeVirtualMethod(Descriptors.EVALUATED_PARAMS_GET_VARARGS_RESULTS,
                     evaluatedParams, tryCatch.load(parameterTypes.size()), componentType);
             // E.g. String, String, String -> String, String[]
@@ -852,7 +852,7 @@ public class ValueResolverGenerator {
                     // Then we need to create an array for the last argument
                     Type varargsParam = parameterTypes.get(parameterTypes.size() - 1);
                     ResultHandle componentType = tryCatch
-                            .loadClass(varargsParam.asArrayType().component().name().toString());
+                            .loadClass(varargsParam.asArrayType().constituent().name().toString());
                     ResultHandle varargsResults = tryCatch.invokeVirtualMethod(Descriptors.EVALUATED_PARAMS_GET_VARARGS_RESULTS,
                             evaluatedParams, tryCatch.load(parameterTypes.size()), componentType);
                     // E.g. String, String, String -> String, String[]

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -1419,7 +1419,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                     || convertible) {
                 builder.setSingle(false);
             }
-            elementType = toClassName(at.component(), currentClassInfo, actualEndpointInfo, index);
+            elementType = toClassName(at.constituent(), currentClassInfo, actualEndpointInfo, index);
             if (convertible) {
                 handleArrayParam(existingConverters, errorLocation, hasRuntimeConverters, builder, elementType);
             }
@@ -1450,8 +1450,8 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
     private boolean isFormParamConvertible(Type paramType) {
         // let's not call the array converter for byte[] for multipart
         if (paramType.kind() == Kind.ARRAY
-                && paramType.asArrayType().component().kind() == Kind.PRIMITIVE
-                && paramType.asArrayType().component().asPrimitiveType().primitive() == Primitive.BYTE) {
+                && paramType.asArrayType().constituent().kind() == Kind.PRIMITIVE
+                && paramType.asArrayType().constituent().asPrimitiveType().primitive() == Primitive.BYTE) {
             return false;
         } else {
             return true;

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/JandexUtil.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/JandexUtil.java
@@ -248,7 +248,7 @@ public final class JandexUtil {
     private static boolean containsTypeParameters(Type type) {
         switch (type.kind()) {
             case ARRAY:
-                return containsTypeParameters(type.asArrayType().component());
+                return containsTypeParameters(type.asArrayType().constituent());
             case PARAMETERIZED_TYPE:
                 ParameterizedType parameterizedType = type.asParameterizedType();
                 if (parameterizedType.owner() != null
@@ -274,7 +274,7 @@ public final class JandexUtil {
         switch (type.kind()) {
             case ARRAY:
                 ArrayType arrayType = type.asArrayType();
-                return ArrayType.create(mapGenerics(arrayType.component(), mapping), arrayType.dimensions());
+                return ArrayType.create(mapGenerics(arrayType.constituent(), mapping), arrayType.dimensions());
             case CLASS:
                 return type;
             case PARAMETERIZED_TYPE:

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/ClassInjectorTransformer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/scanning/ClassInjectorTransformer.java
@@ -377,7 +377,7 @@ public class ClassInjectorTransformer implements BiFunction<String, ClassVisitor
             if (!extractor.isSingle()) {
                 boolean isArray = type.kind() == org.jboss.jandex.Type.Kind.ARRAY;
                 // it's T[] or List<T>
-                type = isArray ? type.asArrayType().component()
+                type = isArray ? type.asArrayType().constituent()
                         : type.asParameterizedType().arguments().get(0);
             }
             // type
@@ -489,7 +489,7 @@ public class ClassInjectorTransformer implements BiFunction<String, ClassVisitor
                 // [instance, instance, converter]
                 // array converter wants the array instance type
                 if (converter instanceof ArrayConverter.ArraySupplier) {
-                    org.jboss.jandex.Type componentType = fieldInfo.type().asArrayType().component();
+                    org.jboss.jandex.Type componentType = fieldInfo.type().asArrayType().constituent();
                     initConverterMethod.visitLdcInsn(componentType.name().toString('.'));
                     // [instance, instance, converter, componentType]
                     initConverterMethod.visitMethodInsn(Opcodes.INVOKESPECIAL, delegatorBinaryName, "<init>",
@@ -862,8 +862,8 @@ public class ClassInjectorTransformer implements BiFunction<String, ClassVisitor
             } else if (param.getElementType().equals(InputStream.class.getName())) {
                 return MultipartFormParamExtractor.Type.InputStream;
             } else if (param.getParamType().kind() == Kind.ARRAY
-                    && param.getParamType().asArrayType().component().kind() == Kind.PRIMITIVE
-                    && param.getParamType().asArrayType().component().asPrimitiveType().primitive() == Primitive.BYTE) {
+                    && param.getParamType().asArrayType().constituent().kind() == Kind.PRIMITIVE
+                    && param.getParamType().asArrayType().constituent().asPrimitiveType().primitive() == Primitive.BYTE) {
                 return MultipartFormParamExtractor.Type.ByteArray;
             } else if (mimeType != null && !mimeType.equals(MediaType.TEXT_PLAIN)) {
                 return MultipartFormParamExtractor.Type.PartType;


### PR DESCRIPTION
 - Reactive messaging - SRye Channel and Emitter leftovers, switch to MP based annotations
 - OpenTelemetry - WithSpan and SpanAttribute deprecated package switch
 - Jandex related - Replace deprecated WildcardType.create with createUpperBound and createLowerBound
 - Jandex related - Replace deprecated ArrayType.component() with ArrayType.constituent()