### PR TITLE
Unify container readiness checks

### DIFF
--- a/extensions/hibernate-reactive/deployment/pom.xml
+++ b/extensions/hibernate-reactive/deployment/pom.xml
@@ -185,13 +185,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                            and that's the truth the second time only.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                            See also how the condition is configured in testcontainers:
+                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/extensions/panache/hibernate-reactive-panache-kotlin/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/deployment/pom.xml
@@ -221,13 +221,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                            and that's the truth the second time only.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                            See also how the condition is configured in testcontainers:
+                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
@@ -159,13 +159,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                            and that's the truth the second time only.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                            See also how the condition is configured in testcontainers:
+                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/pom.xml
@@ -145,13 +145,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                            and that's the truth the second time only.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                            See also how the condition is configured in testcontainers:
+                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -170,9 +170,10 @@
                                             <timeout>3s</timeout>
                                             <startPeriod>5s</startPeriod>
                                             <retries>5</retries>
-                                            <!--     Note that mysqladmin ping returns 0 even if the password is wrong-->
+                                            <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
+                                            Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
                                             <cmd>
-                                                <shell>mysqladmin ping -h localhost || exit 1</shell>
+                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
                                             </cmd>
                                         </healthCheck>
                                     </build>

--- a/extensions/reactive-oracle-client/deployment/pom.xml
+++ b/extensions/reactive-oracle-client/deployment/pom.xml
@@ -160,6 +160,8 @@
                                             <time>60000</time>
                                             <!-- leverage the healthcheck in the image we use -->
                                             <healthy>yes</healthy>
+                                            <!-- In case of any issues with the built-in healthcheck we can revert back to the original log check:-->
+                                            <!--<log>DATABASE IS READY TO USE!</log>-->
                                         </wait>
                                     </run>
                                 </image>

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -150,13 +150,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                            and that's the truth the second time only.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                            See also how the condition is configured in testcontainers:
+                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/extensions/security-jpa-reactive/deployment/pom.xml
+++ b/extensions/security-jpa-reactive/deployment/pom.xml
@@ -155,13 +155,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                            and that's the truth the second time only.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                            See also how the condition is configured in testcontainers:
+                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/hibernate-orm-compatibility-5.6/mariadb/pom.xml
+++ b/integration-tests/hibernate-orm-compatibility-5.6/mariadb/pom.xml
@@ -208,7 +208,7 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${mariadb.image}</name>
+                                    <name>healthcheck-${mariadb.image}</name>
                                     <alias>quarkus-test-mariadb</alias>
                                     <build>
                                         <from>${mariadb.image}</from>

--- a/integration-tests/hibernate-orm-compatibility-5.6/postgresql/pom.xml
+++ b/integration-tests/hibernate-orm-compatibility-5.6/postgresql/pom.xml
@@ -219,13 +219,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                            and that's the truth the second time only.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                            See also how the condition is configured in testcontainers:
+                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/pom.xml
@@ -207,7 +207,6 @@
                                         <from>${mariadb.image}</from>
                                         <healthCheck>
                                             <!-- The exact values for these aren't very important, but it is important they are there -->
-                                            <!-- The exact values for these aren't very important, but it is important they are there -->
                                             <interval>5s</interval>
                                             <timeout>3s</timeout>
                                             <startPeriod>5s</startPeriod>

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver/pom.xml
@@ -205,7 +205,6 @@
                                         <from>${mariadb.image}</from>
                                         <healthCheck>
                                             <!-- The exact values for these aren't very important, but it is important they are there -->
-                                            <!-- The exact values for these aren't very important, but it is important they are there -->
                                             <interval>5s</interval>
                                             <timeout>3s</timeout>
                                             <startPeriod>5s</startPeriod>

--- a/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
@@ -225,7 +225,6 @@
                                         <from>${mariadb.image}</from>
                                         <healthCheck>
                                             <!-- The exact values for these aren't very important, but it is important they are there -->
-                                            <!-- The exact values for these aren't very important, but it is important they are there -->
                                             <interval>5s</interval>
                                             <timeout>3s</timeout>
                                             <startPeriod>5s</startPeriod>

