### PR TITLE
Fix blank DEV UI extension pages when loading data from Back End

### DIFF
--- a/extensions/arc/deployment/src/main/resources/dev-ui/qwc-arc-fired-events.js
+++ b/extensions/arc/deployment/src/main/resources/dev-ui/qwc-arc-fired-events.js
@@ -1,5 +1,4 @@
 import { LitElement, html, css} from 'lit';
-import { until } from 'lit/directives/until.js';
 import { JsonRpc } from 'jsonrpc';
 import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
@@ -54,12 +53,15 @@ export class QwcArcFiredEvents extends LitElement {
     }
         
     render() {
-        return html`${until(this._renderFiredEvents(), html`<span>Loading ArC fired event...</span>`)}`;
+        if(this._firedEvents){
+            return this._renderFiredEvents();
+        } else {
+            return html`<span>Loading ArC fired event...</span>`;
+        }
     }
 
     _renderFiredEvents(){
-        if(this._firedEvents){
-            return html`<div class="menubar">
+        return html`<div class="menubar">
                     <vaadin-button theme="small" @click=${() => this._refresh()} class="button">
                         <vaadin-icon icon="font-awesome-solid:rotate"></vaadin-icon> Refresh
                     </vaadin-button> 

--- a/extensions/arc/deployment/src/main/resources/dev-ui/qwc-arc-invocation-trees.js
+++ b/extensions/arc/deployment/src/main/resources/dev-ui/qwc-arc-invocation-trees.js
@@ -1,5 +1,4 @@
 import { LitElement, html, css} from 'lit';
-import { until } from 'lit/directives/until.js';
 import { JsonRpc } from 'jsonrpc';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/grid';
@@ -50,12 +49,15 @@ export class QwcArcInvocationTrees extends LitElement {
     }
   
     render() {
-        return html`${until(this._renderInvocations(), html`<span>Loading ArC invocation trees...</span>`)}`;
+        if(this._invocations){
+            return this._renderInvocations();
+        } else {
+            return html`<span>Loading ArC invocation trees...</span>`;
+        }
     }
   
     _renderInvocations(){
-        if(this._invocations){
-            return html`<div class="menubar">
+        return html`<div class="menubar">
                     <vaadin-button theme="small" @click=${() => this._refresh()} class="button">
                         <vaadin-icon icon="font-awesome-solid:rotate"></vaadin-icon> Refresh
                     </vaadin-button> 
@@ -76,7 +78,6 @@ export class QwcArcInvocationTrees extends LitElement {
                         resizable>
                     </vaadin-grid-column>
                 </vaadin-grid>`;
-        }
     }
     
      _invocationsRenderer(invocation) {

--- a/extensions/cache/deployment/src/main/resources/dev-ui/qwc-cache-caches.js
+++ b/extensions/cache/deployment/src/main/resources/dev-ui/qwc-cache-caches.js
@@ -7,7 +7,6 @@ import '@vaadin/text-area';
 import '@vaadin/form-layout';
 import '@vaadin/progress-bar';
 import '@vaadin/checkbox';
-import { until } from 'lit/directives/until.js';
 import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
@@ -52,15 +51,18 @@ export class QwcCacheCaches extends LitElement {
      * @returns {*}
      */
     render() {
-        return html`${until(this._renderCacheTable(), html`<span>Loading caches...</span>`)}`;
+        if (this._caches) {
+            return this._renderCacheTable();
+        } else {
+            return html`<span>Loading caches...</span>`;
+        }
     }
 
     // View / Templates
 
     _renderCacheTable() {
-        if (this._caches) {
-            let caches = [...this._caches.values()];
-            return html`
+        let caches = [...this._caches.values()];
+        return html`
                 <vaadin-grid .items="${caches}" class="datatable" theme="no-border">
                     <vaadin-grid-column auto-width
                                         header="Name"
@@ -78,7 +80,6 @@ export class QwcCacheCaches extends LitElement {
                                         resizable>
                     </vaadin-grid-column>
                 </vaadin-grid>`;
-        }
     }
 
     _actionRenderer(cache) {

--- a/extensions/container-image/deployment/src/main/resources/dev-ui/qwc-container-image-build.js
+++ b/extensions/container-image/deployment/src/main/resources/dev-ui/qwc-container-image-build.js
@@ -2,7 +2,6 @@ import {LitElement, html, css, render} from 'lit';
 import {JsonRpc} from 'jsonrpc';
 import '@vaadin/icon';
 import '@vaadin/button';
-import {until} from 'lit/directives/until.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
 import {builderTypes} from 'build-time-data';
@@ -62,10 +61,6 @@ export class QwcContainerImageBuild extends LitElement {
      * @returns {*}
      */
     render() {
-        return html`${until(this._renderForm(), html`<span>Loading...</span>`)}`;
-    }
-
-    _renderForm() {
         const _builders = [];
         let _defaultBuilder = "";
         if(this.builders){

--- a/extensions/datasource/deployment/src/main/resources/dev-ui/qwc-datasources-reset.js
+++ b/extensions/datasource/deployment/src/main/resources/dev-ui/qwc-datasources-reset.js
@@ -7,7 +7,6 @@ import '@vaadin/text-area';
 import '@vaadin/form-layout';
 import '@vaadin/progress-bar';
 import '@vaadin/checkbox';
-import { until } from 'lit/directives/until.js';
 import '@vaadin/grid';
 import 'qui-alert';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
@@ -49,12 +48,15 @@ export class QwcDatasourcesReset extends LitElement {
     }
 
     render() {
-        return html`${until(this._renderDataSourceTable(), html`<span>Loading datasources...</span>`)}`;
+        if (this._ds) {
+            return this._renderDataSourceTable();
+        } else {
+            return html`<span>Loading datasources...</span>`;
+        }
     }
 
     _renderDataSourceTable() {
-        if (this._ds) {
-            return html`
+        return html`
                 ${this._message}
                 <vaadin-grid .items="${this._ds}" class="datatable" theme="no-border">
                     <vaadin-grid-column auto-width
@@ -67,7 +69,6 @@ export class QwcDatasourcesReset extends LitElement {
                                         resizable>
                     </vaadin-grid-column>
                 </vaadin-grid>`;
-        }
     }
 
     _actionRenderer(ds) {

--- a/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-entity-types.js
+++ b/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-entity-types.js
@@ -2,7 +2,6 @@ import { LitElement, html, css} from 'lit';
 import { JsonRpc } from 'jsonrpc';
 import '@vaadin/icon';
 import '@vaadin/button';
-import { until } from 'lit/directives/until.js';
 import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 
@@ -28,14 +27,17 @@ export class HibernateOrmEntityTypesComponent extends LitElement {
     }
 
     render() {
-        return html`${until(this._renderAllPUs(), html`<span>Loading...</span>`)}`;
+        if (this._persistenceUnits) {
+            return this._renderAllPUs();
+        } else {
+            return html`<span>Loading...</span>`;
+        }
     }
 
     _renderAllPUs() {
-        if (this._persistenceUnits) {
-            return this._persistenceUnits.length == 0
-                ? html`<p>No persistence units were found.</p>`
-                : html`
+        return this._persistenceUnits.length == 0
+            ? html`<p>No persistence units were found.</p>`
+            : html`
                     <vaadin-tabsheet class="full-height">
                         <span slot="prefix">Persistence Unit</span>
                         <vaadin-tabs slot="tabs">
@@ -53,7 +55,6 @@ export class HibernateOrmEntityTypesComponent extends LitElement {
                             </div>
                             `)}
                     </vaadin-tabsheet>`;
-        }
     }
 
     _renderEntityTypesTable(pu) {

--- a/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-named-queries.js
+++ b/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-named-queries.js
@@ -2,7 +2,6 @@ import { LitElement, html, css} from 'lit';
 import { JsonRpc } from 'jsonrpc';
 import '@vaadin/icon';
 import '@vaadin/button';
-import { until } from 'lit/directives/until.js';
 import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 
@@ -28,14 +27,17 @@ export class HibernateOrmNamedQueriesComponent extends LitElement {
     }
 
     render() {
-        return html`${until(this._renderAllPUs(), html`<span>Loading...</span>`)}`;
+        if (this._persistenceUnits) {
+            return this._renderAllPUs();
+        } else {
+            return html`<span>Loading...</span>`;
+        }
     }
 
     _renderAllPUs() {
-        if (this._persistenceUnits) {
-            return this._persistenceUnits.length == 0
-                ? html`<p>No persistence units were found.</p>`
-                : html`
+        return this._persistenceUnits.length == 0
+            ? html`<p>No persistence units were found.</p>`
+            : html`
                     <vaadin-tabsheet class="full-height">
                         <span slot="prefix">Persistence Unit</span>
                         <vaadin-tabs slot="tabs">
@@ -53,7 +55,6 @@ export class HibernateOrmNamedQueriesComponent extends LitElement {
                             </div>
                             `)}
                     </vaadin-tabsheet>`;
-        }
     }
 
     _renderNamedQueriesTable(pu) {

--- a/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-persistence-units.js
+++ b/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-persistence-units.js
@@ -2,7 +2,6 @@ import { LitElement, html, css} from 'lit';
 import { JsonRpc } from 'jsonrpc';
 import '@vaadin/icon';
 import '@vaadin/button';
-import { until } from 'lit/directives/until.js';
 import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import { notifier } from 'notifier';
@@ -38,14 +37,17 @@ export class HibernateOrmPersistenceUnitsComponent extends LitElement {
     }
 
     render() {
-        return html`${until(this._renderAllPUs(), html`<span>Loading...</span>`)}`;
+        if (this._persistenceUnits) {
+            return this._renderAllPUs();
+        } else {
+            return html`<span>Loading...</span>`;
+        }
     }
 
     _renderAllPUs() {
-        if (this._persistenceUnits) {
-            return this._persistenceUnits.length == 0
-                ? html`<p>No persistence units were found.</p>`
-                : html`
+        return this._persistenceUnits.length == 0
+            ? html`<p>No persistence units were found.</p>`
+            : html`
                     <vaadin-tabsheet class="full-height">
                         <span slot="prefix">Persistence Unit</span>
                         <vaadin-tabs slot="tabs">
@@ -62,7 +64,6 @@ export class HibernateOrmPersistenceUnitsComponent extends LitElement {
                             </div>
                             `)}
                     </vaadin-tabsheet>`;
-        }
     }
 
     _renderPersistenceUnit(pu) {

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/resources/dev-ui/hibernate-search-orm-elasticsearch-indexed-entity-types.js
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/resources/dev-ui/hibernate-search-orm-elasticsearch-indexed-entity-types.js
@@ -2,7 +2,6 @@ import { LitElement, html, css} from 'lit';
 import { JsonRpc } from 'jsonrpc';
 import '@vaadin/icon';
 import '@vaadin/button';
-import { until } from 'lit/directives/until.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-selection-column.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
@@ -35,14 +34,17 @@ export class HibernateSearchOrmElasticsearchIndexedEntitiesComponent extends Lit
     }
 
     render() {
-        return html`${until(this._renderAllPUs(), html`<span>Loading...</span>`)}`;
+        if (this._persistenceUnits) {
+            return this._renderAllPUs();
+        } else {
+            return html`<span>Loading...</span>`;
+        }
     }
 
     _renderAllPUs() {
-        if (this._persistenceUnits) {
-            return this._persistenceUnits.length == 0
-                ? html`<p>No persistence units were found.</p>`
-                : html`
+        return this._persistenceUnits.length == 0
+            ? html`<p>No persistence units were found.</p>`
+            : html`
                     <vaadin-tabsheet class="full-height">
                         <span slot="prefix">Persistence Unit</span>
                         <vaadin-tabs slot="tabs">
@@ -60,7 +62,6 @@ export class HibernateSearchOrmElasticsearchIndexedEntitiesComponent extends Lit
                             </div>
                             `)}
                     </vaadin-tabsheet>`;
-        }
     }
 
     _renderEntityTypesTable(pu) {

--- a/extensions/kubernetes/openshift/deployment/src/main/resources/dev-ui/qwc-openshift-deployment.js
+++ b/extensions/kubernetes/openshift/deployment/src/main/resources/dev-ui/qwc-openshift-deployment.js
@@ -2,7 +2,6 @@ import {LitElement, html, css, render} from 'lit';
 import {JsonRpc} from 'jsonrpc';
 import '@vaadin/icon';
 import '@vaadin/button';
-import {until} from 'lit/directives/until.js';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
 import {builderTypes} from 'build-time-data';
@@ -68,10 +67,6 @@ export class QwcOpenshiftDeployment extends LitElement {
      * @returns {*}
      */
     render() {
-        return html`${until(this._renderForm(), html`<span>Loading...</span>`)}`;
-    }
-
-    _renderForm() {
         const _builders = [];
         let _defaultBuilder = "";
         if (this.builders) {

--- a/extensions/liquibase/deployment/src/main/resources/dev-ui/qwc-liquibase-datasources.js
+++ b/extensions/liquibase/deployment/src/main/resources/dev-ui/qwc-liquibase-datasources.js
@@ -11,7 +11,6 @@ import '@vaadin/checkbox';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
 import 'qui-alert';
-import { until } from 'lit/directives/until.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 
 export class QwcLiquibaseDatasources extends LitElement {
@@ -54,12 +53,15 @@ export class QwcLiquibaseDatasources extends LitElement {
     }
 
     render() {
-        return html`${until(this._renderDataSourceTable(), html`<span>Loading datasources...</span>`)}`;
+        if (this._factories) {
+            return this._renderDataSourceTable();
+        } else {
+            return html`<span>Loading datasources...</span>`;
+        }
     }
 
     _renderDataSourceTable() {
-        if (this._factories) {
-            return html`
+        return html`
                 ${this._message}
                 <vaadin-grid .items="${this._factories}" class="datatable" theme="no-border">
                     <vaadin-grid-column auto-width
@@ -78,16 +80,15 @@ export class QwcLiquibaseDatasources extends LitElement {
                   confirm-text="Clear"
                   .opened="${this._dialogOpened}"
                   @confirm="${() => {
-                    this._clear(this._ds);
-                  }}"
+            this._clear(this._ds);
+        }}"
                   @cancel="${() => {
-                    this._dialogOpened = false;
-                  }}"
+            this._dialogOpened = false;
+        }}"
                 >
                   This will drop all objects (tables, views, procedures, triggers, ...) in the configured schema. Do you want to continue?
                 </vaadin-confirm-dialog>
             `;
-        }
     }
 
     _actionRenderer(ds) {

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/resources/dev-ui/qwc-rest-client-clients.js
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/resources/dev-ui/qwc-rest-client-clients.js
@@ -3,7 +3,6 @@ import { JsonRpc } from 'jsonrpc';
 import '@vaadin/icon';
 import '@vaadin/progress-bar';
 import '@vaadin/checkbox';
-import { until } from 'lit/directives/until.js';
 import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
@@ -45,14 +44,17 @@ export class QwcRestClientClients extends LitElement {
      * @returns {*}
      */
     render() {
-        return html`${until(this._renderClientsTable(), html`<span>Loading REST Clients...</span>`)}`;
+        if (this._clients) {
+            return this._renderClientsTable();
+        } else {
+            return html`<span>Loading REST Clients...</span>`;
+        }
     }
 
     // View / Templates
 
     _renderClientsTable() {
-        if (this._clients) {
-            return html`
+        return html`
                 <vaadin-grid .items="${this._clients}" class="datatable" theme="no-border">
                     <vaadin-grid-column auto-width
                                         header="Client interface"
@@ -72,7 +74,6 @@ export class QwcRestClientClients extends LitElement {
                                         resizable>
                     </vaadin-grid-column>
                 </vaadin-grid>`;
-        }
     }
 
   _clientInterfaceRenderer(client){

--- a/extensions/scheduler/deployment/src/main/resources/dev-ui/qwc-scheduler-scheduled-methods.js
+++ b/extensions/scheduler/deployment/src/main/resources/dev-ui/qwc-scheduler-scheduled-methods.js
@@ -1,6 +1,5 @@
 import { LitElement, html, css} from 'lit';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
-import { until } from 'lit/directives/until.js';
 import { notifier } from 'notifier';
 import { JsonRpc } from 'jsonrpc';
 import '@vaadin/grid';
@@ -89,35 +88,38 @@ export class QwcSchedulerScheduledMethods extends LitElement {
     }
 
     render() {
-        return html`${until(this._renderScheduledMethods(), html`<span>Loading scheduled methods...</span>`)}`;
+        if (this._scheduledMethods){
+            return this._renderScheduledMethods();
+        } else {
+            return html`<span>Loading scheduled methods...</span>`;
+        }
     }
 
     _renderScheduledMethods(){
-        if (this._scheduledMethods){
-            let schedulerButton;
-            if (this._schedulerRunning) {
-                schedulerButton = html`<vaadin-button class="scheduler" theme="tertiary" @click=${() => this._pauseScheduler()}>
+        let schedulerButton;
+        if (this._schedulerRunning) {
+            schedulerButton = html`<vaadin-button class="scheduler" theme="tertiary" @click=${() => this._pauseScheduler()}>
                 <vaadin-icon icon="font-awesome-solid:circle-pause"></vaadin-icon>
                 Pause scheduler</vaadin-button>`;
-            } else {
-                schedulerButton = html`<vaadin-button class="scheduler" theme="tertiary" @click=${() => this._resumeScheduler()}>
+        } else {
+            schedulerButton = html`<vaadin-button class="scheduler" theme="tertiary" @click=${() => this._resumeScheduler()}>
                 <vaadin-icon icon="font-awesome-solid:circle-play"></vaadin-icon>
                 Resume scheduler</vaadin-button>`;
-            }
-            
-            const searchBox = html`
+        }
+
+        const searchBox = html`
             <vaadin-text-field class="searchField"
                 placeholder="Search"
                 @value-changed="${e => {
-                    const searchTerm = (e.detail.value || '').trim().toLowerCase();
-                    this._filteredScheduledMethods = this._scheduledMethods.filter(method => this._matchesTerm(method, searchTerm));
-                }}"
+            const searchTerm = (e.detail.value || '').trim().toLowerCase();
+            this._filteredScheduledMethods = this._scheduledMethods.filter(method => this._matchesTerm(method, searchTerm));
+        }}"
             >
                 <vaadin-icon slot="prefix" icon="font-awesome-solid:magnifying-glass"></vaadin-icon>
             </vaadin-text-field>
             `
-            
-            return html`
+
+        return html`
                 <div class="topBar">
                     ${searchBox}
                     ${schedulerButton}
@@ -135,7 +137,6 @@ export class QwcSchedulerScheduledMethods extends LitElement {
                     </vaadin-grid-column>
                 </vaadin-grid>
                 `;
-        }
     }
     
     _scheduleRenderer(scheduledMethod) {

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/resources/dev-ui/qwc-fault-tolerance-methods.js
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/resources/dev-ui/qwc-fault-tolerance-methods.js
@@ -1,5 +1,4 @@
 import {css, html, LitElement} from 'lit';
-import {until} from 'lit/directives/until.js';
 import {JsonRpc} from 'jsonrpc';
 import '@vaadin/grid';
 import {columnBodyRenderer} from '@vaadin/grid/lit.js';
@@ -29,12 +28,15 @@ export class QwcFaultToleranceMethods extends LitElement {
     }
 
     render() {
-        return html`${until(this._renderGuardedMethods(), html`<span>Loading guarded methods...</span>`)}`;
+        if (this._guardedMethods) {
+            return this._renderGuardedMethods();
+        } else {
+            return html`<span>Loading guarded methods...</span>`;
+        }
     }
 
     _renderGuardedMethods() {
-        if (this._guardedMethods) {
-            return html`
+        return html`
                 <vaadin-grid .items="${this._guardedMethods}" theme="no-border">
                     <vaadin-grid-column header="Bean Class" auto-width flex-grow="0"
                                         ${columnBodyRenderer(this._renderBeanClass, [])}
@@ -52,7 +54,6 @@ export class QwcFaultToleranceMethods extends LitElement {
                     </vaadin-grid-column>
                 </vaadin-grid>
             `;
-        }
     }
 
     _renderBeanClass(guardedMethod) {

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/resources/dev-ui/qwc-smallrye-reactive-messaging-channels.js
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/resources/dev-ui/qwc-smallrye-reactive-messaging-channels.js
@@ -2,7 +2,6 @@ import { LitElement, html, css} from 'lit';
 import { JsonRpc } from 'jsonrpc';
 import '@vaadin/icon';
 import '@vaadin/button';
-import { until } from 'lit/directives/until.js';
 import '@vaadin/grid';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
@@ -46,12 +45,15 @@ export class QwcSmallryeReactiveMessagingChannels extends LitElement {
      * @returns {*}
      */
     render() {
-        return html`${until(this._renderChannelTable(), html`<span>Loading channels...</span>`)}`;
+        if (this._channels) {
+            return this._renderChannelTable();
+        } else {
+            return html`<span>Loading channels...</span>`;
+        }
     }
 
     _renderChannelTable() {
-        if (this._channels) {
-            return html`
+        return html`
                 <vaadin-grid .items="${this._channels}" class="datatable" theme="no-border">
                     <vaadin-grid-column auto-width
                                         header="Channel"
@@ -69,7 +71,6 @@ export class QwcSmallryeReactiveMessagingChannels extends LitElement {
                                         resizable>
                     </vaadin-grid-column>
                 </vaadin-grid>`;
-        }
     }
 
     _channelNameRenderer(channel) {

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration.js
@@ -1,7 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { JsonRpc } from 'jsonrpc';
 import { RouterController } from 'router-controller';
-import { until } from 'lit/directives/until.js';
 import '@vaadin/grid';
 import 'qui/qui-alert.js';
 import { columnBodyRenderer } from '@vaadin/grid/lit.js';
@@ -106,7 +105,11 @@ export class QwcConfiguration extends observeState(LitElement) {
     }
 
     render() {
-        return html`${until(this._render(), html`<span>Loading configuration properties...</span>`)}`;
+        if (this._filtered && this._values) {
+            return this._render();
+        } else {
+            return html`<span>Loading configuration properties...</span>`;
+        }
     }
 
     _match(value, term) {
@@ -138,8 +141,7 @@ export class QwcConfiguration extends observeState(LitElement) {
     }
 
     _render() {
-        if (this._filtered && this._values) {
-            return html`<div class="conf">
+        return html`<div class="conf">
                 <vaadin-text-field
                         placeholder="Filter"
                         value="${this._filteredValue}"
@@ -150,7 +152,6 @@ export class QwcConfiguration extends observeState(LitElement) {
                 </vaadin-text-field>
                 ${this._renderGrid()}
                 </div>`;
-        }
     }
 
     _renderGrid(){


### PR DESCRIPTION
I saw that all DEV UI web components that are using `lit/directives/until.js` https://lit.dev/docs/templates/directives/#until are actually using it  incorrectly and their fallback text (usually something like 'Loading...') is never shown and user is waiting on white page for backend data. It actually works for Promises and if you try it here https://lit.dev/playground/#sample=examples/directive-until with your methods, you will see that fallback text is never returned (tested with the latest stable Chrome).

More importantly, you don't actually need it - as long as you assing backend data to webcomponent properties with watched state and rendered html will change with their state, you can use IF (I have data) condition instead.