### PR TITLE
Enhance the existing docs for integrating Quarkus with Azure  (apply style, diataxis, new conceptual information)

### DIFF
--- a/docs/src/main/asciidoc/azure-extensions.adoc
+++ b/docs/src/main/asciidoc/azure-extensions.adoc
@@ -1,0 +1,58 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id="azure-extensions"]
+= Quarkus extensions for Azure integration
+include::_attributes.adoc[]
+:diataxis-type: reference
+:categories: cloud,integration
+
+Quarkus provides extensions to help you to integrate and deploy your code with some of the Microsoft Azure cloud-managed services and functions.
+Use the information provided here to determine which Quarkus Azure extensions to use when writing, building, and deploying your Quarkus native or JVM applications.
+
+You can find and download the available extensions for deploying and integrating with Azure on the link:https://code.quarkus.io/[Code with Quarkus] starter page in the main Quarkus portal.
+
+.Quarkus extensions for integrating with Azure
+[cols="15%a,55%a,10%,20%"]
+|===
+|Quarkus extension |Use to ... |Status |Learn more
+
+|link:https://quarkus.io/extensions/io.quarkus/quarkus-azure-functions[Azure Functions]
+
+`quarkus-azure-functions`
+|Build cloud-native Java applications by using Quarkus and Azure Functions.
+For example, you can write microservices with RESTEasy Reactive (our Jakarta REST implementation), Undertow (servlet), Reactive Routes, or Funqy HTTP and to make these microservices deployable to the link:https://learn.microsoft.com/en-us/azure/azure-functions/[Azure Functions] runtime.
+
+The `quarkus-azure-functions` extension also provides support for Azure Functions triggers and bindings, making it easy to integrate your Java code with other Azure services.
+Use when you want your function to be triggered by multiple sources, for example, `HttpTrigger`, `BlobTrigger``, and `CosmosDBTrigger`.
+|Preview
+|xref:azure-functions.adoc[Integrate and deploy an HTTP Trigger function to Azure Functions]
+
+|link:https://quarkus.io/extensions/io.quarkus/quarkus-azure-functions-http[Azure Functions HTTP]
+
+`quarkus-azure-functions-http`
+|Write functions in your Quarkus applications that are developed with and run on the Azure Functions cloud service.
+Use when you want your function to be triggered by HTTP requests only.
+Otherwise, use the `quarkus-azure-functions` extension.
+|Preview
+|xref:azure-functions-http.adoc[Integrate and deploy a RESTEasy Reactive endpoint to Azure Functions]
+
+|link:https://quarkus.io/extensions/io.quarkus/quarkus-funqy-http[Funqy HTTP Binding]
+
+`quarkus-funqy-http`
+|Write and deploy serverless Quarkus applications that use link:https://quarkus.io/guides/funqy[Quarkus Funqy HTTP binding] with Azure functions.
+
+link:https://quarkus.io/guides/funqy[Quarkus Funqy] provides a portable Java API to write functions, mapped to the HTTP binding model.
+This makes them deployable to various Function-as-a-Service (FaaS) environments such as link:https://learn.microsoft.com/en-us/azure/azure-functions/[Azure Functions].
+|Preview
+|xref:funqy-azure-functions-http.adoc[Funqy HTTP binding with Azure Functions]
+// What other Quarkus Azure extensions should we document here.
+
+|===
+
+== References
+
+* xref:azure-integration-built-in.adoc[Quarkus integration with Microsoft Azure]
+* link:https://www.infoq.com/articles/azure-functions-quarkus/[Azure Functions in Quarkus 3]

--- a/docs/src/main/asciidoc/azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/azure-functions-http.adoc
@@ -3,191 +3,216 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Azure Functions with RESTEasy Reactive, Undertow, or Reactive Routes
+[id="azure-functions-resteasy"]
+= Integrate and deploy a RESTEasy Reactive endpoint to Azure Functions
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
-:summary: Deploy Vert.x Web, Servlet, or RESTEasy microservices as a Microsoft Azure Function.
+:diataxis-type: howto
+:categories: cloud,integration
 
-The `quarkus-azure-functions-http` extension allows you to write microservices with RESTEasy Reactive (our Jakarta REST implementation),
-Undertow (servlet), Reactive Routes, or xref:funqy-http.adoc[Funqy HTTP] and make these microservices deployable to the Azure Functions runtime.
-In other words, this extension is a bridge from the Azure Functions HttpTrigger and the Quarkus family
-of HTTP APIs.
-One azure function deployment can represent any number of Jakarta REST, servlet, Reactive Routes, or xref:funqy-http.adoc[Funqy HTTP] endpoints.
+Integrate and deploy your Quarkus RESTEasy Reactive microservice with link:https://learn.microsoft.com/en-us/azure/azure-functions/[Microsoft Azure Functions] by adding the `quarkus-azure-functions-http` extension to your code project.
+You can also deploy other HTTP microservices as an Azure Function, including Vert.x Web, Undertow Servlet, Reactive Routes, or Funqy HTTP.
+
+== About the `quarkus-azure-functions-http` extension
 
 include::{includes}/extension-status.adoc[]
 
-NOTE: Only text based media types are supported at the moment as Azure Functions HTTP Trigger for Java does not support a binary format
+The `quarkus-azure-functions-http` extension is an integration point between the Azure Functions runtime and the most commonly used HTTP frameworks for writing microservices in Quarkus.
+This extension is a bridge that connects the Azure Functions `HTTPTrigger` and the Quarkus family of HTTP APIs.
+
+When you add the `quarkus-azure-functions-http` extension to your Quarkus project, you can write and deploy RESTEasy Reactive, Vert.x Web, Undertow Servlet, Reactive Routes, or Funqy HTTP microservices to the Azure Functions runtime.
+
+One Azure Functions deployment can represent any number of Jakarta REST, Undertow Servlets, Reactive Routes, or xref:funqy-http.adoc[Funqy HTTP] endpoints.
+
+[IMPORTANT]
+====
+* The Azure Functions HTTP trigger for Java does not support a binary format, therefore only text-based media types are supported.
+* Quarkus integration with Azure Functions does not currently apply to xref:dev-mode-differences.adoc[Quarkus dev mode].
+====
 
 == Prerequisites
 
 include::{includes}/prerequisites.adoc[]
-* https://azure.microsoft.com[An Azure Account].  Free accounts work.
-* https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local#v2[Azure Functions Core Tools] version 4.x
-* https://docs.microsoft.com/en-us/cli/azure/install-azure-cli[Azure CLI Installed]
+* https://azure.microsoft.com[A Microsoft Azure account]
++
+[TIP]
+====
+If you don't have an existing Microsoft Azure subscription, you can create a free link:https://azure.microsoft.com/en-us/free/[Azure account].
+====
++
+* https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local#v2[Azure Functions Core Tools version 4.x] installed
+* https://learn.microsoft.com/en-us/cli/azure/install-azure-cli[Azure CLI] installed
 
 == Solution
 
-This guide walks you through running a maven project that can deploy a Resteasy Reactive endpoint to Azure Functions.
-While only Jakarta REST is provided as an example, you can easily replace it with the HTTP framework of your choice.
+By completing this tutorial, you will learn how to build and run a project that can deploy a RESTEasy Reactive endpoint to Azure Functions.
+While only the Jakarta REST implementation is provided as an example here, you can easily replace it with the HTTP framework of your choice.
 
-== Creating the Maven/Gradle Project
+:sectnums:
+:sectnumlevels: 3
 
-You can generate the example code from Quarkus's online application generator at https://code.quarkus.io/d?e=azure-functions-http&cn=code.quarkus.io[this link].
+== Create the code deployment project
 
-You can also generate this example with the Quarkus CLI:
+You can generate the example `code-with-quarkus` project with the `quarkus-azure-functions-http` extension from the link:https://code.quarkus.io/d?e=azure-functions-http&cn=code.quarkus.io[Start coding with Quarkus] application generator web page.
 
-[source,bash,subs=attributes+]
-----
-quarkus create app --extension=quarkus-azure-functions-http
-----
+Alternatively, you can use the xref:cli-tooling.adoc[Quarkus CLI] to generate the `code-with-quarkus` project and extension required for this tutorial:
 
-Add the `--gradle` switch if you want to generate a gradle project.
+:create-app-extensions: azure-functions-http
+include::{includes}/devtools/create-app.adoc[]
 
-== Login to Azure
+== Log in to Microsoft Azure
 
 If you don't log in to Azure you won't be able to deploy.
 
 [source,bash,subs=attributes+]
 ----
 az login
-----
-
-== Quarkus dev mode
-
-Quarkus dev mode works by just running your application as a HTTP endpoint.  In dev mode
-there is no special interaction with the Azure Functions local runtime.
-
-[source,bash,subs=attributes+]
-----
-./mvnw clean package quarkus:dev
 ----
 
 == Examining the project
 
-If you open the `pom.xml` or `build.gradle` build file of the generated project you'll see that
-the project is similar to any other Quarkus project.
-The `quarkus-azure-functions-http` extension is the integration point between
-Quarkus and Azure Functions.
+If you open the build file of the generated project, for example, `pom.xml`, you'll see that the project is similar to any other Quarkus project.
+The `quarkus-azure-functions-http` extension is the integration point between Quarkus and Azure Functions.
 
-The current implementation of the `quarkus-azure-functions-http` extension no longer requires the
-`azure-functions-maven-plugin` or gradle equivalent.  Local development and Azure Functions packaging and
-deployment is now all done by Quarkus.
+[IMPORTANT]
+====
+From version 3.0, the `quarkus-azure-functions-http` extension no longer requires `azure-functions-maven-plugin` or equivalent plugins.
+Local development and Azure Functions packaging and deployment are now all done by Quarkus.
+====
 
-Build configuration is now all within `application.properties`.  The only required configuration switch
-is `quarkus.azure-functions.app-name`.
+You can configure how your application builds in the Quarkus `application.properties` file.
+The only required configuration switch is `quarkus.azure-functions.app-name`.
 
-== Azure Deployment Descriptors
+== Azure deployment descriptors
 
-The Azure Functions `host.json` deployment descriptor is automatically
-generated, but if you need to override it, declare it in the root directory of the project and
-rerun the build when you are ready.
+The Azure Functions `host.json` deployment descriptor gets automatically generated, but if you need to override it, declare it in the root directory of the project and rerun the build when you are ready.
+
+You can find the templates for the Azure Functions deployment descriptors in the base directory of the project, for example, `host.json` and `function.json`.
 
 [#config-azure-paths]
-== Configuring Root Paths
+== Configure the root path
 
-The default route prefix for an Azure Function is `/api`.  All of your Jakarta REST, Servlet, Reactive Routes, and xref:funqy-http.adoc[Funqy HTTP] endpoints must
-explicitly take this into account.  In the generated project this is handled by the
-`quarkus.http.root-path` switch in `application.properties`
+The default root prefix for an Azure Function is `/api`.
+All of your Jakarta REST, Undertow Servlet, Reactive Routes, and xref:funqy-http.adoc[Funqy HTTP] endpoints must explicitly use this prefix.
 
-== Login to Azure
+In the generated `code-with-quarkus` example project, the root path is configured by the `quarkus.http.root-path` switch in the `application.properties` file as outlined in the following example:
 
-If you don't log in to Azure you won't be able to deploy.
-
-[source,bash,subs=attributes+]
+[source,properties]
 ----
-az login
+quarkus.http.root-path=/api
 ----
 
-== Quarkus dev mode
+== Run the application within the Azure Functions local environment
 
-Quarkus dev mode does not work currently with Azure Functions.
+[IMPORTANT]
+====
+You must have the link://https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local#v2[Azure Functions Core Tools]
+installed.
+====
 
-== Run locally in Azure Functions local environment
-
-If you want to try this example within the local Azure Functions environment, you can
-use this command
+If you want to try this example within the local Azure Functions environment, use following Maven command:
 
 [source,bash,subs=attributes+]
 ----
 ./mvnw quarkus:run
 ----
 
-or
+//Hiding until Gradle is supported * Gradle
+//[source,bash,subs=attributes+]
+//----
+//./gradlew --info --no-daemon quarkusRun
+//----
 
-[source,bash,subs=attributes+]
-----
-./gradlew --info --no-daemon quarkusRun
-----
-
-Gradle is a bit quirky with process management, so you need the `--no-daemon` switch or control-c will not
-destroy the process cleanly and you'll have open ports.
-
-Note that you must have the https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local#v2[Azure Functions Core Tools]
-installed for this to work!
+//Hiding this note until Gradle is supported  [NOTE]
+====
+Gradle can be a bit quirky with process management, so you need the `--no-daemon` switch, otherwise when you press *Ctrl* + *C* the process does not end cleanly, resulting in open ports.
+====
+//
+.Result
 
 The URL to access the example would be:
 
-http://localhost:8081/api/hello
+/http://localhost:8081/api/hello
 
 == Quarkus Integration Testing
 
-You can implement integration tests using `@QuarkusIntegrationTest` functionality.  When these
-integration tests run, the local Azure Functions environment will be spun up for the duration of integration testing.
+You can implement integration tests by using `@QuarkusIntegrationTest` functionality.
+When these integration tests run, the local Azure Functions environment is spun up for the duration of integration testing.
 
+* For maven:
 
-For maven:
 [source,bash,subs=attributes+]
 ----
 ./mvnw -DskipITs=false verify
 ----
 
-Make sure any integration tests you execute with maven use the `*IT.java` file pattern so that regular builds do not execute
-the test.
+To ensure that regular builds do not execute the test, always use the `*IT.java` file pattern.
 
-For Gradle:
-[source,bash,subs=attributes+]
-----
-./gradlew --info quarkusIntTest
-----
-
-Make sure any integration tests you execute with Gradle are located within `src/integrationTest/java`.  Integration
-tests that exist in `src/test` will run with normal build and fail.
+//* For Gradle:
+//[source,bash,subs=attributes+]
+//----
+//./gradlew --info quarkusIntTest
+//----
+//
+//Make sure any integration tests you execute with Gradle are located within the `src integrationTest/java` directory.
+//Integration tests that exist in `src/test` will run with the regular build and fail.
 
 == Deploy to Azure
 
-The `quarkus-azure-functions-http` extension handles all the work to deploy to Azure.  By default,
-Quarkus will use the Azure CLI in the background to authenticate and deploy to Azure.  If you have
-multiple subscriptions associated with your account, you must set the `quarkus.azure-functions.subscription-id`
-property in your `application.properties` file to the subscription you want to use.
-For other authentication mechanisms and deployment options see our config properties https://quarkus.io/guides/all-config[here].
+The `quarkus-azure-functions-http` extension handles all of the work to deploy to Azure.
+By default, Quarkus uses the Azure CLI in the background to authenticate and deploy to Azure.
+If you have multiple subscriptions associated with your account, you must set the `quarkus.azure-functions.subscription-id` property in your `application.properties` file to the subscription you want to use.
+For other authentication mechanisms and deployment options, see the link:https://quarkus.io/guides/all-config[Quarkus configuration properties] guide.
 
-To run the deploy, after you build your project execute:
+To run the deploy command, after you build your project, use the following command:
 
 [source,bash,subs=attributes+]
 ----
 ./mvnw quarkus:deploy
 ----
 
-or
+//hiding until Gradle is supported * For Gradle:
+//
+//[source,bash,subs=attributes+]
+//----
+//./gradlew --info deploy
+//----
 
-[source,bash,subs=attributes+]
-----
-./gradlew --info deploy
-----
+== Access your function
 
-If deployment is a success, Quarkus will output the endpoint URL of the example function to the console
-For Gradle, you must use the `--info` switch to see this output!
+When the deployment completes, Quarkus returns the endpoint of the example function to the console.
 
-i.e.
+.Example
+
 [source]
 ----
 [INFO] HTTP Trigger Urls:
 [INFO] 	 HttpExample : https://{appName}.azurewebsites.net/api/{*path}
 ----
 
-The URL to access the service would be something like
+//Hiding until Gradle is supported [NOTE]
+====
+For Gradle, you must use the `--info` switch to see this output.
+====
 
-https://{appName}.azurewebsites.net/api/hello
+In the example provided, the URL to access the service is:
 
+\https://{appName}.azurewebsites.net/api/hello
 
+:sectnums!:
+
+== Summary
+
+Congratulations!
+You have learned how to create, build, and deploy a sample Quarkus RESTEasy microservice to Azure Functions.
+
+== References
+
+* link:https://www.infoq.com/articles/azure-functions-quarkus/[Azure Functions in Quarkus 3]
+* xref:azure-integration-built-in.adoc[Quarkus integration with Microsoft Azure]
+* xref:azure-extensions-reference.adoc[Quarkus extensions for Azure integration]
+* xref:deploying-to-azure-cloud.adoc[Deploy a Quarkus native executable to Microsoft Azure]
+* xref:azure-functions.adoc[Integrate and deploy a Quarkus HTTP function to Azure Functions]
+* xref:funqy-azure-functions-http.adoc[Funqy HTTP Binding with Azure Functions]
+* link:https://learn.microsoft.com/en-us/azure/azure-functions/[Azure Functions]
+* link:https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-first-quarkus[Deploy serverless Java apps with Quarkus on Azure Functions]

--- a/docs/src/main/asciidoc/azure-functions.adoc
+++ b/docs/src/main/asciidoc/azure-functions.adoc
@@ -3,19 +3,44 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Azure Functions
+[id="azure-functions-trigger"]
+
+= Integrate and deploy an HTTP Trigger function to Azure Functions
 :extension-status: preview
 include::_attributes.adoc[]
-:categories: cloud
-:summary: Integrate Quarkus with the Microsoft Azure functions that you have written.
+:diataxis-type: howto
+:categories: cloud,integration
 
-The `quarkus-azure-functions` extension is a simple integration point between Azure Functions
-and Quarkus.  It interacts with Azure Functions runtime to bootstrap quarkus and turns any
-Azure Functions class you write into a CDI/Arc bean.
+Integrate your Quarkus functions with link:https://learn.microsoft.com/en-us/azure/azure-functions/[Microsoft Azure Functions] by adding the `quarkus-azure-functions` extension to your code project.
+You can write HTTP functions in your Quarkus applications that integrate with, deploy, and run on Azure Functions by using the extension and link:https://quarkus.io/blog/quarkus-dependency-injection/[Quarkus ArC].
+This tutorial shows an example of how a Quarkus application that includes an HTTP Trigger function can be deployed to the Azure Functions runtime.
 
-This allows you to inject any service or component initialized by quarkus directly into your function
-classes.  You can also change the lifecycle of your function class from request scoped (the default)
-to application scope too if you want your function class to be a singleton.
+// Diataxis: If this section grows, I propose that the following section == is moved into a reference topic that describes all Azure extensions, which is linked from here.
+
+== About the `quarkus-azure-functions` extension
+
+include::{includes}/extension-status.adoc[]
+
+The `quarkus-azure-functions` extension is one of the integration points between Azure Functions and Quarkus.
+
+`quarkus-azure-functions` provides the following capabilities for integrating your Quarkus code projects with Azure Functions.
+
+* Interacts with the Azure Functions runtime to bootstrap Quarkus
+* Registers a callback to set up link:https://quarkus.io/blog/quarkus-dependency-injection/[Quarkus ArC] as the function factory for function classes
+* Turns any Azure Functions class you write into a Quarkus ArC CDI bean
+* Injects any service or component initialized by Quarkus directly into your function classes
+
+[IMPORTANT]
+====
+Quarkus integration with Azure Functions does not currently apply to xref:dev-mode-differences.adoc[Quarkus dev mode].
+====
+
+// Diataxis: The following section could be a step in the main procedure or later on in this topic as an advanced/option step. Doesn't make sense to be here at the beginning.
+== Lifecycle of your function classes
+
+If you want your function class to be a singleton, you can change the lifecycle of your function class from the default request-scoped to application-scoped.
+
+.Example
 
 [source, java]
 ----
@@ -57,112 +82,65 @@ public class Function {
 }
 ----
 
-include::{includes}/extension-status.adoc[]
-
 == Prerequisites
 
 include::{includes}/prerequisites.adoc[]
-* https://azure.microsoft.com[An Azure Account].  Free accounts work.
-* https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local#v2[Azure Functions Core Tools] version 4.x
-* https://docs.microsoft.com/en-us/cli/azure/install-azure-cli[Azure CLI Installed]
+* link:https://azure.microsoft.com[A Microsoft Azure account]
++
+[TIP]
+====
+If you don't have an existing Microsoft Azure subscription, you can create a free link:https://azure.microsoft.com/en-us/free/[Azure account].
+====
++
+* link:https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local#v2[Azure Functions Core Tools version 4.x] installed
+* link:https://learn.microsoft.com/en-us/cli/azure/install-azure-cli[Azure CLI] installed
 
 == Solution
 
-This guide walks you through running a maven project that can deploy an Http Trigger Azure Function class.
-This function class injects a CDI bean service that generates a greeting message that is passed back
-to the client.
+By completing this tutorial, you will learn how to build and run a code project that can deploy an HTTP Trigger class on Azure Functions.
+The HTTP Trigger function class provided in the example injects a CDI bean service that generates a greeting message that is passed back to the client.
 
-== Creating the Maven/Gradle Project
+:sectnums:
+:sectnumlevels: 3
 
-You can generate the example code from Quarkus's online application generator at https://code.quarkus.io/d?e=azure-functions&cn=code.quarkus.io[this link].
+== Create the code deployment project
 
-You can also generate this example with the Quarkus CLI:
+You can generate the example code `code-with-quarkus` project with the `quarkus-azure-functions-http` extension from the link:https://code.quarkus.io/d?e=azure-functions&cn=code.quarkus.io[Start coding with Quarkus] application generator web page.
 
-[source,bash,subs=attributes+]
-----
-quarkus create app --extension=quarkus-azure-functions
-----
+Alternatively, you can use the xref:cli-tooling.adoc[Quarkus CLI] to generate the `code-with-quarkus` project that's needed for this tutorial:
 
-Add the `--gradle` switch if you want to generate a gradle project.
+:create-app-extensions: azure-functions
+include::{includes}/devtools/create-app.adoc[]
+
+[IMPORTANT]
+====
+When creating the Maven project, you must include the `quarkus-azure-functions` extension because this is the integration point between Quarkus and Azure Functions.
+====
 
 == Examining the project
 
-If you open the `pom.xml` or `build.gradle` build file of the generated project you'll see that
-the project is similar to any other Quarkus project.
-The `quarkus-azure-functions` extension is the integration point between
-Quarkus and Azure Functions.  It registers callback with the Azure Functions runtime to bootstrap
-Quarkus and to set up Quarkus/Arc as the function factory for your function classes.
+If you open the build file of the generated project, for example, `pom.xml`, you'll see that the project is similar to any other Quarkus project.
+The `quarkus-azure-functions` extension is the integration point between Quarkus and Azure Functions.
+It registers a `callback`` function with the Azure Functions runtime to bootstrap Quarkus and to set up Quarkus/Arc as the function factory for your function classes.
 
