### PR TITLE
Provide correct generic type and annotations in ParamConverterProvider

### DIFF
--- a/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/ParameterDescriptorFromClassSupplier.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/ParameterDescriptorFromClassSupplier.java
@@ -1,0 +1,52 @@
+package io.quarkus.jaxrs.client.reactive.runtime;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class ParameterDescriptorFromClassSupplier
+        implements Supplier<Map<String, ParameterDescriptorFromClassSupplier.ParameterDescriptor>> {
+
+    private final Class clazz;
+    private volatile Map<String, ParameterDescriptor> value;
+
+    public ParameterDescriptorFromClassSupplier(Class clazz) {
+        this.clazz = clazz;
+    }
+
+    @Override
+    public Map<String, ParameterDescriptor> get() {
+        if (value == null) {
+            value = new HashMap<>();
+            Class currentClass = clazz;
+            while (currentClass != null && currentClass != Object.class) {
+                for (Field field : currentClass.getDeclaredFields()) {
+                    ParameterDescriptor descriptor = new ParameterDescriptor();
+                    descriptor.annotations = field.getAnnotations();
+                    descriptor.genericType = field.getGenericType();
+                    value.put(field.getName(), descriptor);
+                }
+
+                for (Method method : currentClass.getDeclaredMethods()) {
+                    ParameterDescriptor descriptor = new ParameterDescriptor();
+                    descriptor.annotations = method.getAnnotations();
+                    descriptor.genericType = method.getGenericReturnType();
+                    value.put(method.getName(), descriptor);
+                }
+
+                currentClass = currentClass.getSuperclass();
+            }
+        }
+
+        return value;
+    }
+
+    public static class ParameterDescriptor {
+        public Annotation[] annotations;
+        public Type genericType;
+    }
+}

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamItem.java
@@ -6,17 +6,17 @@ public class BeanParamItem extends Item {
     private final List<Item> items;
     private final String className;
 
+    public BeanParamItem(String fieldName, List<Item> items, String className, ValueExtractor extractor) {
+        super(fieldName, ItemType.BEAN_PARAM, extractor);
+        this.items = items;
+        this.className = className;
+    }
+
     public String className() {
         return className;
     }
 
     public List<Item> items() {
         return items;
-    }
-
-    public BeanParamItem(List<Item> items, String className, ValueExtractor extractor) {
-        super(ItemType.BEAN_PARAM, extractor);
-        this.items = items;
-        this.className = className;
     }
 }

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamParser.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamParser.java
@@ -61,18 +61,19 @@ public class BeanParamParser {
             }
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, QUERY_PARAM,
-                    (annotationValue, fieldInfo) -> new QueryParamItem(annotationValue,
+                    (annotationValue, fieldInfo) -> new QueryParamItem(fieldInfo.name(), annotationValue,
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString()),
                             fieldInfo.type()),
-                    (annotationValue, getterMethod) -> new QueryParamItem(annotationValue, new GetterExtractor(getterMethod),
+                    (annotationValue, getterMethod) -> new QueryParamItem(getterMethod.name(), annotationValue,
+                            new GetterExtractor(getterMethod),
                             getterMethod.returnType())));
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, REST_QUERY_PARAM,
-                    (annotationValue, fieldInfo) -> new QueryParamItem(
+                    (annotationValue, fieldInfo) -> new QueryParamItem(fieldInfo.name(),
                             annotationValue != null ? annotationValue : fieldInfo.name(),
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString()),
                             fieldInfo.type()),
-                    (annotationValue, getterMethod) -> new QueryParamItem(
+                    (annotationValue, getterMethod) -> new QueryParamItem(getterMethod.name(),
                             annotationValue != null ? annotationValue : getterName(getterMethod),
                             new GetterExtractor(getterMethod),
                             getterMethod.returnType())));
