### PR TITLE
Improve log messages related to OIDC session cookie encryption secret

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -372,15 +372,23 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public boolean splitTokens;
 
         /**
-         * Requires that the tokens are encrypted before being stored in the cookies.
+         * Mandates that the session cookie that stores the tokens is encrypted.
          */
         @ConfigItem(defaultValue = "true")
         public boolean encryptionRequired = true;
 
         /**
-         * Secret which will be used to encrypt the tokens.
-         * This secret must be set if the token encryption is required but no client secret is set.
-         * The length of the secret which will be used to encrypt the tokens must be 32 characters long.
+         * Secret which will be used to encrypt the session cookie storing the tokens when {@link #encryptionRequired} property
+         * is enabled.
+         * <p>
+         * If this secret is not set, the client secret configured with
+         * either `quarkus.oidc.credentials.secret` or `quarkus.oidc.credentials.client-secret.value` will be checked.
+         * Finally, `quarkus.oidc.credentials.jwt.secret` which can be used for `client_jwt_secret` authentication will be
+         * checked.
+         * The secret will be auto-generated if it remains uninitialized after checking all of these properties.
+         * <p>
+         * The length of the secret which will be used to encrypt the tokens should be at least 32 characters long.
+         * Warning will be logged if the secret length is less than 16 characters.
          */
         @ConfigItem
         public Optional<String> encryptionSecret = Optional.empty();


### PR DESCRIPTION
Fixes #33532.

@geoand Can you please review and help to improve the wording ? No OIDC logic has been affected, only more log messages are added, and the warning is issued when the encryption key strength is low.

@rgmz FYI. 

Note, OIDC code could've avoided falling back to the configured secrets and just generated a random secret but that would increase the risk of the applications being broken (after restarts in devmode, multiple pods) and force users disable the encryption in any case. Seeing a log message is less intrusive. 

What I have also done is to log a warning when the key strength is very low (less than 16 chars) but only debug when the key is strong enough - that should improve the experience as the secrets generated by providers will most definitelybe at least 16 characters long. It looks like the warning message can frustrate quite a few users - the whole session cookie encryption is a hardening fix, so for users running securely over HTTPS or internal networks it can be a bit annoying having to go and disable the encryption just to get rid of the warning.

I also did not go into all the details how the fallback works, as the client secret can be configured in one of the 2 ways, and then if it is a `client_jwt_secret` authentication between Quarkus and OIDC then it is a jwt secret property, and listing all of that would make a difficult to follow doc. But I added more log messages to show how the fallback might work.