### PR TITLE
Renamed doc filename and xrefs to include token

### DIFF
--- a/docs/src/main/asciidoc/security-authentication-mechanisms-concept.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms-concept.adoc
@@ -3,7 +3,7 @@
 include::_attributes.adoc[]
 :categories: security,web
 
-The Quarkus Security framework supports multiple authentication mechanisms, which you can use to secure your applications. 
+The Quarkus Security framework supports multiple authentication mechanisms, which you can use to secure your applications.
 You can also combine authentication mechanisms.
 
 [TIP]
@@ -27,7 +27,7 @@ The following table maps specific authentication requirements to a supported mec
 
 |Username and password |xref:security-basic-authentication-concept.adoc[Basic], xref:security-authentication-mechanisms-concept.adoc#form-auth[Form]
 
-|Bearer access token |xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer], xref:security-jwt.adoc[JWT], xref:security-oauth2.adoc[OAuth2]
+|Bearer access token |xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication], xref:security-jwt.adoc[JWT], xref:security-oauth2.adoc[OAuth2]
 
 |Single sign-on (SSO) |xref:security-oidc-code-flow-authentication-concept.adoc[OIDC Code Flow], xref:security-authentication-mechanisms-concept.adoc#form-auth[Form]
 
@@ -51,7 +51,7 @@ Quarkus Security provides the following built-in authentication support:
 
 === Basic authentication
 
-You can secure your Quarkus application endpoints with the built-in HTTP Basic authentication mechanism. 
+You can secure your Quarkus application endpoints with the built-in HTTP Basic authentication mechanism.
 For more information, see the following documentation:
 
 * xref:security-basic-authentication-concept.adoc[Basic authentication]
@@ -69,7 +69,7 @@ Instead, the authentication information is stored in an encrypted cookie, which 
 
 To apply encryption, add the `quarkus.http.auth.session.encryption-key` property, and ensure that the value you set is at least 16 characters long.
 This key is hashed using SHA-256.
-The resulting digest is used as a key for AES-256 encryption of the cookie value. 
+The resulting digest is used as a key for AES-256 encryption of the cookie value.
 The cookie contains an expiry time as part of the encrypted value, so all nodes in the cluster must have their clocks synchronized.
 At one-minute intervals, a new cookie gets generated with an updated expiry time if the session is in use.
 
@@ -195,7 +195,7 @@ For more information about OIDC authentication and authorization methods you can
 [options="header"]
 |====
 |OIDC topic |Quarkus information resource
-|Bearer token authentication mechanism |xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
+|Bearer token authentication mechanism |xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
 |Authorization code flow authentication mechanism |xref:security-oidc-code-flow-authentication-concept.adoc[OpenID Connect (OIDC) authorization code flow mechanism]
 |Multiple tenants that can support bearer token or authorization code flow mechanisms |xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect (OIDC) multi-tenancy]
 |Using Keycloak to centralize authorization |xref:security-keycloak-authorization.adoc[Using OpenID Connect (OIDC) and Keycloak to centralize authorization]
