### PR TITLE
Fix detection of project root in Quarkus CLI

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginCatalogService.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginCatalogService.java
@@ -10,7 +10,7 @@ import java.util.function.Predicate;
 
 public class PluginCatalogService extends CatalogService<PluginCatalog> {
 
-    private static final Function<Path, Path> RELATIVE_CATALOG_JSON = p -> p.resolve(".quarkus").resolve("cli")
+    static final Function<Path, Path> RELATIVE_CATALOG_JSON = p -> p.resolve(".quarkus").resolve("cli")
             .resolve("plugins").resolve("quarkus-cli-catalog.json");
 
     public PluginCatalogService() {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginMangerState.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginMangerState.java
@@ -19,7 +19,7 @@ import io.quarkus.platform.catalog.processor.ExtensionProcessor;
 
 class PluginMangerState {
 
-    PluginMangerState(PluginManagerSettings settings, MessageWriter output, Optional<Path> userHome, Optional<Path> projectRoot,
+    PluginMangerState(PluginManagerSettings settings, MessageWriter output, Optional<Path> userHome, Optional<Path> currentDir,
             Supplier<QuarkusProject> quarkusProject) {
         this.settings = settings;
         this.output = output;
@@ -27,11 +27,11 @@ class PluginMangerState {
         this.quarkusProject = quarkusProject;
 
         //Inferred
-        this.projectRoot = projectRoot.filter(p -> !p.equals(userHome.orElse(null)));
         this.jbangCatalogService = new JBangCatalogService(settings.isInteractiveMode(), output, settings.getPluginPrefix(),
                 settings.getFallbackJBangCatalog(),
                 settings.getRemoteJBangCatalogs());
         this.pluginCatalogService = new PluginCatalogService(settings.getToRelativePath());
+        this.projectRoot = currentDir.flatMap(CatalogService::findProjectRoot);
         this.util = PluginManagerUtil.getUtil(settings);
     }
 

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/cli/plugin/PluginCatalogServiceTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/cli/plugin/PluginCatalogServiceTest.java
@@ -1,0 +1,173 @@
+package io.quarkus.cli.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+public class PluginCatalogServiceTest {
+
+    PluginCatalogService service = new PluginCatalogService();
+
+    Path rootDir;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        rootDir = Files.createTempDirectory("quarkus-cli-test-project-root");
+    }
+
+    @AfterEach
+    public void cleanUp() throws Exception {
+        makeWritable(rootDir);
+    }
+
+    @Test
+    public void shouldFindGitRootCatalogPath() throws Exception {
+        Path expectedCatalogPath = PluginCatalogService.RELATIVE_CATALOG_JSON.apply(rootDir);
+        Path moduleA = rootDir.resolve("module-a");
+        Path moduleAA = moduleA.resolve("module-aa");
+        Path dotGit = rootDir.resolve(".git");
+        dotGit.toFile().mkdir();
+        moduleAA.toFile().mkdirs();
+
+        Optional<Path> result = service.findProjectCatalogPath(rootDir);
+        assertEquals(expectedCatalogPath, result.get());
+
+        result = service.findProjectCatalogPath(moduleA);
+        assertEquals(expectedCatalogPath, result.get());
+    }
+
+    @Test
+    public void shouldFindDotQuakursRootCatalogPath() throws Exception {
+        Path moduleB = rootDir.resolve("module-b");
+        Path moduleBA = moduleB.resolve("module-ba");
+
+        Path dotGit = rootDir.resolve(".git");
+        dotGit.toFile().mkdir();
+
+        Path dotQuarkus = PluginCatalogService.RELATIVE_CATALOG_JSON.apply(moduleB);
+        dotQuarkus.getParent().toFile().mkdirs();
+        Files.write(dotQuarkus, new byte[0]);
+
+        moduleBA.toFile().mkdirs();
+
+        Path expectedCatalogPath = PluginCatalogService.RELATIVE_CATALOG_JSON.apply(rootDir);
+
+        Optional<Path> result = service.findProjectCatalogPath(moduleB);
+        assertEquals(expectedCatalogPath, result.get());
+
+        result = service.findProjectCatalogPath(moduleBA);
+        assertEquals(expectedCatalogPath, result.get());
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS) //Test changes File permissions
+    public void shouldFindLastReadableCatalogPath() throws Exception {
+
+        Path moduleC = rootDir.resolve("module-c");
+        Path moduleCA = moduleC.resolve("module-ca");
+
+        Path dotGit = rootDir.resolve(".git");
+        dotGit.toFile().mkdir();
+
+        moduleCA.toFile().mkdirs();
+        // Parent not readable
+        try {
+            if (moduleC.toFile().setWritable(false)) {
+                Optional<Path> result = service.findProjectCatalogPath(moduleCA);
+                assertTrue(result.isEmpty());
+            }
+        } finally {
+            moduleC.toFile().setWritable(true);
+        }
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS) //Test changes File permissions
+    public void shouldFindLastMavenRootCatalogPath() throws Exception {
+
+        Path moduleM = rootDir.resolve("module-m");
+        Path moduleMA = moduleM.resolve("module-ma");
+        Path moduleMAA = moduleMA.resolve("module-maa");
+
+        Path dotGit = rootDir.resolve(".git");
+        dotGit.toFile().mkdir();
+
+        moduleMAA.toFile().mkdirs();
+
+        Path pomMA = moduleMA.resolve("pom.xml");
+        Files.write(pomMA, new byte[0]);
+
+        Path pomMAA = moduleMAA.resolve("pom.xml");
+        Files.write(pomMAA, new byte[0]);
+
+        Path expectedCatalogPath = PluginCatalogService.RELATIVE_CATALOG_JSON.apply(moduleMA);
+
+        // Parent not readable
+        try {
+            if (rootDir.toFile().setWritable(false)) {
+                Optional<Path> result = service.findProjectCatalogPath(moduleMA);
+                assertEquals(expectedCatalogPath, result.get());
+            }
+        } finally {
+            moduleM.toFile().setWritable(true);
+        }
+        Optional<Path> result = service.findProjectCatalogPath(moduleMAA);
+        assertEquals(expectedCatalogPath, result.get());
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS) //Test changes File permissions
+    public void shouldFindLastGradleRootCatalogPath() throws Exception {
+
+        Path moduleG = rootDir.resolve("module-g");
+        Path moduleGA = moduleG.resolve("module-ga");
+        Path moduleGAA = moduleGA.resolve("module-gaa");
+
+        Path dotGit = rootDir.resolve(".git");
+        dotGit.toFile().mkdir();
+
+        moduleGAA.toFile().mkdirs();
+
+        Path pomGA = moduleGA.resolve("build.gradle");
+        Files.write(pomGA, new byte[0]);
+
+        Path pomGAA = moduleGAA.resolve("build.gradle");
+        Files.write(pomGAA, new byte[0]);
+
+        Path expectedCatalogPath = PluginCatalogService.RELATIVE_CATALOG_JSON.apply(moduleGA);
+
+        // Parent not readable
+        try {
+            if (rootDir.toFile().setWritable(false)) {
+                Optional<Path> result = service.findProjectCatalogPath(moduleGA);
+                assertEquals(expectedCatalogPath, result.get());
+            }
+        } finally {
+            moduleG.toFile().setWritable(true);
+        }
+        Optional<Path> result = service.findProjectCatalogPath(moduleGAA);
+        assertEquals(expectedCatalogPath, result.get());
+    }
+
+    private static void makeWritable(Path path) throws IOException {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(path)) {
+            for (Path sub : stream) {
+                if (Files.isDirectory(sub)) {
+                    makeWritable(sub);
+                }
+            }
+            path.toFile().setWritable(true);
+        }
+    }
+}


### PR DESCRIPTION
Resolves: #33402

The pull request fixes the following:

- initialize quarkus plugin catalog if not initialized (fix for #33402).
- support project root detection for unversioned projects.
- fix defaulting to current dir as project root.