### PR TITLE
Read process output from a new Thread

### DIFF
--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker/verify.groovy
@@ -1,5 +1,7 @@
 import io.quarkus.deployment.util.ExecUtil
 
+ExecUtil.useSystemLogging() //prevents stack overflow issues
+
 try {
     ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-appcds/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-appcds/verify.groovy
@@ -2,6 +2,7 @@ import io.quarkus.deployment.util.ExecUtil
 
 import java.util.concurrent.ThreadLocalRandom
 
+ExecUtil.useSystemLogging() //prevents stack overflow issues
 try {
     ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-inherit/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-inherit/verify.groovy
@@ -2,6 +2,8 @@ import io.quarkus.deployment.util.ExecUtil
 
 import java.util.concurrent.ThreadLocalRandom
 
+ExecUtil.useSystemLogging() //prevents stack overflow issues
+
 try {
     ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib/verify.groovy
@@ -4,6 +4,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
+ExecUtil.useSystemLogging() //prevents stack overflow issues
 try {
     ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-docker/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-docker/verify.groovy
@@ -1,5 +1,6 @@
 import io.quarkus.deployment.util.ExecUtil
 
+ExecUtil.useSystemLogging() //prevents stack overflow issues
 try {
     ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-jib/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-jib/verify.groovy
@@ -1,5 +1,6 @@
 import io.quarkus.deployment.util.ExecUtil
 
+ExecUtil.useSystemLogging() //prevents stack overflow issues
 try {
     ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-image-push/setup.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-image-push/setup.groovy
@@ -1,5 +1,6 @@
 import io.quarkus.deployment.util.ExecUtil
 
+ExecUtil.useSystemLogging() //prevents stack overflow issues
 try {
     ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-image-push/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-image-push/verify.groovy
@@ -3,6 +3,7 @@ import io.quarkus.deployment.util.ExecUtil
 import static io.restassured.RestAssured.get
 import static org.hamcrest.Matchers.containsString
 
+ExecUtil.useSystemLogging() //prevents stack overflow issues
 try {
     ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {


### PR DESCRIPTION
The pull request uses a new Thread to read the process output (in ExecUtil).
This seems to work around the issue we are dealing with in pull request: #33410

*Update*
The failure seems to originate from an SO that occurs when logging. The SO is most probably a side effect of https://github.com/apache/maven-script-interpreter/blob/master/src/main/java/org/apache/maven/shared/scriptinterpreter/GroovyScriptInterpreter.java#L54 messing with System.out / System.err. This seem to somehow upset jboss logging, causing SO.

The original pull request moved logging to each thread, so the SO didn't affect the main thread. However, it didn't fix the logging output which created log files of almost 2G.

The followup commit introduces the option to use system logging, which seems to be a better choice for code invoked from maven-invoker plugin and GroovySciprtInterpreter. 

It also updates the verify.groovy files that use Exec so that they all use system logging.

