### PR TITLE
Workaround for unnecessary info logs in Hibernate ORM (HHH-16546)

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateLogFilterBuildStep.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateLogFilterBuildStep.java
@@ -30,5 +30,7 @@ public final class HibernateLogFilterBuildStep {
         // Silence incubating settings warnings as we will use some for compatibility
         filters.produce(new LogCleanupFilterBuildItem("org.hibernate.orm.incubating",
                 "HHH90006001"));
+        // https://hibernate.atlassian.net/browse/HHH-16546
+        filters.produce(new LogCleanupFilterBuildItem("org.hibernate.tuple.entity.EntityMetamodel", "HHH000157"));
     }
 }


### PR DESCRIPTION
Fixes #33089

Creating as draft because I would like to get to the bottom of [this](https://github.com/quarkusio/quarkus/issues/33089#issuecomment-1532984509) before we merge anything.

Alternatively, we might want to just wait for the [upstream fix](https://github.com/hibernate/hibernate-orm/pull/6498) to be integrated and to upgrade to the next ORM version.