### PR TITLE
Enable function with same name for Funqy

### DIFF
--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/NameConflict.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/NameConflict.java
@@ -1,0 +1,17 @@
+package io.quarkus.funqy.test;
+
+import io.quarkus.funqy.Funq;
+
+public class NameConflict {
+
+    @Funq
+    public String function(String s) {
+        return s.toUpperCase();
+    }
+
+    @Funq
+    public int function(int i) {
+        return i * 2;
+    }
+
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/NameConflictTest.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/NameConflictTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.funqy.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.*;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NameConflictTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClass(NameConflict.class))
+            .setLogRecordPredicate(logRecord -> logRecord.getLevel().intValue() >= Level.WARNING.intValue() &&
+                    logRecord.getLoggerName().startsWith("io.quarkus.funqy"))
+            .assertLogRecords(logRecords -> {
+                boolean match = logRecords
+                        .stream()
+                        .anyMatch(logRecord -> logRecord.getMessage().contains("Name conflict"));
+                if (!match) {
+                    fail("Log does not contain message about name conflict.");
+                }
+            });
+
+    @Test
+    void test() {
+        assertTrue(true);
+    }
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/Overloading.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/Overloading.java
@@ -1,0 +1,17 @@
+package io.quarkus.funqy.test;
+
+import io.quarkus.funqy.Funq;
+
+public class Overloading {
+
+    @Funq("intfun")
+    public int function(int i) {
+        return i * 2;
+    }
+
+    @Funq("strfun")
+    public String function(String s) {
+        return s.toUpperCase();
+    }
+
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/OverloadingTest.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/OverloadingTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.funqy.test;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OverloadingTest {
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Overloading.class));
+
+    @Test
+    public void testMapping() {
+        RestAssured.given().contentType("application/json")
+                .body("\"a\"")
+                .post("/strfun")
+                .then().statusCode(200)
+                .body(equalTo("\"A\""));
+
+        RestAssured.given().contentType("application/json")
+                .body("10")
+                .post("/intfun")
+                .then().statusCode(200)
+                .body(equalTo("20"));
+    }
+}

--- a/extensions/funqy/funqy-server-common/deployment/src/main/java/io/quarkus/funqy/deployment/FunctionBuildItem.java
+++ b/extensions/funqy/funqy-server-common/deployment/src/main/java/io/quarkus/funqy/deployment/FunctionBuildItem.java
@@ -5,11 +5,13 @@ import io.quarkus.builder.item.MultiBuildItem;
 public final class FunctionBuildItem extends MultiBuildItem {
     protected String className;
     protected String methodName;
+    protected String descriptor;
     protected String functionName;
 
-    public FunctionBuildItem(String className, String methodName, String functionName) {
+    public FunctionBuildItem(String className, String methodName, String descriptor, String functionName) {
         this.className = className;
         this.methodName = methodName;
+        this.descriptor = descriptor;
         this.functionName = functionName;
     }
 
@@ -19,6 +21,10 @@ public final class FunctionBuildItem extends MultiBuildItem {
 
     public String getMethodName() {
         return methodName;
+    }
+
+    public String getDescriptor() {
+        return descriptor;
     }
 
     public String getFunctionName() {

--- a/extensions/funqy/funqy-server-common/deployment/src/main/java/io/quarkus/funqy/deployment/FunctionScannerBuildStep.java
+++ b/extensions/funqy/funqy-server-common/deployment/src/main/java/io/quarkus/funqy/deployment/FunctionScannerBuildStep.java
@@ -76,7 +76,7 @@ public class FunctionScannerBuildStep {
             }
             if (functionName != null && functionName.isEmpty())
                 functionName = null;
-            functions.produce(new FunctionBuildItem(className, methodName, functionName));
+            functions.produce(new FunctionBuildItem(className, methodName, method.descriptor(), functionName));
 
             String source = FunctionScannerBuildStep.class.getSimpleName() + " > " + method.declaringClass() + "[" + method
                     + "]";
@@ -167,10 +167,11 @@ public class FunctionScannerBuildStep {
         recorder.init();
         for (FunctionBuildItem function : functions) {
             if (function.getFunctionName() == null) {
-                recorder.register(context.classProxy(function.getClassName()), function.getMethodName());
+                recorder.register(context.classProxy(function.getClassName()), function.getMethodName(),
+                        function.getDescriptor());
             } else {
                 recorder.register(context.classProxy(function.getClassName()), function.getMethodName(),
-                        function.getFunctionName());
+                        function.getDescriptor(), function.getFunctionName());
             }
         }
         return FunctionInitializedBuildItem.SINGLETON;

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionRecorder.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionRecorder.java
@@ -10,11 +10,11 @@ public class FunctionRecorder {
         registry = new FunctionRegistry();
     }
 
-    public void register(Class functionClass, String methodName) {
-        registry.register(functionClass, methodName, methodName);
+    public void register(Class functionClass, String methodName, String descriptor) {
+        registry.register(functionClass, methodName, descriptor, methodName);
     }
 
-    public void register(Class functionClass, String methodName, String functionName) {
-        registry.register(functionClass, methodName, functionName);
+    public void register(Class functionClass, String methodName, String descriptor, String functionName) {
+        registry.register(functionClass, methodName, descriptor, functionName);
     }
 }

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionRegistry.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionRegistry.java
@@ -8,9 +8,9 @@ import java.util.Map;
 public class FunctionRegistry {
     protected Map<String, FunctionInvoker> functions = new HashMap<>();
 
-    public void register(Class clz, String methodName, String functionName) {
+    public void register(Class clz, String methodName, String descriptor, String functionName) {
         for (Method m : clz.getMethods()) {
-            if (m.getName().equals(methodName)) {
+            if (m.getName().equals(methodName) && descriptor.equals(getMethodDescriptor(m))) {
                 functions.put(functionName, new FunctionInvoker(functionName, clz, m));
             }
         }
@@ -22,5 +22,40 @@ public class FunctionRegistry {
 
     public Collection<FunctionInvoker> invokers() {
         return functions.values();
+    }
+
+    private static String getDescriptorForClass(final Class c) {
+        if (c.isPrimitive()) {
+            if (c == byte.class)
+                return "B";
+            if (c == char.class)
+                return "C";
+            if (c == double.class)
+                return "D";
+            if (c == float.class)
+                return "F";
+            if (c == int.class)
+                return "I";
+            if (c == long.class)
+                return "J";
+            if (c == short.class)
+                return "S";
+            if (c == boolean.class)
+                return "Z";
+            if (c == void.class)
+                return "V";
+            throw new RuntimeException("Unrecognized primitive " + c);
+        }
+        if (c.isArray())
+            return c.getName().replace('.', '/');
+        return ('L' + c.getName() + ';').replace('.', '/');
+    }
+
+    private static String getMethodDescriptor(Method m) {
+        String s = "(";
+        for (final Class c : m.getParameterTypes())
+            s += getDescriptorForClass(c);
+        s += ')';
+        return s + getDescriptorForClass(m.getReturnType());
     }
 }


### PR DESCRIPTION
* Allow function overload (provided functions are re-named by Funq annotation):
  ```java
  @Funq("intfun")
  public int function(int i) {
      return i * 2;
  }
  
  @Funq("strfun")
  public String function(String s) {
      return s.toUpperCase();
  }
  ```

* Check for name conflict. If two function have the same name the build will print warning.