### PR TITLE
Remove k8s client from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,6 @@ updates:
       - dependency-name: org.liquibase:*
       - dependency-name: org.liquibase.ext:*
       - dependency-name: org.freemarker:freemarker
-      - dependency-name: io.fabric8:*
       - dependency-name: org.apache.httpcomponents:*
       - dependency-name: org.apache.james:apache-mime4j
       - dependency-name: org.quartz-scheduler:quartz


### PR DESCRIPTION
This is done because we pretty don't want
to blindly merge the client updates
without feedback from upstream and downstream