### PR TITLE
Ensure the classes to be bound in JAXB are cleared in DEV mode

### DIFF
--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
@@ -322,6 +322,7 @@ public class JaxbProcessor {
             SynthesisFinishedBuildItem beanContainerState,
             JaxbContextConfigRecorder jaxbContextConfig /* Force the build time container to invoke this method */) {
 
+        jaxbContextConfig.reset();
         final BeanResolver beanResolver = beanContainerState.getBeanResolver();
         final Set<BeanInfo> beans = beanResolver
                 .resolveBeans(Type.create(DotName.createSimple(JAXBContext.class), org.jboss.jandex.Type.Kind.CLASS));

--- a/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextConfigRecorder.java
+++ b/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextConfigRecorder.java
@@ -15,6 +15,10 @@ public class JaxbContextConfigRecorder {
         this.classesToBeBound.addAll(classes);
     }
 
+    public void reset() {
+        classesToBeBound.clear();
+    }
+
     public static Set<Class<?>> getClassesToBeBound() {
         return Collections.unmodifiableSet(classesToBeBound);
     }

--- a/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextProducer.java
+++ b/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextProducer.java
@@ -4,8 +4,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
@@ -71,7 +73,7 @@ public class JaxbContextProducer {
                 customizer.customizeContextProperties(properties);
             }
 
-            List<Class> classes = new ArrayList<>();
+            Set<Class> classes = new HashSet<>();
             classes.addAll(Arrays.asList(extraClasses));
             classes.addAll(JaxbContextConfigRecorder.getClassesToBeBound());
 


### PR DESCRIPTION
The classes in the recorder were not cleared when restaring the app, so the classes to be bound were accumulated in each iteration. 

Fix https://github.com/quarkusio/quarkus/issues/33441