### PR TITLE
Add a column before a table column separator `|`

### DIFF
--- a/docs/src/main/asciidoc/doc-reference.adoc
+++ b/docs/src/main/asciidoc/doc-reference.adoc
@@ -57,7 +57,7 @@ Your titles and headings must also follow the specific guidance for the Quarkus 
 .Title guidance for different Quarkus content types
 [cols="15%,25%a,30%,30%"]
 |===
-|Content type |Should ... |Good example|Bad example
+|Content type |Should ... |Good example |Bad example
 
 |Concept
 |* Start with a noun that names the concept or topic

--- a/docs/src/main/asciidoc/security-authentication-mechanisms-concept.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms-concept.adoc
@@ -195,11 +195,11 @@ For more information about OIDC authentication and authorization methods you can
 [options="header"]
 |====
 |OIDC topic |Quarkus information resource
-|Bearer token authentication mechanism|xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
-|Authorization code flow authentication mechanism|xref:security-oidc-code-flow-authentication-concept.adoc[OpenID Connect (OIDC) authorization code flow mechanism]
-|Multiple tenants that can support bearer token or authorization code flow mechanisms|xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect (OIDC) multi-tenancy]
-|Using Keycloak to centralize authorization|xref:security-keycloak-authorization.adoc[Using OpenID Connect (OIDC) and Keycloak to centralize authorization]
-|Configuring Keycloak programmatically|xref:security-keycloak-admin-client.adoc[Using the Keycloak admin client]
+|Bearer token authentication mechanism |xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
+|Authorization code flow authentication mechanism |xref:security-oidc-code-flow-authentication-concept.adoc[OpenID Connect (OIDC) authorization code flow mechanism]
+|Multiple tenants that can support bearer token or authorization code flow mechanisms |xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect (OIDC) multi-tenancy]
+|Using Keycloak to centralize authorization |xref:security-keycloak-authorization.adoc[Using OpenID Connect (OIDC) and Keycloak to centralize authorization]
+|Configuring Keycloak programmatically |xref:security-keycloak-admin-client.adoc[Using the Keycloak admin client]
 |====
 
 [NOTE]


### PR DESCRIPTION
Without the space, po4a, which is used to build localized quarkus.io sites(i.e. ja.quarkus.io, and cn.quarkus.io) fails to parse the asciidoc.