### PR TITLE
Properly include Prometheus related code

### DIFF
--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/PrometheusRegistryProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/PrometheusRegistryProcessor.java
@@ -39,7 +39,8 @@ public class PrometheusRegistryProcessor {
         MicrometerConfig mConfig;
 
         public boolean getAsBoolean() {
-            return REGISTRY_CLASS != null && mConfig.checkRegistryEnabledWithDefault(mConfig.export.prometheus);
+            return (REGISTRY_CLASS != null) && QuarkusClassLoader.isClassPresentAtRuntime(REGISTRY_CLASS_NAME)
+                    && mConfig.checkRegistryEnabledWithDefault(mConfig.export.prometheus);
         }
     }
 


### PR DESCRIPTION
The way the test was being done previously
was checking the build time classpath instead
of the runtime class for the presence of the
Prometheus Registry.

Fixes: #33547