### PR TITLE
Exclude gradle-wrapper/.gradle dir from the codestarts artifact

### DIFF
--- a/devtools/project-core-extension-codestarts/pom.xml
+++ b/devtools/project-core-extension-codestarts/pom.xml
@@ -27,6 +27,19 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <configuration>
+                        <excludes>
+                            <exclude>gradle-wrapper/.gradle/**</exclude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This dir isn't necessary and will help with Quarkus Gradle build caching.