### PR TITLE
Removed manual OTel properties for fallback, since they are now provided automatically

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryLegacyConfigurationTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryLegacyConfigurationTest.java
@@ -17,6 +17,7 @@ import io.quarkus.opentelemetry.runtime.config.build.exporter.OtlpExporterBuildC
 import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
 import io.quarkus.opentelemetry.runtime.config.runtime.exporter.OtlpExporterRuntimeConfig;
 import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.config.SmallRyeConfig;
 
 class OpenTelemetryLegacyConfigurationTest {
     @RegisterExtension
@@ -41,6 +42,8 @@ class OpenTelemetryLegacyConfigurationTest {
     OtlpExporterBuildConfig otlpExporterBuildConfig;
     @Inject
     OtlpExporterRuntimeConfig otlpExporterRuntimeConfig;
+    @Inject
+    SmallRyeConfig config;
 
     @Test
     void config() {
@@ -60,5 +63,26 @@ class OpenTelemetryLegacyConfigurationTest {
         assertTrue(otlpExporterRuntimeConfig.traces().headers().isPresent());
         assertEquals("header=value", otlpExporterRuntimeConfig.traces().headers().get().get(0));
         assertEquals("http://localhost:4318/", otlpExporterRuntimeConfig.traces().legacyEndpoint().get());
+    }
+
+    @Test
+    void names() {
+        assertTrue(config.isPropertyPresent("quarkus.otel.enabled"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.metrics.exporter"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.propagators"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.logs.exporter"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.traces.enabled"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.traces.exporter"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.traces.sampler"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.sdk.disabled"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.service.name"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.attribute.count.limit"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.span.attribute.count.limit"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.span.event.count.limit"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.span.link.count.limit"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.bsp.schedule.delay"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.bsp.max.queue.size"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.bsp.max.export.batch.size"));
+        assertTrue(config.isPropertyPresent("quarkus.otel.bsp.export.timeout"));
     }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/OTelFallbackConfigSourceInterceptor.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/OTelFallbackConfigSourceInterceptor.java
@@ -72,27 +72,6 @@ public class OTelFallbackConfigSourceInterceptor extends FallbackConfigSourceInt
                 names.add(name);
             }
         }
-
-        // TODO - Required because the defaults ConfigSource for mappings does not provide configuration names.
-        names.add("quarkus.otel.enabled");
-        names.add("quarkus.otel.metrics.exporter");
-        names.add("quarkus.otel.propagators");
-        names.add("quarkus.otel.logs.exporter");
-        names.add("quarkus.otel.traces.enabled");
-        names.add("quarkus.otel.traces.exporter");
-        names.add("quarkus.otel.traces.sampler");
-        names.add("quarkus.otel.sdk.disabled");
-        names.add("quarkus.otel.service.name");
-        names.add("quarkus.otel.attribute.value.length.limit");
-        names.add("quarkus.otel.attribute.count.limit");
-        names.add("quarkus.otel.span.attribute.count.limit");
-        names.add("quarkus.otel.span.event.count.limit");
-        names.add("quarkus.otel.span.link.count.limit");
-        names.add("quarkus.otel.bsp.schedule.delay");
-        names.add("quarkus.otel.bsp.max.queue.size");
-        names.add("quarkus.otel.bsp.max.export.batch.size");
-        names.add("quarkus.otel.bsp.export.timeout");
-        names.add("quarkus.otel.experimental.resource.disabled-keys");
         return names.iterator();
     }
 }


### PR DESCRIPTION
- Fixes #33493

The issue was caused by the manual list provided of the OTel properties. Because this was provided manually and the interceptor was applied to every config phase, there was no distinction between build time or runtime properties. This resulted in the property appearing to be available when it was not.