### PR TITLE
Replaced the inversed return types for each methods in redis client

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ReactiveTransactionalValueCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ReactiveTransactionalValueCommands.java
@@ -273,7 +273,7 @@ public interface ReactiveTransactionalValueCommands<K, V> extends ReactiveTransa
      * @param key the key
      * @param value the value
      * @param setArgs the set command extra-arguments
-     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *@return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
      *         otherwise. In the case of failure, the transaction is discarded.
      */
     Uni<Void> setGet(K key, V value, SetArgs setArgs);
@@ -286,6 +286,8 @@ public interface ReactiveTransactionalValueCommands<K, V> extends ReactiveTransa
      *
      * @param key the key
      * @param value the value
+     *@return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *        otherwise. In the case of failure, the transaction is discarded.
      */
     Uni<Void> setex(K key, long seconds, V value);
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ValueCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ValueCommands.java
@@ -195,7 +195,6 @@ public interface ValueCommands<K, V> extends RedisCommands {
      * Requires Redis 1.0.1
      *
      * @param map the key/value map containing the items to store
-     * @return a Uni producing a {@code null} item on success, a failure otherwise
      **/
     void mset(Map<K, V> map);
 
@@ -219,7 +218,6 @@ public interface ValueCommands<K, V> extends RedisCommands {
      * @param key the key
      * @param milliseconds the duration in ms
      * @param value the value
-     * @return a Uni producing a {@code null} item on success, a failure otherwise
      **/
     void psetex(K key, long milliseconds, V value);
 
@@ -231,8 +229,7 @@ public interface ValueCommands<K, V> extends RedisCommands {
      *
      * @param key the key
      * @param value the value
-     * @return a Uni producing a {@code null} item on success, a failure otherwise
-     **/
+    **/
     void set(K key, V value);
 
     /**
@@ -244,7 +241,6 @@ public interface ValueCommands<K, V> extends RedisCommands {
      * @param key the key
      * @param value the value
      * @param setArgs the set command extra-arguments
-     * @return a Uni producing a {@code null} item on success, a failure otherwise
      **/
     void set(K key, V value, SetArgs setArgs);
 


### PR DESCRIPTION
  As described in #32951,  All the return types for each methods in redis client which are inversed are replaced with correct return type  Fix #32951