### PR TITLE
Gradle modules build: Allow Java 20

### DIFF
--- a/devtools/gradle/build-logic/build.gradle.kts
+++ b/devtools/gradle/build-logic/build.gradle.kts
@@ -6,5 +6,13 @@ dependencies {
     implementation(plugin("com.gradle.plugin-publish", "1.2.0"))
 }
 
+java { toolchain {
+    // this is fine, even for Java 1.x
+    val javaMajor = JavaVersion.current().majorVersion.toInt()
+    // Need to limit the Java version for Kotlin to 17, because 20 doesn't work.
+    // Also prefer the current version to prevent JDK downloads.
+    languageVersion.set(JavaLanguageVersion.of(javaMajor.coerceAtMost(17)))
+} }
+
 fun DependencyHandler.plugin(id: String, version: String) =
     create("$id:$id.gradle.plugin:$version")


### PR DESCRIPTION
Gradle's Kotlin scripts don't (yet) build using Java 20. Force Java 11 for build scripts.