### PR TITLE
Add MicroMeter Netty support

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/RegisteredComponentsBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/RegisteredComponentsBuildItem.java
@@ -11,7 +11,12 @@ import io.quarkus.arc.processor.InjectionPointInfo;
 import io.quarkus.arc.processor.ObserverInfo;
 import io.quarkus.builder.item.SimpleBuildItem;
 
-abstract class RegisteredComponentsBuildItem extends SimpleBuildItem {
+/**
+ * It's made public so that you can make use of the abstraction.
+ * e.g. if you need to do a similar inspection over {@link BeanDiscoveryFinishedBuildItem} and
+ * {@link SynthesisFinishedBuildItem}
+ */
+public abstract class RegisteredComponentsBuildItem extends SimpleBuildItem {
 
     private final Collection<BeanInfo> beans;
     private final Collection<InjectionPointInfo> injectionPoints;

--- a/extensions/micrometer/deployment/pom.xml
+++ b/extensions/micrometer/deployment/pom.xml
@@ -126,6 +126,12 @@
             <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.quarkus.resteasy.reactive</groupId>
+            <artifactId>resteasy-reactive-client</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/NettyBinderProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/NettyBinderProcessor.java
@@ -1,0 +1,148 @@
+package io.quarkus.micrometer.deployment.binder;
+
+import java.util.function.BooleanSupplier;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.micrometer.runtime.MicrometerRecorder;
+import io.quarkus.micrometer.runtime.binder.netty.NettyMetricsProvider;
+import io.quarkus.micrometer.runtime.binder.netty.ReactiveNettyMetricsProvider;
+import io.quarkus.micrometer.runtime.binder.netty.VertxNettyAllocatorMetricsProvider;
+import io.quarkus.micrometer.runtime.binder.netty.VertxNettyEventExecutorMetricsProvider;
+import io.quarkus.micrometer.runtime.config.MicrometerConfig;
+
+/**
+ * Add support for Netty allocator metrics. Note that
+ * various bits of support may not be present at deploy time. Avoid referencing
+ * classes that in turn import optional dependencies.
+ */
+public class NettyBinderProcessor {
+    static final String NETTY_ALLOCATOR_METRICS_NAME = "io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics";
+    static final Class<?> NETTY_ALLOCATOR_METRICS_CLASS = MicrometerRecorder.getClassForName(NETTY_ALLOCATOR_METRICS_NAME);
+
+    static final String NETTY_EVENT_EXECUTOR_METRICS_NAME = "io.micrometer.core.instrument.binder.netty4.NettyEventExecutorMetrics";
+    static final Class<?> NETTY_EVENT_EXECUTOR_METRICS_CLASS = MicrometerRecorder
+            .getClassForName(NETTY_EVENT_EXECUTOR_METRICS_NAME);
+
+    static final String NETTY_BYTE_BUF_ALLOCATOR_NAME = "io.netty.buffer.PooledByteBufAllocator";
+    static final Class<?> NETTY_BYTE_BUF_ALLOCATOR_CLASS = MicrometerRecorder.getClassForName(NETTY_BYTE_BUF_ALLOCATOR_NAME);
+
+    static final String VERTX_BYTE_BUF_ALLOCATOR_NAME = "io.vertx.core.buffer.impl.VertxByteBufAllocator";
+    static final Class<?> VERTX_BYTE_BUF_ALLOCATOR_CLASS = MicrometerRecorder.getClassForName(VERTX_BYTE_BUF_ALLOCATOR_NAME);
+
+    static final String REACTIVE_USAGE_NAME = "org.jboss.resteasy.reactive.client.impl.multipart.QuarkusMultipartFormUpload";
+    static final Class<?> REACTIVE_USAGE_CLASS = MicrometerRecorder.getClassForName(REACTIVE_USAGE_NAME);
+
+    static final String VERTX_NAME = "io.vertx.core.Vertx";
+    static final Class<?> VERTX_CLASS = MicrometerRecorder.getClassForName(VERTX_NAME);
+
+    private static abstract class AbstractSupportEnabled implements BooleanSupplier {
+        abstract MicrometerConfig getMicrometerConfig();
+
+        Class<?> metricsClass() {
+            return NETTY_ALLOCATOR_METRICS_CLASS;
+        }
+
+        abstract Class<?> getCheckClass();
+
+        public boolean getAsBoolean() {
+            return metricsClass() != null && getCheckClass() != null
+                    && getMicrometerConfig().checkBinderEnabledWithDefault(getMicrometerConfig().binder.netty);
+        }
+    }
+
+    static class NettySupportEnabled extends AbstractSupportEnabled {
+        MicrometerConfig mConfig;
+
+        @Override
+        MicrometerConfig getMicrometerConfig() {
+            return mConfig;
+        }
+
+        @Override
+        Class<?> getCheckClass() {
+            return NETTY_BYTE_BUF_ALLOCATOR_CLASS;
+        }
+    }
+
+    static class VertxAllocatorSupportEnabled extends AbstractSupportEnabled {
+        MicrometerConfig mConfig;
+
+        @Override
+        MicrometerConfig getMicrometerConfig() {
+            return mConfig;
+        }
+
+        @Override
+        Class<?> getCheckClass() {
+            return VERTX_BYTE_BUF_ALLOCATOR_CLASS;
+        }
+    }
+
+    static class VertxEventExecutorSupportEnabled extends AbstractSupportEnabled {
+        MicrometerConfig mConfig;
+
+        @Override
+        MicrometerConfig getMicrometerConfig() {
+            return mConfig;
+        }
+
+        @Override
+        Class<?> metricsClass() {
+            return NETTY_EVENT_EXECUTOR_METRICS_CLASS;
+        }
+
+        @Override
+        Class<?> getCheckClass() {
+            return VERTX_CLASS;
+        }
+    }
+
+    static class ReactiveSupportEnabled extends AbstractSupportEnabled {
+        MicrometerConfig mConfig;
+
+        @Override
+        MicrometerConfig getMicrometerConfig() {
+            return mConfig;
+        }
+
+        @Override
+        Class<?> getCheckClass() {
+            return REACTIVE_USAGE_CLASS;
+        }
+    }
+
+    @BuildStep(onlyIf = NettySupportEnabled.class)
+    void createNettyNettyAllocatorMetrics(BuildProducer<AdditionalBeanBuildItem> beans) {
+        beans.produce(AdditionalBeanBuildItem.unremovableOf(NettyMetricsProvider.class));
+    }
+
+    @BuildStep(onlyIf = VertxAllocatorSupportEnabled.class)
+    void createVertxNettyAllocatorMetrics(BuildProducer<AdditionalBeanBuildItem> beans) {
+        beans.produce(AdditionalBeanBuildItem.unremovableOf(VertxNettyAllocatorMetricsProvider.class));
+        // TODO -- VertxByteBufAllocator.DEFAULT ??
+    }
+
+    @BuildStep(onlyIf = VertxEventExecutorSupportEnabled.class)
+    void createVertxNettyEventExecutorMetrics(BuildProducer<AdditionalBeanBuildItem> beans, Capabilities capabilities) {
+        // this is the best we can do, since we cannot check for a Vertx bean, since this itself produces a bean
+        if (capabilities.isPresent(Capability.VERTX_CORE)) {
+            beans.produce(AdditionalBeanBuildItem.unremovableOf(VertxNettyEventExecutorMetricsProvider.class));
+        }
+    }
+
+    @BuildStep(onlyIf = ReactiveSupportEnabled.class)
+    void createReactiveNettyAllocatorMetrics(
+            BuildProducer<AdditionalBeanBuildItem> beans,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
+        beans.produce(AdditionalBeanBuildItem.unremovableOf(ReactiveNettyMetricsProvider.class));
+        reflectiveClasses.produce(
+                ReflectiveClassBuildItem.builder(REACTIVE_USAGE_NAME)
+                        .fields()
+                        .build());
+    }
+}

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/NettyMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/NettyMetricsTest.java
@@ -1,0 +1,150 @@
+package io.quarkus.micrometer.deployment.binder;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics;
+import io.micrometer.core.instrument.binder.netty4.NettyEventExecutorMetrics;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.SingleThreadEventExecutor;
+import io.quarkus.micrometer.test.HelloResource;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.impl.VertxByteBufAllocator;
+import io.vertx.core.impl.VertxInternal;
+
+public class NettyMetricsTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(HelloResource.class))
+            .withConfigurationResource("test-logging.properties")
+            .overrideConfigKey("quarkus.micrometer.binder-enabled-default", "false")
+            .overrideConfigKey("quarkus.micrometer.binder.netty.enabled", "true")
+            .overrideConfigKey("quarkus.redis.devservices.enabled", "false");
+
+    @Inject
+    @Any
+    Instance<MeterBinder> binders;
+
+    @Inject
+    MeterRegistry registry;
+
+    @Inject
+    Vertx vertx;
+
+    private static final Set<Tag> NAM_PBBA_TAGS = Tags.of(
+            "id", String.valueOf(PooledByteBufAllocator.DEFAULT.hashCode()),
+            "allocator.type", "PooledByteBufAllocator")
+            .stream()
+            .collect(Collectors.toSet());
+
+    private static final Set<Tag> NAM_UNPBBA_TAGS = Tags.of(
+            "id", String.valueOf(UnpooledByteBufAllocator.DEFAULT.hashCode()),
+            "allocator.type", "UnpooledByteBufAllocator")
+            .stream()
+            .collect(Collectors.toSet());
+
+    private static final Set<Tag> VX_NAM_PBBA_TAGS = Tags.of(
+            "id", String.valueOf(VertxByteBufAllocator.POOLED_ALLOCATOR.hashCode()),
+            "allocator.type", "PooledByteBufAllocator")
+            .stream()
+            .collect(Collectors.toSet());
+
+    private static final Set<Tag> VX_NAM_UNPBBA_TAGS = Tags.of(
+            "id", String.valueOf(VertxByteBufAllocator.UNPOOLED_ALLOCATOR.hashCode()),
+            "allocator.type", "UnpooledByteBufAllocator")
+            .stream()
+            .collect(Collectors.toSet());
+
+    private void testNettyMetrics(long expected, Class<? extends MeterBinder> mbClass) {
+        Assertions.assertFalse(binders.isUnsatisfied());
+        long count = binders.stream()
+                .filter(mbClass::isInstance)
+                .count();
+        Assertions.assertEquals(expected, count);
+    }
+
+    @Test
+    public void testNettyAllocatorMetrics() {
+        testNettyMetrics(5L, NettyAllocatorMetrics.class);
+    }
+
+    @Test
+    public void testNettyEventExecutorMetrics() {
+        testNettyMetrics(2L, NettyEventExecutorMetrics.class);
+    }
+
+    @Test
+    public void testAllocatorMetricsValues() {
+        RestAssured.get("/hello/Netty").then().body(Matchers.equalTo("hello Netty"));
+
+        boolean pbba_found = false;
+        boolean unpbba_found = false;
+        boolean vx_pbba_found = false;
+        boolean vx_unpbba_found = false;
+        List<Meter> meters = registry.getMeters();
+        for (Meter meter : meters) {
+            List<Tag> tags = meter.getId().getTags();
+            if (tags.containsAll(NAM_PBBA_TAGS)) {
+                pbba_found = true;
+            }
+            if (tags.containsAll(NAM_UNPBBA_TAGS)) {
+                unpbba_found = true;
+            }
+            if (tags.containsAll(VX_NAM_PBBA_TAGS)) {
+                vx_pbba_found = true;
+            }
+            if (tags.containsAll(VX_NAM_UNPBBA_TAGS)) {
+                vx_unpbba_found = true;
+            }
+        }
+        Assertions.assertTrue(pbba_found);
+        Assertions.assertTrue(unpbba_found);
+        Assertions.assertTrue(vx_pbba_found);
+        Assertions.assertTrue(vx_unpbba_found);
+    }
+
+    @Test
+    public void testEventExecutorMetricsValues() {
+        VertxInternal vi = (VertxInternal) vertx;
+        assertEventGroup(vi.getEventLoopGroup());
+        assertEventGroup(vi.getAcceptorEventLoopGroup());
+    }
+
+    private void assertEventGroup(EventLoopGroup eventLoopGroup) {
+        for (EventExecutor eventExecutor : eventLoopGroup) {
+            if (eventExecutor instanceof SingleThreadEventExecutor) {
+                SingleThreadEventExecutor singleThreadEventExecutor = (SingleThreadEventExecutor) eventExecutor;
+                Tag tag = Tag.of("name", singleThreadEventExecutor.threadProperties().name());
+                boolean found = false;
+                List<Meter> meters = registry.getMeters();
+                for (Meter meter : meters) {
+                    List<Tag> tags = meter.getId().getTags();
+                    if (tags.contains(tag)) {
+                        found = true;
+                    }
+                }
+                Assertions.assertTrue(found);
+            }
+        }
+    }
+}

