### PR TITLE
Dev UI: Allow runtime links in external page

### DIFF
--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-extensions.js
@@ -136,6 +136,7 @@ export class QwcExtensions extends observeState(LitElement) {
                                 path="${page.id}"
                                 ?embed=${page.embed}
                                 externalUrl="${page.metadata.externalUrl}"
+                                dynamicUrlMethodName="${page.metadata.dynamicUrlMethodName}"
                                 webcomponent="${page.componentLink}" >
                             </qwc-extension-link>
                         `)}`;

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-external-page.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-external-page.js
@@ -1,5 +1,6 @@
 import { LitElement, html, css} from 'lit';
 import { RouterController } from 'router-controller';
+import { JsonRpc } from 'jsonrpc';
 import '@vaadin/icon';
 import 'qui-code-block';
 import '@vaadin/progress-bar';
@@ -35,7 +36,20 @@ export class QwcExternalPage extends LitElement {
     connectedCallback() {
         super.connectedCallback();
         var metadata = this.routerController.getCurrentMetaData();
-        if(metadata){
+        if(metadata && metadata.dynamicUrlMethodName){
+            let ns = this.routerController.getCurrentNamespace();
+            this.jsonRpc = new JsonRpc(ns);
+            this.jsonRpc[metadata.dynamicUrlMethodName]().then(jsonRpcResponse => {
+                this._externalUrl = jsonRpcResponse.result;
+                
+                if(metadata.mimeType){
+                    this._mimeType = metadata.mimeType;
+                    this._deriveModeFromMimeType(this._mimeType);
+                }else{
+                    this._autoDetectMimeType();
+                }
+            });
+        } else if (metadata && metadata.externalUrl){
             this._externalUrl = metadata.externalUrl;
             if(metadata.mimeType){
                 this._mimeType = metadata.mimeType;

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/ExternalPageBuilder.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/ExternalPageBuilder.java
@@ -5,6 +5,7 @@ import io.quarkus.logging.Log;
 public class ExternalPageBuilder extends PageBuilder<ExternalPageBuilder> {
     private static final String QWC_EXTERNAL_PAGE_JS = "qwc-external-page.js";
     private static final String EXTERNAL_URL = "externalUrl";
+    private static final String DYNAMIC_URL = "dynamicUrlMethodName";
     private static final String MIME_TYPE = "mimeType";
 
     public static final String MIME_TYPE_HTML = "text/html";
@@ -24,6 +25,15 @@ public class ExternalPageBuilder extends PageBuilder<ExternalPageBuilder> {
             throw new RuntimeException("Invalid external URL, can not be empty");
         }
         super.metadata.put(EXTERNAL_URL, url);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public ExternalPageBuilder dynamicUrlJsonRPCMethodName(String methodName) {
+        if (methodName == null || methodName.isEmpty()) {
+            throw new RuntimeException("Invalid dynamic URL Method name, can not be empty");
+        }
+        super.metadata.put(DYNAMIC_URL, methodName);
         return this;
     }
 


### PR DESCRIPTION
Fix #32859

This PR Allows extensions to create external links on a card that gets the url during runtime.

To use:

In the Processor in Deployment module:

```
cardPageBuildItem.addPage(Page.externalPageBuilder("Dynamic Link")
                .icon("font-awesome-solid:link") // Your own icon
                .dynamicUrlJsonRPCMethodName("getDynamicLink")); // Method name in Json-RPC Service
```

In the JsonRPC Service in Runtime:

```
public String getDynamicLink() {
        // Here get your link dynamicly
        return "/q/info";
    }
```
