### PR TITLE
Fix support of InputStream multipart without filename in REST Client

### DIFF
--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -1706,10 +1706,12 @@ public class JaxrsClientReactiveProcessor {
 
     private void addInputStream(BytecodeCreator methodCreator, AssignableResultHandle multipartForm, String formParamName,
             String partType, String partFilename, ResultHandle fieldValue, String type) {
+        ResultHandle formParamResult = methodCreator.load(formParamName);
+        ResultHandle partFilenameResult = partFilename == null ? formParamResult : methodCreator.load(partFilename);
         methodCreator.assign(multipartForm,
                 methodCreator.invokeVirtualMethod(MethodDescriptor.ofMethod(QuarkusMultipartForm.class, "entity",
                         QuarkusMultipartForm.class, String.class, String.class, Object.class, String.class, Class.class),
-                        multipartForm, methodCreator.load(formParamName), methodCreator.load(partFilename), fieldValue,
+                        multipartForm, formParamResult, partFilenameResult, fieldValue,
                         methodCreator.load(partType),
                         // FIXME: doesn't support generics
                         methodCreator.loadClassFromTCCL(type)));

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/MultipartFilenameTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/multipart/MultipartFilenameTest.java
@@ -111,6 +111,10 @@ public class MultipartFilenameTest {
         // Using a field form param
         assertThat(client.postMultipartWithPartFilenameUsingInputStream(new ByteArrayInputStream(bytes)))
                 .isEqualTo(EXPECTED_OUTPUT);
+        // Using rest data annotation without filename
+        ClientRestFormUsingInputStream restForm = new ClientRestFormUsingInputStream();
+        restForm.file = new ByteArrayInputStream(bytes);
+        assertThat(client.postMultipartWithPartFilenameUsingInputStream(restForm)).isEqualTo("myFile:" + FILE_CONTENT);
     }
 
     @Test
@@ -279,6 +283,11 @@ public class MultipartFilenameTest {
         @POST
         @Path("/using-form-data")
         @Consumes(MediaType.MULTIPART_FORM_DATA)
+        String postMultipartWithPartFilenameUsingInputStream(@MultipartForm ClientRestFormUsingInputStream clientForm);
+
+        @POST
+        @Path("/using-form-data")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
         String postMultipartWithPartFilenameUsingInputStream(
                 @FormParam("myFile") @PartType(APPLICATION_OCTET_STREAM) @PartFilename(FILE_NAME) InputStream file);
 
@@ -342,6 +351,12 @@ public class MultipartFilenameTest {
         @FormParam("myFile")
         @PartType(APPLICATION_OCTET_STREAM)
         @PartFilename(FILE_NAME)
+        public InputStream file;
+    }
+
+    public static class ClientRestFormUsingInputStream {
+        @RestForm("myFile")
+        @PartType(APPLICATION_OCTET_STREAM)
         public InputStream file;
     }
 


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/33601

I've confirmed that when using Multi<Byte>, it works fine and it also uses the field name as filename by default. 