### PR TITLE
Update docs on running @QuarkusIntegrationTest against a running application

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1385,11 +1385,6 @@ public class CustomResource implements QuarkusTestResourceLifecycleManager, DevS
 
 === Executing against a running application
 
-[WARNING]
-====
-This feature is considered experimental and is likely to change in future versions of Quarkus.
-====
-
 `@QuarkusIntegrationTest` supports executing tests against an already running instance of the application. This can be achieved by setting the
 `quarkus.http.test-host` system property when running the tests.
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestHostLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestHostLauncher.java
@@ -7,8 +7,6 @@ import java.util.Map;
  * A launcher that simply sets the {@code quarkus.http.host} property based on the value {@code quarkus.http.test-host}
  * in order to support the case of running integration tests against an already running application
  * using RestAssured without any chances.
- *
- * This is highly experimental, so changes are to be expected.
  */
 @SuppressWarnings("rawtypes")
 public class TestHostLauncher implements ArtifactLauncher {


### PR DESCRIPTION
The feature has been around for over 18 months
and has not changed much, so there is no reason
to still call it experimental