### PR TITLE
Enable DebugCodeInfoUseSourceMappings with GraalVM >= 23.0

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -754,6 +754,8 @@ public class NativeImageBuildStep {
                      * See https://github.com/quarkusio/quarkus/issues/30772 for more details.
                      */
                     nativeImageArgs.add("-H:+TrackNodeSourcePosition");
+                    /* See https://github.com/Karm/mandrel-integration-tests/issues/154 for more details. */
+                    nativeImageArgs.add("-H:+DebugCodeInfoUseSourceMappings");
                 }
 
                 /**


### PR DESCRIPTION
Starting with GraalVM 23.1 debug info generation defaults to not using `SourceMapping`s when building the `CompilationResultTree`. This choice was made in order to improve build times (only when generating debug info), but as expected it comes at the cost of less accurate generated-code to source mapping.

Relates to https://github.com/Karm/mandrel-integration-tests/issues/154

cc @jerboaa 