@@ -84,7 +85,7 @@ public class BeanParamParser {
                             DotName beanParamClassName = type.asClassType().name();
                             List<Item> subBeanParamItems = parseInternal(index.getClassByName(beanParamClassName), index,
                                     processedBeanParamClasses);
-                            return new BeanParamItem(subBeanParamItems, beanParamClassName.toString(),
+                            return new BeanParamItem(fieldInfo.name(), subBeanParamItems, beanParamClassName.toString(),
                                     new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString()));
                         } else {
                             throw new IllegalArgumentException("BeanParam annotation used on a field that is not an object: "
@@ -95,69 +96,71 @@ public class BeanParamParser {
                         Type returnType = getterMethod.returnType();
                         List<Item> items = parseInternal(index.getClassByName(returnType.name()), index,
                                 processedBeanParamClasses);
-                        return new BeanParamItem(items, beanParamClass.name().toString(), new GetterExtractor(getterMethod));
+                        return new BeanParamItem(getterMethod.name(), items, beanParamClass.name().toString(),
+                                new GetterExtractor(getterMethod));
                     }));
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, COOKIE_PARAM,
-                    (annotationValue, fieldInfo) -> new CookieParamItem(annotationValue,
+                    (annotationValue, fieldInfo) -> new CookieParamItem(fieldInfo.name(), annotationValue,
                             new FieldExtractor(null, fieldInfo.name(),
                                     fieldInfo.declaringClass().name().toString()),
                             fieldInfo.type().name().toString()),
-                    (annotationValue, getterMethod) -> new CookieParamItem(annotationValue,
+                    (annotationValue, getterMethod) -> new CookieParamItem(getterMethod.name(), annotationValue,
                             new GetterExtractor(getterMethod), getterMethod.returnType().name().toString())));
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, REST_COOKIE_PARAM,
-                    (annotationValue, fieldInfo) -> new CookieParamItem(
+                    (annotationValue, fieldInfo) -> new CookieParamItem(fieldInfo.name(),
                             annotationValue != null ? annotationValue : fieldInfo.name(),
                             new FieldExtractor(null, fieldInfo.name(),
                                     fieldInfo.declaringClass().name().toString()),
                             fieldInfo.type().name().toString()),
-                    (annotationValue, getterMethod) -> new CookieParamItem(
+                    (annotationValue, getterMethod) -> new CookieParamItem(getterMethod.name(),
                             annotationValue != null ? annotationValue : getterName(getterMethod),
                             new GetterExtractor(getterMethod), getterMethod.returnType().name().toString())));
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, HEADER_PARAM,
-                    (annotationValue, fieldInfo) -> new HeaderParamItem(annotationValue,
+                    (annotationValue, fieldInfo) -> new HeaderParamItem(fieldInfo.name(), annotationValue,
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString()),
                             fieldInfo.type().name().toString()),
-                    (annotationValue, getterMethod) -> new HeaderParamItem(annotationValue,
+                    (annotationValue, getterMethod) -> new HeaderParamItem(getterMethod.name(), annotationValue,
                             new GetterExtractor(getterMethod), getterMethod.returnType().name().toString())));
 
             // @RestHeader with no explicit value are hyphenated
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, REST_HEADER_PARAM,
-                    (annotationValue, fieldInfo) -> new HeaderParamItem(
+                    (annotationValue, fieldInfo) -> new HeaderParamItem(fieldInfo.name(),
                             annotationValue != null ? annotationValue
                                     : StringUtil.hyphenateWithCapitalFirstLetter(fieldInfo.name()),
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString()),
                             fieldInfo.type().name().toString()),
