### PR TITLE
Make it easier to get well known properties from TokenIntrospection

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -23,10 +23,13 @@ public final class OidcConstants {
     public static final String INTROSPECTION_TOKEN_TYPE_HINT = "token_type_hint";
     public static final String INTROSPECTION_TOKEN = "token";
     public static final String INTROSPECTION_TOKEN_ACTIVE = "active";
+    public static final String INTROSPECTION_TOKEN_CLIENT_ID = "client_id";
     public static final String INTROSPECTION_TOKEN_EXP = "exp";
     public static final String INTROSPECTION_TOKEN_IAT = "iat";
     public static final String INTROSPECTION_TOKEN_USERNAME = "username";
     public static final String INTROSPECTION_TOKEN_SUB = "sub";
+    public static final String INTROSPECTION_TOKEN_AUD = "aud";
+    public static final String INTROSPECTION_TOKEN_ISS = "iss";
 
     public static final String REVOCATION_TOKEN = "token";
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenIntrospection.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenIntrospection.java
@@ -1,7 +1,11 @@
 package io.quarkus.oidc;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import jakarta.json.JsonObject;
 
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.runtime.AbstractJsonObjectResponse;
 
 /**
@@ -19,6 +23,44 @@ public class TokenIntrospection extends AbstractJsonObjectResponse {
 
     public TokenIntrospection(JsonObject json) {
         super(json);
+    }
+
+    public boolean isActive() {
+        return getBoolean(OidcConstants.INTROSPECTION_TOKEN_ACTIVE);
+    }
+
+    public String getUsername() {
+        return getString(OidcConstants.INTROSPECTION_TOKEN_USERNAME);
+    }
+
+    public String getSubject() {
+        return getString(OidcConstants.INTROSPECTION_TOKEN_SUB);
+    }
+
+    public String getAudience() {
+        return getString(OidcConstants.INTROSPECTION_TOKEN_AUD);
+    }
+
+    public String getIssuer() {
+        return getString(OidcConstants.INTROSPECTION_TOKEN_ISS);
+    }
+
+    public Set<String> getScopes() {
+        if (this.contains(OidcConstants.TOKEN_SCOPE)) {
+            String[] scopesArray = getString(OidcConstants.TOKEN_SCOPE).split(" ");
+            Set<String> scopes = new HashSet<>(scopesArray.length);
+            for (String scope : scopesArray) {
+                scopes.add(scope.trim());
+            }
+            return scopes;
+        } else {
+            return null;
+        }
+
+    }
+
+    public String getClientId() {
+        return getString(OidcConstants.INTROSPECTION_TOKEN_CLIENT_ID);
     }
 
     public String getIntrospectionString() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -225,7 +225,7 @@ public class OidcProvider implements Closeable {
                         if (t != null) {
                             throw new AuthenticationFailedException(t);
                         }
-                        if (!Boolean.TRUE.equals(introspectionResult.getBoolean(OidcConstants.INTROSPECTION_TOKEN_ACTIVE))) {
+                        if (!introspectionResult.isActive()) {
                             LOG.debugf("Token issued to client %s is not active", oidcConfig.clientId.get());
                             verifyTokenExpiry(introspectionResult.getLong(OidcConstants.INTROSPECTION_TOKEN_EXP));
                             throw new AuthenticationFailedException();

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TokenIntrospectionTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/TokenIntrospectionTest.java
@@ -1,0 +1,108 @@
+package io.quarkus.oidc.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.oidc.TokenIntrospection;
+
+public class TokenIntrospectionTest {
+    TokenIntrospection introspection = new TokenIntrospection(
+            "{"
+                    + "\"active\": true,"
+                    + "\"username\": \"alice\","
+                    + "\"sub\": \"1234567\","
+                    + "\"aud\": \"http://localhost:8080\","
+                    + "\"iss\": \"http://keycloak/realm\","
+                    + "\"client_id\": \"quarkus\","
+                    + "\"custom\": null,"
+                    + "\"id\": 1234,"
+                    + "\"permissions\": [\"read\", \"write\"],"
+                    + "\"scope\": \"add divide\","
+                    + "\"scopes\": {\"scope\": \"see\"}"
+                    + "}");
+
+    @Test
+    public void testActive() {
+        assertTrue(introspection.isActive());
+    }
+
+    @Test
+    public void testGetUsername() {
+        assertEquals("alice", introspection.getUsername());
+    }
+
+    @Test
+    public void testGetSubject() {
+        assertEquals("1234567", introspection.getSubject());
+    }
+
+    @Test
+    public void testGetAudience() {
+        assertEquals("http://localhost:8080", introspection.getAudience());
+    }
+
+    @Test
+    public void testGetIssuer() {
+        assertEquals("http://keycloak/realm", introspection.getIssuer());
+    }
+
+    @Test
+    public void testGetScopes() {
+        assertEquals(Set.of("add", "divide"), introspection.getScopes());
+    }
+
+    @Test
+    public void testGetClientId() {
+        assertEquals("quarkus", introspection.getClientId());
+    }
+
+    @Test
+    public void testGetString() {
+        assertEquals("alice", introspection.getString("username"));
+        assertNull(introspection.getString("usernames"));
+    }
+
+    @Test
+    public void testGetBoolean() {
+        assertTrue(introspection.getBoolean("active"));
+        assertNull(introspection.getBoolean("activate"));
+    }
+
+    @Test
+    public void testGetLong() {
+        assertEquals(1234, introspection.getLong("id"));
+        assertNull(introspection.getLong("ids"));
+    }
+
+    @Test
+    public void testGetArray() {
+        JsonArray array = introspection.getArray("permissions");
+        assertNotNull(array);
+        assertEquals(2, array.size());
+        assertEquals("read", array.getString(0));
+        assertEquals("write", array.getString(1));
+        assertNull(introspection.getArray("permit"));
+    }
+
+    @Test
+    public void testGetObject() {
+        JsonObject map = introspection.getObject("scopes");
+        assertNotNull(map);
+        assertEquals(1, map.size());
+        assertEquals("see", map.getString("scope"));
+    }
+
+    @Test
+    public void testGetNullProperty() {
+        assertNull(introspection.getString("custom"));
+    }
+}


### PR DESCRIPTION
Fixes #33282.

This PR adds `TokenIntrospectionTest`, adds a few methods to `TokenIntrospection` to make it easier to get well known properties, which are covered here:
https://datatracker.ietf.org/doc/html/rfc7662

I added methods for nearly all of them which can be useful in the user code, for now I've stopped short of adding expiry/issued at as Quarkus manages them itself, they can be still retrieved as JSON properties if needed.
Some OIDC code got simplified a bit as well.