### PR TITLE
Remove maven-compiler-plugin from dependabot ignore list

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/dependabot.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/dependabot.yml
@@ -1,13 +1,11 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "org.apache.maven.plugins:maven-compiler-plugin"


### PR DESCRIPTION
- Follow up to https://github.com/quarkusio/quarkus/pull/32776
 
Now that quarkiverse-parent does not depend on `jboss-parent`, there is no reason to ignore `maven-compiler-plugin` updates