-The current implementation of the `quarkus-azure-functions` extension no longer requires the
-`azure-functions-maven-plugin` or gradle equivalent.  Local development and Azure Functions packaging and
-deployment is now all done by Quarkus.
+[IMPORTANT]
+====
+From version 3.0, the `quarkus-azure-functions` extension no longer requires `azure-functions-maven-plugin` or an equivalent plugin.
+Local development and Azure Functions packaging and deployment are now all done by Quarkus.
+====
 
-Build configuration is now all within `application.properties`.  The only required configuration switch
-is `quarkus.azure-functions.app-name`.
-
-== Azure Deployment Descriptors
-
-The Azure Functions `host.json` deployment descriptor is automatically
-generated, but if you need to override it, declare it in the root directory of the project and
-rerun the build when you are ready.
-
-== Quarkus dev mode
-
-Quarkus dev mode does not work currently with Azure Functions.
-
-== Run locally in Azure Functions local environment
-
-If you want to try your app with a local Azure Functions environment, you can
-use this command
-
-[source,bash,subs=attributes+]
-----
-./mvnw quarkus:run
-----
-
-or
-
-[source,bash,subs=attributes+]
-----
-./gradlew --info --no-daemon quarkusRun
-----
-
-Gradle is a bit quirky with process management, so you need the `--no-daemon` switch or control-c will not
-destroy the process cleanly and you'll have open ports.
-
-Note that you must have the https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local#v2[Azure Functions Core Tools]
-installed for this to work!
-
-The URL to access the example would be:
-
-https://localhost:8081/HttpExample?name=Bill
+You can configure how your application builds in the Quarkus `application.properties` file.
+The only required configuration switch is `quarkus.azure-functions.app-name`.
 
 
-== Quarkus Integration Testing
+== Azure deployment descriptors
 
