### PR TITLE
Fix resteasy-reactive-client hostname verification default

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientConfig.java
@@ -139,7 +139,8 @@ public class RestClientConfig {
     public Optional<QueryParamStyle> queryParamStyle;
 
     /**
-     * Set whether hostname verification is enabled.
+     * Set whether hostname verification is enabled. Default is enabled.
+     * This setting should not be disabled in production as it makes the client vulnerable to MITM attacks.
      */
     @ConfigItem
     public Optional<Boolean> verifyHost;

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -227,7 +227,8 @@ public class RestClientsConfig {
     public Optional<QueryParamStyle> queryParamStyle;
 
     /**
-     * Set whether hostname verification is enabled.
+     * Set whether hostname verification is enabled. Default is enabled.
+     * This setting should not be disabled in production as it makes the client vulnerable to MITM attacks.
      *
      * Can be overwritten by client-specific settings.
      */

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ConfigurationTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ConfigurationTest.java
@@ -78,9 +78,6 @@ public class ConfigurationTest {
         assertThat(clientConfig.followRedirects.get()).isEqualTo(true);
         assertThat(clientConfig.queryParamStyle).isPresent();
         assertThat(clientConfig.queryParamStyle.get()).isEqualTo(QueryParamStyle.COMMA_SEPARATED);
-        assertThat(clientConfig.hostnameVerifier).isPresent();
-        assertThat(clientConfig.hostnameVerifier.get())
-                .isEqualTo("io.quarkus.rest.client.reactive.HelloClientWithBaseUri$MyHostnameVerifier");
 
         if (checkExtraProperties) {
             assertThat(clientConfig.connectionTTL).isPresent();

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/GlobalConfigurationTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/GlobalConfigurationTest.java
@@ -64,8 +64,6 @@ public class GlobalConfigurationTest {
         assertThat(configRoot.readTimeout).isEqualTo(2001);
         assertThat(configRoot.userAgent.get()).isEqualTo("agent");
         assertThat(configRoot.headers).isEqualTo(Collections.singletonMap("foo", "bar"));
-        assertThat(configRoot.hostnameVerifier.get())
-                .isEqualTo("io.quarkus.rest.client.reactive.HelloClientWithBaseUri$MyHostnameVerifier");
         assertThat(configRoot.connectionTTL.get()).isEqualTo(20000); // value in ms, will be converted to seconds
         assertThat(configRoot.connectionPoolSize.get()).isEqualTo(2);
         assertThat(configRoot.keepAliveEnabled.get()).isTrue();

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/HelloClientWithBaseUri.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/HelloClientWithBaseUri.java
@@ -1,8 +1,5 @@
 package io.quarkus.rest.client.reactive;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSession;
-
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -28,13 +25,6 @@ public interface HelloClientWithBaseUri {
     class MyResponseFilter implements ClientResponseFilter {
         @Override
         public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) {
-        }
-    }
-
-    class MyHostnameVerifier implements HostnameVerifier {
-        @Override
-        public boolean verify(String hostname, SSLSession session) {
-            return true;
         }
     }
 

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/configuration-test-application.properties
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/configuration-test-application.properties
@@ -2,7 +2,6 @@
 io.quarkus.rest.client.reactive.HelloClientWithBaseUri/mp-rest/url=http://localhost:${quarkus.http.test-port:8081}/invalid-endpoint
 io.quarkus.rest.client.reactive.HelloClientWithBaseUri/mp-rest/scope=InvalidScope
 io.quarkus.rest.client.reactive.HelloClientWithBaseUri/mp-rest/providers=InvalidProvider
-io.quarkus.rest.client.reactive.HelloClientWithBaseUri/mp-rest/hostnameVerifier=InvalidVerifier
 
 # client identified by class name
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".url=http://localhost:${quarkus.http.test-port:8081}/hello
@@ -13,7 +12,6 @@ quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".rea
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".follow-redirects=true
 #quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".proxy-address=localhost:8080
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".query-param-style=COMMA_SEPARATED
-quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".hostname-verifier=io.quarkus.rest.client.reactive.HelloClientWithBaseUri$MyHostnameVerifier
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".connection-ttl=30000
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".connection-pool-size=10
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".keep-alive-enabled=false
@@ -30,7 +28,6 @@ quarkus.rest-client.client-prefix.read-timeout=6000
 quarkus.rest-client.client-prefix.follow-redirects=true
 quarkus.rest-client.client-prefix.proxy-address=localhost:8080
 quarkus.rest-client.client-prefix.query-param-style=COMMA_SEPARATED
-quarkus.rest-client.client-prefix.hostname-verifier=io.quarkus.rest.client.reactive.HelloClientWithBaseUri$MyHostnameVerifier
 quarkus.rest-client.client-prefix.connection-ttl=30000
 quarkus.rest-client.client-prefix.connection-pool-size=10
 quarkus.rest-client.client-prefix.keep-alive-enabled=false
@@ -54,4 +51,3 @@ mp-client-prefix/mp-rest/readTimeout=6000
 mp-client-prefix/mp-rest/followRedirects=true
 mp-client-prefix/mp-rest/proxyAddress=localhost:8080
 mp-client-prefix/mp-rest/queryParamStyle=COMMA_SEPARATED
-mp-client-prefix/mp-rest/hostnameVerifier=io.quarkus.rest.client.reactive.HelloClientWithBaseUri$MyHostnameVerifier

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/global-configuration-test-application.properties
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/global-configuration-test-application.properties
@@ -18,7 +18,6 @@ quarkus.rest-client.connect-timeout=2000
 quarkus.rest-client.read-timeout=2001
 quarkus.rest-client.user-agent=agent
 quarkus.rest-client.headers.foo=bar
-quarkus.rest-client.hostname-verifier=io.quarkus.rest.client.reactive.HelloClientWithBaseUri$MyHostnameVerifier
 quarkus.rest-client.connection-ttl=20000
 quarkus.rest-client.connection-pool-size=2
 quarkus.rest-client.keep-alive-enabled=true

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
@@ -12,9 +12,6 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSession;
-
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientResponseContext;
 import jakarta.ws.rs.client.ClientResponseFilter;
@@ -102,7 +99,6 @@ public class RestClientCDIDelegateBuilderTest {
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.USER_AGENT, "agent1");
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.STATIC_HEADERS,
                 Collections.singletonMap("header1", "value"));
-        Mockito.verify(restClientBuilderMock).hostnameVerifier(Mockito.any(MyHostnameVerifier1.class));
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.CONNECTION_TTL, 10); // value converted to seconds
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.CONNECTION_POOL_SIZE, 103);
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.KEEP_ALIVE_ENABLED, false);
@@ -145,7 +141,6 @@ public class RestClientCDIDelegateBuilderTest {
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.USER_AGENT, "agent2");
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.STATIC_HEADERS,
                 Collections.singletonMap("header2", "value"));