-                    (annotationValue, getterMethod) -> new HeaderParamItem(
+                    (annotationValue, getterMethod) -> new HeaderParamItem(getterMethod.name(),
                             annotationValue != null ? annotationValue
                                     : StringUtil.hyphenateWithCapitalFirstLetter(getterName(getterMethod)),
                             new GetterExtractor(getterMethod), getterMethod.returnType().name().toString())));
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, PATH_PARAM,
-                    (annotationValue, fieldInfo) -> new PathParamItem(annotationValue, fieldInfo.type().name().toString(),
+                    (annotationValue, fieldInfo) -> new PathParamItem(fieldInfo.name(), annotationValue,
+                            fieldInfo.type().name().toString(),
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString())),
-                    (annotationValue, getterMethod) -> new PathParamItem(annotationValue,
+                    (annotationValue, getterMethod) -> new PathParamItem(getterMethod.name(), annotationValue,
                             getterMethod.returnType().name().toString(),
                             new GetterExtractor(getterMethod))));
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, REST_PATH_PARAM,
-                    (annotationValue, fieldInfo) -> new PathParamItem(
+                    (annotationValue, fieldInfo) -> new PathParamItem(fieldInfo.name(),
                             annotationValue != null ? annotationValue : fieldInfo.name(), fieldInfo.type().name().toString(),
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString())),
-                    (annotationValue, getterMethod) -> new PathParamItem(
+                    (annotationValue, getterMethod) -> new PathParamItem(getterMethod.name(),
                             annotationValue != null ? annotationValue : getterName(getterMethod),
                             getterMethod.returnType().name().toString(),
                             new GetterExtractor(getterMethod))));
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, FORM_PARAM,
-                    (annotationValue, fieldInfo) -> new FormParamItem(annotationValue,
+                    (annotationValue, fieldInfo) -> new FormParamItem(fieldInfo.name(), annotationValue,
                             fieldInfo.type().name().toString(), AsmUtil.getSignature(fieldInfo.type()),
                             fieldInfo.name(),
                             partType(fieldInfo), fileName(fieldInfo),
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString())),
-                    (annotationValue, getterMethod) -> new FormParamItem(annotationValue,
+                    (annotationValue, getterMethod) -> new FormParamItem(getterMethod.name(), annotationValue,
                             getterMethod.returnType().name().toString(),
                             AsmUtil.getSignature(getterMethod.returnType()),
                             getterMethod.name(),
@@ -165,13 +168,13 @@ public class BeanParamParser {
                             new GetterExtractor(getterMethod))));
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, REST_FORM_PARAM,
-                    (annotationValue, fieldInfo) -> new FormParamItem(
+                    (annotationValue, fieldInfo) -> new FormParamItem(fieldInfo.name(),
                             annotationValue != null ? annotationValue : fieldInfo.name(),
                             fieldInfo.type().name().toString(), AsmUtil.getSignature(fieldInfo.type()),
                             fieldInfo.name(),
                             partType(fieldInfo), fileName(fieldInfo),
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString())),
-                    (annotationValue, getterMethod) -> new FormParamItem(
+                    (annotationValue, getterMethod) -> new FormParamItem(getterMethod.name(),
                             annotationValue != null ? annotationValue : getterName(getterMethod),
                             getterMethod.returnType().name().toString(),
                             AsmUtil.getSignature(getterMethod.returnType()),

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/CookieParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/CookieParamItem.java
@@ -4,8 +4,8 @@ public class CookieParamItem extends Item {
     private final String cookieName;
     private final String paramType;
 
-    public CookieParamItem(String cookieName, ValueExtractor extractor, String paramType) {
-        super(ItemType.COOKIE, extractor);
+    public CookieParamItem(String fieldName, String cookieName, ValueExtractor extractor, String paramType) {
+        super(fieldName, ItemType.COOKIE, extractor);
         this.cookieName = cookieName;
         this.paramType = paramType;
     }

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/FormParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/FormParamItem.java
@@ -9,11 +9,11 @@ public class FormParamItem extends Item {
     private final String fileName;
     private final String sourceName;
 
-    public FormParamItem(String formParamName, String paramType, String paramSignature,
+    public FormParamItem(String fieldName, String formParamName, String paramType, String paramSignature,
             String sourceName,
             String mimeType, String fileName,
             ValueExtractor valueExtractor) {
-        super(ItemType.FORM_PARAM, valueExtractor);
+        super(fieldName, ItemType.FORM_PARAM, valueExtractor);
         this.formParamName = formParamName;
         this.paramType = paramType;
         this.paramSignature = paramSignature;

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/HeaderParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/HeaderParamItem.java
@@ -4,8 +4,8 @@ public class HeaderParamItem extends Item {
     private final String headerName;
     private final String paramType;
 
-    public HeaderParamItem(String headerName, ValueExtractor extractor, String paramType) {
-        super(ItemType.HEADER_PARAM, extractor);
+    public HeaderParamItem(String fieldName, String headerName, ValueExtractor extractor, String paramType) {
+        super(fieldName, ItemType.HEADER_PARAM, extractor);
         this.headerName = headerName;
         this.paramType = paramType;
     }

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/Item.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/Item.java
@@ -5,12 +5,18 @@ import io.quarkus.gizmo.ResultHandle;
 
 public abstract class Item {
 
+    private final String fieldName;
     private final ItemType type;
     private final ValueExtractor valueExtractor;
 
-    public Item(ItemType type, ValueExtractor valueExtractor) {
+    public Item(String fieldName, ItemType type, ValueExtractor valueExtractor) {
+        this.fieldName = fieldName;
         this.type = type;
         this.valueExtractor = valueExtractor;
+    }
+
+    public String fieldName() {
+        return fieldName;
     }
 
     public ItemType type() {

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/PathParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/PathParamItem.java
@@ -5,8 +5,8 @@ public class PathParamItem extends Item {
     private final String pathParamName;
     private final String paramType;
 
-    public PathParamItem(String pathParamName, String paramType, ValueExtractor valueExtractor) {
-        super(ItemType.PATH_PARAM, valueExtractor);
+    public PathParamItem(String fieldName, String pathParamName, String paramType, ValueExtractor valueExtractor) {
+        super(fieldName, ItemType.PATH_PARAM, valueExtractor);
         this.pathParamName = pathParamName;
         this.paramType = paramType;
     }

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/QueryParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/QueryParamItem.java
@@ -7,8 +7,8 @@ public class QueryParamItem extends Item {
     private final String name;
     private final Type valueType;
 
-    public QueryParamItem(String name, ValueExtractor extractor, Type valueType) {
-        super(ItemType.QUERY_PARAM, extractor);
+    public QueryParamItem(String fieldName, String name, ValueExtractor extractor, Type valueType) {
+        super(fieldName, ItemType.QUERY_PARAM, extractor);
         this.name = name;
         this.valueType = valueType;
     }


### PR DESCRIPTION
These changes will provide the correct generic type and array of annotations when the JAX-RS annotation is present on a field or a method of a Bean Param class. 

The solution is similar to what was being done for the parameters of a REST Client method: it will load the metadata (generic type and annotations from fields and methods) of a BeanParam class using reflection only if there is a ParamConverterProvider present.

Fix https://github.com/quarkusio/quarkus/issues/32765