### PR TITLE
Update Vert.x Mutiny bindings to version 3.4.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -67,7 +67,7 @@
         <smallrye-context-propagation.version>2.1.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.0</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.3.0</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.4.1</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.6.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.2.0</smallrye-stork.version>
         <jakarta.activation.version>2.1.2</jakarta.activation.version>


### PR DESCRIPTION
This version uses Vert.x 4.4.2.
