### PR TITLE
Replace `quarkus.log.console.color` with `quarkus.console.color`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleProcessor.java
@@ -74,7 +74,7 @@ public class ConsoleProcessor {
             ConsoleRuntimeConfig consoleRuntimeConfig = new ConsoleRuntimeConfig();
             consoleRuntimeConfig.color = ConfigProvider.getConfig().getOptionalValue("quarkus.console.color", Boolean.class);
             io.quarkus.runtime.logging.ConsoleConfig loggingConsoleConfig = new io.quarkus.runtime.logging.ConsoleConfig();
-            loggingConsoleConfig.color = ConfigProvider.getConfig().getOptionalValue("quarkus.log.console.color",
+            loggingConsoleConfig.color = ConfigProvider.getConfig().getOptionalValue("quarkus.console.color",
                     Boolean.class);
             ConsoleHelper.installConsole(config, consoleConfig, consoleRuntimeConfig, loggingConsoleConfig,
                     launchModeBuildItem.isTest());


### PR DESCRIPTION
Replace `quarkus.log.console.color`, [which was deprecated in Quarkus 2.1](https://github.com/quarkusio/quarkus/pull/18506), with `quarkus.console.color`.

Fixes https://github.com/quarkusio/quarkus/issues/33356

cc: @stuartwdouglas, @geoand 