### PR TITLE
Verify OIDC ID token audience by default

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1112,6 +1112,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         /**
          * Expected audience 'aud' claim value which may be a string or an array of strings.
+         *
+         * Note the audience claim will be verified for ID tokens by default.
+         * ID token audience must be equal to the value of `quarkus.oidc.client-id` property.
+         * Use this property to override the expected value if your OpenID Connect provider
+         * sets a different audience claim value in ID tokens. Set it to `any` if your provider
+         * does not set ID token audience` claim.
+         *
+         * Audience verification for access tokens will only be done if this property is configured.
          */
         @ConfigItem
         public Optional<List<String>> audience = Optional.empty();

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -216,7 +216,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 tokenUni = verifySelfSignedTokenUni(resolvedContext, request.getToken().getToken());
             }
         } else {
-            tokenUni = verifyTokenUni(resolvedContext, request.getToken().getToken(), userInfo);
+            tokenUni = verifyTokenUni(resolvedContext, request.getToken().getToken(), isIdToken(request), userInfo);
         }
 
         return tokenUni.onItemOrFailure()
@@ -246,7 +246,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                                         resolvedContext, tokenJson, rolesJson, userInfo, result.introspectionResult);
                                 // If the primary token is a bearer access token then there's no point of checking if
                                 // it should be refreshed as RT is only available for the code flow tokens
-                                if (tokenCred instanceof IdTokenCredential
+                                if (isIdToken(request)
                                         && tokenAutoRefreshPrepared(result, vertxContext, resolvedContext.oidcConfig)) {
                                     return Uni.createFrom().failure(new TokenAutoRefreshException(securityIdentity));
                                 } else {
@@ -255,7 +255,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                             } catch (Throwable ex) {
                                 return Uni.createFrom().failure(new AuthenticationFailedException(ex));
                             }
-                        } else if (tokenCred instanceof IdTokenCredential
+                        } else if (isIdToken(request)
                                 || tokenCred instanceof AccessTokenCredential
                                         && !((AccessTokenCredential) tokenCred).isOpaque()) {
                             return Uni.createFrom()
@@ -314,7 +314,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                             SecurityIdentity identity = builder.build();
                             // If the primary token is a bearer access token then there's no point of checking if
                             // it should be refreshed as RT is only available for the code flow tokens
-                            if (tokenCred instanceof IdTokenCredential
+                            if (isIdToken(request)
                                     && tokenAutoRefreshPrepared(result, vertxContext, resolvedContext.oidcConfig)) {
                                 return Uni.createFrom().failure(new TokenAutoRefreshException(identity));
                             }
@@ -325,7 +325,11 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     }
 
     private static boolean isInternalIdToken(TokenAuthenticationRequest request) {
-        return (request.getToken() instanceof IdTokenCredential) && ((IdTokenCredential) request.getToken()).isInternal();
+        return isIdToken(request) && ((IdTokenCredential) request.getToken()).isInternal();
+    }
+
+    private static boolean isIdToken(TokenAuthenticationRequest request) {
+        return request.getToken() instanceof IdTokenCredential;
     }
 
     private static boolean tokenAutoRefreshPrepared(TokenVerificationResult result, RoutingContext vertxContext,
@@ -377,13 +381,14 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 && (resolvedContext.oidcConfig.authentication.verifyAccessToken
                         || resolvedContext.oidcConfig.roles.source.orElse(null) == Source.accesstoken)) {
             final String codeAccessToken = (String) vertxContext.get(OidcConstants.ACCESS_TOKEN_VALUE);
-            return verifyTokenUni(resolvedContext, codeAccessToken, userInfo);
+            return verifyTokenUni(resolvedContext, codeAccessToken, false, userInfo);
         } else {
             return NULL_CODE_ACCESS_TOKEN_UNI;
         }
     }
 