@@ -354,7 +354,7 @@ For more information, see xref:security-proactive-authentication-concept.adoc[Pr
 == References
 
 * xref:security-overview-concept.adoc[Quarkus Security overview]
-* xref:security-architecture-concept.adoc[Quarkus Security architecture] 
+* xref:security-architecture-concept.adoc[Quarkus Security architecture]
 * xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
 * xref:security-identity-providers-concept.adoc[Identity providers]
 * xref:security-authorize-web-endpoints-reference.adoc[Authorization of web endpoints]

--- a/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
@@ -515,7 +515,7 @@ You have learned how to create and test a secure Quarkus application by combinin
 After you have completed this tutorial, explore some of the more advanced security mechanisms in Quarkus.
 Use the following information to learn how you can securely use `OpenID Connect` to provide secure single sign-on access to your Quarkus endpoints:
 
-* xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
 * xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 
 == References
@@ -524,7 +524,7 @@ Use the following information to learn how you can securely use `OpenID Connect`
 * xref:security-architecture-concept.adoc[Quarkus Security architecture] 
 * xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
 * xref:security-identity-providers-concept.adoc[Identity providers]
-* xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
 * xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:hibernate-orm-panache.adoc[Simplified Hibernate ORM with Panache]
 * xref:hibernate-orm.adoc[Using Hibernate ORM and Jakarta Persistence]

--- a/docs/src/main/asciidoc/security-jwt-build.adoc
+++ b/docs/src/main/asciidoc/security-jwt-build.adoc
@@ -346,6 +346,6 @@ SmallRye JWT supports the following properties which can be used to customize th
 * link:https://tools.ietf.org/html/rfc7516[JSON Web Encryption]
 * link:https://tools.ietf.org/html/rfc7518[JSON Web Algorithms]
 * link:https://bitbucket.org/b_c/jose4j/wiki/Home[Jose4J]
-* xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
 * xref:security-jwt.adoc[Using Smallrye JWT to Protect Service Applications]
 * xref:security-overview-concept.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -16,7 +16,7 @@ to verify https://tools.ietf.org/html/rfc7519[JSON Web Token]s, represent them a
 and provide secured access to the Quarkus HTTP endpoints using Bearer Token Authorization and https://en.wikipedia.org/wiki/Role-based_access_control[Role-Based Access Control].
 
 NOTE: Quarkus OpenID Connect `quarkus-oidc` extension also supports Bearer Token Authorization and uses `smallrye-jwt` to represent the bearer tokens as `JsonWebToken`.
-For more information, read the xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication] guide.
+For more information, read the xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication] guide.
 OpenID Connect extension has to be used if the Quarkus application needs to authenticate the users using OIDC Authorization Code Flow.
 For more information, see xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 
@@ -804,7 +804,7 @@ Please see the xref:security-openid-connect-client.adoc#token-propagation[Token 
 [[integration-testing-wiremock]]
 ==== Wiremock
 
-If you configure `mp.jwt.verify.publickey.location` to point to HTTPS or HTTP based JsonWebKey (JWK) set then you can use the same approach as described in the xref:security-oidc-bearer-authentication-concept.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] `Wiremock` section but only change the `application.properties` to use MP JWT configuration properties instead:
+If you configure `mp.jwt.verify.publickey.location` to point to HTTPS or HTTP based JsonWebKey (JWK) set then you can use the same approach as described in the xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] `Wiremock` section but only change the `application.properties` to use MP JWT configuration properties instead:
 
 [source, properties]
 ----
@@ -816,7 +816,7 @@ mp.jwt.verify.issuer=${keycloak.url}/realms/quarkus
 [[integration-testing-keycloak]]
 ==== Keycloak
 
-If you work with Keycloak and configure `mp.jwt.verify.publickey.location` to point to HTTPS or HTTP based JsonWebKey (JWK) set then you can use the same approach as described in the xref:security-oidc-bearer-authentication-concept.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] Keycloak section but only change the `application.properties` to use MP JWT configuration properties instead:
+If you work with Keycloak and configure `mp.jwt.verify.publickey.location` to point to HTTPS or HTTP based JsonWebKey (JWK) set then you can use the same approach as described in the xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] Keycloak section but only change the `application.properties` to use MP JWT configuration properties instead:
 
 [source, properties]
 ----
@@ -844,7 +844,7 @@ mp.jwt.verify.issuer=${client.quarkus.oidc.auth-server-url}
 [[integration-testing-public-key]]
 ==== Local Public Key
 
-You can use the same approach as described in the xref:security-oidc-bearer-authentication-concept.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] `Local Public Key` section but only change the `application.properties` to use MP JWT configuration properties instead:
+You can use the same approach as described in the xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] `Local Public Key` section but only change the `application.properties` to use MP JWT configuration properties instead:
 
 [source, properties]
 ----

