### PR TITLE
Allow all configured http methods in the CORS preflight response

### DIFF
--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/cors/CORSFullConfigHandlerTestCase.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/cors/CORSFullConfigHandlerTestCase.java
@@ -27,18 +27,18 @@ public class CORSFullConfigHandlerTestCase {
                 .options("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", "http://custom.origin.quarkus")
-                .header("Access-Control-Allow-Methods", "GET")
+                .header("Access-Control-Allow-Methods", "GET,PUT,POST")
                 .header("Access-Control-Expose-Headers", "Content-Disposition")
                 .header("Access-Control-Allow-Headers", "X-Custom")
                 .header("Access-Control-Max-Age", "86400");
 
         given().header("Origin", "http://www.quarkus.io")
-                .header("Access-Control-Request-Method", "PUT,POST")
+                .header("Access-Control-Request-Method", "PUT")
                 .when()
                 .options("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", "http://www.quarkus.io")
-                .header("Access-Control-Allow-Methods", "PUT,POST")
+                .header("Access-Control-Allow-Methods", "GET,PUT,POST")
                 .header("Access-Control-Expose-Headers", "Content-Disposition");
     }
 
@@ -46,14 +46,14 @@ public class CORSFullConfigHandlerTestCase {
     @DisplayName("Returns only allowed headers and methods")
     public void corsPartialMethodsTestServlet() {
         given().header("Origin", "http://custom.origin.quarkus")
-                .header("Access-Control-Request-Method", "GET,DELETE")
+                .header("Access-Control-Request-Method", "DELETE")
                 .header("Access-Control-Request-Headers", "X-Custom,X-Custom2")
                 .when()
                 .options("/test").then()
-                .statusCode(200)
+                .statusCode(403)
                 .log().headers()
                 .header("Access-Control-Allow-Origin", "http://custom.origin.quarkus")
-                .header("Access-Control-Allow-Methods", "GET") // Should not return DELETE
+                .header("Access-Control-Allow-Methods", "GET,PUT,POST") // Should not return DELETE
                 .header("Access-Control-Expose-Headers", "Content-Disposition")
                 .header("Access-Control-Allow-Headers", "X-Custom");// Should not return X-Custom2
     }

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/cors/CORSFullConfigHandlerTestCase.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/cors/CORSFullConfigHandlerTestCase.java
@@ -50,7 +50,7 @@ public class CORSFullConfigHandlerTestCase {
                 .header("Access-Control-Request-Headers", "X-Custom,X-Custom2")
                 .when()
                 .options("/test").then()
-                .statusCode(403)
+                .statusCode(200)
                 .log().headers()
                 .header("Access-Control-Allow-Origin", "http://custom.origin.quarkus")
                 .header("Access-Control-Allow-Methods", "GET,PUT,POST") // Should not return DELETE

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/cors/CORSHandlerTestCase.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/cors/CORSHandlerTestCase.java
@@ -39,18 +39,13 @@ public class CORSHandlerTestCase {
     @DisplayName("Handles a direct CORS request correctly")
     public void corsNoPreflightTestServlet() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "POST";
-        String headers = "X-Custom";
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .log().headers()
                 .get("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
                 .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
-                .header("Access-Control-Allow-Headers", headers)
                 .body(is("test route"));
     }
 

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/cors/CORSHandlerTestCase.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/cors/CORSHandlerTestCase.java
@@ -22,7 +22,7 @@ public class CORSHandlerTestCase {
     @DisplayName("Handles a preflight CORS request correctly")
     public void corsPreflightTestServlet() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "GET,POST";
+        String methods = "GET";
         String headers = "X-Custom";
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
@@ -31,7 +31,7 @@ public class CORSHandlerTestCase {
                 .options("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Headers", headers);
     }
 
@@ -39,7 +39,7 @@ public class CORSHandlerTestCase {
     @DisplayName("Handles a direct CORS request correctly")
     public void corsNoPreflightTestServlet() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "GET,POST";
+        String methods = "POST";
         String headers = "X-Custom";
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
@@ -49,7 +49,7 @@ public class CORSHandlerTestCase {
                 .get("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Headers", headers)
                 .body(is("test route"));
     }

--- a/extensions/reactive-routes/deployment/src/test/resources/conf/cors-config.properties
+++ b/extensions/reactive-routes/deployment/src/test/resources/conf/cors-config.properties
@@ -1,4 +1,4 @@
 quarkus.http.cors=true
 quarkus.http.cors.origins=*
 # whitespaces added to test that they are not taken into account config is parsed
-quarkus.http.cors.methods=GET, OPTIONS, POST
+quarkus.http.cors.methods=GET,OPTIONS,POST

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/RestEasyCORSTestCase.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/RestEasyCORSTestCase.java
@@ -33,16 +33,10 @@ public class RestEasyCORSTestCase {
     @Test
     public void testCORSRootResource() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "GET,POST";
-        String headers = "X-Custom";
         RestAssured.given()
                 .header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
-                .header("Access-Control-Request-Headers", headers)
                 .when().get("/").then()
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
-                .header("Access-Control-Allow-Headers", headers)
                 .body(Matchers.is("Root Resource"));
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSFullConfigHandlerTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSFullConfigHandlerTestCase.java
@@ -48,10 +48,10 @@ public class CORSFullConfigHandlerTestCase {
     public void corsPartialMethodsTestServlet() {
         given().header("Origin", "http://custom.origin.quarkus")
                 .header("Access-Control-Request-Method", "DELETE")
-                .header("Access-Control-Request-Headers", "X-Custom,X-Custom2")
+                .header("Access-Control-Request-Headers", "X-Custom, X-Custom2")
                 .when()
                 .options("/test").then()
-                .statusCode(403)
+                .statusCode(200)
                 .header("Access-Control-Allow-Origin", "http://custom.origin.quarkus")
                 .header("Access-Control-Allow-Methods", "GET,PUT,POST") // Should not return DELETE
                 .header("Access-Control-Expose-Headers", "Content-Disposition")

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSFullConfigHandlerTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSFullConfigHandlerTestCase.java
@@ -26,19 +26,19 @@ public class CORSFullConfigHandlerTestCase {
                 .options("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", "http://custom.origin.quarkus")
-                .header("Access-Control-Allow-Methods", "GET")
+                .header("Access-Control-Allow-Methods", "GET,PUT,POST")
                 .header("Access-Control-Expose-Headers", "Content-Disposition")
                 .header("Access-Control-Allow-Headers", "X-Custom")
                 .header("Access-Control-Allow-Credentials", "false")
                 .header("Access-Control-Max-Age", "86400");
 
         given().header("Origin", "http://www.quarkus.io")
-                .header("Access-Control-Request-Method", "PUT,POST")
+                .header("Access-Control-Request-Method", "PUT")
                 .when()
                 .options("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", "http://www.quarkus.io")
-                .header("Access-Control-Allow-Methods", "PUT,POST")
+                .header("Access-Control-Allow-Methods", "GET,PUT,POST")
                 .header("Access-Control-Allow-Credentials", "false")
                 .header("Access-Control-Expose-Headers", "Content-Disposition");
     }
@@ -47,13 +47,13 @@ public class CORSFullConfigHandlerTestCase {
     @DisplayName("Returns only allowed headers and methods")
     public void corsPartialMethodsTestServlet() {
         given().header("Origin", "http://custom.origin.quarkus")
-                .header("Access-Control-Request-Method", "GET,DELETE")
+                .header("Access-Control-Request-Method", "DELETE")
                 .header("Access-Control-Request-Headers", "X-Custom,X-Custom2")
                 .when()
                 .options("/test").then()
-                .statusCode(200)
+                .statusCode(403)
                 .header("Access-Control-Allow-Origin", "http://custom.origin.quarkus")
-                .header("Access-Control-Allow-Methods", "GET") // Should not return DELETE
+                .header("Access-Control-Allow-Methods", "GET,PUT,POST") // Should not return DELETE
                 .header("Access-Control-Expose-Headers", "Content-Disposition")
                 .header("Access-Control-Allow-Credentials", "false")
                 .header("Access-Control-Allow-Headers", "X-Custom");// Should not return X-Custom2

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestCase.java
@@ -22,7 +22,7 @@ public class CORSHandlerTestCase {
     @DisplayName("Handles a preflight CORS request correctly")
     public void corsPreflightTestServlet() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "GET,POST";
+        String methods = "POST";
         String headers = "X-Custom,content-type";
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
@@ -31,7 +31,7 @@ public class CORSHandlerTestCase {
                 .options("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Credentials", "true")
                 .header("Access-Control-Allow-Headers", headers);
     }
@@ -39,7 +39,7 @@ public class CORSHandlerTestCase {
     @Test
     public void corsPreflightTestUnmatchedHeader() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "GET,POST";
+        String methods = "GET";
         String headers = "X-Customs,content-types";
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
@@ -48,7 +48,7 @@ public class CORSHandlerTestCase {
                 .options("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Credentials", "true")
                 .header("Access-Control-Allow-Headers", nullValue());
     }
@@ -57,7 +57,7 @@ public class CORSHandlerTestCase {
     @DisplayName("Handles a direct CORS request correctly")
     public void corsNoPreflightTestServlet() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "GET,POST";
+        String methods = "POST";
         String headers = "x-custom,CONTENT-TYPE";
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
@@ -66,7 +66,7 @@ public class CORSHandlerTestCase {
                 .get("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Headers", headers)
                 .header("Access-Control-Allow-Credentials", "true")
                 .body(is("test route"));

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestCase.java
@@ -1,7 +1,6 @@
 package io.quarkus.vertx.http.cors;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 import org.junit.jupiter.api.DisplayName;
@@ -33,7 +32,7 @@ public class CORSHandlerTestCase {
                 .header("Access-Control-Allow-Origin", origin)
                 .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Credentials", "true")
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Headers", "x-custom,CONTENT-TYPE");
     }
 
     @Test
@@ -50,7 +49,7 @@ public class CORSHandlerTestCase {
                 .header("Access-Control-Allow-Origin", origin)
                 .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Credentials", "true")
-                .header("Access-Control-Allow-Headers", nullValue());
+                .header("Access-Control-Allow-Headers", "x-custom,CONTENT-TYPE");
     }
 
     @Test
@@ -60,8 +59,6 @@ public class CORSHandlerTestCase {
         String methods = "POST";
         String headers = "x-custom,CONTENT-TYPE";
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .get("/test").then()
                 .statusCode(200)

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestWildcardOriginCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestWildcardOriginCase.java
@@ -21,7 +21,7 @@ class CORSHandlerTestWildcardOriginCase {
     @DisplayName("Returns true 'Access-Control-Allow-Credentials' header on matching origin")
     void corsMatchingOrigin() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "GET,POST";
+        String methods = "GET";
         String headers = "X-Custom";
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
@@ -30,14 +30,15 @@ class CORSHandlerTestWildcardOriginCase {
                 .options("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Credentials", "true");
+                .header("Access-Control-Allow-Credentials", "true")
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST");
     }
 
     @Test
     @DisplayName("Returns false 'Access-Control-Allow-Credentials' header on matching origin")
     void corsNotMatchingOrigin() {
         String origin = "http://non.matching.origin.quarkus";
-        String methods = "GET,POST";
+        String methods = "POST";
         String headers = "X-Custom";
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
@@ -46,7 +47,8 @@ class CORSHandlerTestWildcardOriginCase {
                 .options("/test").then()
                 .statusCode(403)
                 .header("Access-Control-Allow-Origin", nullValue())
-                .header("Access-Control-Allow-Credentials", "false");
+                .header("Access-Control-Allow-Credentials", "false")
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST");
     }
 
     @Test
@@ -107,7 +109,7 @@ class CORSHandlerTestWildcardOriginCase {
     @DisplayName("Returns false 'Access-Control-Allow-Credentials' header on matching origin '*'")
     void corsMatchingOriginWithWildcard() {
         String origin = "*";
-        String methods = "GET,POST";
+        String methods = "GET";
         String headers = "X-Custom";
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
@@ -116,6 +118,7 @@ class CORSHandlerTestWildcardOriginCase {
                 .options("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", "*")
-                .header("Access-Control-Allow-Credentials", "false");
+                .header("Access-Control-Allow-Credentials", "false")
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST");
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestWildcardOriginCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestWildcardOriginCase.java
@@ -46,9 +46,7 @@ class CORSHandlerTestWildcardOriginCase {
                 .when()
                 .options("/test").then()
                 .statusCode(403)
-                .header("Access-Control-Allow-Origin", nullValue())
-                .header("Access-Control-Allow-Credentials", "false")
-                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST");
+                .header("Access-Control-Allow-Origin", nullValue());
     }
 
     @Test
@@ -105,20 +103,4 @@ class CORSHandlerTestWildcardOriginCase {
                 .header("Access-Control-Allow-Origin", nullValue());
     }
 
-    @Test
-    @DisplayName("Returns false 'Access-Control-Allow-Credentials' header on matching origin '*'")
-    void corsMatchingOriginWithWildcard() {
-        String origin = "*";
-        String methods = "GET";
-        String headers = "X-Custom";
-        given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
-                .header("Access-Control-Request-Headers", headers)
-                .when()
-                .options("/test").then()
-                .statusCode(200)
-                .header("Access-Control-Allow-Origin", "*")
-                .header("Access-Control-Allow-Credentials", "false")
-                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST");
-    }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSecurityTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSecurityTestCase.java
@@ -23,7 +23,7 @@ public class CORSSecurityTestCase {
     private static final String APP_PROPS = "" +
             "quarkus.http.cors=true\n" +
             "quarkus.http.cors.origins=*\n" +
-            "quarkus.http.cors.methods=GET, OPTIONS, POST\n" +
+            "quarkus.http.cors.methods=GET,OPTIONS,POST\n" +
             "quarkus.http.auth.basic=true\n" +
             "quarkus.http.auth.policy.r1.roles-allowed=test\n" +
             "quarkus.http.auth.permission.roles1.paths=/test\n" +
@@ -98,7 +98,7 @@ public class CORSSecurityTestCase {
                 .when()
                 .auth().basic("user", "user")
                 .options("/test").then()
-                .statusCode(403)
+                .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
                 .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Headers", headers);
@@ -108,49 +108,36 @@ public class CORSSecurityTestCase {
     @DisplayName("Handles a direct CORS request correctly")
     public void corsNoPreflightTest() {
         String origin = "http://custom.origin.quarkus";
-        String headers = "X-Custom";
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", "GET")
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .get("/test").then()
                 .statusCode(401)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST");
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", "POST")
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("test", "test")
                 .get("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
                 .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
-                .header("Access-Control-Allow-Headers", headers)
                 .body(Matchers.equalTo("test:/test"));
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", "GET")
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("test", "wrongpassword")
                 .get("/test").then()
                 .statusCode(401)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST");
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", "POST")
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("user", "user")
                 .get("/test").then()
                 .statusCode(403)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST");
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSecurityTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSSecurityTestCase.java
@@ -48,49 +48,59 @@ public class CORSSecurityTestCase {
     @DisplayName("Handles a preflight CORS request correctly")
     public void corsPreflightTest() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "GET,POST";
         String headers = "X-Custom";
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Method", "GET")
                 .header("Access-Control-Request-Headers", headers)
                 .when()
                 .options("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Headers", headers);
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Method", "POST")
                 .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("test", "test")
                 .options("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Headers", headers);
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Method", "GET")
                 .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("test", "wrongpassword")
                 .options("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Headers", headers);
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Method", "POST")
                 .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("user", "user")
                 .options("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
+                .header("Access-Control-Allow-Headers", headers);
+
+        given().header("Origin", origin)
+                .header("Access-Control-Request-Method", "PUT")
+                .header("Access-Control-Request-Headers", headers)
+                .when()
+                .auth().basic("user", "user")
+                .options("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", origin)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Headers", headers);
     }
 
@@ -98,50 +108,49 @@ public class CORSSecurityTestCase {
     @DisplayName("Handles a direct CORS request correctly")
     public void corsNoPreflightTest() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "GET,POST";
         String headers = "X-Custom";
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Method", "GET")
                 .header("Access-Control-Request-Headers", headers)
                 .when()
                 .get("/test").then()
                 .statusCode(401)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Headers", headers);
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Method", "POST")
                 .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("test", "test")
                 .get("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Headers", headers)
                 .body(Matchers.equalTo("test:/test"));
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Method", "GET")
                 .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("test", "wrongpassword")
                 .get("/test").then()
                 .statusCode(401)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Headers", headers);
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
+                .header("Access-Control-Request-Method", "POST")
                 .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("user", "user")
                 .get("/test").then()
                 .statusCode(403)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
+                .header("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
                 .header("Access-Control-Allow-Headers", headers);
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardSecurityTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardSecurityTestCase.java
@@ -97,50 +97,34 @@ public class CORSWildcardSecurityTestCase {
     @DisplayName("Handles a direct CORS request correctly")
     public void corsNoPreflightTest() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "GET,POST";
+        String methods = "GET, POST";
         String headers = "X-Custom";
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .get("/test").then()
                 .statusCode(401)
-                .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Origin", origin);
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("test", "test")
                 .get("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
-                .header("Access-Control-Allow-Headers", headers)
                 .body(Matchers.equalTo("test:/test"));
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("test", "wrongpassword")
                 .get("/test").then()
                 .statusCode(401)
-                .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Origin", origin);
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("user", "user")
                 .get("/test").then()
                 .statusCode(403)
-                .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Origin", origin);
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardStarSecurityTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSWildcardStarSecurityTestCase.java
@@ -49,7 +49,7 @@ public class CORSWildcardStarSecurityTestCase {
     @DisplayName("Handles a preflight CORS request correctly")
     public void corsPreflightTest() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "GET,POST,OPTIONS,DELETE";
+        String methods = "GET, POST, OPTIONS, DELETE";
         String headers = "X-Custom,B-Custom,Test-Headers";
         given().header("Origin", origin)
                 .header("Access-Control-Request-Method", methods)
@@ -99,51 +99,34 @@ public class CORSWildcardStarSecurityTestCase {
     @DisplayName("Handles a direct CORS request correctly")
     public void corsNoPreflightTest() {
         String origin = "http://custom.origin.quarkus";
-        String methods = "GET,POST,OPTIONS,DELETE";
         String headers = "X-Custom,B-Custom,Test-Headers";
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .get("/test").then()
                 .statusCode(401)
-                .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Origin", origin);
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("test", "test")
                 .get("/test").then()
                 .statusCode(200)
                 .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
-                .header("Access-Control-Allow-Headers", headers)
                 .body(Matchers.equalTo("test:/test"));
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("test", "wrongpassword")
                 .get("/test").then()
                 .statusCode(401)
-                .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Origin", origin);
 
         given().header("Origin", origin)
-                .header("Access-Control-Request-Method", methods)
-                .header("Access-Control-Request-Headers", headers)
                 .when()
                 .auth().basic("user", "user")
                 .get("/test").then()
                 .statusCode(403)
-                .header("Access-Control-Allow-Origin", origin)
-                .header("Access-Control-Allow-Methods", methods)
-                .header("Access-Control-Allow-Headers", headers);
+                .header("Access-Control-Allow-Origin", origin);
     }
 
 }

--- a/extensions/vertx-http/deployment/src/test/resources/conf/cors-config-full.properties
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/cors-config-full.properties
@@ -1,6 +1,6 @@
 quarkus.http.cors=true
 quarkus.http.cors.origins=http://custom.origin.quarkus, http://www.quarkus.io
-quarkus.http.cors.methods=GET, PUT, POST
+quarkus.http.cors.methods=GET,PUT,POST
 quarkus.http.cors.headers=X-Custom
 quarkus.http.cors.exposed-headers=Content-Disposition
 quarkus.http.cors.access-control-max-age=24H

--- a/extensions/vertx-http/deployment/src/test/resources/conf/cors-config.properties
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/cors-config.properties
@@ -1,6 +1,6 @@
 quarkus.http.cors=true
 quarkus.http.cors.origins=*
 # whitespaces added to test that they are not taken into account config is parsed
-quarkus.http.cors.methods=GET, OPTIONS, POST
+quarkus.http.cors.methods=GET,OPTIONS,POST
 quarkus.http.cors.access-control-allow-credentials=true
 quarkus.http.cors.headers=x-custom,CONTENT-TYPE

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
@@ -71,7 +71,7 @@ public class CORSConfig {
      * the request’s credentials mode Request.credentials is “include”.
      *
      * The value of this header will default to `true` if `quarkus.http.cors.origins` property is set and
-     * there is a match with the precise `Origin` header and that header is not '*'.
+     * there is a match with the precise `Origin` header.
      */
     @ConfigItem
     public Optional<Boolean> accessControlAllowCredentials = Optional.empty();

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/CorsTestCase.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/CorsTestCase.java
@@ -17,7 +17,7 @@ public class CorsTestCase {
                 .options("/simple/options")
                 .then()
                 .statusCode(200)
-                .header("Access-Control-Allow-Methods", is("GET"))
+                .header("Access-Control-Allow-Methods", is("POST,GET,PUT,OPTIONS,DELETE"))
                 .header("access-control-allow-origin", is("https://example.org/"))
                 .header("access-control-allow-credentials", is("false"))
                 .header("content-length", is("0"))


### PR DESCRIPTION
During cors preflight response should always return all configured http methods which are allowed. If none are configured allow everything.

https://github.com/quarkusio/quarkus/discussions/33155