### PR TITLE
ArC fixes for spec compatibility, round 8

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/ListInvalidTypeParamTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/ListInvalidTypeParamTest.java
@@ -7,9 +7,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.spi.DeploymentException;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -36,7 +36,7 @@ public class ListInvalidTypeParamTest {
         fail();
     }
 
-    @Singleton
+    @Dependent
     static class Foo<T> {
 
         @Inject

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/CustomNonBlockingReturnTypeTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/CustomNonBlockingReturnTypeTest.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.WebApplicationException;
@@ -137,6 +138,7 @@ public class CustomNonBlockingReturnTypeTest {
     }
 
     @Provider
+    @Dependent
     public static class HasMessageMessageBodyWriter<T extends HasMessage> implements ServerMessageBodyWriter<T> {
 
         @Override

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -1422,7 +1422,10 @@ public class BeanDeployment {
                 // Skip vetoed interceptors
                 continue;
             }
-            interceptors.add(Interceptors.createInterceptor(interceptorClass, this, injectionPointTransformer));
+            InterceptorInfo interceptor = Interceptors.createInterceptor(interceptorClass, this, injectionPointTransformer);
+            if (interceptor != null) {
+                interceptors.add(interceptor);
+            }
         }
         if (LOGGER.isTraceEnabled()) {
             for (InterceptorInfo interceptor : interceptors) {
@@ -1448,7 +1451,10 @@ public class BeanDeployment {
                 // Skip vetoed decorators
                 continue;
             }
-            decorators.add(Decorators.createDecorator(decoratorClass, this, injectionPointTransformer));
+            DecoratorInfo decorator = Decorators.createDecorator(decoratorClass, this, injectionPointTransformer);
+            if (decorator != null) {
+                decorators.add(decorator);
+            }
         }
         if (LOGGER.isTraceEnabled()) {
             for (DecoratorInfo decorator : decorators) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -1276,6 +1276,12 @@ public final class Beans {
             } else {
                 scope = scopes.get(0);
             }
+            if (scope != null // `null` is just like `@Dependent`
+                    && !BuiltinScope.DEPENDENT.is(scope)
+                    && !beanClass.typeParameters().isEmpty()) {
+                throw new DefinitionException(
+                        "Declaring class of a managed bean is generic, its scope must be @Dependent: " + beanClass);
+            }
             if (!isAlternative) {
                 isAlternative = initStereotypeAlternative(stereotypes, beanDeployment);
             }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
@@ -108,6 +108,14 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
             getComponents.invokeInterfaceMethod(MethodDescriptors.LIST_ADD, contextsHandle, contextHandle);
         }
 
+        // All interceptor bindings
+        ResultHandle interceptorBindings = getComponents.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
+        for (ClassInfo binding : beanDeployment.getInterceptorBindings()) {
+            getComponents.invokeInterfaceMethod(MethodDescriptors.SET_ADD, interceptorBindings,
+                    getComponents.load(binding.name().toString()));
+        }
+
+        // Transitive interceptor bindings
         ResultHandle transitiveBindingsHandle = getComponents.newInstance(MethodDescriptor.ofConstructor(HashMap.class));
         for (Entry<DotName, Set<AnnotationInstance>> entry : beanDeployment.getTransitiveInterceptorBindings().entrySet()) {
             ResultHandle bindingsHandle = getComponents.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
@@ -160,9 +168,9 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
 
         ResultHandle componentsHandle = getComponents.newInstance(
                 MethodDescriptor.ofConstructor(Components.class, Collection.class, Collection.class, Collection.class,
-                        Map.class, Supplier.class, Map.class, Set.class),
-                beansHandle, observersHandle, contextsHandle, transitiveBindingsHandle, removedBeansSupplier.getInstance(),
-                qualifiersNonbindingMembers, qualifiers);
+                        Set.class, Map.class, Supplier.class, Map.class, Set.class),
+                beansHandle, observersHandle, contextsHandle, interceptorBindings, transitiveBindingsHandle,
+                removedBeansSupplier.getInstance(), qualifiersNonbindingMembers, qualifiers);
         getComponents.returnValue(componentsHandle);
 
         // Finally write the bytecode

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Decorators.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Decorators.java
@@ -26,6 +26,13 @@ final class Decorators {
     private Decorators() {
     }
 
+    /**
+     *
+     * @param decoratorClass
+     * @param beanDeployment
+     * @param transformer
+     * @return a new decorator info, or (only in strict mode) {@code null} if the decorator is disabled
+     */
     static DecoratorInfo createDecorator(ClassInfo decoratorClass, BeanDeployment beanDeployment,
             InjectionPointModifier transformer) {
 
@@ -100,6 +107,11 @@ final class Decorators {
         }
 
         if (priority == null) {
+            if (beanDeployment.strictCompatibility) {
+                // decorator without `@Priority` is disabled per the specification
+                return null;
+            }
+
             LOGGER.info("The decorator " + decoratorClass + " does not declare any @Priority. " +
                     "It will be assigned a default priority value of 0.");
             priority = 0;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Interceptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Interceptors.java
@@ -32,7 +32,7 @@ final class Interceptors {
      *
      * @param interceptorClass
      * @param beanDeployment
-     * @return a new interceptor info
+     * @return a new interceptor info, or (only in strict mode) {@code null} if the interceptor is disabled
      */
     static InterceptorInfo createInterceptor(ClassInfo interceptorClass, BeanDeployment beanDeployment,
             InjectionPointModifier transformer) {
@@ -60,6 +60,11 @@ final class Interceptors {
         }
 
         if (priority == null) {
+            if (beanDeployment.strictCompatibility) {
+                // interceptor without `@Priority` is disabled per the specification
+                return null;
+            }
+
             LOGGER.info("The interceptor " + interceptorClass + " does not declare any @Priority. " +
                     "It will be assigned a default priority value of 0.");
             priority = 0;

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Components.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Components.java
@@ -12,18 +12,21 @@ public final class Components {
     private final Supplier<Collection<RemovedBean>> removedBeans;
     private final Collection<InjectableObserverMethod<?>> observers;
     private final Collection<InjectableContext> contexts;
+    private final Set<String> interceptorBindings;
     private final Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings;
     private final Map<String, Set<String>> qualifierNonbindingMembers;
     private final Set<String> qualifiers;
 
     public Components(Collection<InjectableBean<?>> beans, Collection<InjectableObserverMethod<?>> observers,
             Collection<InjectableContext> contexts,
+            Set<String> interceptorBindings,
             Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings,
             Supplier<Collection<RemovedBean>> removedBeans, Map<String, Set<String>> qualifierNonbindingMembers,
             Set<String> qualifiers) {
         this.beans = beans;
         this.observers = observers;
         this.contexts = contexts;
+        this.interceptorBindings = interceptorBindings;
         this.transitiveInterceptorBindings = transitiveInterceptorBindings;
         this.removedBeans = removedBeans;
         this.qualifierNonbindingMembers = qualifierNonbindingMembers;
@@ -40,6 +43,10 @@ public final class Components {
 
     public Collection<InjectableContext> getContexts() {
         return contexts;
+    }
+
+    public Set<String> getInterceptorBindings() {
+        return interceptorBindings;
     }
 
     public Map<Class<? extends Annotation>, Set<Annotation>> getTransitiveInterceptorBindings() {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableDecorator.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableDecorator.java
@@ -1,6 +1,11 @@
 package io.quarkus.arc;
 
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
 import jakarta.enterprise.inject.spi.Decorator;
+
+import io.quarkus.arc.impl.Qualifiers;
 
 /**
  * Quarkus representation of a decorator bean.
@@ -13,4 +18,8 @@ public interface InjectableDecorator<T> extends InjectableBean<T>, Decorator<T> 
         return Kind.DECORATOR;
     }
 
+    @Override
+    default Set<Annotation> getDelegateQualifiers() {
+        return Qualifiers.DEFAULT_QUALIFIERS;
+    }
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -177,7 +177,8 @@ public class ArcContainerImpl implements ArcContainer {
                         notifierOrNull(Set.of(BeforeDestroyed.Literal.REQUEST, Any.Literal.INSTANCE)),
                         notifierOrNull(Set.of(Destroyed.Literal.REQUEST, Any.Literal.INSTANCE))),
                 new ApplicationContext(),
-                new SingletonContext());
+                new SingletonContext(),
+                new DependentContext());
 
         // Add custom contexts
         for (Components c : components) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
@@ -166,7 +166,7 @@ public class BeanManagerImpl implements BeanManager {
     @Override
     public boolean isInterceptorBinding(Class<? extends Annotation> annotationType) {
         return annotationType.isAnnotationPresent(InterceptorBinding.class)
-                || ArcContainerImpl.instance().getTransitiveInterceptorBindings().containsKey(annotationType);
+                || ArcContainerImpl.instance().registeredInterceptorBindings.isRegistered(annotationType);
     }
 
     @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Contexts.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Contexts.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Singleton;
 
@@ -27,10 +28,12 @@ class Contexts {
     final ManagedContext requestContext;
     final InjectableContext applicationContext;
     final InjectableContext singletonContext;
+    final InjectableContext dependentContext;
 
     // Used to optimize the getContexts(Class<? extends Annotation>)
     private final List<InjectableContext> applicationContextSingleton;
     private final List<InjectableContext> singletonContextSingleton;
+    private final List<InjectableContext> dependentContextSingleton;
     private final List<InjectableContext> requestContextSingleton;
 
     // Lazily computed list of contexts for a scope
@@ -39,14 +42,16 @@ class Contexts {
     // Precomputed values
     final Set<Class<? extends Annotation>> scopes;
 
-    Contexts(ManagedContext requestContext, InjectableContext applicationContext,
-            InjectableContext singletonContext, Map<Class<? extends Annotation>, List<InjectableContext>> contexts) {
+    Contexts(ManagedContext requestContext, InjectableContext applicationContext, InjectableContext singletonContext,
+            InjectableContext dependentContext, Map<Class<? extends Annotation>, List<InjectableContext>> contexts) {
         this.requestContext = requestContext;
         this.applicationContext = applicationContext;
         this.singletonContext = singletonContext;
+        this.dependentContext = dependentContext;
 
         this.applicationContextSingleton = Collections.singletonList(applicationContext);
         this.singletonContextSingleton = Collections.singletonList(singletonContext);
+        this.dependentContextSingleton = Collections.singletonList(dependentContext);
         List<InjectableContext> requestContexts = contexts.get(RequestScoped.class);
         this.requestContextSingleton = requestContexts != null ? requestContexts : Collections.singletonList(requestContext);
 
@@ -77,21 +82,24 @@ class Contexts {
             Set<Class<? extends Annotation>> all = new HashSet<>(contexts.keySet());
             all.add(ApplicationScoped.class);
             all.add(Singleton.class);
+            all.add(Dependent.class);
             all.add(RequestScoped.class);
             this.scopes = Set.copyOf(all);
         } else {
             // No custom context is registered
             this.unoptimizedContexts = null;
-            this.scopes = Set.of(ApplicationScoped.class, Singleton.class, RequestScoped.class);
+            this.scopes = Set.of(ApplicationScoped.class, Singleton.class, Dependent.class, RequestScoped.class);
         }
     }
 
     InjectableContext getActiveContext(Class<? extends Annotation> scopeType) {
-        // Application/Singleton context is always active and it's not possible to register a custom context for these scopes
+        // Application/Singleton/Dependent context is always active and it's not possible to register a custom context for these scopes
         if (ApplicationScoped.class.equals(scopeType)) {
             return applicationContext;
         } else if (Singleton.class.equals(scopeType)) {
             return singletonContext;
+        } else if (Dependent.class.equals(scopeType)) {
+            return dependentContext;
         }
         List<InjectableContext> contextsForScope = getContexts(scopeType);
         InjectableContext selected = null;
@@ -99,7 +107,7 @@ class Contexts {
             if (context.isActive()) {
                 if (selected != null) {
                     throw new IllegalArgumentException(
-                            "More than one context object for the given scope: " + selected + " " + context);
+                            "More than one active context object for the given scope: " + selected + " " + context);
                 }
                 selected = context;
             }
@@ -108,13 +116,15 @@ class Contexts {
     }
 
     List<InjectableContext> getContexts(Class<? extends Annotation> scopeType) {
-        // Optimize for buil-in normal scopes - this method is used internally during client proxy invocation
+        // Optimize for built-in scopes - this method is used internally during client proxy invocation
         if (ApplicationScoped.class.equals(scopeType)) {
             return applicationContextSingleton;
         } else if (RequestScoped.class.equals(scopeType)) {
             return requestContextSingleton;
         } else if (Singleton.class.equals(scopeType)) {
             return singletonContextSingleton;
+        } else if (Dependent.class.equals(scopeType)) {
+            return dependentContextSingleton;
         }
         return unoptimizedContexts != null ? unoptimizedContexts.get(scopeType) : Collections.emptyList();
     }
@@ -124,13 +134,15 @@ class Contexts {
         private final ManagedContext requestContext;
         private final InjectableContext applicationContext;
         private final InjectableContext singletonContext;
+        private final InjectableContext dependentContext;
         private final Map<Class<? extends Annotation>, List<InjectableContext>> contexts = new HashMap<>();
 
         public Builder(ManagedContext requestContext, InjectableContext applicationContext,
-                InjectableContext singletonContext) {
+                InjectableContext singletonContext, InjectableContext dependentContext) {
             this.requestContext = requestContext;
             this.applicationContext = applicationContext;
             this.singletonContext = singletonContext;
+            this.dependentContext = dependentContext;
         }
 
         Builder putContext(InjectableContext context) {
@@ -151,7 +163,7 @@ class Contexts {
                 // If a custom request context is registered then add the built-in context as well
                 putContext(requestContext);
             }
-            return new Contexts(requestContext, applicationContext, singletonContext, contexts);
+            return new Contexts(requestContext, applicationContext, singletonContext, dependentContext, contexts);
         }
 
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/DependentContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/DependentContext.java
@@ -1,0 +1,64 @@
+package io.quarkus.arc.impl;
+
+import java.lang.annotation.Annotation;
+import java.util.Objects;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.spi.Contextual;
+import jakarta.enterprise.context.spi.CreationalContext;
+
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableContext;
+
+/**
+ * The built-in context for {@link jakarta.enterprise.context.Dependent}.
+ */
+class DependentContext implements InjectableContext {
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return Dependent.class;
+    }
+
+    @Override
+    public <T> T get(Contextual<T> contextual, CreationalContext<T> creationalContext) {
+        Objects.requireNonNull(contextual, "Contextual must not be null");
+
+        if (creationalContext == null) {
+            // there's never an "existing instance" of a dependent-scoped bean
+            return null;
+        }
+
+        T instance = contextual.create(creationalContext);
+        if (creationalContext instanceof CreationalContextImpl) {
+            // we can remove this `if` and cast unconditionally after https://github.com/jakartaee/cdi-tck/pull/452
+            CreationalContextImpl<T> ccimpl = (CreationalContextImpl<T>) creationalContext;
+            ccimpl.addDependentInstance((InjectableBean<T>) contextual, instance, creationalContext);
+        }
+        return instance;
+    }
+
+    @Override
+    public <T> T get(Contextual<T> contextual) {
+        return get(contextual, null);
+    }
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
+    public void destroy(Contextual<?> contextual) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void destroy() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ContextState getState() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptorBindings.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptorBindings.java
@@ -1,0 +1,70 @@
+package io.quarkus.arc.impl;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Repeatable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+public final class InterceptorBindings {
+    private final Set<String> allInterceptorBindings;
+    private final Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings;
+
+    InterceptorBindings(Set<String> interceptorBindings,
+            Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings) {
+        this.allInterceptorBindings = interceptorBindings;
+        this.transitiveInterceptorBindings = transitiveInterceptorBindings;
+    }
+
+    boolean isRegistered(Class<? extends Annotation> annotationType) {
+        return allInterceptorBindings.contains(annotationType.getName());
+    }
+
+    Set<Annotation> getTransitive(Class<? extends Annotation> interceptorBinding) {
+        return transitiveInterceptorBindings.get(interceptorBinding);
+    }
+
+    void verify(Annotation[] interceptorBindings) {
+        if (interceptorBindings.length == 0) {
+            return;
+        }
+        if (interceptorBindings.length == 1) {
+            verifyInterceptorBinding(interceptorBindings[0].annotationType());
+        } else {
+            Map<Class<? extends Annotation>, Integer> timesQualifierWasSeen = new HashMap<>();
+            for (Annotation interceptorBinding : interceptorBindings) {
+                verifyInterceptorBinding(interceptorBinding.annotationType());
+                timesQualifierWasSeen.compute(interceptorBinding.annotationType(), TimesSeenBiFunction.INSTANCE);
+            }
+            checkInterceptorBindingsForDuplicates(timesQualifierWasSeen);
+        }
+    }
+
+    // in various cases, specification requires to check interceptor bindings for duplicates and throw IAE
+    private static void checkInterceptorBindingsForDuplicates(Map<Class<? extends Annotation>, Integer> timesSeen) {
+        timesSeen.forEach(InterceptorBindings::checkInterceptorBindingsForDuplicates);
+    }
+
+    private static void checkInterceptorBindingsForDuplicates(Class<? extends Annotation> annClass, Integer timesSeen) {
+        if (timesSeen > 1 && !annClass.isAnnotationPresent(Repeatable.class)) {
+            throw new IllegalArgumentException("Interceptor binding " + annClass
+                    + " was used repeatedly but is not @Repeatable");
+        }
+    }
+
+    private void verifyInterceptorBinding(Class<? extends Annotation> annotationType) {
+        if (!allInterceptorBindings.contains(annotationType.getName())) {
+            throw new IllegalArgumentException("Annotation is not a registered interceptor binding: " + annotationType);
+        }
+    }
+
+    private static class TimesSeenBiFunction implements BiFunction<Class<? extends Annotation>, Integer, Integer> {
+        private static final TimesSeenBiFunction INSTANCE = new TimesSeenBiFunction();
+
+        @Override
+        public Integer apply(Class<? extends Annotation> k, Integer v) {
+            return v == null ? 1 : v + 1;
+        }
+    }
+}

--- a/independent-projects/arc/tcks/cdi-tck-porting-pkg/src/main/java/io/quarkus/arc/tck/porting/ContextsImpl.java
+++ b/independent-projects/arc/tcks/cdi-tck-porting-pkg/src/main/java/io/quarkus/arc/tck/porting/ContextsImpl.java
@@ -1,13 +1,10 @@
 package io.quarkus.arc.tck.porting;
 
-import java.lang.annotation.Annotation;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.spi.Context;
-import jakarta.enterprise.context.spi.Contextual;
-import jakarta.enterprise.context.spi.CreationalContext;
 
 import org.jboss.cdi.tck.spi.Contexts;
 
@@ -40,30 +37,7 @@ public class ContextsImpl implements Contexts<Context> {
 
     @Override
     public Context getDependentContext() {
-        // ArC doesn't have a context object for the dependent context, let's fake it here for now
-        // TODO we'll likely have to implement this in ArC properly
-
-        return new Context() {
-            @Override
-            public Class<? extends Annotation> getScope() {
-                return Dependent.class;
-            }
-
-            @Override
-            public <T> T get(Contextual<T> contextual, CreationalContext<T> creationalContext) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public <T> T get(Contextual<T> contextual) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean isActive() {
-                return true;
-            }
-        };
+        return Arc.container().getActiveContext(Dependent.class);
     }
 
     @Override

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -167,8 +167,6 @@
             </class>
             <class name="org.jboss.cdi.tck.tests.interceptors.definition.InterceptorDefinitionTest">
                 <methods>
-                    <exclude name="testNonBindingTypeToResolveInterceptorsFails"/>
-                    <exclude name="testSameBindingTypesToResolveInterceptorsFails"/>
                     <exclude name="testInterceptorsImplementInterceptorInterface"/>
                 </methods>
             </class>

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -192,24 +192,7 @@
             </class>
             <class name="org.jboss.cdi.tck.tests.context.dependent.DependentContextTest">
                 <methods>
-                    <exclude name="testContextGetWithCreationalContextReturnsNewInstance"/>
-                    <exclude name="testContextIsActiveWhenInvokingProducerMethod"/>
-                    <exclude name="testDependentsDestroyedWhenProducerMethodCompletes"/>
                     <exclude name="testContextIsActiveDuringInjection"/>
-                    <exclude name="testInstanceUsedForProducerFieldNotShared"/>
-                    <exclude name="testDependentsDestroyedWhenProducerFieldCompletes"/>
-                    <exclude name="testInstanceUsedForObserverMethodNotShared"/>
-                    <exclude name="testContextGetWithCreateFalseReturnsNull"/>
-                    <exclude name="testContextIsActiveDuringBeanCreation"/>
-                    <exclude name="testDependentsDestroyedWhenObserverMethodEvaluationCompletes"/>
-                    <exclude name="testContextIsActiveWhenInvokingProducerField"/>
-                    <exclude name="testContextIsActiveWhenCreatingObserverMethodInstance"/>
-                    <exclude name="testContextIsActiveWhenInvokingDisposalMethod"/>
-                    <exclude name="testDependentsDestroyedWhenDisposerMethodCompletes"/>
-                    <exclude name="testInstanceUsedForDisposalMethodNotShared"/>
-                    <exclude name="testInstanceUsedForProducerMethodNotShared"/>
-                    <exclude name="testContextIsActive"/>
-                    <exclude name="testContextScopeType"/>
                     <!-- https://github.com/jakartaee/cdi-tck/issues/454 -->
                     <exclude name="testDependentScopedInterceptorsAreDependentObjectsOfBean"></exclude>
                 </methods>
@@ -217,11 +200,6 @@
             <class name="org.jboss.cdi.tck.tests.context.GetFromContextualTest">
                 <methods>
                     <exclude name="testGetMayNotCreateNewInstanceUnlessCreationalContextGiven"/>
-                </methods>
-            </class>
-            <class name="org.jboss.cdi.tck.tests.definition.bean.BeanDefinitionTest">
-                <methods>
-                    <exclude name="testBeanClientCanCastBeanInstanceToAnyBeanType"/>
                 </methods>
             </class>
         </classes>

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -167,7 +167,6 @@
             </class>
             <class name="org.jboss.cdi.tck.tests.interceptors.definition.InterceptorDefinitionTest">
                 <methods>
-                    <exclude name="testInstanceOfInterceptorForEveryEnabledInterceptor"/>
                     <exclude name="testNonBindingTypeToResolveInterceptorsFails"/>
                     <exclude name="testSameBindingTypesToResolveInterceptorsFails"/>
                     <exclude name="testResolveInterceptorsReturnsOrderedList"/>

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -169,7 +169,6 @@
                 <methods>
                     <exclude name="testNonBindingTypeToResolveInterceptorsFails"/>
                     <exclude name="testSameBindingTypesToResolveInterceptorsFails"/>
-                    <exclude name="testResolveInterceptorsReturnsOrderedList"/>
                     <exclude name="testInterceptorsImplementInterceptorInterface"/>
                 </methods>
             </class>

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -138,11 +138,6 @@
                     <exclude name="testGetBean"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.definition.bean.genericbroken.GenericManagedBeanTest">
-                <methods>
-                    <exclude name="testNonDependentGenericManagedBeanNotOk"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.implementation.simple.lifecycle.unproxyable.UnproxyableManagedBeanTest">
                 <methods>
                     <exclude name="testNormalScopedUnproxyableBeanWithPublicFinalMethodResolution"/>

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -80,6 +80,7 @@
             </class>
             <class name="org.jboss.cdi.tck.tests.context.DestroyForSameCreationalContext2Test">
                 <methods>
+                    <!-- https://github.com/jakartaee/cdi-tck/issues/457 -->
                     <exclude name="testDestroyForSameCreationalContextOnly"/>
                 </methods>
             </class>
@@ -162,6 +163,7 @@
             </class>
             <class name="org.jboss.cdi.tck.tests.interceptors.definition.InterceptorDefinitionTest">
                 <methods>
+                    <!-- https://github.com/jakartaee/cdi-tck/issues/455 -->
                     <exclude name="testInterceptorsImplementInterceptorInterface"/>
                 </methods>
             </class>
@@ -185,7 +187,7 @@
                 <methods>
                     <exclude name="testContextIsActiveDuringInjection"/>
                     <!-- https://github.com/jakartaee/cdi-tck/issues/454 -->
-                    <exclude name="testDependentScopedInterceptorsAreDependentObjectsOfBean"></exclude>
+                    <exclude name="testDependentScopedInterceptorsAreDependentObjectsOfBean"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.context.GetFromContextualTest">

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/illegal/NonDependentGenericBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/illegal/NonDependentGenericBeanTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.arc.test.bean.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class NonDependentGenericBeanTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(IllegalBean.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DefinitionException.class, error);
+        assertTrue(error.getMessage().contains("Declaring class of a managed bean is generic, its scope must be @Dependent"));
+    }
+
+    @ApplicationScoped
+    static class IllegalBean<T> {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/disabled/DisabledDecoratorInStrictModeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/disabled/DisabledDecoratorInStrictModeTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.arc.test.decorators.disabled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DisabledDecoratorInStrictModeTest {
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Converter.class, ToUpperCaseConverter.class, TrimConverterDecorator.class)
+            .strictCompatibility(true)
+            .build();
+
+    @Test
+    public void test() {
+        ToUpperCaseConverter converter = Arc.container().instance(ToUpperCaseConverter.class).get();
+        assertEquals(" HOLA! ", converter.convert(" holA! "));
+    }
+
+    interface Converter<T> {
+        T convert(T value);
+    }
+
+    @Singleton
+    static class ToUpperCaseConverter implements Converter<String> {
+        @Override
+        public String convert(String value) {
+            return value.toUpperCase();
+        }
+    }
+
+    @Decorator
+    // no @Priority, the decorator is disabled in strict mode
+    static class TrimConverterDecorator implements Converter<String> {
+        @Inject
+        @Delegate
+        Converter<String> delegate;
+
+        @Override
+        public String convert(String value) {
+            return delegate.convert(value.trim());
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/discovery/ParameterizedBeanTypeWithVariableTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/discovery/ParameterizedBeanTypeWithVariableTest.java
@@ -2,7 +2,7 @@ package io.quarkus.arc.test.discovery;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -22,7 +22,7 @@ public class ParameterizedBeanTypeWithVariableTest {
 
     }
 
-    @ApplicationScoped
+    @Dependent
     static class Foo<T> {
 
         protected String ping() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/disabled/DisabledInterceptorInStrictModeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/disabled/DisabledInterceptorInStrictModeTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.arc.test.interceptors.disabled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.inject.Singleton;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class DisabledInterceptorInStrictModeTest {
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class)
+            .strictCompatibility(true)
+            .build();
+
+    @Test
+    public void test() {
+        MyBean bean = Arc.container().instance(MyBean.class).get();
+        assertEquals("pong", bean.ping());
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean {
+        String ping() {
+            return "pong";
+        }
+    }
+
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    // no @Priority, the interceptor is disabled in strict mode
+    static class MyInterceptor {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return "intercepted: " + ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/predestroy/PreDestroyInterceptorAndClientProxyTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/predestroy/PreDestroyInterceptorAndClientProxyTest.java
@@ -25,18 +25,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ClientProxy;
-import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.test.ArcTestContainer;
 
 public class PreDestroyInterceptorAndClientProxyTest {
     @RegisterExtension
     ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
-
-    @Test
-    public void bagr() {
-        InstanceHandle<MyBean> handle = Arc.container().instance(MyBean.class);
-        handle.destroy();
-    }
 
     @Test
     public void test() {


### PR DESCRIPTION
Related to #28558

- add a context object for the `@Dependent` pseudo-scope
- disable interceptors/decorators without `@Priority` in strict mode
  - in the default mode, they have an implicit priority of 0, so they are never disabled
- fix order of `BeanManager.resolveInterceptors()` and `resolveDecorators()`
  - this has a few more fixes for decorators that probably deserve extra attention, see the commit message
- treat interceptor bindings at runtime properly
  - this includes actually transferring the full set of interceptor bindings to runtime
- validate managed beans whose declaring class is generic
  - they must be `@Dependent`
- add links to TCK challenges to some test exclusions