### PR TITLE
Gradle-Model: make kotlin-gradle-plugin-api a compileOnly dependency

### DIFF
--- a/devtools/gradle/gradle-model/build.gradle.kts
+++ b/devtools/gradle/gradle-model/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation(libs.kotlin.gradle.plugin.api)
+    compileOnly(libs.kotlin.gradle.plugin.api)
 }
 
 group = "io.quarkus"


### PR DESCRIPTION
... to avoid having potential kotlin plugin dependency issues.

Also unifies the common code to configure compile tasks (bit more complicated, because the KotlinJvmCompile does not extend AbstractCompile like all other/most compile tasks).

And moves the actual use of `KotlinJvmCompile` to a separate method, so that the safeguard `Class.forName("...KotlinJvmCompile") can actually trigger the intended behavior.

/cc @geoand 