### PR TITLE
Disable DEV UI for remote dev mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/LaunchModeBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/LaunchModeBuildItem.java
@@ -44,6 +44,15 @@ public final class LaunchModeBuildItem extends SimpleBuildItem {
     }
 
     /**
+     * Whether the development mode type is not local.
+     *
+     * @return true if {@link #getDevModeType()} is not {@link DevModeType#LOCAL}
+     */
+    public boolean isNotLocalDevModeType() {
+        return devModeType.orElse(null) != DevModeType.LOCAL;
+    }
+
+    /**
      * An Auxiliary Application is a second application running in the same JVM as a primary application.
      * <p>
      * Currently, this is done to allow running tests in dev mode, while the main dev mode process continues to

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
@@ -57,6 +57,7 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
 
         //also verify that the dev ui console is disabled
         DevModeTestUtils.getHttpResponse("/q/dev-v1", 404, 10, TimeUnit.SECONDS);
+        DevModeTestUtils.getHttpResponse("/q/dev-ui", 404, 10, TimeUnit.SECONDS);
     }
 
     @Test


### PR DESCRIPTION
fixes: #32836

Prevents DEV UI from being exposed and its web jar from being created when DEV  mode is not local. Intention is definitely not to prevent all DEV UI related build steps as that would be dangerous (e.g.  extensions may rely on JsonRPC classes to be available as beans; also it would mean cascade of conditions preventing NPE for missing build items prone to changes). 