### PR TITLE
Set correct OIDC Google principal claim

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -429,6 +429,9 @@ public final class OidcUtils {
         if (tenant.token.issuer.isEmpty()) {
             tenant.token.issuer = provider.token.issuer;
         }
+        if (tenant.token.principalClaim.isEmpty()) {
+            tenant.token.principalClaim = provider.token.principalClaim;
+        }
 
         return tenant;
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
@@ -63,6 +63,7 @@ public class KnownOidcProviders {
         ret.setAuthServerUrl("https://accounts.google.com");
         ret.setApplicationType(OidcTenantConfig.ApplicationType.WEB_APP);
         ret.getAuthentication().setScopes(List.of("openid", "email", "profile"));
+        ret.getToken().setPrincipalClaim("name");
         return ret;
     }
 

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -195,6 +195,7 @@ public class OidcUtilsTest {
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
         assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
         assertEquals("https://accounts.google.com", config.getAuthServerUrl().get());
+        assertEquals("name", config.getToken().getPrincipalClaim().get());
         assertEquals(List.of("openid", "email", "profile"), config.authentication.scopes.get());
     }
 
@@ -206,12 +207,14 @@ public class OidcUtilsTest {
         tenant.setApplicationType(ApplicationType.HYBRID);
         tenant.setAuthServerUrl("http://localhost/wiremock");
         tenant.authentication.setScopes(List.of("write"));
+        tenant.token.setPrincipalClaim("firstname");
 
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.GOOGLE));
 
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
         assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
+        assertEquals("firstname", config.getToken().getPrincipalClaim().get());
         assertEquals(List.of("write"), config.authentication.scopes.get());
     }
 


### PR DESCRIPTION
Fixes #32824 

With this PR, instead of having to do `jwt.getClaim("name")`, it will just work with `jwt.getName()`, and this PR is the simplest option to have `SecurityIdentity.getPrincipal().getName()` returning the correct name.

CC @FroMage @stuartwdouglas 