-        Mockito.verify(restClientBuilderMock).hostnameVerifier(Mockito.any(MyHostnameVerifier2.class));
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.CONNECTION_TTL, 20);
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.CONNECTION_POOL_SIZE, 203);
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.KEEP_ALIVE_ENABLED, true);
@@ -174,8 +169,6 @@ public class RestClientCDIDelegateBuilderTest {
         configRoot.readTimeout = 201L;
         configRoot.userAgent = Optional.of("agent2");
         configRoot.headers = Collections.singletonMap("header2", "value");
-        configRoot.hostnameVerifier = Optional
-                .of("io.quarkus.rest.client.reactive.runtime.RestClientCDIDelegateBuilderTest$MyHostnameVerifier2");
         configRoot.connectionTTL = Optional.of(20000); // value in ms, will be converted to seconds
         configRoot.connectionPoolSize = Optional.of(203);
         configRoot.keepAliveEnabled = Optional.of(true);
@@ -213,8 +206,6 @@ public class RestClientCDIDelegateBuilderTest {
         clientConfig.readTimeout = Optional.of(101L);
         clientConfig.userAgent = Optional.of("agent1");
         clientConfig.headers = Collections.singletonMap("header1", "value");
-        clientConfig.hostnameVerifier = Optional
-                .of("io.quarkus.rest.client.reactive.runtime.RestClientCDIDelegateBuilderTest$MyHostnameVerifier1");
         clientConfig.connectionTTL = Optional.of(10000); // value in milliseconds, will be converted to seconds
         clientConfig.connectionPoolSize = Optional.of(103);
         clientConfig.keepAliveEnabled = Optional.of(false);
@@ -249,20 +240,6 @@ public class RestClientCDIDelegateBuilderTest {
     public static class MyResponseFilter2 implements ClientResponseFilter {
         @Override
         public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) {
-        }
-    }
-
-    public static class MyHostnameVerifier1 implements HostnameVerifier {
-        @Override
-        public boolean verify(String hostname, SSLSession session) {
-            return true;
-        }
-    }
-
-    public static class MyHostnameVerifier2 implements HostnameVerifier {
-        @Override
-        public boolean verify(String hostname, SSLSession session) {
-            return true;
         }
     }
 

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
@@ -91,7 +91,7 @@ public class ClientBuilderImpl extends ClientBuilder {
     @Override
     public ClientBuilder sslContext(SSLContext sslContext) {
         // TODO
-        throw new RuntimeException("Specifying SSLContext is not supported at the moment");
+        throw new UnsupportedOperationException("Specifying SSLContext is not supported at the moment");
     }
 
     @Override
@@ -114,8 +114,8 @@ public class ClientBuilderImpl extends ClientBuilder {
 
     @Override
     public ClientBuilder hostnameVerifier(HostnameVerifier verifier) {
-        this.hostnameVerifier = verifier;
-        return this;
+        // TODO
+        throw new UnsupportedOperationException("Specifying HostnameVerifier is not supported at the moment");
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
@@ -67,7 +67,7 @@ public class ClientBuilderImpl extends ClientBuilder {
 
     private boolean followRedirects;
     private boolean trustAll;
-    private boolean verifyHost;
+    private boolean verifyHost = true;
 
     private LoggingScope loggingScope;
     private Integer loggingBodySize = 100;

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ClientCallingResource.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ClientCallingResource.java
@@ -22,6 +22,7 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.quarkus.it.rest.client.main.MyResponseExceptionMapper.MyException;
 import io.quarkus.it.rest.client.main.selfsigned.ExternalSelfSignedClient;
 import io.quarkus.it.rest.client.main.wronghost.WrongHostClient;
+import io.quarkus.it.rest.client.main.wronghost.WrongHostRejectedClient;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Future;
@@ -51,6 +52,9 @@ public class ClientCallingResource {
 
     @RestClient
     WrongHostClient wrongHostClient;
+
+    @RestClient
+    WrongHostRejectedClient wrongHostRejectedClient;
 
     @Inject
     InMemorySpanExporter inMemorySpanExporter;
@@ -198,6 +202,15 @@ public class ClientCallingResource {
 
         router.get("/wrong-host").blockingHandler(
                 rc -> rc.response().setStatusCode(200).end(String.valueOf(wrongHostClient.invoke().getStatus())));
+
+        router.get("/wrong-host-rejected").blockingHandler(rc -> {
+            try {
+                int result = wrongHostRejectedClient.invoke().getStatus();
+                rc.response().setStatusCode(200).end(String.valueOf(result));
+            } catch (Exception e) {
+                rc.response().setStatusCode(500).end(e.getCause().getClass().getSimpleName());
+            }
+        });
     }
 
     private Future<Void> success(RoutingContext rc, String body) {

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/wronghost/WrongHostRejectedClient.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/wronghost/WrongHostRejectedClient.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.rest.client.main.wronghost;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(baseUri = "https://wrong.host.badssl.com/", configKey = "wrong-host-rejected")
+public interface WrongHostRejectedClient {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    Response invoke();
+}

--- a/integration-tests/rest-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/rest-client-reactive/src/main/resources/application.properties
@@ -5,7 +5,10 @@ io.quarkus.it.rest.client.multipart.MultipartClient/mp-rest/url=${test.url}
 # Self-Signed client
 quarkus.rest-client.self-signed.trust-store=${self-signed.trust-store}
 quarkus.rest-client.self-signed.trust-store-password=${self-signed.trust-store-password}
-# Wrong Host client
+# Wrong Host client (connection accepted, as host verification is turned off)
 quarkus.rest-client.wrong-host.trust-store=${wrong-host.trust-store}
 quarkus.rest-client.wrong-host.trust-store-password=${wrong-host.trust-store-password}
 quarkus.rest-client.wrong-host.verify-host=false
+# Wrong Host client verified (connection rejected, as host verification is turned on by default)
+quarkus.rest-client.wrong-host-rejected.trust-store=${wrong-host.trust-store}
+quarkus.rest-client.wrong-host-rejected.trust-store-password=${wrong-host.trust-store-password}

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestCase.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestCase.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.rest.client.wronghost;
 
 import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
@@ -16,5 +17,14 @@ public class ExternalWrongHostTestCase {
                 .then()
                 .statusCode(200)
                 .body(is("200"));
+    }
+
+    @Test
+    public void restClientRejected() {
+        when()
+                .get("/wrong-host-rejected")
+                .then()
+                .statusCode(500)
+                .body(containsString("SSLHandshakeException"));
     }
 }


### PR DESCRIPTION
Since introduction of the setting [`verifyHost` in `2.15.0.Final`](https://github.com/quarkusio/quarkus/issues/27901) the hostname verification was disabled by default for the `resteasy-reactive-client`, as the [default value for `boolean` in Java](https://docs.oracle.com/javase/specs/jls/se17/html/jls-4.html#jls-4.12.5) (primitive) is `false`.
https://github.com/gsmet/quarkus/commit/941d3a6f7a1857d01a1a2b0eada67e3628895c0c#diff-28d8221e6b920ee90f85249d3c250b932c207d6b2099fc9377984d7f550fe28d

A better configuration name value would have been a negated name like `disableHostnameVerification`, but renaming it is no longer possible as it would break compatibility.

This disabled default currently makes the reactive client vulnerable to MITM attacks. 
E.g. the following [rest client builder from the documentation](https://quarkus.io/guides/rest-client-reactive#programmatic-client-creation-with-restclientbuilder) with `quarkus-rest-client-reactive-jackson` is vulnerable, as it does not fail during the SSL handshake:
```java
RestClientBuilder.newBuilder()
    .baseUri(URI.create("https://wrong.host.badssl.com"))
    .build(WrongHostClient.class);
```
The expected exception has the cause `javax.net.ssl.SSLHandshakeException`. The test case `ExternalWrongHostTestCase.java` currently only tests the disabling of hostname verification but not for a default secure behaviour.

In the meantime setting the config explicitly is a workaround e.g. with `quarkus.rest-client.verify-host=true`.
This enables hostname verification again also for the reactive client. But the default of Quarkus should instead be secure!

This change now adds a proper default both in the configuration and assigns safe initial values for the fields in the reactive client builder implementation.

Both custom `HostnameVerifier` and `SSLContext` are currently not supported by resteasy-reactive-client. 
This is documented as [known limitations](https://quarkus.io/guides/rest-client-reactive#known-limitations). 

This change also aligns the implementation for both to the already present state for `SSLContext`. 
It makes the builder fail when `HostnameVerifier` is tried to be configured. The benefit is that it fails as early as
currently possible and not only when the custom hostname verification would be needed later on.

The general need for the configuration option of a custom hostname verifier still stays relevant, as it was also requested in https://github.com/quarkusio/quarkus/issues/27901. Currently just having the possibility to completely disable hostname verification is preventing the chance to supply a suitable customised hostname verifier that implements custom verification rules.