--- a/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
@@ -202,6 +202,6 @@ include::{generated-dir}/config/quarkus-keycloak-admin-client.adoc[leveloffset=+
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * xref:security-keycloak-authorization.adoc[Keycloak Authorization extension]
 * xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
-* xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
 * xref:security-openid-connect-client.adoc[OpenID Connect Client and Token Propagation Quickstart]
 * xref:security-overview-concept.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -10,7 +10,7 @@ include::_attributes.adoc[]
 
 This guide demonstrates how your Quarkus application can authorize a bearer token access to protected resources using https://www.keycloak.org/docs/latest/authorization_services/index.html[Keycloak Authorization Services].
 
-The `quarkus-keycloak-authorization` extension is based on `quarkus-oidc` and provides a policy enforcer that enforces access to protected resources based on permissions managed by Keycloak and currently can only be used with the Quarkus xref:security-oidc-bearer-authentication-concept.adoc[OIDC service applications].
+The `quarkus-keycloak-authorization` extension is based on `quarkus-oidc` and provides a policy enforcer that enforces access to protected resources based on permissions managed by Keycloak and currently can only be used with the Quarkus xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC service applications].
 
 It provides a flexible and dynamic authorization capability based on Resource-Based Access Control.
 
@@ -20,7 +20,7 @@ Use `quarkus-keycloak-authorization` only if you work with Keycloak and have Key
 
 By externalizing authorization from your application, you are allowed to protect your applications using different access control mechanisms as well as avoid re-deploying your application every time your security requirements change, where Keycloak will be acting as a centralized authorization service from where your protected resources and their associated permissions are managed.
 
-See the xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication] guide for more information about `Bearer Token` authentication mechanism. It is important to realize that it is the `Bearer Token` authentication mechanism which does the authentication and creates a security identity - while the `quarkus-keycloak-authorization` extension is responsible for applying a Keycloak Authorization Policy to this identity based on the current request path and other policy settings.
+See the xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication] guide for more information about `Bearer Token` authentication mechanism. It is important to realize that it is the `Bearer Token` authentication mechanism which does the authentication and creates a security identity - while the `quarkus-keycloak-authorization` extension is responsible for applying a Keycloak Authorization Policy to this identity based on the current request path and other policy settings.
 
 Please see https://www.keycloak.org/docs/latest/authorization_services/index.html#_enforcer_overview[Keycloak Authorization Services documentation] for more information.
 
@@ -361,7 +361,7 @@ Note that, depending on how many resources you have in Keycloak the time taken t
 
 In the default configuration, Keycloak is responsible for managing the roles and deciding who can access which routes.
 
-To configure the protected routes using the `@RolesAllowed` annotation or the `application.properties` file, check the xref:security-oidc-bearer-authentication-concept.adoc[Using OpenID Connect Adapter to Protect Jakarta REST Applications] and xref:security-authorize-web-endpoints-reference.adoc[Security Authorization] guides. For more details, check the xref:security-overview-concept.adoc[Security guide].
+To configure the protected routes using the `@RolesAllowed` annotation or the `application.properties` file, check the xref:security-oidc-bearer-token-authentication-concept.adoc[Using OpenID Connect Adapter to Protect Jakarta REST Applications] and xref:security-authorize-web-endpoints-reference.adoc[Security Authorization] guides. For more details, check the xref:security-overview-concept.adoc[Security guide].
 
 == Access to Public Resources
 

--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -16,7 +16,7 @@ It can be used to implement an application authentication mechanism based on tok
 
 This extension provides a light-weight support for using the opaque Bearer Tokens and validating them by calling an introspection endpoint.
 
