### PR TITLE
ArC fixes for spec compatibility, round 10

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -49,7 +49,7 @@
         <commonmark.version>0.21.0</commonmark.version>
 
         <!-- Arquillian BOM -->
-        <arquillian.version>1.7.0.Alpha13</arquillian.version>
+        <arquillian.version>1.7.0.Final</arquillian.version>
 
         <!-- Enable APT by default for Eclipse -->
         <m2e.apt.activation>jdt_apt</m2e.apt.activation>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -58,7 +58,7 @@
         <version.kotlin-coroutines>1.6.4</version.kotlin-coroutines>
         <version.mockito>5.3.1</version.mockito>
         <!-- TCK versions -->
-        <version.arquillian>1.7.0.Alpha14</version.arquillian>
+        <version.arquillian>1.7.0.Final</version.arquillian>
         <version.atinject-tck>2.0.1</version.atinject-tck>
         <version.cdi-tck>4.0.9</version.cdi-tck>
         <version.junit4>4.13.2</version.junit4>

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -582,8 +582,8 @@ public class BeanInfo implements InjectionTargetInfo {
     }
 
     void validate(List<Throwable> errors, Consumer<BytecodeTransformer> bytecodeTransformerConsumer,
-            Set<DotName> classesReceivingNoArgsCtor) {
-        Beans.validateBean(this, errors, bytecodeTransformerConsumer, classesReceivingNoArgsCtor);
+            Set<DotName> classesReceivingNoArgsCtor, Set<BeanInfo> injectedBeans) {
+        Beans.validateBean(this, errors, bytecodeTransformerConsumer, classesReceivingNoArgsCtor, injectedBeans);
     }
 
     void validateInterceptorDecorator(List<Throwable> errors, Consumer<BytecodeTransformer> bytecodeTransformerConsumer) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -797,7 +797,7 @@ public class BeanInfo implements InjectionTargetInfo {
 
     private void addClassLevelBindings(ClassInfo targetClass, Collection<AnnotationInstance> bindings) {
         List<AnnotationInstance> classLevelBindings = new ArrayList<>();
-        doAddClassLevelBindings(targetClass, classLevelBindings, Set.of());
+        doAddClassLevelBindings(targetClass, classLevelBindings, Set.of(), false);
         bindings.addAll(classLevelBindings);
         if (!stereotypes.isEmpty()) {
             // interceptor binding declared on a bean class replaces an interceptor binding of the same type
@@ -808,22 +808,27 @@ public class BeanInfo implements InjectionTargetInfo {
             }
             for (StereotypeInfo stereotype : Beans.stereotypesWithTransitive(stereotypes,
                     beanDeployment.getStereotypesMap())) {
-                doAddClassLevelBindings(stereotype.getTarget(), bindings, skip);
+                doAddClassLevelBindings(stereotype.getTarget(), bindings, skip, false);
             }
         }
     }
 
     // bindings whose class name is present in `skip` are ignored (this is used to ignore bindings on stereotypes
     // when the original class has a binding of the same type)
-    private void doAddClassLevelBindings(ClassInfo classInfo, Collection<AnnotationInstance> bindings, Set<DotName> skip) {
+    private void doAddClassLevelBindings(ClassInfo classInfo, Collection<AnnotationInstance> bindings, Set<DotName> skip,
+            boolean onlyInherited) {
         beanDeployment.getAnnotations(classInfo).stream()
                 .filter(a -> beanDeployment.getInterceptorBinding(a.name()) != null)
                 .filter(a -> !skip.contains(a.name()))
+                .filter(a -> !onlyInherited
+                        || beanDeployment.hasAnnotation(beanDeployment.getInterceptorBinding(a.name()), DotNames.INHERITED))
                 .forEach(bindings::add);
         if (classInfo.superClassType() != null && !classInfo.superClassType().name().equals(DotNames.OBJECT)) {
             ClassInfo superClass = getClassByName(beanDeployment.getBeanArchiveIndex(), classInfo.superName());
             if (superClass != null) {
-                doAddClassLevelBindings(superClass, bindings, skip);
+                // proper interceptor binding inheritance only in strict mode, due to Quarkus expecting security
+                // annotations (such as `@RolesAllowed`) to be inherited, even though they are not `@Inherited`
+                doAddClassLevelBindings(superClass, bindings, skip, beanDeployment.strictCompatibility);
             }
         }
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
@@ -78,6 +78,12 @@ public class ClientProxyGenerator extends AbstractGenerator {
     Collection<Resource> generate(BeanInfo bean, String beanClassName,
             Consumer<BytecodeTransformer> bytecodeTransformerConsumer, boolean transformUnproxyableClasses) {
 
+        // see `BeanGenerator` -- if this bean is unproxyable and that error is deferred to runtime,
+        // we don't need to (and cannot, in fact) generate the client proxy class
+        if (bean.getDeployment().hasRuntimeDeferredUnproxyableError(bean)) {
+            return Collections.emptySet();
+        }
+
         ProviderType providerType = new ProviderType(bean.getProviderType());
         ClassInfo providerClass = getClassByName(bean.getDeployment().getBeanArchiveIndex(), providerType.name());
         String baseName = getBaseName(bean, beanClassName);

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InstanceHandle.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InstanceHandle.java
@@ -64,6 +64,12 @@ public interface InstanceHandle<T> extends AutoCloseable, Instance.Handle<T> {
      */
     @Override
     default void close() {
+        // https://github.com/quarkusio/quarkus/issues/33665
+        if (Arc.container().strictCompatibility()) {
+            destroy();
+            return;
+        }
+
         InjectableBean<T> bean = getBean();
         if (bean == null || Dependent.class.equals(bean.getScope())) {
             destroy();

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -60,11 +60,7 @@
             <class name="org.jboss.cdi.tck.tests.interceptors.definition.inheritance.InterceptorBindingInheritanceTest">
                 <methods>
                     <exclude name="testInterceptorBindingDirectlyInheritedFromManagedBean"/>
-                    <exclude name="testMethodInterceptorBindingDirectlyInheritedFromManagedBean"/>
-                    <exclude name="testMethodInterceptorBindingDirectlyNotInheritedFromManagedBean"/>
-                    <exclude name="testMethodInterceptorBindingIndirectlyInheritedFromManagedBean"/>
                     <exclude name="testInterceptorBindingIndirectlyInheritedFromManagedBean"/>
-                    <exclude name="testMethodInterceptorBindingIndirectlyNotInheritedFromManagedBean"/>
                 </methods>
             </class>
             <class name="org.jboss.cdi.tck.tests.lookup.injectionpoint.InjectionPointTest">

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -100,12 +100,6 @@
                     <exclude name="testInterceptorsImplementInterceptorInterface"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.lookup.dynamic.handle.InstanceHandleTest">
-                <methods>
-                    <exclude name="testGetHandle"/>
-                    <exclude name="testHandles"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.context.dependent.DependentContextTest">
                 <methods>
                     <!-- https://github.com/jakartaee/cdi-tck/pull/452 -->

--- a/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/src/test/resources/testng.xml
@@ -81,15 +81,6 @@
                     <exclude name="testGetBean"/>
                 </methods>
             </class>
-            <class name="org.jboss.cdi.tck.tests.implementation.simple.lifecycle.unproxyable.UnproxyableManagedBeanTest">
-                <methods>
-                    <exclude name="testNormalScopedUnproxyableBeanWithPublicFinalMethodResolution"/>
-                    <exclude name="testNormalScopedUnproxyableBeanWithPrivateConstructorResolution"/>
-                    <exclude name="testNormalScopedUnproxyableBeanWithFinalClassResolution"/>
-                    <exclude name="testNormalScopedUnproxyableBeanWithPackagePrivateFinalMethodResolution"/>
-                    <exclude name="testNormalScopedUnproxyableBeanWithProtectedFinalMethodResolution"/>
-                </methods>
-            </class>
             <class name="org.jboss.cdi.tck.tests.interceptors.definition.InterceptorDefinitionTest">
                 <methods>
                     <!-- https://github.com/jakartaee/cdi-tck/issues/455 -->

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcInitConfig;
 import io.quarkus.arc.ComponentsProvider;
 import io.quarkus.arc.ResourceReferenceProvider;
 import io.quarkus.arc.processor.AlternativePriorities;
@@ -468,7 +469,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
                     .setContextClassLoader(testClassLoader);
 
             // Now we are ready to initialize Arc
-            Arc.initialize();
+            Arc.initialize(ArcInitConfig.builder().setStrictCompatibility(strictCompatibility).build());
 
         } catch (Throwable e) {
             if (shouldFail) {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/finalmethod/FinalMethodIllegalWhenInjectedTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/finalmethod/FinalMethodIllegalWhenInjectedTest.java
@@ -5,17 +5,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.test.ArcTestContainer;
 
-public class FinalMethodIllegalTest {
+public class FinalMethodIllegalWhenInjectedTest {
     @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
-            .beanClasses(Moo.class)
+            .beanClasses(Moo.class, MooConsumer.class)
             .strictCompatibility(true)
             .shouldFail()
             .build();
@@ -33,5 +35,12 @@ public class FinalMethodIllegalTest {
         final int getVal() {
             return -1;
         }
+    }
+
+    // to trigger deployment-time error (in strict compatible mode)
+    @Dependent
+    static class MooConsumer {
+        @Inject
+        Moo moo;
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/finalmethod/FinalMethodIllegalWhenNotInjectedTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/finalmethod/FinalMethodIllegalWhenNotInjectedTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.arc.test.clientproxy.finalmethod;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.UnproxyableResolutionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class FinalMethodIllegalWhenNotInjectedTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Moo.class)
+            .strictCompatibility(true)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void test() {
+        assertThrows(UnproxyableResolutionException.class, () -> {
+            Arc.container().instance(Moo.class).get();
+        });
+    }
+
+    @ApplicationScoped
+    static class Moo {
+        final int getVal() {
+            return -1;
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/destroy/InstanceHandleDestroyTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/destroy/InstanceHandleDestroyTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.arc.test.instance.destroy;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InstanceHandleDestroyTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer.Builder()
+            .beanClasses(MyDependentBean.class, MyAppScopedBean.class)
+            .strictCompatibility(true)
+            .build();
+
+    @Test
+    public void testDestroy() {
+        assertFalse(MyDependentBean.DESTROYED.get());
+        try (InstanceHandle<MyDependentBean> handle = Arc.container().instance(MyDependentBean.class)) {
+            assertNotNull(handle.get().toString());
+        }
+        assertTrue(MyDependentBean.DESTROYED.get());
+
+        // normal-scoped
+        String oldId;
+        assertFalse(MyAppScopedBean.DESTROYED.get());
+        try (InstanceHandle<MyAppScopedBean> handle = Arc.container().instance(MyAppScopedBean.class)) {
+            assertNotNull(handle.get().toString());
+            oldId = handle.get().getId();
+        }
+        assertTrue(MyAppScopedBean.DESTROYED.get());
+
+        String newId = Arc.container().instance(MyAppScopedBean.class).get().getId();
+        assertNotEquals(oldId, newId);
+    }
+
+    @Dependent
+    static class MyDependentBean {
+        static final AtomicBoolean DESTROYED = new AtomicBoolean(false);
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.set(true);
+        }
+    }
+
+    @ApplicationScoped
+    static class MyAppScopedBean {
+        static final AtomicBoolean DESTROYED = new AtomicBoolean(false);
+
+        String id;
+
+        String getId() {
+            return id;
+        }
+
+        @PostConstruct
+        void init() {
+            this.id = UUID.randomUUID().toString();
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.set(true);
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/inherited/InheritedBindingOnBeanTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/inherited/InheritedBindingOnBeanTest.java
@@ -1,0 +1,96 @@
+package io.quarkus.arc.test.interceptors.bindings.inherited;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InheritedBindingOnBeanTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer.Builder()
+            .beanClasses(MyBean.class, FooBinding.class, BarBinding.class, FooInterceptor.class, BarInterceptor.class)
+            .strictCompatibility(true) // correct interceptor binding inheritance
+            .build();
+
+    @Test
+    public void testInterception() {
+        MyBean bean = Arc.container().instance(MyBean.class).get();
+        assertNotNull(bean);
+        bean.doSomething();
+        assertTrue(FooInterceptor.intercepted);
+        assertFalse(BarInterceptor.intercepted);
+    }
+
+    @FooBinding
+    @BarBinding
+    static class MySuperclass {
+    }
+
+    @Singleton
+    static class MyBean extends MySuperclass {
+        void doSomething() {
+        }
+    }
+
+    @Target({ TYPE, METHOD })
+    @Retention(RUNTIME)
+    @Documented
+    @InterceptorBinding
+    @Inherited
+    @interface FooBinding {
+    }
+
+    @Target({ TYPE, METHOD })
+    @Retention(RUNTIME)
+    @Documented
+    @InterceptorBinding
+    // not @Inherited
+    @interface BarBinding {
+    }
+
+    @FooBinding
+    @Interceptor
+    @Priority(1)
+    static class FooInterceptor {
+        static boolean intercepted = false;
+
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            intercepted = true;
+            return ctx.proceed();
+        }
+    }
+
+    @BarBinding
+    @Interceptor
+    @Priority(1)
+    static class BarInterceptor {
+        static boolean intercepted = false;
+
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            intercepted = true;
+            return ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/inherited/InheritedMethodsWithInterceptorBindingTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/inherited/InheritedMethodsWithInterceptorBindingTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.arc.test.interceptors.bindings.inherited;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class InheritedMethodsWithInterceptorBindingTest {
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(MyBean.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void test() {
+        MyBean bean = Arc.container().instance(MyBean.class).get();
+        assertEquals("foobar", bean.foobar());
+        assertEquals("intercepted: foobar", bean.foobarNotInherited());
+    }
+
+    static class MySuperclass {
+        @MyInterceptorBinding
+        String foobar() {
+            return "this should be ignored";
+        }
+
+        @MyInterceptorBinding
+        String foobarNotInherited() {
+            return "foobar";
+        }
+    }
+
+    @Dependent
+    static class MyBean extends MySuperclass {
+        @Override
+        String foobar() {
+            return "foobar";
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Priority(1)
+    @Interceptor
+    static class MyInterceptor {
+        @AroundInvoke
+        public Object intercept(InvocationContext ctx) throws Exception {
+            return "intercepted: " + ctx.proceed();
+        }
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/noclassinterceptors/InheritedClassLevel.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/noclassinterceptors/InheritedClassLevel.java
@@ -6,6 +6,7 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -15,5 +16,6 @@ import jakarta.interceptor.InterceptorBinding;
 @Retention(RUNTIME)
 @Documented
 @InterceptorBinding
+@Inherited
 public @interface InheritedClassLevel {
 }


### PR DESCRIPTION
Related to #28558

- fix `InstanceHandle.close()` to behave as specified in strict mode
  - there's a contention between what we want in ArC and what CDI specifies, so this needs future work
- fix inheritance of interceptor binding annotations
  - 2 fixes actually:
    - fix inheritance of non-`@Inherited` class-level interceptor bindings, but only in strict mode, because Quarkus expects security annotations to be inherited even though they are not `@Inherited`
    - fix inheritance of interceptor bindings on methods, as method-level annotations are never inherited
  - ideally, the fix for class-level interceptor bindings would apply unconditionally, but I'm leaving that for the future
- defer unproxyability errors to runtime in strict mode
  - the CDI spec demands that if a bean isn't injected anywhere, unproxyability shouldn't be a deployment problem, but an exception at runtime
  - this is not necessarily what we want in ArC, so again, this needs future work
- upgrade Arquillian to 1.7.0.Final

With these changes, the only remaining TCK exclusions are tests that have been challenged. With an upcoming release of CDI TCK 4.0.10, we'll pass the entire CDI Lite TCK (with exactly 1 exclusion for a challenged test) :tada: 