### PR TITLE
Bump Resteasy Classic to 6.2.4.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -31,7 +31,7 @@
         <parsson.version>1.1.1</parsson.version>
         <resteasy-microprofile.version>2.1.1.Final</resteasy-microprofile.version>
         <resteasy-spring-web.version>3.0.2.Final</resteasy-spring-web.version>
-        <resteasy.version>6.2.3.Final</resteasy.version>
+        <resteasy.version>6.2.4.Final</resteasy.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-jdbc.version>0.2.4</opentracing-jdbc.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>


### PR DESCRIPTION
Resteasy 6.2.3.Final has some CVEs caused by following dependencies of resteasy:

angus-mail (NOT fixed in 6.2.4.Final)
CVE: https://ossindex.sonatype.org/vuln/CVE-2021-44549
Update: https://github.com/resteasy/resteasy/commit/51210045d140c302f60c3e6de3d339df75c48834

apache-mime4j-storage (fixed in 6.2.4.Final)
CVE: https://ossindex.sonatype.org/vuln/CVE-2022-45787
Update: https://github.com/resteasy/resteasy/commit/d38689b0d0cda1b72facd4f2c8acfa63bbbcc414