### PR TITLE
Fix nesting of cli plugins

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCommandFactory.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCommandFactory.java
@@ -81,7 +81,9 @@ public class PluginCommandFactory {
         plugins.entrySet().stream()
                 .map(Map.Entry::getValue).forEach(plugin -> {
                     CommandLine current = cmd;
-                    String name = plugin.getName();
+                    // The plugin is stripped from its prefix when added to the catalog.
+                    // Let's added back to ensure it matches the CLI root command.
+                    String name = cmd.getCommandName() + "-" + plugin.getName();
                     while (current != null && current.getCommandName() != null
                             && name.startsWith(current.getCommandName() + "-")) {
                         String remaining = name.substring(current.getCommandName().length() + 1);


### PR DESCRIPTION
ATM it seems that CLI plugin do not properlly nest / blend (they are always added right root).
The pull request address that.