### PR TITLE
Set OIDC `user-info-required` when `UserInfo` is known to be required

### DIFF
--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OpaqueTokenVerificationWithUserInfoValidationTest.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/OpaqueTokenVerificationWithUserInfoValidationTest.java
@@ -16,7 +16,9 @@ public class OpaqueTokenVerificationWithUserInfoValidationTest {
     @RegisterExtension
     static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addAsResource(new StringAsset("quarkus.oidc.token.verify-access-token-with-user-info=true\n"),
+                    .addAsResource(new StringAsset(
+                            "quarkus.oidc.token.verify-access-token-with-user-info=true\n"
+                                    + "quarkus.oidc.authentication.user-info-required=false\n"),
                             "application.properties"))
             .assertException(t -> {
                 Throwable e = t;

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -137,6 +137,8 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     config.setTokenPath(tokenUri);
                     String jwksUri = uri.replace("/tenant-refresh/tenant-web-app-refresh/api/user", "/oidc/jwks");
                     config.setJwksPath(jwksUri);
+                    String userInfoPath = uri.replace("/tenant-refresh/tenant-web-app-refresh/api/user", "/oidc/userinfo");
+                    config.setUserInfoPath(userInfoPath);
                     config.getToken().setIssuer("any");
                     config.tokenStateManager.setSplitTokens(true);
                     config.tokenStateManager.setEncryptionRequired(false);

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -49,7 +49,6 @@ quarkus.oidc.tenant-web-app.auth-server-url=${keycloak.url}/realms/quarkus-webap
 quarkus.oidc.tenant-web-app.client-id=quarkus-app-webapp
 quarkus.oidc.tenant-web-app.credentials.secret=secret
 quarkus.oidc.tenant-web-app.application-type=web-app
-quarkus.oidc.tenant-web-app.authentication.user-info-required=true
 quarkus.oidc.tenant-web-app.roles.source=userinfo
 quarkus.oidc.tenant-web-app.allow-user-info-cache=false
 

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -56,7 +56,6 @@ quarkus.oidc.code-flow-user-info-only.authorization-path=/
 quarkus.oidc.code-flow-user-info-only.token-path=access_token
 quarkus.oidc.code-flow-user-info-only.user-info-path=protocol/openid-connect/userinfo
 quarkus.oidc.code-flow-user-info-only.authentication.id-token-required=false
-quarkus.oidc.code-flow-user-info-only.authentication.user-info-required=true
 quarkus.oidc.code-flow-user-info-only.code-grant.extra-params.extra-param=extra-param-value
 quarkus.oidc.code-flow-user-info-only.code-grant.headers.X-Custom=XCustomHeaderValue
 quarkus.oidc.code-flow-user-info-only.client-id=quarkus-web-app


### PR DESCRIPTION
`quarkus.oidc.authentication.user-info-required` can be at times one property too many during the configuration which is annoying, especially during the demo. 
There are a few cases where it is known from some other configuration that it will definitely be required, for example, when the userinfo contains the roles which will be typical when the binary access token is veriifed via the Userinfo acquisition for example, so when the user says `quarkus.oidc.roles.source=userinfo`, having to add  `quarkus.oidc.authentication.user-info-required=true` in properties is not cool. Similarly, for 2 other cases where the userinfo must be acquired in order to verify the token.

`quarkus.oidc.authentication.user-info-required=true` is always valid if it is needed, it is just unnecessary to set directly in such cases so it is set internally.

`quarkus.oidc.authentication.user-info-required=true` is useful on its own, when `UserInfo` injection is needed for whatever purposes, so enabling it is needed as it involves a remote call.

Tweaked some of the tests to confirm it does not have to be set, had to fix one test to add the userinfo path - that test disabled the ID token requirement (=> with this PR userinfo is required), it was done for the test convenience only as the mock OIDC server does not  support the code flow