### PR TITLE
Speed up the Gradle build

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -50,6 +50,7 @@ env:
   DB_NAME: hibernate_orm_test
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
   PULL_REQUEST_NUMBER: ${{ github.event.number }}
+  CI_INCREMENTAL: true
 jobs:
   # This is a hack to work around a GitHub API limitation:
   # when the PR is coming from another fork, the pull_requests field of the

--- a/devtools/gradle/README.adoc
+++ b/devtools/gradle/README.adoc
@@ -33,6 +33,7 @@ or any of the subprojects.
 
 However, see the important notes about <<testing, testing>>.
 
+The Maven build runs Gradle from "its parent pom" and not from the individual submodules to speed up the whole build.
 
 [[testing]]
 == Running Tests

--- a/devtools/gradle/gradle-application-plugin/pom.xml
+++ b/devtools/gradle/gradle-application-plugin/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <artifactFilePrefix>gradle-application-plugin</artifactFilePrefix>
+        <gradle.project.name>:gradle-application-plugin</gradle.project.name>
     </properties>
 
     <dependencies>

--- a/devtools/gradle/gradle-extension-plugin/pom.xml
+++ b/devtools/gradle/gradle-extension-plugin/pom.xml
@@ -18,6 +18,7 @@
 
     <properties>
         <artifactFilePrefix>gradle-extension-plugin</artifactFilePrefix>
+        <gradle.project.name>:gradle-extension-plugin</gradle.project.name>
     </properties>
 
     <dependencies>

--- a/devtools/gradle/gradle-model/pom.xml
+++ b/devtools/gradle/gradle-model/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <artifactFilePrefix>gradle-model</artifactFilePrefix>
+        <gradle.project.name>:gradle-model</gradle.project.name>
     </properties>
 
     <dependencies>

--- a/devtools/gradle/gradle.properties
+++ b/devtools/gradle/gradle.properties
@@ -1,8 +1,5 @@
 version = 999-SNAPSHOT
 
-# Idle timeout in milliseconds
-systemProp.org.gradle.daemon.idletimeout=10000
-
 # enable the Gradle build cache
 org.gradle.caching=true
 # enable Gradle parallel builds

--- a/devtools/gradle/gradle.properties
+++ b/devtools/gradle/gradle.properties
@@ -1,1 +1,11 @@
 version = 999-SNAPSHOT
+
+# Idle timeout in milliseconds
+systemProp.org.gradle.daemon.idletimeout=10000
+
+# enable the Gradle build cache
+org.gradle.caching=true
+# enable Gradle parallel builds
+org.gradle.parallel=true
+# configure only necessary Gradle tasks
+org.gradle.configureondemand=true

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -50,34 +50,6 @@
             </properties>
         </profile>
         <profile>
-            <id>run-gradle-clean</id>
-            <activation>
-                <file>
-                    <missing>${basedir}/src</missing> <!-- only for this pom, so the clean's only run once for all -->
-                </file>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-clean-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>gradle</id>
-                                <phase>clean</phase>
-                                <configuration>
-                                    <executable>${gradle.executable}</executable>
-                                    <arguments>
-                                        <argument>clean</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>run-gradle</id>
             <activation>
                 <file>

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -16,7 +16,7 @@
     <description>Quarkus - Gradle Plugin</description>
 
     <properties>
-        <gradle.executable>./../gradlew</gradle.executable>
+        <gradle.executable>./gradlew</gradle.executable>
         <gradle.task>build</gradle.task>
         <skip.gradle.build>false</skip.gradle.build>
     </properties>
@@ -46,14 +46,42 @@
                 </os>
             </activation>
             <properties>
-                <gradle.executable>..\gradlew.bat</gradle.executable>
+                <gradle.executable>gradlew.bat</gradle.executable>
             </properties>
+        </profile>
+        <profile>
+            <id>run-gradle-clean</id>
+            <activation>
+                <file>
+                    <missing>${basedir}/src</missing> <!-- only for this pom, so the clean's only run once for all -->
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>gradle</id>
+                                <phase>clean</phase>
+                                <configuration>
+                                    <executable>${gradle.executable}</executable>
+                                    <arguments>
+                                        <argument>clean</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>run-gradle</id>
             <activation>
                 <file>
