### PR TITLE
Have OIDC DevUI web-app function included with quarkus.oidc.provider

### DIFF
--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -291,9 +291,7 @@ var port = {config:property('quarkus.http.port')};
 
     {/if}
     
-{/if}
-
-{#if info:oidcApplicationType is 'web-app'}
+{#else}
 function signInToService(servicePath) {
     window.open("http://localhost:" + port + servicePath);
 }


### PR DESCRIPTION
This is a minor tweak to OIDC DevUI `provider.html` to have a function dealing with `quarkus.oidc.application-type=web-app` included in the produced script, when we only have something like `quarkus.oidc.provider=google` etc.

With `quarkus.oidc.provider=google` only, the `application-type=web-app` is set internally on `OidcTenantConfig`.
Build steps can detect it, but `provider.html` itself sees `info:oidcApplicationType` prepared by the build step only if `quarkus.oidc.application-type` is explicitly set in `application.properties`. Looks like the scripts are resolved early, before the build step (`OidcDevConsoleProcessor`) prepares  `info:oidcApplicationType` by fetching the correct value from `OidcTenantConfig` created from `quarkus.oidc.provider=google`.

So the solution I've come up with is this, the top branch in `provider.html` checks if is the type is either `service` or `hybrid` and now, instead of also checking if it is `web-app` I just do `else` - it can only be `web-app` in this branch because we only have 3 application types. 

And now  `quarkus.oidc.application-type=web-app`  is working correctly for `quarkus.oidc.provider=google` .
This is not a proper fix, kind of a hack, but it is safe nonetheless, it will work fine for explicitly declared `quarkus.oidc.application-type`.

The other thing is that testing `web-app` from Dev UI is not useful - since Quarkus is in control of the flow (i.e, once the authentication is complete, the control is not returned back to DevUI, it stays with the browser), but for the purpose of the demo, it can be useful to show it and thus explain why `quarkus.oidc.provider=google` should have an extra `quarkus.oidc.application-type=service` (or `hybrid`) property in `application.properties` for it to be tested from SPA such as Dev UI