### PR TITLE
Avoid null pointer exception when resolving generics in RR

### DIFF
--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/TypeArgMapper.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/TypeArgMapper.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.reactive.common.processor;
 
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.OBJECT;
+
 import java.util.List;
 import java.util.function.Function;
 
@@ -24,7 +26,7 @@ public class TypeArgMapper implements Function<String, Type> {
         ClassInfo declarer = declaringClass;
         int pos = -1;
         for (;;) {
-            if (declarer == null) {
+            if (declarer == null || OBJECT.equals(declarer.name())) {
                 return null;
             }
             List<TypeVariable> typeParameters = declarer.typeParameters();


### PR DESCRIPTION
This pull request does not provide support for generics when using sub resources, but avoid giving a null pointer exception. I found this issue when looking at https://github.com/quarkusio/quarkus/issues/30127.