### PR TITLE
Fix native compilation when using the kafka-client without netty

### DIFF
--- a/extensions/kafka-client/runtime/pom.xml
+++ b/extensions/kafka-client/runtime/pom.xml
@@ -62,6 +62,8 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http-dev-console-runtime-spi</artifactId>
+            <!-- avoid the native compilation to fail because this would pull netty, without the extension -->
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fix #32968