-You can implement integration tests using `@QuarkusIntegrationTest` functionality.  When these
-integration tests run, the local Azure Functions environment will be spun up for the duration of integration testing.
+The Azure Functions `host.json` deployment descriptor gets automatically generated, but if you need to override it, declare it in the root directory of the project and rerun the build when you are ready.
+
+You can find the templates for the Azure Functions deployment descriptors in the base directory of the project, for example, `host.json` and `function.json`.
 
 
-For maven:
-[source,bash,subs=attributes+]
-----
-./mvnw -DskipITs=false verify
-----
-
-Make sure any integration tests you execute with maven use the `*IT.java` file pattern so that regular builds do not execute
-the test.
-
-For Gradle:
-[source,bash,subs=attributes+]
-----
-./gradlew --info quarkusIntTest
-----
-
-Make sure any integration tests you execute with Gradle are located within `src/integrationTest/java`.  Integration
-tests that exist in `src/test` will run with normal build and fail.
-
-== Login to Azure
+== Log in to Microsoft Azure
 
 If you don't log in to Azure you won't be able to deploy.
 
@@ -171,41 +149,119 @@ If you don't log in to Azure you won't be able to deploy.
 az login
 ----
 
+== Run the application within the Azure Functions local environment
+
+[IMPORTANT]
+====
+You must have the link://https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local#v2[Azure Functions Core Tools]
+installed.
+====
+
+If you want to try this example within the local Azure Functions environment, submit the following command:
+[source,bash,subs=attributes+]
+----
+./mvnw quarkus:run
+----
+
+//Hiding Grade content until it is supported in this scenario. * Gradle:
+//
+//[source,bash,subs=attributes+]
+//----
+//./gradlew --info --no-daemon quarkusRun
+//----
+
+//[NOTE]
+====
+Gradle can be a bit quirky with process management, so you need the `--no-daemon` switch, otherwise when you press *Ctrl* + *C* the process does not end cleanly, resulting in open ports.
+====
+
+.Result
+
+The URL to access the example would be:
+
+/http://localhost:8081/api/hello
+
+
+== Quarkus Integration Testing
+
+You can implement integration tests by using `@QuarkusIntegrationTest` functionality, as follows:
+
+[source,bash,subs=attributes+]
+----
+./mvnw -DskipITs=false verify
+----
+
+.Result
+When these integration tests run, the local Azure Functions environment is spun up for the duration of integration testing.
+
+To ensure that regular builds do not execute the test, always use the `*IT.java` file pattern.
+
+//* For Gradle:
+//[source,bash,subs=attributes+]
+//----
+//./gradlew --info quarkusIntTest
+//----
+
+//Make sure any integration tests you execute with Gradle are located within the `src/integrationTest/java` directory.
+//Integration tests that exist in `src/test` will run with the regular build and fail.
+
 == Deploy to Azure
 
