### PR TITLE
Automatically execute plugin goals configured in phases preceding quarkus:dev

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/Playground.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/Playground.java
@@ -1,0 +1,19 @@
+package io.quarkus.bootstrap.resolver.maven.workspace;
+
+import java.io.File;
+
+import org.eclipse.aether.artifact.DefaultArtifact;
+
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+
+public class Playground {
+
+    public static void main(String[] args) throws Exception {
+
+        MavenArtifactResolver.builder()
+                .setWorkspaceDiscovery(false)
+                .setUserSettings(new File("/home/aloubyansky/playground/quarkus3-proxy-auth-issue/settings.xml"))
+                .build()
+                .resolve(new DefaultArtifact("org.mvnpm", "lit", "pom", "2.7.4"));
+    }
+}


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/32816
Fix https://github.com/quarkusio/quarkus/issues/30166

This change enhances DevMojo autocompile feature by figuring out the necessary phases and plugin goals that need to be handled before launching the app in dev mode.

@famod would you mind reviewing this one? Thanks.