### PR TITLE
Use `@WithUnnamedKey` in Hibernate Search extension config

### DIFF
--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingBuildTimeConfig.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingBuildTimeConfig.java
@@ -2,29 +2,26 @@ package io.quarkus.hibernate.search.orm.coordination.outboxpolling.runtime;
 
 import java.util.Map;
 
+import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
 
 @ConfigMapping(prefix = "quarkus.hibernate-search-orm")
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public interface HibernateSearchOutboxPollingBuildTimeConfig {
 
     /**
-     * Configuration for the default persistence unit.
-     */
-    @WithParentName
-    HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit defaultPersistenceUnit();
-
-    /**
-     * Configuration for additional named persistence units.
+     * Configuration for persistence units.
      */
     @ConfigDocSection
-    @ConfigDocMapKey("persistence-unit-name")
     @WithParentName
+    @WithUnnamedKey(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME)
+    @ConfigDocMapKey("persistence-unit-name")
     Map<String, HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit> persistenceUnits();
 
 }

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRecorder.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRecorder.java
@@ -10,7 +10,6 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.HibernateOrmMapperOutboxPollingSettings;
 
-import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationRuntimeInitListener;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationStaticInitListener;
 import io.quarkus.hibernate.search.orm.coordination.outboxpolling.runtime.HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit.AgentsConfig;
