### PR TITLE
Arc - log a WARN if we encounter unproxyable JDK class since we cannot transform it either

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -123,9 +123,15 @@ final class Methods {
                             .add(NameAndDescriptor.fromMethodInfo(method));
                     return false;
                 }
-
+                // in case we want to transform classes but are unable to, we log a WARN
                 LOGGER.warn(String.format(
                         "Final method %s.%s() is ignored during proxy generation and should never be invoked upon the proxy instance!",
+                        className, method.name()));
+            } else {
+                // JDK classes with final method are not proxyable and not transformable, we skip those methods and log a WARN
+                LOGGER.warn(String.format(
+                        "JDK class %s with final method %s() cannot be proxied and is not transformable. " +
+                                "This method will be ignored during proxy generation and should never be invoked upon the proxy instance!",
                         className, method.name()));
             }
             return true;


### PR DESCRIPTION
Fixes #33417 

An example of when this happens is creating an `@ApplicationScoped` bean for `AtomicBoolean` which has many methods `final`. For each such method, there will be a log looking something like this:

> 2023-05-17 13:31:33,401 WARN  [io.qua.arc.pro.Methods] (build-17) JDK class java.util.concurrent.atomic.AtomicBoolean with final method weakCompareAndSetVolatile() cannot be proxied and is not transformable. This method will be ignored during proxy generation and should never be invoked upon the proxy instance!