-The `quarkus-azure-functions` extension handles all the work to deploy to Azure.  By default,
-Quarkus will use the Azure CLI in the background to authenticate and deploy to Azure.  If you have
-multiple subscriptions associated with your account, you must set the `quarkus.azure-functions.subscription-id`
-property in your `application.properties` file to the subscription you want to use.
-For other authentication mechanisms and deployment options see our config properties https://quarkus.io/guides/all-config[here].
+The `quarkus-azure-functions-http` extension handles all of the work to deploy to Azure.
+By default, Quarkus uses the Azure CLI in the background to authenticate and deploy to Azure.
+If you have multiple subscriptions associated with your account, you must set the `quarkus.azure-functions.subscription-id` property in your `application.properties` file to the subscription you want to use.
+For other authentication mechanisms and deployment options, see the link:https://quarkus.io/guides/all-config[Quarkus configuration properties] guide.
 
-To run the deploy, after you build your project execute:
+To run the deploy command, after you build your project, use the following command:
 
 [source,bash,subs=attributes+]
 ----
 ./mvnw quarkus:deploy
 ----
 
-or
+//* For Gradle
 
-[source,bash,subs=attributes+]
-----
-./gradlew --info deploy
-----
+//[source,bash,subs=attributes+]
+//----
+//./gradlew --info deploy
+//----
 