-If the OAuth2 Authentication server provides JWT Bearer Tokens, consider using either xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication] or xref:security-jwt.adoc[SmallRye JWT] extensions instead.
+If the OAuth2 Authentication server provides JWT Bearer Tokens, consider using either xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication] or xref:security-jwt.adoc[SmallRye JWT] extensions instead.
 OpenID Connect extension has to be used if the Quarkus application needs to authenticate the users using OIDC Authorization Code Flow. For more information, see the xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications] guide.
 
 include::{includes}/extension-status.adoc[]

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-concept.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-concept.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-[id="security-oidc-bearer-authentication-concept"]
+[id="security-oidc-bearer-token-authentication-concept"]
 = OpenID Connect (OIDC) Bearer authentication
 include::_attributes.adoc[]
 :categories: security,web

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
@@ -11,7 +11,7 @@ include::_attributes.adoc[]
 Here, you use the Quarkus OpenID Connect (OIDC) extension to secure a Jakarta REST application using Bearer authentication.
 The bearer tokens are issued by OIDC and OAuth 2.0 compliant authorization servers, such as link:https://www.keycloak.org[Keycloak].
 
-To better understand OIDC Bearer authentication, see xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication].
+To better understand OIDC Bearer authentication, see xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication].
 
 == Prerequisites
 
@@ -311,12 +311,12 @@ export access_token=$(\
  )
 ----
 
-Please also see the xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-keycloak-devservices[OIDC Bearer authentication, Dev Services for Keycloak] section, about writing the integration tests which depend on `Dev Services for Keycloak`.
+Please also see the xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing-keycloak-devservices[OIDC Bearer authentication, Dev Services for Keycloak] section, about writing the integration tests which depend on `Dev Services for Keycloak`.
 
 == References
 
 * xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties]
-* xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
 * link:https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * link:https://openid.net/connect/[OpenID Connect]
 * link:https://tools.ietf.org/html/rfc7519[JSON Web Token]

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-concept.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-concept.adoc
@@ -40,7 +40,7 @@ See also the xref:security-oidc-configuration-properties-reference.adoc[OIDC con
 
 To learn about how you can protect web applications by using the OIDC authorization code flow mechanism, see xref:security-oidc-code-flow-authentication-tutorial.adoc[Protect a web application by using OIDC authorization code flow]
 
-If you want to protect your applications by using Bearer Token authentication, see xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication].
+If you want to protect your applications by using Bearer Token authentication, see xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication].
 For information about how to support multiple tenants, see xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect Multi-Tenancy].
 
 == Using the authorization code flow mechanism
@@ -130,7 +130,7 @@ The default tenant's `OidcConfigurationMetadata` is injected if the endpoint is 
 [[token-claims-roles]]
 === Token claims and SecurityIdentity roles
 
-The way the roles are mapped to the SecurityIdentity roles from the verified tokens is identical to how it is done for the xref:security-oidc-bearer-authentication-concept.adoc[Bearer tokens] with the only difference being that https://openid.net/specs/openid-connect-core-1_0.html#IDToken[ID Token] is used as a source of the roles by default.
+The way the roles are mapped to the SecurityIdentity roles from the verified tokens is identical to how it is done for the xref:security-oidc-bearer-token-authentication-concept.adoc[Bearer tokens] with the only difference being that https://openid.net/specs/openid-connect-core-1_0.html#IDToken[ID Token] is used as a source of the roles by default.
 
 Note if you use Keycloak then you should set a Microprofile JWT client scope for ID token to contain a `groups` claim, please see the https://www.keycloak.org/docs/latest/server_admin/#protocol[Keycloak Server Administration Guide] for more information.
 
@@ -143,7 +143,7 @@ Additionally, a custom `SecurityIdentityAugmentor` can also be used to add the r
 [[token-verification-introspection]]
 === Token verification and introspection
 
-Please see xref:security-oidc-bearer-authentication-concept.adoc#token-verification-introspection[Token Verification And Introspection] for details about how the tokens are verified and introspected.
+Please see xref:security-oidc-bearer-token-authentication-concept.adoc#token-verification-introspection[Token Verification And Introspection] for details about how the tokens are verified and introspected.
 
 Note that in case of `web-app` applications only `IdToken` is verified by default since the access token is not used by default to access the current Quarkus `web-app` endpoint and instead meant to be propagated to the services expecting this access token, for example, to the OpenID Connect Provider's UserInfo endpoint, and so on. However, if you expect the access token to contain the roles required to access the current Quarkus endpoint (`quarkus.oidc.roles.source=accesstoken`) then it will also be verified.
 
