### PR TITLE
Fix order of actual and expectation in SecurityTestUtils assertion

### DIFF
--- a/extensions/security/test-utils/src/main/java/io/quarkus/security/test/utils/SecurityTestUtils.java
+++ b/extensions/security/test-utils/src/main/java/io/quarkus/security/test/utils/SecurityTestUtils.java
@@ -17,7 +17,7 @@ public class SecurityTestUtils {
     public static <T> void assertSuccess(Supplier<T> action, T expectedResult, AuthData... auth) {
         for (AuthData authData : auth) {
             setUpAuth(authData);
-            Assertions.assertEquals(action.get(), expectedResult);
+            Assertions.assertEquals(expectedResult, action.get());
         }
 
     }


### PR DESCRIPTION
The order of expectation and actual object are inverted in `SecurityTestUtils.assertSuccess`, providing misleading error messages in case of failure of the test. This change fixes the order of the parameters in the assertion.