### PR TITLE
Pass additional parameters to podman/docker on MacOS

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -17,7 +17,7 @@ public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContai
 
     public NativeImageBuildLocalContainerRunner(NativeConfig nativeConfig) {
         super(nativeConfig);
-        if (SystemUtils.IS_OS_LINUX) {
+        if (SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_MAC) {
             final ArrayList<String> containerRuntimeArgs = new ArrayList<>(Arrays.asList(baseContainerRuntimeArgs));
             if (containerRuntime.isDocker() && containerRuntime.isRootless()) {
                 Collections.addAll(containerRuntimeArgs, "--user", String.valueOf(0));


### PR DESCRIPTION
Tested with podman 4.5.0 both rootless and rootfull. Also tested with colima 0.5.4 and docker (rootfull AFAIK, I didn't find how to make it rootless) 24.0.0.

Closes #33188