### PR TITLE
Fix check to return existing marshaller if class is already bounded

### DIFF
--- a/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextConfigRecorder.java
+++ b/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextConfigRecorder.java
@@ -24,6 +24,6 @@ public class JaxbContextConfigRecorder {
     }
 
     public static boolean isClassBound(Class<?> clazz) {
-        return classesToBeBound.contains(clazz.getName());
+        return classesToBeBound.contains(clazz);
     }
 }


### PR DESCRIPTION
It used to create new marshaller everytime.

Closes: #33579