### PR TITLE
Use Maven 3.9.1 in generated projects

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -63,7 +63,7 @@
         <supported-maven-versions>[3.8.2,)</supported-maven-versions>
 
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
-        <proposed-maven-version>3.8.8</proposed-maven-version>
+        <proposed-maven-version>3.9.1</proposed-maven-version>
         <maven-wrapper.version>3.2.0</maven-wrapper.version>
         <gradle-wrapper.version>8.1</gradle-wrapper.version>
         <quarkus-gradle-plugin.version>${project.version}</quarkus-gradle-plugin.version>


### PR DESCRIPTION
Now that we support it, let's make it the default for 3.1.