### PR TITLE
No need to exclude javax validation-api anymore

### DIFF
--- a/extensions/hibernate-validator/runtime/pom.xml
+++ b/extensions/hibernate-validator/runtime/pom.xml
@@ -107,9 +107,6 @@
                     <capabilities>
                         <provides>io.quarkus.hibernate.validator</provides>
                     </capabilities>
-                    <excludedArtifacts>
-                        <excludedArtifact>javax.validation:validation-api</excludedArtifact>
-                    </excludedArtifacts>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This was first introduced with the Big ClassLoader Change in 1.3 but the move to Jakarta this is no longer needed

Relates to [this](https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Does.20Quarkus.203.20remove.20javax.20Dependecy.20like.20javax.2Evalidation.3F)

P.S. This actually works around an issue (?) where bootstrap's `excludedArtifact` overrides an explicitly added user dependency 