### PR TITLE
Allow configuration of Flyway connectRetriesInterval

### DIFF
--- a/extensions/flyway/deployment/src/test/resources/config-for-default-datasource.properties
+++ b/extensions/flyway/deployment/src/test/resources/config-for-default-datasource.properties
@@ -6,6 +6,7 @@ quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test_quarkus;DB_CLOSE_DE
 
 # Flyway config properties
 quarkus.flyway.connect-retries=10
+quarkus.flyway.connect-retries-interval=100ms
 quarkus.flyway.schemas=TEST_SCHEMA
 quarkus.flyway.table=flyway_quarkus_history
 quarkus.flyway.locations=db/location1,db/location2

--- a/extensions/flyway/deployment/src/test/resources/config-for-missing-named-datasource.properties
+++ b/extensions/flyway/deployment/src/test/resources/config-for-missing-named-datasource.properties
@@ -7,6 +7,7 @@ quarkus.datasource.inventory.jdbc.transactions=xa
 
 # Flyway configuration for missing "users" datasource 
 quarkus.flyway.users.connect-retries=11
+quarkus.flyway.connect-retries-interval=1
 quarkus.flyway.users.schemas=USERS_TEST_SCHEMA
 quarkus.flyway.users.table=users_flyway_quarkus_history
 quarkus.flyway.users.locations=db/users/location1,db/users/location2

--- a/extensions/flyway/deployment/src/test/resources/config-for-multiple-datasources-without-default.properties
+++ b/extensions/flyway/deployment/src/test/resources/config-for-multiple-datasources-without-default.properties
@@ -14,6 +14,7 @@ quarkus.datasource.inventory.jdbc.transactions=xa
 
 # Flyway configuration for "users" datasource
 quarkus.flyway.users.connect-retries=11
+quarkus.flyway.users.connect-retries-interval=2s
 quarkus.flyway.users.schemas=USERS_TEST_SCHEMA
 quarkus.flyway.users.table=users_flyway_quarkus_history
 quarkus.flyway.users.locations=db/users/location1,db/users/location2
@@ -27,6 +28,7 @@ quarkus.flyway.users.callbacks=io.quarkus.flyway.test.FlywayExtensionCallback
 
 # Flyway configuration for "inventory" datasource
 quarkus.flyway.inventory.connect-retries=12
+quarkus.flyway.inventory.connect-retries-interval=2s
 quarkus.flyway.inventory.schemas=INVENTORY_TEST_SCHEMA
 quarkus.flyway.inventory.table=inventory_flyway_quarkus_history
 quarkus.flyway.inventory.locations=db/inventory/location1,db/inventory/location2

--- a/extensions/flyway/deployment/src/test/resources/config-for-multiple-datasources.properties
+++ b/extensions/flyway/deployment/src/test/resources/config-for-multiple-datasources.properties
@@ -20,6 +20,7 @@ quarkus.datasource.inventory.jdbc.max-size=12
 
 # Flyway configuration for default datasource
 quarkus.flyway.connect-retries=10
+quarkus.flyway.connect-retries-interval=1000ms
 quarkus.flyway.schemas=TEST_SCHEMA
 quarkus.flyway.table=flyway_quarkus_history
 quarkus.flyway.locations=db/location1,db/location2
@@ -33,6 +34,7 @@ quarkus.flyway.callbacks=io.quarkus.flyway.test.FlywayExtensionCallback
 
 # Flyway configuration for "users" datasource
 quarkus.flyway.users.connect-retries=11
+quarkus.flyway.users.connect-retries-interval=10s
 quarkus.flyway.users.schemas=USERS_TEST_SCHEMA
 quarkus.flyway.users.table=users_flyway_quarkus_history
 quarkus.flyway.users.locations=db/users/location1,db/users/location2
@@ -46,6 +48,7 @@ quarkus.flyway.users.callbacks=io.quarkus.flyway.test.FlywayExtensionCallback
 
 # Flyway configuration for "inventory" datasource
 quarkus.flyway.inventory.connect-retries=12
+quarkus.flyway.inventory.connect-retries-interval=2s
 quarkus.flyway.inventory.schemas=INVENTORY_TEST_SCHEMA
 quarkus.flyway.inventory.table=inventory_flyway_quarkus_history
 quarkus.flyway.inventory.locations=db/inventory/location1,db/inventory/location2

--- a/extensions/flyway/deployment/src/test/resources/config-for-named-datasource-without-default.properties
+++ b/extensions/flyway/deployment/src/test/resources/config-for-named-datasource-without-default.properties
@@ -6,6 +6,7 @@ quarkus.datasource.users.jdbc.max-size=11
 
 # Flyway configuration for "users" datasource
 quarkus.flyway.users.connect-retries=11
+quarkus.flyway.users.connect-retries-interval=12
 quarkus.flyway.users.schemas=USERS_TEST_SCHEMA
 quarkus.flyway.users.table=users_flyway_quarkus_history
 quarkus.flyway.users.locations=db/users/location1,db/users/location2

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayCreator.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayCreator.java
@@ -1,5 +1,6 @@
 package io.quarkus.flyway.runtime;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -19,6 +20,7 @@ import io.quarkus.runtime.configuration.ConfigurationException;
 class FlywayCreator {
 
     private static final String[] EMPTY_ARRAY = new String[0];
+    public static final Duration DEFAULT_CONNECT_RETRIES_INTERVAL = Duration.ofSeconds(120L);
 
     private final FlywayDataSourceRuntimeConfig flywayRuntimeConfig;
     private final FlywayDataSourceBuildTimeConfig flywayBuildTimeConfig;
@@ -76,6 +78,8 @@ class FlywayCreator {
         if (flywayRuntimeConfig.connectRetries.isPresent()) {
             configure.connectRetries(flywayRuntimeConfig.connectRetries.getAsInt());
         }
+        configure.connectRetriesInterval(
+                (int) flywayRuntimeConfig.connectRetriesInterval.orElse(DEFAULT_CONNECT_RETRIES_INTERVAL).toSeconds());
         if (flywayRuntimeConfig.defaultSchema.isPresent()) {
             configure.defaultSchema(flywayRuntimeConfig.defaultSchema.get());
         }

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceRuntimeConfig.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceRuntimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.flyway.runtime;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -22,11 +23,21 @@ public final class FlywayDataSourceRuntimeConfig {
     }
 
     /**
-     * The maximum number of retries when attempting to connect to the database. After each failed attempt, Flyway will wait 1
-     * second before attempting to connect again, up to the maximum number of times specified by connectRetries.
+     * The maximum number of retries when attempting to connect to the database.
+     * <p>
+     * After each failed attempt, Flyway will wait up to the configured `connect-retries-interval` duration before
+     * attempting to connect again, up to the maximum number of times specified by connectRetries.
      */
     @ConfigItem
     public OptionalInt connectRetries = OptionalInt.empty();
+
+    /**
+     * The maximum time between retries when attempting to connect to the database.
+     * <p>
+     * This will cap the interval between connect retries to the value provided.
+     */
+    @ConfigItem(defaultValueDocumentation = "120 seconds")
+    public Optional<Duration> connectRetriesInterval = Optional.empty();
 
     /**
      * Sets the default schema managed by Flyway. This schema name is case-sensitive. If not specified, but <i>schemas</i>


### PR DESCRIPTION
Flyway extension allows the configuration of the connectRetries i.e the number of times a db connection will be retried. 
However the extension didn't allow for the configuration of the retry wait interval. This patch adds that possibility.
