### PR TITLE
ArC fixes for spec compatibility, round 7

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -1534,10 +1534,36 @@ public class BeanDeployment {
         }
     }
 
+    /**
+     * Returns the set of names of non-binding annotation members of given interceptor
+     * binding annotation that was registered through {@code InterceptorBindingRegistrar}.
+     * <p>
+     * Does <em>not</em> return non-binding members of interceptor bindings that were
+     * discovered based on the {@code @InterceptorBinding} annotation; in such case,
+     * one has to manually check presence of the {@code @NonBinding} annotation on
+     * the annotation member declaration.
+     *
+     * @param name name of the interceptor binding annotation that was registered through
+     *        {@code InterceptorBindingRegistrar}
+     * @return set of non-binding annotation members of the interceptor binding annotation
+     */
     public Set<String> getInterceptorNonbindingMembers(DotName name) {
         return interceptorNonbindingMembers.getOrDefault(name, Collections.emptySet());
     }
 
+    /**
+     * Returns the set of names of non-binding annotation members of given qualifier
+     * annotation that was registered through {@code QualifierRegistrar}.
+     * <p>
+     * Does <em>not</em> return non-binding members of interceptor bindings that were
+     * discovered based on the {@code @Qualifier} annotation; in such case, one has to
+     * manually check presence of the {@code @NonBinding} annotation on the annotation member
+     * declaration.
+     *
+     * @param name name of the qualifier annotation that was registered through
+     *        {@code QualifierRegistrar}
+     * @return set of non-binding annotation members of the qualifier annotation
+     */
     public Set<String> getQualifierNonbindingMembers(DotName name) {
         return qualifierNonbindingMembers.getOrDefault(name, Collections.emptySet());
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -1653,6 +1653,8 @@ public class BeanGenerator extends AbstractGenerator {
                     create.invokeStaticMethod(MethodDescriptors.SETS_OF, bindingsArray));
             TryBlock tryCatch = create.tryBlock();
             CatchBlockCreator exceptionCatch = tryCatch.addCatch(Exception.class);
+            exceptionCatch.ifFalse(exceptionCatch.instanceOf(exceptionCatch.getCaughtException(), RuntimeException.class))
+                    .falseBranch().throwException(exceptionCatch.getCaughtException());
             // throw new RuntimeException(e)
             exceptionCatch.throwException(RuntimeException.class, "Error invoking aroundConstructs",
                     exceptionCatch.getCaughtException());
@@ -1836,6 +1838,8 @@ public class BeanGenerator extends AbstractGenerator {
 
             TryBlock tryCatch = create.tryBlock();
             CatchBlockCreator exceptionCatch = tryCatch.addCatch(Exception.class);
+            exceptionCatch.ifFalse(exceptionCatch.instanceOf(exceptionCatch.getCaughtException(), RuntimeException.class))
+                    .falseBranch().throwException(exceptionCatch.getCaughtException());
             // throw new RuntimeException(e)
             exceptionCatch.throwException(RuntimeException.class, "Error invoking postConstructs",
                     exceptionCatch.getCaughtException());

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -819,16 +819,38 @@ public class BeanGenerator extends AbstractGenerator {
 
         if (bean.isClassBean()) {
             if (!bean.isInterceptor()) {
+                // if there's no `@PreDestroy` interceptor, we'll generate code to invoke `@PreDestroy` callbacks
+                // directly into the `destroy` method:
+                //
+                // public void destroy(MyBean var1, CreationalContext var2) {
+                //     var1.myPreDestroyCallback();
+                //     var2.release();
+                // }
+                BytecodeCreator preDestroyBytecode = destroy;
+
                 // PreDestroy interceptors
                 if (!bean.getLifecycleInterceptors(InterceptionType.PRE_DESTROY).isEmpty()) {
+                    // if there _is_ some `@PreDestroy` interceptor, however, we'll reify the chain of `@PreDestroy`
+                    // callbacks into a `Runnable` that we pass into the interceptor chain to be called
+                    // by the last `proceed()` call:
+                    //
+                    // public void destroy(MyBean var1, CreationalContext var2) {
+                    //     // this is a `Runnable` that calls `MyBean.myPreDestroyCallback()`
+                    //     MyBean_Bean$$function$$2 var3 = new MyBean_Bean$$function$$2(var1);
+                    //     ((MyBean_Subclass)var1).arc$destroy((Runnable)var3);
+                    //     var2.release();
+                    // }
+                    FunctionCreator preDestroyForwarder = destroy.createFunction(Runnable.class);
+                    preDestroyBytecode = preDestroyForwarder.getBytecode();
+
                     destroy.invokeVirtualMethod(
                             MethodDescriptor.ofMethod(SubclassGenerator.generatedName(bean.getProviderType().name(), baseName),
-                                    SubclassGenerator.DESTROY_METHOD_NAME,
-                                    void.class),
-                            destroy.getMethodParam(0));
+                                    SubclassGenerator.DESTROY_METHOD_NAME, void.class, Runnable.class),
+                            destroy.getMethodParam(0), preDestroyForwarder.getInstance());
                 }
 
                 // PreDestroy callbacks
+                // possibly wrapped into Runnable so that PreDestroy interceptors can proceed() correctly
                 List<MethodInfo> preDestroyCallbacks = Beans.getCallbacks(bean.getTarget().get().asClass(),
                         DotNames.PRE_DESTROY,
                         bean.getDeployment().getBeanArchiveIndex());
@@ -839,15 +861,20 @@ public class BeanGenerator extends AbstractGenerator {
                                     callback.declaringClass().name(), callback.name()));
                         }
                         reflectionRegistration.registerMethod(callback);
-                        destroy.invokeStaticMethod(MethodDescriptors.REFLECTIONS_INVOKE_METHOD,
-                                destroy.loadClass(callback.declaringClass().name().toString()),
-                                destroy.load(callback.name()), destroy.newArray(Class.class, destroy.load(0)),
+                        preDestroyBytecode.invokeStaticMethod(MethodDescriptors.REFLECTIONS_INVOKE_METHOD,
+                                preDestroyBytecode.loadClass(callback.declaringClass().name().toString()),
+                                preDestroyBytecode.load(callback.name()),
+                                preDestroyBytecode.newArray(Class.class, preDestroyBytecode.load(0)),
                                 destroy.getMethodParam(0),
-                                destroy.newArray(Object.class, destroy.load(0)));
+                                preDestroyBytecode.newArray(Object.class, preDestroyBytecode.load(0)));
                     } else {
                         // instance.superCoolDestroyCallback()
-                        destroy.invokeVirtualMethod(MethodDescriptor.of(callback), destroy.getMethodParam(0));
+                        preDestroyBytecode.invokeVirtualMethod(MethodDescriptor.of(callback), destroy.getMethodParam(0));
                     }
+                }
+                if (preDestroyBytecode != destroy) {
+                    // only if we're generating a `Runnable`, see above
+                    preDestroyBytecode.returnVoid();
                 }
             }
 
@@ -1750,9 +1777,35 @@ public class BeanGenerator extends AbstractGenerator {
                     SubclassGenerator.MARK_CONSTRUCTED_METHOD_NAME, void.class), instanceHandle);
         }
 
