### PR TITLE
Do not build the REST Client instances in CDI wrapper constructor for RequestScoped clients

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -16,6 +16,7 @@ import static java.util.stream.Collectors.*;
 import static org.jboss.resteasy.reactive.common.processor.EndpointIndexer.CDI_WRAPPER_SUFFIX;
 import static org.jboss.resteasy.reactive.common.processor.JandexUtil.isImplementorOf;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.BLOCKING;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REQUEST_SCOPED;
 import static org.jboss.resteasy.reactive.common.processor.scanning.ResteasyReactiveScanner.BUILTIN_HTTP_ANNOTATIONS_TO_METHOD;
 
 import java.lang.annotation.RetentionPolicy;
@@ -456,11 +457,12 @@ class RestClientReactiveProcessor {
                     ResultHandle baseUriHandle = constructor.load(baseUri != null ? baseUri.asString() : "");
                     constructor.invokeSpecialMethod(
                             MethodDescriptor.ofConstructor(RestClientReactiveCDIWrapperBase.class, Class.class, String.class,
-                                    String.class),
+                                    String.class, boolean.class),
                             constructor.getThis(),
                             constructor.loadClassFromTCCL(jaxrsInterface.toString()),
                             baseUriHandle,
-                            configKey.isPresent() ? constructor.load(configKey.get()) : constructor.loadNull());
+                            configKey.isPresent() ? constructor.load(configKey.get()) : constructor.loadNull(),
+                            constructor.load(scope.getDotName().equals(REQUEST_SCOPED)));
                     constructor.returnValue(null);
 
                     // METHODS:

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/TestHeaderConfig.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/TestHeaderConfig.java
@@ -1,0 +1,16 @@
+package io.quarkus.rest.client.reactive;
+
+import jakarta.enterprise.context.RequestScoped;
+
+import io.quarkus.arc.Unremovable;
+
+@RequestScoped
+@Unremovable
+public class TestHeaderConfig {
+
+    public static final String HEADER_PARAM_NAME = "filterheader";
+
+    public String getHeaderPropertyName() {
+        return HEADER_PARAM_NAME;
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/TestRestClientListener.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/TestRestClientListener.java
@@ -1,5 +1,6 @@
 package io.quarkus.rest.client.reactive;
 
+import jakarta.enterprise.inject.spi.CDI;
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientRequestFilter;
 
@@ -8,19 +9,25 @@ import org.eclipse.microprofile.rest.client.spi.RestClientListener;
 
 public class TestRestClientListener implements RestClientListener {
 
-    public static final String HEADER_PARAM_NAME = "filterheader";
     public static final String HEADER_PARAM_VALUE = "present";
 
     @Override
     public void onNewClient(Class<?> aClass, RestClientBuilder restClientBuilder) {
-        restClientBuilder.register(new TestRestClientFilter());
+        String headerPropertyName = CDI.current().select(TestHeaderConfig.class).get().getHeaderPropertyName();
+        restClientBuilder.register(new TestRestClientFilter(headerPropertyName));
     }
 
     static class TestRestClientFilter implements ClientRequestFilter {
 
+        private final String headerPropertyName;
+
+        public TestRestClientFilter(String headerPropertyName) {
+            this.headerPropertyName = headerPropertyName;
+        }
+
         @Override
         public void filter(ClientRequestContext clientRequestContext) {
-            clientRequestContext.getHeaders().putSingle(HEADER_PARAM_NAME, HEADER_PARAM_VALUE);
+            clientRequestContext.getHeaders().putSingle(headerPropertyName, HEADER_PARAM_VALUE);
         }
     }
 }


### PR DESCRIPTION
Creating REST Client instance in the CDI wrapper constructor makes the beans to use wrong CDI contexts (and it does not work for Request bean context).

Fix https://github.com/quarkusio/quarkus/issues/33377