### PR TITLE
Remove the `quarkus-maven-plugin` from the docs module

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/docs/pom.tpl.qute.xml
@@ -28,17 +28,6 @@
         <sourceDirectory>modules/ROOT/examples</sourceDirectory>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>it.ozimov</groupId>
                 <artifactId>yaml-properties-maven-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
- The plugin is skipped in Quarkiverse projects when building the docs
- Closes #33061