@@ -152,12 +152,12 @@ Note that in case of `web-app` applications only `IdToken` is verified by defaul
 
 Code flow access tokens are not introspected unless they are expected to be the source of roles but will be used to get `UserInfo`. So there will be one or two remote calls with the code flow access token, if the token introspection and/or `UserInfo` are required.
 
-Please see xref:security-oidc-bearer-authentication-concept.adoc#token-introspection-userinfo-cache[Token Introspection and UserInfo cache] for more information about using a default token cache or registering a custom cache implementation.
+Please see xref:security-oidc-bearer-token-authentication-concept.adoc#token-introspection-userinfo-cache[Token Introspection and UserInfo cache] for more information about using a default token cache or registering a custom cache implementation.
 
 [[jwt-claim-verification]]
 === JSON web token claim verification
 
-Please see xref:security-oidc-bearer-authentication-concept.adoc#jwt-claim-verification[JSON Web Token Claim verification] section about the claim verification, including the `iss` (issuer) claim.
+Please see xref:security-oidc-bearer-token-authentication-concept.adoc#jwt-claim-verification[JSON Web Token Claim verification] section about the claim verification, including the `iss` (issuer) claim.
 It applies to ID tokens but also to access tokens in a JWT format if the `web-app` application has requested the access token verification.
 
 === Redirection
