### PR TITLE
Fix new vale error on 'source:' attribute in yml rules - compatibility issue with Vale 2.24.1 & later

### DIFF
--- a/docs/.vale/styles/Quarkus/CaseSensitiveTerms.yml
+++ b/docs/.vale/styles/Quarkus/CaseSensitiveTerms.yml
@@ -4,7 +4,7 @@ ignorecase: false
 level: suggestion
 link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-reference.adoc
 message: Use '%s' rather than '%s'.
-source: Quarkus contributor guide
+# source: Quarkus contributor guide
 action:
   name: replace
 swap:

--- a/docs/.vale/styles/Quarkus/ConsciousLanguage.yml
+++ b/docs/.vale/styles/Quarkus/ConsciousLanguage.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: warning
 link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-reference.adoc
 message: Use '%s' rather than '%s.'
-source: Quarkus contributor guide
+# source: Quarkus contributor guide
 action:
   name: replace
 swap:

--- a/docs/.vale/styles/Quarkus/Ellipses.yml
+++ b/docs/.vale/styles/Quarkus/Ellipses.yml
@@ -4,7 +4,7 @@ level: suggestion
 link: https://developers.google.com/style/ellipses?hl=en
 message: "Avoid the ellipsis (...) except to indicate omitted words. Insert a space before and after an ellipsis."
 nonword: true
-source: Quarkus contributor guide
+# source: Quarkus contributor guide
 action:
   name: remove
 tokens:

--- a/docs/.vale/styles/Quarkus/Fluff.yml
+++ b/docs/.vale/styles/Quarkus/Fluff.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: suggestion
 link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-reference.adoc
 message: "Depending on the context, consider using '%s' rather than '%s'."
-source: Quarkus contributor guide
+# source: Quarkus contributor guide
 action:
   name: replace
 swap:

--- a/docs/.vale/styles/Quarkus/HeadingPunctuation.yml
+++ b/docs/.vale/styles/Quarkus/HeadingPunctuation.yml
@@ -5,7 +5,7 @@ link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-
 message: "Do not use end punctuation in headings."
 nonword: true
 scope: heading
-source: "Quarkus style guide on titles and headings"
+# source: "Quarkus style guide on titles and headings"
 action:
   name: edit
   params:

--- a/docs/.vale/styles/Quarkus/Headings.yml
+++ b/docs/.vale/styles/Quarkus/Headings.yml
@@ -5,7 +5,7 @@ link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-
 match: $sentence
 message: "Use sentence-style capitalization in '%s'."
 scope: heading
-source: Quarkus contributor guide
+# source: Quarkus contributor guide
 indicators:
   - ":"
 exceptions:

--- a/docs/.vale/styles/Quarkus/OxfordComma.yml
+++ b/docs/.vale/styles/Quarkus/OxfordComma.yml
@@ -3,6 +3,6 @@ extends: existence
 level: suggestion
 link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-reference.adoc
 message: "Use the Oxford comma in '%s'."
-source: Quarkus contributor guide
+# source: Quarkus contributor guide
 tokens:
   - '(?:[^,]+,){1,}\s\w+\sand'

--- a/docs/.vale/styles/Quarkus/RepeatedWords.yml
+++ b/docs/.vale/styles/Quarkus/RepeatedWords.yml
@@ -3,9 +3,8 @@ extends: repetition
 link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-reference.adoc
 message: "'%s' is repeated!"
 level: error
-source: Quarkus contributor guide
+# source: Quarkus contributor guide
 alpha: true
 tokens:
   - '[^\s\.]+'
   - '[^\s]+'
-  

--- a/docs/.vale/styles/Quarkus/SentenceLength.yml
+++ b/docs/.vale/styles/Quarkus/SentenceLength.yml
@@ -4,6 +4,6 @@ level: suggestion
 link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-reference.adoc
 message: "Try to keep sentences to an average of 32 words or fewer."
 scope: sentence
-source: Quarkus contributor guide
+# source: Quarkus contributor guide
 max: 32
 token: \b(\w+)\b

--- a/docs/.vale/styles/Quarkus/Spacing.yml
+++ b/docs/.vale/styles/Quarkus/Spacing.yml
@@ -4,7 +4,7 @@ level: error
 link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-reference.adoc
 message: "Keep one space between words in '%s'."
 nonword: true
-source: Quarkus contributor guide
+# source: Quarkus contributor guide
 tokens:
   - "[a-z][.?!] {2,}[A-Z]"
   - "[a-z][.?!][A-Z]"

--- a/docs/.vale/styles/Quarkus/Spelling.yml
+++ b/docs/.vale/styles/Quarkus/Spelling.yml
@@ -3,7 +3,7 @@ extends: spelling
 level: warning
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/reference-guide/spelling/
 message: "Use correct American English spelling. Did you really mean '%s'?"
-source: Quarkus contributor guide
+# source: Quarkus contributor guide
 
 # A "filter" is a case-sensitive regular expression specifying words to ignore during spell checking.
 # Spelling rule applies to individual words
@@ -50,8 +50,6 @@ filters:
   - "[gG]etter"
   - "[gG]it"
   - "[gG]radle"
-  
-
   - "[gG]rafana"
   - "[hH]ardcoding"
   - "[hH]eatmap"

--- a/docs/.vale/styles/Quarkus/TermsErrors.yml
+++ b/docs/.vale/styles/Quarkus/TermsErrors.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: error
 link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-reference.adoc
 message: "Use '%s' rather than '%s'."
-source: Quarkus contributor guide
+# source: Quarkus contributor guide
 action:
   name: replace
 # swap maps tokens in form of bad: good

--- a/docs/.vale/styles/Quarkus/TermsSuggestions.yml
+++ b/docs/.vale/styles/Quarkus/TermsSuggestions.yml
@@ -4,7 +4,7 @@ ignorecase: false
 level: suggestion
 link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-reference.adoc
 message: "Depending on the context, consider using '%s' rather than '%s'."
-source: Quarkus contributor guide
+# source: Quarkus contributor guide
 action:
   name: replace
 swap:

--- a/docs/.vale/styles/Quarkus/TermsWarnings.yml
+++ b/docs/.vale/styles/Quarkus/TermsWarnings.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: warning
 link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-reference.adoc
 message: "Consider using '%s' rather than '%s' unless updating existing content that uses it."
-source: Quarkus contributor guide
+# source: Quarkus contributor guide
 action:
   name: replace
 swap:


### PR DESCRIPTION
With [Vale v2.24.1](https://github.com/errata-ai/vale/releases/tag/v2.24.1), unknown keys are now an error, see: https://github.com/errata-ai/vale/releases/tag/v2.24.1

The `source` key in all yml rule files is now obsolete

Fixes `invalid value` errors in the Vale linter results.

![image](https://github.com/quarkusio/quarkus/assets/92924207/e95d663b-834c-4bbb-a4aa-2e76e1e79984)
