### PR TITLE
Fix pom.xml for owasp dependency check plugin

### DIFF
--- a/docs/src/main/asciidoc/security-vulnerability-detection-concept.adoc
+++ b/docs/src/main/asciidoc/security-vulnerability-detection-concept.adoc
@@ -93,7 +93,7 @@ To detect less severe issues, adjust the value of `failBuildOnCVSS` to suppress 
                 Suppress the false positive CPE for Smallrye Mutiny to mutiny:mutiny
             ]]>
         </notes>
-        <gav regex="true">^io\.smallrye.reactive:mutiny.*:.*$</gav>
+        <gav regex="true">^io\.smallrye\.reactive:mutiny.*:.*$</gav>
         <cpe>cpe:/a:mutiny:mutiny</cpe>
     </suppress>
     <suppress>
@@ -102,7 +102,7 @@ To detect less severe issues, adjust the value of `failBuildOnCVSS` to suppress 
                 Suppress the false positive CPE for Smallrye Mutiny to mutiny:mutiny
             ]]>
         </notes>
-        <gav regex="true">^io\.smallrye.reactive:smallrye-mutiny.*:.*$</gav>
+        <gav regex="true">^io\.smallrye\.reactive:smallrye-mutiny.*:.*$</gav>
         <cpe>cpe:/a:mutiny:mutiny</cpe>
     </suppress>
     <suppress>
@@ -111,7 +111,7 @@ To detect less severe issues, adjust the value of `failBuildOnCVSS` to suppress 
                 Suppress the false positive CPE for Smallrye Mutiny to mutiny:mutiny
             ]]>
         </notes>
-        <gav regex="true">^io\.smallrye.reactive:vertx-mutiny.*:.*$</gav>
+        <gav regex="true">^io\.smallrye\.reactive:vertx-mutiny.*:.*$</gav>
         <cpe>cpe:/a:mutiny:mutiny</cpe>
     </suppress>
     <suppress>
@@ -120,7 +120,7 @@ To detect less severe issues, adjust the value of `failBuildOnCVSS` to suppress 
                 Suppress the false positive CPE for graal-sdk to GraalVM (the JVM distribution)
             ]]>
         </notes>
-        <gav regex="true">^org\.graalvm\.sdk:g like this
+        <gav regex="true">^org\.graalvm\.sdk:graal-sdk.*:.*$</gav>
     </suppress>
 </suppressions>
 ----


### PR DESCRIPTION
Escaped `.` in regular expression and fixed broken xml tag.