### PR TITLE
Bump kubernetes-client-bom from 6.6.0 to 6.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
         <!-- Dependency versions -->
         <jacoco.version>0.8.10</jacoco.version>
-        <kubernetes-client.version>6.6.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>6.6.2</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.55.1</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
         <!-- Dependency versions -->
         <jacoco.version>0.8.10</jacoco.version>
-        <kubernetes-client.version>6.6.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>6.6.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.55.1</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->


### PR DESCRIPTION
Kubernetes Client 6.6.2 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v6.6.2

Just speeding up the dependabot process to see if CI reports any issue.

No breaking changes, just a few fixes for problems with scaling, verbose logging, and better enforcement of HTTP request timeouts.

/cc @metacosm