### PR TITLE
Fix oidc path getter

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -311,8 +311,8 @@ public class OidcTenantConfig extends OidcCommonConfig {
             this.path = path;
         }
 
-        public String getPath() {
-            return path.get();
+        public Optional<String> getPath() {
+            return path;
         }
     }
 
@@ -328,8 +328,8 @@ public class OidcTenantConfig extends OidcCommonConfig {
             this.path = path;
         }
 
-        public String getPath() {
-            return path.get();
+        public Optional<String> getPath() {
+            return path;
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -254,8 +254,8 @@ public class OidcTenantConfig extends OidcCommonConfig {
             this.path = path;
         }
 
-        public String getPath() {
-            return path.get();
+        public Optional<String> getPath() {
+            return path;
         }
 
         public void setPostLogoutPath(Optional<String> postLogoutPath) {


### PR DESCRIPTION
I found an issue with the Oidc tenant config $Logout path getter.

To give a bit of a context, I use OidcTenantConfig to set tenant configurations dynamically. To save time and resources, I cache the `OidcTenantConfig` using Redis Cache `Redis cache extension`, as loading the Tenant configuration can be quite taxing and requires many DB operations.

Internally, Redis cache extension utilizes Jackson Marshaller to serialize the cache value - `OidcTenantConfig` in this case - into Json.

To get the Marshaller work properly, I had to set `quarkus.jackson.serialization-inclusion=NON_ABSENT` property as the `OidcTenantConfig` object relies on Java 8 Optional's.

Normally everything suppose to work without any issues, but `java.util.NoSuchElementException` exception is thrown during the marshaling process because of the Optional#get invocation while no actual value assigned to the Logout path.

Even though the proposed solution might breaks backward compatibility, I believe the original implementation doesn't follow the convention and has to be resolved.

**Stacktrace**
```java
2023-05-15 21:06:38,090 ERROR [io.qua.ver.htt.run.QuarkusErrorHandler] (vert.x-eventloop-thread-2) HTTP Request to / failed, error id: 81e8d67f-7b78-4b29-a247-3dd5f5f778dc-1: io.vertx.core.json.EncodeException: Failed to encode as JSON: No value present (through reference chain: io.quarkus.oidc.OidcTenantConfig["logout"]->io.quarkus.oidc.OidcTenantConfig$Logout["path"])
	at io.quarkus.vertx.runtime.jackson.QuarkusJacksonJsonCodec.toBuffer(QuarkusJacksonJsonCodec.java:157)
	at io.vertx.core.spi.json.JsonCodec.toBuffer(JsonCodec.java:69)
	at io.vertx.core.json.Json.encodeToBuffer(Json.java:60)
	at io.quarkus.redis.datasource.codecs.Codecs$JsonCodec.encode(Codecs.java:42)
	at io.quarkus.redis.runtime.datasource.Marshaller.encode(Marshaller.java:66)
	at io.quarkus.cache.redis.runtime.RedisCacheImpl$2.lambda$apply$0(RedisCacheImpl.java:206)
	at io.smallrye.context.impl.wrappers.SlowContextualFunction.apply(SlowContextualFunction.java:21)
	at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.performInnerSubscription(UniOnItemTransformToUni.java:68)
	at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.onItem(UniOnItemTransformToUni.java:57)
	at io.smallrye.mutiny.operators.uni.UniOnItemTransform$UniOnItemTransformProcessor.onItem(UniOnItemTransform.java:43)
	at io.smallrye.mutiny.operators.uni.UniOnItemTransform$UniOnItemTransformProcessor.onItem(UniOnItemTransform.java:43)
	at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.onItem(UniOnItemTransformToUni.java:60)
	at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.onItem(UniOnItemTransformToUni.java:60)
	at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.onItem(UniOnItemTransformToUni.java:60)
	at io.smallrye.mutiny.operators.uni.UniOnItemConsume$UniOnItemComsumeProcessor.onItem(UniOnItemConsume.java:43)
	at io.smallrye.mutiny.operators.uni.builders.UniCreateFromKnownItem$KnownItemSubscription.forward(UniCreateFromKnownItem.java:38)
	at io.smallrye.mutiny.operators.uni.builders.UniCreateFromKnownItem.subscribe(UniCreateFromKnownItem.java:23)
	at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:36)
	at io.smallrye.mutiny.operators.uni.UniOnItemConsume.subscribe(UniOnItemConsume.java:30)
	at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:36)
	at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.performInnerSubscription(UniOnItemTransformToUni.java:81)
	at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.onItem(UniOnItemTransformToUni.java:57)
	at io.smallrye.mutiny.operators.uni.builders.UniCreateFromPublisher$PublisherSubscriber.onNext(UniCreateFromPublisher.java:70)
	at io.smallrye.mutiny.helpers.HalfSerializer.onNext(HalfSerializer.java:30)
	at io.smallrye.mutiny.helpers.StrictMultiSubscriber.onItem(StrictMultiSubscriber.java:84)
	at io.smallrye.mutiny.operators.multi.MultiSelectFirstOp$MultiSelectFirstProcessor.onItem(MultiSelectFirstOp.java:79)
	at io.smallrye.mutiny.operators.multi.MultiMapOp$MapProcessor.onItem(MultiMapOp.java:50)
	at io.smallrye.mutiny.operators.multi.MultiEmitOnOp$MultiEmitOnProcessor.run(MultiEmitOnOp.java:198)
	at io.quarkus.mongodb.impl.Wrappers.lambda$toMulti$2(Wrappers.java:32)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:264)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:246)
	at io.vertx.core.impl.EventLoopContext.lambda$runOnContext$0(EventLoopContext.java:43)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: com.fasterxml.jackson.databind.JsonMappingException: No value present (through reference chain: io.quarkus.oidc.OidcTenantConfig["logout"]->io.quarkus.oidc.OidcTenantConfig$Logout["path"])
	at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:402)
	at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:361)
	at com.fasterxml.jackson.databind.ser.std.StdSerializer.wrapAndThrow(StdSerializer.java:316)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:782)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:178)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:733)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:774)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:178)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
	at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4624)
	at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsBytes(ObjectMapper.java:3892)
	at io.quarkus.vertx.runtime.jackson.QuarkusJacksonJsonCodec.toBuffer(QuarkusJacksonJsonCodec.java:155)
	... 39 more
Caused by: java.util.NoSuchElementException: No value present
	at java.base/java.util.Optional.get(Optional.java:143)
	at io.quarkus.oidc.OidcTenantConfig$Logout.getPath(OidcTenantConfig.java:258)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:689)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:774)
	... 48 more
```



