### PR TITLE
Gradle plugins update build fixup

### DIFF
--- a/integration-tests/gradle/build.gradle.kts
+++ b/integration-tests/gradle/build.gradle.kts
@@ -1,3 +1,6 @@
+// This file doesn't configure integration tests and kept just to update gradle wrapper.
+// To run tests use `./mvnw -f integration-tests/gradle test` from project root directory.
+
 tasks.wrapper {
     // not sure if it's still required: IntelliJ works fine with `-bin` distribution 
     // after indexing Gradle API jars

--- a/integration-tests/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/integration-tests/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+# https://gradle.org/release-checksums/
 distributionSha256Sum=2cbafcd2c47a101cb2165f636b4677fac0b954949c9429c1c988da399defe6a9
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-all.zip
 networkTimeout=10000

--- a/integration-tests/gradle/settings.gradle.kts
+++ b/integration-tests/gradle/settings.gradle.kts
@@ -1,1 +1,4 @@
+// This file is required to run gradle from this directory to simplify wrapper
+// update since gradle requires `settings.gradle[.kts]` to be present.
+
 rootProject.name = "gradle-plugins-integration-tests"


### PR DESCRIPTION
Follow up for #32668

* add back `# https://gradle.org/release-checksums/` to gradle integration tests `gradle-wrapper.properties`
* add note about reason for `build.gradle.kts`/`settings.gradle.kts`

@snazy, @aloubyansky