### PR TITLE
Use default value from `quarkus.http.read-timeout` in RESTEasy Reactive

### DIFF
--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -240,7 +240,7 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
             context.getBody().getBytes(data);
             return new ByteArrayInputStream(data);
         }
-        return new VertxInputStream(context, 10000, this);
+        return new VertxInputStream(context, getDeployment().getRuntimeConfiguration().readTimeout().toMillis(), this);
     }
 
     @Override


### PR DESCRIPTION
Relates https://github.com/quarkusio/quarkus/issues/32992