### PR TITLE
Update OIDC Dev code to recognize quarkus.oidc.provider

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcAuthorizationCodePostHandler.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcAuthorizationCodePostHandler.java
@@ -18,6 +18,7 @@ import io.vertx.mutiny.ext.web.client.WebClient;
 
 public class OidcAuthorizationCodePostHandler extends DevConsolePostHandler {
     private static final Logger LOG = Logger.getLogger(OidcAuthorizationCodePostHandler.class);
+    private static final String APPLICATION_JSON = "application/json";
 
     Vertx vertxInstance;
     Duration timeout;
@@ -41,6 +42,7 @@ public class OidcAuthorizationCodePostHandler extends DevConsolePostHandler {
 
             HttpRequest<Buffer> request = client.postAbs(tokenUrl);
             request.putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString());
+            request.putHeader(HttpHeaders.ACCEPT.toString(), APPLICATION_JSON);
 
             io.vertx.mutiny.core.MultiMap props = new io.vertx.mutiny.core.MultiMap(MultiMap.caseInsensitiveMultiMap());
             props.add("client_id", form.get("client"));

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.oidc.deployment.devservices;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -16,8 +17,12 @@ import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleTemplateInfoBuildItem;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
+import io.quarkus.oidc.OidcTenantConfig.Provider;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.deployment.OidcBuildTimeConfig;
+import io.quarkus.oidc.runtime.providers.KnownOidcProviders;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
@@ -34,6 +39,7 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
     private static final String DISCOVERY_ENABLED_CONFIG_KEY = CONFIG_PREFIX + "discovery-enabled";
     private static final String AUTH_SERVER_URL_CONFIG_KEY = CONFIG_PREFIX + "auth-server-url";
     private static final String APP_TYPE_CONFIG_KEY = CONFIG_PREFIX + "application-type";
+    private static final String OIDC_PROVIDER_CONFIG_KEY = "quarkus.oidc.provider";
     private static final String SERVICE_APP_TYPE = "service";
 
     // Well-known providers
@@ -51,7 +57,12 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
             CuratedApplicationShutdownBuildItem closeBuildItem,
             BuildProducer<DevConsoleRouteBuildItem> devConsoleRoute,
             Capabilities capabilities, CurateOutcomeBuildItem curateOutcomeBuildItem) {
-        if (isOidcTenantEnabled() && isAuthServerUrlSet() && isClientIdSet()) {
+        if (!isOidcTenantEnabled() || !isClientIdSet()) {
+            return;
+        }
+        final OidcTenantConfig providerConfig = getProviderConfig();
+        final String authServerUrl = getAuthServerUrl(providerConfig);
+        if (authServerUrl != null) {
 
             if (vertxInstance == null) {
                 vertxInstance = Vertx.vertx();
@@ -72,13 +83,6 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
                 closeBuildItem.addCloseTask(closeTask, true);
             }
 
-            String authServerUrl = null;
-            try {
-                authServerUrl = getConfigProperty(AUTH_SERVER_URL_CONFIG_KEY);
-            } catch (Exception ex) {
-                // It is not possible to initialize OIDC Dev Console UI without being able to access this property at the build time
-                return;
-            }
             JsonObject metadata = null;
             if (isDiscoveryEnabled()) {
                 metadata = discoverMetadata(authServerUrl);
@@ -96,7 +100,7 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
                     devConsoleRuntimeInfo,
                     curateOutcomeBuildItem,
                     providerName,
-                    getApplicationType(),
+                    getApplicationType(providerConfig),
                     oidcConfig.devui.grant.type.isPresent() ? oidcConfig.devui.grant.type.get().getGrantType() : "code",
                     metadata != null ? metadata.getString("authorization_endpoint") : null,
                     metadata != null ? metadata.getString("token_endpoint") : null,
@@ -150,7 +154,7 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
         }
     }
 
-    private String getConfigProperty(String name) {
+    private static String getConfigProperty(String name) {
         return ConfigProvider.getConfig().getValue(name, String.class);
     }
 
@@ -170,12 +174,31 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
         return ConfigUtils.isPropertyPresent(CLIENT_ID_CONFIG_KEY);
     }
 
-    private static boolean isAuthServerUrlSet() {
-        return ConfigUtils.isPropertyPresent(AUTH_SERVER_URL_CONFIG_KEY);
+    private static String getAuthServerUrl(OidcTenantConfig providerConfig) {
+        try {
+            return getConfigProperty(AUTH_SERVER_URL_CONFIG_KEY);
+        } catch (Exception ex) {
+            return providerConfig != null ? providerConfig.authServerUrl.get() : null;
+        }
     }
 
-    private static String getApplicationType() {
-        return ConfigProvider.getConfig().getOptionalValue(APP_TYPE_CONFIG_KEY, String.class).orElse(SERVICE_APP_TYPE);
+    private static String getApplicationType(OidcTenantConfig providerConfig) {
+        Optional<ApplicationType> appType = ConfigProvider.getConfig().getOptionalValue(APP_TYPE_CONFIG_KEY,
+                ApplicationType.class);
+        if (appType.isEmpty() && providerConfig != null) {
+            appType = providerConfig.applicationType;
+        }
+        return appType.isPresent() ? appType.get().name().toLowerCase() : SERVICE_APP_TYPE;
+    }
+
+    private static OidcTenantConfig getProviderConfig() {
+        try {
+            Provider p = ConfigProvider.getConfig().getValue(OIDC_PROVIDER_CONFIG_KEY, Provider.class);
+            return KnownOidcProviders.provider(p);
+        } catch (Exception ex) {
+            return null;
+        }
+
     }
 
 }

--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -231,11 +231,13 @@ var port = {config:property('quarkus.http.port')};
             function(data, status){
                 var tokens = JSON.parse(data);
                 accessToken = tokens.access_token
-                idToken = tokens.id_token
                 $('#accessTokenEncodedArea').html(prettyToken(accessToken));
                 $('#accessTokenDecodedArea').html(decodeToken(accessToken));
-                $('#idTokenEncodedArea').html(prettyToken(idToken));
-                $('#idTokenDecodedArea').html(decodeToken(idToken));
+                if ("id_token" in tokens) {
+	                idToken = tokens.id_token
+	                $('#idTokenEncodedArea').html(prettyToken(idToken));
+	                $('#idTokenDecodedArea').html(decodeToken(idToken));
+	            }
             });
     }
     


### PR DESCRIPTION
Fixes #32826

This PR checks if a provider is configured and if yes, use its configuration as a fallback.
This PR is sufficient to test `quarkus.oidc.provider=google` in DevUI. Another PR will follow to support providers like `github` in DevUI (which do not support the discovery, etc)