### PR TITLE
Register PGobject subtypes for reflection

### DIFF
--- a/extensions/jdbc/jdbc-postgresql/deployment/src/main/java/io/quarkus/jdbc/postgresql/deployment/PostgreSQLJDBCReflections.java
+++ b/extensions/jdbc/jdbc-postgresql/deployment/src/main/java/io/quarkus/jdbc/postgresql/deployment/PostgreSQLJDBCReflections.java
@@ -20,6 +20,27 @@ public final class PostgreSQLJDBCReflections {
         final String driverName = "org.postgresql.Driver";
         reflectiveClass.produce(ReflectiveClassBuildItem.builder(driverName).build());
 
+        // We want to register these postgresql "object" types since they are used by a driver to build result set elements
+        // and reflection is used to create their instances. While ORM might only use a `PGInterval` if a @JdbcType(PostgreSQLIntervalSecondJdbcType.class)
+        // is applied to a Duration property, we still register other types as users might create their own JdbcTypes that
+        // would rely on some subtype of a PGobject:
+        final String[] pgObjectClasses = new String[] {
+                "org.postgresql.util.PGobject",
+                "org.postgresql.util.PGInterval",
+                "org.postgresql.util.PGmoney",
+                "org.postgresql.geometric.PGbox",
+                "org.postgresql.geometric.PGcircle",
+                "org.postgresql.geometric.PGline",
+                "org.postgresql.geometric.PGlseg",
+                "org.postgresql.geometric.PGpath",
+                "org.postgresql.geometric.PGpoint",
+                "org.postgresql.geometric.PGpolygon",
+                // One more subtype of the PGobject, it doesn't look like that this one will be instantiated through reflection,
+                // so let's not include it:
+                // "org.postgresql.jdbc.PgResultSet.NullObject"
+        };
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(pgObjectClasses).build());
+
         // Needed when quarkus.datasource.jdbc.transactions=xa for the setting of the username and password
         reflectiveClass.produce(ReflectiveClassBuildItem.builder("org.postgresql.ds.common.BaseDataSource").constructors(false)
                 .methods().build());

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityTestEndpoint.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityTestEndpoint.java
@@ -2,6 +2,7 @@ package io.quarkus.it.jpa.postgresql;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 
@@ -135,6 +136,7 @@ public class JPAFunctionalityTestEndpoint extends HttpServlet {
         person.setName(name);
         person.setStatus(Status.LIVING);
         person.setAddress(new SequencedAddress("Street " + randomName()));
+        person.setLatestLunchBreakDuration(Duration.ofMinutes(30));
         entityManager.persist(person);
     }
 

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/Person.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/Person.java
@@ -1,6 +1,9 @@
 package io.quarkus.it.jpa.postgresql;
 
+import java.time.Duration;
+
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -9,6 +12,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
+
+import org.hibernate.annotations.JdbcType;
+import org.hibernate.dialect.PostgreSQLIntervalSecondJdbcType;
 
 @Entity
 @Table(schema = "myschema")
@@ -19,6 +25,7 @@ public class Person {
     private String name;
     private SequencedAddress address;
     private Status status;
+    private Duration latestLunchBreakDuration = Duration.ZERO;
 
     public Person() {
     }
@@ -64,8 +71,27 @@ public class Person {
         this.status = status;
     }
 
+    /**
+     * Need to explicitly set the scale (and the precision so that the scale will actually be read from the annotation).
+     * Postgresql would only allow maximum scale of 6 for a `interval second`.
+     *
+     * @see org.hibernate.type.descriptor.sql.internal.Scale6IntervalSecondDdlType
+     */
+    @Column(precision = 5, scale = 5)
+    //NOTE: while https://hibernate.atlassian.net/browse/HHH-16591 is open we cannot replace the currently used @JdbcType annotation
+    // with a @JdbcTypeCode( INTERVAL_SECOND )
+    @JdbcType(PostgreSQLIntervalSecondJdbcType.class)
+    public Duration getLatestLunchBreakDuration() {
+        return latestLunchBreakDuration;
+    }
+
+    public void setLatestLunchBreakDuration(Duration duration) {
+        this.latestLunchBreakDuration = duration;
+    }
+
     public void describeFully(StringBuilder sb) {
         sb.append("Person with id=").append(id).append(", name='").append(name).append("', status='").append(status)
+                .append("', latestLunchBreakDuration='").append(latestLunchBreakDuration)
                 .append("', address { ");
         getAddress().describeFully(sb);
         sb.append(" }");


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus/issues/33206

The original bug report is for `hypersistence` lib. And I'd suspect that it would be up to the lib users to register whatever it needs to function since we don't have an extension for it. But we could still get ourselves into a similar situation as ORM provides a `PostgreSQLIntervalSecondJdbcType` for a `Duration` mapping.