### PR TITLE
Update mariadb to latest LTS 10.11 for devservices and integration tests

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -90,7 +90,7 @@
 
         <!-- Database images for JDBC/Reactive/Hibernate tests and devservices -->
         <postgres.image>docker.io/postgres:14</postgres.image>
-        <mariadb.image>docker.io/mariadb:10.6</mariadb.image>
+        <mariadb.image>docker.io/mariadb:10.11</mariadb.image>
         <db2.image>docker.io/ibmcom/db2:11.5.7.0a</db2.image>
         <mssql.image>mcr.microsoft.com/mssql/server:2019-latest</mssql.image>
         <mysql.image>docker.io/mysql:8.0</mysql.image>


### PR DESCRIPTION
See https://endoflife.date/mariadb for an overview