### PR TITLE
Disable flaky OTel-GraphQL test for now

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GraphQLOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/GraphQLOpenTelemetryTest.java
@@ -38,6 +38,7 @@ import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -116,6 +117,7 @@ public class GraphQLOpenTelemetryTest {
     }
 
     @Test
+    @Disabled // TODO: flaky test, find out how to fix it
     void nestedCdiBeanInsideQueryTraceTest() throws ExecutionException, InterruptedException {
         String request = getPayload("query {\n" +
                 "  helloAfterSecond\n" +


### PR DESCRIPTION
CC @geoand 

I think it will actually need some changes in SmallRye GraphQL or OTel, so until then, I think the highest priority is to get the CI stable
