### PR TITLE
Support registering a HttpClientOptions in REST Client Reactive API

### DIFF
--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -497,23 +497,16 @@ public class ExtensionsResource {
     private final ExtensionsService extensionsService;
 
     public ExtensionsResource() {
+        HttpClientOptions options = new HttpClientOptions();
+        // ...
+
         extensionsService = QuarkusRestClientBuilder.newBuilder()
             .baseUri(URI.create("https://stage.code.quarkus.io/api"))
-            .register(CustomHttpClientOptions.class) <1>
+            .httpClientOptions(options) <1>
             .build(ExtensionsService.class);
     }
 
     // ...
-}
-
-public class CustomHttpClientOptions implements ContextResolver<HttpClientOptions> {
-
-    @Override
-    public HttpClientOptions getContext(Class<?> aClass) {
-        HttpClientOptions options = new HttpClientOptions();
-        // ...
-        return options;
-    }
 }
 ----
 

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/CustomHttpOptionsViaProgrammaticallyClientCreatedTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/CustomHttpOptionsViaProgrammaticallyClientCreatedTest.java
@@ -30,7 +30,7 @@ public class CustomHttpOptionsViaProgrammaticallyClientCreatedTest {
             .withApplicationRoot((jar) -> jar.addClasses(Client.class));
 
     @Test
-    void shouldUseCustomHttpOptions() {
+    void shouldUseCustomHttpOptionsUsingProvider() {
         // First verify the standard configuration
         assertThat(QuarkusRestClientBuilder.newBuilder().baseUri(baseUri).build(Client.class).get())
                 .isEqualTo(EXPECTED_VALUE);
@@ -39,6 +39,21 @@ public class CustomHttpOptionsViaProgrammaticallyClientCreatedTest {
 
         Client client = QuarkusRestClientBuilder.newBuilder().baseUri(baseUri)
                 .register(CustomHttpClientOptionsWithLimit.class)
+                .build(Client.class);
+        assertThatThrownBy(() -> client.get()).hasMessageContaining("HTTP header is larger than 1 bytes.");
+    }
+
+    @Test
+    void shouldUseCustomHttpOptionsUsingAPI() {
+        // First verify the standard configuration
+        assertThat(QuarkusRestClientBuilder.newBuilder().baseUri(baseUri).build(Client.class).get())
+                .isEqualTo(EXPECTED_VALUE);
+
+        // Now, it should fail if we use a custom http client options with a very limited max header size:
+        HttpClientOptions options = new HttpClientOptions();
+        options.setMaxHeaderSize(1); // this is just to verify that this HttpClientOptions is indeed used.
+        Client client = QuarkusRestClientBuilder.newBuilder().baseUri(baseUri)
+                .httpClientOptions(options)
                 .build(Client.class);
         assertThatThrownBy(() -> client.get()).hasMessageContaining("HTTP header is larger than 1 bytes.");
     }

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
@@ -19,6 +19,7 @@ import org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener;
 
 import io.quarkus.rest.client.reactive.runtime.QuarkusRestClientBuilderImpl;
 import io.quarkus.rest.client.reactive.runtime.RestClientBuilderImpl;
+import io.vertx.core.http.HttpClientOptions;
 
 /**
  * This is the main entry point for creating a Type Safe Quarkus Rest Client.
@@ -232,6 +233,22 @@ public interface QuarkusRestClientBuilder extends Configurable<QuarkusRestClient
      * @return the current builder
      */
     QuarkusRestClientBuilder clientHeadersFactory(ClientHeadersFactory clientHeadersFactory);
+
+    /**
+     * Specifies the HTTP client options to use.
+     *
+     * @param httpClientOptionsClass the HTTP client options to use.
+     * @return the current builder
+     */
+    QuarkusRestClientBuilder httpClientOptions(Class<? extends HttpClientOptions> httpClientOptionsClass);
+
+    /**
+     * Specifies the HTTP client options to use.
+     *
+     * @param httpClientOptions the HTTP client options to use.
+     * @return the current builder
+     */
+    QuarkusRestClientBuilder httpClientOptions(HttpClientOptions httpClientOptions);
 
     /**
      * Based on the configured QuarkusRestClientBuilder, creates a new instance of the given REST interface to invoke API calls

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/QuarkusRestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/QuarkusRestClientBuilderImpl.java
@@ -17,6 +17,8 @@ import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.quarkus.rest.client.reactive.runtime.context.ClientHeadersFactoryContextResolver;
+import io.quarkus.rest.client.reactive.runtime.context.HttpClientOptionsContextResolver;
+import io.vertx.core.http.HttpClientOptions;
 
 public class QuarkusRestClientBuilderImpl implements QuarkusRestClientBuilder {
 
@@ -195,6 +197,23 @@ public class QuarkusRestClientBuilderImpl implements QuarkusRestClientBuilder {
     @Override
     public QuarkusRestClientBuilder clientHeadersFactory(ClientHeadersFactory clientHeadersFactory) {
         proxy.register(new ClientHeadersFactoryContextResolver(clientHeadersFactory));
+        return this;
+    }
+
+    @Override
+    public QuarkusRestClientBuilder httpClientOptions(Class<? extends HttpClientOptions> httpClientOptionsClass) {
+        HttpClientOptions bean = BeanGrabber.getBeanIfDefined(httpClientOptionsClass);
+        if (bean == null) {
+            throw new IllegalArgumentException("Failed to instantiate the HTTP client options " + httpClientOptionsClass
+                    + ". Make sure the bean is properly configured for CDI injection.");
+        }
+
+        return httpClientOptions(bean);
+    }
+
+    @Override
+    public QuarkusRestClientBuilder httpClientOptions(HttpClientOptions httpClientOptions) {
+        proxy.register(new HttpClientOptionsContextResolver(httpClientOptions));
         return this;
     }
 

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/context/HttpClientOptionsContextResolver.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/context/HttpClientOptionsContextResolver.java
@@ -1,0 +1,23 @@
+package io.quarkus.rest.client.reactive.runtime.context;
+
+import jakarta.ws.rs.ext.ContextResolver;
+
+import io.vertx.core.http.HttpClientOptions;
+
+public class HttpClientOptionsContextResolver implements ContextResolver<HttpClientOptions> {
+
+    private final HttpClientOptions component;
+
+    public HttpClientOptionsContextResolver(HttpClientOptions component) {
+        this.component = component;
+    }
+
+    @Override
+    public HttpClientOptions getContext(Class<?> wantedClass) {
+        if (wantedClass.equals(HttpClientOptions.class)) {
+            return component;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Similar to https://github.com/quarkusio/quarkus/pull/32880, we can extend the new REST Client Reactive API to provide a custom HttpClientOptions.

Follow-up task of https://github.com/quarkusio/quarkus/issues/32856