### PR TITLE
Produce EventLoopGroup build item

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/EventLoopGroupBuildItem.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/EventLoopGroupBuildItem.java
@@ -1,0 +1,30 @@
+package io.quarkus.netty.deployment;
+
+import java.util.function.Supplier;
+
+import io.netty.channel.EventLoopGroup;
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Provides suppliers that return EventLoopGroup used by the application.
+ *
+ * See EventLoopSupplierBuildItem to register custom EventLoopGroup
+ */
+public final class EventLoopGroupBuildItem extends SimpleBuildItem {
+    private final Supplier<EventLoopGroup> bossEventLoopGroup;
+    private final Supplier<EventLoopGroup> mainEventLoopGroup;
+
+    public EventLoopGroupBuildItem(Supplier<EventLoopGroup> boss, Supplier<EventLoopGroup> main) {
+        this.bossEventLoopGroup = boss;
+        this.mainEventLoopGroup = main;
+    }
+
+    public Supplier<EventLoopGroup> getBossEventLoopGroup() {
+        return bossEventLoopGroup;
+    }
+
+    public Supplier<EventLoopGroup> getMainEventLoopGroup() {
+        return mainEventLoopGroup;
+    }
+
+}

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/EventLoopSupplierBuildItem.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/EventLoopSupplierBuildItem.java
@@ -5,6 +5,12 @@ import java.util.function.Supplier;
 import io.netty.channel.EventLoopGroup;
 import io.quarkus.builder.item.SimpleBuildItem;
 
+/**
+ * Register EventLoopGroup suppliers to be used to produce main EventLoopGroup and boss EventLoopGroup annotated beans.
+ * If not provided, both will be created from a default supplier.
+ *
+ * See EventLoopGroupBuildItem for actual supplier instances
+ */
 public final class EventLoopSupplierBuildItem extends SimpleBuildItem {
 
     private final Supplier<EventLoopGroup> mainSupplier;

--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -180,9 +180,10 @@ class NettyProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void registerEventLoopBeans(BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             Optional<EventLoopSupplierBuildItem> loopSupplierBuildItem,
-            NettyRecorder recorder) {
-        Supplier<Object> boss;
-        Supplier<Object> main;
+            NettyRecorder recorder,
+            BuildProducer<EventLoopGroupBuildItem> eventLoopGroups) {
+        Supplier<EventLoopGroup> boss;
+        Supplier<EventLoopGroup> main;
         if (loopSupplierBuildItem.isPresent()) {
             boss = (Supplier) loopSupplierBuildItem.get().getBossSupplier();
             main = (Supplier) loopSupplierBuildItem.get().getMainSupplier();
@@ -209,6 +210,8 @@ class NettyProcessor {
                 .unremovable()
                 .setRuntimeInit()
                 .done());
+
+        eventLoopGroups.produce(new EventLoopGroupBuildItem(boss, main));
     }
 
     @BuildStep

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettyRecorder.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/NettyRecorder.java
@@ -35,8 +35,8 @@ public class NettyRecorder {
         }).start();
     }
 
-    public Supplier<Object> createEventLoop(int nThreads) {
-        return new Supplier<Object>() {
+    public Supplier<EventLoopGroup> createEventLoop(int nThreads) {
+        return new Supplier<EventLoopGroup>() {
 
             volatile EventLoopGroup val;
 


### PR DESCRIPTION
Allow other extensions to reuse the EventLoopGroup that is effectively used without making assumptions on the presence of Vert.x extension.

As a non-CDI expert, I'm not sure if there's a better way to expose those suppliers. Consumers would implement a build step as follows:

```java
@BuildStep(onlyIf = AmazonHttpClients.IsAmazonNettyHttpServicePresent.class)
@Record(ExecutionTime.RUNTIME_INIT)
void setupClient(EventLoopGroupBuildItem eventLoopGroupSupplier, ...) {
    produceSyntheticBean(..., recoder.createClientWithEventLoopGroup(eventLoopGroupSupplier.getMainEventLoopGroup());
}
```

The drawback is that supplier must return a singleton since it can be called multiple times.