### PR TITLE
OpenAPI: Add support for `apiKey` security scheme configuration

### DIFF
--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -93,6 +93,18 @@ public final class SmallRyeOpenApiConfig {
     public boolean autoAddSecurity;
 
     /**
+     * Required when using `apiKey` security. The location of the API key. Valid values are "query", "header" or "cookie".
+     */
+    @ConfigItem
+    public Optional<String> apiKeyParameterIn;
+
+    /**
+     * Required when using `apiKey` security. The name of the header, query or cookie parameter to be used.
+     */
+    @ConfigItem
+    public Optional<String> apiKeyParameterName;
+
+    /**
      * Add a scheme value to the Basic HTTP Security Scheme
      */
     @ConfigItem(defaultValue = "basic")
@@ -213,6 +225,7 @@ public final class SmallRyeOpenApiConfig {
     public Optional<OperationIdStrategy> operationIdStrategy;
 
     public enum SecurityScheme {
+        apiKey,
         basic,
         jwt,
         oauth2,

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -347,7 +347,7 @@ public class SmallRyeOpenApiProcessor {
             addToOpenAPIDefinitionProducer
                     .produce(new AddToOpenAPIDefinitionBuildItem(
                             new SecurityConfigFilter(config)));
-        } else {
+        } else if (config.autoAddSecurity) {
             OASFilter autoSecurityFilter = getAutoSecurityFilter(securityInformationBuildItems, config);
 
             if (autoSecurityFilter != null) {

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilter.java
@@ -2,6 +2,8 @@ package io.quarkus.smallrye.openapi.deployment.filter;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.eclipse.microprofile.openapi.OASFactory;
 import org.eclipse.microprofile.openapi.OASFilter;
@@ -11,6 +13,7 @@ import org.eclipse.microprofile.openapi.models.security.OAuthFlows;
 import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
 import org.jboss.logging.Logger;
 
+import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 
 /**
@@ -26,78 +29,88 @@ public class SecurityConfigFilter implements OASFilter {
     }
 
     @Override
+    /**
+     * Add a security scheme from config
+     */
     public void filterOpenAPI(OpenAPI openAPI) {
-
-        // Add a security scheme from config
-        if (config.securityScheme.isPresent()) {
-
-            // Make sure components are created
-            if (openAPI.getComponents() == null) {
-                openAPI.setComponents(OASFactory.createComponents());
-            }
-
-            Map<String, SecurityScheme> securitySchemes = new HashMap<>();
-
-            // Add any existing security
-            if (openAPI.getComponents().getSecuritySchemes() != null
-                    && !openAPI.getComponents().getSecuritySchemes().isEmpty()) {
-                securitySchemes.putAll(openAPI.getComponents().getSecuritySchemes());
-            }
-
-            SmallRyeOpenApiConfig.SecurityScheme securitySchemeOption = config.securityScheme.get();
-
-            SecurityScheme securityScheme = OASFactory.createSecurityScheme();
-            securityScheme.setDescription(config.securitySchemeDescription);
-            config.getValidSecuritySchemeExtentions().forEach(securityScheme::addExtension);
-
-            switch (securitySchemeOption) {
-                case basic:
-                    securityScheme.setType(SecurityScheme.Type.HTTP);
-                    securityScheme.setScheme(config.basicSecuritySchemeValue);
-                    break;
-                case jwt:
-                    securityScheme.setType(SecurityScheme.Type.HTTP);
-                    securityScheme.setScheme(config.jwtSecuritySchemeValue);
-                    securityScheme.setBearerFormat(config.jwtBearerFormat);
-                    break;
-                case oauth2:
-                    securityScheme.setType(SecurityScheme.Type.HTTP);
-                    securityScheme.setScheme(config.oauth2SecuritySchemeValue);
-                    securityScheme.setBearerFormat(config.oauth2BearerFormat);
-                    break;
-                case oidc:
-                    securityScheme.setType(SecurityScheme.Type.OPENIDCONNECT);
-                    securityScheme.setOpenIdConnectUrl(config.oidcOpenIdConnectUrl.orElse(null));
-                    break;
-                case oauth2Implicit:
-                    securityScheme.setType(SecurityScheme.Type.OAUTH2);
-                    OAuthFlows oAuthFlows = OASFactory.createOAuthFlows();
-                    OAuthFlow oAuthFlow = OASFactory.createOAuthFlow();
-                    if (config.oauth2ImplicitAuthorizationUrl.isPresent()) {
-                        oAuthFlow.authorizationUrl(config.oauth2ImplicitAuthorizationUrl.get());
-                    }
-                    if (config.oauth2ImplicitRefreshUrl.isPresent()) {
-                        oAuthFlow.refreshUrl(config.oauth2ImplicitRefreshUrl.get());
-                    }
-                    if (config.oauth2ImplicitTokenUrl.isPresent()) {
-                        oAuthFlow.tokenUrl(config.oauth2ImplicitTokenUrl.get());
-                    }
-                    oAuthFlows.setImplicit(oAuthFlow);
-                    securityScheme.setType(SecurityScheme.Type.OAUTH2);
-                    securityScheme.setFlows(oAuthFlows);
-                    break;
-            }
-            securitySchemes.put(config.securitySchemeName, securityScheme);
-            openAPI.getComponents().setSecuritySchemes(securitySchemes);
+        if (config.securityScheme.isEmpty()) {
+            return;
         }
 
-        if (openAPI.getComponents() != null && openAPI.getComponents().getSecuritySchemes() != null) {
-
-            Map<String, SecurityScheme> securitySchemes = openAPI.getComponents().getSecuritySchemes();
-            if (securitySchemes.size() > 1) {
-                log.warn("Detected multiple Security Schemes, only one scheme is supported at the moment "
-                        + securitySchemes.keySet().toString());
-            }
+        // Make sure components are created
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(OASFactory.createComponents());
         }
+
+        Map<String, SecurityScheme> securitySchemes = new HashMap<>();
+
+        // Add any existing security
+        Optional.ofNullable(openAPI.getComponents().getSecuritySchemes())
+                .ifPresent(securitySchemes::putAll);
+
+        SmallRyeOpenApiConfig.SecurityScheme securitySchemeOption = config.securityScheme.get();
+        SecurityScheme securityScheme = OASFactory.createSecurityScheme();
+        securityScheme.setDescription(config.securitySchemeDescription);
+        config.getValidSecuritySchemeExtentions().forEach(securityScheme::addExtension);
+
+        switch (securitySchemeOption) {
+            case apiKey:
+                configureApiKeySecurityScheme(securityScheme);
+                break;
+            case basic:
+                securityScheme.setType(SecurityScheme.Type.HTTP);
+                securityScheme.setScheme(config.basicSecuritySchemeValue);
+                break;
+            case jwt:
+                securityScheme.setType(SecurityScheme.Type.HTTP);
+                securityScheme.setScheme(config.jwtSecuritySchemeValue);
+                securityScheme.setBearerFormat(config.jwtBearerFormat);
+                break;
+            case oauth2:
+                securityScheme.setType(SecurityScheme.Type.HTTP);
+                securityScheme.setScheme(config.oauth2SecuritySchemeValue);
+                securityScheme.setBearerFormat(config.oauth2BearerFormat);
+                break;
+            case oidc:
+                securityScheme.setType(SecurityScheme.Type.OPENIDCONNECT);
+                securityScheme.setOpenIdConnectUrl(config.oidcOpenIdConnectUrl.orElse(null));
+                break;
+            case oauth2Implicit:
+                securityScheme.setType(SecurityScheme.Type.OAUTH2);
+                OAuthFlows oAuthFlows = OASFactory.createOAuthFlows();
+                OAuthFlow oAuthFlow = OASFactory.createOAuthFlow();
+                config.oauth2ImplicitAuthorizationUrl.ifPresent(oAuthFlow::authorizationUrl);
+                config.oauth2ImplicitRefreshUrl.ifPresent(oAuthFlow::refreshUrl);
+                config.oauth2ImplicitTokenUrl.ifPresent(oAuthFlow::tokenUrl);
+                oAuthFlows.setImplicit(oAuthFlow);
+                securityScheme.setType(SecurityScheme.Type.OAUTH2);
+                securityScheme.setFlows(oAuthFlows);
+                break;
+        }
+
+        securitySchemes.put(config.securitySchemeName, securityScheme);
+        openAPI.getComponents().setSecuritySchemes(securitySchemes);
+
+        if (securitySchemes.size() > 1) {
+            log.warn("Detected multiple Security Schemes, only one scheme is supported at the moment "
+                    + securitySchemes.keySet().toString());
+        }
+    }
+
+    void configureApiKeySecurityScheme(SecurityScheme securityScheme) {
+        securityScheme.setType(SecurityScheme.Type.APIKEY);
+
+        securityScheme.setName(config.apiKeyParameterName
+                .orElseThrow(
+                        () -> new ConfigurationException("Parameter `name` is required for `apiKey` OpenAPI security scheme")));
+
+        securityScheme.setIn(config.apiKeyParameterIn
+                .map(in -> Stream.of(SecurityScheme.In.values())
+                        .filter(v -> v.toString().equals(in))
+                        .findFirst()
+                        .orElseThrow(() -> new ConfigurationException(
+                                "Parameter `in` given for `apiKey` OpenAPI security schema is invalid: [" + in + ']')))
+                .orElseThrow(
+                        () -> new ConfigurationException("Parameter `in` is required for `apiKey` OpenAPI security scheme")));
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilterTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/deployment/filter/SecurityConfigFilterTest.java
@@ -1,0 +1,64 @@
+package io.quarkus.smallrye.openapi.deployment.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
+
+class SecurityConfigFilterTest {
+
+    SmallRyeOpenApiConfig config;
+    SecurityConfigFilter target;
+
+    @BeforeEach
+    void setup() {
+        config = new SmallRyeOpenApiConfig();
+        target = new SecurityConfigFilter(config);
+    }
+
+    @Test
+    void testConfigureApiKeySecuritySchemeMissingName() {
+        SecurityScheme securityScheme = OASFactory.createSecurityScheme();
+        config.securityScheme = Optional.of(SmallRyeOpenApiConfig.SecurityScheme.apiKey);
+        config.apiKeyParameterName = Optional.empty();
+        assertThrows(ConfigurationException.class, () -> target.configureApiKeySecurityScheme(securityScheme));
+    }
+
+    @Test
+    void testConfigureApiKeySecuritySchemeMissingParamIn() {
+        SecurityScheme securityScheme = OASFactory.createSecurityScheme();
+        config.securityScheme = Optional.of(SmallRyeOpenApiConfig.SecurityScheme.apiKey);
+        config.apiKeyParameterName = Optional.of("KeyParamName");
+        config.apiKeyParameterIn = Optional.empty();
+        assertThrows(ConfigurationException.class, () -> target.configureApiKeySecurityScheme(securityScheme));
+    }
+
+    @Test
+    void testConfigureApiKeySecuritySchemeInvalidParamIn() {
+        SecurityScheme securityScheme = OASFactory.createSecurityScheme();
+        config.securityScheme = Optional.of(SmallRyeOpenApiConfig.SecurityScheme.apiKey);
+        config.apiKeyParameterName = Optional.of("KeyParamName");
+        config.apiKeyParameterIn = Optional.of("path");
+        assertThrows(ConfigurationException.class, () -> target.configureApiKeySecurityScheme(securityScheme));
+    }
+
+    @Test
+    void testConfigureApiKeySecuritySchemeSuccess() {
+        SecurityScheme securityScheme = OASFactory.createSecurityScheme();
+        config.securityScheme = Optional.of(SmallRyeOpenApiConfig.SecurityScheme.apiKey);
+        config.apiKeyParameterName = Optional.of("KeyParamName");
+        config.apiKeyParameterIn = Optional.of("header");
+        target.configureApiKeySecurityScheme(securityScheme);
+        assertEquals("KeyParamName", securityScheme.getName());
+        assertEquals(SecurityScheme.In.HEADER, securityScheme.getIn());
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/ApiKeySecurityWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/ApiKeySecurityWithConfigTestCase.java
@@ -1,0 +1,38 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+class ApiKeySecurityWithConfigTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
+                    .addAsResource(
+                            new StringAsset("quarkus.smallrye-openapi.security-scheme=apiKey\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-name=APIKeyCompanyAuthentication\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-description=API Key Authentication\n"
+                                    + "quarkus.smallrye-openapi.api-key-parameter-in=cookie\n"
+                                    + "quarkus.smallrye-openapi.api-key-parameter-name=APIKEY"),
+                            "application.properties"));
+
+    @Test
+    void testApiKeyAuthentication() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get("/q/openapi")
+                .then()
+                .body("components.securitySchemes.APIKeyCompanyAuthentication", allOf(
+                        hasEntry("type", "apiKey"),
+                        hasEntry("description", "API Key Authentication"),
+                        hasEntry("in", "cookie"),
+                        hasEntry("name", "APIKEY")));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoAddSecurityDisabledTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoAddSecurityDisabledTestCase.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+class AutoAddSecurityDisabledTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
+                    .addAsResource(
+                            new StringAsset("quarkus.smallrye-openapi.auto-add-security=false\n"),
+                            "application.properties"));
+
+    @Test
+    void testAutoSecurityRequirement() {
+        RestAssured.given().header("Accept", "application/json")
+                .when()
+                .get("/q/openapi")
+                .then()
+                .log().ifValidationFails()
+                .body("components", not(hasKey(equalTo("securitySchemes"))));
+    }
+
+}


### PR DESCRIPTION
Fixes #33159 

Additionally, do not configure auto security filter when auto-add-security is false (also reported in #33159)