### PR TITLE
Fix config for Vale linter GitHub Action on PR

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -27,7 +27,7 @@ jobs:
         uses: errata-ai/vale-action@reviewdog
         with:
           fail_on_error: false
-          vale_flags: "--no-exit --config=docs/.vale/vale.ini"
+          vale_flags: "--no-exit --config=docs/.vale.ini"
           filter_mode: diff_context
           files: docs/src/main/asciidoc/
         env:


### PR DESCRIPTION
This PR aims to resolve the following [GitHub Action errors](https://github.com/quarkusio/quarkus/actions/workflows/vale.yml), which prevent the Vale linter job with the Quarkus-preferred style rules from executing:

`/github/home/vale --no-exit --config=docs/.vale/vale.ini sync
E100 [--config] Runtime error

path 'docs/.vale/vale.ini' does not exist

Execution stopped with code 1.
Error: Error: The process '/github/home/vale' failed with exit code 2 `