@@ -338,7 +338,7 @@ public class ServiceResource {
 [[session-management]]
 === Session management
 
-If you have a xref:security-oidc-bearer-authentication-concept.adoc#single-page-applications[Single Page Application for Service Applications] where your OpenID Connect Provider script such as `keycloak.js` is managing an authorization code flow then that script will also control the SPA authentication session lifespan.
+If you have a xref:security-oidc-bearer-token-authentication-concept.adoc#single-page-applications[Single Page Application for Service Applications] where your OpenID Connect Provider script such as `keycloak.js` is managing an authorization code flow then that script will also control the SPA authentication session lifespan.
 
 If you work with a Quarkus OIDC `web-app` application then it is Quarkus OIDC Code Authentication mechanism which is managing the user session lifespan.
 
@@ -492,7 +492,7 @@ public class SecurityEventListener {
 
 === Single-page applications
 
-Check if implementing SPAs the way it is suggested in the xref:security-oidc-bearer-authentication-concept.adoc#single-page-applications[Single-page Applications for Service Applications] section can meet your requirements.
+Check if implementing SPAs the way it is suggested in the xref:security-oidc-bearer-token-authentication-concept.adoc#single-page-applications[Single-page Applications for Service Applications] section can meet your requirements.
 
 If you prefer to use SPA and JavaScript API such as `Fetch` or `XMLHttpRequest`(XHR) with Quarkus web applications, be aware that OpenID Connect Providers may not support CORS for Authorization endpoints where the users are authenticated after a redirect from Quarkus. This will lead to authentication failures if the Quarkus application and the OpenID Connect Provider are hosted on the different HTTP domains/ports.
 
@@ -540,7 +540,7 @@ If the OAuth2 provider supports the introspection endpoint then you may be able 
 
 Configuring the endpoint to request <<user-info,UserInfo>> is the only way `quarkus-oidc` can be integrated with the providers such as GitHub.
 
-Note that requiring <<user-info,UserInfo>> involves making a remote call on every request - therefore you may want to consider caching `UserInfo` data, see xref:security-oidc-bearer-authentication-concept.adoc#token-introspection-userinfo-cache[Token Introspection and UserInfo cache] for more details.
+Note that requiring <<user-info,UserInfo>> involves making a remote call on every request - therefore you may want to consider caching `UserInfo` data, see xref:security-oidc-bearer-token-authentication-concept.adoc#token-introspection-userinfo-cache[Token Introspection and UserInfo cache] for more details.
 
 Alternatively, you may want to request that `UserInfo` is embedded into the internal generated `IdToken` with the `quarkus.oidc.cache-user-info-in-idtoken=true` property - the advantage of this approach is that by default no cached `UserInfo` state will be kept with the endpoint - instead it will be stored in a session cookie. You may also want to consider encrypting `IdToken` in this case if `UserInfo` contains sensitive data. For more information, see <<token-state-manager,Encrypt tokens with TokenStateManager>>.
 
@@ -1155,7 +1155,7 @@ Default realm name is `quarkus` and client id - `quarkus-web-app` - set `keycloa
 [[integration-testing-security-annotation]]
 ==== TestSecurity annotation
 
-See xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-security-annotation[Use TestingSecurity with injected JsonWebToken] section for more information about using `@TestSecurity` and `@OidcSecurity` annotations for testing the `web-app` application endpoint code which depends on the injected ID and access `JsonWebToken` as well as `UserInfo` and `OidcConfigurationMetadata`.
+See xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing-security-annotation[Use TestingSecurity with injected JsonWebToken] section for more information about using `@TestSecurity` and `@OidcSecurity` annotations for testing the `web-app` application endpoint code which depends on the injected ID and access `JsonWebToken` as well as `UserInfo` and `OidcConfigurationMetadata`.
 
 === Checking errors in the logs
 

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -248,7 +248,7 @@ Congratulations!
 You have learned how to set up and use the OIDC authorization code flow mechanism to protect and test application HTTP endpoints.
 After you have completed this tutorial, explore some of the other security mechanisms in Quarkus.
 
-* xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
 * xref:security-overview-concept.adoc[Quarkus Security overview]
 
 

--- a/docs/src/main/asciidoc/security-oidc-configuration-properties-reference.adoc
+++ b/docs/src/main/asciidoc/security-oidc-configuration-properties-reference.adoc
@@ -14,7 +14,7 @@ include::{generated-dir}/config/quarkus-oidc.adoc[opts=optional, leveloffset=+1]
 
 == References
 
-* xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
 * xref:security-oidc-bearer-token-authentication-tutorial.adoc[Protect a service application by using OpenID Connect (OIDC) bearer authentication]
 // * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * https://openid.net/connect/[OpenID Connect]

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -838,7 +838,7 @@ and finally write the test code. Given the Wiremock-based resource above, the fi
 
 ==== Keycloak
 
-If you work with Keycloak then you can use the same approach as described in the xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-keycloak[OpenID Connect Bearer Token Integration testing] Keycloak section.
+If you work with Keycloak then you can use the same approach as described in the xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing-keycloak[OpenID Connect Bearer Token Integration testing] Keycloak section.
 
 === How to check the errors in the logs
 
@@ -861,7 +861,7 @@ quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".min-lev
 [[token-propagation-reactive]]
 == Token Propagation Reactive
 
-The `quarkus-oidc-token-propagation-reactive` extension provides RestEasy Reactive Client `io.quarkus.oidc.token.propagation.reactive.AccessTokenRequestReactiveFilter` that simplifies the propagation of authentication information by propagating the xref:security-oidc-bearer-authentication-concept.adoc[Bearer token] present in the current active request or the token acquired from the xref:security-oidc-code-flow-authentication-concept.adoc[Authorization code flow mechanism], as the HTTP `Authorization` header's `Bearer` scheme value.
+The `quarkus-oidc-token-propagation-reactive` extension provides RestEasy Reactive Client `io.quarkus.oidc.token.propagation.reactive.AccessTokenRequestReactiveFilter` that simplifies the propagation of authentication information by propagating the xref:security-oidc-bearer-token-authentication-concept.adoc[Bearer token] present in the current active request or the token acquired from the xref:security-oidc-code-flow-authentication-concept.adoc[Authorization code flow mechanism], as the HTTP `Authorization` header's `Bearer` scheme value.
 
 You can selectively register `AccessTokenRequestReactiveFilter` by using either `io.quarkus.oidc.token.propagation.AccessToken` or `org.eclipse.microprofile.rest.client.annotation.RegisterProvider` annotation, for example:
 
@@ -937,7 +937,7 @@ quarkus.oidc-token-propagation-reactive.exchange-token=true
 == Token Propagation
 
 The `quarkus-oidc-token-propagation` extension provides two Jakarta REST `jakarta.ws.rs.client.ClientRequestFilter` class implementations that simplify the propagation of authentication information.
-`io.quarkus.oidc.token.propagation.AccessTokenRequestFilter` propagates the xref:security-oidc-bearer-authentication-concept.adoc[Bearer token] present in the current active request or the token acquired from the xref:security-oidc-code-flow-authentication-concept.adoc[Authorization code flow mechanism], as the HTTP `Authorization` header's `Bearer` scheme value.
+`io.quarkus.oidc.token.propagation.AccessTokenRequestFilter` propagates the xref:security-oidc-bearer-token-authentication-concept.adoc[Bearer token] present in the current active request or the token acquired from the xref:security-oidc-code-flow-authentication-concept.adoc[Authorization code flow mechanism], as the HTTP `Authorization` header's `Bearer` scheme value.
 The `io.quarkus.oidc.token.propagation.JsonWebTokenRequestFilter` provides the same functionality, but in addition provides support for JWT tokens.
 
 When you need to propagate the current Authorization Code Flow access token then the immediate token propagation will work well - as the code flow access tokens (as opposed to ID tokens) are meant to be propagated for the current Quarkus endpoint to access the remote services on behalf of the currently authenticated user.
@@ -1085,7 +1085,7 @@ As already noted above, please use `AccessTokenRequestFilter` if you work with K
 [[integration-testing-token-propagation]]
 === Testing
 
-You can generate the tokens as described in xref:security-oidc-bearer-authentication-concept.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] section.
+You can generate the tokens as described in xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] section.
 Prepare the REST test endpoints, you can have the test frontend endpoint which uses the injected MP REST client with a registered token propagation filter to invoke on the downstream endpoint, for example, see the `integration-tests/oidc-token-propagation` in the `main` Quarkus repository.
 
 [[reactive-token-propagation]]
@@ -1109,6 +1109,6 @@ However, these features may be added in the future.
 == References
 
 * xref:security-openid-connect-client.adoc[OpenID Connect Client and Token Propagation Quickstart]
-* xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
 * xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:security-overview-concept.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -12,7 +12,7 @@ This quickstart demonstrates how to use `OpenID Connect Client Reactive Filter` 
 
 Please check xref:security-openid-connect-client-reference.adoc[OpenID Connect Client and Token Propagation Reference Guide] for all the information related to `Oidc Client` and `Token Propagation` support in Quarkus.
 
-Please also read xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication] guide if you need to protect your applications using Bearer Token Authorization.
+Please also read xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication] guide if you need to protect your applications using Bearer Token Authorization.
 
 == Prerequisites
 
@@ -501,5 +501,5 @@ will return `403` status code.
 == References
 
 * xref:security-openid-connect-client-reference.adoc[OpenID Connect Client and Token Propagation Reference Guide]
-* xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
 * xref:security-overview-concept.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -67,7 +67,7 @@ Click on the `Provider: Keycloak` link, and you will see a Keycloak page which w
 [[develop-service-applications]]
 === Developing Service Applications
 
-By default, the Keycloak page can be used to support the development of a xref:security-oidc-bearer-authentication-concept.adoc[Quarkus OIDC service application].
+By default, the Keycloak page can be used to support the development of a xref:security-oidc-bearer-token-authentication-concept.adoc[Quarkus OIDC service application].
 
 [[keycloak-authorization-code-grant]]
 ==== Authorization Code Grant
@@ -217,7 +217,7 @@ It will ensure that if you access the application from the browser in dev mode, 
 You can run the tests against a Keycloak container started in a test mode in a xref:continuous-testing.adoc[Continuous Testing] mode.
 
 It is also recommended to run the integration tests against Keycloak using `Dev Services for Keycloak`.
-For more information, see xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-keycloak-devservices[Testing OpenID onnect Service Applications with Dev Services] and xref:security-oidc-code-flow-authentication-concept.adoc#integration-testing-keycloak-devservices[Testing OpenID Connect WebApp Applications with Dev Services].
+For more information, see xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing-keycloak-devservices[Testing OpenID onnect Service Applications with Dev Services] and xref:security-oidc-code-flow-authentication-concept.adoc#integration-testing-keycloak-devservices[Testing OpenID Connect WebApp Applications with Dev Services].
 
 [[keycloak-initialization]]
 === Keycloak Initialization
@@ -413,6 +413,6 @@ This document refers to the `http://localhost:8080/q/dev-v1` Dev UI URL in sever
 * xref:dev-ui.adoc[Dev UI]
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * https://openid.net/connect/[OpenID Connect]
-* xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
 * xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:security-overview-concept.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -12,7 +12,7 @@ This guide demonstrates how your OpenID Connect (OIDC) application can support m
 
 When serving multiple customers from the same application (e.g.: SaaS), each customer is a tenant. By enabling multi-tenancy support to your applications you are allowed to also support distinct authentication policies for each tenant even though if that means authenticating against different OpenID Providers, such as Keycloak and Google.
 
-Please read the xref:security-oidc-bearer-authentication-concept.adoc[OIDC Bearer authentication] guide if you need to authorize a tenant using Bearer Token Authorization.
+Please read the xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication] guide if you need to authorize a tenant using Bearer Token Authorization.
 
 If you need to authenticate and authorize a tenant using OpenID Connect Authorization Code Flow, read the xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications] guide.
 

