### PR TITLE
Fix the generation init-tasks by database migration on Kubernetes

### DIFF
--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
@@ -221,13 +221,15 @@ class FlywayProcessor {
     }
 
     @BuildStep
-    public InitTaskBuildItem configureInitTask() {
-        return InitTaskBuildItem.create()
-                .withName("flyway-init")
-                .withTaskEnvVars(Map.of("QUARKUS_INIT_AND_EXIT", "true", "QUARKUS_FLYWAY_ENABLED", "true"))
-                .withAppEnvVars(Map.of("QUARKUS_FLYWAY_ENABLED", "false"))
-                .withSharedEnvironment(true)
-                .withSharedFilesystem(true);
+    public void configureInitTask(FlywayBuildTimeConfig config, BuildProducer<InitTaskBuildItem> initTasks) {
+        if (config.generateInitTask && config.defaultDataSource.migrateWithInitTask) {
+            initTasks.produce(InitTaskBuildItem.create()
+                    .withName("flyway-init")
+                    .withTaskEnvVars(Map.of("QUARKUS_INIT_AND_EXIT", "true", "QUARKUS_FLYWAY_ENABLED", "true"))
+                    .withAppEnvVars(Map.of("QUARKUS_FLYWAY_ENABLED", "false"))
+                    .withSharedEnvironment(true)
+                    .withSharedFilesystem(true));
+        }
     }
 
     private Set<String> getDataSourceNames(List<JdbcDataSourceBuildItem> jdbcDataSourceBuildItems) {

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayBuildTimeConfig.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayBuildTimeConfig.java
@@ -22,6 +22,15 @@ public final class FlywayBuildTimeConfig {
     }
 
     /**
+     * Flag to enable / disable the generation of the init task Kubernetes resources.
+     * This property is only relevant if the Quarkus Kubernetes/OpenShift extensions are present.
+     *
+     * The default value is `quarkus.flyway.enabled`.
+     */
+    @ConfigItem(defaultValue = "${quarkus.flyway.enabled:true}")
+    public boolean generateInitTask;
+
+    /**
      * Flyway configuration for the default datasource.
      */
     @ConfigItem(name = ConfigItem.PARENT)

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceBuildTimeConfig.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceBuildTimeConfig.java
@@ -37,6 +37,15 @@ public final class FlywayDataSourceBuildTimeConfig {
     public Optional<List<String>> callbacks = Optional.empty();
 
     /**
+     * Flag to enable / disable the migration using the generated init task Kubernetes resources.
+     * This property is only relevant if the Quarkus Kubernetes/OpenShift extensions are present.
+     *
+     * The default value is `quarkus.flyway.migrate-at-start`.
+     */
+    @ConfigItem(defaultValue = "${quarkus.flyway.migrate-at-start:false}")
+    public boolean migrateWithInitTask;
+
+    /**
      * Creates a {@link FlywayDataSourceBuildTimeConfig} with default settings.
      *
      * @return {@link FlywayDataSourceBuildTimeConfig}

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesInitContainerBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesInitContainerBuildItem.java
@@ -24,8 +24,8 @@ public final class KubernetesInitContainerBuildItem extends MultiBuildItem {
     private final boolean sharedEnvironment;
     private final boolean sharedFilesystem;
 
-    public static KubernetesInitContainerBuildItem create(String image) {
-        return new KubernetesInitContainerBuildItem("init", null, image, Collections.emptyList(), Collections.emptyList(),
+    public static KubernetesInitContainerBuildItem create(String name, String image) {
+        return new KubernetesInitContainerBuildItem(name, null, image, Collections.emptyList(), Collections.emptyList(),
                 Collections.emptyMap(), false, false);
     }
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddInitContainerDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddInitContainerDecorator.java
@@ -1,0 +1,74 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.kubernetes.adapter.ContainerAdapter;
+import io.dekorate.kubernetes.config.Container;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PodSpecBuilder;
+
+public abstract class AddInitContainerDecorator extends NamedResourceDecorator<PodSpecBuilder> {
+
+    private final Container container;
+
+    public AddInitContainerDecorator(String deployment, Container container) {
+        super(deployment);
+        this.container = container;
+    }
+
+    @Override
+    public void andThenVisit(PodSpecBuilder podSpec, ObjectMeta resourceMeta) {
+        var resource = ContainerAdapter.adapt(container);
+        if (podSpec.hasMatchingInitContainer(this::hasInitContainer)) {
+            update(podSpec, resource);
+        } else {
+            add(podSpec, resource);
+        }
+    }
+
+    private void add(PodSpecBuilder podSpec, io.fabric8.kubernetes.api.model.Container resource) {
+        podSpec.addToInitContainers(resource);
+    }
+
+    private void update(PodSpecBuilder podSpec, io.fabric8.kubernetes.api.model.Container resource) {
+        var matching = podSpec.editMatchingInitContainer(this::hasInitContainer);
+        if (resource.getImage() != null) {
+            matching.withImage(resource.getImage());
+        }
+
+        if (resource.getImage() != null) {
+            matching.withImage(resource.getImage());
+        }
+
+        if (resource.getWorkingDir() != null) {
+            matching.withWorkingDir(resource.getWorkingDir());
+        }
+
+        if (resource.getCommand() != null && !resource.getCommand().isEmpty()) {
+            matching.withCommand(resource.getCommand());
+        }
+
+        if (resource.getArgs() != null && !resource.getArgs().isEmpty()) {
+            matching.withArgs(resource.getArgs());
+        }
+
+        if (resource.getReadinessProbe() != null) {
+            matching.withReadinessProbe(resource.getReadinessProbe());
+        }
+
+        if (resource.getLivenessProbe() != null) {
+            matching.withLivenessProbe(resource.getLivenessProbe());
+        }
+
+        matching.addAllToEnv(resource.getEnv());
+        if (resource.getPorts() != null && !resource.getPorts().isEmpty()) {
+            matching.withPorts(resource.getPorts());
+        }
+
+        matching.endInitContainer();
+    }
+
+    private boolean hasInitContainer(ContainerBuilder containerBuilder) {
+        return containerBuilder.getName().equals(container.getName());
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddInitContainerFromExtensionsDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddInitContainerFromExtensionsDecorator.java
@@ -1,0 +1,15 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.kubernetes.config.Container;
+import io.dekorate.kubernetes.decorator.Decorator;
+
+public class AddInitContainerFromExtensionsDecorator extends AddInitContainerDecorator {
+
+    public AddInitContainerFromExtensionsDecorator(String deployment, Container container) {
+        super(deployment, container);
+    }
+
+    public Class<? extends Decorator>[] before() {
+        return new Class[] { AddInitContainerFromUserConfigDecorator.class };
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddInitContainerFromUserConfigDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddInitContainerFromUserConfigDecorator.java
@@ -1,0 +1,10 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.kubernetes.config.Container;
+
+public class AddInitContainerFromUserConfigDecorator extends AddInitContainerDecorator {
+
+    public AddInitContainerFromUserConfigDecorator(String name, Container container) {
+        super(name, container);
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyContainerImageDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyContainerImageDecorator.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import io.dekorate.ConfigReference;
 import io.dekorate.WithConfigReferences;
-import io.dekorate.kubernetes.decorator.AddInitContainerDecorator;
 import io.dekorate.kubernetes.decorator.AddSidecarDecorator;
 import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
 import io.dekorate.kubernetes.decorator.ApplyImageDecorator;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ChangeContainerNameDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ChangeContainerNameDecorator.java
@@ -1,7 +1,6 @@
 package io.quarkus.kubernetes.deployment;
 
 import io.dekorate.kubernetes.decorator.AddEnvVarDecorator;
-import io.dekorate.kubernetes.decorator.AddInitContainerDecorator;
 import io.dekorate.kubernetes.decorator.AddLivenessProbeDecorator;
 import io.dekorate.kubernetes.decorator.AddMountDecorator;
 import io.dekorate.kubernetes.decorator.AddPortDecorator;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ChangeContainerNameInDeploymentTriggerDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ChangeContainerNameInDeploymentTriggerDecorator.java
@@ -1,7 +1,23 @@
 package io.quarkus.kubernetes.deployment;
 
-import io.dekorate.kubernetes.decorator.*;
+import io.dekorate.kubernetes.decorator.AddAwsElasticBlockStoreVolumeDecorator;
+import io.dekorate.kubernetes.decorator.AddAzureDiskVolumeDecorator;
+import io.dekorate.kubernetes.decorator.AddEnvVarDecorator;
+import io.dekorate.kubernetes.decorator.AddLivenessProbeDecorator;
+import io.dekorate.kubernetes.decorator.AddMountDecorator;
+import io.dekorate.kubernetes.decorator.AddPortDecorator;
+import io.dekorate.kubernetes.decorator.AddPvcVolumeDecorator;
+import io.dekorate.kubernetes.decorator.AddReadinessProbeDecorator;
 import io.dekorate.kubernetes.decorator.AddSidecarDecorator;
+import io.dekorate.kubernetes.decorator.ApplyApplicationContainerDecorator;
+import io.dekorate.kubernetes.decorator.ApplyArgsDecorator;
+import io.dekorate.kubernetes.decorator.ApplyCommandDecorator;
+import io.dekorate.kubernetes.decorator.ApplyImageDecorator;
+import io.dekorate.kubernetes.decorator.ApplyImagePullPolicyDecorator;
+import io.dekorate.kubernetes.decorator.ApplyServiceAccountNamedDecorator;
+import io.dekorate.kubernetes.decorator.ApplyWorkingDirDecorator;
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
 import io.dekorate.openshift.decorator.ApplyDeploymentTriggerDecorator;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.openshift.api.model.DeploymentConfigSpecFluent;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
@@ -1,6 +1,6 @@
 package io.quarkus.kubernetes.deployment;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -20,10 +20,14 @@ import io.quarkus.kubernetes.spi.PolicyRule;
 
 public class InitTaskProcessor {
 
+    private static final String INIT_CONTAINER_WAITER_NAME = "init";
+    private static final String INIT_CONTAINER_WAITER_DEFAULT_IMAGE = "groundnuty/k8s-wait-for:1.3";
+
     static void process(
             String target, // kubernetes, openshift, etc.
             String name,
-            ContainerImageInfoBuildItem image, List<InitTaskBuildItem> initTasks,
+            ContainerImageInfoBuildItem image,
+            List<InitTaskBuildItem> initTasks,
             BuildProducer<KubernetesJobBuildItem> jobs,
             BuildProducer<KubernetesInitContainerBuildItem> initContainers,
             BuildProducer<KubernetesEnvBuildItem> env,
@@ -31,11 +35,11 @@ public class InitTaskProcessor {
             BuildProducer<KubernetesRoleBindingBuildItem> roleBindings,
             BuildProducer<DecoratorBuildItem> decorators) {
 
-        initTasks.forEach(task -> {
-            initContainers.produce(KubernetesInitContainerBuildItem.create("groundnuty/k8s-wait-for:1.3")
-                    .withTarget(target)
-                    .withArguments(Arrays.asList("job", task.getName())));
+        List<String> initContainerWaiterArgs = new ArrayList<>(initTasks.size() + 1);
+        initContainerWaiterArgs.add("job");
 
+        initTasks.forEach(task -> {
+            initContainerWaiterArgs.add(task.getName());
             jobs.produce(KubernetesJobBuildItem.create(image.getImage())
                     .withName(task.getName())
                     .withTarget(target)
@@ -63,5 +67,12 @@ public class InitTaskProcessor {
             roleBindings.produce(new KubernetesRoleBindingBuildItem(null, "view-jobs", false, target));
 
         });
+
+        if (!initTasks.isEmpty()) {
+            initContainers.produce(KubernetesInitContainerBuildItem.create(INIT_CONTAINER_WAITER_NAME,
+                    INIT_CONTAINER_WAITER_DEFAULT_IMAGE)
+                    .withTarget(target)
+                    .withArguments(initContainerWaiterArgs));
+        }
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/InitTaskProcessor.java
@@ -21,7 +21,7 @@ import io.quarkus.kubernetes.spi.PolicyRule;
 public class InitTaskProcessor {
 
     private static final String INIT_CONTAINER_WAITER_NAME = "init";
-    private static final String INIT_CONTAINER_WAITER_DEFAULT_IMAGE = "groundnuty/k8s-wait-for:1.3";
+    private static final String INIT_CONTAINER_WAITER_DEFAULT_IMAGE = "groundnuty/k8s-wait-for:no-root-v1.7";
 
     static void process(
             String target, // kubernetes, openshift, etc.

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
@@ -40,7 +40,6 @@ import io.dekorate.kubernetes.decorator.AddEmptyDirVolumeDecorator;
 import io.dekorate.kubernetes.decorator.AddEnvVarDecorator;
 import io.dekorate.kubernetes.decorator.AddHostAliasesDecorator;
 import io.dekorate.kubernetes.decorator.AddImagePullSecretDecorator;
-import io.dekorate.kubernetes.decorator.AddInitContainerDecorator;
 import io.dekorate.kubernetes.decorator.AddLabelDecorator;
 import io.dekorate.kubernetes.decorator.AddLivenessProbeDecorator;
 import io.dekorate.kubernetes.decorator.AddMetadataToTemplateDecorator;
@@ -602,7 +601,7 @@ public class KubernetesCommonHelper {
             }
 
             result.add(new DecoratorBuildItem(target,
-                    new AddInitContainerDecorator(name, containerBuilder
+                    new AddInitContainerFromExtensionsDecorator(name, containerBuilder
                             .addAllToEnvVars(item.getEnvVars().entrySet().stream().map(e -> new EnvBuilder()
                                     .withName(e.getKey())
                                     .withValue(e.getValue())
@@ -750,7 +749,8 @@ public class KubernetesCommonHelper {
         });
 
         config.getInitContainers().entrySet().forEach(e -> {
-            result.add(new DecoratorBuildItem(target, new AddInitContainerDecorator(name, ContainerConverter.convert(e))));
+            result.add(new DecoratorBuildItem(target,
+                    new AddInitContainerFromUserConfigDecorator(name, ContainerConverter.convert(e))));
         });
 
         config.getSidecars().entrySet().forEach(e -> {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/MinikubeManifestGenerator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/MinikubeManifestGenerator.java
@@ -17,7 +17,6 @@ import io.dekorate.kubernetes.config.KubernetesConfig;
 import io.dekorate.kubernetes.config.KubernetesConfigBuilder;
 import io.dekorate.kubernetes.configurator.ApplyDeployToApplicationConfiguration;
 import io.dekorate.kubernetes.decorator.AddIngressDecorator;
-import io.dekorate.kubernetes.decorator.AddInitContainerDecorator;
 import io.dekorate.kubernetes.decorator.AddServiceResourceDecorator;
 import io.dekorate.kubernetes.decorator.ApplyHeadlessDecorator;
 import io.dekorate.kubernetes.decorator.ApplyImageDecorator;
@@ -108,7 +107,7 @@ public class MinikubeManifestGenerator extends AbstractKubernetesManifestGenerat
         super.addDecorators(group, config);
 
         for (Container container : config.getInitContainers()) {
-            resourceRegistry.decorate(group, new AddInitContainerDecorator(config.getName(), container));
+            resourceRegistry.decorate(group, new AddInitContainerFromUserConfigDecorator(config.getName(), container));
         }
 
         if (config.getPorts().length > 0) {

--- a/extensions/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
+++ b/extensions/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
@@ -254,14 +254,16 @@ class LiquibaseMongodbProcessor {
     }
 
     @BuildStep
-    public InitTaskBuildItem configureInitTask() {
-        return InitTaskBuildItem.create()
-                .withName("liquibase-mongodb-init")
-                .withTaskEnvVars(
-                        Map.of("QUARKUS_INIT_AND_EXIT", "true", "QUARKUS_LIQUIBASE_MONGODB_ENABLED", "true"))
-                .withAppEnvVars(Map.of("QUARKUS_LIQUIBASE_MONGODB_ENABLED", "false"))
-                .withSharedEnvironment(true)
-                .withSharedFilesystem(true);
+    public void configureInitTask(LiquibaseMongodbBuildTimeConfig config, BuildProducer<InitTaskBuildItem> initTasks) {
+        if (config.generateInitTask && config.migrateWithInitTask) {
+            initTasks.produce(InitTaskBuildItem.create()
+                    .withName("liquibase-mongodb-init")
+                    .withTaskEnvVars(
+                            Map.of("QUARKUS_INIT_AND_EXIT", "true", "QUARKUS_LIQUIBASE_MONGODB_ENABLED", "true"))
+                    .withAppEnvVars(Map.of("QUARKUS_LIQUIBASE_MONGODB_ENABLED", "false"))
+                    .withSharedEnvironment(true)
+                    .withSharedFilesystem(true));
+        }
     }
 
     /**

--- a/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbBuildTimeConfig.java
+++ b/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbBuildTimeConfig.java
@@ -15,4 +15,22 @@ public class LiquibaseMongodbBuildTimeConfig {
      */
     @ConfigItem(defaultValue = "db/changeLog.xml")
     public String changeLog;
+
+    /**
+     * Flag to enable / disable the generation of the init task Kubernetes resources.
+     * This property is only relevant if the Quarkus Kubernetes/OpenShift extensions are present.
+     *
+     * The default value is `quarkus.liquibase-mongodb.enabled`.
+     */
+    @ConfigItem(defaultValue = "${quarkus.liquibase-mongodb.enabled:true}")
+    public boolean generateInitTask;
+
+    /**
+     * Flag to enable / disable the migration using the generated init task Kubernetes resources.
+     * This property is only relevant if the Quarkus Kubernetes/OpenShift extensions are present.
+     *
+     * The default value is `quarkus.liquibase-mongodb.migrate-at-start`.
+     */
+    @ConfigItem(defaultValue = "${quarkus.liquibase-mongodb.migrate-at-start:false}")
+    public boolean migrateWithInitTask;
 }

--- a/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
+++ b/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
@@ -314,13 +314,15 @@ class LiquibaseProcessor {
     }
 
     @BuildStep
-    public InitTaskBuildItem configureInitTask() {
-        return InitTaskBuildItem.create()
-                .withName("liquibase-init")
-                .withTaskEnvVars(Map.of("QUARKUS_INIT_AND_EXIT", "true", "QUARKUS_LIQUIBASE_ENABLED", "true"))
-                .withAppEnvVars(Map.of("QUARKUS_LIQUIBASE_ENABLED", "false"))
-                .withSharedEnvironment(true)
-                .withSharedFilesystem(true);
+    public void configureInitTask(LiquibaseBuildTimeConfig config, BuildProducer<InitTaskBuildItem> initTasks) {
+        if (config.generateInitTask && config.defaultDataSource.migrateWithInitTask) {
+            initTasks.produce(InitTaskBuildItem.create()
+                    .withName("liquibase-init")
+                    .withTaskEnvVars(Map.of("QUARKUS_INIT_AND_EXIT", "true", "QUARKUS_LIQUIBASE_ENABLED", "true"))
+                    .withAppEnvVars(Map.of("QUARKUS_LIQUIBASE_ENABLED", "false"))
+                    .withSharedEnvironment(true)
+                    .withSharedFilesystem(true));
+        }
     }
 
     private Set<String> getDataSourceNames(List<JdbcDataSourceBuildItem> jdbcDataSourceBuildItems) {

--- a/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseBuildTimeConfig.java
+++ b/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseBuildTimeConfig.java
@@ -32,6 +32,15 @@ public final class LiquibaseBuildTimeConfig {
     }
 
     /**
+     * Flag to enable / disable the generation of the init task Kubernetes resources.
+     * This property is only relevant if the Quarkus Kubernetes/OpenShift extensions are present.
+     *
+     * The default value is `quarkus.liquibase.enabled`.
+     */
+    @ConfigItem(defaultValue = "${quarkus.liquibase.enabled:true}")
+    public boolean generateInitTask;
+
+    /**
      * Liquibase configuration for the default datasource.
      */
     @ConfigItem(name = ConfigItem.PARENT)

--- a/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseDataSourceBuildTimeConfig.java
+++ b/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/runtime/LiquibaseDataSourceBuildTimeConfig.java
@@ -28,4 +28,13 @@ public final class LiquibaseDataSourceBuildTimeConfig {
     @ConfigItem(defaultValue = DEFAULT_CHANGE_LOG)
     public String changeLog;
 
+    /**
+     * Flag to enable / disable the migration using the generated init task Kubernetes resources.
+     * This property is only relevant if the Quarkus Kubernetes/OpenShift extensions are present.
+     *
+     * The default value is `quarkus.liquibase.migrate-at-start`.
+     */
+    @ConfigItem(defaultValue = "${quarkus.liquibase.migrate-at-start:false}")
+    public boolean migrateWithInitTask;
+
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitMigrationDisabledTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitMigrationDisabledTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.kubernetes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -24,9 +25,9 @@ import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
 
-public class KubernetesWithFlywayInitTest {
+public class KubernetesWithFlywayInitMigrationDisabledTest {
 
-    private static final String NAME = "kubernetes-with-flyway-init";
+    private static final String NAME = "kubernetes-with-flyway-init-migration-disabled";
 
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
@@ -34,7 +35,7 @@ public class KubernetesWithFlywayInitTest {
             .setApplicationName(NAME)
             .setApplicationVersion("0.1-SNAPSHOT")
             .setLogFileName("k8s.log")
-            .overrideConfigKey("quarkus.flyway.migrate-at-start", "true")
+            .overrideConfigKey("quarkus.flyway.migrate-at-start", "false")
             .setForcedDependencies(Arrays.asList(
                     new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
                     new AppArtifact("io.quarkus", "quarkus-flyway", Version.getVersion())));
@@ -66,7 +67,7 @@ public class KubernetesWithFlywayInitTest {
             assertThat(d.getSpec()).satisfies(deploymentSpec -> {
                 assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
-                        assertThat(podSpec.getInitContainers()).singleElement().satisfies(container -> {
+                        assertThat(podSpec.getInitContainers()).noneSatisfy(container -> {
                             assertThat(container.getName()).isEqualTo("init");
                         });
 
@@ -78,32 +79,11 @@ public class KubernetesWithFlywayInitTest {
         Optional<Job> job = kubernetesList.stream()
                 .filter(j -> "Job".equals(j.getKind()) && "flyway-init".equals(j.getMetadata().getName())).map(j -> (Job) j)
                 .findAny();
-        assertTrue(job.isPresent());
-
-        assertThat(job.get()).satisfies(j -> {
-            assertThat(j.getSpec()).satisfies(jobSpec -> {
-                assertThat(jobSpec.getTemplate()).satisfies(t -> {
-                    assertThat(t.getSpec()).satisfies(podSpec -> {
-                        assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
-                            assertThat(container.getName()).isEqualTo("flyway-init");
-                            assertThat(container.getEnv()).filteredOn(env -> "QUARKUS_FLYWAY_ENABLED".equals(env.getName()))
-                                    .singleElement().satisfies(env -> {
-                                        assertThat(env.getValue()).isEqualTo("true");
-                                    });
-                            assertThat(container.getEnv())
-                                    .filteredOn(env -> "QUARKUS_INIT_AND_EXIT".equals(env.getName())).singleElement()
-                                    .satisfies(env -> {
-                                        assertThat(env.getValue()).isEqualTo("true");
-                                    });
-                        });
-                    });
-                });
-            });
-        });
+        assertFalse(job.isPresent());
 
         Optional<RoleBinding> roleBinding = kubernetesList.stream().filter(
                 r -> r instanceof RoleBinding && (NAME + "-view-jobs").equals(r.getMetadata().getName()))
                 .map(r -> (RoleBinding) r).findFirst();
-        assertTrue(roleBinding.isPresent());
+        assertFalse(roleBinding.isPresent());
     }
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitOverrideWaiterImageTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitOverrideWaiterImageTest.java
@@ -24,9 +24,10 @@ import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
 
-public class KubernetesWithFlywayInitTest {
+public class KubernetesWithFlywayInitOverrideWaiterImageTest {
 
-    private static final String NAME = "kubernetes-with-flyway-init";
+    private static final String NAME = "kubernetes-with-flyway-init-override-waiter-image";
+    private static final String OVERRIDDEN_WAITER_IMAGE = "overridden:latest";
 
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
@@ -35,6 +36,7 @@ public class KubernetesWithFlywayInitTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .setLogFileName("k8s.log")
             .overrideConfigKey("quarkus.flyway.migrate-at-start", "true")
+            .overrideConfigKey("quarkus.kubernetes.init-containers.\"init\".image", OVERRIDDEN_WAITER_IMAGE)
             .setForcedDependencies(Arrays.asList(
                     new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
                     new AppArtifact("io.quarkus", "quarkus-flyway", Version.getVersion())));
@@ -68,7 +70,7 @@ public class KubernetesWithFlywayInitTest {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         assertThat(podSpec.getInitContainers()).singleElement().satisfies(container -> {
                             assertThat(container.getName()).isEqualTo("init");
-                            assertThat(container.getImage()).isEqualTo("groundnuty/k8s-wait-for:1.3");
+                            assertThat(container.getImage()).isEqualTo(OVERRIDDEN_WAITER_IMAGE);
                         });
 
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithFlywayInitTest.java
@@ -68,7 +68,7 @@ public class KubernetesWithFlywayInitTest {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         assertThat(podSpec.getInitContainers()).singleElement().satisfies(container -> {
                             assertThat(container.getName()).isEqualTo("init");
-                            assertThat(container.getImage()).isEqualTo("groundnuty/k8s-wait-for:1.3");
+                            assertThat(container.getImage()).isEqualTo("groundnuty/k8s-wait-for:no-root-v1.7");
                         });
 
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithLiquibaseInitTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithLiquibaseInitTest.java
@@ -24,9 +24,9 @@ import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
 
-public class KubernetesWithFlywayInitTest {
+public class KubernetesWithLiquibaseInitTest {
 
-    private static final String NAME = "kubernetes-with-flyway-init";
+    private static final String NAME = "kubernetes-with-liquibase-init";
 
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
@@ -34,10 +34,10 @@ public class KubernetesWithFlywayInitTest {
             .setApplicationName(NAME)
             .setApplicationVersion("0.1-SNAPSHOT")
             .setLogFileName("k8s.log")
-            .overrideConfigKey("quarkus.flyway.migrate-at-start", "true")
+            .overrideConfigKey("quarkus.liquibase.migrate-at-start", "true")
             .setForcedDependencies(Arrays.asList(
                     new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
-                    new AppArtifact("io.quarkus", "quarkus-flyway", Version.getVersion())));
+                    new AppArtifact("io.quarkus", "quarkus-liquibase", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;
@@ -76,7 +76,7 @@ public class KubernetesWithFlywayInitTest {
         });
 
         Optional<Job> job = kubernetesList.stream()
-                .filter(j -> "Job".equals(j.getKind()) && "flyway-init".equals(j.getMetadata().getName())).map(j -> (Job) j)
+                .filter(j -> "Job".equals(j.getKind()) && "liquibase-init".equals(j.getMetadata().getName())).map(j -> (Job) j)
                 .findAny();
         assertTrue(job.isPresent());
 
@@ -85,8 +85,8 @@ public class KubernetesWithFlywayInitTest {
                 assertThat(jobSpec.getTemplate()).satisfies(t -> {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
-                            assertThat(container.getName()).isEqualTo("flyway-init");
-                            assertThat(container.getEnv()).filteredOn(env -> "QUARKUS_FLYWAY_ENABLED".equals(env.getName()))
+                            assertThat(container.getName()).isEqualTo("liquibase-init");
+                            assertThat(container.getEnv()).filteredOn(env -> "QUARKUS_LIQUIBASE_ENABLED".equals(env.getName()))
                                     .singleElement().satisfies(env -> {
                                         assertThat(env.getValue()).isEqualTo("true");
                                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithLiquibaseMongoDbInitMigrationDisabledTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithLiquibaseMongoDbInitMigrationDisabledTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.kubernetes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -24,9 +25,9 @@ import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
 
-public class KubernetesWithFlywayInitTest {
+public class KubernetesWithLiquibaseMongoDbInitMigrationDisabledTest {
 
-    private static final String NAME = "kubernetes-with-flyway-init";
+    private static final String NAME = "kubernetes-with-liquibase-mongodb-init-migration-disabled";
 
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
@@ -34,10 +35,10 @@ public class KubernetesWithFlywayInitTest {
             .setApplicationName(NAME)
             .setApplicationVersion("0.1-SNAPSHOT")
             .setLogFileName("k8s.log")
-            .overrideConfigKey("quarkus.flyway.migrate-at-start", "true")
+            .overrideConfigKey("quarkus.liquibase-mongodb.migrate-at-start", "false")
             .setForcedDependencies(Arrays.asList(
                     new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
-                    new AppArtifact("io.quarkus", "quarkus-flyway", Version.getVersion())));
+                    new AppArtifact("io.quarkus", "quarkus-liquibase-mongodb", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;
@@ -66,7 +67,7 @@ public class KubernetesWithFlywayInitTest {
             assertThat(d.getSpec()).satisfies(deploymentSpec -> {
                 assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
-                        assertThat(podSpec.getInitContainers()).singleElement().satisfies(container -> {
+                        assertThat(podSpec.getInitContainers()).noneSatisfy(container -> {
                             assertThat(container.getName()).isEqualTo("init");
                         });
 
@@ -76,34 +77,14 @@ public class KubernetesWithFlywayInitTest {
         });
 
         Optional<Job> job = kubernetesList.stream()
-                .filter(j -> "Job".equals(j.getKind()) && "flyway-init".equals(j.getMetadata().getName())).map(j -> (Job) j)
+                .filter(j -> "Job".equals(j.getKind()) && "liquibase-mongodb-init".equals(j.getMetadata().getName()))
+                .map(j -> (Job) j)
                 .findAny();
-        assertTrue(job.isPresent());
-
-        assertThat(job.get()).satisfies(j -> {
-            assertThat(j.getSpec()).satisfies(jobSpec -> {
-                assertThat(jobSpec.getTemplate()).satisfies(t -> {
-                    assertThat(t.getSpec()).satisfies(podSpec -> {
-                        assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
-                            assertThat(container.getName()).isEqualTo("flyway-init");
-                            assertThat(container.getEnv()).filteredOn(env -> "QUARKUS_FLYWAY_ENABLED".equals(env.getName()))
-                                    .singleElement().satisfies(env -> {
-                                        assertThat(env.getValue()).isEqualTo("true");
-                                    });
-                            assertThat(container.getEnv())
-                                    .filteredOn(env -> "QUARKUS_INIT_AND_EXIT".equals(env.getName())).singleElement()
-                                    .satisfies(env -> {
-                                        assertThat(env.getValue()).isEqualTo("true");
-                                    });
-                        });
-                    });
-                });
-            });
-        });
+        assertFalse(job.isPresent());
 
         Optional<RoleBinding> roleBinding = kubernetesList.stream().filter(
                 r -> r instanceof RoleBinding && (NAME + "-view-jobs").equals(r.getMetadata().getName()))
                 .map(r -> (RoleBinding) r).findFirst();
-        assertTrue(roleBinding.isPresent());
+        assertFalse(roleBinding.isPresent());
     }
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithLiquibaseMongoDbInitTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithLiquibaseMongoDbInitTest.java
@@ -24,9 +24,9 @@ import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
 
-public class KubernetesWithFlywayInitTest {
+public class KubernetesWithLiquibaseMongoDbInitTest {
 
-    private static final String NAME = "kubernetes-with-flyway-init";
+    private static final String NAME = "kubernetes-with-liquibase-mongodb-init";
 
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
@@ -34,10 +34,10 @@ public class KubernetesWithFlywayInitTest {
             .setApplicationName(NAME)
             .setApplicationVersion("0.1-SNAPSHOT")
             .setLogFileName("k8s.log")
-            .overrideConfigKey("quarkus.flyway.migrate-at-start", "true")
+            .overrideConfigKey("quarkus.liquibase-mongodb.migrate-at-start", "true")
             .setForcedDependencies(Arrays.asList(
                     new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
-                    new AppArtifact("io.quarkus", "quarkus-flyway", Version.getVersion())));
+                    new AppArtifact("io.quarkus", "quarkus-liquibase-mongodb", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;
@@ -76,7 +76,8 @@ public class KubernetesWithFlywayInitTest {
         });
 
         Optional<Job> job = kubernetesList.stream()
-                .filter(j -> "Job".equals(j.getKind()) && "flyway-init".equals(j.getMetadata().getName())).map(j -> (Job) j)
+                .filter(j -> "Job".equals(j.getKind()) && "liquibase-mongodb-init".equals(j.getMetadata().getName()))
+                .map(j -> (Job) j)
                 .findAny();
         assertTrue(job.isPresent());
 
@@ -85,8 +86,9 @@ public class KubernetesWithFlywayInitTest {
                 assertThat(jobSpec.getTemplate()).satisfies(t -> {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
-                            assertThat(container.getName()).isEqualTo("flyway-init");
-                            assertThat(container.getEnv()).filteredOn(env -> "QUARKUS_FLYWAY_ENABLED".equals(env.getName()))
+                            assertThat(container.getName()).isEqualTo("liquibase-mongodb-init");
+                            assertThat(container.getEnv())
+                                    .filteredOn(env -> "QUARKUS_LIQUIBASE_MONGODB_ENABLED".equals(env.getName()))
                                     .singleElement().satisfies(env -> {
                                         assertThat(env.getValue()).isEqualTo("true");
                                     });


### PR DESCRIPTION
These changes include:
**- Don't generate the init task for db migration if migrate at start is off:**

The `quarkus.[flyway or liquibase or liquibase-mongodb].enabled` and `quarkus.[flyway or liquibase or liquibase-mongodb].migrate-at-start` properties are runtime properties, so I have to create the following build time properties to read these values and allow users configurating it:

- `quarkus.[flyway or liquibase or liquibase-mongodb].generate-init-task` with default value `quarkus.[flyway or liquibase or liquibase-mongodb].enabled`
- `quarkus.[flyway or liquibase or liquibase-mongodb].migrate-with-init-task` with default value `quarkus.[flyway or liquibase or liquibase-mongodb].migrate-at-start`

Plus, I've extended the coverage of these extensions with the K8s tests. 

**- Allow overriding generated init-container of extensions from user config** (related to [this comment](https://github.com/quarkusio/quarkus/issues/33097#issuecomment-1533019528))
**- Change default image for init container waiters (necessary for OpenShift deployments)** (related to [this comment](https://github.com/quarkusio/quarkus/issues/33097#issuecomment-1532989601))

Each of these changes is included in an individual commit on purpose to ease up the review. 

Fix https://github.com/quarkusio/quarkus/issues/33097