### PR TITLE
Arc: Implement validation for various erroneous cases of bean metadata, re-enable TCK tests

### DIFF
--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/DefaultScopeTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/DefaultScopeTest.java
@@ -55,9 +55,9 @@ public class DefaultScopeTest {
     public static class NoScopeButResource {
 
         @Inject
-        Bean<NoScope> bean;
+        Bean<NoScopeButResource> bean;
 
-        public Bean<NoScope> getBean() {
+        public Bean<NoScopeButResource> getBean() {
             return bean;
         }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -1154,7 +1154,7 @@ public class BeanDeployment {
             BeanInfo declaringBean = beanClassToBean.get(disposerMethod.declaringClass());
             if (declaringBean != null) {
                 Injection injection = Injection.forDisposer(disposerMethod, declaringBean.getImplClazz(), this,
-                        injectionPointTransformer, declaringBean);
+                        injectionPointTransformer);
                 injection.init(declaringBean);
                 disposers.add(new DisposerInfo(declaringBean, disposerMethod, injection));
                 injectionPoints.addAll(injection.injectionPoints);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -189,7 +189,8 @@ public final class Beans {
                     + "its scope must be @Dependent: " + producerMethod);
         }
 
-        List<Injection> injections = Injection.forBean(producerMethod, declaringBean, beanDeployment, transformer);
+        List<Injection> injections = Injection.forBean(producerMethod, declaringBean, beanDeployment, transformer,
+                Injection.BeanType.PRODUCER_METHOD);
         BeanInfo bean = new BeanInfo(producerMethod, beanDeployment, scope, beanTypes, qualifiers, injections, declaringBean,
                 disposer, isAlternative, stereotypes, name, isDefaultBean, null, priority);
         for (Injection injection : injections) {
@@ -1293,7 +1294,8 @@ public final class Beans {
                 }
             }
 
-            List<Injection> injections = Injection.forBean(beanClass, null, beanDeployment, transformer);
+            List<Injection> injections = Injection.forBean(beanClass, null, beanDeployment, transformer,
+                    Injection.BeanType.MANAGED_BEAN);
             BeanInfo bean = new BeanInfo(beanClass, beanDeployment, scope, types, qualifiers,
                     injections, null, null, isAlternative, stereotypes, name, isDefaultBean, null, priority);
             for (Injection injection : injections) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Decorators.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Decorators.java
@@ -31,7 +31,8 @@ final class Decorators {
 
         // Find the delegate injection point
         List<InjectionPointInfo> delegateInjectionPoints = new LinkedList<>();
-        List<Injection> injections = Injection.forBean(decoratorClass, null, beanDeployment, transformer);
+        List<Injection> injections = Injection.forBean(decoratorClass, null, beanDeployment, transformer,
+                Injection.BeanType.DECORATOR);
         for (Injection injection : injections) {
             for (InjectionPointInfo injectionPoint : injection.injectionPoints) {
                 if (injectionPoint.isDelegate()) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
@@ -87,6 +87,7 @@ public final class DotNames {
     public static final DotName PROVIDER = create(Provider.class);
     public static final DotName INJECTION_POINT = create(InjectionPoint.class);
     public static final DotName INTERCEPTOR = create(Interceptor.class);
+    public static final DotName INTERCEPTOR_BEAN = create(jakarta.enterprise.inject.spi.Interceptor.class);
     public static final DotName INTERCEPTOR_BINDING = create(InterceptorBinding.class);
     public static final DotName INTERCEPTED = create(Intercepted.class);
     public static final DotName AROUND_INVOKE = create(AroundInvoke.class);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Interceptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Interceptors.java
@@ -71,7 +71,8 @@ final class Interceptors {
         return new InterceptorInfo(interceptorClass, beanDeployment,
                 bindings.size() == 1 ? Collections.singleton(bindings.iterator().next())
                         : Collections.unmodifiableSet(bindings),
-                Injection.forBean(interceptorClass, null, beanDeployment, transformer), priority);
+                Injection.forBean(interceptorClass, null, beanDeployment, transformer, Injection.BeanType.INTERCEPTOR),
+                priority);
     }
 
     private static void addBindings(BeanDeployment beanDeployment, ClassInfo classInfo, Collection<AnnotationInstance> bindings,

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -62,11 +62,6 @@
                     <exclude name="testGetTargetMethod"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptorTypeParamConstructorTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.lookup.circular.CircularDependencyTest">
                 <methods>
                     <exclude name="testCircularInjectionOnTwoNormalBeans"/>
@@ -76,21 +71,6 @@
                     <exclude name="testNormalAndDependentCircularConstructors"/>
                     <exclude name="testNormalProducerMethodDeclaredOnDependentBeanWhichInjectsProducedBean"/>
                     <exclude name="testNormalCircularConstructors"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptedBeanTypeParamFieldTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.BeanTypeParamConstructorTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.BeanTypeParamDisposerTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.context.DestroyForSameCreationalContextTest">
@@ -103,11 +83,6 @@
                     <exclude name="testDestroyForSameCreationalContextOnly"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptedBeanTypeParamInitializerTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.definition.scope.ScopeDefinitionTest">
                 <methods>
                     <exclude name="testScopeTypeHasCorrectTarget"/>
@@ -116,29 +91,9 @@
                     <exclude name="testScopeTypeDeclaredInheritedIsBlockedByIntermediateScopeTypeNotMarkedInherited"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.BeanTypeParamInitializerTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptedBeanTypeParamConstructorTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.definition.qualifier.builtin.BuiltInQualifierDefinitionTest">
                 <methods>
                     <exclude name="testDefaultQualifierForInjectionPoint"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.BeanTypeParamProducerTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.BeanTypeParamFieldTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.implementation.simple.definition.SimpleBeanDefinitionTest">
@@ -188,11 +143,6 @@
                     <exclude name="testNonDependentGenericManagedBeanNotOk"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.injection.intercepted.InterceptedBeanConstructorInjectionTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.implementation.simple.lifecycle.unproxyable.UnproxyableManagedBeanTest">
                 <methods>
                     <exclude name="testNormalScopedUnproxyableBeanWithPublicFinalMethodResolution"/>
@@ -200,16 +150,6 @@
                     <exclude name="testNormalScopedUnproxyableBeanWithFinalClassResolution"/>
                     <exclude name="testNormalScopedUnproxyableBeanWithPackagePrivateFinalMethodResolution"/>
                     <exclude name="testNormalScopedUnproxyableBeanWithProtectedFinalMethodResolution"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptorTypeParamFieldTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.injection.intercepted.InterceptedBeanInitializerInjectionTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.event.fires.FireEventTest">
@@ -244,25 +184,10 @@
                     <exclude name="testCustomScopeInOtherBDAisBeanDefiningAnnotation"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.injection.intercepted.InterceptedBeanFieldInjectionTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.injection.BuiltinInterceptorInjectionTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.lookup.dynamic.handle.InstanceHandleTest">
                 <methods>
                     <exclude name="testGetHandle"/>
                     <exclude name="testHandles"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.builtin.metadata.broken.typeparam.interceptor.InterceptorTypeParamInitializerTest">
-                <methods>
-                    <exclude name="testDeploymentFails"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.context.dependent.DependentContextTest">

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/beanMetadata/BeanMetadataWrongTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/beanMetadata/BeanMetadataWrongTypeTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.arc.test.injection.erroneous.beanMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class BeanMetadataWrongTypeTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder().beanClasses(BeanMetadataWrongTypeTest.class,
+            MyBean.class).shouldFail().build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).isInstanceOf(DefinitionException.class);
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        @Inject
+        MyBean(Bean<String> beanMetadata) {
+
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptedBean/InterceptedBeanConstructorInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptedBean/InterceptedBeanConstructorInjectionTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.arc.test.injection.erroneous.interceptedBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Intercepted;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptedBeanConstructorInjectionTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder().beanClasses(InterceptedBeanConstructorInjectionTest.class,
+            MyBean.class).shouldFail().build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).isInstanceOf(DefinitionException.class);
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        @Inject
+        MyBean(@Intercepted Bean<MyBean> bean) {
+
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptedBean/InterceptedBeanFieldInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptedBean/InterceptedBeanFieldInjectionTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.arc.test.injection.erroneous.interceptedBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Intercepted;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptedBeanFieldInjectionTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder().beanClasses(InterceptedBeanFieldInjectionTest.class,
+            MyBean.class).shouldFail().build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).isInstanceOf(DefinitionException.class);
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        @Inject
+        @Intercepted
+        Bean<MyBean> bean;
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptedBean/InterceptedBeanInitializerInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptedBean/InterceptedBeanInitializerInjectionTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.arc.test.injection.erroneous.interceptedBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Intercepted;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptedBeanInitializerInjectionTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder().beanClasses(InterceptedBeanInitializerInjectionTest.class,
+            MyBean.class).shouldFail().build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).isInstanceOf(DefinitionException.class);
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        @Inject
+        void init(@Intercepted Bean<MyBean> bean) {
+
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptedBean/InterceptedBeanNotUnboundWildcardTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptedBean/InterceptedBeanNotUnboundWildcardTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.arc.test.injection.erroneous.interceptedBean;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Intercepted;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptedBeanNotUnboundWildcardTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder().beanClasses(InterceptedBeanNotUnboundWildcardTest.class,
+            MyInterceptor.class, Binding.class).shouldFail().build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).isInstanceOf(DefinitionException.class);
+    }
+
+    @Interceptor
+    @Priority(1)
+    @Binding
+    static class MyInterceptor {
+
+        @Inject
+        @Intercepted
+        Bean<? extends String> interceptedBean;
+
+        @AroundInvoke
+        public Object doNothing(InvocationContext ctx) throws Exception {
+            return ctx.proceed();
+        }
+    }
+
+    @Target({ TYPE, METHOD })
+    @Retention(RUNTIME)
+    @Documented
+    @InterceptorBinding
+    @interface Binding {
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptorBean/InterceptorBeanInjectionBeanClassTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptorBean/InterceptorBeanInjectionBeanClassTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.arc.test.injection.erroneous.interceptorBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.enterprise.inject.spi.Interceptor;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptorBeanInjectionBeanClassTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder().beanClasses(InterceptorBeanInjectionBeanClassTest.class,
+            MyBean.class).shouldFail().build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).isInstanceOf(DefinitionException.class);
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        @Inject
+        Interceptor<MyBean> interceptor;
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptorBean/InterceptorBeanInjectionConstructorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptorBean/InterceptorBeanInjectionConstructorTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.arc.test.injection.erroneous.interceptorBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.enterprise.inject.spi.Interceptor;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptorBeanInjectionConstructorTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder().beanClasses(InterceptorBeanInjectionDisposerTest.class,
+            InterceptorBeanInjectionDisposerTest.MyBean.class).shouldFail().build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).isInstanceOf(DefinitionException.class);
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        @Inject
+        public MyBean(Interceptor<MyBean> interceptor) {
+
+        }
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptorBean/InterceptorBeanInjectionDisposerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptorBean/InterceptorBeanInjectionDisposerTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.arc.test.injection.erroneous.interceptorBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.enterprise.inject.spi.Interceptor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptorBeanInjectionDisposerTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder().beanClasses(InterceptorBeanInjectionDisposerTest.class,
+            MyBean.class).shouldFail().build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).isInstanceOf(DefinitionException.class);
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        @Produces
+        String produceSth() {
+            return "foo";
+        }
+
+        void disposer(@Disposes String s, Interceptor<InterceptorBeanInjectionProducerTest.MyBean> interceptor) {
+
+        }
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptorBean/InterceptorBeanInjectionInitializerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptorBean/InterceptorBeanInjectionInitializerTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.arc.test.injection.erroneous.interceptorBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.enterprise.inject.spi.Interceptor;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptorBeanInjectionInitializerTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder().beanClasses(InterceptorBeanInjectionInitializerTest.class,
+            MyBean.class).shouldFail().build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).isInstanceOf(DefinitionException.class);
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        @Inject
+        void initMethod(Interceptor<MyBean> interceptor) {
+
+        }
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptorBean/InterceptorBeanInjectionProducerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptorBean/InterceptorBeanInjectionProducerTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.arc.test.injection.erroneous.interceptorBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.enterprise.inject.spi.Interceptor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptorBeanInjectionProducerTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder().beanClasses(InterceptorBeanInjectionProducerTest.class,
+            MyBean.class).shouldFail().build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).isInstanceOf(DefinitionException.class);
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+
+        @Produces
+        String produceSth(Interceptor<MyBean> interceptor) {
+            return "foo";
+        }
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptorBean/InterceptorBeanWrongTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/erroneous/interceptorBean/InterceptorBeanWrongTypeTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.arc.test.injection.erroneous.interceptorBean;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InterceptorBeanWrongTypeTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder().beanClasses(InterceptorBeanWrongTypeTest.class,
+            MyInterceptor.class, Binding.class).shouldFail().build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).isInstanceOf(DefinitionException.class);
+    }
+
+    @Interceptor
+    @Priority(1)
+    @Binding
+    static class MyInterceptor {
+
+        @Inject
+        jakarta.enterprise.inject.spi.Interceptor<String> interceptor;
+
+        @AroundInvoke
+        public Object doNothing(InvocationContext ctx) throws Exception {
+            return ctx.proceed();
+        }
+    }
+
+    @Target({ TYPE, METHOD })
+    @Retention(RUNTIME)
+    @Documented
+    @InterceptorBinding
+    @interface Binding {
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/intercepted/InterceptedBeanInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/intercepted/InterceptedBeanInjectionTest.java
@@ -38,7 +38,7 @@ public class InterceptedBeanInjectionTest {
     static class InterceptedBean {
 
         @Inject
-        Bean<?> bean;
+        Bean<InterceptedBean> bean;
 
         @Inject
         InterceptedDependent dependent;


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/issues/28558

This PR adds various validations, mostly related to restrictions on bean metadata injection as per [this spec part](https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0.html#bean_metadata).

I've added at least some Arc test for all of the validations but didn't go 1:1 with what the TCK has since we're running it anyway.
I've also re-enabled relevant (15) TCK test classes.