### PR TITLE
Add links to Well-Known OIDC providers doc

### DIFF
--- a/docs/src/main/asciidoc/security-authentication-mechanisms-concept.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms-concept.adoc
@@ -198,6 +198,7 @@ For more information about OIDC authentication and authorization methods you can
 |Bearer token authentication mechanism |xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
 |Authorization code flow authentication mechanism |xref:security-oidc-code-flow-authentication-concept.adoc[OpenID Connect (OIDC) authorization code flow mechanism]
 |Multiple tenants that can support bearer token or authorization code flow mechanisms |xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect (OIDC) multi-tenancy]
+|Securing Quarkus with commonly-used OpenID Connect providers |xref:security-openid-connect-providers.adoc[Configuring Well-Known OpenID Connect Providers]
 |Using Keycloak to centralize authorization |xref:security-keycloak-authorization.adoc[Using OpenID Connect (OIDC) and Keycloak to centralize authorization]
 |Configuring Keycloak programmatically |xref:security-keycloak-admin-client.adoc[Using the Keycloak admin client]
 |====

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-concept.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-concept.adoc
@@ -1233,7 +1233,7 @@ It is important that this error endpoint is a public resource to avoid the user 
 == References
 
 * xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties]
-* xref:security-openid-connect-providers.adoc[OpenID Connect providers]
+* xref:security-openid-connect-providers.adoc[Configuring well-known OpenID Connect Providers]
 * xref:security-openid-connect-client-reference.adoc[OpenID Connect and OAuth2 Client and Filters Reference Guide]
 * xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak]
 * xref:security-authentication-mechanisms-concept.adoc#oidc-jwt-oauth2-comparison[Choosing between OpenID Connect, SmallRye JWT, and OAuth2 authentication mechanisms]

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -5,7 +5,9 @@ include::_attributes.adoc[]
 
 With the Quarkus OpenID Connect (OIDC) extension, you can protect application HTTP endpoints by using the OIDC Authorization Code Flow mechanism.
 
-To learn more about the OIDC authorization code flow mechanism, see xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications] or to learn about other authentication mechanisms, see xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[authentication mechanisms].
+To learn more about the OIDC authorization code flow mechanism, see xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications].
+To learn about how well-known social providers such as Google, GitHub, Microsoft, Twitter, Apple, Facebook, and Spotify can be used with Quarkus OIDC, see xref:security-openid-connect-providers.adoc[Configuring Well-Known OpenID Connect Providers].
+See also, xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus].
 
 == Prerequisites
 
@@ -246,19 +248,18 @@ For more information about writing the integration tests that depend on `Dev Ser
 
 Congratulations!
 You have learned how to set up and use the OIDC authorization code flow mechanism to protect and test application HTTP endpoints.
-After you have completed this tutorial, explore some of the other security mechanisms in Quarkus.
-
-* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
-
+After you have completed this tutorial, explore xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication] and xref:security-authentication-mechanisms-concept.adoc[other authentication mechanisms].
 
 == References
+* xref:security-overview-concept.adoc[Quarkus Security overview]
 * xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
-* https://www.keycloak.org/documentation.html[Keycloak Documentation]
-* https://openid.net/connect/[OpenID Connect]
-* https://tools.ietf.org/html/rfc7519[JSON Web Token]
+* xref:security-openid-connect-providers.adoc[Configuring well-known OpenID Connect Providers]
 * xref:security-openid-connect-client-reference.adoc[OpenID Connect and OAuth2 Client and Filters Reference Guide]
 * xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak]
 * xref:security-jwt-build.adoc[Sign and encrypt JWT tokens with SmallRye JWT Build]
 * xref:security-authentication-mechanisms-concept.adoc#oidc-jwt-oauth2-comparison[Choosing between OpenID Connect, SmallRye JWT, and OAuth2 authentication mechanisms]
 * xref:security-keycloak-admin-client.adoc[Quarkus Keycloak Admin Client]
+* https://www.keycloak.org/documentation.html[Keycloak Documentation]
+* https://openid.net/connect/[OpenID Connect]
+* https://tools.ietf.org/html/rfc7519[JSON Web Token]
+


### PR DESCRIPTION
Fixes #33056.

Hi @michelle-purcell @sheilamjones, it is an attempt to make the [Well Known Providers](https://quarkus.io/guides/security-openid-connect-providers) doc more visible from within OIDC specific docs and sections, I've added extra links from the authentication mechanism concept doc, in the OIDC code flow concept and tutorials, and along the way updated the reference links section on the code flow tutorial (non-Quarkus doc links moved to the very end, minor optimization in the `Summary` section).
Have a look please.
The plan is to follow up with adding tags like `google`, `github` etc in the website for the users to immediately find the [Well Known Providers](https://quarkus.io/guides/security-openid-connect-providers) doc if they type for example `twitter` in the `Search` area.
Do you think though if we can also add such tags to the [Well Known Providers](https://quarkus.io/guides/security-openid-connect-providers) doc itself with this PR ?
Thanks
 