### PR TITLE
Reduce LauncherUtil check-interval from 500 to 50 ms

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -32,7 +32,7 @@ import io.smallrye.config.SmallRyeConfig;
 
 public final class LauncherUtil {
 
-    public static final int LOG_CHECK_INTERVAL = 500;
+    public static final int LOG_CHECK_INTERVAL = 50;
 
     private LauncherUtil() {
     }


### PR DESCRIPTION
500ms feels a bit long and can cause some wasted time during test runs, especially on beefier machines. It feels safe to reduce this to 50ms, which should work even on tiny CI runner instances, as it's mostly sleep time + a cheap-ish "has more data" check against the log file.