### PR TITLE
Qute - support optional end tags for sections

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -150,6 +150,7 @@ Sections::
 A <<sections,section>> may contain static text, expressions and nested sections: `{#if foo.active}{foo.name}{/if}`.
 The name in the closing tag is optional: `{#if active}ACTIVE!{/}`.
 A section can be empty: `{#myTag image=true /}`.
+Some sections support optional end tags, i.e. if the end tag is missing then the section ends where the parent section ends.
 A section may also declare nested section blocks: `{#if item.valid} Valid. {#else} Invalid. {/if}` and decide which block to render.
 
 Unparsed Character Data::
@@ -585,6 +586,54 @@ A section has a start tag that starts with `#`, followed by the name of the sect
 It may be empty, i.e. the start tag ends with `/`: `{#myEmptySection /}`.
 Sections usually contain nested expressions and other sections.
 The end tag starts with `/` and contains the name of the section (optional): `{#if foo}Foo!{/if}` or `{#if foo}Foo!{/}`.
+Some sections support optional end tags, i.e. if the end tag is missing then the section ends where the parent section ends.
+
+.`#let` Optional End Tag Example
+[source,html]
+----
+{#if item.isActive}
+  {#let price = item.price} <1>
+  {price}
+  // synthetic {/let} added here automatically
+{/if}
+// {price} cannot be used here!
+----
+<1> Defines the local variable that can be used inside the parent `{#if}` section.
+
+|===
+|Built-in section |Supports Optional End Tag
+
+|`{#for}`
+|❌
+
+|`{#if}`
+|❌
+
+|`{#when}`
+|❌
+
+|`{#let}`
+|✅
+
+|`{#with}`
+|❌
+
+|`{#include}`
+|✅
+
+|User-defined Tags
+|❌
+
+|`{#fragment}`
+|❌
+
+|`{#cached}`
+|❌
+
+|===
+
+[[sections_params]]
+==== Parameters
 
 A start tag can define parameters with optional names, e.g. `{#if item.isActive}` and `{#let foo=1 bar=false}`.
 Parameters are separated by one or more spaces.

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
@@ -332,6 +332,11 @@ public final class EngineBuilder {
             return delegate.initializeBlock(outerScope, block);
         }
 
+        @Override
+        public MissingEndTagStrategy missingEndTagStrategy() {
+            return delegate.missingEndTagStrategy();
+        }
+
     }
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/IncludeSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/IncludeSectionHelper.java
@@ -108,6 +108,11 @@ public class IncludeSectionHelper implements SectionHelper {
         }
 
         @Override
+        public MissingEndTagStrategy missingEndTagStrategy() {
+            return MissingEndTagStrategy.BIND_TO_PARENT;
+        }
+
+        @Override
         protected boolean ignoreParameterInit(String key, String value) {
             return key.equals(TEMPLATE)
                     // {#include foo _isolated=true /}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParserError.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParserError.java
@@ -60,6 +60,11 @@ public enum ParserError implements ErrorCode {
     UNTERMINATED_SECTION,
 
     /**
+     * <code>{name</code>
+     */
+    UNTERMINATED_EXPRESSION,
+
+    /**
      * <code>{#if (foo || bar}{/}</code>
      */
     UNTERMINATED_STRING_LITERAL_OR_COMPOSITE_PARAMETER,

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
@@ -118,6 +118,31 @@ public interface SectionHelperFactory<T extends SectionHelper> {
         return outerScope;
     }
 
+    /**
+     * A section end tag may be mandatory or optional.
+     *
+     * @return the strategy
+     */
+    default MissingEndTagStrategy missingEndTagStrategy() {
+        return MissingEndTagStrategy.ERROR;
+    }
+
+    /**
+     * This strategy is used when an unterminated section is detected during parsing.
+     */
+    public enum MissingEndTagStrategy {
+
+        /**
+         * The end tag is mandatory. A missing end tag results in a parser error.
+         */
+        ERROR,
+
+        /**
+         * The end tag is optional. The section ends where the parent section ends.
+         */
+        BIND_TO_PARENT;
+    }
+
     interface ParserDelegate extends ErrorInitializer {
 
         default TemplateException createParserError(String message) {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SetSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SetSectionHelper.java
@@ -116,6 +116,11 @@ public class SetSectionHelper implements SectionHelper {
         }
 
         @Override
+        public MissingEndTagStrategy missingEndTagStrategy() {
+            return MissingEndTagStrategy.BIND_TO_PARENT;
+        }
+
+        @Override
         public SetSectionHelper initialize(SectionInitContext context) {
             Map<String, Expression> params = new HashMap<>();
             Map<String, Expression> keys = null;

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/EvalTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/EvalTest.java
@@ -37,7 +37,7 @@ public class EvalTest {
         assertThatExceptionOfType(TemplateException.class)
                 .isThrownBy(() -> Engine.builder().addDefaults().build().parse("{#eval invalid /}").data("invalid", "{foo")
                         .render())
-                .withMessageContainingAll("Parser error in the evaluated template", "unterminated section");
+                .withMessageContainingAll("Parser error in the evaluated template", "unterminated expression");
     }
 
 }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/IncludeTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/IncludeTest.java
@@ -222,7 +222,19 @@ public class IncludeTest {
         assertEquals(
                 "Rendering error in template [bum.html] line 1: invalid fragment identifier [foo-and_bar]",
                 expected.getMessage());
+    }
 
+    @Test
+    public void testOptionalEndTag() {
+        Engine engine = Engine.builder().addDefaults().build();
+
+        engine.putTemplate("super", engine.parse("{#insert header}default header{/insert}::{#insert}{/}"));
+        assertEquals("super header:: body",
+                engine.parse("{#include super}{#header}super header{/header} body").render());
+        assertEquals("super header:: 1",
+                engine.parse("{#let foo = 1}{#include super}{#header}super header{/header} {foo}").render());
+        assertEquals("default header:: 1",
+                engine.parse("{#include super}{#let foo=1} {foo}").render());
     }
 
 }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/SetSectionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/SetSectionTest.java
@@ -74,4 +74,19 @@ public class SetSectionTest {
                         .render());
     }
 
+    @Test
+    public void testOptionalEndTag() {
+        Engine engine = Engine.builder().addDefaults().build();
+        assertEquals("true",
+                engine.parse("{#let foo=true}{foo}").render());
+        assertEquals("true  ?",
+                engine.parse("{#let foo=true}{foo}  ?").render());
+        assertEquals("true::1",
+                engine.parse("{#let foo=true}{#let bar = 1}{foo}::{bar}").render());
+        assertEquals("true",
+                engine.parse("{#let foo=true}{#if baz}{foo}{/}").data("baz", true).render());
+        assertEquals("true::null",
+                engine.parse("{#if baz}{#let foo=true}{foo}{/if}::{foo ?: 'null'}").data("baz", true).render());
+    }
+
 }


### PR DESCRIPTION
- resolves #33293

```
{#let foo=true}
// foo can be used here

// synthetic {/let} added automatically
```

```
// foo cannot be used here
{#if baz}
{#let foo=true}
// foo can be used here

// synthetic {/let} added automatically
{/if}
// foo cannot be used here
```

So far only the `{#let}` and `{#include}` section support optional end tags. I think that it would be quite confusing for `{#if}`, `{#for}` and others...

CC @ia3andy @angelozerr