### PR TITLE
Fix bad vale rule in Quarkus style rules that breaks vale linter

### DIFF
--- a/docs/.vale/styles/Quarkus/CaseSensitiveTerms.yml
+++ b/docs/.vale/styles/Quarkus/CaseSensitiveTerms.yml
@@ -13,7 +13,6 @@ swap:
   '(?<!\.)yaml|Yaml': YAML
   '(?<!Business )Resource Planner|(?<!Business Resource )Planner': Business Resource Planner
   '(?<!JBoss )EAP|(?<!Red Hat )JBoss(?!\sCommunity|\sBroker|\sClients|\sConsole|\sAMQ|\sData\sGrid|\sBRMS|\sBPMS|\sEnterprise\sApplication\sPlatform|\.org|\sInterconnect|\sEAP|\sBPM\sSuite)': JBoss EAP
-  '(?<!Microsoft )Azure': Microsoft Azure
   '(?<!Microsoft Azure )On-Demand Marketplace': Microsoft Azure On-Demand Marketplace
   '(?<!Realtime )Decision\sServer': Realtime Decision Server
   '(?<!Red Hat )Customer Portal': Red Hat Customer Portal

--- a/docs/.vale/styles/Quarkus/TermsErrors.yml
+++ b/docs/.vale/styles/Quarkus/TermsErrors.yml
@@ -9,6 +9,5 @@ action:
   name: replace
 # swap maps tokens in form of bad: good
 swap:
- "I(?!/O)": you
+  "I(?!/O)": you
   he|she: you
- 


### PR DESCRIPTION
Fixes the following error that occurs when you run the Vale linter with Quarkus style rules in local IDE:

![image](https://user-images.githubusercontent.com/92924207/236767558-dc7a0c61-c8e3-4e51-b427-c66f97372277.png)

Also removes the rule that suggests you must put "Microsoft" in front of "Azure" every time. It creates a lot of noise in a guide that's all about Azure integration with Quarkus. 

_Most folks know by now that it's good practice for findability/SEO to use the full product/vendor name on the first reference on the page and don't need a linter to remind on every instance. I will also add a note to the contributor guide to say same._  
