### PR TITLE
Integration of Reactive Messaging 4.6.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -68,7 +68,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.0</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.3.0</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>4.5.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>4.6.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.2.0</smallrye-stork.version>
         <jakarta.activation.version>2.1.2</jakarta.activation.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingDotNames.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingDotNames.java
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.reactive.messaging.spi.IncomingConnectorFactory;
 import org.eclipse.microprofile.reactive.messaging.spi.OutgoingConnectorFactory;
 import org.jboss.jandex.DotName;
 
+import io.smallrye.reactive.messaging.MessageConverter;
 import io.smallrye.reactive.messaging.MutinyEmitter;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.annotations.Broadcast;
@@ -23,6 +24,9 @@ import io.smallrye.reactive.messaging.annotations.Merge;
 import io.smallrye.reactive.messaging.annotations.OnOverflow;
 import io.smallrye.reactive.messaging.connector.InboundConnector;
 import io.smallrye.reactive.messaging.connector.OutboundConnector;
+import io.smallrye.reactive.messaging.keyed.KeyValueExtractor;
+import io.smallrye.reactive.messaging.keyed.Keyed;
+import io.smallrye.reactive.messaging.keyed.KeyedMulti;
 
 public final class ReactiveMessagingDotNames {
 
@@ -60,6 +64,12 @@ public final class ReactiveMessagingDotNames {
     static final DotName OUTBOUND_CONNECTOR = DotName.createSimple(OutboundConnector.class.getName());
 
     static final DotName SMALLRYE_BLOCKING = DotName.createSimple(io.smallrye.common.annotation.Blocking.class.getName());
+
+    static final DotName MESSAGE_CONVERTER = DotName.createSimple(MessageConverter.class.getName());
+    static final DotName KEY_VALUE_EXTRACTOR = DotName.createSimple(KeyValueExtractor.class.getName());
+
+    static final DotName KEYED = DotName.createSimple(Keyed.class.getName());
+    public static final DotName KEYED_MULTI = DotName.createSimple(KeyedMulti.class.getName());
 
     // Do not directly reference the MetricDecorator (due to its direct references to MP Metrics, which may not be present)
     static final DotName METRIC_DECORATOR = DotName

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -148,7 +148,13 @@ public class SmallRyeReactiveMessagingProcessor {
                                 ReactiveMessagingDotNames.INCOMINGS)),
                 new UnremovableBeanBuildItem(
                         new BeanClassAnnotationExclusion(
-                                ReactiveMessagingDotNames.OUTGOING)));
+                                ReactiveMessagingDotNames.OUTGOING)),
+                new UnremovableBeanBuildItem(
+                        new BeanClassAnnotationExclusion(
+                                ReactiveMessagingDotNames.MESSAGE_CONVERTER)),
+                new UnremovableBeanBuildItem(
+                        new BeanClassAnnotationExclusion(
+                                ReactiveMessagingDotNames.KEY_VALUE_EXTRACTOR)));
     }
 
     @BuildStep

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/MediatorConfigurationSupportTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/MediatorConfigurationSupportTest.java
@@ -5,9 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 import jakarta.enterprise.inject.spi.DefinitionException;
 
