### PR TITLE
Ignore malformed language ranges when resolving locales for validation

### DIFF
--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -368,6 +368,16 @@ public class HibernateValidatorFunctionalityTest {
     }
 
     @Test
+    public void testValidationMessageInvalidAcceptLanguageHeaderLeadsToDefaultLocaleBeingUsed() {
+        RestAssured.given()
+                .header("Accept-Language", "invalid string")
+                .when()
+                .get("/hibernate-validator/test/test-validation-message-locale/1")
+                .then()
+                .body(containsString("Value is not in line with the pattern"));
+    }
+
+    @Test
     public void testValidationMessageDefaultLocale() {
         RestAssured.given()
                 .when()


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/33150

additionally, I've tried to make both `AbstractLocaleResolver` and `SmallRyeGraphQLLocaleResolver` look even more similar. 
As for logging a message, I thought since it's not a validation error caused by bad values in the request body, and (hopefully) in most cases, headers aren't typed by users 😃 but generated by an API client, that would indicate a problem in a client, which is more of a dev problem... so they might want to see it 😃 
I didn't see any locale-/validation- specific tests in `quarkus-integration-test-hibernate-validator-resteasy-reactive` or `quarkus-integration-test-smallrye-graphql` so I haven't introduced any new ones there ... 