### PR TITLE
Fix typo in grpc in-process runtime config

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/InProcess.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/InProcess.java
@@ -10,13 +10,13 @@ import io.quarkus.runtime.annotations.ConfigItem;
 @ConfigGroup
 public class InProcess {
     /**
-     * Explicitly enable use of in-progress.
+     * Explicitly enable use of in-process.
      */
     @ConfigItem(defaultValue = "false")
     public boolean enabled;
 
     /**
-     * Set in-progress name.
+     * Set in-process name.
      */
     @ConfigItem(defaultValue = "quarkus-grpc")
     public String name;


### PR DESCRIPTION
This affects what is displayed in the docs at
https://quarkus.io/guides/grpc-service-implementation#server-configuration