### PR TITLE
Make it simpler to get well-known properties from UserInfo

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/UserInfo.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/UserInfo.java
@@ -2,9 +2,16 @@ package io.quarkus.oidc;
 
 import jakarta.json.JsonObject;
 
+import org.eclipse.microprofile.jwt.Claims;
+
 import io.quarkus.oidc.runtime.AbstractJsonObjectResponse;
 
 public class UserInfo extends AbstractJsonObjectResponse {
+
+    private static final String EMAIL = "email";
+    private static final String NAME = "name";
+    private static final String FIRST_NAME = "first_name";
+    private static final String FAMILY_NAME = "family_name";
 
     public UserInfo() {
     }
@@ -19,5 +26,29 @@ public class UserInfo extends AbstractJsonObjectResponse {
 
     public String getUserInfoString() {
         return getNonNullJsonString();
+    }
+
+    public String getName() {
+        return getString(NAME);
+    }
+
+    public String getFirstName() {
+        return getString(FIRST_NAME);
+    }
+
+    public String getFamilyName() {
+        return getString(FAMILY_NAME);
+    }
+
+    public String getPreferredUserName() {
+        return getString(Claims.preferred_username.name());
+    }
+
+    public String getSubject() {
+        return getString(Claims.sub.name());
+    }
+
+    public String getEmail() {
+        return getString(EMAIL);
     }
 }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/UserInfoTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/UserInfoTest.java
@@ -15,13 +15,48 @@ import io.quarkus.oidc.UserInfo;
 public class UserInfoTest {
     UserInfo userInfo = new UserInfo(
             "{"
+                    + "\"sub\": \"alice123456\","
                     + "\"name\": \"alice\","
+                    + "\"first_name\": \"Alice\","
+                    + "\"family_name\": \"Alice\","
+                    + "\"preferred_username\": \"Alice Alice\","
+                    + "\"email\": \"alice@email.com\","
                     + "\"admin\": true,"
-                    + "\"email\": null,"
+                    + "\"custom\": null,"
                     + "\"id\": 1234,"
                     + "\"permissions\": [\"read\", \"write\"],"
                     + "\"scopes\": {\"scope\": \"see\"}"
                     + "}");
+
+    @Test
+    public void testGetName() {
+        assertEquals("alice", userInfo.getName());
+    }
+
+    @Test
+    public void testGetFirstName() {
+        assertEquals("Alice", userInfo.getFirstName());
+    }
+
+    @Test
+    public void testGetFamilyName() {
+        assertEquals("Alice", userInfo.getFamilyName());
+    }
+
+    @Test
+    public void testPreferredName() {
+        assertEquals("Alice Alice", userInfo.getPreferredUserName());
+    }
+
+    @Test
+    public void testGetEmail() {
+        assertEquals("alice@email.com", userInfo.getEmail());
+    }
+
+    @Test
+    public void testGetSubject() {
+        assertEquals("alice123456", userInfo.getSubject());
+    }
 
     @Test
     public void testGetString() {
@@ -62,6 +97,6 @@ public class UserInfoTest {
 
     @Test
     public void testGetNullProperty() {
-        assertNull(userInfo.getString("email"));
+        assertNull(userInfo.getString("custom"));
     }
 }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
@@ -33,7 +33,7 @@ public class CodeFlowUserInfoResource {
     public String access() {
         int cacheSize = tokenCache.getCacheSize();
         tokenCache.clearCache();
-        return identity.getPrincipal().getName() + ":" + userInfo.getString("preferred_username") + ":" + accessToken.getName()
+        return identity.getPrincipal().getName() + ":" + userInfo.getPreferredUserName() + ":" + accessToken.getName()
                 + ", cache size: "
                 + cacheSize;
     }


### PR DESCRIPTION
Right now it is not quite cool to demo a transition from

```
@Inject
JsonWebToken jwt;

public String getName() {
    return jwt.getName();
}
```

to 

```
@Inject
UserInfo userInfo;

public String getName() {
    return userInfo.getString("name");
}
```

JWT tokens have been specified to have some known claims but UserInfo has not, though typically its properties would be named the same as well-known  JWT token claims.
So I've started with adding a few typed methods to get some well-known properties as  shown here:
https://openid.net/specs/openid-connect-core-1_0.html#UserInfo

The updated integration test also shows it is getting simpler 
