### PR TITLE
Create all the required directories before copying native JSON files

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -1030,6 +1030,7 @@ public class JarResultBuildStep {
                     @Override
                     public void accept(Path jsonPath) {
                         try {
+                            Files.createDirectories(thinJarDirectory);
                             Files.copy(jsonPath, thinJarDirectory.resolve(jsonPath.getFileName().toString()));
                         } catch (IOException e) {
                             throw new UncheckedIOException(


### PR DESCRIPTION
Fix #33450

FWIW, I tried to create the directory in the caller instead and it weirdly failed sometimes. Not sure exactly what's going on but I think it's OK this way so I'll switch to another subject.