-If deployment is a success, Quarkus will output the endpoint URL of the example function to the console
-For Gradle, you must use the `--info` switch to see this output!
+== Access your function
 
-i.e.
+When the deployment completes, Quarkus returns the endpoint of the example function to the console.
+
+.Example
+
 [source]
 ----
 [INFO] HTTP Trigger Urls:
-[INFO] 	 HttpExample : https://{appName}.azurewebsites.net/api/httpexample
+[INFO] 	 HttpExample : https://{appName}.azurewebsites.net/api/{*path}
 ----
 
-The URL to access the service would be
+//[NOTE]
+====
+For Gradle, you must use the `--info` switch to see this output.
+====
 
-https://{appName}.azurewebsites.net/api/HttpExample
+In the example provided, the URL to access the service is:
+
+\https://{appName}.azurewebsites.net/api/hello
 
 
+:sectnums!:
 
+== Summary
+
+Congratulations!
+You have learned how to create, build, and deploy a sample Quarkus application that includes an HTTP Trigger function to Microsoft Azure Functions by using Quarkus.
+
+== References
+
+* link:https://www.infoq.com/articles/azure-functions-quarkus/[Azure Functions in Quarkus 3]
+* xref:azure-integration-built-in.adoc[Quarkus integration with Microsoft Azure]
+* xref:azure-extensions-reference.adoc[Quarkus extensions for Azure integration]
+* xref:deploying-to-azure-cloud.adoc[Deploy a Quarkus native executable to Microsoft Azure]
+* xref:azure-functions-http.adoc[Integrate and deploy a RESTEasy Reactive endpoint to Azure Functions]
+* xref:funqy-azure-functions-http.adoc[Funqy HTTP Binding with Azure Functions]
+* link:https://learn.microsoft.com/en-us/azure/azure-functions/[Azure Functions]
+* link:https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-first-quarkus[Deploy serverless Java apps with Quarkus on Azure Functions]

--- a/docs/src/main/asciidoc/azure-integration-built-in.adoc
+++ b/docs/src/main/asciidoc/azure-integration-built-in.adoc
@@ -1,0 +1,103 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id="azure-integration-built-in"]
+= Quarkus integration with Microsoft Azure
+include::_attributes.adoc[]
+:diataxis-type: concept
+:categories: cloud,integration
+
+Quarkus provides built-in extensions for integrating your containerized Java applications with Microsoft Azure.
+You can use the cloud-hosting capabilities of Azure to run and scale your Quarkus applications in a Java runtime on the Azure App Service.
+You can also integrate your Quarkus application with Azure developer services, for example, Azure Database and Web services, and you can also write complex functions with Quarkus on Azure Functions.
+
+== Quarkus on Microsoft Azure
+
+Quarkus can be integrated with developer tools and managed services that are available on the Microsoft Azure cloud platform.
+
+You can deploy and host your containerized Quarkus applications to Microsoft Azure by using link:https://learn.microsoft.com/en-us/azure/container-apps/[Azure Container Apps] and then push them to the link:https://azure.microsoft.com/en-us/products/app-service/[Azure App Service] where they can run in a scalable Java runtime.
+
+You can also integrate your Quarkus IDE with Azure Developer services and create functions with link:https://learn.microsoft.com/en-us/azure/azure-functions/[Azure Functions].
+
+== Application deployment to Azure overview
+
+There are multiple paths for deploying a Quarkus application to the link:https://learn.microsoft.com/en-us/azure/?product=popular[Microsoft Azure] cloud platform.
+You can also use several different tools during that deployment to achieve the same goal, including the following items:
+
+* xref:cli-tooling.adoc[Quarkus CLI]
+* link:https://learn.microsoft.com/en-us/cli/azure/install-azure-cli[Azure CLI]
+* link:https://azure.microsoft.com/en-us/get-started/azure-portal[Microsoft Azure Portal]
+
+The specific steps involved in deploying a Quarkus application on Azure depend on the deployment approach you prefer and the specific Azure services and tools you want to integrate with Quarkus.
+
+[NOTE]
+====
+The information in the Quarkus doc portal primarily focuses on the Quarkus built-in methods and support.
+For some steps in the process, you can also use the Azure CLI and portal tools to deploy your applications instead.
+For more information, see the link:https://learn.microsoft.com/en-us/azure/?product=popular[Microsoft Azure] documentation.
+====
+
+// TO DO: Create an overview diagram here of the key steps supported from the Quarkus perspective.
+
+One way to deploy a locally-developed Quarkus application is by using the built-in Quarkus extensions and deploying a Linux container image of your Quarkus application to a preconfigured link:https://learn.microsoft.com/en-us/azure/container-apps/[Azure Container Apps] instance.
+
+You then push your application to the link:https://azure.microsoft.com/en-us/products/app-service/[Azure Apps Service], which provides multiple cloud-hosting capabilities to run your applications, gain insights, and automatically scale resources according to needs.
+
+== Get runtime metrics and insights into your Quarkus applications
+
+Use and integrate the Quarkus open telemetry features to collect and analyze data to better understand how your Quarkus applications are running and performing on the Azure cloud platform.
+//Is a tutorial that shows you how to get Quarkus in-built metrics from apps specifically running on Azure needed here? Or do we have a link to a cloud-platform agnostic Quarkus tutorial about this topic?
+
+You can also use a combination of Azure cloud platform management tools to get insights, for example, link:https://learn.microsoft.com/en-us/azure/azure-monitor/overview[Azure Monitor] and link:https://azure.microsoft.com/en-us/products/devops[Azure DevOps].
+See also link:https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions?tabs=portal[Monitoring Azure Functions].
+
+== Application development with Azure overview
+
+To write code that integrates with Azure and can be deployed to the Azure Container registry or Azure Apps Service, Quarkus provides extensions, which you must add to your Quarkus code projects.
+For more details, see also xref:azure-extensions-reference.adoc[Quarkus extensions for Azure integration].
+
+You can also explore all of the available extensions for coding with Quarkus at link:https://quarkus.io/extensions/[Quarkus Extensions].
+
+=== Integration with Azure Functions
+
+Quarkus supports link:https://learn.microsoft.com/en-us/azure/azure-functions/[Azure Functions] by providing extensions, for example, `quarkus-azure-functions` and `quarkus-azure-functions-http`, which are specifically for building Azure Functions with Quarkus and integrating with Azure Developer services.
+See also, * link:https://www.infoq.com/articles/azure-functions-quarkus/[Azure Functions in Quarkus 3].
+
+In Microsoft Azure, every function must have a trigger, which defines how a function gets invoked and makes it run.
+Bindings make it possible to connect another resource to a function as input, output, or both.
+For more information see link:https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings?tabs=csharp#supported-bindings[Supported triggers and bindings] in the Microsoft Azure Functions product documentation.
+
+== Get started with Quarkus and Azure integration
+
+To help you get started with writing functions, integrating, or simply deploying your locally-developed Quarkus applications to Azure, see the following tutorials and supporting information.
+
+* xref:deploying-to-azure-cloud.adoc[Deploy a Quarkus native executable to Microsoft Azured]
+* xref:azure-functions.adoc[Integrate and deploy an HTTP Trigger function to Azure Functions]
+* xref:azure-functions-http.adoc[Integrate and deploy a RESTEasy Reactive endpoint to Azure Functions]
+* xref:funqy-azure-functions-http.adoc[Funqy HTTP Binding with Azure Functions]
+
+// What tutorials to describe and step through common Azure integration use cases/needs are missing from the Quarkus docs?  Please contact michelle-purcell.
+
+=== Other resources for getting started with Azure integration
+
+Explore the link:[Quarkus community documentation portal] and the link:[Microsoft website] for the most up-to-date learning resources and information.
+
+You can also find a wealth of information about writing and deploying Quarkus applications on the Microsoft Azure documentation and learning sites, including the following Quarkus tutorials:
+
+* link:https://quarkus.io/quarkus-workshops/super-heroes/index-azure.html[Deploy to Azure Container Apps Workshop]
+
+* link:https://learn.microsoft.com/en-us/events/jdconf-2022/zero-to-hero-in-azure-functions-with-java-americas-1[Zero to hero in Azure Functions with Java]
+
+* link:https://learn.microsoft.com/en-us/training/modules/deploy-java-quarkus-azure-container-app-postgres/[Deploy a Quarkus application connected to Azure for PostgreSQL database to Azure Container Apps]
+
+* link:https://learn.microsoft.com/en-us/azure/developer/java/eclipse-microprofile/deploy-microprofile-quarkus-java-app-with-maven-plugin[Deploy a Quarkus Web App to Azure App Service with Maven]
+
+* link:https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-first-quarkus[Deploy serverless Java apps with Quarkus on Azure Functions]
+
+
+== References
+
+* link:https://learn.microsoft.com/en-us/azure/?product=popular[Microsoft Azure documentation]
+* link:https://learn.microsoft.com/en-us/azure/container-instances/[Azure Container Instances (ACI)]

