### PR TITLE
Dev UI new common component for no-service/data

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/qwc-resteasy-reactive-endpoint-scores.js
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/resources/dev-ui/qwc-resteasy-reactive-endpoint-scores.js
@@ -5,6 +5,7 @@ import '@vaadin/details';
 import '@vaadin/horizontal-layout';
 import 'echarts-gauge-grade';
 import 'qui-badge';
+import 'qwc-no-data';
 
 /**
  * This component shows the Rest Easy Reactive Endpoint scores
@@ -98,10 +99,13 @@ export class QwcResteasyReactiveEndpointScores extends QwcHotReloadElement {
                 return html`${this._latestScores.endpoints.map(endpoint=>{
                     return html`${this._renderEndpoint(endpoint)}`;
                 })}`;
-            }else{
-                return html`<p>No endpoints detected</p>`;
             }
         }
+        return html`<qwc-no-data message="You do not have any REST endpoints." 
+                                    link="https://quarkus.io/guides/resteasy-reactive"
+                                    linkText="Learn how to write REST Services with RESTEasy Reactive">
+                </qwc-no-data>
+            `;
     }
 
     _renderEndpoint(endpoint){

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -81,6 +81,7 @@ public class BuildTimeContentProcessor {
         internalImportMapBuildItem.add("devui/", contextRoot);
         // Quarkus Web Components
         internalImportMapBuildItem.add("qwc/", contextRoot + "qwc/");
+        internalImportMapBuildItem.add("qwc-no-data", contextRoot + "qwc/qwc-no-data.js");
         internalImportMapBuildItem.add("qwc-hot-reload-element", contextRoot + "qwc/qwc-hot-reload-element.js");
         internalImportMapBuildItem.add("qwc-server-log", contextRoot + "qwc/qwc-server-log.js");
         internalImportMapBuildItem.add("qwc-extension-link", contextRoot + "qwc/qwc-extension-link.js");

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-dev-services.js
@@ -3,6 +3,7 @@ import { devServices } from 'devui-data';
 import '@vaadin/icon';
 import 'qui-code-block';
 import 'qui-card';
+import 'qwc-no-data';
 
 /**
  * This component shows the Dev Services Page
@@ -35,22 +36,7 @@ export class QwcDevServices extends QwcHotReloadElement {
             padding-left: 10px;
             background: var(--lumo-contrast-5pct);
         }
-
-        .no-dev-services {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 10px;
-            border: 1px solid var(--lumo-contrast-20pct);
-            border-radius: 9px;
-            padding: 30px;
-            margin: 30px;
-        }
-        .no-dev-services a {
-            color: var(--lumo-contrast-90pct);
-        }
     `;
-
 
     static properties = {
         _services: {state: true}
@@ -73,10 +59,10 @@ export class QwcDevServices extends QwcHotReloadElement {
                             ${this._services.map(devService => this._renderCard(devService))}  
                         </div>`;
         } else {
-            return html`<p class="no-dev-services">
-                    <span>You do not have any Dev Services running.</span>
-                    <a href="https://quarkus.io/guides/dev-services" target="_blank">Read more about Dev Services</a>
-                </p>
+            return html`<qwc-no-data message="You do not have any Dev Services running." 
+                                    link="https://quarkus.io/guides/dev-services"
+                                    linkText="Read more about Dev Services">
+                </qwc-no-data>
             `;
         }
     }

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-no-data.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-no-data.js
@@ -1,0 +1,52 @@
+import { LitElement, html, css } from 'lit';
+
+/**
+ * This component can we used to show if there is not data to show
+ */
+export class QwcNoData extends LitElement {
+    static styles = css`
+        .nodata {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 10px;
+            border: 1px solid var(--lumo-contrast-20pct);
+            border-radius: 9px;
+            padding: 30px;
+            margin: 30px;
+        }
+        .nodata a {
+            color: var(--lumo-contrast-90pct);
+        }
+    `;
+
+
+    static properties = {
+        message: {attribute: true},
+        link: {attribute: true},
+        linkText: {attribute: true},
+    };
+
+    constructor() {
+        super();
+        this.message = "No data to display";
+        this.link = null;
+        this.linkText = "See the documentation for more information";
+    }
+
+    render() {
+        return html`<p class="nodata">
+                <span>${this.message}</span>
+                ${this._renderLink()}
+            </p>
+        `;
+    }
+    
+    _renderLink(){
+        if(this.link){
+            return html`<a href="${this.link}" target="_blank"> ${this.linkText}</a>`;
+        }
+    }
+}
+
+customElements.define('qwc-no-data', QwcNoData);


### PR DESCRIPTION
Fix #32234

This PR introduce a new component that can be used to show if there is no data / services. It's taken from the part used if there is no dev services, and no also used for Rest Endpoints.

Here the REST Endpoint example:

![common-component-for-no-data](https://github.com/quarkusio/quarkus/assets/6836179/8c3e475b-3184-4c63-9463-b5200c87c0f7)
