### PR TITLE
Remove redundant modifiers for interface fields from NativeConfig

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -19,8 +19,8 @@ import io.smallrye.config.WithDefault;
 @ConfigMapping(prefix = "quarkus.native")
 public interface NativeConfig {
 
-    public static final String DEFAULT_GRAALVM_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3-java17";
-    public static final String DEFAULT_MANDREL_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17";
+    String DEFAULT_GRAALVM_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3-java17";
+    String DEFAULT_MANDREL_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17";
 
     /**
      * Comma-separated, additional arguments to pass to the build process.


### PR DESCRIPTION
Spotted this as I was looking at the NativeConfig.java interface and I opened room for a minor PR to fix this.
/cc @gsmet @geoand can you've a look?