-                    <exists>${basedir}/src</exists> <!-- basically for all submodules -->
+                    <missing>${basedir}/src</missing> <!-- Gradle builds all subprojects, so only run it once -->
                 </file>
             </activation>
             <build>
@@ -63,18 +91,28 @@
                         <artifactId>exec-maven-plugin</artifactId>
                         <executions>
                             <execution>
+                                <id>gradle-clean</id>
+                                <phase>pre-clean</phase>
+                                <configuration>
+                                    <executable>${gradle.executable}</executable>
+                                    <arguments>
+                                        <argument>clean</argument>
+                                    </arguments>
+                                </configuration>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                            <execution>
                                 <id>gradle</id>
                                 <phase>prepare-package</phase>
                                 <configuration>
                                     <executable>${gradle.executable}</executable>
                                     <arguments>
-                                        <argument>clean</argument>
                                         <argument>${gradle.task}</argument>
                                         <argument>-Pdescription=${project.description}</argument>
                                         <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
-                                        <argument>-S</argument>
                                         <argument>--stacktrace</argument>
-                                        <argument>--no-daemon</argument>
                                     </arguments>
                                     <environmentVariables>
                                         <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
@@ -88,6 +126,18 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>install-gradle</id>
+            <activation>
+                <file>
+                    <exists>${basedir}/src</exists> <!-- basically for all submodules -->
+                </file>
+            </activation>
+            <build>
+                <plugins>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>build-helper-maven-plugin</artifactId>

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -19,6 +19,7 @@
         <gradle.executable>./gradlew</gradle.executable>
         <gradle.task>build</gradle.task>
         <skip.gradle.build>false</skip.gradle.build>
+        <gradle.daemon.arg>--daemon</gradle.daemon.arg>
     </properties>
 
     <modules>
@@ -47,6 +48,17 @@
             </activation>
             <properties>
                 <gradle.executable>gradlew.bat</gradle.executable>
+            </properties>
+        </profile>
+        <profile>
+            <id>gradle-ci</id>
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                </property>
+            </activation>
+            <properties>
+                <gradle.daemon.arg>--no-daemon</gradle.daemon.arg>
             </properties>
         </profile>
         <profile>
@@ -85,6 +97,7 @@
                                         <argument>-Pdescription=${project.description}</argument>
                                         <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
                                         <argument>--stacktrace</argument>
+                                        <argument>${gradle.daemon.arg}</argument>
                                     </arguments>
                                     <environmentVariables>
                                         <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <gradle.executable>./gradlew</gradle.executable>
+        <gradle.executable.incremental>../gradlew</gradle.executable.incremental>
         <gradle.task>build</gradle.task>
         <skip.gradle.build>false</skip.gradle.build>
         <gradle.daemon.arg>--daemon</gradle.daemon.arg>
@@ -48,6 +49,7 @@
             </activation>
             <properties>
                 <gradle.executable>gradlew.bat</gradle.executable>
+                <gradle.executable.incremental>..\gradlew.bat</gradle.executable.incremental>
             </properties>
         </profile>
         <profile>
@@ -57,9 +59,77 @@
                     <name>env.CI</name>
                 </property>
             </activation>
+        </profile>
+        <profile>
+            <id>run-gradle-incremental</id>
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                </property>
+            </activation>
             <properties>
-                <gradle.daemon.arg>--no-daemon</gradle.daemon.arg>
+                <gradle.daemon.idletimeout>10000</gradle.daemon.idletimeout>
             </properties>