@@ -53,17 +51,16 @@ public class MediatorConfigurationSupportTest {
     private MediatorConfigurationSupport create(String method) {
         for (MethodInfo m : classInfo.methods()) {
             if (m.name().equalsIgnoreCase(method)) {
-                List<? extends Class<?>> list = m.parameterTypes().stream().map(t -> load(t.name().toString()))
-                        .collect(Collectors.toList());
                 return new MediatorConfigurationSupport(
                         method,
                         load(m.returnType().name().toString()),
-                        list.toArray(new Class[0]),
+                        m.parameterTypes().stream().map(t -> load(t.name().toString())).toArray(Class[]::new),
                         new QuarkusMediatorConfigurationUtil.ReturnTypeGenericTypeAssignable(m, classLoader),
                         m.parametersCount() == 0
                                 ? new QuarkusMediatorConfigurationUtil.AlwaysInvalidIndexGenericTypeAssignable()
                                 : new QuarkusMediatorConfigurationUtil.MethodParamGenericTypeAssignable(m, 0,
-                                        classLoader));
+                                        classLoader),
+                        null);
             }
         }
         fail("Unable to find method " + method);

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/KeyedMultiInjectionTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/KeyedMultiInjectionTest.java
@@ -1,0 +1,123 @@
+package io.quarkus.smallrye.reactivemessaging.signatures;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.keyed.KeyValueExtractor;
+import io.smallrye.reactive.messaging.keyed.KeyedMulti;
+
+public class KeyedMultiInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MsgMetadata.class, ProcessorIngestingPayload.class, MyKeyValueExtractor.class, Source.class,
+                            Sink.class));
+
+    @Inject
+    Sink sink;
+
+    @Inject
+    ProcessorIngestingPayload processor;
+
+    @Test
+    void test() {
+        assertThat(sink.list()).allSatisfy(message -> {
+            assertThat(message.getPayload()).containsAnyOf("key-0", "key-1");
+        }).hasSize(10);
+
+        assertThat(processor.called()).isEqualTo(2);
+    }
+
+    public static class MsgMetadata {
+
+        private final String message;
+
+        public MsgMetadata(String m) {
+            this.message = m;
+        }
+
+        String getMessage() {
+            return message;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class ProcessorIngestingPayload {
+
+        private int called = 0;
+
+        @Incoming("source")
+        @Outgoing("sink")
+        public Multi<String> process(KeyedMulti<String, String> multi) {
+            called++;
+            return multi.map(s -> multi.key() + "-" + s);
+        }
+
+        public int called() {
+            return called;
+        }
+    }
+
+    @ApplicationScoped
+    public static class Source {
+
+        @Outgoing("source")
+        public Multi<Message<String>> source() {
+            return Multi.createFrom().range(1, 11)
+                    .map(i -> Message.of(Integer.toString(i), Metadata.of(new MsgMetadata("key-" + (i % 2 == 0 ? 0 : 1)))));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class Sink {
+        List<Message<String>> list = new ArrayList<>();
+
+        @Incoming("sink")
+        public CompletionStage<Void> consume(Message<String> message) {
+            list.add(message);
+            return message.ack();
+        }
+
+        public List<Message<String>> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyKeyValueExtractor implements KeyValueExtractor {
+
+        @Override
+        public boolean canExtract(Message<?> message, Type type, Type type1) {
+            return message.getMetadata(MsgMetadata.class).isPresent();
+        }
+
+        @Override
+        public Object extractKey(Message<?> message, Type type) {
+            return message.getMetadata(MsgMetadata.class).get().message;
+        }
+
+        @Override
+        public Object extractValue(Message<?> message, Type type) {
+            return message.getPayload();
+        }
+    }
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/KeyedMultiInjectionWithKeyedTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/KeyedMultiInjectionWithKeyedTest.java
@@ -1,0 +1,124 @@
+package io.quarkus.smallrye.reactivemessaging.signatures;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.keyed.KeyValueExtractor;
+import io.smallrye.reactive.messaging.keyed.Keyed;
+import io.smallrye.reactive.messaging.keyed.KeyedMulti;
+
+public class KeyedMultiInjectionWithKeyedTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MsgMetadata.class, ProcessorIngestingPayload.class, MyKeyValueExtractor.class, Source.class,
+                            Sink.class));
+
+    @Inject
+    Sink sink;
+
+    @Inject
+    ProcessorIngestingPayload processor;
+
+    @Test
+    void test() {
+        assertThat(sink.list()).allSatisfy(message -> {
+            assertThat(message.getPayload()).containsAnyOf("key-0", "key-1");
+        }).hasSize(10);
+
+        assertThat(processor.called()).isEqualTo(2);
+    }
+
+    public static class MsgMetadata {
+
+        private final String message;
+
+        public MsgMetadata(String m) {
+            this.message = m;
+        }
+
+        String getMessage() {
+            return message;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class ProcessorIngestingPayload {
+
+        private int called = 0;
+
+        @Incoming("source")
+        @Outgoing("sink")
+        public Multi<String> process(@Keyed(MyKeyValueExtractor.class) KeyedMulti<String, String> multi) {
+            called++;
+            return multi.map(s -> multi.key() + "-" + s);
+        }
+
+        public int called() {
+            return called;
+        }
+    }
+
+    @ApplicationScoped
+    public static class Source {
+
+        @Outgoing("source")
+        public Multi<Message<String>> source() {
+            return Multi.createFrom().range(1, 11)
+                    .map(i -> Message.of(Integer.toString(i), Metadata.of(new MsgMetadata("key-" + (i % 2 == 0 ? 0 : 1)))));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class Sink {
+        List<Message<String>> list = new ArrayList<>();
+
+        @Incoming("sink")
+        public CompletionStage<Void> consume(Message<String> message) {
+            list.add(message);
+            return message.ack();
+        }
+
+        public List<Message<String>> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyKeyValueExtractor implements KeyValueExtractor {
+
+        @Override
+        public boolean canExtract(Message<?> message, Type type, Type type1) {
+            throw new UnsupportedOperationException("Should not be called when @Keyed is used");
+        }
+
+        @Override
+        public Object extractKey(Message<?> message, Type type) {
+            return message.getMetadata(MsgMetadata.class).get().message;
+        }
+
+        @Override
+        public Object extractValue(Message<?> message, Type type) {
+            return message.getPayload();
+        }
+    }
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/MetadataInjectionTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/MetadataInjectionTest.java
@@ -1,0 +1,124 @@
+package io.quarkus.smallrye.reactivemessaging.signatures;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class MetadataInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MsgMetadata.class, CounterMetadata.class, ProcessorIngestingPayload.class, Source.class,
+                            Sink.class));
+
+    @Inject
+    Sink sink;
+
+    @Test
+    void test() {
+        assertThat(sink.list()).allSatisfy(message -> {
+            CounterMetadata c = message.getMetadata(CounterMetadata.class)
+                    .orElseThrow(() -> new AssertionError("Metadata expected"));
+            MsgMetadata m = message.getMetadata(MsgMetadata.class).orElseThrow(() -> new AssertionError("Metadata expected"));
+            assertThat(m.getMessage()).isEqualTo("foo");
+            assertThat(c.getCount()).isNotEqualTo(0);
+        }).hasSize(10);
+
+    }
+
+    public static class MsgMetadata {
+
+        private final String message;
+
+        public MsgMetadata(String m) {
+            this.message = m;
+        }
+
+        String getMessage() {
+            return message;
+        }
+
+    }
+
+    public static class CounterMetadata {
+
+        private final int count;
+
+        public CounterMetadata(int count) {
+            this.count = count;
+        }
+
+        int getCount() {
+            return count;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class ProcessorIngestingPayload {
+        @Incoming("source")
+        @Outgoing("intermediary")
+        public String process(String p, MsgMetadata metadata) {
+            assertThat(p).isNotNull();
+            assertThat(metadata).isNotNull();
+            assertThat(metadata.getMessage()).isEqualTo("foo");
+            return p;
+        }
+
+        @Incoming("intermediary")
+        @Outgoing("sink")
+        public String process(String p, Optional<MsgMetadata> metadata, Optional<Locale> missing,
+                Optional<List<String>> missingWithSubGeneric) {
+            assertThat(p).isNotNull();
+            assertThat(missing).isEmpty();
+            assertThat(missingWithSubGeneric).isEmpty();
+            assertThat(metadata).isPresent();
+            assertThat(metadata.get().getMessage()).isEqualTo("foo");
+            return p;
+        }
+    }
+
+    @ApplicationScoped
+    public static class Source {
+
+        @Outgoing("source")
+        public Multi<Message<String>> source() {
+            return Multi.createFrom().range(1, 11)
+                    .map(i -> Message.of(Integer.toString(i), Metadata.of(new CounterMetadata(i), new MsgMetadata("foo"))));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class Sink {
+        List<Message<String>> list = new ArrayList<>();
+
+        @Incoming("sink")
+        public CompletionStage<Void> consume(Message<String> message) {
+            list.add(message);
+            return message.ack();
+        }
+
+        public List<Message<String>> list() {
+            return list;
+        }
+    }
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusMediatorConfiguration.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusMediatorConfiguration.java
@@ -12,8 +12,10 @@ import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import io.quarkus.arc.Arc;
 import io.smallrye.reactive.messaging.Invoker;
 import io.smallrye.reactive.messaging.MediatorConfiguration;
+import io.smallrye.reactive.messaging.MethodParameterDescriptor;
 import io.smallrye.reactive.messaging.Shape;
 import io.smallrye.reactive.messaging.annotations.Merge;
+import io.smallrye.reactive.messaging.keyed.KeyValueExtractor;
 
 public class QuarkusMediatorConfiguration implements MediatorConfiguration {
 
@@ -55,6 +57,12 @@ public class QuarkusMediatorConfiguration implements MediatorConfiguration {
 
     private boolean useReactiveStreams = false;
 
+    private MethodParameterDescriptor descriptor;
+
+    private Type keyType;
+    private Type valueType;
+    private Class<? extends KeyValueExtractor> keyed;
+
     public String getBeanId() {
         return beanId;
     }
@@ -83,15 +91,6 @@ public class QuarkusMediatorConfiguration implements MediatorConfiguration {
 
     public void setReturnType(Class<?> returnType) {
         this.returnType = returnType;
-    }
-
-    @Override
-    public Class<?>[] getParameterTypes() {
-        return parameterTypes;
-    }
-
-    public void setParameterTypes(Class<?>[] parameterTypes) {
-        this.parameterTypes = parameterTypes;
     }
 
     public Shape getShape() {
@@ -204,6 +203,21 @@ public class QuarkusMediatorConfiguration implements MediatorConfiguration {
         return ingestedPayload;
     }
 
+    @Override
+    public Type getKeyType() {
+        return keyType;
+    }
+
+    @Override
+    public Type getValueType() {
+        return valueType;
+    }
+
+    @Override
+    public Class<? extends KeyValueExtractor> getKeyed() {
+        return keyed;
+    }
+
     public void setIngestedPayloadType(Type ingestedPayload) {
         this.ingestedPayload = ingestedPayload;
     }
@@ -274,5 +288,26 @@ public class QuarkusMediatorConfiguration implements MediatorConfiguration {
     @Override
     public boolean usesReactiveStreams() {
         return useReactiveStreams;
+    }
+
+    @Override
+    public MethodParameterDescriptor getParameterDescriptor() {
+        return descriptor;
+    }
+
+    public void setParameterDescriptor(MethodParameterDescriptor descriptor) {
+        this.descriptor = descriptor;
+    }
+
+    public void setKeyType(Type keyType) {
+        this.keyType = keyType;
+    }
+
+    public void setValueType(Type valueType) {
+        this.valueType = valueType;
+    }
+
+    public void setKeyed(Class<? extends KeyValueExtractor> keyed) {
+        this.keyed = keyed;
     }
 }

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusParameterDescriptor.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusParameterDescriptor.java
@@ -1,0 +1,45 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.smallrye.reactive.messaging.MethodParameterDescriptor;
+
+/**
+ * A Quarkus specific implementation of the {@link MethodParameterDescriptor} class.
+ * It uses data discovered at build-time to provide the data required at runtime.
+ */
+public class QuarkusParameterDescriptor implements MethodParameterDescriptor {
+
+    private List<TypeInfo> infos;
+
+    public QuarkusParameterDescriptor() {
+        // Empty constructor, required for the proxies
+    }
+
+    public QuarkusParameterDescriptor(List<TypeInfo> infos) {
+        this.infos = infos;
+    }
+
+    public List<TypeInfo> getInfos() {
+        return infos;
+    }
+
+    public void setInfos(List<TypeInfo> infos) {
+        this.infos = infos;
+    }
+
+    @Override
+    public List<Class<?>> getTypes() {
+        if (infos == null) {
+            return new ArrayList<>();
+        }
+        return infos.stream().map(TypeInfo::getName).collect(Collectors.toList());
+    }
+
+    @Override
+    public Class<?> getGenericParameterType(int paramIndex, int genericIndex) {
+        return infos.get(paramIndex).getGenerics().get(genericIndex);
+    }
+}

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/TypeInfo.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/TypeInfo.java
@@ -1,0 +1,29 @@
+package io.quarkus.smallrye.reactivemessaging.runtime;
+
+import java.util.List;
+
+/**
+ * Structure storing details of method parameters.
+ */
+public class TypeInfo {
+
+    private Class<?> name;
+
+    private List<Class<?>> generics;
+
+    public Class<?> getName() {
+        return name;
+    }
+
+    public void setName(Class<?> name) {
+        this.name = name;
+    }
+
+    public List<Class<?>> getGenerics() {
+        return generics;
+    }
+
+    public void setGenerics(List<Class<?>> generics) {
+        this.generics = generics;
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -16,10 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -813,7 +810,13 @@ public class VertxHttpRecorder {
                             try {
                                 vertx.undeploy(deploymentIdIfAny, handler);
                             } catch (Exception e) {
-                                LOGGER.warn("Failed to undeploy deployment ", e);
+                                if (e instanceof RejectedExecutionException) {
+                                    // Shutting down
+                                    LOGGER.debug("Failed to undeploy deployment because a task was rejected (due to shutdown)",
+                                            e);
+                                } else {
+                                    LOGGER.warn("Failed to undeploy deployment", e);
+                                }
                             }
                         }
 

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/DataForKeyedProducer.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/DataForKeyedProducer.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.kafka;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
+
+@ApplicationScoped
+public class DataForKeyedProducer {
+    @Outgoing("data-for-keyed-out")
+    public Multi<Message<String>> generateDataWithMetadata() {
+        return Multi.createFrom().items(
+                Message.of("a").addMetadata(OutgoingKafkaRecordMetadata.builder().withKey("a").build()),
+                Message.of("b").addMetadata(OutgoingKafkaRecordMetadata.builder().withKey("b").build()),
+                Message.of("c").addMetadata(OutgoingKafkaRecordMetadata.builder().withKey("a").build()));
+    }
+}

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/DataWithMetadataProducer.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/DataWithMetadataProducer.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.kafka;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
+
+@ApplicationScoped
+public class DataWithMetadataProducer {
+    @Outgoing("data-with-metadata-out")
+    public Multi<Message<String>> generateDataWithMetadata() {
+        return Multi.createFrom().items(
+                Message.of("a").addMetadata(OutgoingKafkaRecordMetadata.builder().withKey("a").build()),
+                Message.of("b").addMetadata(OutgoingKafkaRecordMetadata.builder().withKey("b").build()),
+                Message.of("c").addMetadata(OutgoingKafkaRecordMetadata.builder().withKey("a").build()));
+    }
+}

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/KafkaEndpoint.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/KafkaEndpoint.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.kafka;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
@@ -50,5 +51,19 @@ public class KafkaEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public List<Pet> getPets() {
         return receivers.getPets().stream().map(Record::key).collect(Collectors.toList());
+    }
+
+    @GET
+    @Path("/data-with-metadata")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, String> getDataWithMetadata() {
+        return receivers.getDataWithMetadata();
+    }
+
+    @GET
+    @Path("/data-for-keyed")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getDataForKeyed() {
+        return receivers.getDataForKeyed();
     }
 }

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/KafkaReceivers.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/KafkaReceivers.java
@@ -1,16 +1,24 @@
 package io.quarkus.it.kafka;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
+import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.kafka.Record;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata;
 import io.smallrye.reactive.messaging.kafka.commit.CheckpointMetadata;
+import io.smallrye.reactive.messaging.keyed.Keyed;
+import io.smallrye.reactive.messaging.keyed.KeyedMulti;
 
 @ApplicationScoped
 public class KafkaReceivers {
@@ -18,6 +26,8 @@ public class KafkaReceivers {
     private final List<Person> people = new CopyOnWriteArrayList<>();
     private final List<Fruit> fruits = new CopyOnWriteArrayList<>();
     private final List<Record<Pet, Person>> pets = new CopyOnWriteArrayList<>();
+    private Map<String, String> dataWithMetadata = new ConcurrentHashMap<>();
+    private List<String> dataForKeyed = new CopyOnWriteArrayList<>();
 
     static class PeopleState {
         public String names;
@@ -59,5 +69,39 @@ public class KafkaReceivers {
 
     public List<Record<Pet, Person>> getPets() {
         return pets;
+    }
+
+    @Incoming("data-with-metadata-in")
+    public void consume(String data, IncomingKafkaRecordMetadata<String, String> metadata,
+            Optional<IncomingKafkaRecordMetadata<String, String>> metadataAsOptional) {
+        if (metadataAsOptional.isEmpty()) {
+            throw new IllegalArgumentException("Expected incoming kafka metadata");
+        }
+        dataWithMetadata.put(data, metadata.getKey());
+    }
+
+    public Map<String, String> getDataWithMetadata() {
+        return dataWithMetadata;
+    }
+
+    @Incoming("data-for-keyed-in")
+    @Outgoing("data-for-keyed-intermediary")
+    public Multi<String> processFromKafka(KeyedMulti<String, String> data) {
+        return data.map(s -> data.key() + "-" + s);
+    }
+
+    @Incoming("data-for-keyed-intermediary")
+    @Outgoing("data-for-keyed-sink")
+    public Multi<String> processIntermediary(@Keyed(MyPayloadExtractor.class) KeyedMulti<String, String> data) {
+        return data.map(s -> data.key() + "-" + s);
+    }
+
+    @Incoming("data-for-keyed-sink")
+    public void consumeDataForKeyed(String s) {
+        dataForKeyed.add(s);
+    }
+
+    public List<String> getDataForKeyed() {
+        return dataForKeyed;
     }
 }

--- a/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/MyPayloadExtractor.java
+++ b/integration-tests/reactive-messaging-kafka/src/main/java/io/quarkus/it/kafka/MyPayloadExtractor.java
@@ -1,0 +1,29 @@
+package io.quarkus.it.kafka;
+
+import java.lang.reflect.Type;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.reactive.messaging.keyed.KeyValueExtractor;
+
+@ApplicationScoped
+public class MyPayloadExtractor implements KeyValueExtractor {
+    @Override
+    public boolean canExtract(Message<?> message, Type type, Type type1) {
+        return false; // Only used with @Keyed
+    }
+
+    @Override
+    public Object extractKey(Message<?> message, Type type) {
+        String[] seg = ((String) message.getPayload()).split("-");
+        return seg[0].toUpperCase();
+    }
+
+    @Override
+    public Object extractValue(Message<?> message, Type type) {
+        String[] seg = ((String) message.getPayload()).split("-");
+        return seg[1];
+    }
+}

--- a/integration-tests/reactive-messaging-kafka/src/main/resources/application.properties
+++ b/integration-tests/reactive-messaging-kafka/src/main/resources/application.properties
@@ -31,3 +31,12 @@ mp.messaging.outgoing.prices-out2.topic=prices2
 
 mp.messaging.incoming.prices-in.topic=prices
 mp.messaging.incoming.prices-in2.topic=prices2
+
+###### Metadata injection test
+mp.messaging.outgoing.data-with-metadata-out.topic=data-with-metadata
+mp.messaging.incoming.data-with-metadata-in.topic=data-with-metadata
+
+###### Metadata injection test
+mp.messaging.outgoing.data-for-keyed-out.topic=data-for-keyed
+mp.messaging.incoming.data-for-keyed-in.topic=data-for-keyed
+

--- a/integration-tests/reactive-messaging-kafka/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
+++ b/integration-tests/reactive-messaging-kafka/src/test/java/io/quarkus/it/kafka/KafkaConnectorTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.get;
 import static org.awaitility.Awaitility.await;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,30 @@ public class KafkaConnectorTest {
     public void testPrices() {
         KafkaRepeatableReceivers repeatableReceivers = Arc.container().instance(KafkaRepeatableReceivers.class).get();
         await().untilAsserted(() -> Assertions.assertEquals(repeatableReceivers.getPrices().size(), 6));
+    }
+
+    @Test
+    public void testDataWithMetadata() {
+        await().untilAsserted(() -> {
+            Map<String, String> map = get("/kafka/data-with-metadata").as(new TypeRef<Map<String, String>>() {
+            });
+            Assertions.assertEquals(3, map.size());
+            Assertions.assertEquals("a", map.get("a"));
+            Assertions.assertEquals("a", map.get("a"));
+            Assertions.assertEquals("b", map.get("b"));
+        });
+    }
+
+    @Test
+    public void testDataForKeyed() {
+        await().untilAsserted(() -> {
+            List<String> list = get("/kafka/data-for-keyed").as(new TypeRef<List<String>>() {
+            });
+            Assertions.assertEquals(3, list.size());
+            Assertions.assertTrue(list.contains("A-a"));
+            Assertions.assertTrue(list.contains("A-c"));
+            Assertions.assertTrue(list.contains("B-b"));
+        });
     }
 
 }


### PR DESCRIPTION
- Bump the version
- Integrate metadata injection
- Change the deserializer discovery logic when metadata injection is used
- Make sure metadata injection works with Kafka, including in native mode
- Improve exception handling when the dev mode terminates
- Integrate KeyedMulti
- Make sure keyed multi works with Kafka, including in native mode
- Handle deserializer extraction when using a KeyedMulti