--- a/docs/src/main/asciidoc/deploying-to-azure-cloud.adoc
+++ b/docs/src/main/asciidoc/deploying-to-azure-cloud.adoc
@@ -3,38 +3,69 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Deploying to Microsoft Azure Cloud
+[id="deploying-to-azure-cloud"]
+= Deploy a Quarkus native executable to Microsoft Azure
 include::_attributes.adoc[]
-:categories: cloud
-:summary: Deploy a Quarkus application to the Microsoft Azure cloud platform.
+:diataxis-type: tutorial
+:categories: cloud,native,integration
 
-This guide covers:
+You can run a Quarkus native executable in a scalable Java runtime on the Microsoft Azure cloud platform.
+Deploy your locally-built containerized native applications by using the built-in deployment features of Quarkus.
+Learn how to use the Quarkus CLI to build, package, and deploy a native executable to link:https://learn.microsoft.com/en-us/azure/container-apps/[Azure Container Apps] and then push to link:https://azure.microsoft.com/en-us/products/app-service/[Azure App Service].
 
-* Update Quarkus HTTP Port
-* Install the Azure CLI
-* Create an Azure Registry Service instance and upload the Docker image
-* Deploy the Docker image to Azure Container Instances
-* Deploy the Docker image to Azure Kubernetes Service
-* Deploy the Docker image to Azure App Service for Linux Containers
+== Azure deployment overview
+
+There are multiple paths for deploying a Quarkus application to the link:https://learn.microsoft.com/en-us/azure/?product=popular[Microsoft Azure] cloud platform.
+You can also use several different tools during that deployment to achieve the same goal, including the following items:
+
+* xref:cli-tooling.adoc[Quarkus CLI]
+* link:https://learn.microsoft.com/en-us/cli/azure/install-azure-cli[Azure CLI]
+* link:https://azure.microsoft.com/en-us/get-started/azure-portal[Microsoft Azure Portal]
+
+The specific steps involved in deploying a Quarkus application on Azure depend on the type of applications you are writing and the specific Azure services and tools you want to integrate with Quarkus.
+
+[NOTE]
+====
+The information in this tutorial primarily focuses on the built-in Quarkus methods and support.
+====
 
 == Prerequisites
 
 :prerequisites-time: 2 hours for all modalities
 :prerequisites-no-graalvm:
 include::{includes}/prerequisites.adoc[]
-* Having access to an Azure subscription. https://azure.microsoft.com/free/?WT.mc_id=opensource-quarkus-brborges[Get a free one here]
+* https://azure.microsoft.com[A Microsoft Azure account]
++
+[TIP]
+====
+If you don't have an existing Microsoft Azure subscription, you can create a free link:https://azure.microsoft.com/en-us/free/[Azure account].
+====
++
+* link:https://learn.microsoft.com/en-us/cli/azure/install-azure-cli[Azure CLI] installed
+* Have created a native application by following the steps in Quarkus xref:building-native-image.adoc[Building a Native Executable] guide
 
-This guide will take as input a native application developed in the xref:building-native-image.adoc[building native image guide].
+== Solution
 
-Make sure you have the getting-started application at hand, or clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive]. The solution is located in the `getting-started` directory.
+By completing this tutorial, you will learn how to:
 
