### PR TITLE
Upgrade Hibernate ORM to 6.2.4.Final and Hibernate Reactive to 2.0.0.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -100,7 +100,7 @@
         <hibernate-orm.version>6.2.4.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
         <bytebuddy.version>1.12.18</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
-        <hibernate-reactive.version>2.0.0.CR1</hibernate-reactive.version>
+        <hibernate-reactive.version>2.0.0.Final</hibernate-reactive.version>
         <hibernate-validator.version>8.0.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.1.7.Final</hibernate-search.version>
         <narayana.version>6.0.1.Final</narayana.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -97,7 +97,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>6.2.1.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
+        <hibernate-orm.version>6.2.4.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
         <bytebuddy.version>1.12.18</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
         <hibernate-reactive.version>2.0.0.CR1</hibernate-reactive.version>

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -233,7 +233,7 @@ public final class HibernateOrmProcessor {
         if (capabilities.isPresent(Capability.HIBERNATE_VALIDATOR)) {
             reflectiveClasses.produce(ReflectiveClassBuildItem.builder("org.hibernate.boot.beanvalidation.TypeSafeActivator")
                     .methods().fields().build());
-            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(BeanValidationIntegrator.BV_CHECK_CLASS)
+            reflectiveClasses.produce(ReflectiveClassBuildItem.builder(BeanValidationIntegrator.JAKARTA_BV_CHECK_CLASS)
                     .constructors(false).build());
         }
     }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -442,6 +442,7 @@ public class FastBootMetadataBuilder {
                 fullMeta.getMetadataBuildingOptions(), //TODO Replace this
                 fullMeta.getEntityBindingMap(),
                 fullMeta.getComposites(),
+                fullMeta.getGenericComponentsMap(),
                 fullMeta.getMappedSuperclassMap(),
                 fullMeta.getCollectionBindingMap(),
                 fullMeta.getTypeDefinitionMap(),

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
@@ -20,6 +20,7 @@ import org.hibernate.engine.jdbc.internal.JdbcServicesInitiator;
 import org.hibernate.engine.jdbc.internal.SqlStatementLoggerInitiator;
 import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
 import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.loader.ast.internal.BatchLoaderFactoryInitiator;
 import org.hibernate.persister.internal.PersisterClassResolverInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
@@ -234,6 +235,9 @@ public class PreconfiguredServiceRegistryBuilder {
 
         // Default implementation
         serviceInitiators.add(ParameterMarkerStrategyInitiator.INSTANCE);
+
+        // Default implementation
+        serviceInitiators.add(BatchLoaderFactoryInitiator.INSTANCE);
 
         // Default implementation
         serviceInitiators.add(SqlStatementLoggerInitiator.INSTANCE);

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
@@ -290,6 +290,11 @@ public final class PrevalidatedQuarkusMetadata implements MetadataImplementor {
         metadata.visitRegisteredComponents(consumer);
     }
 
+    @Override
+    public Component getGenericComponent(Class<?> componentClass) {
+        return metadata.getGenericComponent(componentClass);
+    }
+
     public Map<String, PersistentClass> getEntityBindingMap() {
         return metadata.getEntityBindingMap();
     }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/StandardHibernateORMInitiatorListProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/StandardHibernateORMInitiatorListProvider.java
@@ -14,6 +14,7 @@ import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator;
 import org.hibernate.engine.jdbc.internal.JdbcServicesInitiator;
 import org.hibernate.engine.jdbc.internal.SqlStatementLoggerInitiator;
 import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
+import org.hibernate.loader.ast.internal.BatchLoaderFactoryInitiator;
 import org.hibernate.persister.internal.PersisterClassResolverInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
@@ -105,6 +106,9 @@ public final class StandardHibernateORMInitiatorListProvider implements InitialI
 
         // Default implementation
         serviceInitiators.add(ParameterMarkerStrategyInitiator.INSTANCE);
+
+        // Default implementation
+        serviceInitiators.add(BatchLoaderFactoryInitiator.INSTANCE);
 
         // Default implementation
         serviceInitiators.add(SqlStatementLoggerInitiator.INSTANCE);

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/ReactiveSessionFactoryProducer.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/ReactiveSessionFactoryProducer.java
@@ -8,7 +8,6 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceUnit;
 
 import org.hibernate.reactive.common.spi.Implementor;
-import org.hibernate.reactive.common.spi.MutinyImplementor;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.mutiny.impl.MutinySessionFactoryImpl;
 
@@ -29,7 +28,7 @@ public class ReactiveSessionFactoryProducer {
     @ApplicationScoped
     @DefaultBean
     @Unremovable
-    @Typed({ Mutiny.SessionFactory.class, MutinyImplementor.class, Implementor.class })
+    @Typed({ Mutiny.SessionFactory.class, Implementor.class })
     public MutinySessionFactoryImpl mutinySessionFactory() {
         if (jpaConfig.getDeactivatedPersistenceUnitNames()
                 .contains(HibernateReactive.DEFAULT_REACTIVE_PERSISTENCE_UNIT_NAME)) {
@@ -38,7 +37,6 @@ public class ReactiveSessionFactoryProducer {
                             + HibernateReactive.DEFAULT_REACTIVE_PERSISTENCE_UNIT_NAME
                             + ": Hibernate Reactive was deactivated through configuration properties");
         }
-        // TODO Remove this cast when we get rid of the dependency to MutinyImplementor
         return (MutinySessionFactoryImpl) emf.unwrap(Mutiny.SessionFactory.class);
     }
 

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
@@ -23,6 +23,7 @@ import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
 import org.hibernate.reactive.engine.jdbc.mutation.internal.ReactiveMutationExecutorServiceInitiator;
 import org.hibernate.reactive.id.factory.spi.ReactiveIdentifierGeneratorFactoryInitiator;
+import org.hibernate.reactive.loader.ast.internal.ReactiveBatchLoaderFactoryInitiator;
 import org.hibernate.reactive.provider.service.NativeParametersHandling;
 import org.hibernate.reactive.provider.service.NoJtaPlatformInitiator;
 import org.hibernate.reactive.provider.service.ReactiveMarkerServiceInitiator;
@@ -244,6 +245,9 @@ public class PreconfiguredReactiveServiceRegistryBuilder {
 
         // Default implementation
         serviceInitiators.add(SqlStatementLoggerInitiator.INSTANCE);
+
+        // Custom for Hibernate Reactive: BatchLoaderFactory
+        serviceInitiators.add(ReactiveBatchLoaderFactoryInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
         return serviceInitiators;

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/ReactiveHibernateInitiatorListProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/ReactiveHibernateInitiatorListProvider.java
@@ -17,6 +17,7 @@ import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
 import org.hibernate.reactive.id.factory.spi.ReactiveIdentifierGeneratorFactoryInitiator;
+import org.hibernate.reactive.loader.ast.internal.ReactiveBatchLoaderFactoryInitiator;
 import org.hibernate.reactive.provider.service.NativeParametersHandling;
 import org.hibernate.reactive.provider.service.NoJtaPlatformInitiator;
 import org.hibernate.reactive.provider.service.ReactiveMarkerServiceInitiator;
@@ -126,6 +127,9 @@ public final class ReactiveHibernateInitiatorListProvider implements InitialInit
 
         // Default implementation
         serviceInitiators.add(SqlStatementLoggerInitiator.INSTANCE);
+
+        // Custom for Hibernate Reactive: BatchLoaderFactory
+        serviceInitiators.add(ReactiveBatchLoaderFactoryInitiator.INSTANCE);
 
         serviceInitiators.trimToSize();
         return serviceInitiators;


### PR DESCRIPTION
[versions changed since the initial PR]
Upgrading to:
 - Hibernate ORM 6.2.4.Final
 - Hibernate Reactive 2.0.0.Final to match the above upgrade (they need to be aligned).

This works best when paired with vert.x 4.2.2 but it's not strictly required: some Hibernate Reactive bugs were fixed with the vert.x upgrade; the previous version of HR had a couple workarounds for these - the workarounds are now removed  (This comment is slightly out of date as Quarkus was already upgraded to vert.x 4.2.2 in the meantime, but still applicable in case of backports)