### PR TITLE
Allow access token verification for Google,Github

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1256,8 +1256,16 @@ public class OidcTenantConfig extends OidcCommonConfig {
          * provider does not have a token introspection endpoint.
          * This property will have no effect when JWT tokens have to be verified.
          */
-        @ConfigItem(defaultValue = "false")
-        public boolean verifyAccessTokenWithUserInfo;
+        @ConfigItem(defaultValueDocumentation = "false")
+        public Optional<Boolean> verifyAccessTokenWithUserInfo = Optional.empty();
+
+        public Optional<Boolean> isVerifyAccessTokenWithUserInfo() {
+            return verifyAccessTokenWithUserInfo;
+        }
+
+        public void setVerifyAccessTokenWithUserInfo(boolean verify) {
+            this.verifyAccessTokenWithUserInfo = Optional.of(verify);
+        }
 
         public Optional<String> getIssuer() {
             return issuer;

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -100,7 +100,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             TokenAuthenticationRequest request,
             TenantConfigContext resolvedContext) {
 
-        if (resolvedContext.oidcConfig.token.verifyAccessTokenWithUserInfo
+        if (resolvedContext.oidcConfig.token.verifyAccessTokenWithUserInfo.orElse(false)
                 && isOpaqueAccessToken(vertxContext, request, resolvedContext)) {
             // UserInfo has to be acquired first as a precondition for verifying opaque access tokens.
             // Typically it will be done for bearer access tokens therefore even if the access token has expired
@@ -269,7 +269,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                             final String userName;
                             if (result.introspectionResult == null) {
                                 if (resolvedContext.oidcConfig.token.allowOpaqueTokenIntrospection &&
-                                        resolvedContext.oidcConfig.token.verifyAccessTokenWithUserInfo) {
+                                        resolvedContext.oidcConfig.token.verifyAccessTokenWithUserInfo.orElse(false)) {
                                     userName = "";
                                 } else {
                                     // we don't expect this to ever happen
@@ -386,7 +386,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 throw new AuthenticationFailedException();
             }
             // verify opaque access token with UserInfo if enabled and introspection URI is absent
-            if (resolvedContext.oidcConfig.token.verifyAccessTokenWithUserInfo
+            if (resolvedContext.oidcConfig.token.verifyAccessTokenWithUserInfo.orElse(false)
                     && resolvedContext.provider.getMetadata().getIntrospectionUri() == null) {
                 if (userInfo == null) {
                     return Uni.createFrom().failure(

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -176,7 +176,8 @@ public class OidcRecorder {
             throw new ConfigurationException(
                     "UserInfo is not required but UserInfo is expected to be the source of authorization roles");
         }
-        if (oidcConfig.token.verifyAccessTokenWithUserInfo && !enableUserInfo(oidcConfig)) {
+        if (oidcConfig.token.verifyAccessTokenWithUserInfo.orElse(false) && !isWebApp(oidcConfig)
+                && !enableUserInfo(oidcConfig)) {
             throw new ConfigurationException(
                     "UserInfo is not required but 'verifyAccessTokenWithUserInfo' is enabled");
         }
@@ -238,7 +239,7 @@ public class OidcRecorder {
             }
         }
 
-        if (oidcConfig.token.verifyAccessTokenWithUserInfo) {
+        if (oidcConfig.token.verifyAccessTokenWithUserInfo.orElse(false)) {
             if (!oidcConfig.isDiscoveryEnabled().orElse(true)) {
                 if (oidcConfig.userInfoPath.isEmpty()) {
                     throw new ConfigurationException(
@@ -441,6 +442,10 @@ public class OidcRecorder {
 
     private static boolean isServiceApp(OidcTenantConfig oidcConfig) {
         return ApplicationType.SERVICE.equals(oidcConfig.applicationType.orElse(ApplicationType.SERVICE));
+    }
+
+    private static boolean isWebApp(OidcTenantConfig oidcConfig) {
+        return ApplicationType.WEB_APP.equals(oidcConfig.applicationType.orElse(ApplicationType.SERVICE));
     }
 
     private static void verifyAuthServerUrl(OidcCommonConfig oidcConfig) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -432,6 +432,9 @@ public final class OidcUtils {
         if (tenant.token.principalClaim.isEmpty()) {
             tenant.token.principalClaim = provider.token.principalClaim;
         }
+        if (tenant.token.verifyAccessTokenWithUserInfo.isEmpty()) {
+            tenant.token.verifyAccessTokenWithUserInfo = provider.token.verifyAccessTokenWithUserInfo;
+        }
 
         return tenant;
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
@@ -39,6 +39,7 @@ public class KnownOidcProviders {
         ret.getAuthentication().setScopes(List.of("user:email"));
         ret.getAuthentication().setUserInfoRequired(true);
         ret.getAuthentication().setIdTokenRequired(false);
+        ret.getToken().setVerifyAccessTokenWithUserInfo(true);
         return ret;
     }
 
@@ -64,6 +65,7 @@ public class KnownOidcProviders {
         ret.setApplicationType(OidcTenantConfig.ApplicationType.WEB_APP);
         ret.getAuthentication().setScopes(List.of("openid", "email", "profile"));
         ret.getToken().setPrincipalClaim("name");
+        ret.getToken().setVerifyAccessTokenWithUserInfo(true);
         return ret;
     }
 

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -49,6 +49,7 @@ public class OidcUtilsTest {
 
         assertFalse(config.authentication.idTokenRequired.get());
         assertTrue(config.authentication.userInfoRequired.get());
+        assertTrue(config.token.verifyAccessTokenWithUserInfo.get());
         assertEquals(List.of("user:email"), config.authentication.scopes.get());
     }
 
@@ -66,6 +67,7 @@ public class OidcUtilsTest {
 
         tenant.authentication.setIdTokenRequired(true);
         tenant.authentication.setUserInfoRequired(false);
+        tenant.token.setVerifyAccessTokenWithUserInfo(false);
         tenant.authentication.setScopes(List.of("write"));
 
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.GITHUB));
@@ -80,6 +82,7 @@ public class OidcUtilsTest {
 
         assertTrue(config.authentication.idTokenRequired.get());
         assertFalse(config.authentication.userInfoRequired.get());
+        assertFalse(config.token.verifyAccessTokenWithUserInfo.get());
         assertEquals(List.of("write"), config.authentication.scopes.get());
     }
 
@@ -197,6 +200,7 @@ public class OidcUtilsTest {
         assertEquals("https://accounts.google.com", config.getAuthServerUrl().get());
         assertEquals("name", config.getToken().getPrincipalClaim().get());
         assertEquals(List.of("openid", "email", "profile"), config.authentication.scopes.get());
+        assertTrue(config.token.verifyAccessTokenWithUserInfo.get());
     }
 
     @Test
@@ -208,6 +212,7 @@ public class OidcUtilsTest {
         tenant.setAuthServerUrl("http://localhost/wiremock");
         tenant.authentication.setScopes(List.of("write"));
         tenant.token.setPrincipalClaim("firstname");
+        tenant.token.setVerifyAccessTokenWithUserInfo(false);
 
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.GOOGLE));
 
@@ -216,6 +221,7 @@ public class OidcUtilsTest {
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals("firstname", config.getToken().getPrincipalClaim().get());
         assertEquals(List.of("write"), config.authentication.scopes.get());
+        assertFalse(config.token.verifyAccessTokenWithUserInfo.get());
     }
 
     @Test

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -97,6 +97,7 @@ quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.credentials.secret=AyM
 
 
 quarkus.oidc.code-flow-token-introspection.provider=github
+quarkus.oidc.code-flow-token-introspection.token.verify-access-token-with-user-info=false
 quarkus.oidc.code-flow-token-introspection.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-token-introspection.authorization-path=/
 quarkus.oidc.code-flow-token-introspection.user-info-path=protocol/openid-connect/userinfo


### PR DESCRIPTION
Both Google and Github issue binary access tokens which can only be verified indirectly by using them to request UserInfo, neither of these providers offers an introspection endpoint.

So this PR makes it possible to save on typing one property when Quarkus application needs to accept Google or Github tokens as bearer tokens, instead of
```
quarkus.oidc.provider=google
quarkus.oidc.application-type=service
quarkus.oidc.client-id=<client-id>
quarkus.oidc.credentials.secret=<client-secret>
quarkus.oidc.token.verify-access-token-with-user-info=true
```

the user will type:
```
quarkus.oidc.provider=google
quarkus.oidc.application-type=service
quarkus.oidc.client-id=<client-id>
quarkus.oidc.credentials.secret=<client-secret>
```