-    private Uni<TokenVerificationResult> verifyTokenUni(TenantConfigContext resolvedContext, String token, UserInfo userInfo) {
+    private Uni<TokenVerificationResult> verifyTokenUni(TenantConfigContext resolvedContext,
+            String token, boolean enforceAudienceVerification, UserInfo userInfo) {
         if (OidcUtils.isOpaqueToken(token)) {
             if (!resolvedContext.oidcConfig.token.allowOpaqueTokenIntrospection) {
                 LOG.debug("Token is opaque but the opaque token introspection is not allowed");
@@ -411,11 +416,11 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             // Verify JWT token with the local JWK keys with a possible remote introspection fallback
             try {
                 LOG.debug("Verifying the JWT token with the local JWK keys");
-                return Uni.createFrom().item(resolvedContext.provider.verifyJwtToken(token));
+                return Uni.createFrom().item(resolvedContext.provider.verifyJwtToken(token, enforceAudienceVerification));
             } catch (Throwable t) {
                 if (t.getCause() instanceof UnresolvableKeyException) {
                     LOG.debug("No matching JWK key is found, refreshing and repeating the verification");
-                    return refreshJwksAndVerifyTokenUni(resolvedContext, token);
+                    return refreshJwksAndVerifyTokenUni(resolvedContext, token, enforceAudienceVerification);
                 } else {
                     LOG.debugf("Token verification has failed: %s", t.getMessage());
                     return Uni.createFrom().failure(t);
@@ -432,8 +437,9 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
         }
     }
 
-    private Uni<TokenVerificationResult> refreshJwksAndVerifyTokenUni(TenantConfigContext resolvedContext, String token) {
-        return resolvedContext.provider.refreshJwksAndVerifyJwtToken(token)
+    private Uni<TokenVerificationResult> refreshJwksAndVerifyTokenUni(TenantConfigContext resolvedContext, String token,
+            boolean enforceAudienceVerification) {
+        return resolvedContext.provider.refreshJwksAndVerifyJwtToken(token, enforceAudienceVerification)
                 .onFailure(f -> f.getCause() instanceof UnresolvableKeyException
                         && resolvedContext.oidcConfig.token.allowJwtIntrospection)
                 .recoverWithUni(f -> introspectTokenUni(resolvedContext, token));
@@ -473,7 +479,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             TenantConfigContext resolvedContext) {
 
         try {
-            TokenVerificationResult result = resolvedContext.provider.verifyJwtToken(request.getToken().getToken());
+            TokenVerificationResult result = resolvedContext.provider.verifyJwtToken(request.getToken().getToken(), false);
             return Uni.createFrom()
                     .item(validateAndCreateIdentity(null, request.getToken(), resolvedContext,
                             result.localVerificationResult, result.localVerificationResult, null, null));

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -13,6 +13,7 @@ import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.OidcTenantConfig.Roles.Source;
 import io.quarkus.oidc.TenantConfigResolver;
 import io.quarkus.oidc.common.runtime.OidcCommonConfig.Credentials;
+import io.quarkus.oidc.common.runtime.OidcCommonConfig.Credentials.Secret.Method;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
@@ -126,10 +127,12 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     config.setTenantId("tenant-web-app-refresh");
                     config.setApplicationType(ApplicationType.WEB_APP);
                     config.getToken().setRefreshExpired(true);
+                    config.getToken().setRefreshTokenTimeSkew(Duration.ofSeconds(3));
                     config.setAuthServerUrl(getIssuerUrl() + "/realms/quarkus-webapp");
                     config.setClientId("quarkus-app-webapp");
-                    config.getCredentials().setSecret(
+                    config.getCredentials().getClientSecret().setValue(
                             "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow");
+                    config.getCredentials().getClientSecret().setMethod(Method.POST);
 
                     // Let Keycloak issue a login challenge but use the test token endpoint
                     String uri = context.request().absoluteURI();

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -126,7 +126,7 @@ public class BearerTokenAuthorizationTest {
             // id and access tokens should have new values, refresh token value should remain the same.
             // No new sign-in process is required.
             //await().atLeast(6, TimeUnit.SECONDS);
-            Thread.sleep(6 * 1000);
+            Thread.sleep(2 * 1000);
 
             webClient.getOptions().setRedirectEnabled(false);
             WebResponse webResponse = webClient
@@ -138,7 +138,7 @@ public class BearerTokenAuthorizationTest {
 
             Cookie sessionCookie2 = getSessionCookie(webClient, "tenant-web-app-refresh");
             assertNotNull(sessionCookie2);
-            assertNotEquals(sessionCookie2.getValue(), sessionCookie.getValue());
+            assertEquals(sessionCookie2.getValue(), sessionCookie.getValue());
             assertNotNull(getSessionAtCookie(webClient, "tenant-web-app-refresh"));
             Cookie rtCookie2 = getSessionRtCookie(webClient, "tenant-web-app-refresh");
             assertNotNull(rtCookie2);

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -19,6 +19,7 @@ quarkus.oidc.code-flow.logout.post-logout-uri-param=returnTo
 quarkus.oidc.code-flow.logout.extra-params.client_id=${quarkus.oidc.code-flow.client-id}
 quarkus.oidc.code-flow.credentials.secret=secret
 quarkus.oidc.code-flow.application-type=web-app
+quarkus.oidc.code-flow.token.audience=https://server.example.com
 
 quarkus.oidc.code-flow-encrypted-id-token-jwk.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-encrypted-id-token-jwk.client-id=quarkus-web-app
@@ -26,6 +27,7 @@ quarkus.oidc.code-flow-encrypted-id-token-jwk.credentials.secret=secret
 quarkus.oidc.code-flow-encrypted-id-token-jwk.application-type=web-app
 quarkus.oidc.code-flow-encrypted-id-token-jwk.token-path=${keycloak.url}/realms/quarkus/encrypted-id-token
 quarkus.oidc.code-flow-encrypted-id-token-jwk.token.decryption-key-location=privateKeyEncryptedIdToken.jwk
+quarkus.oidc.code-flow-encrypted-id-token-jwk.token.audience=https://server.example.com
 
 quarkus.oidc.code-flow-encrypted-id-token-pem.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-encrypted-id-token-pem.client-id=quarkus-web-app
@@ -33,6 +35,7 @@ quarkus.oidc.code-flow-encrypted-id-token-pem.credentials.secret=secret
 quarkus.oidc.code-flow-encrypted-id-token-pem.application-type=web-app
 quarkus.oidc.code-flow-encrypted-id-token-pem.token-path=encrypted-id-token
 quarkus.oidc.code-flow-encrypted-id-token-pem.token.decryption-key-location=privateKey.pem
+quarkus.oidc.code-flow-encrypted-id-token-pem.token.audience=any
 
 quarkus.oidc.code-flow-form-post.auth-server-url=${keycloak.url}/realms/quarkus-form-post/
 quarkus.oidc.code-flow-form-post.client-id=quarkus-web-app
@@ -48,7 +51,7 @@ quarkus.oidc.code-flow-form-post.token-path=${keycloak.url}/realms/quarkus/token
 quarkus.oidc.code-flow-form-post.jwks-path=${keycloak.url}/realms/quarkus/protocol/openid-connect/certs
 quarkus.oidc.code-flow-form-post.logout.backchannel.path=/back-channel-logout
 quarkus.oidc.code-flow-form-post.logout.frontchannel.path=/code-flow-form-post/front-channel-logout
-
+quarkus.oidc.code-flow-form-post.token.audience=https://server.example.com
 
 quarkus.oidc.code-flow-user-info-only.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-user-info-only.discovery-enabled=false

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -85,8 +85,12 @@ public class CodeFlowAuthorizationTest {
     }
 
     @Test
-    public void testCodeFlowEncryptedIdToken() throws IOException {
+    public void testCodeFlowEncryptedIdTokenJwk() throws IOException {
         doTestCodeFlowEncryptedIdToken("code-flow-encrypted-id-token-jwk");
+    }
+
+    @Test
+    public void testCodeFlowEncryptedIdTokenPem() throws IOException {
         doTestCodeFlowEncryptedIdToken("code-flow-encrypted-id-token-pem");
     }
 


### PR DESCRIPTION
Fixes #32909.

This PR does the following:
* enables ID token audience verification by default, ID token audience is expected to be set to the client id of Quarkus application, as per the OIDC spec requirement.
* Most tests just passed since Keycloak sets an ID token audience as expected
*  `integration-test/oidc-wiremock` - it tests two variations, where OIDC provider 1) sets an audience to something else but the client id, typical alternative - endpoint URL as indeed done by `OidcWiremockTestResource` and 2) where it does not set an ID token audience claim at all - thus requiring users set the expected audience to `any`. These 2 cases will be highlighted in the migration note
* `integration-test/oidc-tenancy` - the tests there depend on `OidcResource` JAX-RS endpoint emulating OIDC provider, so I had to tweak the test setup to 1) make sure the current `client_id` is available to `OidcResource` as a form parameter (which is a standard `client_secret_post` authentication) for `OidcResource` to correctly set the audience claim on generated ID tokens 2) The test is setting `idTokenRequired=false` to verify it is not interfering with the case where an ID token is actually returned (as in this test) - while debugging I found a bit of a problem related to a edge case where a provider does not return an ID token after a token refresh - in which case the current ID token, if it is still valid, should continue be used - on `main`, such a token is incorrectly replaced by an internally generated ID token - so I had to tweak `CodeAuthenticationMechanism` and the test assertion to confirm that indeed, the original ID token (session cookie) is used after a refresh.
* Bearer tokens can't be enforced to contain an audience by default: it is unspecified what access tokens should have it set to, providers may not set it on access tokens (ex Keycloak), nearly all of social providers will issue binary access tokens

All in all, another PR toward making a best effort at achieving a Secure by Default status

Setting to a draft status for now as I think Guillaume may have asked not to open PRs (or merge), will open tomorrow

CC @maxandersen @stuartwdouglas 