### PR TITLE
Use specific PgPoolOptions in reactive-pg-client

### DIFF
--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -755,7 +755,7 @@ import jakarta.inject.Singleton;
 
 import io.quarkus.reactive.pg.client.PgPoolCreator;
 import io.vertx.pgclient.PgConnectOptions;
-import io.vertx.pgclient.PgPool;
+import io.vertx.pgclient.PgPoolOptions;
 import io.vertx.sqlclient.PoolOptions;
 
 @Singleton
@@ -764,7 +764,7 @@ public class CustomPgPoolCreator implements PgPoolCreator {
     @Override
     public PgPool create(Input input) {
         PgConnectOptions connectOptions = input.pgConnectOptions();
-        PoolOptions poolOptions = input.poolOptions();
+        PgPoolOptions poolOptions = input.poolOptions();
         // Customize connectOptions, poolOptions or both, as required
         return PgPool.pool(input.vertx(), connectOptions, poolOptions);
     }

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/PgPoolCreator.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/PgPoolCreator.java
@@ -6,6 +6,7 @@ import io.quarkus.reactive.datasource.ReactiveDataSource;
 import io.vertx.core.Vertx;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
+import io.vertx.pgclient.impl.PgPoolOptions;
 import io.vertx.sqlclient.PoolOptions;
 
 /**
@@ -25,7 +26,7 @@ public interface PgPoolCreator {
 
         Vertx vertx();
 
-        PoolOptions poolOptions();
+        PgPoolOptions poolOptions();
 
         List<PgConnectOptions> pgConnectOptionsList();
     }

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
@@ -36,6 +36,7 @@ import io.vertx.core.Vertx;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.pgclient.SslMode;
+import io.vertx.pgclient.impl.PgPoolOptions;
 import io.vertx.sqlclient.PoolOptions;
 
 @Recorder
@@ -73,7 +74,7 @@ public class PgPoolRecorder {
             DataSourceRuntimeConfig dataSourceRuntimeConfig,
             DataSourceReactiveRuntimeConfig dataSourceReactiveRuntimeConfig,
             DataSourceReactivePostgreSQLConfig dataSourceReactivePostgreSQLConfig) {
-        PoolOptions poolOptions = toPoolOptions(eventLoopCount, dataSourceRuntimeConfig, dataSourceReactiveRuntimeConfig,
+        PgPoolOptions poolOptions = toPoolOptions(eventLoopCount, dataSourceRuntimeConfig, dataSourceReactiveRuntimeConfig,
                 dataSourceReactivePostgreSQLConfig);
         List<PgConnectOptions> pgConnectOptionsList = toPgConnectOptions(dataSourceRuntimeConfig,
                 dataSourceReactiveRuntimeConfig, dataSourceReactivePostgreSQLConfig);
@@ -86,7 +87,7 @@ public class PgPoolRecorder {
         return createPool(vertx, poolOptions, pgConnectOptionsList, dataSourceName);
     }
 
-    private PoolOptions toPoolOptions(Integer eventLoopCount,
+    private PgPoolOptions toPoolOptions(Integer eventLoopCount,
             DataSourceRuntimeConfig dataSourceRuntimeConfig,
             DataSourceReactiveRuntimeConfig dataSourceReactiveRuntimeConfig,
             DataSourceReactivePostgreSQLConfig dataSourceReactivePostgreSQLConfig) {
@@ -113,7 +114,7 @@ public class PgPoolRecorder {
             poolOptions.setEventLoopSize(Math.max(0, eventLoopCount));
         }
 
-        return poolOptions;
+        return new PgPoolOptions(poolOptions);
     }
 
     private List<PgConnectOptions> toPgConnectOptions(DataSourceRuntimeConfig dataSourceRuntimeConfig,
@@ -196,7 +197,7 @@ public class PgPoolRecorder {
         return pgConnectOptionsList;
     }
 
-    private PgPool createPool(Vertx vertx, PoolOptions poolOptions, List<PgConnectOptions> pgConnectOptionsList,
+    private PgPool createPool(Vertx vertx, PgPoolOptions poolOptions, List<PgConnectOptions> pgConnectOptionsList,
             String dataSourceName) {
         Instance<PgPoolCreator> instance;
         if (DataSourceUtil.isDefault(dataSourceName)) {
@@ -214,10 +215,10 @@ public class PgPoolRecorder {
 
     private static class DefaultInput implements PgPoolCreator.Input {
         private final Vertx vertx;
-        private final PoolOptions poolOptions;
+        private final PgPoolOptions poolOptions;
         private final List<PgConnectOptions> pgConnectOptionsList;
 
-        public DefaultInput(Vertx vertx, PoolOptions poolOptions, List<PgConnectOptions> pgConnectOptionsList) {
+        public DefaultInput(Vertx vertx, PgPoolOptions poolOptions, List<PgConnectOptions> pgConnectOptionsList) {
             this.vertx = vertx;
             this.poolOptions = poolOptions;
             this.pgConnectOptionsList = pgConnectOptionsList;
@@ -229,7 +230,7 @@ public class PgPoolRecorder {
         }
 
         @Override
-        public PoolOptions poolOptions() {
+        public PgPoolOptions poolOptions() {
             return poolOptions;
         }
 


### PR DESCRIPTION
The idea behind this is to allow `PgPoolCreator`
to be able to set pipelining as well

Fixes: #32822