@@ -21,19 +20,15 @@ public class HibernateSearchOutboxPollingRecorder {
 
     public HibernateOrmIntegrationStaticInitListener createStaticInitListener(
             HibernateSearchOutboxPollingBuildTimeConfig buildTimeConfig, String persistenceUnitName) {
-        HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit puConfig = PersistenceUnitUtil
-                .isDefaultPersistenceUnit(persistenceUnitName)
-                        ? buildTimeConfig.defaultPersistenceUnit()
-                        : buildTimeConfig.persistenceUnits().get(persistenceUnitName);
+        HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit puConfig = buildTimeConfig.persistenceUnits()
+                .get(persistenceUnitName);
         return new StaticInitListener(puConfig);
     }
 
     public HibernateOrmIntegrationRuntimeInitListener createRuntimeInitListener(
             HibernateSearchOutboxPollingRuntimeConfig runtimeConfig, String persistenceUnitName) {
-        HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit puConfig = PersistenceUnitUtil
-                .isDefaultPersistenceUnit(persistenceUnitName)
-                        ? runtimeConfig.defaultPersistenceUnit()
-                        : runtimeConfig.persistenceUnits().get(persistenceUnitName);
+        HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit puConfig = runtimeConfig.persistenceUnits()
+                .get(persistenceUnitName);
         return new RuntimeInitListener(puConfig);
     }
 

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfig.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfig.java
@@ -2,29 +2,26 @@ package io.quarkus.hibernate.search.orm.coordination.outboxpolling.runtime;
 
 import java.util.Map;
 
+import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
 
 @ConfigMapping(prefix = "quarkus.hibernate-search-orm")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public interface HibernateSearchOutboxPollingRuntimeConfig {
 
     /**
-     * Configuration for the default persistence unit.
-     */
-    @WithParentName
-    HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit defaultPersistenceUnit();
-
-    /**
-     * Configuration for additional named persistence units.
+     * Configuration for persistence units.
      */
     @ConfigDocSection
-    @ConfigDocMapKey("persistence-unit-name")
     @WithParentName
+    @WithUnnamedKey(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME)
+    @ConfigDocMapKey("persistence-unit-name")
     Map<String, HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit> persistenceUnits();
 
 }

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfig.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfig.java
@@ -4,7 +4,6 @@ import java.util.Map;
 
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -18,7 +17,6 @@ public interface HibernateSearchOutboxPollingRuntimeConfig {
     /**
      * Configuration for persistence units.
      */
-    @ConfigDocSection
     @WithParentName
     @WithUnnamedKey(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME)
     @ConfigDocMapKey("persistence-unit-name")

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit.java
@@ -24,14 +24,13 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
     interface CoordinationConfig {
 
         /**
-         * Default config
+         * Default configuration.
          */
-        @ConfigDocSection
         @WithParentName
         AgentsConfig defaults();
 
         /**
-         * Per-tenant config
+         * Per-tenant configuration overrides.
          */
         @ConfigDocSection
         @ConfigDocMapKey("tenant-id")

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit.java
@@ -21,7 +21,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
     CoordinationConfig coordination();
 
     @ConfigGroup
-    public interface CoordinationConfig {
+    interface CoordinationConfig {
 
         /**
          * Default config
@@ -40,7 +40,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface AgentsConfig {
+    interface AgentsConfig {
 
         /**
          * Configuration for the event processor agent.
@@ -55,7 +55,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface EventProcessorConfig {
+    interface EventProcessorConfig {
 
         // @formatter:off
         /**
@@ -209,7 +209,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface EventProcessorShardsConfig {
+    interface EventProcessorShardsConfig {
 
         // @formatter:off
         /**
@@ -257,7 +257,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface MassIndexerConfig {
+    interface MassIndexerConfig {
 
         // @formatter:off
         /**

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -93,7 +93,7 @@ class HibernateSearchElasticsearchProcessor {
                 index);
 
         Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> configByPU = buildTimeConfig
-                .getAllPersistenceUnitConfigsAsMap();
+                .persistenceUnits();
 
         for (PersistenceUnitDescriptorBuildItem puDescriptor : persistenceUnitDescriptorBuildItems) {
             Collection<AnnotationInstance> indexedAnnotationsForPU = new ArrayList<>();
@@ -379,13 +379,15 @@ class HibernateSearchElasticsearchProcessor {
 
     @BuildStep(onlyIfNot = IsNormal.class)
     DevservicesElasticsearchBuildItem devServices(HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig) {
-        if (buildTimeConfig.defaultPersistenceUnit() == null) {
+        var defaultPUConfig = buildTimeConfig.persistenceUnits().get(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME);
+        if (defaultPUConfig == null) {
             // Currently we only start dev-services for the default backend of the default persistence unit.
             // See https://github.com/quarkusio/quarkus/issues/24011
             return null;
         }
-        if (buildTimeConfig.defaultPersistenceUnit().defaultBackend() == null
-                || !buildTimeConfig.defaultPersistenceUnit().defaultBackend().version().isPresent()) {
+        var defaultPUDefaultBackendConfig = defaultPUConfig.defaultBackend();
+        if (defaultPUDefaultBackendConfig == null
+                || !defaultPUDefaultBackendConfig.version().isPresent()) {
             // If the version is not set, the default backend is not in use.
             return null;
         }
@@ -395,7 +397,7 @@ class HibernateSearchElasticsearchProcessor {
             // If Hibernate Search is deactivated, we don't want to trigger dev services.
             return null;
         }
-        ElasticsearchVersion version = buildTimeConfig.defaultPersistenceUnit().defaultBackend().version().get();
+        ElasticsearchVersion version = defaultPUDefaultBackendConfig.version().get();
         String hostsPropertyKey = backendPropertyKey(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, null, null,
                 "hosts");
         return new DevservicesElasticsearchBuildItem(hostsPropertyKey,

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -293,7 +293,7 @@ class HibernateSearchElasticsearchProcessor {
 
         Set<String> propertyKeysWithNoVersion = new LinkedHashSet<>();
         Map<String, ElasticsearchBackendBuildTimeConfig> backends = buildTimeConfig != null
-                ? buildTimeConfig.getAllBackendConfigsAsMap()
+                ? buildTimeConfig.backends()
                 : Collections.emptyMap();
 
         Set<String> allBackendNames = new LinkedHashSet<>(configuredPersistenceUnit.getBackendNamesForIndexedEntities());
@@ -385,7 +385,7 @@ class HibernateSearchElasticsearchProcessor {
             // See https://github.com/quarkusio/quarkus/issues/24011
             return null;
         }
-        var defaultPUDefaultBackendConfig = defaultPUConfig.defaultBackend();
+        var defaultPUDefaultBackendConfig = defaultPUConfig.backends().get(null);
         if (defaultPUDefaultBackendConfig == null
                 || !defaultPUDefaultBackendConfig.version().isPresent()) {
             // If the version is not set, the default backend is not in use.

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchConfigUtil.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchConfigUtil.java
@@ -39,7 +39,7 @@ public class HibernateSearchConfigUtil {
             T value,
             Function<T, Boolean> shouldBeAdded, Function<T, ?> getValue) {
         if (shouldBeAdded.apply(value)) {
-            propertyCollector.accept(BackendSettings.backendKey(backendName, configPath), getValue.apply(value));
+            addBackendConfig(propertyCollector, backendName, configPath, getValue.apply(value));
         }
     }
 
@@ -62,8 +62,7 @@ public class HibernateSearchConfigUtil {
                 propertyCollector.accept(
                         IndexSettings.indexKey(backendName, indexName, configPath), getValue.apply(value));
             } else {
-                propertyCollector.accept(
-                        BackendSettings.backendKey(backendName, configPath), getValue.apply(value));
+                addBackendConfig(propertyCollector, backendName, configPath, getValue.apply(value));
             }
         }
     }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
@@ -1,7 +1,6 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.runtime;
 
 import java.util.Map;
-import java.util.TreeMap;
 
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
@@ -11,6 +10,7 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
 
 @ConfigMapping(prefix = "quarkus.hibernate-search-orm")
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
@@ -29,46 +29,12 @@ public interface HibernateSearchElasticsearchBuildTimeConfig {
     boolean enabled();
 
     /**
-     * Configuration for the default persistence unit.
-     */
-    @WithParentName
-    HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit defaultPersistenceUnit();
-
-    /**
-     * Configuration for additional named persistence units.
+     * Configuration for persistence units.
      */
     @ConfigDocSection
-    @ConfigDocMapKey("persistence-unit-name")
     @WithParentName
+    @WithUnnamedKey(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME)
+    @ConfigDocMapKey("persistence-unit-name")
     Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> persistenceUnits();
 
-    default Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> getAllPersistenceUnitConfigsAsMap() {
-        Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> map = new TreeMap<>();
-        HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit defaultPersistenceUnit = defaultPersistenceUnit();
-
-        if (defaultPersistenceUnit != null) {
-            map.put(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, defaultPersistenceUnit);
-        }
-        map.putAll(persistenceUnits());
-        return map;
-    }
-
-    default HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit getPersistenceUnitConfig(String persistenceUnitName) {
-        if (persistenceUnitName == null) {
-            throw new IllegalArgumentException("Persistence unit name may not be null");
-        }
-
-        if (PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME.equals(persistenceUnitName)) {
-            return defaultPersistenceUnit();
-        }
-
-        HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit persistenceUnitConfig = persistenceUnits()
-                .get(persistenceUnitName);
-
-        if (persistenceUnitConfig == null) {
-            throw new IllegalStateException("No persistence unit config exists for name " + persistenceUnitName);
-        }
-
-        return persistenceUnitConfig;
-    }
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
@@ -4,7 +4,6 @@ import java.util.Map;
 
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -31,7 +30,6 @@ public interface HibernateSearchElasticsearchBuildTimeConfig {
     /**
      * Configuration for persistence units.
      */
-    @ConfigDocSection
     @WithParentName
     @WithUnnamedKey(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME)
     @ConfigDocMapKey("persistence-unit-name")

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
@@ -51,7 +51,7 @@ public interface HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
     CoordinationConfig coordination();
 
     @ConfigGroup
-    public interface ElasticsearchBackendBuildTimeConfig {
+    interface ElasticsearchBackendBuildTimeConfig {
         /**
          * The version of Elasticsearch used in the cluster.
          *
@@ -87,7 +87,7 @@ public interface HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface ElasticsearchIndexBuildTimeConfig {
+    interface ElasticsearchIndexBuildTimeConfig {
         /**
          * Configuration for automatic creation and validation of the Elasticsearch schema:
          * indexes, their mapping, their settings.
@@ -101,7 +101,7 @@ public interface HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface SchemaManagementConfig {
+    interface SchemaManagementConfig {
 
         // @formatter:off
         /**
@@ -163,7 +163,7 @@ public interface HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface LayoutConfig {
+    interface LayoutConfig {
         /**
          * A xref:hibernate-search-orm-elasticsearch.adoc#bean-reference-note-anchor[bean reference] to the component
          * used to configure layout (e.g. index names, index aliases).
@@ -199,7 +199,7 @@ public interface HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface CoordinationConfig {
+    interface CoordinationConfig {
 
         /**
          * The strategy to use for coordinating between threads or even separate instances of the application,

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
@@ -1,6 +1,5 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.runtime;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -13,23 +12,19 @@ import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithName;
 import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
 
 @ConfigGroup
 public interface HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
 
     /**
-     * Default backend
+     * Configuration for backends.
      */
     @ConfigDocSection
     @WithName("elasticsearch")
-    ElasticsearchBackendBuildTimeConfig defaultBackend();
-
-    /**
-     * Named backends
-     */
-    @ConfigDocSection
-    @WithName("elasticsearch")
-    ElasticsearchNamedBackendsBuildTimeConfig namedBackends();
+    @WithUnnamedKey // The default backend has the null key
+    @ConfigDocMapKey("backend-name")
+    Map<String, ElasticsearchBackendBuildTimeConfig> backends();
 
     /**
      * A xref:hibernate-search-orm-elasticsearch.adoc#bean-reference-note-anchor[bean reference] to a component
@@ -54,28 +49,6 @@ public interface HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
      * Configuration for coordination between threads or application instances.
      */
     CoordinationConfig coordination();
-
-    default Map<String, ElasticsearchBackendBuildTimeConfig> getAllBackendConfigsAsMap() {
-        Map<String, ElasticsearchBackendBuildTimeConfig> map = new LinkedHashMap<>();
-        if (defaultBackend() != null) {
-            map.put(null, defaultBackend());
-        }
-        if (namedBackends() != null) {
-            map.putAll(namedBackends().backends());
-        }
-        return map;
-    }
-
-    @ConfigGroup
-    public interface ElasticsearchNamedBackendsBuildTimeConfig {
-
-        /**
-         * Named backends
-         */
-        @ConfigDocMapKey("backend-name")
-        public Map<String, ElasticsearchBackendBuildTimeConfig> backends();
-
-    }
 
     @ConfigGroup
     public interface ElasticsearchBackendBuildTimeConfig {

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
@@ -80,8 +80,9 @@ public interface HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
         ElasticsearchIndexBuildTimeConfig indexDefaults();
 
         /**
-         * Per-index specific configuration.
+         * Per-index configuration overrides.
          */
+        @ConfigDocSection
         @ConfigDocMapKey("index-name")
         Map<String, ElasticsearchIndexBuildTimeConfig> indexes();
     }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -223,7 +223,7 @@ public class HibernateSearchElasticsearchRecorder {
             // (Well maybe not for backends, but... let's keep it simple.)
             Map<String, ElasticsearchBackendBuildTimeConfig> backendConfigs = buildTimeConfig == null
                     ? Collections.emptyMap()
-                    : buildTimeConfig.getAllBackendConfigsAsMap();
+                    : buildTimeConfig.backends();
             Map<String, Set<String>> backendAndIndexNames = new LinkedHashMap<>();
             mergeInto(backendAndIndexNames, backendAndIndexNamesForSearchExtensions);
             for (Entry<String, ElasticsearchBackendBuildTimeConfig> entry : backendConfigs.entrySet()) {
@@ -391,7 +391,7 @@ public class HibernateSearchElasticsearchRecorder {
             // (Well maybe not for backends, but... let's keep it simple.)
             Map<String, ElasticsearchBackendRuntimeConfig> backendConfigs = runtimeConfig == null
                     ? Collections.emptyMap()
-                    : runtimeConfig.getAllBackendConfigsAsMap();
+                    : runtimeConfig.backends();
             Map<String, Set<String>> backendAndIndexNames = new LinkedHashMap<>();
             mergeInto(backendAndIndexNames, backendAndIndexNamesForSearchExtensions);
             for (Entry<String, ElasticsearchBackendRuntimeConfig> entry : backendConfigs.entrySet()) {

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -70,7 +70,7 @@ public class HibernateSearchElasticsearchRecorder {
             }
         }
         return new HibernateSearchIntegrationStaticInitListener(persistenceUnitName,
-                buildTimeConfig.getPersistenceUnitConfig(persistenceUnitName),
+                buildTimeConfig.persistenceUnits().get(persistenceUnitName),
                 backendAndIndexNamesForSearchExtensions, rootAnnotationMappedClasses,
                 integrationStaticInitListeners);
     }
@@ -83,14 +83,14 @@ public class HibernateSearchElasticsearchRecorder {
             HibernateSearchElasticsearchRuntimeConfig runtimeConfig, String persistenceUnitName,
             Map<String, Set<String>> backendAndIndexNamesForSearchExtensions,
             List<HibernateOrmIntegrationRuntimeInitListener> integrationRuntimeInitListeners) {
-        HibernateSearchElasticsearchRuntimeConfigPersistenceUnit puConfig = runtimeConfig.getAllPersistenceUnitConfigsAsMap()
+        HibernateSearchElasticsearchRuntimeConfigPersistenceUnit puConfig = runtimeConfig.persistenceUnits()
                 .get(persistenceUnitName);
         return new HibernateSearchIntegrationRuntimeInitListener(persistenceUnitName, puConfig,
                 backendAndIndexNamesForSearchExtensions, integrationRuntimeInitListeners);
     }
 
     public void checkNoExplicitActiveTrue(HibernateSearchElasticsearchRuntimeConfig runtimeConfig) {
-        for (var entry : runtimeConfig.getAllPersistenceUnitConfigsAsMap().entrySet()) {
+        for (var entry : runtimeConfig.persistenceUnits().entrySet()) {
             var config = entry.getValue();
             if (config.active().orElse(false)) {
                 var puName = entry.getKey();
@@ -120,7 +120,7 @@ public class HibernateSearchElasticsearchRecorder {
             @Override
             public SearchMapping get() {
                 HibernateSearchElasticsearchRuntimeConfigPersistenceUnit puRuntimeConfig = runtimeConfig
-                        .getAllPersistenceUnitConfigsAsMap().get(persistenceUnitName);
+                        .persistenceUnits().get(persistenceUnitName);
                 if (puRuntimeConfig != null && !puRuntimeConfig.active().orElse(true)) {
                     throw new IllegalStateException(
                             "Cannot retrieve the SearchMapping for persistence unit " + persistenceUnitName
@@ -144,7 +144,7 @@ public class HibernateSearchElasticsearchRecorder {
             @Override
             public SearchSession get() {
                 HibernateSearchElasticsearchRuntimeConfigPersistenceUnit puRuntimeConfig = runtimeConfig
-                        .getAllPersistenceUnitConfigsAsMap().get(persistenceUnitName);
+                        .persistenceUnits().get(persistenceUnitName);
                 if (puRuntimeConfig != null && !puRuntimeConfig.active().orElse(true)) {
                     throw new IllegalStateException(
                             "Cannot retrieve the SearchSession for persistence unit " + persistenceUnitName

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -25,17 +25,17 @@ public interface HibernateSearchElasticsearchRuntimeConfig {
     @ConfigDocMapKey("persistence-unit-name")
     Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> persistenceUnits();
 
-    public static String elasticsearchVersionPropertyKey(String persistenceUnitName, String backendName) {
+    static String elasticsearchVersionPropertyKey(String persistenceUnitName, String backendName) {
         return backendPropertyKey(persistenceUnitName, backendName, null, "version");
     }
 
-    public static String extensionPropertyKey(String radical) {
+    static String extensionPropertyKey(String radical) {
         StringBuilder keyBuilder = new StringBuilder("quarkus.hibernate-search-orm.");
         keyBuilder.append(radical);
         return keyBuilder.toString();
     }
 
-    public static String mapperPropertyKey(String persistenceUnitName, String radical) {
+    static String mapperPropertyKey(String persistenceUnitName, String radical) {
         StringBuilder keyBuilder = new StringBuilder("quarkus.hibernate-search-orm.");
         if (!PersistenceUnitUtil.isDefaultPersistenceUnit(persistenceUnitName)) {
             keyBuilder.append("\"").append(persistenceUnitName).append("\".");
@@ -44,7 +44,7 @@ public interface HibernateSearchElasticsearchRuntimeConfig {
         return keyBuilder.toString();
     }
 
-    public static List<String> mapperPropertyKeys(String persistenceUnitName, String radical) {
+    static List<String> mapperPropertyKeys(String persistenceUnitName, String radical) {
         if (PersistenceUnitUtil.isDefaultPersistenceUnit(persistenceUnitName)) {
             return List.of("quarkus.hibernate-search-orm." + radical);
         } else {
@@ -54,7 +54,7 @@ public interface HibernateSearchElasticsearchRuntimeConfig {
         }
     }
 
-    public static String backendPropertyKey(String persistenceUnitName, String backendName, String indexName, String radical) {
+    static String backendPropertyKey(String persistenceUnitName, String backendName, String indexName, String radical) {
         StringBuilder keyBuilder = new StringBuilder("quarkus.hibernate-search-orm.");
         if (!PersistenceUnitUtil.isDefaultPersistenceUnit(persistenceUnitName)) {
             keyBuilder.append("\"").append(persistenceUnitName).append("\".");
@@ -70,7 +70,7 @@ public interface HibernateSearchElasticsearchRuntimeConfig {
         return keyBuilder.toString();
     }
 
-    public static List<String> defaultBackendPropertyKeys(String persistenceUnitName, String radical) {
+    static List<String> defaultBackendPropertyKeys(String persistenceUnitName, String radical) {
         return mapperPropertyKeys(persistenceUnitName, "elasticsearch." + radical);
     }
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -19,7 +18,6 @@ public interface HibernateSearchElasticsearchRuntimeConfig {
     /**
      * Configuration for persistence units.
      */
-    @ConfigDocSection
     @WithParentName
     @WithUnnamedKey(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME)
     @ConfigDocMapKey("persistence-unit-name")

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -2,7 +2,6 @@ package io.quarkus.hibernate.search.orm.elasticsearch.runtime;
 
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
@@ -11,33 +10,20 @@ import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
 
 @ConfigMapping(prefix = "quarkus.hibernate-search-orm")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public interface HibernateSearchElasticsearchRuntimeConfig {
 
     /**
-     * Configuration for the default persistence unit.
-     */
-    @WithParentName
-    HibernateSearchElasticsearchRuntimeConfigPersistenceUnit defaultPersistenceUnit();
-
-    /**
-     * Configuration for additional named persistence units.
+     * Configuration for persistence units.
      */
     @ConfigDocSection
-    @ConfigDocMapKey("persistence-unit-name")
     @WithParentName
+    @WithUnnamedKey(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME)
+    @ConfigDocMapKey("persistence-unit-name")
     Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> persistenceUnits();
-
-    default Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> getAllPersistenceUnitConfigsAsMap() {
-        Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> map = new TreeMap<>();
-        if (defaultPersistenceUnit() != null) {
-            map.put(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, defaultPersistenceUnit());
-        }
-        map.putAll(persistenceUnits());
-        return map;
-    }
 
     public static String elasticsearchVersionPropertyKey(String persistenceUnitName, String backendName) {
         return backendPropertyKey(persistenceUnitName, backendName, null, "version");

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
@@ -1,7 +1,6 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.runtime;
 
 import java.time.Duration;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -21,6 +20,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
 
 @ConfigGroup
 public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
@@ -41,18 +41,13 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     Optional<Boolean> active();
 
     /**
-     * Default backend
+     * Configuration for backends.
      */
-    @WithName("elasticsearch")
     @ConfigDocSection
-    ElasticsearchBackendRuntimeConfig defaultBackend();
-
-    /**
-     * Named backends
-     */
     @WithName("elasticsearch")
-    @ConfigDocSection
-    ElasticsearchNamedBackendsRuntimeConfig namedBackends();
+    @WithUnnamedKey // The default backend has the null key
+    @ConfigDocMapKey("backend-name")
+    Map<String, ElasticsearchBackendRuntimeConfig> backends();
 
     /**
      * Configuration for automatic creation and validation of the Elasticsearch schema:
@@ -83,28 +78,6 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
      * Configuration for multi-tenancy.
      */
     MultiTenancyConfig multiTenancy();
-
-    default Map<String, ElasticsearchBackendRuntimeConfig> getAllBackendConfigsAsMap() {
-        Map<String, ElasticsearchBackendRuntimeConfig> map = new LinkedHashMap<>();
-        if (defaultBackend() != null) {
-            map.put(null, defaultBackend());
-        }
-        if (namedBackends() != null) {
-            map.putAll(namedBackends().backends());
-        }
-        return map;
-    }
-
-    @ConfigGroup
-    public interface ElasticsearchNamedBackendsRuntimeConfig {
-
-        /**
-         * Named backends
-         */
-        @ConfigDocMapKey("backend-name")
-        Map<String, ElasticsearchBackendRuntimeConfig> backends();
-
-    }
 
     @ConfigGroup
     public interface ElasticsearchBackendRuntimeConfig {

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
@@ -166,8 +166,9 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
         ElasticsearchIndexRuntimeConfig indexDefaults();
 
         /**
-         * Per-index specific configuration.
+         * Per-index configuration overrides.
          */
+        @ConfigDocSection
         @ConfigDocMapKey("index-name")
         Map<String, ElasticsearchIndexRuntimeConfig> indexes();
     }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
@@ -80,7 +80,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     MultiTenancyConfig multiTenancy();
 
     @ConfigGroup
-    public interface ElasticsearchBackendRuntimeConfig {
+    interface ElasticsearchBackendRuntimeConfig {
         /**
          * The list of hosts of the Elasticsearch servers.
          */
@@ -172,7 +172,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
         Map<String, ElasticsearchIndexRuntimeConfig> indexes();
     }
 
-    public enum ElasticsearchClientProtocol {
+    enum ElasticsearchClientProtocol {
         /**
          * Use clear-text HTTP, with SSL/TLS disabled.
          */
@@ -207,7 +207,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface ElasticsearchIndexRuntimeConfig {
+    interface ElasticsearchIndexRuntimeConfig {
         /**
          * Configuration for the schema management of the indexes.
          */
@@ -220,7 +220,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface DiscoveryConfig {
+    interface DiscoveryConfig {
 
         /**
          * Defines if automatic discovery is enabled.
@@ -347,7 +347,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
 
     @ConfigGroup
     @Deprecated
-    public interface AutomaticIndexingConfig {
+    interface AutomaticIndexingConfig {
 
         /**
          * Configuration for synchronization with the index when indexing automatically.
@@ -372,7 +372,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
 
     @ConfigGroup
     @Deprecated
-    public interface AutomaticIndexingSynchronizationConfig {
+    interface AutomaticIndexingSynchronizationConfig {
 
         // @formatter:off
         /**
@@ -386,7 +386,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface SearchQueryLoadingConfig {
+    interface SearchQueryLoadingConfig {
 
         /**
          * Configuration for cache lookup when loading entities during the execution of a search query.
@@ -411,7 +411,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface SchemaManagementConfig {
+    interface SchemaManagementConfig {
 
         // @formatter:off
         /**
@@ -481,7 +481,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface ThreadPoolConfig {
+    interface ThreadPoolConfig {
         /**
          * The size of the thread pool assigned to the backend.
          *
@@ -507,7 +507,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     // We can't set actual default values in this section,
     // otherwise "quarkus.hibernate-search-orm.elasticsearch.index-defaults" will be ignored.
     @ConfigGroup
-    public interface ElasticsearchIndexSchemaManagementConfig {
+    interface ElasticsearchIndexSchemaManagementConfig {
         /**
          * The minimal https://www.elastic.co/guide/en/elasticsearch/reference/7.17/cluster-health.html[Elasticsearch cluster
          * status] required on startup.
@@ -529,7 +529,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     // We can't set actual default values in this section,
     // otherwise "quarkus.hibernate-search-orm.elasticsearch.index-defaults" will be ignored.
     @ConfigGroup
-    public interface ElasticsearchIndexIndexingConfig {
+    interface ElasticsearchIndexIndexingConfig {
         /**
          * The number of indexing queues assigned to each index.
          *
@@ -581,7 +581,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface MultiTenancyConfig {
+    interface MultiTenancyConfig {
 
         /**
          * An exhaustive list of all tenant identifiers that may be used by the application when multi-tenancy is enabled.

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/dev/HibernateSearchElasticsearchDevRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/dev/HibernateSearchElasticsearchDevRecorder.java
@@ -25,7 +25,7 @@ public class HibernateSearchElasticsearchDevRecorder {
     public void initController(
             HibernateSearchElasticsearchRuntimeConfig runtimeConfig, Set<String> persistenceUnitNames) {
         Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> puConfigs = runtimeConfig
-                .getAllPersistenceUnitConfigsAsMap();
+                .persistenceUnits();
         Set<String> activePersistenceUnitNames = persistenceUnitNames.stream()
                 .filter(name -> {
                     var puConfig = puConfigs.get(name);


### PR DESCRIPTION
Relates to #32295

~~Creating as draft since we will need to upgrade the smallrye-config dependency to 3.3.0 before we can use `@WithUnnamedKey`.~~ => Done as far as I can see.

---

Before we apply this change we need to find a solution to the generation of documentation. Since we no longer have a `@ConfigDocSection` dedicated to the "unnamed" section, just a map for both named and unnamed, we only get documentation for the map, and that one only mentions the property keys with the map key:

![image](https://user-images.githubusercontent.com/412878/233974083-daa9a430-3a26-4b3f-8017-d1949d3be352.png)

while before this change we also had entries for the property keys of the "unnamed" entry:

![image](https://user-images.githubusercontent.com/412878/233968479-c6a6f6d5-7891-45c3-9e9d-93e881e4d123.png)

I wonder if we could take this opportunity to make the documentation less verbose, by avoiding the duplication when the same property can be used with or without a map key?

E.g. instead of displaying two rows in the documentation like we used to:

```asciidoc
`quarkus.hibernate-search-orm.background-failure-handler`::
This is a long description [...].
`quarkus.hibernate-search-orm."persistence-unit-name".background-failure-handler`::
This is a long description [...].
```

(which is a mess due to combinatory explosion with nested maps, see https://quarkus.io/guides/hibernate-search-orm-elasticsearch#configuration-reference-main)

... we'd just merge all rows pertaining to the same "leaf" with or without map keys, listing all possible property keys:

```asciidoc
`quarkus.hibernate-search-orm.background-failure-handler`, `quarkus.hibernate-search-orm."persistence-unit-name".background-failure-handler`::
This is a long description [...].
```

I'm not sure how complex that would be, though, especially in the case of nested maps (e.g. `quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".version`).