### PR TITLE
Use configured principal claim when the token is verified with UserInfo

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
@@ -40,6 +40,7 @@ public class KnownOidcProviders {
         ret.getAuthentication().setUserInfoRequired(true);
         ret.getAuthentication().setIdTokenRequired(false);
         ret.getToken().setVerifyAccessTokenWithUserInfo(true);
+        ret.getToken().setPrincipalClaim("name");
         return ret;
     }
 

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -51,6 +51,7 @@ public class OidcUtilsTest {
         assertTrue(config.authentication.userInfoRequired.get());
         assertTrue(config.token.verifyAccessTokenWithUserInfo.get());
         assertEquals(List.of("user:email"), config.authentication.scopes.get());
+        assertEquals("name", config.getToken().getPrincipalClaim().get());
     }
 
     @Test
@@ -69,6 +70,7 @@ public class OidcUtilsTest {
         tenant.authentication.setUserInfoRequired(false);
         tenant.token.setVerifyAccessTokenWithUserInfo(false);
         tenant.authentication.setScopes(List.of("write"));
+        tenant.token.setPrincipalClaim("firstname");
 
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.GITHUB));
 
@@ -84,6 +86,7 @@ public class OidcUtilsTest {
         assertFalse(config.authentication.userInfoRequired.get());
         assertFalse(config.token.verifyAccessTokenWithUserInfo.get());
         assertEquals(List.of("write"), config.authentication.scopes.get());
+        assertEquals("firstname", config.getToken().getPrincipalClaim().get());
     }
 
     @Test

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
@@ -21,7 +21,6 @@ public class CustomSecurityIdentityAugmentor implements SecurityIdentityAugmento
         if (routingContext != null &&
                 (routingContext.normalizedPath().endsWith("code-flow-user-info-only")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-github")
-                        || routingContext.normalizedPath().endsWith("bearer-user-info-github-service")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-dynamic-github")
                         || routingContext.normalizedPath().endsWith("code-flow-token-introspection")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-github-cached-in-idtoken"))) {

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -73,6 +73,7 @@ quarkus.oidc.code-flow-user-info-github.client-id=quarkus-web-app
 quarkus.oidc.code-flow-user-info-github.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 
 quarkus.oidc.bearer-user-info-github-service.provider=github
+quarkus.oidc.bearer-user-info-github-service.token.principal-claim=preferred_username
 quarkus.oidc.bearer-user-info-github-service.token.verify-access-token-with-user-info=true
 quarkus.oidc.bearer-user-info-github-service.token.allow-jwt-introspection=false
 quarkus.oidc.bearer-user-info-github-service.application-type=service


### PR DESCRIPTION
When the binary token is verified indirectly, via `UserInfo` acquisition, one has to augment the identity with a custom `Principal` which picks up a correct principal name from `UserInfo`, as the test augmentor shows, for `SecurityIdentity.getPrincipal().getName()` return an expected value.

So this PR does the following:
- `OidcIdentityProvider`: if it is a case of the binary token being verified via `UserInfo` - get a configured `quarkus.oidc.token.principal-name` out of `UserInfo` - `UserInfo` is the only source of information.
- This is a little bit orthogonal, but Github, like Google, has a `name` property in its UserInfo, but no `preferred_username`/etc available in Keycloak tokens, so I updated the `github` config to set the principal claim as `name`, same as I did a few PRs back for Google.
- And then this PR updates the test for one of the tenants, which wiremocks a github binary token, by updating the test augmentor not to do anything for this tenant, while also verifying that overriding the preconfigured github principal claim `name` works (have to be done for the test anyway as the test tokens have `preferred_username` but no `name`).

So with this PR, can just do: 
```
@Inject SecurityIdentity id;

return id.getPrincipal.getName(); 
```

instead of 1) transition to the UserInfo injection 2) modify the augmentor to create a custom Principal