### PR TITLE
Fix Resource Class reflection registration when custom Writer is used

### DIFF
--- a/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/Message2.java
+++ b/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/Message2.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.envers;
+
+public class Message2 {
+
+    private String data;
+
+    public Message2() {
+    }
+
+    public Message2(String data) {
+        this.data = data;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+}

--- a/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/Message2Provider.java
+++ b/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/Message2Provider.java
@@ -1,0 +1,54 @@
+package io.quarkus.it.envers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+@Consumes(MediaType.WILDCARD)
+@Produces(MediaType.WILDCARD)
+public class Message2Provider implements MessageBodyReader<Message2>, MessageBodyWriter<Message2> {
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return Message2.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public Message2 readFrom(Class<Message2> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+        return new Message2("in");
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return Message2.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public void writeTo(Message2 event, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        String data = "out";
+        if (annotations != null) {
+            for (Annotation annotation : annotations) {
+                if (annotation.annotationType().equals(CustomOutput.class)) {
+                    data = ((CustomOutput) annotation).value();
+                    break;
+                }
+            }
+        }
+        entityStream.write(String.format("{\"data\": \"%s\"}", data).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/Output2Resource.java
+++ b/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/Output2Resource.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.envers;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("output2")
+public class Output2Resource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Message2 out() {
+        return new Message2("test");
+    }
+}

--- a/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/OutputResource.java
+++ b/integration-tests/hibernate-orm-envers/src/main/java/io/quarkus/it/envers/OutputResource.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.reactive.RestStreamElementType;
@@ -13,12 +12,6 @@ import io.smallrye.mutiny.Multi;
 
 @Path("output")
 public class OutputResource {
-
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    public Message out() {
-        return new Message("test");
-    }
 
     @GET
     @RestStreamElementType(MediaType.APPLICATION_JSON)

--- a/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/OutputResourceTest.java
+++ b/integration-tests/hibernate-orm-envers/src/test/java/io/quarkus/it/envers/OutputResourceTest.java
@@ -38,7 +38,7 @@ class OutputResourceTest {
     void test() {
         given().accept(ContentType.JSON)
                 .when()
-                .get(RESOURCE_PATH)
+                .get(RESOURCE_PATH + "2")
                 .then()
                 .statusCode(200)
                 .body("data", equalTo("out"));


### PR DESCRIPTION
Originally reported [here](https://quarkusio.zulipchat.com/#narrow/stream/306418-resteasy-reactive/topic/CloudEvents.20lib.20doesn't.20work.20in.20native.20mode/near/357052399)