### PR TITLE
Disable non configured default OIDC tenant if TenantConfigResolver is available

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -637,6 +637,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import java.util.function.Supplier;
 
 import io.smallrye.mutiny.Uni;
+import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.TenantConfigResolver;
 import io.vertx.ext.web.RoutingContext;
@@ -645,7 +646,7 @@ import io.vertx.ext.web.RoutingContext;
 public class CustomTenantConfigResolver implements TenantConfigResolver {
 
     @Override
-    public Uni<OidcTenantConfig> resolve(RoutingContext context, TenantConfigResolver.TenantConfigRequestContext requestContext) {
+    public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
         String path = context.request().path();
         String[] parts = path.split("/");
 

--- a/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
@@ -8,4 +8,3 @@ quarkus.oidc.application-type=web-app
 quarkus.oidc.logout.path=/protected/logout
 
 quarkus.log.category."com.gargoylesoftware.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL
-

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -30,6 +30,10 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
     /**
      * If this tenant configuration is enabled.
+     *
+     * Note that the default tenant will be disabled if it is not configured
+     * but either {@link TenantResolver} or {@link TenantConfigResolver} are registered.
+     * You do not have to disable the default tenant in this case.
      */
     @ConfigItem(defaultValue = "true")
     public boolean tenantEnabled = true;


### PR DESCRIPTION
Fixes #33120.

When multi-tenant OIDC applications are supported with `quarkus.oidc.TenantConfigResolver`, OIDC configurations are created [dynamically for every tenant](https://quarkus.io/guides/security-openid-connect-multitenancy#tenant-config-resolver), i.e, `application.properties` are not even required, well, nearly not required, as one needs to disable the default tenant: `quarkus.oidc.tenant-enabled=false` in `application.properties` - otherwise Quarkus OIDC detects its `quarkus.oidc.auth-server-url` is not configured and fails.

Having to do `quarkus.oidc.tenant-enabled=false` in `application.properties`. when the focus is on the dynamic OIDC configuration creating in the  `quarkus.oidc.TenantConfigResolver` code, is annoying and can also cause users some headache: @lennartj had to ask us at the Devoxx Greece boot why his application was failing to start up - that was fixed with  `quarkus.oidc.tenant-enabled=false`, but really, it should be done automatically by `quarkus-oidc`.


Similarly, if we have for example 2 custom tenants configured in `application.properties`:
```
quarkus.oidc.tenant-1.provider.google=google
quarkus.oidc.tenant-2.provider.google=apple
```
then having to disable the default tenant with `quarkus.oidc.tenant-enabled=false` is also not great.

Note the default tenant can definitely be configured alongside other resolvers but only if if a fallback to some defaukt provider authentication is needed.

So this PR just checks if either  `quarkus.oidc.TenantConfigResolver` or `quarkus.oidc.TenantResolver` (if named tenants are available) are registered, when the default tenant is not configured, and if yes, disables disables the default tenant. 

Unfortunately I can't test it with the integration test - as the tests either directly or indirectly configure `quarkus.oidc.auth-server-url`.

However, I've verified that if I build `quarkus-quickstarts/security-openid-connect-quaikstart` where I move all the Keycloak configuration to `TenantConfigResolver` (i.e, application.properties is empty) then the application starts immediately in JVM mode - then, after starting Keycloak - I can test the demo with `TenantConfigResolver`  providing OIDC configuration.
