### PR TITLE
Allow for a larger timeout for the Logging-Gelf integration tests

### DIFF
--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -199,7 +199,7 @@
                                         <log>
                                             <prefix>Logstash:</prefix>
                                             <date>default</date>
-                                            <color>cyan</color>
+                                            <color>magenta</color>
                                         </log>
                                         <volumes>
                                             <bind>
@@ -213,7 +213,7 @@
                                                 <status>200</status>
                                             </http>
                                             <!-- Starting the pipeline can be long as it needs to communicate with Elasticsearch -->
-                                            <time>45000</time>
+                                            <time>90000</time>
                                         </wait>
                                         <dependsOn>
                                             <container>elasticsearch</container>


### PR DESCRIPTION
This fixed the build on podman for me locally.

Resolves https://github.com/quarkusio/quarkus/issues/33090