-== Change Quarkus HTTP Port
+* Prepare your native executable container image of the Quarkus `getting-started`` application you created earlier
+* Change the default Quarkus HTTP port (`8080`) to the required Azure  port (`80`)
+* Upload your container image to an Azure Registry Service instance
+* Deploy the Docker image to Azure Container Instances
+* Deploy the Docker image to Azure Kubernetes Service
+* Run your Quarkus application on the Azure App Service for Linux Containers.
 
-If you correctly followed the xref:building-native-image.adoc[building native image guide], you should have a local container image named `quarkus-quickstart/getting-started`.
+:sectnums:
+:sectnumlevels: 3
 
-While Quarkus by default runs on port 8080, most Azure services expect web applications to be running on port 80. Before we continue, go back to your quickstart code and open the file `src/main/docker/Dockerfile.native`.
+== Configure the Quarkus HTTP port
 
-Change the last two commands in the `Dockerfile.native` file and make it read like this:
+If you created a native application by following the prerequisite steps in the Quarkus xref:building-native-image.adoc[Building a Native Executable] guide, you should have a local container image named `quarkus-quickstart/getting-started`.
+
+While Quarkus by default runs on port 8080, most Azure services expect web applications to be running on port 80.
+Before you begin the deployment to Azure, you need to back to your quickstart code project and open the file `src/main/docker/Dockerfile.native`.
+
+Change the last two commands in the `Dockerfile.native` file, as follows:
 
 [source,docker]
 ----
@@ -42,29 +73,33 @@ EXPOSE 80
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Dquarkus.http.port=80"]
 ----
 
-Now you can rebuild the docker image:
+== Rebuild and test the docker image
+
+After changing the HTTP port, rebuild your Docker image by using the following command:
 
 [source,shell]
 ----
 $ docker build -f src/main/docker/Dockerfile.native -t quarkus-quickstart/getting-started .
 ----
 
-To test, run it by exposing port 80 into port 8080 in your host:
+Test the `getting-started` docker application to ensure that it runs before continuing further.
+You can run it by exposing port 80 to port 8080 in the host part of the command.
 
 [source,shell]
 ----
 $ docker run -i --rm -p 8080:80 quarkus-quickstart/getting-started
 ----
 
-Your container image is now ready to run on Azure. Remember, the Quarkus application is mapped to run on port 80.
+Your container image is now ready to run on Azure.
 
-== Install the Azure CLI
+[NOTE]
+====
+Remember, the Quarkus application is mapped to run on port 80.
+====
 
-To ease the user experience throughout this guide, it is better to have the Azure CLI installed and authenticated.
+== Log in to Azure
 
-Visit the https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest?WT.mc_id=opensource-quarkus-brborges[Azure CLI] installation page for instructions specific to your operating system.
-
-Once installed, ensure you are authenticated:
+To complete the deployment, you must be logged in to the Azure cloud platform.
 
 [source,shell]
 ----
@@ -73,32 +108,30 @@ $ az login
 
 == Create an Azure Container Registry instance
 
-It is possible to deploy images hosted on Docker Hub, but this location by default leaves images accessible to anyone. To better protect your container images, this guide shows how to host your images on a private instance of the Azure Container Registry service.
+It is possible to deploy images hosted on Docker Hub, however, this location is open by default and your images will be publicly accessible.
+To secure your container images, complete the following steps to host your Quarkus image on a private instance of the Azure Container Registry service.
 
-First, create an Azure Resource Group:
-
+. Create an Azure resource group:
 [source,shell]
 ----
 $ az group create --name <resource-group-name> --location eastus
 ----
-
-Then you can create the ACR:
+. Create the Azure container registry (ACR) instance:
 
 [source,shell]
 ----
 $ az acr create --resource-group <resource-group-name> --name <registry-name> --sku Basic --admin-enabled true
 ----
-
-Finally, authenticate your local Docker installation with this container registry by running:
+. Authenticate your local Docker installation with the ACR instance by running:
 
 [source,shell]
 ----
 $ az acr login --name <registry-name>
 ----
 
-== Upload Container Image on Azure
+== Upload your container image to Azure
 
-If you've followed the build native image guide, you should have a local container image named `quarkus-quickstart/getting-started`.
+If you completed the prerequisite step to build a native image according to the Quarkus guide, you will have a local container image named `quarkus-quickstart/getting-started`.
 
 To upload this image to your ACR, you must tag and push the image under the ACR login server. To find the login server of the Azure Container Registry, run this command:
 
@@ -107,7 +140,7 @@ To upload this image to your ACR, you must tag and push the image under the ACR 
 $ az acr show -n <registry-name> --query loginServer -o tsv
 ----
 
-To upload, now do:
+To upload, run the following commands:
 
 [source,shell]
 ----
@@ -115,28 +148,32 @@ $ docker tag quarkus-quickstart/getting-started <acr-login-server>/quarkus-quick
 $ docker push <acr-login-server>/quarkus-quickstart/getting-started
 ----
 
-At this point, you should have your Quarkus container image on your Azure Container Registry. To verify, run the following command:
+At this point, you should have your Quarkus container image on your Azure Container Registry.
+To verify, run the following command:
 
 [source,shell]
 ----
 $ az acr repository list -n <registry-name>
 ----
 
-== Deploy to Azure Container Instances
+== Deploy to Azure Container Instances (ACI)
 
-The simplest way to start this container in the cloud is with the Azure Container Instances service. It simply creates a container on Azure infrastructure.
+The simplest way to start this container in the cloud is with the Azure Container Instances (ACI) service.
+ACI simply creates a container on the Azure infrastructure.
 
-There are different approaches for using ACI. Check the documentation for details. The quickest way to get a container up and running goes as it follows.
+There are different approaches for using ACI.
+For more details, see the link:http:[ACI] documentation.
 
-First step is to find the username and password for the admin, so that ACI can authenticate into ACR and pull the Docker image:
+To quickly get your container up and running, complete the following steps:
 
+. Find the username and password for the administrator so that ACI can authenticate into ACR and pull the Docker image:
++
 [source,shell]
 ----
 $ az acr credential show --name <registry-name>
 ----
-
-Now create the Docker instance on ACI pointing to your image on ACR:
-
++
+. Create the Docker instance on ACI pointing to your image on ACR:
 [source,shell]
 ----
 $ az container create \
@@ -150,27 +187,50 @@ $ az container create \
     --query ipAddress.fqdn
 ----
 
-The command above, if run successfully, will give you the address of your container in the Cloud. Access your Quarkus application in the address displayed as output.
+.Result
+If the command runs successfully, the address of your container in the Cloud is returned.
 
-For more information and details on ACR authentication and the use of service principals, follow this guide below and remember the Azure Container Registry `loginServer` and the image name of your Quarkus application now hosted on the ACR.
+You can access your Quarkus application by using the address displayed in the output of the CLI.
 
-https://docs.microsoft.com/en-us/azure/container-instances/container-instances-using-azure-container-registry?WT.mc_id=opensource-quarkus-brborges[Deploy to Azure Container Instances from Azure Container Registry]
+For more information and details on ACR authentication and the use of service principals, see the following guide:
 
-Keep in mind that this service does not provide scalability. A container instance is unique and does not scale.
+link:https://docs.microsoft.com/en-us/azure/container-instances/container-instances-using-azure-container-registry?WT.mc_id=opensource-quarkus-brborges[Deploy to Azure Container Instances from Azure Container Registry]
+
+[NOTE]
+====
+* Make a note of the Azure Container Registry `loginServer` and the image name of your Quarkus application that is now hosted on the ACR.
+* This service does not provide scalability.
+A container instance is unique and does not scale.
+You can use Azure App Service to automatically scale your web applications as outlined later in this guide.
+====
 
 == Deploy to Azure Kubernetes Service
 
-You can also deploy the container image as a microservice in a Kubernetes cluster on Azure. To do that, follow this tutorial:
+You can also deploy the container image as a microservice in a Kubernetes cluster on Azure.
+To do that, follow the steps in this tutorial:
 
 https://docs.microsoft.com/en-us/azure/aks/tutorial-kubernetes-deploy-cluster?WT.mc_id=opensource-quarkus-brborges[Tutorial: Deploy an Azure Kubernetes Service (AKS) cluster]
 
-Once deployed, the application will be running on whatever port is used to expose the service. By default, Quarkus apps run on port 8080 internally.
+Once deployed, the application will be running on whatever port is used to expose the service.
+By default, Quarkus apps run on port 8080 internally.
 
 == Deploy to Azure App Service on Linux Containers
 
-This service provides scalability out of the box for web applications. If more instances are required, it will provide a load-balancing automatically, plus monitoring, metrics, logging and so on.
+Azure App Service automatically scales web applications.
+If more instances are required, the service automatically provides load-balancing, monitoring, metrics, logging and other cloud-hosting features to help you to manage your applications.
 
-To deploy your Quarkus Native container image to this service, follow this tutorial:
+To deploy your Quarkus native container image to Azure App Service, see the following tutorial:
 
-https://docs.microsoft.com/en-us/azure/app-service/containers/tutorial-custom-docker-image?WT.mc_id=opensource-quarkus-brborges[Tutorial: Build a custom image and run in App Service from a private registry]
+* https://docs.microsoft.com/en-us/azure/app-service/containers/tutorial-custom-docker-image?WT.mc_id=opensource-quarkus-brborges*[Tutorial: Build a custom image and run in App Service from a private registry]
 
+:sectnums!:
+
+== References
+
+* xref:azure-integration-built-in.adoc[Quarkus integration with Microsoft Azure]
+* xref:azure-extensions-reference.adoc[Quarkus extensions for Azure integration]
+* link:https://www.infoq.com/articles/azure-functions-quarkus/[Azure Functions in Quarkus 3]
+* xref:azure-functions-http.adoc[Integrate and deploy a RESTEasy Reactive endpoint to Azure Functions]
+* xref:azure-functions.adoc[Integrate and deploy a Quarkus HTTP function to Azure Functions]
+* xref:funqy-azure-functions-http.adoc[Funqy HTTP Binding with Azure Functions]
+* link:https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-first-quarkus[Deploy serverless Java apps with Quarkus on Azure Functions]

--- a/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/funqy-azure-functions-http.adoc
@@ -3,24 +3,40 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Funqy HTTP Binding with Azure Functions
+[id="funqy-http-azure-functions"]
+= Funqy HTTP binding with Azure Functions
 :extension-status: preview
 include::_attributes.adoc[]
+:diataxis-type: concept
 :categories: cloud
-:summary: Use Funqy HTTP binding with Microsoft Azure Functions to deploy your serverless Quarkus applications.
 
-You can use xref:funqy-http.adoc[Funqy HTTP] on Azure Functions.  This allows you to invoke on multiple Funqy functions
-using HTTP deployed as one Azure Function.
-
-WARNING: The Funqy HTTP + Azure Functions binding is not a replacement for REST over HTTP.  Because Funqy
-needs to be portable cross a lot of different protocols and function providers its HTTP binding
-is very minimalistic and you will lose REST features like linking and the ability to leverage
-HTTP features like cache-control and conditional GETs.  You may want to consider using Quarkus's
-Jakarta REST, Spring MVC, or Vert.x Web Reactive Route xref:azure-functions-http.adoc[support] instead.  They also work with Quarkus and Azure Functions.
-
+Use xref:funqy-http.adoc[Quarkus Funqy HTTP] binding with Microsoft Azure Functions to deploy your serverless Quarkus applications.
+By integrating your Quarkus applications with Azure Functions, you can invoke multiple Funqy HTTP functions as one Azure function.
 
 include::{includes}/extension-status.adoc[]
 
-Follow the xref:azure-functions-http.adoc[Azure Functions HTTP Guide].  It walks through using a variety of HTTP
-frameworks on Azure Functions.  Including Funqy.
+== Overview
 
+// More overview information about Funqy and Quarkus and the integration with Azure is needed here.
+
+[IMPORTANT]
+====
+The Quarkus Funqy HTTP with Azure Functions binding is not a replacement for REST over HTTP.
+This is because Funqy needs to be portable across many different protocols and function providers and its HTTP binding is very basic.
+====
+
+With Funqy, you can lose REST features such as linking and the ability to use some HTTP features, for example, cache-control and conditional GETs.
+
+To build RESTful Quarkus applications, consider using the Quarkus implementation of Jakarta REST, Spring MVC, or Vert.x Web Reactive Route support instead, as described in xref:azure-functions-http.adoc[Azure Functions with RESTEasy Reactive, Undertow, or Reactive Routes].
+These HTTP frameworks can be easily integrated with Quarkus and Azure Functions.
+
+== Get started
+
+For more information about the HTTP frameworks in Quarkus that you can integrate with Azure Functions, including Funqy, see the following tutorial:
+
+xref:azure-functions-http.adoc[Integrate and deploy a RESTEasy Reactive endpoint to Azure Functions].
+
+== References
+
+* xref:azure-integration-built-in.adoc[Quarkus integration with Microsoft Azure]
+* xref:funqy-http.adoc[Quarkus Funqy HTTP]


### PR DESCRIPTION
This PR aims to enhance the existing Quarkus docs for Azure integration as follows:

- Iteration 1 of the restructure into Diataxis content types. Depending on SME input, more restructuring might be needed later. _(Left file renaming & URL redirection until later... after initial input.)_
- Edits to enhance and style the 4 existing guides as per the [Quarkus doc contributor guide](https://quarkus.io/guides/doc-reference).
- Added a new concept topic [Quarkus integration with Microsoft Azure](https://quarkus-pr-main-32823-preview.surge.sh/version/main/guides/azure-integration-built-in-concept), which aims to:
  -  Explain and introduce Quarkus integration with Microsoft Azure and link to other valuable Quarkus docs
  -  Links to existing valuable tutorial resources in Quarkus docs, the Microsoft website, and the superheroes workshops.
 - Added a new reference topic: [Quarkus extensions for Azure integration](https://quarkus-pr-main-32823-preview.surge.sh/version/main/guides/azure-extensions-reference)

- Fixes #32441