+        // if there's no `@PostConstruct` interceptor, we'll generate code to invoke `@PostConstruct` callbacks
+        // directly into the `doCreate` method:
+        //
+        // private MyBean doCreate(CreationalContext var1) {
+        //     MyBean var2 = new MyBean();
+        //     var2.myPostConstructCallback();
+        //     return var2;
+        // }
+        BytecodeCreator postConstructsBytecode = create;
+
         // PostConstruct lifecycle callback interceptors
         InterceptionInfo postConstructs = bean.getLifecycleInterceptors(InterceptionType.POST_CONSTRUCT);
         if (!postConstructs.isEmpty()) {
+            // if there _is_ some `@PostConstruct` interceptor, however, we'll reify the chain of `@PostConstruct`
+            // callbacks into a `Runnable` that we pass into the interceptor chain to be called
+            // by the last `proceed()` call:
+            //
+            // private MyBean doCreate(CreationalContext var1) {
+            //     ...
+            //     MyBean var7 = new MyBean();
+            //     // this is a `Runnable` that calls `MyBean.myPostConstructCallback()`
+            //     MyBean_Bean$$function$$1 var11 = new MyBean_Bean$$function$$1(var7);
+            //     ...
+            //     InvocationContext var12 = InvocationContexts.postConstruct(var7, (List)var5, var10, (Runnable)var11);
+            //     var12.proceed();
+            //     return var7;
+            // }
+            FunctionCreator postConstructForwarder = create.createFunction(Runnable.class);
+            postConstructsBytecode = postConstructForwarder.getBytecode();
 
             // Interceptor bindings
             ResultHandle bindingsArray = create.newArray(Object.class, postConstructs.bindings.size());
@@ -1768,7 +1821,8 @@ public class BeanGenerator extends AbstractGenerator {
             // InvocationContextImpl.postConstruct(instance,postConstructs).proceed()
             ResultHandle invocationContextHandle = create.invokeStaticMethod(
                     MethodDescriptors.INVOCATION_CONTEXTS_POST_CONSTRUCT, instanceHandle,
-                    postConstructsHandle, create.invokeStaticMethod(MethodDescriptors.SETS_OF, bindingsArray));
+                    postConstructsHandle, create.invokeStaticMethod(MethodDescriptors.SETS_OF, bindingsArray),
+                    postConstructForwarder.getInstance());
 
             TryBlock tryCatch = create.tryBlock();
             CatchBlockCreator exceptionCatch = tryCatch.addCatch(Exception.class);
@@ -1780,10 +1834,11 @@ public class BeanGenerator extends AbstractGenerator {
         }
 
         // PostConstruct callbacks
+        // possibly wrapped into Runnable so that PostConstruct interceptors can proceed() correctly
         if (!bean.isInterceptor()) {
             List<MethodInfo> postConstructCallbacks = Beans.getCallbacks(bean.getTarget().get().asClass(),
-                    DotNames.POST_CONSTRUCT,
-                    bean.getDeployment().getBeanArchiveIndex());
+                    DotNames.POST_CONSTRUCT, bean.getDeployment().getBeanArchiveIndex());
+
             for (MethodInfo callback : postConstructCallbacks) {
                 if (isReflectionFallbackNeeded(callback, targetPackage)) {
                     if (Modifier.isPrivate(callback.flags())) {
@@ -1792,14 +1847,19 @@ public class BeanGenerator extends AbstractGenerator {
                                         callback.name()));
                     }
                     reflectionRegistration.registerMethod(callback);
-                    create.invokeStaticMethod(MethodDescriptors.REFLECTIONS_INVOKE_METHOD,
-                            create.loadClass(callback.declaringClass().name().toString()),
-                            create.load(callback.name()), create.newArray(Class.class, create.load(0)), instanceHandle,
-                            create.newArray(Object.class, create.load(0)));
+                    postConstructsBytecode.invokeStaticMethod(MethodDescriptors.REFLECTIONS_INVOKE_METHOD,
+                            postConstructsBytecode.loadClass(callback.declaringClass().name().toString()),
+                            postConstructsBytecode.load(callback.name()),
+                            postConstructsBytecode.newArray(Class.class, postConstructsBytecode.load(0)), instanceHandle,
+                            postConstructsBytecode.newArray(Object.class, postConstructsBytecode.load(0)));
                 } else {
-                    create.invokeVirtualMethod(MethodDescriptor.of(callback), instanceHandle);
+                    postConstructsBytecode.invokeVirtualMethod(MethodDescriptor.of(callback), instanceHandle);
                 }
             }