--- a/integration-tests/hibernate-reactive-mysql/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql/pom.xml
@@ -175,7 +175,6 @@
                                         <from>${mariadb.image}</from>
                                         <healthCheck>
                                             <!-- The exact values for these aren't very important, but it is important they are there -->
-                                            <!-- The exact values for these aren't very important, but it is important they are there -->
                                             <interval>5s</interval>
                                             <timeout>3s</timeout>
                                             <startPeriod>5s</startPeriod>
@@ -205,8 +204,8 @@
                                             <date>default</date>
                                             <color>cyan</color>
                                         </log>
-                                        <!--                                         Speed things up a bit by not actually flushing writes to disk -->
-                                        <!--                                         <tmpfs>/var/lib/mysql</tmpfs> -->
+                                        <!-- Speed things up a bit by not actually flushing writes to disk -->
+                                        <tmpfs>/var/lib/mysql</tmpfs>
                                         <wait>
                                             <!-- good docs found at: https://dmp.fabric8.io/#start-wait -->
                                             <time>20000</time>

--- a/integration-tests/hibernate-reactive-panache-kotlin/pom.xml
+++ b/integration-tests/hibernate-reactive-panache-kotlin/pom.xml
@@ -304,13 +304,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                             and that's the truth the second time only.
+                                             See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                             See also how the condition is configured in testcontainers:
+                                             https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/hibernate-reactive-panache/pom.xml
+++ b/integration-tests/hibernate-reactive-panache/pom.xml
@@ -291,13 +291,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                            and that's the truth the second time only.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                            See also how the condition is configured in testcontainers:
+                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/hibernate-reactive-postgresql/pom.xml
+++ b/integration-tests/hibernate-reactive-postgresql/pom.xml
@@ -198,13 +198,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                             and that's the truth the second time only.
+                                             See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                             See also how the condition is configured in testcontainers:
+                                             https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/jpa-mariadb/pom.xml
+++ b/integration-tests/jpa-mariadb/pom.xml
@@ -179,7 +179,6 @@
                                         <from>${mariadb.image}</from>
                                         <healthCheck>
                                             <!-- The exact values for these aren't very important, but it is important they are there -->
-                                            <!-- The exact values for these aren't very important, but it is important they are there -->
                                             <interval>5s</interval>
                                             <timeout>3s</timeout>
                                             <startPeriod>5s</startPeriod>

--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -214,7 +214,10 @@
                                             <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
                                             <time>60000</time>
-                                            <log>DATABASE IS READY TO USE!</log>
+                                            <!-- leverage the healthcheck in the image we use -->
+                                            <healthy>yes</healthy>
+                                            <!-- In case of any issues with the built-in healthcheck we can revert back to the original log check:-->
+                                            <!--<log>DATABASE IS READY TO USE!</log>-->
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/jpa-postgresql-withxml/pom.xml
+++ b/integration-tests/jpa-postgresql-withxml/pom.xml
@@ -171,13 +171,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                            and that's the truth the second time only.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                            See also how the condition is configured in testcontainers:
+                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/jpa-postgresql/pom.xml
+++ b/integration-tests/jpa-postgresql/pom.xml
@@ -181,13 +181,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                             and that's the truth the second time only.
+                                             See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                             See also how the condition is configured in testcontainers:
+                                             https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/kubernetes-service-binding-jdbc/pom.xml
+++ b/integration-tests/kubernetes-service-binding-jdbc/pom.xml
@@ -236,13 +236,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                            and that's the truth the second time only.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                            See also how the condition is configured in testcontainers:
+                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/kubernetes-service-binding-reactive/pom.xml
+++ b/integration-tests/kubernetes-service-binding-reactive/pom.xml
@@ -238,13 +238,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                            and that's the truth the second time only.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                            See also how the condition is configured in testcontainers:
+                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -615,13 +615,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                            and that's the truth the second time only.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                            See also how the condition is configured in testcontainers:
+                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/opentelemetry-jdbc-instrumentation/pom.xml
+++ b/integration-tests/opentelemetry-jdbc-instrumentation/pom.xml
@@ -358,7 +358,10 @@
                                             <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
                                             <time>60000</time>
