### PR TITLE
Update OIDC Spotify properties

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
@@ -46,7 +46,7 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
 
     private static final String KEYCLOAK = "Keycloak";
     private static final String AZURE = "Azure";
-    private static final Set<String> OTHER_PROVIDERS = Set.of("Auth0", "Okta", "Google", "Github");
+    private static final Set<String> OTHER_PROVIDERS = Set.of("Auth0", "Okta", "Google", "Github", "Spotify");
 
     OidcBuildTimeConfig oidcConfig;
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/UserInfo.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/UserInfo.java
@@ -12,6 +12,7 @@ public class UserInfo extends AbstractJsonObjectResponse {
     private static final String NAME = "name";
     private static final String FIRST_NAME = "first_name";
     private static final String FAMILY_NAME = "family_name";
+    private static final String DISPLAY_NAME = "display_name";
 
     public UserInfo() {
     }
@@ -38,6 +39,10 @@ public class UserInfo extends AbstractJsonObjectResponse {
 
     public String getFamilyName() {
         return getString(FAMILY_NAME);
+    }
+
+    public String getDisplayName() {
+        return getString(DISPLAY_NAME);
     }
 
     public String getPreferredUserName() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
@@ -117,10 +117,12 @@ public class KnownOidcProviders {
 
         OidcTenantConfig.Authentication authentication = ret.getAuthentication();
         authentication.setAddOpenidScope(false);
-        authentication.setScopes(List.of("user-read-email"));
-        authentication.setUserInfoRequired(true);
+        authentication.setScopes(List.of("user-read-private", "user-read-email"));
         authentication.setIdTokenRequired(false);
         authentication.setPkceRequired(true);
+
+        ret.getToken().setVerifyAccessTokenWithUserInfo(true);
+        ret.getToken().setPrincipalClaim("display_name");
 
         return ret;
     }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -312,7 +312,9 @@ public class OidcUtilsTest {
         assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
         assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
         assertEquals("https://accounts.spotify.com", config.getAuthServerUrl().get());
-        assertEquals(List.of("user-read-email"), config.authentication.scopes.get());
+        assertEquals(List.of("user-read-private", "user-read-email"), config.authentication.scopes.get());
+        assertTrue(config.token.verifyAccessTokenWithUserInfo.get());
+        assertEquals("display_name", config.getToken().getPrincipalClaim().get());
     }
 
     @Test
@@ -325,6 +327,8 @@ public class OidcUtilsTest {
         tenant.getToken().setIssuer("http://localhost/wiremock");
         tenant.authentication.setScopes(List.of("write"));
         tenant.authentication.setForceRedirectHttpsScheme(false);
+        tenant.token.setPrincipalClaim("firstname");
+        tenant.token.setVerifyAccessTokenWithUserInfo(false);
 
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.SPOTIFY));
 
@@ -334,6 +338,8 @@ public class OidcUtilsTest {
         assertEquals(List.of("write"), config.authentication.scopes.get());
         assertEquals("http://localhost/wiremock", config.getToken().getIssuer().get());
         assertFalse(config.authentication.forceRedirectHttpsScheme.get());
+        assertEquals("firstname", config.getToken().getPrincipalClaim().get());
+        assertFalse(config.token.verifyAccessTokenWithUserInfo.get());
     }
 
     @Test

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/UserInfoTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/UserInfoTest.java
@@ -18,8 +18,9 @@ public class UserInfoTest {
                     + "\"sub\": \"alice123456\","
                     + "\"name\": \"alice\","
                     + "\"first_name\": \"Alice\","
-                    + "\"family_name\": \"Alice\","
+                    + "\"family_name\": \"Brown\","
                     + "\"preferred_username\": \"Alice Alice\","
+                    + "\"display_name\": \"Alice Brown\","
                     + "\"email\": \"alice@email.com\","
                     + "\"admin\": true,"
                     + "\"custom\": null,"
@@ -40,12 +41,17 @@ public class UserInfoTest {
 
     @Test
     public void testGetFamilyName() {
-        assertEquals("Alice", userInfo.getFamilyName());
+        assertEquals("Brown", userInfo.getFamilyName());
     }
 
     @Test
     public void testPreferredName() {
         assertEquals("Alice Alice", userInfo.getPreferredUserName());
+    }
+
+    @Test
+    public void testDisplayName() {
+        assertEquals("Alice Brown", userInfo.getDisplayName());
     }
 
     @Test


### PR DESCRIPTION
This PR makes it a bit easier to use `Spotify` provider:
* User name can now be extracted from the injected `UserInfo` as `userInfo.getDisplayName()`
* For the above to work, another scope `user_read_private` is added (it is like `profile` scope we add to Github/Google/etc provider definitions - it won't go unnoticed by the users, Spotify authorization screen will let them know), and also a principal claim name is customized as `display_name` (Spotify specific claim name)

Also, an access token is binary so to verify it one would need to fetch `UserInfo` (so a property is added to the provider definition, same as we do for other social providers producing binary tokens) and a minor update is done to the deployment code for `Provider: Spotify` link to appear in Dev UI OIDC card