--- a/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/NettyMetricsTest.java
+++ b/extensions/micrometer/deployment/src/test/java/io/quarkus/micrometer/deployment/binder/NettyMetricsTest.java
@@ -1,7 +1,12 @@
 package io.quarkus.micrometer.deployment.binder;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.inject.Any;
@@ -11,8 +16,11 @@ import jakarta.inject.Inject;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -75,12 +83,69 @@ public class NettyMetricsTest {
             .stream()
             .collect(Collectors.toSet());
 
+    private static final Tag HEAP_MEMORY = Tag.of(AllocatorMemoryKeyNames.MEMORY_TYPE.asString(), "heap");
+    private static final Tag DIRECT_MEMORY = Tag.of(AllocatorMemoryKeyNames.MEMORY_TYPE.asString(), "direct");
+
+    enum AllocatorKeyNames implements KeyName {
+        ID {
+            public String asString() {
+                return "id";
+            }
+        },
+        ALLOCATOR_TYPE {
+            public String asString() {
+                return "allocator.type";
+            }
+        };
+    }
+
+    enum AllocatorMemoryKeyNames implements KeyName {
+        MEMORY_TYPE {
+            public String asString() {
+                return "memory.type";
+            }
+        };
+    }
+
     private void testNettyMetrics(long expected, Class<? extends MeterBinder> mbClass) {
         Assertions.assertFalse(binders.isUnsatisfied());
         long count = binders.stream()
                 .filter(mbClass::isInstance)
                 .count();
         Assertions.assertEquals(expected, count);
+    }
+
+    private static Double getValue(List<Meter> meters, Set<Tag> expected) {
+        for (Meter meter : meters) {
+            List<Tag> tags = meter.getId().getTags();
+            if (tags.containsAll(expected)) {
+                return meter.match(Gauge::value, null, null, null, null, null, null, null, null);
+            }
+        }
+        return null;
+    }
+
+    private static Set<Tag> tags(Set<Tag> tags, Tag tag) {
+        Set<Tag> newTags = new HashSet<>(tags);
+        newTags.add(tag);
+        return newTags;
+    }
+
+    private void testAllocatorMetricsValues(Set<Tag> tags) {
+        List<Meter> meters = registry.getMeters();
+
+        Double heap0 = getValue(meters, tags(tags, HEAP_MEMORY));
+        Assertions.assertNotNull(heap0);
+        Double direct0 = getValue(meters, tags(tags, DIRECT_MEMORY));
+        Assertions.assertNotNull(direct0);
+
+        RestAssured.get("/hello/Netty").then().body(Matchers.equalTo("hello Netty"));
+
+        Double heap1 = getValue(meters, tags(tags, HEAP_MEMORY));
+        Double direct1 = getValue(meters, tags(tags, DIRECT_MEMORY));
+
+        Assertions.assertTrue(heap0 <= heap1);
+        Assertions.assertTrue(direct0 <= direct1);
     }
 
     @Test
@@ -95,56 +160,72 @@ public class NettyMetricsTest {
 
     @Test
     public void testAllocatorMetricsValues() {
-        RestAssured.get("/hello/Netty").then().body(Matchers.equalTo("hello Netty"));
-
-        boolean pbba_found = false;
-        boolean unpbba_found = false;
-        boolean vx_pbba_found = false;
-        boolean vx_unpbba_found = false;
-        List<Meter> meters = registry.getMeters();
-        for (Meter meter : meters) {
-            List<Tag> tags = meter.getId().getTags();
-            if (tags.containsAll(NAM_PBBA_TAGS)) {
-                pbba_found = true;
-            }
-            if (tags.containsAll(NAM_UNPBBA_TAGS)) {
-                unpbba_found = true;
-            }
-            if (tags.containsAll(VX_NAM_PBBA_TAGS)) {
-                vx_pbba_found = true;
-            }
-            if (tags.containsAll(VX_NAM_UNPBBA_TAGS)) {
-                vx_unpbba_found = true;
-            }
-        }
-        Assertions.assertTrue(pbba_found);
-        Assertions.assertTrue(unpbba_found);
-        Assertions.assertTrue(vx_pbba_found);
-        Assertions.assertTrue(vx_unpbba_found);
+        testAllocatorMetricsValues(NAM_PBBA_TAGS);
+        testAllocatorMetricsValues(NAM_UNPBBA_TAGS);
+        testAllocatorMetricsValues(VX_NAM_PBBA_TAGS);
+        testAllocatorMetricsValues(VX_NAM_UNPBBA_TAGS);
     }
 
     @Test
-    public void testEventExecutorMetricsValues() {
+    @Timeout(60L)
+    public void testEventExecutorMetricsValues() throws Exception {
         VertxInternal vi = (VertxInternal) vertx;
         assertEventGroup(vi.getEventLoopGroup());
         assertEventGroup(vi.getAcceptorEventLoopGroup());
     }
 
-    private void assertEventGroup(EventLoopGroup eventLoopGroup) {
-        for (EventExecutor eventExecutor : eventLoopGroup) {
-            if (eventExecutor instanceof SingleThreadEventExecutor) {
-                SingleThreadEventExecutor singleThreadEventExecutor = (SingleThreadEventExecutor) eventExecutor;
-                Tag tag = Tag.of("name", singleThreadEventExecutor.threadProperties().name());
-                boolean found = false;
-                List<Meter> meters = registry.getMeters();
-                for (Meter meter : meters) {
-                    List<Tag> tags = meter.getId().getTags();
-                    if (tags.contains(tag)) {
-                        found = true;
-                    }
+    private void assertEventGroup(EventLoopGroup group) throws Exception {
+        int tasks = 0;
+        for (EventExecutor ee : group) {
+            tasks++;
+        }
+        final CyclicBarrier allPendingTasksAreIn = new CyclicBarrier(tasks + 1);
+        CountDownLatch waitCollectingMeasures = new CountDownLatch(1);
+        List<Future<Future<?>>> pendingTasksCompleted = new ArrayList<>(tasks);
+        for (EventExecutor eventLoop : group) {
+            pendingTasksCompleted.add(eventLoop.submit(() -> {
+                try {
+                    Future<?> pendingTask = eventLoop.submit(() -> {
+                    });
+                    // this executor will have 1 pending task because is still running this current one
+                    allPendingTasksAreIn.await();
+                    waitCollectingMeasures.await();
+                    return pendingTask;
+                } catch (Throwable ignore) {
+                    return null;
                 }
-                Assertions.assertTrue(found);
-            }
+            }));
+        }
+        allPendingTasksAreIn.await();
+        List<Meter> meters = registry.getMeters();
+        // this would return 1 for everyone
+        for (EventExecutor eventLoop : group) {
+            checkMetrics(meters, eventLoop, 1);
+        }
+        waitCollectingMeasures.countDown();
+        for (Future<Future<?>> pendingTaskCompleted : pendingTasksCompleted) {
+            pendingTaskCompleted.get().get();
+        }
+        // this would return 0 for everyone
+        for (EventExecutor eventLoop : group) {
+            checkMetrics(meters, eventLoop, 0);
+        }
+    }
+
+    private void checkMetrics(List<Meter> meters, EventExecutor executor, int expected) {
+        if (executor instanceof SingleThreadEventExecutor) {
+            SingleThreadEventExecutor stee = (SingleThreadEventExecutor) executor;
+
+            int pendingTasks = stee.pendingTasks();
+            Assertions.assertEquals(expected, pendingTasks);
+
+            Tag tag = Tag.of("name", stee.threadProperties().name());
+            Set<Tag> tags = Set.of(tag);
+
+            Double metricsValue = getValue(meters, tags);
+            Assertions.assertNotNull(metricsValue);
+            int mvInt = metricsValue.intValue();
+            Assertions.assertEquals(expected, mvInt);
         }
     }
 }

--- a/extensions/micrometer/runtime/pom.xml
+++ b/extensions/micrometer/runtime/pom.xml
@@ -78,7 +78,6 @@
             <optional>true</optional>
         </dependency>
 
-
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow</artifactId>
@@ -111,6 +110,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-redis-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus.resteasy.reactive</groupId>
+            <artifactId>resteasy-reactive-client</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/NettyMetricsProvider.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/NettyMetricsProvider.java
@@ -1,0 +1,26 @@
+package io.quarkus.micrometer.runtime.binder.netty;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
+
+@Singleton
+public class NettyMetricsProvider {
+
+    @Produces
+    @Singleton
+    public MeterBinder pooledByteBufAllocatorMetrics() {
+        return new NettyAllocatorMetrics(PooledByteBufAllocator.DEFAULT);
+    }
+
+    @Produces
+    @Singleton
+    public MeterBinder unpooledByteBufAllocatorMetrics() {
+        return new NettyAllocatorMetrics(UnpooledByteBufAllocator.DEFAULT);
+    }
+
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/ReactiveNettyMetricsProvider.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/ReactiveNettyMetricsProvider.java
@@ -1,0 +1,26 @@
+package io.quarkus.micrometer.runtime.binder.netty;
+
+import java.lang.reflect.Field;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics;
+import io.netty.buffer.ByteBufAllocatorMetricProvider;
+
+@Singleton
+public class ReactiveNettyMetricsProvider {
+
+    @Produces
+    @Singleton
+    public MeterBinder reactiveAllocatorMetrics() throws Exception {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        Class<?> clazz = tccl.loadClass("org.jboss.resteasy.reactive.client.impl.multipart.QuarkusMultipartFormUpload");
+        Field af = clazz.getDeclaredField("ALLOC");
+        af.setAccessible(true);
+        ByteBufAllocatorMetricProvider provider = (ByteBufAllocatorMetricProvider) af.get(null);
+        return new NettyAllocatorMetrics(provider);
+    }
+
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/VertxNettyAllocatorMetricsProvider.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/VertxNettyAllocatorMetricsProvider.java
@@ -1,0 +1,26 @@
+package io.quarkus.micrometer.runtime.binder.netty;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics;
+import io.netty.buffer.ByteBufAllocatorMetricProvider;
+import io.vertx.core.buffer.impl.VertxByteBufAllocator;
+
+@Singleton
+public class VertxNettyAllocatorMetricsProvider {
+
+    @Produces
+    @Singleton
+    public MeterBinder vertxPooledByteBufAllocatorMetrics() {
+        return new NettyAllocatorMetrics((ByteBufAllocatorMetricProvider) VertxByteBufAllocator.POOLED_ALLOCATOR);
+    }
+
+    @Produces
+    @Singleton
+    public MeterBinder vertxUnpooledByteBufAllocatorMetrics() {
+        return new NettyAllocatorMetrics((ByteBufAllocatorMetricProvider) VertxByteBufAllocator.UNPOOLED_ALLOCATOR);
+    }
+
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/VertxNettyEventExecutorMetricsProvider.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/netty/VertxNettyEventExecutorMetricsProvider.java
@@ -1,0 +1,28 @@
+package io.quarkus.micrometer.runtime.binder.netty;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.netty4.NettyEventExecutorMetrics;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.VertxInternal;
+
+@Singleton
+public class VertxNettyEventExecutorMetricsProvider {
+
+    @Produces
+    @Singleton
+    public MeterBinder vertxEventLoopGroupMetrics(Vertx vertx) {
+        VertxInternal vi = (VertxInternal) vertx;
+        return new NettyEventExecutorMetrics(vi.getEventLoopGroup());
+    }
+
+    @Produces
+    @Singleton
+    public MeterBinder vertxAcceptorEventLoopGroupMetrics(Vertx vertx) {
+        VertxInternal vi = (VertxInternal) vertx;
+        return new NettyEventExecutorMetrics(vi.getAcceptorEventLoopGroup());
+    }
+
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/MicrometerConfig.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/MicrometerConfig.java
@@ -53,11 +53,7 @@ public final class MicrometerConfig {
     public boolean checkRegistryEnabledWithDefault(CapabilityEnabled config) {
         if (enabled) {
             Optional<Boolean> configValue = config.getEnabled();
-            if (configValue.isPresent()) {
-                return configValue.get();
-            } else {
-                return registryEnabledDefault;
-            }
+            return configValue.orElseGet(() -> registryEnabledDefault);
         }
         return false;
     }
@@ -70,11 +66,7 @@ public final class MicrometerConfig {
     public boolean checkBinderEnabledWithDefault(CapabilityEnabled config) {
         if (enabled) {
             Optional<Boolean> configValue = config.getEnabled();
-            if (configValue.isPresent()) {
-                return configValue.get();
-            } else {
-                return binderEnabledDefault;
-            }
+            return configValue.orElseGet(() -> binderEnabledDefault);
         }
         return false;
     }
@@ -125,6 +117,8 @@ public final class MicrometerConfig {
         public Optional<Boolean> system;
 
         public VertxConfigGroup vertx;
+
+        public NettyConfigGroup netty;
     }
 
     /** Build / static runtime config for exporters */

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/NettyConfigGroup.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/config/NettyConfigGroup.java
@@ -1,0 +1,35 @@
+package io.quarkus.micrometer.runtime.config;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * Build / static runtime config for Netty Binders
+ */
+@ConfigGroup
+public class NettyConfigGroup implements MicrometerConfig.CapabilityEnabled {
+    /**
+     * Netty metrics support.
+     * <p>
+     * Support for Netty metrics will be enabled if Micrometer support is enabled,
+     * the Netty allocator classes are on the classpath
+     * and either this value is true, or this value is unset and
+     * {@code quarkus.micrometer.binder-enabled-default} is true.
+     */
+    @ConfigItem
+    public Optional<Boolean> enabled;
+
+    @Override
+    public Optional<Boolean> getEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName()
+                + "{enabled=" + enabled
+                + '}';
+    }
+}


### PR DESCRIPTION
Adding initial Netty bytebuf allocator metrics support from Micrometer.

This currently adds all available / used allocators found in Quarkus code, but ...
... `VertxByteBufAllocator.DEFAULT`, which does not implement `ByteBufAllocatorMetricProvider`.

For `QuarkusMultipartFormUpload.ALLOC` reflection was used
(a) for loading the class in `ReactiveNettyMetricsProvider` -- TODO on why is that?
(b) and for accessing `ALLOC` field -- we could add a public static method if/when we resolve (a)