### PR TITLE
Mark the avro extensions as "stable"

### DIFF
--- a/extensions/avro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/avro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -4,7 +4,7 @@ name: "Apache Avro"
 metadata:
   keywords:
   - "avro"
-  guide: "https://quarkus.io/guides/kafka"
+  guide: "https://quarkus.io/guides/kafka-schema-registry-avro"
   categories:
   - "serialization"
-  status: "experimental"
+  status: "stable"

--- a/extensions/schema-registry/apicurio/avro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/schema-registry/apicurio/avro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,6 +8,6 @@ metadata:
   guide: "https://quarkus.io/guides/kafka-schema-registry-avro"
   categories:
   - "serialization"
-  status: "experimental"
+  status: "stable"
   config:
   - "avro.codegen."

--- a/extensions/schema-registry/confluent/avro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/schema-registry/confluent/avro/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,6 +8,6 @@ metadata:
   guide: "https://quarkus.io/guides/kafka-schema-registry-avro"
   categories:
   - "serialization"
-  status: "experimental"
+  status: "stable"
   config:
   - "avro.codegen."


### PR DESCRIPTION
Currently the `quarkus-avro`, `quarkus-apicurio-registry-avro`, and `quarkus-confluent-registry-avro` extensions are shown as `experimental`. This PR moves them to `stable`.