### PR TITLE
Do not create session and PKCE encryption keys if only bearer tokens are expected

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -187,7 +187,7 @@ public class OidcRecorder {
                 throw new ConfigurationException("'quarkus.oidc.auth-server-url' property must be configured");
             }
             OidcCommonUtils.verifyEndpointUrl(oidcConfig.getAuthServerUrl().get());
-            OidcCommonUtils.verifyCommonConfiguration(oidcConfig, isServiceApp(oidcConfig), true);
+            OidcCommonUtils.verifyCommonConfiguration(oidcConfig, OidcUtils.isServiceApp(oidcConfig), true);
         } catch (ConfigurationException t) {
             return Uni.createFrom().failure(t);
         }
@@ -196,7 +196,7 @@ public class OidcRecorder {
             throw new ConfigurationException(
                     "UserInfo is not required but UserInfo is expected to be the source of authorization roles");
         }
-        if (oidcConfig.token.verifyAccessTokenWithUserInfo.orElse(false) && !isWebApp(oidcConfig)
+        if (oidcConfig.token.verifyAccessTokenWithUserInfo.orElse(false) && !OidcUtils.isWebApp(oidcConfig)
                 && !enableUserInfo(oidcConfig)) {
             throw new ConfigurationException(
                     "UserInfo is not required but 'verifyAccessTokenWithUserInfo' is enabled");
@@ -207,7 +207,7 @@ public class OidcRecorder {
         }
 
         if (!oidcConfig.discoveryEnabled.orElse(true)) {
-            if (!isServiceApp(oidcConfig)) {
+            if (!OidcUtils.isServiceApp(oidcConfig)) {
                 if (!oidcConfig.authorizationPath.isPresent() || !oidcConfig.tokenPath.isPresent()) {
                     throw new ConfigurationException(
                             "'web-app' applications must have 'authorization-path' and 'token-path' properties "
@@ -228,7 +228,7 @@ public class OidcRecorder {
             }
         }
 
-        if (isServiceApp(oidcConfig)) {
+        if (OidcUtils.isServiceApp(oidcConfig)) {
             if (oidcConfig.token.refreshExpired) {
                 throw new ConfigurationException(
                         "The 'token.refresh-expired' property can only be enabled for " + ApplicationType.WEB_APP
@@ -294,7 +294,7 @@ public class OidcRecorder {
     }
 
     private static TenantConfigContext createTenantContextFromPublicKey(OidcTenantConfig oidcConfig) {
-        if (!isServiceApp(oidcConfig)) {
+        if (!OidcUtils.isServiceApp(oidcConfig)) {
             throw new ConfigurationException("'public-key' property can only be used with the 'service' applications");
         }
         LOG.debug("'public-key' property for the local token verification is set,"
@@ -443,6 +443,7 @@ public class OidcRecorder {
                         }
                         return Uni.createFrom().item(new OidcProviderClient(client, metadata, oidcConfig));
                     }
+
                 });
     }
 
@@ -458,13 +459,5 @@ public class OidcRecorder {
         return new OidcConfigurationMetadata(tokenUri,
                 introspectionUri, authorizationUri, jwksUri, userInfoUri, endSessionUri,
                 oidcConfig.token.issuer.orElse(null));
-    }
-
-    private static boolean isServiceApp(OidcTenantConfig oidcConfig) {
-        return ApplicationType.SERVICE.equals(oidcConfig.applicationType.orElse(ApplicationType.SERVICE));
-    }
-
-    private static boolean isWebApp(OidcTenantConfig oidcConfig) {
-        return ApplicationType.WEB_APP.equals(oidcConfig.applicationType.orElse(ApplicationType.SERVICE));
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -29,6 +29,7 @@ import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.AuthorizationCodeTokens;
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.OidcTenantConfig.Authentication;
 import io.quarkus.oidc.RefreshToken;
 import io.quarkus.oidc.TokenIntrospection;
@@ -76,6 +77,14 @@ public final class OidcUtils {
 
     private OidcUtils() {
 
+    }
+
+    public static boolean isServiceApp(OidcTenantConfig oidcConfig) {
+        return ApplicationType.SERVICE.equals(oidcConfig.applicationType.orElse(ApplicationType.SERVICE));
+    }
+
+    public static boolean isWebApp(OidcTenantConfig oidcConfig) {
+        return ApplicationType.WEB_APP.equals(oidcConfig.applicationType.orElse(ApplicationType.SERVICE));
     }
 
     public static boolean isEncryptedToken(String token) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -47,8 +47,9 @@ public class TenantConfigContext {
         this.oidcConfig = config;
         this.ready = ready;
 
-        pkceSecretKey = provider != null && provider.client != null ? createPkceSecretKey(config) : null;
-        tokenEncSecretKey = provider != null && provider.client != null ? createTokenEncSecretKey(config) : null;
+        boolean isService = OidcUtils.isServiceApp(config);
+        pkceSecretKey = !isService && provider != null && provider.client != null ? createPkceSecretKey(config) : null;
+        tokenEncSecretKey = !isService && provider != null && provider.client != null ? createTokenEncSecretKey(config) : null;
     }
 
     private static SecretKey createPkceSecretKey(OidcTenantConfig config) {


### PR DESCRIPTION
Fixes #33475.

Session cookie and PKCE verifier encryption keys are only relevant when Users are authenticating into `quarkus.oidc.application-type=web-app` or `quarkus.oidc.application-type=hybrid`, when Quarkus itself manages authorization code flow.

This PR avoids creating such keys when only bearer tokens are expected - PKCE and session encryption will never be used in such cases. 