### PR TITLE
Report OTel config unknowns only when fallback properties used

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryLegacyConfigurationTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryLegacyConfigurationTest.java
@@ -5,7 +5,7 @@ import static java.lang.Boolean.TRUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
+import java.util.List;
 
 import jakarta.inject.Inject;
 
@@ -24,6 +24,7 @@ class OpenTelemetryLegacyConfigurationTest {
             .overrideConfigKey("quarkus.opentelemetry.enabled", "false")
             .overrideConfigKey("quarkus.opentelemetry.tracer.enabled", "false")
             .overrideConfigKey("quarkus.opentelemetry.propagators", "tracecontext")
+            .overrideConfigKey("quarkus.opentelemetry.tracer.resource-attributes", "service.name=authservice")
             .overrideConfigKey("quarkus.opentelemetry.tracer.suppress-non-application-uris", "false")
             .overrideConfigKey("quarkus.opentelemetry.tracer.include-static-resources", "true")
             .overrideConfigKey("quarkus.opentelemetry.tracer.sampler", "off")
@@ -46,7 +47,9 @@ class OpenTelemetryLegacyConfigurationTest {
         assertEquals(FALSE, oTelBuildConfig.enabled());
         assertTrue(oTelBuildConfig.traces().enabled().isPresent());
         assertEquals(FALSE, oTelBuildConfig.traces().enabled().get());
-        assertEquals(Arrays.asList("tracecontext"), oTelBuildConfig.propagators()); // will not include the default baggagge
+        assertEquals(List.of("tracecontext"), oTelBuildConfig.propagators()); // will not include the default baggagge
+        assertTrue(oTelRuntimeConfig.resourceAttributes().isPresent());
+        assertEquals("service.name=authservice", oTelRuntimeConfig.resourceAttributes().get().get(0));
         assertEquals(FALSE, oTelRuntimeConfig.traces().suppressNonApplicationUris());
         assertEquals(TRUE, oTelRuntimeConfig.traces().includeStaticResources());
         assertEquals("always_off", oTelBuildConfig.traces().sampler());

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/OTelFallbackConfigSourceInterceptor.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/OTelFallbackConfigSourceInterceptor.java
@@ -1,5 +1,6 @@
 package io.quarkus.opentelemetry.runtime.config;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -15,21 +16,27 @@ import io.smallrye.config.Priorities;
 
 @Priority(Priorities.LIBRARY + 300 + 5)
 public class OTelFallbackConfigSourceInterceptor extends FallbackConfigSourceInterceptor {
+    private final static Map<String, String> FALLBACKS = new HashMap<>();
     private final static LegacySamplerNameConverter LEGACY_SAMPLER_NAME_CONVERTER = new LegacySamplerNameConverter();
 
+    static {
+        FALLBACKS.put("quarkus.otel.enabled", "quarkus.opentelemetry.enabled");
+        FALLBACKS.put("quarkus.otel.traces.enabled", "quarkus.opentelemetry.tracer.enabled");
+        FALLBACKS.put("quarkus.otel.propagators", "quarkus.opentelemetry.propagators");
+        FALLBACKS.put("quarkus.otel.resource.attributes", "quarkus.opentelemetry.tracer.resource-attributes");
+        FALLBACKS.put("quarkus.otel.traces.suppress-non-application-uris",
+                "quarkus.opentelemetry.tracer.suppress-non-application-uris");
+        FALLBACKS.put("quarkus.otel.traces.include-static-resources", "quarkus.opentelemetry.tracer.include-static-resources");
+        FALLBACKS.put("quarkus.otel.traces.sampler", "quarkus.opentelemetry.tracer.sampler");
+        FALLBACKS.put("quarkus.otel.traces.sampler.arg", "quarkus.opentelemetry.tracer.sampler.ratio");
+        FALLBACKS.put("quarkus.otel.exporter.otlp.enabled", "quarkus.opentelemetry.tracer.exporter.otlp.enabled");
+        FALLBACKS.put("quarkus.otel.exporter.otlp.traces.legacy-endpoint",
+                "quarkus.opentelemetry.tracer.exporter.otlp.endpoint");
+        FALLBACKS.put("quarkus.otel.exporter.otlp.traces.headers", "quarkus.opentelemetry.tracer.exporter.otlp.headers");
+    }
+
     public OTelFallbackConfigSourceInterceptor() {
-        super(Map.of(
-                "quarkus.otel.enabled", "quarkus.opentelemetry.enabled",
-                "quarkus.otel.traces.enabled", "quarkus.opentelemetry.tracer.enabled",
-                "quarkus.otel.propagators", "quarkus.opentelemetry.propagators",
-                "quarkus.otel.traces.suppress-non-application-uris",
-                "quarkus.opentelemetry.tracer.suppress-non-application-uris",
-                "quarkus.otel.traces.include-static-resources", "quarkus.opentelemetry.tracer.include-static-resources",
-                "quarkus.otel.traces.sampler", "quarkus.opentelemetry.tracer.sampler",
-                "quarkus.otel.traces.sampler.arg", "quarkus.opentelemetry.tracer.sampler.ratio",
-                "quarkus.otel.exporter.otlp.enabled", "quarkus.opentelemetry.tracer.exporter.otlp.enabled",
-                "quarkus.otel.exporter.otlp.traces.headers", "quarkus.opentelemetry.tracer.exporter.otlp.headers",
-                "quarkus.otel.exporter.otlp.traces.legacy-endpoint", "quarkus.opentelemetry.tracer.exporter.otlp.endpoint"));
+        super(FALLBACKS);
     }
 
     @Override
@@ -44,10 +51,28 @@ public class OTelFallbackConfigSourceInterceptor extends FallbackConfigSourceInt
     @Override
     public Iterator<String> iterateNames(final ConfigSourceInterceptorContext context) {
         Set<String> names = new HashSet<>();
-        Iterator<String> namesIterator = super.iterateNames(context);
+        Iterator<String> namesIterator = context.iterateNames();
         while (namesIterator.hasNext()) {
-            names.add(namesIterator.next());
+            String name = namesIterator.next();
+            String fallback = FALLBACKS.get(name);
+            // We only include the used property, so if it is a fallback (not mapped), it will be reported as unknown
+            if (fallback != null) {
+                ConfigValue nameValue = context.proceed(name);
+                ConfigValue fallbackValue = context.proceed(fallback);
+                if (nameValue == null) {
+                    names.add(fallback);
+                } else if (fallbackValue == null) {
+                    names.add(name);
+                } else if (nameValue.getConfigSourceOrdinal() >= fallbackValue.getConfigSourceOrdinal()) {
+                    names.add(name);
+                } else {
+                    names.add(fallback);
+                }
+            } else {
+                names.add(name);
+            }
         }
+
         // TODO - Required because the defaults ConfigSource for mappings does not provide configuration names.
         names.add("quarkus.otel.enabled");
         names.add("quarkus.otel.metrics.exporter");


### PR DESCRIPTION
- Fixes #32210 

This should improve the experience with warnings. The intended behavior was to report the old properties as unknown (due to a lack of a proper deprecated mechanism), so users would migrate. This was not working correctly, but this PR should fix.

The plan is to add a proper deprecation warning (instead of the unknown) for the entire Config system.