### PR TITLE
Enhance direct access to protected, package-private, private and superclass entity fields in Hibernate ORM

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -620,7 +620,7 @@ public final class HibernateOrmProcessor {
     @BuildStep
     public HibernateModelClassCandidatesForFieldAccessBuildItem candidatesForFieldAccess(JpaModelBuildItem jpaModel) {
         // Ask Panache to replace direct access to public fields with calls to accessors for all model classes.
-        return new HibernateModelClassCandidatesForFieldAccessBuildItem(jpaModel.getAllModelClassNames());
+        return new HibernateModelClassCandidatesForFieldAccessBuildItem(jpaModel.getManagedClassNames());
     }
 
     @BuildStep
@@ -1235,7 +1235,7 @@ public final class HibernateOrmProcessor {
             List<AdditionalJpaModelBuildItem> additionalJpaModelBuildItems,
             BuildProducer<GeneratedClassBuildItem> additionalClasses) {
         HibernateEntityEnhancer hibernateEntityEnhancer = new HibernateEntityEnhancer();
-        for (String i : jpaModel.getAllModelClassNames()) {
+        for (String i : jpaModel.getManagedClassNames()) {
             transformers.produce(new BytecodeTransformerBuildItem(true, i, hibernateEntityEnhancer, true));
         }
         for (AdditionalJpaModelBuildItem additionalJpaModel : additionalJpaModelBuildItems) {

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
@@ -102,9 +102,9 @@ public final class JpaJandexScavenger {
             enlistExplicitMappings(collector, persistenceUnitContribution);
         }
 
-        Set<String> allModelClassNames = new HashSet<>(collector.entityTypes);
-        allModelClassNames.addAll(collector.modelTypes);
-        for (String className : allModelClassNames) {
+        Set<String> managedClassNames = new HashSet<>(collector.entityTypes);
+        managedClassNames.addAll(collector.modelTypes);
+        for (String className : managedClassNames) {
             reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).methods().fields().build());
         }
 
@@ -119,12 +119,6 @@ public final class JpaJandexScavenger {
         // we just register them for reflection
         for (String javaType : collector.javaTypes) {
             reflectiveClass.produce(ReflectiveClassBuildItem.builder(javaType).methods().build());
-        }
-
-        // Converters need to be in the list of model types in order for @Converter#autoApply to work,
-        // but they don't need reflection enabled.
-        for (DotName potentialCdiBeanType : collector.potentialCdiBeanTypes) {
-            allModelClassNames.add(potentialCdiBeanType.toString());
         }
 
         if (!collector.unindexedClasses.isEmpty()) {
@@ -143,8 +137,8 @@ public final class JpaJandexScavenger {
             }
         }
 
-        return new JpaModelBuildItem(collector.packages, collector.entityTypes, collector.potentialCdiBeanTypes,
-                allModelClassNames, collector.xmlMappingsByPU);
+        return new JpaModelBuildItem(collector.packages, collector.entityTypes, managedClassNames,
+                collector.potentialCdiBeanTypes, collector.xmlMappingsByPU);
     }
 
     private void enlistExplicitMappings(Collector collector,

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaModelBuildItem.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaModelBuildItem.java
@@ -22,17 +22,24 @@ public final class JpaModelBuildItem extends SimpleBuildItem {
 
     private final Set<String> allModelPackageNames = new TreeSet<>();
     private final Set<String> entityClassNames = new TreeSet<>();
+    private final Set<String> managedClassNames = new TreeSet<>();
     private final Set<DotName> potentialCdiBeanClassNames = new TreeSet<>();
     private final Set<String> allModelClassNames = new TreeSet<>();
     private final Map<String, List<RecordableXmlMapping>> xmlMappingsByPU = new HashMap<>();
 
     public JpaModelBuildItem(Set<String> allModelPackageNames, Set<String> entityClassNames,
-            Set<DotName> potentialCdiBeanClassNames, Set<String> allModelClassNames,
+            Set<String> managedClassNames, Set<DotName> potentialCdiBeanClassNames,
             Map<String, List<RecordableXmlMapping>> xmlMappingsByPU) {
         this.allModelPackageNames.addAll(allModelPackageNames);
         this.entityClassNames.addAll(entityClassNames);
+        this.managedClassNames.addAll(managedClassNames);
         this.potentialCdiBeanClassNames.addAll(potentialCdiBeanClassNames);
-        this.allModelClassNames.addAll(allModelClassNames);
+        this.allModelClassNames.addAll(managedClassNames);
+        // Converters need to be in the list of model types in order for @Converter#autoApply to work,
+        // but they don't need reflection enabled.
+        for (DotName potentialCdiBeanClassName : potentialCdiBeanClassNames) {
+            this.allModelClassNames.add(potentialCdiBeanClassName.toString());
+        }
         this.xmlMappingsByPU.putAll(xmlMappingsByPU);
     }
 
@@ -48,6 +55,13 @@ public final class JpaModelBuildItem extends SimpleBuildItem {
      */
     public Set<String> getEntityClassNames() {
         return entityClassNames;
+    }
+
+    /**
+     * @return the list of managed class names: entities, mapped super classes and embeddables only.
+     */
+    public Set<String> getManagedClassNames() {
+        return managedClassNames;
     }
 
     /**

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/NonStandardAccessTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/NonStandardAccessTest.java
@@ -1,0 +1,917 @@
+package io.quarkus.hibernate.orm.applicationfieldaccess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Checks that non-standard access to fields by the application works correctly,
+ * i.e. when exposing fields through accessors with non-standard names,
+ * static accessors, accessors defined in a subclass,
+ * or accessors defined in an inner class.
+ */
+public class NonStandardAccessTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAbstractMappedSuperClass.class, MyAbstractEntity.class, MyAbstractConfusingEntity.class,
+                            MyConcreteEntity.class)
+                    .addClass(ExternalClassAccessors.class)
+                    .addClass(AccessDelegate.class))
+            .withConfigurationResource("application.properties");
+
+    @Inject
+    EntityManager em;
+
+    @Test
+    public void nonStandardInstanceGetterSetterPublicField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.nonStandardSetterForPublicField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.nonStandardGetterForPublicField();
+            }
+        });
+    }
+
+    @Test
+    public void nonStandardInstanceGetterSetterProtectedField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.nonStandardSetterForProtectedField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.nonStandardGetterForProtectedField();
+            }
+        });
+    }
+
+    @Test
+    public void nonStandardInstanceGetterSetterPackagePrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.nonStandardSetterForPackagePrivateField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.nonStandardGetterForPackagePrivateField();
+            }
+        });
+    }
+
+    @Test
+    public void nonStandardInstanceGetterSetterPrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.nonStandardSetterForPrivateField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.nonStandardGetterForPrivateField();
+            }
+        });
+    }
+
+    @Test
+    public void staticGetterSetterPublicField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                MyConcreteEntity.staticSetPublicField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return MyConcreteEntity.staticGetPublicField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void staticGetterSetterProtectedField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                MyConcreteEntity.staticSetProtectedField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return MyConcreteEntity.staticGetProtectedField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void staticGetterSetterPackagePrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                MyConcreteEntity.staticSetPackagePrivateField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return MyConcreteEntity.staticGetPackagePrivateField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void staticGetterSetterPrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                MyConcreteEntity.staticSetPrivateField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return MyConcreteEntity.staticGetPrivateField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void innerClassStaticGetterSetterPublicField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                MyConcreteEntity.InnerClassAccessors.staticSetPublicField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return MyConcreteEntity.InnerClassAccessors.staticGetPublicField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void innerClassStaticGetterSetterProtectedField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                MyConcreteEntity.InnerClassAccessors.staticSetProtectedField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return MyConcreteEntity.InnerClassAccessors.staticGetProtectedField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void innerClassStaticGetterSetterPackagePrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                MyConcreteEntity.InnerClassAccessors.staticSetPackagePrivateField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return MyConcreteEntity.InnerClassAccessors.staticGetPackagePrivateField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void innerClassStaticGetterSetterPrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                MyConcreteEntity.InnerClassAccessors.staticSetPrivateField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return MyConcreteEntity.InnerClassAccessors.staticGetPrivateField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void innerClassInstanceGetterSetterPublicField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                new MyConcreteEntity.InnerClassAccessors().instanceSetPublicField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return new MyConcreteEntity.InnerClassAccessors().instanceGetPublicField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void innerClassInstanceGetterSetterProtectedField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                new MyConcreteEntity.InnerClassAccessors().instanceSetProtectedField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return new MyConcreteEntity.InnerClassAccessors().instanceGetProtectedField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void innerClassInstanceGetterSetterPackagePrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                new MyConcreteEntity.InnerClassAccessors().instanceSetPackagePrivateField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return new MyConcreteEntity.InnerClassAccessors().instanceGetPackagePrivateField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void innerClassInstanceGetterSetterPrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                new MyConcreteEntity.InnerClassAccessors().instanceSetPrivateField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return new MyConcreteEntity.InnerClassAccessors().instanceGetPrivateField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void externalClassStaticGetterSetterPublicField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                ExternalClassAccessors.staticSetPublicField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return ExternalClassAccessors.staticGetPublicField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void externalClassStaticGetterSetterProtectedField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                ExternalClassAccessors.staticSetProtectedField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return ExternalClassAccessors.staticGetProtectedField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void externalClassStaticGetterSetterPackagePrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                ExternalClassAccessors.staticSetPackagePrivateField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return ExternalClassAccessors.staticGetPackagePrivateField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void externalClassInstanceGetterSetterPublicField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                new ExternalClassAccessors().instanceSetPublicField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return new ExternalClassAccessors().instanceGetPublicField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void externalClassInstanceGetterSetterProtectedField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                new ExternalClassAccessors().instanceSetProtectedField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return new ExternalClassAccessors().instanceGetProtectedField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void externalClassInstanceGetterSetterPackagePrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                new ExternalClassAccessors().instanceSetPackagePrivateField(entity, value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return new ExternalClassAccessors().instanceGetPackagePrivateField(entity);
+            }
+        });
+    }
+
+    @Test
+    public void mappedSuperClassSubClassInstanceGetterSetterPublicField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.setAbstractEntityPublicField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.getAbstractEntityPublicField();
+            }
+        });
+    }
+
+    @Test
+    public void mappedSuperClassSubClassInstanceGetterSetterProtectedField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.setAbstractEntityProtectedField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.getAbstractEntityProtectedField();
+            }
+        });
+    }
+
+    @Test
+    public void mappedSuperClassSubClassInstanceGetterSetterPackagePrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.setAbstractEntityPackagePrivateField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.getAbstractEntityPackagePrivateField();
+            }
+        });
+    }
+
+    @Test
+    public void mappedSuperClassSubClassNonStandardInstanceGetterSetterPublicField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.nonStandardSetterForAbstractEntityPublicField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.nonStandardGetterForAbstractEntityPublicField();
+            }
+        });
+    }
+
+    @Test
+    public void mappedSuperClassSubClassNonStandardInstanceGetterSetterProtectedField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.nonStandardSetterForAbstractEntityProtectedField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.nonStandardGetterForAbstractEntityProtectedField();
+            }
+        });
+    }
+
+    @Test
+    public void mappedSuperClassSubClassNonStandardInstanceGetterSetterPackagePrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.nonStandardSetterForAbstractEntityPackagePrivateField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.nonStandardGetterForAbstractEntityPackagePrivateField();
+            }
+        });
+    }
+
+    @Test
+    public void entitySubClassInstanceGetterSetterPublicField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.setAbstractEntityPublicField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.getAbstractEntityPublicField();
+            }
+        });
+    }
+
+    @Test
+    public void entitySubClassInstanceGetterSetterProtectedField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.setAbstractEntityProtectedField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.getAbstractEntityProtectedField();
+            }
+        });
+    }
+
+    @Test
+    public void entitySubClassInstanceGetterSetterPackagePrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.setAbstractEntityPackagePrivateField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.getAbstractEntityPackagePrivateField();
+            }
+        });
+    }
+
+    @Test
+    public void entitySubClassNonStandardInstanceGetterSetterPublicField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.nonStandardSetterForAbstractEntityPublicField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.nonStandardGetterForAbstractEntityPublicField();
+            }
+        });
+    }
+
+    @Test
+    public void entitySubClassNonStandardInstanceGetterSetterProtectedField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.nonStandardSetterForAbstractEntityProtectedField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.nonStandardGetterForAbstractEntityProtectedField();
+            }
+        });
+    }
+
+    @Test
+    public void entitySubClassNonStandardInstanceGetterSetterPackagePrivateField() {
+        doTestFieldAccess(new AccessDelegate() {
+            @Override
+            public void setValue(MyConcreteEntity entity, Long value) {
+                entity.nonStandardSetterForAbstractEntityPackagePrivateField(value);
+            }
+
+            @Override
+            public Long getValue(MyConcreteEntity entity) {
+                return entity.nonStandardGetterForAbstractEntityPackagePrivateField();
+            }
+        });
+    }
+
+    // Ideally we'd make this a @ParameterizedTest and pass the access delegate as parameter,
+    // but we cannot do that due to JUnit using a different classloader than the test.
+    private void doTestFieldAccess(AccessDelegate delegate) {
+        Long id = QuarkusTransaction.disallowingExisting().call(() -> {
+            var entity = new MyConcreteEntity();
+            em.persist(entity);
+            return entity.id;
+        });
+
+        QuarkusTransaction.disallowingExisting().run(() -> {
+            var entity = em.find(MyConcreteEntity.class, id);
+            assertThat(delegate.getValue(entity))
+                    .as("Loaded value before update")
+                    .isNull();
+        });
+
+        QuarkusTransaction.disallowingExisting().run(() -> {
+            var entity = em.getReference(MyConcreteEntity.class, id);
+            // Since field access is replaced with accessor calls,
+            // we expect this change to be detected by dirty tracking and persisted.
+            delegate.setValue(entity, 42L);
+        });
+
+        QuarkusTransaction.disallowingExisting().run(() -> {
+            var entity = em.find(MyConcreteEntity.class, id);
+            // We're working on an initialized entity.
+            assertThat(entity)
+                    .as("find() should return uninitialized entity")
+                    .returns(true, Hibernate::isInitialized);
+            // The above should have persisted a value that passes the assertion.
+            assertThat(delegate.getValue(entity))
+                    .as("Loaded value after update")
+                    .isEqualTo(42L);
+        });
+
+        QuarkusTransaction.disallowingExisting().run(() -> {
+            var entity = em.getReference(MyConcreteEntity.class, id);
+            // We're working on an uninitialized entity.
+            assertThat(entity)
+                    .as("getReference() should return uninitialized entity")
+                    .returns(false, Hibernate::isInitialized);
+            // The above should have persisted a value that passes the assertion.
+            assertThat(delegate.getValue(entity))
+                    .as("Lazily loaded value after update")
+                    .isEqualTo(42L);
+            // Accessing the value should trigger initialization of the entity.
+            assertThat(entity)
+                    .as("Getting the value should initialize the entity")
+                    .returns(true, Hibernate::isInitialized);
+        });
+    }
+
+    @MappedSuperclass
+    public static abstract class MyAbstractMappedSuperClass {
+        public Long abstractMappedSuperClassPublicField;
+
+        protected Long abstractMappedSuperClassProtectedField;
+
+        Long abstractMappedSuperClassPackagePrivateField;
+    }
+
+    @Entity(name = "abstract")
+    public static abstract class MyAbstractEntity extends MyAbstractMappedSuperClass {
+        @Id
+        @GeneratedValue
+        public long id;
+
+        public Long abstractEntityPublicField;
+
+        protected Long abstractEntityProtectedField;
+
+        Long abstractEntityPackagePrivateField;
+    }
+
+    // Just to confuse panache: the fields are not declared in the *direct* superclass.
+    @Entity(name = "abstract2")
+    public static abstract class MyAbstractConfusingEntity extends MyAbstractEntity {
+    }
+
+    @Entity(name = "concrete")
+    public static class MyConcreteEntity extends MyAbstractConfusingEntity {
+        public Long publicField;
+        protected Long protectedField;
+        Long packagePrivateField;
+        private Long privateField;
+
+        public Long getAbstractMappedSuperClassPublicField() {
+            return abstractMappedSuperClassPublicField;
+        }
+
+        public void setAbstractMappedSuperClassPublicField(Long abstractMappedSuperClassPublicField) {
+            this.abstractMappedSuperClassPublicField = abstractMappedSuperClassPublicField;
+        }
+
+        public Long nonStandardGetterForAbstractMappedSuperClassPublicField() {
+            return abstractMappedSuperClassPublicField;
+        }
+
+        public void nonStandardSetterForAbstractMappedSuperClassPublicField(Long value) {
+            abstractMappedSuperClassPublicField = value;
+        }
+
+        public Long getAbstractMappedSuperClassProtectedField() {
+            return abstractMappedSuperClassProtectedField;
+        }
+
+        public void setAbstractMappedSuperClassProtectedField(Long abstractMappedSuperClassProtectedField) {
+            this.abstractMappedSuperClassProtectedField = abstractMappedSuperClassProtectedField;
+        }
+
+        public Long nonStandardGetterForAbstractMappedSuperClassProtectedField() {
+            return abstractMappedSuperClassProtectedField;
+        }
+
+        public void nonStandardSetterForAbstractMappedSuperClassProtectedField(Long value) {
+            abstractMappedSuperClassProtectedField = value;
+        }
+
+        public Long getAbstractMappedSuperClassPackagePrivateField() {
+            return abstractMappedSuperClassPackagePrivateField;
+        }
+
+        public void setAbstractMappedSuperClassPackagePrivateField(Long abstractMappedSuperClassPackagePrivateField) {
+            this.abstractMappedSuperClassPackagePrivateField = abstractMappedSuperClassPackagePrivateField;
+        }
+
+        public Long nonStandardGetterForAbstractMappedSuperClassPackagePrivateField() {
+            return abstractMappedSuperClassPackagePrivateField;
+        }
+
+        public void nonStandardSetterForAbstractMappedSuperClassPackagePrivateField(Long value) {
+            abstractMappedSuperClassPackagePrivateField = value;
+        }
+
+        public Long getAbstractEntityPublicField() {
+            return abstractEntityPublicField;
+        }
+
+        public void setAbstractEntityPublicField(Long abstractEntityPublicField) {
+            this.abstractEntityPublicField = abstractEntityPublicField;
+        }
+
+        public Long nonStandardGetterForAbstractEntityPublicField() {
+            return abstractEntityPublicField;
+        }
+
+        public void nonStandardSetterForAbstractEntityPublicField(Long value) {
+            abstractEntityPublicField = value;
+        }
+
+        public Long getAbstractEntityProtectedField() {
+            return abstractEntityProtectedField;
+        }
+
+        public void setAbstractEntityProtectedField(Long abstractEntityProtectedField) {
+            this.abstractEntityProtectedField = abstractEntityProtectedField;
+        }
+
+        public Long nonStandardGetterForAbstractEntityProtectedField() {
+            return abstractEntityProtectedField;
+        }
+
+        public void nonStandardSetterForAbstractEntityProtectedField(Long value) {
+            abstractEntityProtectedField = value;
+        }
+
+        public Long getAbstractEntityPackagePrivateField() {
+            return abstractEntityPackagePrivateField;
+        }
+
+        public void setAbstractEntityPackagePrivateField(Long abstractEntityPackagePrivateField) {
+            this.abstractEntityPackagePrivateField = abstractEntityPackagePrivateField;
+        }
+
+        public Long nonStandardGetterForAbstractEntityPackagePrivateField() {
+            return abstractEntityPackagePrivateField;
+        }
+
+        public void nonStandardSetterForAbstractEntityPackagePrivateField(Long value) {
+            abstractEntityPackagePrivateField = value;
+        }
+
+        public Long nonStandardGetterForPublicField() {
+            return publicField;
+        }
+
+        public void nonStandardSetterForPublicField(Long value) {
+            publicField = value;
+        }
+
+        public Long nonStandardGetterForPackagePrivateField() {
+            return packagePrivateField;
+        }
+
+        public void nonStandardSetterForPackagePrivateField(Long value) {
+            packagePrivateField = value;
+        }
+
+        public Long nonStandardGetterForProtectedField() {
+            return protectedField;
+        }
+
+        public void nonStandardSetterForProtectedField(Long value) {
+            protectedField = value;
+        }
+
+        public Long nonStandardGetterForPrivateField() {
+            return privateField;
+        }
+
+        public void nonStandardSetterForPrivateField(Long value) {
+            privateField = value;
+        }
+
+        public static Long staticGetPublicField(MyConcreteEntity entity) {
+            return entity.publicField;
+        }
+
+        public static void staticSetPublicField(MyConcreteEntity entity, Long value) {
+            entity.publicField = value;
+        }
+
+        public static Long staticGetProtectedField(MyConcreteEntity entity) {
+            return entity.protectedField;
+        }
+
+        public static void staticSetProtectedField(MyConcreteEntity entity, Long value) {
+            entity.protectedField = value;
+        }
+
+        public static Long staticGetPackagePrivateField(MyConcreteEntity entity) {
+            return entity.packagePrivateField;
+        }
+
+        public static void staticSetPackagePrivateField(MyConcreteEntity entity, Long value) {
+            entity.packagePrivateField = value;
+        }
+
+        public static Long staticGetPrivateField(MyConcreteEntity entity) {
+            return entity.privateField;
+        }
+
+        public static void staticSetPrivateField(MyConcreteEntity entity, Long value) {
+            entity.privateField = value;
+        }
+
+        public static final class InnerClassAccessors {
+            public static Long staticGetPublicField(MyConcreteEntity entity) {
+                return entity.publicField;
+            }
+
+            public static void staticSetPublicField(MyConcreteEntity entity, Long value) {
+                entity.publicField = value;
+            }
+
+            public static Long staticGetProtectedField(MyConcreteEntity entity) {
+                return entity.protectedField;
+            }
+
+            public static void staticSetProtectedField(MyConcreteEntity entity, Long value) {
+                entity.protectedField = value;
+            }
+
+            public static Long staticGetPackagePrivateField(MyConcreteEntity entity) {
+                return entity.packagePrivateField;
+            }
+
+            public static void staticSetPackagePrivateField(MyConcreteEntity entity, Long value) {
+                entity.packagePrivateField = value;
+            }
+
+            public static Long staticGetPrivateField(MyConcreteEntity entity) {
+                return entity.privateField;
+            }
+
+            public static void staticSetPrivateField(MyConcreteEntity entity, Long value) {
+                entity.privateField = value;
+            }
+
+            public Long instanceGetPublicField(MyConcreteEntity entity) {
+                return entity.publicField;
+            }
+
+            public void instanceSetPublicField(MyConcreteEntity entity, Long value) {
+                entity.publicField = value;
+            }
+
+            public Long instanceGetProtectedField(MyConcreteEntity entity) {
+                return entity.protectedField;
+            }
+
+            public void instanceSetProtectedField(MyConcreteEntity entity, Long value) {
+                entity.protectedField = value;
+            }
+
+            public Long instanceGetPackagePrivateField(MyConcreteEntity entity) {
+                return entity.packagePrivateField;
+            }
+
+            public void instanceSetPackagePrivateField(MyConcreteEntity entity, Long value) {
+                entity.packagePrivateField = value;
+            }
+
+            public Long instanceGetPrivateField(MyConcreteEntity entity) {
+                return entity.privateField;
+            }
+
+            public void instanceSetPrivateField(MyConcreteEntity entity, Long value) {
+                entity.privateField = value;
+            }
+        }
+    }
+
+    public static final class ExternalClassAccessors {
+        public static Long staticGetPublicField(MyConcreteEntity entity) {
+            return entity.publicField;
+        }
+
+        public static void staticSetPublicField(MyConcreteEntity entity, Long value) {
+            entity.publicField = value;
+        }
+
+        public static Long staticGetProtectedField(MyConcreteEntity entity) {
+            return entity.protectedField;
+        }
+
+        public static void staticSetProtectedField(MyConcreteEntity entity, Long value) {
+            entity.protectedField = value;
+        }
+
+        public static Long staticGetPackagePrivateField(MyConcreteEntity entity) {
+            return entity.packagePrivateField;
+        }
+
+        public static void staticSetPackagePrivateField(MyConcreteEntity entity, Long value) {
+            entity.packagePrivateField = value;
+        }
+
+        public Long instanceGetPublicField(MyConcreteEntity entity) {
+            return entity.publicField;
+        }
+
+        public void instanceSetPublicField(MyConcreteEntity entity, Long value) {
+            entity.publicField = value;
+        }
+
+        public Long instanceGetProtectedField(MyConcreteEntity entity) {
+            return entity.protectedField;
+        }
+
+        public void instanceSetProtectedField(MyConcreteEntity entity, Long value) {
+            entity.protectedField = value;
+        }
+
+        public Long instanceGetPackagePrivateField(MyConcreteEntity entity) {
+            return entity.packagePrivateField;
+        }
+
+        public void instanceSetPackagePrivateField(MyConcreteEntity entity, Long value) {
+            entity.packagePrivateField = value;
+        }
+    }
+
+    private interface AccessDelegate {
+        void setValue(MyConcreteEntity entity, Long value);
+
+        Long getValue(MyConcreteEntity entity);
+    }
+}