+        }
+        if (postConstructsBytecode != create) {
+            // only if we're generating a `Runnable`, see above
+            postConstructsBytecode.returnVoid();
         }
 
         create.returnValue(instanceHandle);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -754,7 +754,8 @@ public class BeanInfo implements InjectionTargetInfo {
             putLifecycleInterceptors(lifecycleInterceptors, classLevelBindings, InterceptionType.PRE_DESTROY);
             MethodInfo interceptedConstructor = findInterceptedConstructor(target.get().asClass());
             if (beanDeployment.getAnnotation(interceptedConstructor, DotNames.NO_CLASS_INTERCEPTORS) == null) {
-                constructorLevelBindings.addAll(classLevelBindings);
+                constructorLevelBindings = Methods.mergeMethodAndClassLevelBindings(constructorLevelBindings,
+                        classLevelBindings);
             }
             putLifecycleInterceptors(lifecycleInterceptors, constructorLevelBindings, InterceptionType.AROUND_CONSTRUCT);
             return lifecycleInterceptors;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -178,11 +178,11 @@ public final class MethodDescriptors {
     public static final MethodDescriptor INVOCATION_CONTEXTS_POST_CONSTRUCT = MethodDescriptor.ofMethod(
             InvocationContexts.class,
             "postConstruct",
-            InvocationContext.class, Object.class, List.class, Set.class);
+            InvocationContext.class, Object.class, List.class, Set.class, Runnable.class);
 
     public static final MethodDescriptor INVOCATION_CONTEXTS_PRE_DESTROY = MethodDescriptor.ofMethod(InvocationContexts.class,
             "preDestroy",
-            InvocationContext.class, Object.class, List.class, Set.class);
+            InvocationContext.class, Object.class, List.class, Set.class, Runnable.class);
 
     public static final MethodDescriptor INVOCATION_CONTEXTS_PERFORM_SUPERCLASS = MethodDescriptor.ofMethod(
             InvocationContexts.class,

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.context.spi.Context;
@@ -173,7 +174,7 @@ public final class MethodDescriptors {
     public static final MethodDescriptor INVOCATION_CONTEXTS_AROUND_CONSTRUCT = MethodDescriptor.ofMethod(
             InvocationContexts.class,
             "aroundConstruct",
-            InvocationContext.class, Constructor.class, Object[].class, List.class, Supplier.class, Set.class);
+            InvocationContext.class, Constructor.class, Object[].class, List.class, Function.class, Set.class);
 
     public static final MethodDescriptor INVOCATION_CONTEXTS_POST_CONSTRUCT = MethodDescriptor.ofMethod(
             InvocationContexts.class,

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -145,6 +145,9 @@ public final class MethodDescriptors {
     public static final MethodDescriptor CLIENT_PROXY_GET_CONTEXTUAL_INSTANCE = MethodDescriptor.ofMethod(ClientProxy.class,
             ClientProxyGenerator.GET_CONTEXTUAL_INSTANCE_METHOD_NAME, Object.class);
 
+    public static final MethodDescriptor CLIENT_PROXY_UNWRAP = MethodDescriptor.ofMethod(ClientProxy.class,
+            "unwrap", Object.class, Object.class);
+
     public static final MethodDescriptor INJECTABLE_BEAN_DESTROY = MethodDescriptor.ofMethod(InjectableBean.class, "destroy",
             void.class, Object.class,
             CreationalContext.class);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -272,12 +272,7 @@ final class Methods {
         if (methodLevelBindings.isEmpty()) {
             merged = classLevelBindings;
         } else {
-            merged = new HashSet<>(methodLevelBindings);
-            for (AnnotationInstance binding : classLevelBindings) {
-                if (methodLevelBindings.stream().noneMatch(a -> binding.name().equals(a.name()))) {
-                    merged.add(binding);
-                }
-            }
+            merged = mergeMethodAndClassLevelBindings(methodLevelBindings, classLevelBindings);
 
             if (Modifier.isPrivate(method.flags())
                     && !Annotations.containsAny(methodAnnotations, OBSERVER_PRODUCER_ANNOTATIONS)) {
@@ -300,6 +295,26 @@ final class Methods {
             }
         }
         return merged;
+    }
+
+    static Set<AnnotationInstance> mergeMethodAndClassLevelBindings(Collection<AnnotationInstance> methodLevelBindings,
+            Set<AnnotationInstance> classLevelBindings) {
+        if (methodLevelBindings.isEmpty()) {
+            return classLevelBindings;
+        }
+
+        Set<DotName> methodLevelNames = new HashSet<>();
+        for (AnnotationInstance methodLevelBinding : methodLevelBindings) {
+            methodLevelNames.add(methodLevelBinding.name());
+        }
+
+        Set<AnnotationInstance> result = new HashSet<>(methodLevelBindings);
+        for (AnnotationInstance classLevelBinding : classLevelBindings) {
+            if (!methodLevelNames.contains(classLevelBinding.name())) {
+                result.add(classLevelBinding);
+            }
+        }
+        return result;
     }
 
     static class NameAndDescriptor {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -947,9 +947,10 @@ public class SubclassGenerator extends AbstractGenerator {
     protected void createDestroy(ClassOutput classOutput, BeanInfo bean, ClassCreator subclass,
             FieldDescriptor preDestroysField) {
         if (preDestroysField != null) {
-            MethodCreator destroy = subclass
-                    .getMethodCreator(MethodDescriptor.ofMethod(subclass.getClassName(), DESTROY_METHOD_NAME, void.class));
+            MethodCreator destroy = subclass.getMethodCreator(MethodDescriptor.ofMethod(subclass.getClassName(),
+                    DESTROY_METHOD_NAME, void.class, Runnable.class));
             ResultHandle predestroysHandle = destroy.readInstanceField(preDestroysField, destroy.getThis());
+            ResultHandle forward = destroy.getMethodParam(0);
 
             // Interceptor bindings
             InterceptionInfo preDestroy = bean.getLifecycleInterceptors(InterceptionType.PRE_DESTROY);
@@ -972,7 +973,8 @@ public class SubclassGenerator extends AbstractGenerator {
             // InvocationContextImpl.preDestroy(this,predestroys)
             ResultHandle invocationContext = tryCatch.invokeStaticMethod(MethodDescriptors.INVOCATION_CONTEXTS_PRE_DESTROY,
                     tryCatch.getThis(), predestroysHandle,
-                    tryCatch.invokeStaticMethod(MethodDescriptors.SETS_OF, bindingsArray));
+                    tryCatch.invokeStaticMethod(MethodDescriptors.SETS_OF, bindingsArray),
+                    forward);
 
             // InvocationContext.proceed()
             tryCatch.invokeInterfaceMethod(MethodDescriptors.INVOCATION_CONTEXT_PROCEED, invocationContext);

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundConstructInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundConstructInvocationContext.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 /**
- * An InvocationContext implementation used for AroundConstruct callbacks.
+ * An {@code InvocationContext} implementation used for {@code AroundConstruct} callbacks.
  */
 class AroundConstructInvocationContext extends LifecycleCallbackInvocationContext {
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundConstructInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundConstructInvocationContext.java
@@ -4,7 +4,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 /**
  * An {@code InvocationContext} implementation used for {@code AroundConstruct} callbacks.
@@ -12,17 +12,17 @@ import java.util.function.Supplier;
 class AroundConstructInvocationContext extends LifecycleCallbackInvocationContext {
 
     private final Constructor<?> constructor;
-    private final Supplier<Object> aroundConstructForward;
+    private final Function<Object[], Object> forward;
 
     AroundConstructInvocationContext(Constructor<?> constructor, Object[] parameters, Set<Annotation> interceptorBindings,
-            List<InterceptorInvocation> chain, Supplier<Object> aroundConstructForward) {
+            List<InterceptorInvocation> chain, Function<Object[], Object> forward) {
         super(null, parameters, interceptorBindings, chain);
-        this.aroundConstructForward = aroundConstructForward;
+        this.forward = forward;
         this.constructor = constructor;
     }
 
-    protected void interceptorChainCompleted() throws Exception {
-        target = aroundConstructForward.get();
+    protected void interceptorChainCompleted() {
+        target = forward.apply(parameters);
     }
 
     @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InvocationContexts.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InvocationContexts.java
@@ -46,11 +46,12 @@ public final class InvocationContexts {
      * @param target
      * @param chain
      * @param interceptorBindings
+     * @param forward
      * @return a new invocation context
      */
     public static InvocationContext postConstruct(Object target, List<InterceptorInvocation> chain,
-            Set<Annotation> interceptorBindings) {
-        return new LifecycleCallbackInvocationContext(target, null, interceptorBindings, chain);
+            Set<Annotation> interceptorBindings, Runnable forward) {
+        return new PostConstructPreDestroyInvocationContext(target, null, interceptorBindings, chain, forward);
     }
 
     /**
@@ -58,11 +59,12 @@ public final class InvocationContexts {
      * @param target
      * @param chain
      * @param interceptorBindings
+     * @param forward
      * @return a new invocation context
      */
     public static InvocationContext preDestroy(Object target, List<InterceptorInvocation> chain,
-            Set<Annotation> interceptorBindings) {
-        return new LifecycleCallbackInvocationContext(target, null, interceptorBindings, chain);
+            Set<Annotation> interceptorBindings, Runnable forward) {
+        return new PostConstructPreDestroyInvocationContext(target, null, interceptorBindings, chain, forward);
     }
 
     /**

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InvocationContexts.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InvocationContexts.java
@@ -5,7 +5,7 @@ import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import jakarta.interceptor.InvocationContext;
 
@@ -77,10 +77,9 @@ public final class InvocationContexts {
     public static InvocationContext aroundConstruct(Constructor<?> constructor,
             Object[] parameters,
             List<InterceptorInvocation> chain,
-            Supplier<Object> aroundConstructForward,
+            Function<Object[], Object> forward,
             Set<Annotation> interceptorBindings) {
-        return new AroundConstructInvocationContext(constructor, parameters, interceptorBindings, chain,
-                aroundConstructForward);
+        return new AroundConstructInvocationContext(constructor, parameters, interceptorBindings, chain, forward);
     }
 
     /**

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/LifecycleCallbackInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/LifecycleCallbackInvocationContext.java
@@ -7,11 +7,11 @@ import java.util.Set;
 
 /**
  * A simple stateful {@link jakarta.interceptor.InvocationContext} implementation used for
- * {@link jakarta.annotation.PostConstruct} and {@link jakarta.annotation.PreDestroy} callbacks.
+ * lifecycle callback interceptors.
  * <p>
  * All lifecycle callback interceptors of a specific chain must be invoked on the same thread.
  */
-class LifecycleCallbackInvocationContext extends AbstractInvocationContext {
+abstract class LifecycleCallbackInvocationContext extends AbstractInvocationContext {
 
     protected final Set<Annotation> bindings;
     protected final List<InterceptorInvocation> chain;
@@ -31,7 +31,8 @@ class LifecycleCallbackInvocationContext extends AbstractInvocationContext {
                 // Invoke the next interceptor in the chain
                 invokeNext();
             } else {
-                // The invocation of proceed in the last interceptor method in the chain
+                // The invocation of proceed in the last interceptor method in the chain,
+                // need to forward to the target class
                 interceptorChainCompleted();
             }
             // The return value of a lifecycle callback is ignored
@@ -53,19 +54,7 @@ class LifecycleCallbackInvocationContext extends AbstractInvocationContext {
         return bindings;
     }
 
-    @Override
-    public Object[] getParameters() {
-        throw new IllegalStateException();
-    }
-
-    @Override
-    public void setParameters(Object[] params) {
-        throw new IllegalStateException();
-    }
-
-    protected void interceptorChainCompleted() throws Exception {
-        // No-op
-    }
+    protected abstract void interceptorChainCompleted() throws Exception;
 
     private Object invokeNext() throws Exception {
         try {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/PostConstructPreDestroyInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/PostConstructPreDestroyInvocationContext.java
@@ -1,0 +1,35 @@
+package io.quarkus.arc.impl;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * An {@code InvocationContext} implementation used for {@code PostConstruct} and {@code PreDestroy} callbacks.
+ */
+class PostConstructPreDestroyInvocationContext extends LifecycleCallbackInvocationContext {
+    private final Runnable forward;
+
+    PostConstructPreDestroyInvocationContext(Object target, Object[] parameters,
+            Set<Annotation> bindings, List<InterceptorInvocation> chain, Runnable forward) {
+        super(target, parameters, bindings, chain);
+        this.forward = forward;
+    }
+
+    @Override
+    protected void interceptorChainCompleted() {
+        if (forward != null) {
+            forward.run();
+        }
+    }
+
+    @Override
+    public Object[] getParameters() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public void setParameters(Object[] params) {
+        throw new IllegalStateException();
+    }
+}

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -184,15 +184,6 @@
                     <exclude name="testAbstractClassDeclaredInJavaNotDiscovered"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.interceptors.tests.bindings.aroundConstruct.ConstructorInterceptionTest">
-                <methods>
-                    <exclude name="testTypeLevelAndConstructorLevelBinding"/>
-                    <exclude name="testTypeLevelBinding"/>
-                    <exclude name="testConstructorLevelBinding"/>
-                    <exclude name="testOverridingTypeLevelBinding"/>
-                    <exclude name="testMultipleConstructorLevelBinding"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.interceptors.definition.inheritance.InterceptorBindingInheritanceTest">
                 <methods>
                     <exclude name="testInterceptorBindingDirectlyInheritedFromManagedBean"/>

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -284,13 +284,6 @@
                     <exclude name="testHandles"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.interceptors.tests.bindings.resolution.InterceptorBindingResolutionTest">
-                <methods>
-                    <exclude name="testBusinessMethodInterceptorBindings"/>
-                    <exclude name="testConstructorInterceptorBindings"/>
-                    <exclude name="testLifecycleInterceptorBindings"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptorTypeParamInitializerTest">
                 <methods>
                     <exclude name="testDeploymentFails"/>

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -101,11 +101,6 @@
                     <exclude name="testExceptions"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.interceptors.tests.bindings.broken.InvalidTransitiveInterceptorBindingAnnotationsTest">
-                <methods>
-                    <exclude name="testInterceptorBindingsWithConflictingAnnotationMembersNotOk"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.BeanTypeParamConstructorTest">
                 <methods>
                     <exclude name="testDeploymentFails"/>
@@ -142,11 +137,6 @@
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.BeanTypeParamInitializerTest">
                 <methods>
                     <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.interceptors.tests.bindings.broken.InvalidStereotypeInterceptorBindingAnnotationsTest">
-                <methods>
-                    <exclude name="testInterceptorBindingsWithConflictingAnnotationMembersNotOk"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptedBeanTypeParamConstructorTest">

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -230,12 +230,6 @@
                     <exclude name="testDeploymentFails"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.interceptors.tests.contract.interceptorLifeCycle.aroundConstruct.AroundConstructLifeCycleTest">
-                <methods>
-                    <exclude name="testAroundConstructInvokedAfterDependencyInjectionOnInterceptorClasses"/>
-                    <exclude name="testInstanceNotCreatedUnlessInvocationContextProceedCalled"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.event.fires.FireEventTest">
                 <methods>
                     <exclude name="testFireContainerLifecycleEvent"/>

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -79,8 +79,6 @@
             </class>
             <class name="org.jboss.cdi.tck.interceptors.tests.contract.aroundConstruct.AroundConstructTest">
                 <methods>
-                    <exclude name="testInterceptorInvocation"/>
-                    <exclude name="testReplacingParameters"/>
                     <exclude name="testExceptions"/>
                 </methods>
             </class>
@@ -91,8 +89,6 @@
             </class>
             <class name="org.jboss.cdi.tck.interceptors.tests.contract.aroundConstruct.bindings.AroundConstructTest">
                 <methods>
-                    <exclude name="testInterceptorInvocation"/>
-                    <exclude name="testReplacingParameters"/>
                     <exclude name="testExceptions"/>
                 </methods>
             </class>

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -77,19 +77,9 @@
                     <exclude name="testNormalCircularConstructors"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.interceptors.tests.contract.aroundConstruct.AroundConstructTest">
-                <methods>
-                    <exclude name="testExceptions"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptedBeanTypeParamFieldTest">
                 <methods>
                     <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.interceptors.tests.contract.aroundConstruct.bindings.AroundConstructTest">
-                <methods>
-                    <exclude name="testExceptions"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.BeanTypeParamConstructorTest">

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -61,20 +61,6 @@
                     <exclude name="testGetTargetMethod"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.disposal.method.definition.DisposalMethodDefinitionTest">
-                <methods>
-                    <exclude name="testDisposalMethodForMultipleProducerMethods"/>
-                    <exclude name="testDisposalMethodCalledForProducerField"/>
-                    <exclude name="testBindingTypesAppliedToDisposalMethodParameters"/>
-                    <exclude name="testDisposalMethodOnNonBean"/>
-                    <exclude name="testDisposalMethodParametersGetInjected"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.definition.scope.broken.tooManyScopes.producer.method.ProducerMethodTooManyScopesTest">
-                <methods>
-                    <exclude name="testTooManyScopesSpecifiedInJava"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.interceptors.tests.contract.lifecycleCallback.exceptions.LifecycleCallbackInterceptorExceptionTest">
                 <methods>
                     <exclude name="testLifecycleCallbackInterceptorCanCatchException"/>
@@ -101,11 +87,6 @@
                     <exclude name="testInterceptorInvocation"/>
                     <exclude name="testReplacingParameters"/>
                     <exclude name="testExceptions"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.full.lookup.injection.visibility.InjectionVisibilityTest">
-                <methods>
-                    <exclude name="testPackagePrivateSetMethodInjection"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptedBeanTypeParamFieldTest">
@@ -171,13 +152,6 @@
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptedBeanTypeParamConstructorTest">
                 <methods>
                     <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.interceptors.tests.contract.aroundInvoke.AroundInvokeAccessInterceptorTest">
-                <methods>
-                    <exclude name="testPrivateAroundInvokeInterceptor"/>
-                    <exclude name="testPackagePrivateAroundInvokeInterceptor"/>
-                    <exclude name="testProtectedAroundInvokeInterceptor"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.definition.qualifier.builtin.BuiltInQualifierDefinitionTest">
@@ -265,26 +239,9 @@
                     <exclude name="testNormalScopedUnproxyableBeanWithProtectedFinalMethodResolution"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.event.EventTest">
-                <methods>
-                    <exclude name="testStaticObserverMethodInvoked"/>
-                    <exclude name="testObserverCalledOnSpecializedBeanOnly"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptorTypeParamFieldTest">
                 <methods>
                     <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.interceptors.tests.contract.lifecycleCallback.bindings.LifecycleInterceptorDefinitionTest">
-                <methods>
-                    <exclude name="testMultipleLifecycleInterceptors"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.interceptors.definition.interceptorOrder.InterceptorOrderTest">
-                <methods>
-                    <exclude name="testInterceptorsInvocationOrder"/>
-                    <exclude name="testInterceptorsCalledInOrderDefinedByBeansXml"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.injection.intercepted.InterceptedBeanInitializerInjectionTest">
@@ -335,11 +292,6 @@
                     <exclude name="testDeploymentFails"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.interceptors.tests.contract.aroundInvoke.bindings.AroundInvokeInterceptorTest">
-                <methods>
-                    <exclude name="testBusinessMethodIntercepted"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.injection.BuiltinInterceptorInjectionTest">
                 <methods>
                     <exclude name="testDeploymentFails"/>
@@ -383,12 +335,6 @@
                     <exclude name="testInstanceUsedForProducerMethodNotShared"/>
                     <exclude name="testContextIsActive"/>
                     <exclude name="testContextScopeType"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.lookup.manager.ManagerTest">
-                <methods>
-                    <!-- This test should be CDI Full only -->
-                    <exclude name="testManagerBeanIsPassivationCapable"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.context.GetFromContextualTest">

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -43,6 +43,7 @@
                     <exclude name="testContextualDestroyCatchesException"/>
                 </methods>
             </class>
+            <!-- must be excluded due to a TCK bug that shall be fixed in CDI TCK 4.0.10 -->
             <class name="org.jboss.cdi.tck.interceptors.tests.contract.lifecycleCallback.LifecycleCallbackInterceptorTest">
                 <methods>
                     <exclude name="testPostConstructInterceptor"/>

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -61,11 +61,6 @@
                     <exclude name="testGetTargetMethod"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.interceptors.tests.contract.lifecycleCallback.exceptions.LifecycleCallbackInterceptorExceptionTest">
-                <methods>
-                    <exclude name="testLifecycleCallbackInterceptorCanCatchException"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptorTypeParamConstructorTest">
                 <methods>
                     <exclude name="testDeploymentFails"/>

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/LifecycleInterceptor.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/LifecycleInterceptor.java
@@ -22,21 +22,23 @@ public class LifecycleInterceptor {
     static final List<Object> PRE_DESTROYS = new CopyOnWriteArrayList<>();
 
     @PostConstruct
-    void simpleInit(InvocationContext ctx) {
+    void simpleInit(InvocationContext ctx) throws Exception {
         Object bindings = ctx.getContextData().get(ArcInvocationContext.KEY_INTERCEPTOR_BINDINGS);
         if (bindings == null) {
             throw new IllegalArgumentException("No bindings found");
         }
         POST_CONSTRUCTS.add(ctx.getTarget());
+        ctx.proceed();
     }
 
     @PreDestroy
-    void simpleDestroy(InvocationContext ctx) {
+    void simpleDestroy(InvocationContext ctx) throws Exception {
         Object bindings = ctx.getContextData().get(ArcInvocationContext.KEY_INTERCEPTOR_BINDINGS);
         if (bindings == null) {
             throw new IllegalArgumentException("No bindings found");
         }
         PRE_DESTROYS.add(ctx.getTarget());
+        ctx.proceed();
     }
 
     @AroundConstruct

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructExceptionHandlingTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructExceptionHandlingTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.arc.test.interceptors.aroundconstruct;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class AroundConstructExceptionHandlingTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(SimpleBean.class,
+            MyInterceptorBinding.class, MyInterceptor1.class, MyInterceptor2.class);
+
+    @Test
+    public void test() {
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> {
+            Arc.container().instance(SimpleBean.class).get();
+        });
+
+        assertTrue(MyInterceptor1.intercepted);
+        assertTrue(MyInterceptor2.intercepted);
+
+        assertNotNull(e.getCause());
+        assertEquals(IllegalArgumentException.class, e.getCause().getClass());
+        assertEquals("intentional", e.getCause().getMessage());
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class SimpleBean {
+    }
+
+    @Target({ ElementType.TYPE, ElementType.CONSTRUCTOR })
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor1 {
+        static boolean intercepted = false;
+
+        @AroundConstruct
+        void aroundConstruct(InvocationContext ctx) throws Exception {
+            intercepted = true;
+            try {
+                ctx.proceed();
+            } catch (IllegalArgumentException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(2)
+    static class MyInterceptor2 {
+        static boolean intercepted = false;
+
+        @AroundConstruct
+        void aroundConstruct(InvocationContext ctx) {
+            intercepted = true;
+            throw new IllegalArgumentException("intentional");
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructWithClassAndConstructorLevelBindingTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructWithClassAndConstructorLevelBindingTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.arc.test.interceptors.aroundconstruct;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class AroundConstructWithClassAndConstructorLevelBindingTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBinding.class, MyInterceptor1.class,
+            MyInterceptor2.class, MyBean.class);
+
+    @Test
+    public void test() {
+        MyBean bean = Arc.container().instance(MyBean.class).get();
+        assertNotNull(bean);
+        assertTrue(MyBean.constructed);
+        assertFalse(MyInterceptor1.intercepted);
+        assertTrue(MyInterceptor2.intercepted);
+    }
+
+    @Target({ TYPE, CONSTRUCTOR })
+    @Retention(RUNTIME)
+    @InterceptorBinding
+    public @interface MyBinding {
+        int value();
+    }
+
+    @MyBinding(1)
+    @Interceptor
+    @Priority(1)
+    public static class MyInterceptor1 {
+        static boolean intercepted = false;
+
+        @AroundConstruct
+        void intercept(InvocationContext ctx) throws Exception {
+            intercepted = true;
+            ctx.proceed();
+        }
+    }
+
+    @MyBinding(2)
+    @Interceptor
+    @Priority(1)
+    public static class MyInterceptor2 {
+        static boolean intercepted = false;
+
+        @AroundConstruct
+        void intercept(InvocationContext ctx) throws Exception {
+            intercepted = true;
+            ctx.proceed();
+        }
+    }
+
+    @Dependent
+    @MyBinding(1)
+    static class MyBean {
+        static boolean constructed = false;
+
+        @Inject
+        @MyBinding(2)
+        MyBean() {
+            constructed = true;
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructWithParameterChangeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/aroundconstruct/AroundConstructWithParameterChangeTest.java
@@ -1,0 +1,78 @@
+package io.quarkus.arc.test.interceptors.aroundconstruct;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class AroundConstructWithParameterChangeTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(SimpleBean.class, MyDependency.class,
+            MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        SimpleBean simpleBean = Arc.container().instance(SimpleBean.class).get();
+        assertNotNull(simpleBean);
+        assertNotNull(simpleBean.dependency);
+        assertEquals("from interceptor", simpleBean.dependency.value);
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class SimpleBean {
+        final MyDependency dependency;
+
+        @Inject
+        SimpleBean(MyDependency dependency) {
+            this.dependency = dependency;
+        }
+    }
+
+    @Singleton
+    static class MyDependency {
+        final String value;
+
+        MyDependency() {
+            this("default");
+        }
+
+        MyDependency(String value) {
+            this.value = value;
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.CONSTRUCTOR })
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor {
+        @AroundConstruct
+        void aroundConstruct(InvocationContext ctx) throws Exception {
+            ctx.setParameters(new Object[] { new MyDependency("from interceptor") });
+            ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/conflicting/ConflictingStereotypeBindingOnBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/conflicting/ConflictingStereotypeBindingOnBeanTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.arc.test.interceptors.bindings.conflicting;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Stereotype;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.interceptor.InterceptorBinding;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ConflictingStereotypeBindingOnBeanTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyBean.class, FooBinding.class, BarBinding.class, Stereotype1.class, Stereotype2.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Multiple instances of non-repeatable interceptor binding annotation"));
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    @interface FooBinding {
+        int value();
+    }
+
+    @FooBinding(10)
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    @interface BarBinding {
+    }
+
+    @FooBinding(1)
+    @Stereotype
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Stereotype1 {
+    }
+
+    @BarBinding
+    @Stereotype
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Stereotype2 {
+    }
+
+    @Stereotype1
+    @Stereotype2
+    @Dependent
+    static class MyBean {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/conflicting/ConflictingTransitiveBindingOnBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/conflicting/ConflictingTransitiveBindingOnBeanTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.arc.test.interceptors.bindings.conflicting;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.interceptor.InterceptorBinding;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ConflictingTransitiveBindingOnBeanTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyBean.class, FooBinding.class, BarBinding.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Multiple instances of non-repeatable interceptor binding annotation"));
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    @interface FooBinding {
+        int value();
+    }
+
+    @FooBinding(10)
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    @interface BarBinding {
+    }
+
+    @FooBinding(1)
+    @BarBinding
+    @Dependent
+    static class MyBean {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/conflicting/ConflictingTransitiveBindingOnInterceptorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/conflicting/ConflictingTransitiveBindingOnInterceptorTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.arc.test.interceptors.bindings.conflicting;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ConflictingTransitiveBindingOnInterceptorTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyInterceptor.class, FooBinding.class, BarBinding.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Multiple instances of non-repeatable interceptor binding annotation"));
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    @interface FooBinding {
+        int value();
+    }
+
+    @FooBinding(10)
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    @interface BarBinding {
+    }
+
+    @FooBinding(1)
+    @BarBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/conflicting/ConflictingTransitiveStereotypeBindingOnBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/conflicting/ConflictingTransitiveStereotypeBindingOnBeanTest.java
@@ -1,0 +1,78 @@
+package io.quarkus.arc.test.interceptors.bindings.conflicting;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Stereotype;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.interceptor.InterceptorBinding;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ConflictingTransitiveStereotypeBindingOnBeanTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyBean.class, FooBinding.class, BarBinding.class, Stereotype1.class, Stereotype2.class,
+                    Stereotype3.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Multiple instances of non-repeatable interceptor binding annotation"));
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    @interface FooBinding {
+        int value();
+    }
+
+    @FooBinding(10)
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    @interface BarBinding {
+    }
+
+    @FooBinding(1)
+    @Stereotype
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Stereotype1 {
+    }
+
+    @BarBinding
+    @Stereotype
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Stereotype2 {
+    }
+
+    @Stereotype1
+    @Stereotype2
+    @Stereotype
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Stereotype3 {
+    }
+
+    @Stereotype3
+    @Dependent
+    static class MyBean {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/inherited/InheritedBindingOnInterceptorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/inherited/InheritedBindingOnInterceptorTest.java
@@ -1,0 +1,104 @@
+package io.quarkus.arc.test.interceptors.bindings.inherited;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InheritedBindingOnInterceptorTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, FooBinding.class, BarBinding.class,
+            BarBindingUnused.class, FooInterceptor.class, BarInterceptor.class);
+
+    @Test
+    public void testInterception() {
+        MyBean bean = Arc.container().instance(MyBean.class).get();
+        assertNotNull(bean);
+        bean.doSomething();
+        assertTrue(FooInterceptor.intercepted);
+        assertFalse(BarInterceptor.intercepted);
+    }
+
+    @Singleton
+    @FooBinding
+    @BarBinding
+    static class MyBean {
+        void doSomething() {
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    @Inherited
+    @interface FooBinding {
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    // not @Inherited
+    @interface BarBinding {
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    @interface BarBindingUnused {
+    }
+
+    @FooBinding
+    static class FooInterceptorSuperclass {
+    }
+
+    @Interceptor
+    @Priority(1)
+    static class FooInterceptor extends FooInterceptorSuperclass {
+        static boolean intercepted = false;
+
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            intercepted = true;
+            return ctx.proceed();
+        }
+    }
+
+    @BarBinding
+    static class BarInterceptorSuperclass {
+    }
+
+    @BarBindingUnused // just to prevent the "Interceptor has no bindings" error, not used otherwise
+    @Interceptor
+    @Priority(1)
+    static class BarInterceptor extends BarInterceptorSuperclass {
+        static boolean intercepted = false;
+
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            intercepted = true;
+            return ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/stereotype/InterceptorBindingOnStereotypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/stereotype/InterceptorBindingOnStereotypeTest.java
@@ -1,0 +1,121 @@
+package io.quarkus.arc.test.interceptors.bindings.stereotype;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Stereotype;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptorBindingOnStereotypeTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyStereotype.class,
+            MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void testInterception() {
+        assertEquals(0, MyInterceptor.aroundConstruct);
+        assertEquals(0, MyInterceptor.postConstruct);
+        assertEquals(0, MyInterceptor.aroundInvoke);
+        assertEquals(0, MyInterceptor.preDestroy);
+
+        InstanceHandle<MyBean> bean = Arc.container().instance(MyBean.class);
+        MyBean instance = bean.get();
+
+        assertEquals(1, MyInterceptor.aroundConstruct);
+        assertEquals(1, MyInterceptor.postConstruct);
+        assertEquals(0, MyInterceptor.aroundInvoke);
+        assertEquals(0, MyInterceptor.preDestroy);
+
+        instance.doSomething();
+
+        assertEquals(1, MyInterceptor.aroundConstruct);
+        assertEquals(1, MyInterceptor.postConstruct);
+        assertEquals(1, MyInterceptor.aroundInvoke);
+        assertEquals(0, MyInterceptor.preDestroy);
+
+        bean.destroy();
+
+        assertEquals(1, MyInterceptor.aroundConstruct);
+        assertEquals(1, MyInterceptor.postConstruct);
+        assertEquals(1, MyInterceptor.aroundInvoke);
+        assertEquals(1, MyInterceptor.preDestroy);
+    }
+
+    @Singleton
+    @MyStereotype
+    static class MyBean {
+        void doSomething() {
+        }
+    }
+
+    @MyInterceptorBinding
+    @Stereotype
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyStereotype {
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor {
+        static int aroundConstruct = 0;
+        static int postConstruct = 0;
+        static int aroundInvoke = 0;
+        static int preDestroy = 0;
+
+        @AroundConstruct
+        Object aroundConstruct(InvocationContext ctx) throws Exception {
+            aroundConstruct++;
+            return ctx.proceed();
+        }
+
+        @PostConstruct
+        Object postConstruct(InvocationContext ctx) throws Exception {
+            postConstruct++;
+            return ctx.proceed();
+        }
+
+        @AroundInvoke
+        Object aroundInvoke(InvocationContext ctx) throws Exception {
+            aroundInvoke++;
+            return ctx.proceed();
+        }
+
+        @PreDestroy
+        Object preDestroy(InvocationContext ctx) throws Exception {
+            preDestroy++;
+            return ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/complex/MyInterceptor.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/complex/MyInterceptor.java
@@ -21,13 +21,15 @@ public class MyInterceptor {
     public static AtomicBoolean aroundInvokeInvoked = new AtomicBoolean(false);
 
     @PreDestroy
-    public void preDestroy(InvocationContext ic) {
+    public void preDestroy(InvocationContext ic) throws Exception {
         preDestroyInvoked.set(true);
+        ic.proceed();
     }
 
     @PostConstruct
-    public void postConstruct(InvocationContext ic) {
+    public void postConstruct(InvocationContext ic) throws Exception {
         postConstructInvoked.set(true);
+        ic.proceed();
     }
 
     @AroundConstruct

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/postconstruct/PostConstructExceptionHandlingTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/postconstruct/PostConstructExceptionHandlingTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.arc.test.interceptors.postconstruct;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class PostConstructExceptionHandlingTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(SimpleBean.class,
+            MyInterceptorBinding.class, MyInterceptor1.class, MyInterceptor2.class);
+
+    @Test
+    public void test() {
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> {
+            Arc.container().instance(SimpleBean.class).get();
+        });
+
+        assertTrue(MyInterceptor1.intercepted);
+        assertTrue(MyInterceptor2.intercepted);
+
+        assertNotNull(e.getCause());
+        assertEquals(IllegalArgumentException.class, e.getCause().getClass());
+        assertEquals("intentional", e.getCause().getMessage());
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class SimpleBean {
+    }
+
+    @Target({ ElementType.TYPE, ElementType.CONSTRUCTOR })
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor1 {
+        static boolean intercepted = false;
+
+        @PostConstruct
+        void postConstruct(InvocationContext ctx) throws Exception {
+            intercepted = true;
+            try {
+                ctx.proceed();
+            } catch (IllegalArgumentException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(2)
+    static class MyInterceptor2 {
+        static boolean intercepted = false;
+
+        @PostConstruct
+        void postConstruct(InvocationContext ctx) {
+            intercepted = true;
+            throw new IllegalArgumentException("intentional");
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/predestroy/PreDestroyInterceptorAndClientProxyTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/predestroy/PreDestroyInterceptorAndClientProxyTest.java
@@ -1,0 +1,80 @@
+package io.quarkus.arc.test.interceptors.predestroy;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class PreDestroyInterceptorAndClientProxyTest {
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void bagr() {
+        InstanceHandle<MyBean> handle = Arc.container().instance(MyBean.class);
+        handle.destroy();
+    }
+
+    @Test
+    public void test() {
+        BeanManager beanManager = Arc.container().beanManager();
+
+        Bean<MyBean> bean = (Bean<MyBean>) beanManager.resolve(beanManager.getBeans(MyBean.class));
+        CreationalContext<MyBean> ctx = beanManager.createCreationalContext(bean);
+
+        MyBean instance = (MyBean) beanManager.getReference(bean, MyBean.class, ctx);
+        assertNotNull(instance);
+        assertInstanceOf(ClientProxy.class, instance);
+
+        assertFalse(MyInterceptor.intercepted);
+        bean.destroy(instance, ctx);
+        assertTrue(MyInterceptor.intercepted);
+    }
+
+    @ApplicationScoped
+    @MyInterceptorBinding
+    static class MyBean {
+    }
+
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor {
+        static boolean intercepted = false;
+
+        @PreDestroy
+        void intercept(InvocationContext ctx) throws Exception {
+            intercepted = true;
+            ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/AroundInvokeInterceptorNestingTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/AroundInvokeInterceptorNestingTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.arc.test.interceptors.targetclass.mixed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class AroundInvokeInterceptorNestingTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        ArcContainer arc = Arc.container();
+        MyBean bean = arc.instance(MyBean.class).get();
+        assertEquals("expected-exception", bean.doSomething());
+        assertEquals(List.of("MyInterceptor", "MyBean"), MyBean.invocations);
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean {
+        static final List<String> invocations = new ArrayList<>();
+
+        String doSomething() {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @AroundInvoke
+        Object aroundInvoke(InvocationContext ctx) {
+            invocations.add(MyBean.class.getSimpleName());
+            throw new IllegalArgumentException("intentional");
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    public @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    public static class MyInterceptor {
+        @AroundInvoke
+        Object aroundInvoke(InvocationContext ctx) throws Exception {
+            try {
+                MyBean.invocations.add(MyInterceptor.class.getSimpleName());
+                return ctx.proceed();
+            } catch (IllegalArgumentException e) {
+                return "expected-exception";
+            }
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PostConstructInterceptorNestingTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PostConstructInterceptorNestingTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.arc.test.interceptors.targetclass.mixed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class PostConstructInterceptorNestingTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        ArcContainer arc = Arc.container();
+        arc.instance(MyBean.class).get();
+        assertEquals(List.of("MyInterceptor", "MyBean", "expected-exception"), MyBean.invocations);
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean {
+        static final List<String> invocations = new ArrayList<>();
+
+        @PostConstruct
+        void postConstruct() {
+            invocations.add(MyBean.class.getSimpleName());
+            throw new IllegalArgumentException("intentional");
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    public @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    public static class MyInterceptor {
+        @PostConstruct
+        void postConstruct(InvocationContext ctx) throws Exception {
+            try {
+                MyBean.invocations.add(MyInterceptor.class.getSimpleName());
+                ctx.proceed();
+            } catch (IllegalArgumentException e) {
+                MyBean.invocations.add("expected-exception");
+            }
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PostConstructOnTargetClassAndOutsideAndManySuperclassesWithOverridesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PostConstructOnTargetClassAndOutsideAndManySuperclassesWithOverridesTest.java
@@ -1,0 +1,121 @@
+package io.quarkus.arc.test.interceptors.targetclass.mixed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class PostConstructOnTargetClassAndOutsideAndManySuperclassesWithOverridesTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        ArcContainer arc = Arc.container();
+        arc.instance(MyBean.class);
+        assertEquals(List.of("Foxtrot", "MyInterceptor", "Charlie", "MyBean"), MyBean.invocations);
+    }
+
+    static class Alpha {
+        @PostConstruct
+        void intercept() throws Exception {
+            MyBean.invocations.add("this should not be called as the method is overridden in MyBean");
+        }
+    }
+
+    static class Bravo extends Alpha {
+        @PostConstruct
+        void specialIntercept() {
+            MyBean.invocations.add("this should not be called as the method is overridden in Charlie");
+        }
+    }
+
+    static class Charlie extends Bravo {
+        @PostConstruct
+        void superIntercept() throws Exception {
+            MyBean.invocations.add(Charlie.class.getSimpleName());
+        }
+
+        @Override
+        void specialIntercept() {
+            MyBean.invocations.add("this is not an interceptor method");
+        }
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean extends Charlie {
+        static final List<String> invocations = new ArrayList<>();
+
+        @Override
+        @PostConstruct
+        void intercept() throws Exception {
+            invocations.add(MyBean.class.getSimpleName());
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    static class Delta {
+        @PostConstruct
+        Object intercept(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add("this should not be called as the method is overridden in MyInterceptor");
+            return ctx.proceed();
+        }
+    }
+
+    static class Echo extends Delta {
+        @PostConstruct
+        void specialIntercept(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add("this should not be called as the method is overridden in Foxtrot");
+        }
+    }
+
+    static class Foxtrot extends Echo {
+        @PostConstruct
+        Object superIntercept(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(Foxtrot.class.getSimpleName());
+            return ctx.proceed();
+        }
+
+        @Override
+        void specialIntercept(InvocationContext ctx) {
+            MyBean.invocations.add("this is not an interceptor method");
+        }
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor extends Foxtrot {
+        @PostConstruct
+        Object intercept(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(MyInterceptor.class.getSimpleName());
+            return ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PostConstructOnTargetClassAndOutsideAndSuperclassesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PostConstructOnTargetClassAndOutsideAndSuperclassesTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.arc.test.interceptors.targetclass.mixed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class PostConstructOnTargetClassAndOutsideAndSuperclassesTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        ArcContainer arc = Arc.container();
+        arc.instance(MyBean.class);
+        assertEquals(List.of("MyInterceptorSuperclass", "MyInterceptor", "MyBeanSuperclass", "MyBean"), MyBean.invocations);
+    }
+
+    static class MyBeanSuperclass {
+        @PostConstruct
+        void superPostConstruct() {
+            MyBean.invocations.add(MyBeanSuperclass.class.getSimpleName());
+        }
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean extends MyBeanSuperclass {
+        static final List<String> invocations = new ArrayList<>();
+
+        @PostConstruct
+        void postConstruct() {
+            invocations.add(MyBean.class.getSimpleName());
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    public @interface MyInterceptorBinding {
+    }
+
+    static class MyInterceptorSuperclass {
+        @PostConstruct
+        void superPostConstruct(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(MyInterceptorSuperclass.class.getSimpleName());
+            ctx.proceed();
+        }
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    public static class MyInterceptor extends MyInterceptorSuperclass {
+        @PostConstruct
+        Object postConstruct(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(MyInterceptor.class.getSimpleName());
+            return ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PostConstructOnTargetClassAndOutsideAndSuperclassesWithOverridesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PostConstructOnTargetClassAndOutsideAndSuperclassesWithOverridesTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.arc.test.interceptors.targetclass.mixed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class PostConstructOnTargetClassAndOutsideAndSuperclassesWithOverridesTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        ArcContainer arc = Arc.container();
+        arc.instance(MyBean.class);
+        assertEquals(List.of("MyInterceptorSuperclass", "MyInterceptor", "MyBean"), MyBean.invocations);
+    }
+
+    static class MyBeanSuperclass {
+        @PostConstruct
+        void postConstruct() {
+            MyBean.invocations.add("this should not be called as the method is overridden in MyBean");
+        }
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean extends MyBeanSuperclass {
+        static final List<String> invocations = new ArrayList<>();
+
+        @PostConstruct
+        @Override
+        void postConstruct() {
+            invocations.add(MyBean.class.getSimpleName());
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    public @interface MyInterceptorBinding {
+    }
+
+    static class MyInterceptorSuperclass {
+        @PostConstruct
+        void superPostConstruct(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(MyInterceptorSuperclass.class.getSimpleName());
+            ctx.proceed();
+        }
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    public static class MyInterceptor extends MyInterceptorSuperclass {
+        @PostConstruct
+        Object postConstruct(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(MyInterceptor.class.getSimpleName());
+            return ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PostConstructOnTargetClassAndOutsideTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PostConstructOnTargetClassAndOutsideTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.arc.test.interceptors.targetclass.mixed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class PostConstructOnTargetClassAndOutsideTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        ArcContainer arc = Arc.container();
+        arc.instance(MyBean.class);
+        assertEquals(List.of("MyInterceptor", "MyBean"), MyBean.invocations);
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean {
+        static final List<String> invocations = new ArrayList<>();
+
+        @PostConstruct
+        void postConstruct() {
+            invocations.add(MyBean.class.getSimpleName());
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    public @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    public static class MyInterceptor {
+        @PostConstruct
+        Object postConstruct(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(MyInterceptor.class.getSimpleName());
+            return ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PreDestroyInterceptorNestingTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PreDestroyInterceptorNestingTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.arc.test.interceptors.targetclass.mixed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class PreDestroyInterceptorNestingTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        ArcContainer arc = Arc.container();
+        arc.instance(MyBean.class).destroy();
+        assertEquals(List.of("MyInterceptor", "MyBean", "expected-exception"), MyBean.invocations);
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean {
+        static final List<String> invocations = new ArrayList<>();
+
+        @PreDestroy
+        void preDestroy() {
+            invocations.add(MyBean.class.getSimpleName());
+            throw new IllegalArgumentException("intentional");
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    public @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    public static class MyInterceptor {
+        @PreDestroy
+        void preDestroy(InvocationContext ctx) throws Exception {
+            try {
+                MyBean.invocations.add(MyInterceptor.class.getSimpleName());
+                ctx.proceed();
+            } catch (IllegalArgumentException e) {
+                MyBean.invocations.add("expected-exception");
+            }
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PreDestroyOnTargetClassAndOutsideAndManySuperclassesWithOverridesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PreDestroyOnTargetClassAndOutsideAndManySuperclassesWithOverridesTest.java
@@ -1,0 +1,121 @@
+package io.quarkus.arc.test.interceptors.targetclass.mixed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class PreDestroyOnTargetClassAndOutsideAndManySuperclassesWithOverridesTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        ArcContainer arc = Arc.container();
+        arc.instance(MyBean.class).destroy();
+        assertEquals(List.of("Foxtrot", "MyInterceptor", "Charlie", "MyBean"), MyBean.invocations);
+    }
+
+    static class Alpha {
+        @PreDestroy
+        void intercept() throws Exception {
+            MyBean.invocations.add("this should not be called as the method is overridden in MyBean");
+        }
+    }
+
+    static class Bravo extends Alpha {
+        @PreDestroy
+        void specialIntercept() {
+            MyBean.invocations.add("this should not be called as the method is overridden in Charlie");
+        }
+    }
+
+    static class Charlie extends Bravo {
+        @PreDestroy
+        void superIntercept() throws Exception {
+            MyBean.invocations.add(Charlie.class.getSimpleName());
+        }
+
+        @Override
+        void specialIntercept() {
+            MyBean.invocations.add("this is not an interceptor method");
+        }
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean extends Charlie {
+        static final List<String> invocations = new ArrayList<>();
+
+        @Override
+        @PreDestroy
+        void intercept() throws Exception {
+            invocations.add(MyBean.class.getSimpleName());
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    static class Delta {
+        @PreDestroy
+        Object intercept(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add("this should not be called as the method is overridden in MyInterceptor");
+            return ctx.proceed();
+        }
+    }
+
+    static class Echo extends Delta {
+        @PreDestroy
+        void specialIntercept(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add("this should not be called as the method is overridden in Foxtrot");
+        }
+    }
+
+    static class Foxtrot extends Echo {
+        @PreDestroy
+        Object superIntercept(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(Foxtrot.class.getSimpleName());
+            return ctx.proceed();
+        }
+
+        @Override
+        void specialIntercept(InvocationContext ctx) {
+            MyBean.invocations.add("this is not an interceptor method");
+        }
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor extends Foxtrot {
+        @PreDestroy
+        Object intercept(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(MyInterceptor.class.getSimpleName());
+            return ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PreDestroyOnTargetClassAndOutsideAndSuperclassesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PreDestroyOnTargetClassAndOutsideAndSuperclassesTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.arc.test.interceptors.targetclass.mixed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class PreDestroyOnTargetClassAndOutsideAndSuperclassesTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        ArcContainer arc = Arc.container();
+        arc.instance(MyBean.class).destroy();
+        assertEquals(List.of("MyInterceptorSuperclass", "MyInterceptor", "MyBeanSuperclass", "MyBean"), MyBean.invocations);
+    }
+
+    static class MyBeanSuperclass {
+        @PreDestroy
+        void superPreDestroy() {
+            MyBean.invocations.add(MyBeanSuperclass.class.getSimpleName());
+        }
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean extends MyBeanSuperclass {
+        static final List<String> invocations = new ArrayList<>();
+
+        @PreDestroy
+        void preDestroy() {
+            invocations.add(MyBean.class.getSimpleName());
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    public @interface MyInterceptorBinding {
+    }
+
+    static class MyInterceptorSuperclass {
+        @PreDestroy
+        void superPreDestroy(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(MyInterceptorSuperclass.class.getSimpleName());
+            ctx.proceed();
+        }
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    public static class MyInterceptor extends MyInterceptorSuperclass {
+        @PreDestroy
+        Object preDestroy(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(MyInterceptor.class.getSimpleName());
+            return ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PreDestroyOnTargetClassAndOutsideAndSuperclassesWithOverridesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PreDestroyOnTargetClassAndOutsideAndSuperclassesWithOverridesTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.arc.test.interceptors.targetclass.mixed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class PreDestroyOnTargetClassAndOutsideAndSuperclassesWithOverridesTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        ArcContainer arc = Arc.container();
+        arc.instance(MyBean.class).destroy();
+        assertEquals(List.of("MyInterceptorSuperclass", "MyInterceptor", "MyBean"), MyBean.invocations);
+    }
+
+    static class MyBeanSuperclass {
+        @PreDestroy
+        void preDestroy() {
+            MyBean.invocations.add("this should not be called as the method is overridden in MyBean");
+        }
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean extends MyBeanSuperclass {
+        static final List<String> invocations = new ArrayList<>();
+
+        @PreDestroy
+        @Override
+        void preDestroy() {
+            invocations.add(MyBean.class.getSimpleName());
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    public @interface MyInterceptorBinding {
+    }
+
+    static class MyInterceptorSuperclass {
+        @PreDestroy
+        void superPreDestroy(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(MyInterceptorSuperclass.class.getSimpleName());
+            ctx.proceed();
+        }
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    public static class MyInterceptor extends MyInterceptorSuperclass {
+        @PreDestroy
+        Object preDestroy(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(MyInterceptor.class.getSimpleName());
+            return ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PreDestroyOnTargetClassAndOutsideTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/targetclass/mixed/PreDestroyOnTargetClassAndOutsideTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.arc.test.interceptors.targetclass.mixed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class PreDestroyOnTargetClassAndOutsideTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        ArcContainer arc = Arc.container();
+        arc.instance(MyBean.class).destroy();
+        assertEquals(List.of("MyInterceptor", "MyBean"), MyBean.invocations);
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean {
+        static final List<String> invocations = new ArrayList<>();
+
+        @PreDestroy
+        void preDestroy() {
+            invocations.add(MyBean.class.getSimpleName());
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    public @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    public static class MyInterceptor {
+        @PreDestroy
+        Object preDestroy(InvocationContext ctx) throws Exception {
+            MyBean.invocations.add(MyInterceptor.class.getSimpleName());
+            return ctx.proceed();
+        }
+    }
+}


### PR DESCRIPTION
Related to #28558

- remove superfluous CDI TCK exclusions
- fix merging `@AroundConstruct` interceptor bindings
- validate non-`@Repeatable` interceptor bindings for member values conflicts
  - we allow `@Repeatable` bindings to have different member values, as repeatability is their entire point
  - this has a bit of code duplication :-/
- fix class-level interceptor bindings search to always look at stereotypes
- fix searching for bindings on an interceptor declaration to also look for inherited bindings
- fix interceptor method "nesting" for `@PostConstruct`/`@PreDestroy` interceptors
- fix bean creation in presence of `@AroundConstruct` interceptors
- fix wrapping exceptions thrown by `@AroundConstruct` and `@PostConstruct` interceptors
- fix generated `Bean.destroy()` in case a user directly passes in a client proxy