### PR TITLE
Include classes touched by parent for testing

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassUsages.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassUsages.java
@@ -18,13 +18,20 @@ import org.junit.platform.launcher.PostDiscoveryFilter;
 public class TestClassUsages implements Serializable {
 
     private final Map<ClassAndMethod, Set<String>> classNames = new HashMap<>();
+    private final Map<String, Set<String>> classLevel = new HashMap<>();
 
     public synchronized void updateTestData(String currentclass, UniqueId test, Set<String> touched) {
-        classNames.put(new ClassAndMethod(currentclass, test), touched);
+        Set<String> aggregate = touched;
+        var extra = classLevel.get(currentclass);
+        if (extra != null) {
+            aggregate.addAll(extra);
+        }
+        classNames.put(new ClassAndMethod(currentclass, test), aggregate);
     }
 
     public synchronized void updateTestData(String currentclass, Set<String> touched) {
         classNames.put(new ClassAndMethod(currentclass, null), touched);
+        classLevel.put(currentclass, touched);
     }
 
     public synchronized void merge(TestClassUsages newData) {


### PR DESCRIPTION
When deciding if a test should be re-run we should also re-run the test if class level methods touched the changed class.