--- a/extensions/panache/mongodb-panache-common/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/BasePanacheMongoResourceProcessor.java
+++ b/extensions/panache/mongodb-panache-common/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/BasePanacheMongoResourceProcessor.java
@@ -289,14 +289,14 @@ public abstract class BasePanacheMongoResourceProcessor {
     }
 
     private void replaceFieldAccesses(BuildProducer<BytecodeTransformerBuildItem> transformers, MetamodelInfo modelInfo) {
-        Set<String> entitiesWithPublicFields = modelInfo.getEntitiesWithPublicFields();
-        if (entitiesWithPublicFields.isEmpty()) {
-            // There are no public fields to be accessed in the first place.
+        Set<String> entitiesWithExternallyAccessibleFields = modelInfo.getEntitiesWithExternallyAccessibleFields();
+        if (entitiesWithExternallyAccessibleFields.isEmpty()) {
+            // There are no fields to be accessed in the first place.
             return;
         }
 
         Set<String> entityClassNamesInternal = new HashSet<>();
-        for (String entityClassName : entitiesWithPublicFields) {
+        for (String entityClassName : entitiesWithExternallyAccessibleFields) {
             entityClassNamesInternal.add(entityClassName.replace(".", "/"));
         }
 
@@ -323,10 +323,11 @@ public abstract class BasePanacheMongoResourceProcessor {
         EntityModel entityModel = new EntityModel(classInfo);
         for (FieldInfo fieldInfo : classInfo.fields()) {
             String name = fieldInfo.name();
-            if (Modifier.isPublic(fieldInfo.flags())
+            var visibility = EntityField.Visibility.get(fieldInfo.flags());
+            if (EntityField.Visibility.PUBLIC.equals(visibility)
                     && !Modifier.isStatic(fieldInfo.flags())
                     && !fieldInfo.hasAnnotation(BSON_IGNORE)) {
-                entityModel.addField(new EntityField(name, DescriptorUtils.typeToString(fieldInfo.type())));
+                entityModel.addField(new EntityField(name, DescriptorUtils.typeToString(fieldInfo.type()), visibility));
             }
         }
         return entityModel;

--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/MetamodelInfo.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/MetamodelInfo.java
@@ -16,7 +16,7 @@ public class MetamodelInfo {
         entities.put(entityModel.name, entityModel);
     }
 
-    public Set<String> getEntitiesWithPublicFields() {
+    public Set<String> getEntitiesWithExternallyAccessibleFields() {
         return entities.entrySet().stream()
                 .filter(e -> {
                     EntityModel value = e.getValue();

--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheFieldAccessMethodVisitor.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheFieldAccessMethodVisitor.java
@@ -3,7 +3,6 @@ package io.quarkus.panache.common.deployment;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
-import io.quarkus.deployment.bean.JavaBeanUtil;
 import io.quarkus.gizmo.Gizmo;
 
 public class PanacheFieldAccessMethodVisitor extends MethodVisitor {
@@ -31,25 +30,49 @@ public class PanacheFieldAccessMethodVisitor extends MethodVisitor {
                 // if we're in the constructor, do not replace field accesses to this type and its supertypes
                 // otherwise we risk running setters that depend on initialisation
                 || (this.methodName.equals("<init>")
-                        && targetIsInHierarchy(methodOwnerClassName, fieldOwnerClassName))
-                // we only care about entity fields
-                || !isEntityField(fieldOwnerClassName, fieldName)) {
+                        && targetIsInHierarchy(methodOwnerClassName, fieldOwnerClassName))) {
             // In those cases, don't do anything.
             super.visitFieldInsn(opcode, fieldOwner, fieldName, descriptor);
             return;
         }
 
-        String methodName;
+        EntityField entityField = getEntityField(fieldOwnerClassName, fieldName);
+        if (entityField == null) {
+            // Not an entity field: don't do anything.
+            super.visitFieldInsn(opcode, fieldOwner, fieldName, descriptor);
+            return;
+        }
+
+        String javaBeanMethodName;
+        String librarySpecificMethodName;
         String methodDescriptor;
         if (opcode == Opcodes.GETFIELD) {
-            methodName = JavaBeanUtil.getGetterName(fieldName, descriptor);
+            javaBeanMethodName = entityField.getGetterName();
+            librarySpecificMethodName = entityField.librarySpecificGetterName;
             methodDescriptor = "()" + descriptor;
         } else {
-            methodName = JavaBeanUtil.getSetterName(fieldName);
+            javaBeanMethodName = entityField.getSetterName();
+            librarySpecificMethodName = entityField.librarySpecificSetterName;
             methodDescriptor = "(" + descriptor + ")V";
         }
+
+        // For public fields, we'll replace field access with (potentially generated) JavaBean accessors.
+        // For non-public fields, we won't be using JavaBean accessors,
+        // because we might not generate any and pre-existing ones might have unwanted side effects.
+        // Instead, we will replace the field access with a call to internal field access methods, if any,
+        // e.g. generated methods like $$_hibernate_read_myProperty()
+        boolean useJavaBeanAccessor = EntityField.Visibility.PUBLIC.equals(entityField.visibility);
+        if (!useJavaBeanAccessor && librarySpecificMethodName == null) {
+            // Field is non-public, so we won't be using JavaBean accessors,
+            // and there are no library-specific accessors:
+            // don't do anything.
+            super.visitFieldInsn(opcode, fieldOwner, fieldName, descriptor);
+            return;
+        }
+        String methodName = useJavaBeanAccessor ? javaBeanMethodName : librarySpecificMethodName;
+
         if (fieldOwnerClassName.equals(this.methodOwnerClassName)
-                && methodName.equals(this.methodName)
+                && javaBeanMethodName.equals(this.methodName)
                 && methodDescriptor.equals(this.methodDescriptor)) {
             // The current method accessing the entity field is the corresponding getter/setter.
             // We don't perform substitution at all.
@@ -79,15 +102,15 @@ public class PanacheFieldAccessMethodVisitor extends MethodVisitor {
     /**
      * Checks that the given field belongs to an entity (any entity)
      */
-    boolean isEntityField(String className, String fieldName) {
+    EntityField getEntityField(String className, String fieldName) {
         EntityModel entityModel = modelInfo.getEntityModel(className);
         if (entityModel == null)
-            return false;
+            return null;
         EntityField field = entityModel.fields.get(fieldName);
         if (field != null)
-            return true;
+            return field;
         if (entityModel.superClassName != null)
-            return isEntityField(entityModel.superClassName, fieldName);
-        return false;
+            return getEntityField(entityModel.superClassName, fieldName);
+        return null;
     }
 }

--- a/extensions/panache/panache-hibernate-common/deployment/pom.xml
+++ b/extensions/panache/panache-hibernate-common/deployment/pom.xml
@@ -32,6 +32,10 @@
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/extensions/panache/panache-hibernate-common/deployment/src/main/java/io/quarkus/panache/common/deployment/HibernateModelClassCandidatesForFieldAccessBuildItem.java
+++ b/extensions/panache/panache-hibernate-common/deployment/src/main/java/io/quarkus/panache/common/deployment/HibernateModelClassCandidatesForFieldAccessBuildItem.java
@@ -5,13 +5,13 @@ import java.util.Set;
 import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class HibernateModelClassCandidatesForFieldAccessBuildItem extends SimpleBuildItem {
-    private final Set<String> allModelClassNames;
+    private final Set<String> managedClassNames;
 
-    public HibernateModelClassCandidatesForFieldAccessBuildItem(Set<String> allModelClassNames) {
-        this.allModelClassNames = allModelClassNames;
+    public HibernateModelClassCandidatesForFieldAccessBuildItem(Set<String> managedClassNames) {
+        this.managedClassNames = managedClassNames;
     }
 
-    public Set<String> getAllModelClassNames() {
-        return allModelClassNames;
+    public Set<String> getManagedClassNames() {
+        return managedClassNames;
     }
 }

--- a/extensions/panache/panache-hibernate-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheHibernateCommonResourceProcessor.java
+++ b/extensions/panache/panache-hibernate-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheHibernateCommonResourceProcessor.java
@@ -56,7 +56,7 @@ public final class PanacheHibernateCommonResourceProcessor {
         MetamodelInfo modelInfo = new MetamodelInfo();
 
         // Technically we wouldn't need to process embeddables, but we don't have an easy way to exclude them.
-        for (String entityClassName : candidatesForFieldAccess.get().getAllModelClassNames()) {
+        for (String entityClassName : candidatesForFieldAccess.get().getManagedClassNames()) {
             ClassInfo entityClass = index.getIndex().getClassByName(DotName.createSimple(entityClassName));
             if (entityClass == null) {
                 // Probably a synthetic entity, such as Envers' DefaultRevisionEntity.


### PR DESCRIPTION
Fixes #32735

In essence, this changes two things, but for for Hibernate ORM entities only:

1. We used to only replace access to *public* fields with getter/setter calls. This overlooked a few access patterns such as access to protected/package-private fields from other classes in the same package, or access to private fields from inner classes.
We now also replace access to protected, package-private and private fields with calls to `$$_hibernate_{read/write}_*` (though obviously not in the constructor, since that would fail, or the getter/setter, since Hibernate ORM itself will do that).
2. We used to not replace access to fields with getter/setter calls when inside the getter/setter implementation of the subclass. Since Hibernate ORM doesn't, either, this effectively meant that a getter/setter defined in a subclasss would bypass all Hibernate ORM enhancements (lazy initialization, dirty tracking).
We now replace such access with a call to `$$_hibernate_{read/write}_*`, so that we call Hibernate ORM's enhancements.

I didn't apply these to Panache MongoDB, because there's simply no equivalent to `$$_hibernate_{read/write}_*` for MongoDB, and [calling `get*()`/`set*()` (which was my initial approach) could cause other problems](https://github.com/quarkusio/quarkus/pull/32876#issuecomment-1521517516).

I will need some serious review from someone familiar with bytecode enhancement and Hibernate ORM (@Sanne, pretty please!), because this is a rather fundamental change with potential for breaking stuff. I worry in particular about:

* The potential impact on applications that don't rely on public fields.
Such applications, until now, didn't even get most of the field access enhancement code executed, because they didn't need to.
But now that we enhance protected/private field access, we do need to scan those applications, be it just to conclude that they only access these fields in the corresponding getters and don't need any enhancement in the end. So we may discover performance issues or simply bugs in those applications (even if they don't need field access enhancement).
* The potential impact on applications that rely on complex models where we don't detect fields correctly,
in particular if we don't correctly detect fields marked as transient using XML mapping: we will then replace field access with calls to `$$_hibernate_{read/write}_*` methods that may not exist.
That could be considered a pre-existing bug though, since such applications would already behave badly if they have public fields marked as transient using XML mapping (we'd generate an unnecessary getter/setter pair).
Also, I suspect Hibernate ORM also doesn't detect those XML-mapped transient fields correctly, so it may generate those `$$_hibernate_{read/write}_*` methods anyway.

For the reasons mentioned above, I really don't want to backport this patch.