### PR TITLE
Exclude JS files from resource filtering

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -639,6 +639,7 @@
                             <nonFilteredFileExtension>woff2</nonFilteredFileExtension>
                             <nonFilteredFileExtension>svg</nonFilteredFileExtension>
                             <nonFilteredFileExtension>ico</nonFilteredFileExtension>
+                            <nonFilteredFileExtension>js</nonFilteredFileExtension>
                         </nonFilteredFileExtensions>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Fixes: #32956

There are a few alternatives to this:

* We completely change the filtering to only include certain files we know we want changed.
   - The problem with this is that it might break things we don't know about
* Only disable JS files for the `/info` extension
   - This only makes sense if we know of extensions that do need to have Maven filtering enabled