+        </profile>
+        <profile>
+            <id>run-gradle-incremental</id>
+            <activation>
+                <file>
+                    <exists>${basedir}/src</exists> <!-- Gradle builds all subprojects, so only run it once -->
+                </file>
+                <property>
+                    <name>env.CI_INCREMENTAL</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <configuration>
+                            <executable>${gradle.executable.incremental}</executable>
+                            <arguments>
+                                <argument>-Pdescription=${project.description}</argument>
+                                <argument>-Dorg.gradle.daemon.idletimeout=${gradle.daemon.idletimeout}</argument>
+                                <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
+                                <argument>--stacktrace</argument>
+                                <argument>${gradle.daemon.arg}</argument>
+                            </arguments>
+                            <environmentVariables>
+                                <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
+                                <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
+                            </environmentVariables>
+                            <skip>${skip.gradle.build}</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>gradle-clean</id>
+                                <phase>pre-clean</phase>
+                                <configuration>
+                                    <arguments>
+                                        <argument>${gradle.project.name}:clean</argument>
+                                    </arguments>
+                                </configuration>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>gradle</id>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <arguments>
+                                        <argument>${gradle.project.name}:${gradle.task}</argument>
+                                    </arguments>
+                                </configuration>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>run-gradle</id>
@@ -67,18 +137,34 @@
                 <file>
                     <missing>${basedir}/src</missing> <!-- Gradle builds all subprojects, so only run it once -->
                 </file>
+                <property>
+                    <name>!env.CI_INCREMENTAL</name>
+                </property>
             </activation>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <configuration>
+                            <executable>${gradle.executable}</executable>
+                            <arguments>
+                                <argument>-Pdescription=${project.description}</argument>
+                                <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
+                                <argument>--stacktrace</argument>
+                                <argument>${gradle.daemon.arg}</argument>
+                            </arguments>
+                            <environmentVariables>
+                                <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
+                                <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
+                            </environmentVariables>
+                            <skip>${skip.gradle.build}</skip>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>gradle-clean</id>
                                 <phase>pre-clean</phase>
                                 <configuration>
-                                    <executable>${gradle.executable}</executable>
                                     <arguments>
                                         <argument>clean</argument>
                                     </arguments>
@@ -91,19 +177,9 @@
                                 <id>gradle</id>
                                 <phase>prepare-package</phase>
                                 <configuration>
-                                    <executable>${gradle.executable}</executable>
                                     <arguments>
                                         <argument>${gradle.task}</argument>
-                                        <argument>-Pdescription=${project.description}</argument>
-                                        <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
-                                        <argument>--stacktrace</argument>
-                                        <argument>${gradle.daemon.arg}</argument>
                                     </arguments>
-                                    <environmentVariables>
-                                        <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
-                                        <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
-                                    </environmentVariables>
-                                    <skip>${skip.gradle.build}</skip>
                                 </configuration>
                                 <goals>
                                     <goal>exec</goal>


### PR DESCRIPTION
There are a few tweaks in this change:
* The most "prominent" one is that the Gradle build's now called from "its" parent pom, only the "Maven" parts (install to local repo, etc) are "left" in the submodules. Gradle tests are also run from that parent pom. This equates to how a "native" Gradle build would work.
* The Gradle daemon is no longer terminated synchronously, but use a daemon idle timeout of 10s, so that the now separate `./gradlew clean` followed by the `./gradlew build/assemble` share the running daemon.

Following (non scientific) measurements from my local machine using `mvnd clean install -Dquickly`.

Before this change:
```
[INFO] Quarkus - Gradle Plugin - Parent ................... SUCCESS [  0.021 s]
[INFO] Quarkus - Gradle Model ............................. SUCCESS [ 10.175 s]
[INFO] Quarkus - Gradle Plugin ............................ SUCCESS [ 12.984 s]
[INFO] Quarkus - Extension Gradle Plugin .................. SUCCESS [ 15.500 s]
```

After this change:
```
[INFO] Quarkus - Gradle Plugin - Parent ................... SUCCESS [  6.108 s]
[INFO] Quarkus - Gradle Model ............................. SUCCESS [  0.216 s]
[INFO] Quarkus - Gradle Plugin ............................ SUCCESS [  0.052 s]
[INFO] Quarkus - Extension Gradle Plugin .................. SUCCESS [  0.025 s]
```