### PR TITLE
Use 'target' as output dir for platform test classes loaded from JARs

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
@@ -205,7 +205,7 @@ public class BootstrapAppModelFactory {
         if (serializedModel != null) {
             final Path p = Paths.get(serializedModel);
             if (Files.exists(p)) {
-                try (InputStream existing = Files.newInputStream(Paths.get(serializedModel))) {
+                try (InputStream existing = Files.newInputStream(p)) {
                     final ApplicationModel appModel = (ApplicationModel) new ObjectInputStream(existing).readObject();
                     return new CurationResult(appModel);
                 } catch (IOException | ClassNotFoundException e) {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
@@ -292,14 +292,10 @@ public final class PathTestHelper {
      * @return project build dir
      */
     public static Path getProjectBuildDir(Path projectRoot, Path testClassLocation) {
-        Path outputDir;
-        try {
-            // this should work for both maven and gradle
-            outputDir = projectRoot.resolve(projectRoot.relativize(testClassLocation).getName(0));
-        } catch (Exception e) {
-            // this shouldn't happen since testClassLocation is usually found under the project dir
-            outputDir = projectRoot;
+        if (!testClassLocation.startsWith(projectRoot)) {
+            // this typically happens in the platform testsuite where test classes are loaded from jars
+            return projectRoot.resolve("target");
         }
-        return outputDir;
+        return projectRoot.resolve(projectRoot.relativize(testClassLocation).getName(0));
     }
 }


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/33305