-                                            <log>DATABASE IS READY TO USE!</log>
+                                            <!-- leverage the healthcheck in the image we use -->
+                                            <healthy>yes</healthy>
+                                            <!-- In case of any issues with the built-in healthcheck we can revert back to the original log check:-->
+                                            <!--<log>DATABASE IS READY TO USE!</log>-->
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/reactive-mysql-client/pom.xml
+++ b/integration-tests/reactive-mysql-client/pom.xml
@@ -185,7 +185,6 @@
                                         <from>${mariadb.image}</from>
                                         <healthCheck>
                                             <!-- The exact values for these aren't very important, but it is important they are there -->
-                                            <!-- The exact values for these aren't very important, but it is important they are there -->
                                             <interval>5s</interval>
                                             <timeout>3s</timeout>
                                             <startPeriod>5s</startPeriod>

--- a/integration-tests/reactive-oracle-client/pom.xml
+++ b/integration-tests/reactive-oracle-client/pom.xml
@@ -179,7 +179,10 @@
                                             <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
                                             <time>60000</time>
-                                            <log>DATABASE IS READY TO USE!</log>
+                                            <!-- leverage the healthcheck in the image we use -->
+                                            <healthy>yes</healthy>
+                                            <!-- In case of any issues with the built-in healthcheck we can revert back to the original log check:-->
+                                            <!--<log>DATABASE IS READY TO USE!</log>-->
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/reactive-pg-client/pom.xml
+++ b/integration-tests/reactive-pg-client/pom.xml
@@ -185,13 +185,13 @@
                                             <port>5431:5432</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <mode>mapped</mode>
-                                                <ports>
-                                                    <port>5432</port>
-                                                </ports>
-                                            </tcp>
-                                            <time>10000</time>
+                                            <!-- For some reason, Postgres will tell us it's ready *twice*,
+                                            and that's the truth the second time only.
+                                            See https://github.com/fabric8io/docker-maven-plugin/issues/628
+                                            See also how the condition is configured in testcontainers:
+                                            https://github.com/testcontainers/testcontainers-java/blob/c64aab9fd5e3a452ee0faf793560327eb4da9841/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L52-L55 -->
+                                            <time>20000</time>
+                                            <log>(?s)ready to accept connections.*ready to accept connections</log>
                                         </wait>
                                     </run>
                                 </image>


### PR DESCRIPTION
Running Postgresql tests was causing:
```
23-05-10 12:35:11,391 WARN  [org.hib.eng.jdb.env.int.JdbcEnvironmentInitiator] (JPA Startup Thread) HHH000342: Could not obtain connection to query metadata: org.postgresql.util.PSQLException: The connection attempt failed.
    at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:354)
    at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:54)
    at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:263)
    at org.postgresql.Driver.makeConnection(Driver.java:443)
    at org.postgresql.Driver.connect(Driver.java:297)
    at io.agroal.pool.ConnectionFactory.createConnection(ConnectionFactory.java:226)
    at io.agroal.pool.ConnectionPool$CreateConnectionTask.call(ConnectionPool.java:536)
    at io.agroal.pool.ConnectionPool$CreateConnectionTask.call(ConnectionPool.java:517)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at io.agroal.pool.util.PriorityScheduledExecutor.beforeExecute(PriorityScheduledExecutor.java:75)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1134)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.io.EOFException
    at org.postgresql.core.PGStream.receiveChar(PGStream.java:467)
    at org.postgresql.core.v3.ConnectionFactoryImpl.enableSSL(ConnectionFactoryImpl.java:589)
    at org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:191)
    at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:258)
```

Yoann helped narrow it down to be caused by the container not being ready for use. 

Here're a few changes around the container configs:

- use a log check for Postgresql
- use a health check for all Oracle DB containers
- remove some duplicated comments
- use the same check for MariaDBs
- `tmpfs` seems to get commented out by accident in `hibernate-reactive-mysql/pom.xml`