### PR TITLE
Register Resource Class for reflection when custom Reader or Writer is used

### DIFF
--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -313,7 +313,7 @@ public class JaxrsClientReactiveProcessor {
                 })
                 .setResourceMethodCallback(new Consumer<>() {
                     @Override
-                    public void accept(EndpointIndexer.ResourceMethodCallbackData entry) {
+                    public void accept(EndpointIndexer.ResourceMethodCallbackEntry entry) {
                         MethodInfo method = entry.getMethodInfo();
                         String source = JaxrsClientReactiveProcessor.class.getSimpleName() + " > " + method.declaringClass()
                                 + "[" + method + "]";

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -498,7 +498,7 @@ public class ResteasyReactiveProcessor {
                                     : Collections.emptyMap())
                     .setResourceMethodCallback(new Consumer<>() {
                         @Override
-                        public void accept(EndpointIndexer.ResourceMethodCallbackData entry) {
+                        public void accept(EndpointIndexer.ResourceMethodCallbackEntry entry) {
                             MethodInfo method = entry.getMethodInfo();
 
                             resourceMethodEntries.add(new ResteasyReactiveResourceMethodEntriesBuildItem.Entry(
@@ -545,18 +545,27 @@ public class ResteasyReactiveProcessor {
                                             .build());
                                 }
                                 if (parameterType.name().equals(FILE)) {
-                                    reflectiveClassBuildItemBuildProducer
-                                            .produce(ReflectiveClassBuildItem
-                                                    .builder(entry.getActualEndpointInfo().name().toString())
-                                                    .constructors(false).methods().build());
+                                    minimallyRegisterResourceClassForReflection(entry,
+                                            reflectiveClassBuildItemBuildProducer);
                                 }
                             }
 
                             if (filtersAccessResourceMethod) {
-                                reflectiveClassBuildItemBuildProducer.produce(
-                                        ReflectiveClassBuildItem.builder(entry.getActualEndpointInfo().name().toString())
-                                                .constructors(false).methods().build());
+                                minimallyRegisterResourceClassForReflection(entry, reflectiveClassBuildItemBuildProducer);
                             }
+
+                            if (entry.additionalRegisterClassForReflectionCheck()) {
+                                minimallyRegisterResourceClassForReflection(entry, reflectiveClassBuildItemBuildProducer);
+                            }
+                        }
+
+                        private void minimallyRegisterResourceClassForReflection(
+                                EndpointIndexer.ResourceMethodCallbackEntry entry,
+                                BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItemBuildProducer) {
+                            reflectiveClassBuildItemBuildProducer
+                                    .produce(ReflectiveClassBuildItem
+                                            .builder(entry.getActualEndpointInfo().name().toString())
+                                            .constructors(false).methods().build());
                         }
 
                         private boolean hasAnnotation(MethodInfo method, short paramPosition, DotName annotation) {

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
@@ -153,7 +153,6 @@ public class ResteasyReactiveScanner {
                     runtimeType = RuntimeType.SERVER;
                 }
                 List<String> mediaTypeStrings = Collections.emptyList();
-                String readerClassName = readerClass.name().toString();
                 AnnotationInstance consumesAnnotation = readerClass.classAnnotation(ResteasyReactiveDotNames.CONSUMES);
                 if (consumesAnnotation != null) {
                     mediaTypeStrings = Arrays.asList(consumesAnnotation.value().asStringArray());
@@ -167,7 +166,7 @@ public class ResteasyReactiveScanner {
                 if (priorityInstance != null) {
                     priority = priorityInstance.value().asInt();
                 }
-                readerList.add(new ScannedSerializer(readerClassName,
+                readerList.add(new ScannedSerializer(readerClass,
                         typeParameters.get(0).name().toString(), mediaTypeStrings, runtimeType, false, priority));
             }
         }
@@ -192,7 +191,6 @@ public class ResteasyReactiveScanner {
                 List<Type> typeParameters = JandexUtil.resolveTypeParameters(writerClass.name(),
                         ResteasyReactiveDotNames.MESSAGE_BODY_WRITER,
                         index);
-                String writerClassName = writerClass.name().toString();
                 AnnotationInstance constrainedToInstance = writerClass.classAnnotation(ResteasyReactiveDotNames.CONSTRAINED_TO);
                 if (constrainedToInstance != null) {
                     runtimeType = RuntimeType.valueOf(constrainedToInstance.value().asEnum());
@@ -202,7 +200,7 @@ public class ResteasyReactiveScanner {
                 if (priorityInstance != null) {
                     priority = priorityInstance.value().asInt();
                 }
-                writerList.add(new ScannedSerializer(writerClassName,
+                writerList.add(new ScannedSerializer(writerClass,
                         typeParameters.get(0).name().toString(), mediaTypeStrings, runtimeType, false, priority));
             }
         }

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ScannedSerializer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ScannedSerializer.java
@@ -5,8 +5,11 @@ import java.util.List;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.RuntimeType;
 
+import org.jboss.jandex.ClassInfo;
+
 public class ScannedSerializer {
 
+    private final ClassInfo classInfo;
     private final String className;
     private final String handledClassName;
     private final List<String> mediaTypeStrings;
@@ -14,18 +17,35 @@ public class ScannedSerializer {
     private final boolean builtin;
     private final Integer priority;
 
-    public ScannedSerializer(String className, String handledClassName, List<String> mediaTypeStrings) {
-        this(className, handledClassName, mediaTypeStrings, null, true, Priorities.USER);
+    public ScannedSerializer(ClassInfo classInfo, String handledClassName, List<String> mediaTypeStrings) {
+        this(classInfo, handledClassName, mediaTypeStrings, null, true, Priorities.USER);
     }
 
-    public ScannedSerializer(String className, String handledClassName, List<String> mediaTypeStrings,
+    // used only for testing
+    public ScannedSerializer(String className, String handledClassName, List<String> mediaTypeStrings) {
+        this(null, className, handledClassName, mediaTypeStrings, null, true, Priorities.USER);
+    }
+
+    public ScannedSerializer(ClassInfo classInfo, String handledClassName, List<String> mediaTypeStrings,
             RuntimeType runtimeType, boolean builtin, Integer priority) {
+        this(classInfo, classInfo.name().toString(), handledClassName, mediaTypeStrings, runtimeType, builtin, priority);
+    }
+
+    private ScannedSerializer(ClassInfo classInfo, String className, String handledClassName, List<String> mediaTypeStrings,
+            RuntimeType runtimeType, boolean builtin, Integer priority) {
+        this.classInfo = classInfo;
         this.className = className;
         this.handledClassName = handledClassName;
         this.mediaTypeStrings = mediaTypeStrings;
         this.runtimeType = runtimeType;
         this.builtin = builtin;
         this.priority = priority;
+    }
+
+    // used only for tests
+
+    public ClassInfo getClassInfo() {
+        return classInfo;
     }
 
     public String getClassName() {

--- a/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/InputResource.java
+++ b/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/InputResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.envers;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("input")
+public class InputResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String in(Message message) {
+        return message.getData();
+    }
+}

--- a/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/Message.java
+++ b/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/Message.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.envers;
+
+public class Message {
+
+    private String data;
+
+    public Message() {
+    }
+
+    public Message(String data) {
+        this.data = data;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+}

--- a/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/MessageProvider.java
+++ b/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/MessageProvider.java
@@ -1,0 +1,45 @@
+package io.quarkus.it.envers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+@Consumes(MediaType.WILDCARD)
+@Produces(MediaType.WILDCARD)
+public class MessageProvider implements MessageBodyReader<Message>, MessageBodyWriter<Message> {
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return Message.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public Message readFrom(Class<Message> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+        return new Message("in");
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return Message.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public void writeTo(Message event, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        entityStream.write("{\"data\": \"out\"}".getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/OutputResource.java
+++ b/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/OutputResource.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.envers;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("output")
+public class OutputResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Message out() {
+        return new Message("test");
+    }
+}

--- a/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/InputResourceIT.java
+++ b/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/InputResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.envers;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class InputResourceIT extends InputResourceTest {
+}

--- a/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/InputResourceTest.java
+++ b/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/InputResourceTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.envers;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+class InputResourceTest {
+
+    @Test
+    void test() {
+        given().contentType(ContentType.JSON).accept(ContentType.TEXT)
+                .when().post("/jpa-envers-test/input")
+                .then()
+                .statusCode(200)
+                .body(equalTo("in"));
+    }
+}

--- a/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/OutputResourceIT.java
+++ b/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/OutputResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.envers;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class OutputResourceIT extends OutputResourceTest {
+}

--- a/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/OutputResourceTest.java
+++ b/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/OutputResourceTest.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.envers;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+class OutputResourceTest {
+
+    @Test
+    void test() {
+        given().accept(ContentType.JSON)
+                .when()
+                .get("/jpa-envers-test/output")
+                .then()
+                .statusCode(200)
+                .body("data", equalTo("out"));
+    }
+}


### PR DESCRIPTION
This is needed because these Reader and Writer classes expect to be passed the method annotations

The issue was initially mentioned [here](https://quarkusio.zulipchat.com/#narrow/stream/306418-resteasy-reactive/topic/CloudEvents.20lib.20doesn't.20work.20in.20native.20mode).