### PR TITLE
Fix OIDC UserInfo to better handle null, array, map

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractJsonObjectResponse.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractJsonObjectResponse.java
@@ -37,16 +37,16 @@ public class AbstractJsonObjectResponse {
     }
 
     public Long getLong(String name) {
-        JsonNumber number = json.getJsonNumber(name);
+        JsonNumber number = contains(name) ? json.getJsonNumber(name) : null;
         return number != null ? number.longValue() : null;
     }
 
     public JsonArray getArray(String name) {
-        return json.getJsonArray(name);
+        return contains(name) ? json.getJsonArray(name) : null;
     }
 
     public JsonObject getObject(String name) {
-        return json.getJsonObject(name);
+        return contains(name) ? json.getJsonObject(name) : null;
     }
 
     public JsonObject getJsonObject() {
@@ -58,7 +58,7 @@ public class AbstractJsonObjectResponse {
     }
 
     public boolean contains(String propertyName) {
-        return json.containsKey(propertyName);
+        return json.containsKey(propertyName) && !json.isNull(propertyName);
     }
 
     public Set<String> getPropertyNames() {

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/UserInfoTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/UserInfoTest.java
@@ -1,8 +1,12 @@
 package io.quarkus.oidc.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +16,11 @@ public class UserInfoTest {
     UserInfo userInfo = new UserInfo(
             "{"
                     + "\"name\": \"alice\","
-                    + "\"admin\": true"
+                    + "\"admin\": true,"
+                    + "\"email\": null,"
+                    + "\"id\": 1234,"
+                    + "\"permissions\": [\"read\", \"write\"],"
+                    + "\"scopes\": {\"scope\": \"see\"}"
                     + "}");
 
     @Test
@@ -25,5 +33,35 @@ public class UserInfoTest {
     public void testGetBoolean() {
         assertTrue(userInfo.getBoolean("admin"));
         assertNull(userInfo.getBoolean("admins"));
+    }
+
+    @Test
+    public void testGetLong() {
+        assertEquals(1234, userInfo.getLong("id"));
+        assertNull(userInfo.getLong("ids"));
+    }
+
+    @Test
+    public void testGetArray() {
+        JsonArray array = userInfo.getArray("permissions");
+        assertNotNull(array);
+        assertEquals(2, array.size());
+        assertEquals("read", array.getString(0));
+        assertEquals("write", array.getString(1));
+        assertNull(userInfo.getArray("permit"));
+    }
+
+    @Test
+    public void testGetObject() {
+        JsonObject map = userInfo.getObject("scopes");
+        assertNotNull(map);
+        assertEquals(1, map.size());
+        assertEquals("see", map.getString("scope"));
+        assertNull(userInfo.getObject("scope"));
+    }
+
+    @Test
+    public void testGetNullProperty() {
+        assertNull(userInfo.getString("email"));
     }
 }


### PR DESCRIPTION
`UserInfo` currently reports a scary exception when a provider like Github returns something like `"name":null`, so this PR adds a check if the property is JSON null, as well tightens other UserInfo methods and adds the tests 