### PR TITLE
Arc - remove logging when discovering a an illegal bean type in producer type hierarchy

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
@@ -507,7 +507,7 @@ public final class Types {
 
     /**
      * Detects wildcard for given type.
-     * In case this is related to a producer field or method, it either logs or throws a {@link DefinitionException}
+     * In case the annotation target is a producer and the boolean parameter is true, throws a {@link DefinitionException}
      * based on the boolean parameter.
      * Returns true if a wildcard is detected, false otherwise.
      */
@@ -525,16 +525,9 @@ public final class Types {
                         +
                         " contains a parameterized type with a wildcard. This type is not a legal bean type" +
                         " according to CDI specification.");
-            } else if (producerFieldOrMethod != null) {
-                // a producer method with wildcard in the type hierarchy of the return type
-                LOGGER.info("Producer " +
-                        (producerFieldOrMethod.kind().equals(AnnotationTarget.Kind.FIELD) ? "field " : "method ") +
-                        producerFieldOrMethod +
-                        " contains a parameterized typed with a wildcard. This type is not a legal bean type" +
-                        " according to CDI specification and will be ignored during bean resolution.");
-                return true;
             } else {
-                // wildcard detection for class-based beans, these still need to be skipped as they aren't valid bean types
+                // a producer method with wildcard in the type hierarchy of the return type
+                // OR wildcard detection for class-based beans, these still need to be skipped as they aren't valid bean types
                 return true;
             }
         } else if (type.kind().equals(Kind.PARAMETERIZED_TYPE)) {


### PR DESCRIPTION
Fixes #33389 

I found no real reason for why we'd need to keep the logging at `INFO` level.
Spec just defines that given types are illegal and shouldn't be in a resulting set of types which is what we do anyway.
~~I am lowering the logging level to debug as otherwise the msg is too intrusive, affecting even users who consciously defined their bean types via `@Typed`.~~

EDIT: the PR now removes the logging in this scenario entirely