### PR TITLE
Upgrade to SmallRye Fault Tolerance 6.2.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -62,7 +62,7 @@
         <smallrye-open-api.version>3.3.4</smallrye-open-api.version>
         <smallrye-graphql.version>2.2.0</smallrye-graphql.version>
         <smallrye-opentracing.version>3.0.3</smallrye-opentracing.version>
-        <smallrye-fault-tolerance.version>6.2.2</smallrye-fault-tolerance.version>
+        <smallrye-fault-tolerance.version>6.2.3</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.2.1</smallrye-jwt.version>
         <smallrye-context-propagation.version>2.1.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>


### PR DESCRIPTION
- https://smallrye.io/blog/fault-tolerance-6-2-3/