### PR TITLE
Use relative path for JDK 17-based AppCDS dump

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
@@ -309,10 +309,10 @@ public class AppCDSBuildStep {
             command.addAll(javaArgs);
             if (isFastJar) {
                 command
-                        .add(jarResult.getLibraryDir().getParent().resolve(JarResultBuildStep.QUARKUS_RUN_JAR).toAbsolutePath()
-                                .toString());
+                        .add(jarResult.getLibraryDir().getParent().resolve(JarResultBuildStep.QUARKUS_RUN_JAR)
+                                .getFileName().toString());
             } else {
-                command.add(jarResult.getPath().toAbsolutePath().toString());
+                command.add(jarResult.getPath().getFileName().toString());
             }
         }
 


### PR DESCRIPTION
This makes the AppCDS feature more portable where the build and deployment paths differ, but are otherwise identical (for example s2i use-case).

Closes: #33069