### PR TITLE
Quarkus Gradle Plugin: tests with encrypted configuration

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CryptoConfigTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/CryptoConfigTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.gradle.tasks;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Path;
+
+import org.apache.commons.io.FileUtils;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class CryptoConfigTest {
+
+    @TempDir
+    Path testProjectDir;
+
+    @Test
+    @Disabled("To be fixed via https://github.com/quarkusio/quarkus/issues/38007")
+    void smallryeCrypto() throws Exception {
+        URL url = getClass().getClassLoader().getResource("io/quarkus/gradle/tasks/crypto/main");
+        FileUtils.copyDirectory(new File(url.toURI()), testProjectDir.toFile());
+        FileUtils.copyFile(new File("../gradle.properties"), testProjectDir.resolve("gradle.properties").toFile());
+
+        GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments("build", "--info", "--stacktrace", "--build-cache", "--configuration-cache")
+                // .build() checks whether the build failed, which is good enough for this test
+                .build();
+
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EffectiveConfigTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/tasks/EffectiveConfigTest.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -47,6 +48,15 @@ public class EffectiveConfigTest {
         EffectiveConfig effectiveConfig = EffectiveConfig.builder().withTaskProperties(Map.of("quarkus.foo", "bar")).build();
 
         soft.assertThat(effectiveConfig.configMap()).containsEntry("quarkus.foo", "bar");
+    }
+
+    @Test
+    @Disabled("To be fixed via https://github.com/quarkusio/quarkus/issues/38007")
+    void crypto() {
+        EffectiveConfig effectiveConfig = EffectiveConfig.builder()
+                .withTaskProperties(Map.of("quarkus.foo", "${aes-gcm-nopadding::superSecret}")).build();
+
+        soft.assertThat(effectiveConfig.configMap()).containsEntry("quarkus.foo", "superSecret");
     }
 
     @Test

--- a/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/crypto/main/build.gradle.kts
+++ b/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/crypto/main/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    java
+    id("io.quarkus")
+}
+
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation(enforcedPlatform("io.quarkus:quarkus-bom:${project.property("version")}"))
+    implementation("jakarta.inject:jakarta.inject-api:2.0.1")
+}

--- a/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/crypto/main/settings.gradle.kts
+++ b/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/crypto/main/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "gradle-build-caching"

--- a/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/crypto/main/src/main/java/org/acme/Foo.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/crypto/main/src/main/java/org/acme/Foo.java
@@ -1,0 +1,4 @@
+package org.acme;
+
+public class Foo {
+}

--- a/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/crypto/main/src/main/resources/application.properties
+++ b/devtools/gradle/gradle-application-plugin/src/test/resources/io/quarkus/gradle/tasks/crypto/main/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+someValue = ${aes-gcm-nopadding::superSecret}


### PR DESCRIPTION
As decribed in #33135, using encrypted configuration values did not work with the Gradle plugin since Quarkus 3.0.0, prior to SmallRye Config 3.3.0 (#33079).

This change just adds tests to validate the behavior.