### PR TITLE
Fix 'quarkus.otel.exporter.otlp.traces.timeout' default value

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterTracesConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterTracesConfig.java
@@ -63,7 +63,7 @@ public interface OtlpExporterTracesConfig {
      * Sets the maximum time to wait for the collector to process an exported batch of spans. If
      * unset, defaults to {@value OtlpExporterRuntimeConfig#DEFAULT_TIMEOUT_SECS}s.
      */
-    @WithDefault("10S")
+    @WithDefault("10s")
     Duration timeout();
 
     /**


### PR DESCRIPTION
The default duration for timeout property is wrongly defined and causes runtime error.