### PR TITLE
Batching buffer with minChunkSize

### DIFF
--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -649,6 +649,7 @@ public class JaxrsClientReactiveProcessor {
 
         return new org.jboss.resteasy.reactive.common.ResteasyReactiveConfig(
                 getEffectivePropertyValue("input-buffer-size", config.inputBufferSize().asLongValue(), Long.class, mpConfig),
+                getEffectivePropertyValue("min-chunk-size", config.minChunkSize(), Integer.class, mpConfig),
                 getEffectivePropertyValue("output-buffer-size", config.outputBufferSize(), Integer.class, mpConfig),
                 getEffectivePropertyValue("single-default-produces", config.singleDefaultProduces(), Boolean.class, mpConfig),
                 getEffectivePropertyValue("default-produces", config.defaultProduces(), Boolean.class, mpConfig));

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
@@ -19,9 +19,18 @@ public interface ResteasyReactiveConfig {
     MemorySize inputBufferSize();
 
     /**
+     * The size of the chunks of memory allocated when writing data.
+     * <p>
+     * This is a very advanced setting that should only be set if you understand exactly how it affects the output IO operations
+     * of the application.
+     */
+    @WithDefault("128")
+    int minChunkSize();
+
+    /**
      * The size of the output stream response buffer. If a response is larger than this and no content-length
      * is provided then the request will be chunked.
-     *
+     * <p>
      * Larger values may give slight performance increases for large responses, at the expense of more memory usage.
      */
     @WithDefault("8191")

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -1381,6 +1381,7 @@ public class ResteasyReactiveProcessor {
 
         return new org.jboss.resteasy.reactive.common.ResteasyReactiveConfig(
                 getEffectivePropertyValue("input-buffer-size", config.inputBufferSize().asLongValue(), Long.class, mpConfig),
+                getEffectivePropertyValue("min-chunk-size", config.outputBufferSize(), Integer.class, mpConfig),
                 getEffectivePropertyValue("output-buffer-size", config.outputBufferSize(), Integer.class, mpConfig),
                 getEffectivePropertyValue("single-default-produces", config.singleDefaultProduces(), Boolean.class, mpConfig),
                 getEffectivePropertyValue("default-produces", config.defaultProduces(), Boolean.class, mpConfig));

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/ResteasyReactiveConfig.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/ResteasyReactiveConfig.java
@@ -9,9 +9,17 @@ public class ResteasyReactiveConfig {
     private long inputBufferSize;
 
     /**
+     * The size of the chunks of memory allocated when writing data.
+     * <p>
+     * This is a very advanced setting that should only be set if you understand exactly how it affects the output IO operations
+     * of the application.
+     */
+    private int minChunkSize = 128;
+
+    /**
      * The size of the output stream response buffer. If a response is larger than this and no content-length
      * is provided then the request will be chunked.
-     *
+     * <p>
      * Larger values may give slight performance increases for large responses, at the expense of more memory usage.
      */
     private int outputBufferSize = 8192;
@@ -35,9 +43,10 @@ public class ResteasyReactiveConfig {
     public ResteasyReactiveConfig() {
     }
 
-    public ResteasyReactiveConfig(long inputBufferSize, int outputBufferSize, boolean singleDefaultProduces,
+    public ResteasyReactiveConfig(long inputBufferSize, int minChunkSize, int outputBufferSize, boolean singleDefaultProduces,
             boolean defaultProduces) {
         this.inputBufferSize = inputBufferSize;
+        this.minChunkSize = minChunkSize;
         this.outputBufferSize = outputBufferSize;
         this.singleDefaultProduces = singleDefaultProduces;
         this.defaultProduces = defaultProduces;
@@ -53,6 +62,14 @@ public class ResteasyReactiveConfig {
 
     public int getOutputBufferSize() {
         return outputBufferSize;
+    }
+
+    public int getMinChunkSize() {
+        return minChunkSize;
+    }
+
+    public void setMinChunkSize(int minChunkSize) {
+        this.minChunkSize = minChunkSize;
     }
 
     public void setOutputBufferSize(int outputBufferSize) {

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ResteasyReactiveDeploymentManager.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ResteasyReactiveDeploymentManager.java
@@ -82,6 +82,8 @@ public class ResteasyReactiveDeploymentManager {
     public static class ScanStep {
         final IndexView index;
         int inputBufferSize = 10000;
+
+        int minChunkSize = 128;
         int outputBufferSize = 8192;
         /**
          * By default, we assume a default produced media type of "text/plain"
@@ -215,8 +217,9 @@ public class ResteasyReactiveDeploymentManager {
                     .setAdditionalReaders(readers)
                     .setAdditionalWriters(writers)
                     .setInjectableBeans(new HashMap<>())
-                    .setConfig(new ResteasyReactiveConfig(inputBufferSize, outputBufferSize, singleDefaultProduces,
-                            defaultProduces))
+                    .setConfig(
+                            new ResteasyReactiveConfig(inputBufferSize, minChunkSize, outputBufferSize, singleDefaultProduces,
+                                    defaultProduces))
                     .setHttpAnnotationToMethod(resources.getHttpAnnotationToMethod())
                     .setApplicationScanningResult(applicationScanningResult);
             for (MethodScanner scanner : methodScanners) {

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/AppendBuffer.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/AppendBuffer.java
@@ -1,0 +1,192 @@
+package org.jboss.resteasy.reactive.server.vertx;
+
+import java.util.ArrayDeque;
+import java.util.Objects;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+
+/**
+ * It is a bounded (direct) buffer container that can keep on accepting data till {@link #capacity} is exhausted.<br>
+ * In order to keep appending on it, it can {@link #clear} and consolidate its content as a {@link ByteBuf}.
+ */
+final class AppendBuffer {
+    private final ByteBufAllocator allocator;
+
+    private final int minChunkSize;
+    private final int capacity;
+    private ByteBuf buffer;
+    private ArrayDeque<ByteBuf> otherBuffers;
+    private int size;
+
+    private AppendBuffer(ByteBufAllocator allocator, int minChunkSize, int capacity) {
+        this.allocator = allocator;
+        this.minChunkSize = Math.min(minChunkSize, capacity);
+        this.capacity = capacity;
+    }
+
+    /**
+     * This buffer append data in a single eagerly allocated {@link ByteBuf}.
+     */
+    public static AppendBuffer eager(ByteBufAllocator allocator, int capacity) {
+        return new AppendBuffer(allocator, capacity, capacity);
+    }
+
+    /**
+     * This buffer append data in multiples {@link ByteBuf}s sized as each {@code len} in {@link #append}.<br>
+     * The data is consolidated in a single {@link CompositeByteBuf} on {@link #clear}.
+     */
+    public static AppendBuffer exact(ByteBufAllocator allocator, int capacity) {
+        return new AppendBuffer(allocator, 0, capacity);
+    }
+
+    /**
+     * This buffer append data in multiples {@link ByteBuf}s which minimum capacity is {@code minChunkSize} or
+     * as each {@code len}, if greater than it.<br>
+     * The data is consolidated in a single {@link CompositeByteBuf} on {@link #clear}.
+     */
+    public static AppendBuffer withMinChunks(ByteBufAllocator allocator, int minChunkSize, int capacity) {
+        return new AppendBuffer(allocator, minChunkSize, capacity);
+    }
+
+    private ByteBuf lastBuffer() {
+        if (otherBuffers == null || otherBuffers.isEmpty()) {
+            return buffer;
+        }
+        return otherBuffers.peekLast();
+    }
+
+    /**
+     * It returns how many bytes have been appended<br>
+     * If returns a value different from {@code len}, is it required to invoke {@link #clear}
+     * that would refill the available capacity till {@link #capacity()}
+     */
+    public int append(byte[] bytes, int off, int len) {
+        Objects.requireNonNull(bytes);
+        if (len == 0) {
+            return 0;
+        }
+        int alreadyWritten = 0;
+        if (minChunkSize > 0) {
+            var lastBuffer = lastBuffer();
+            if (lastBuffer != null) {
+                int availableOnLast = lastBuffer.writableBytes();
+                if (availableOnLast > 0) {
+                    int toWrite = Math.min(len, availableOnLast);
+                    lastBuffer.writeBytes(bytes, off, toWrite);
+                    size += toWrite;
+                    len -= toWrite;
+                    // we stop if there's no more to append
+                    if (len == 0) {
+                        return toWrite;
+                    }
+                    off += toWrite;
+                    alreadyWritten = toWrite;
+                }
+            }
+        }
+        final int availableCapacity = capacity - size;
+        if (availableCapacity == 0) {
+            return alreadyWritten;
+        }
+        // we can still write some
+        int toWrite = Math.min(len, availableCapacity);
+        assert toWrite > 0;
+        final int chunkCapacity;
+        if (minChunkSize > 0) {
+            // Cannot allocate less than minChunkSize, till the limit of capacity left
+            chunkCapacity = Math.min(Math.max(minChunkSize, toWrite), availableCapacity);
+        } else {
+            chunkCapacity = toWrite;
+        }
+        var tmpBuf = allocator.directBuffer(chunkCapacity);
+        try {
+            tmpBuf.writeBytes(bytes, off, toWrite);
+        } catch (Throwable t) {
+            tmpBuf.release();
+            throw t;
+        }
+        if (buffer == null) {
+            buffer = tmpBuf;
+        } else {
+            boolean resetOthers = false;
+            try {
+                if (otherBuffers == null) {
+                    otherBuffers = new ArrayDeque<>();
+                    resetOthers = true;
+                }
+                otherBuffers.add(tmpBuf);
+            } catch (Throwable t) {
+                rollback(alreadyWritten, tmpBuf, resetOthers);
+                throw t;
+            }
+        }
+        size += toWrite;
+        return toWrite + alreadyWritten;
+    }
+
+    private void rollback(int alreadyWritten, ByteBuf tmpBuf, boolean resetOthers) {
+        tmpBuf.release();
+        if (resetOthers) {
+            otherBuffers = null;
+        }
+        if (alreadyWritten > 0) {
+            var last = lastBuffer();
+            last.writerIndex(last.writerIndex() - alreadyWritten);
+            size -= alreadyWritten;
+            assert last.writerIndex() > 0;
+        }
+    }
+
+    public ByteBuf clear() {
+        var firstBuf = buffer;
+        if (firstBuf == null) {
+            return null;
+        }
+        var others = otherBuffers;
+        if (others == null || others.isEmpty()) {
+            size = 0;
+            buffer = null;
+            // super fast-path
+            return firstBuf;
+        }
+        return clearBuffers();
+    }
+
+    private CompositeByteBuf clearBuffers() {
+        var firstBuf = buffer;
+        var others = otherBuffers;
+        var batch = allocator.compositeDirectBuffer(1 + others.size());
+        try {
+            buffer = null;
+            size = 0;
+            batch.addComponent(true, 0, firstBuf);
+            for (int i = 0, othersCount = others.size(); i < othersCount; i++) {
+                // if addComponent fail, it takes care of releasing curr and throwing the exception:
+                batch.addComponent(true, 1 + i, others.poll());
+            }
+            return batch;
+        } catch (Throwable anyError) {
+            batch.release();
+            releaseOthers(others);
+            throw anyError;
+        }
+    }
+
+    private static void releaseOthers(ArrayDeque<ByteBuf> others) {
+        ByteBuf buf;
+        while ((buf = others.poll()) != null) {
+            buf.release();
+        }
+    }
+
+    public int capacity() {
+        return capacity;
+    }
+
+    public int availableCapacity() {
+        return capacity - size;
+    }
+
+}


### PR DESCRIPTION
Fixes #32546 

This is still in draft due to few still opened questions:
1. what happen to the batch buffer content in case of partial failures within `flushBuffer`? it should cleanup its whole content, loosing it? What's supposed to do the caller?
2. what happen to `ResteasyReactiveOutputStream` in case of failure while using the buffer returned by `flushBuffer`? releasing it if not already released? (in the previous impl it wasn't well defined in each state)
3. why 128? We would like to expose even that configuration parameters to users? It's great for benchmarking tests, but maybe too complex for avg urs @geoand ?
4. how performance looks like? Is any better? [WIP - after or during Quarkus F2F]