--- a/docs/src/main/asciidoc/security-testing.adoc
+++ b/docs/src/main/asciidoc/security-testing.adoc
@@ -89,7 +89,7 @@ This will run the test with an identity with the given username and roles. Note 
 disable authorization while also providing an identity to run the test under, which can be useful if the endpoint expects an
 identity to be present.
 
-See xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-security-annotation[OpenID Connect Bearer Token Integration testing], xref:security-oidc-code-flow-authentication-concept.adoc#integration-testing-security-annotation[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-security-annotation[SmallRye JWT Integration testing] for more details about testing the endpoint code which depends on the injected `JsonWebToken`.
+See xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing-security-annotation[OpenID Connect Bearer Token Integration testing], xref:security-oidc-code-flow-authentication-concept.adoc#integration-testing-security-annotation[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-security-annotation[SmallRye JWT Integration testing] for more details about testing the endpoint code which depends on the injected `JsonWebToken`.
 
 [WARNING]
 ====
@@ -122,7 +122,7 @@ for example by setting `quarkus.http.auth.basic=true` or `%test.quarkus.http.aut
 == Use Wiremock for Integration Testing
 
 You can also use Wiremock to mock the authorization OAuth2 and OIDC services:
-See xref:security-oauth2.adoc#integration-testing[OAuth2 Integration testing], xref:security-oidc-bearer-authentication-concept.adoc#integration-testing-wiremock[OpenID Connect Bearer Token Integration testing], xref:security-oidc-code-flow-authentication-concept.adoc#integration-testing-wiremock[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-wiremock[SmallRye JWT Integration testing] for more details.
+See xref:security-oauth2.adoc#integration-testing[OAuth2 Integration testing], xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing-wiremock[OpenID Connect Bearer Token Integration testing], xref:security-oidc-code-flow-authentication-concept.adoc#integration-testing-wiremock[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-wiremock[SmallRye JWT Integration testing] for more details.
 
 == References
 


### PR DESCRIPTION
Renamed the doc source file `security-oidc-bearer-authentication-concept.adoc` → `security-oidc-bearer-token-authentication-concept.adoc` and all xrefs to it.

Added a URL redirect also in the _quarkusio.github.io_ repo for when this change goes live on the doc portal site: [1708](https://github.com/quarkusio/quarkusio.github.io/pull/1708)