### PR TITLE
Fix K8 service binding with reactive datasource

### DIFF
--- a/extensions/kubernetes-service-binding/runtime/src/main/java/io/quarkus/kubernetes/service/binding/runtime/DatasourceServiceBindingConfigSourceFactory.java
+++ b/extensions/kubernetes-service-binding/runtime/src/main/java/io/quarkus/kubernetes/service/binding/runtime/DatasourceServiceBindingConfigSourceFactory.java
@@ -81,7 +81,7 @@ public abstract class DatasourceServiceBindingConfigSourceFactory
 
     private boolean configureUrlPropertyUsingKey(Map<String, String> properties, String key) {
         String value = serviceBinding.getProperties().get(key);
-        if (value == null) {
+        if (value == null || prefix == null) {
             return false;
         } else if (value.startsWith(prefix)) {
             properties.put(urlPropertyName, value);
@@ -109,7 +109,7 @@ public abstract class DatasourceServiceBindingConfigSourceFactory
         }
 
         public Reactive(String urlFormat) {
-            super("reactive", "quarkus.datasource.reactive.url", "", urlFormat);
+            super("reactive", "quarkus.datasource.reactive.url", null, urlFormat);
         }
     }
 }


### PR DESCRIPTION
fixes service binding with reactive datasources (kinda https://github.com/quarkusio/quarkus/issues/32773 followup)

https://github.com/quarkusio/quarkus/pull/30955 made one mistake: it tests string for starting with empty string, so for example `jdbc:postgresql://postgresql-primary.ts-fknbtwysvs.svc:5432/postgresql?password=6%3EiUV%7Cz_mqGe%2A2pI%5D%2B_%3E9%5Ev6&user=postgresql` always start with `""` and thus, `jdbc-uri` is set for reactive datasource and sb doesn't work with `quarkus-reactive-pg-client`