### PR TITLE
Support `@Encoded` annotation on REST Client Reactive

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/encoded/ClientWithPathParamAndEncodedTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/encoded/ClientWithPathParamAndEncodedTest.java
@@ -1,0 +1,159 @@
+package io.quarkus.rest.client.reactive.encoded;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.resteasy.reactive.ClientWebApplicationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class ClientWithPathParamAndEncodedTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest();
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    public void testClientWithoutEncoded() {
+        ClientWithoutEncoded client = RestClientBuilder.newBuilder()
+                .baseUri(baseUri)
+                .build(ClientWithoutEncoded.class);
+        ClientWebApplicationException ex = assertThrows(ClientWebApplicationException.class, () -> client.call("a/b"));
+        assertTrue(ex.getMessage().contains("Not Found"));
+    }
+
+    @Test
+    public void testClientWithEncodedInParameter() {
+        ClientWithEncodedInParameter client = RestClientBuilder.newBuilder()
+                .baseUri(baseUri)
+                .build(ClientWithEncodedInParameter.class);
+        assertEquals("Hello A/B", client.call("a/b"));
+        assertEquals("Hello A/B/C", client.sub().call("b/c"));
+    }
+
+    @Test
+    public void testClientWithEncodedInMethod() {
+        ClientWithEncodedInMethod client = RestClientBuilder.newBuilder()
+                .baseUri(baseUri)
+                .build(ClientWithEncodedInMethod.class);
+        assertEquals("Hello A/B", client.call("a/b"));
+        assertEquals("Hello A/B/C", client.sub1().call("b/c"));
+        assertEquals("Hello A/B/C", client.sub2().call("b/c"));
+        assertEquals("Hello A/B/C", client.sub3().call("b/c"));
+    }
+
+    @Test
+    public void testClientWithEncodedInClass() {
+        ClientWithEncodedInClass client = RestClientBuilder.newBuilder()
+                .baseUri(baseUri)
+                .build(ClientWithEncodedInClass.class);
+        assertEquals("Hello A/B", client.call("a/b"));
+        assertEquals("Hello A/B/C", client.sub().call("b/c"));
+    }
+
+    @Path("/server")
+    public interface ClientWithoutEncoded {
+        @GET
+        @Path("/{path}")
+        String call(@PathParam("path") String path);
+
+        @GET
+        @Path("/{path}")
+        String callWithQuery(@PathParam("path") String path, @QueryParam("query") String query);
+    }
+
+    @Path("/server")
+    public interface ClientWithEncodedInParameter {
+        @GET
+        @Path("/{path}")
+        String call(@Encoded @PathParam("path") String path);
+
+        @Path("/a")
+        SubClientWithEncodedInParameter sub();
+    }
+
+    @Path("/server")
+    public interface ClientWithEncodedInMethod {
+        @Encoded
+        @GET
+        @Path("/{path}")
+        String call(@PathParam("path") String path);
+
+        @Encoded
+        @Path("/a")
+        SubClientWithoutEncoded sub1();
+
+        @Path("/a")
+        SubClientWithEncodedInMethod sub2();
+
+        @Path("/a")
+        SubClientWithEncodedInClass sub3();
+    }
+
+    @Encoded
+    @Path("/server")
+    public interface ClientWithEncodedInClass {
+        @GET
+        @Path("/{path}")
+        String call(@PathParam("path") String path);
+
+        @Path("/a")
+        SubClientWithoutEncoded sub();
+    }
+
+    public interface SubClientWithoutEncoded {
+        @GET
+        @Path("/{path}")
+        String call(@PathParam("path") String path);
+    }
+
+    public interface SubClientWithEncodedInMethod {
+        @Encoded
+        @GET
+        @Path("/{path}")
+        String call(@PathParam("path") String path);
+    }
+
+    @Encoded
+    public interface SubClientWithEncodedInClass {
+        @GET
+        @Path("/{path}")
+        String call(@PathParam("path") String path);
+    }
+
+    public interface SubClientWithEncodedInParameter {
+        @GET
+        @Path("/{path}")
+        String call(@Encoded @PathParam("path") String path);
+    }
+
+    @Path("/server")
+    static class Resource {
+        @GET
+        @Path("/a/b")
+        public String get() {
+            return "Hello A/B";
+        }
+
+        @GET
+        @Path("/a/b/c")
+        public String getForSubResource() {
+            return "Hello A/B/C";
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/encoded/ClientWithQueryParamAndEncodedTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/encoded/ClientWithQueryParamAndEncodedTest.java
@@ -1,0 +1,149 @@
+package io.quarkus.rest.client.reactive.encoded;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class ClientWithQueryParamAndEncodedTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest();
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    public void testClientWithoutEncoded() {
+        ClientWithoutEncoded client = RestClientBuilder.newBuilder()
+                .baseUri(baseUri)
+                .build(ClientWithoutEncoded.class);
+        assertEquals("Hello query=%2524value", client.call("%24value"));
+    }
+
+    @Test
+    public void testClientWithEncodedInParameter() {
+        ClientWithEncodedInParameter client = RestClientBuilder.newBuilder()
+                .baseUri(baseUri)
+                .build(ClientWithEncodedInParameter.class);
+        assertEquals("Hello query=%24value", client.call("%24value"));
+        assertEquals("Hello query1=%2524value&query2=%24value&query3=%2524value",
+                client.call("%24value", "%24value", "%24value"));
+        assertEquals("Hello subQuery=%24value", client.sub().call("%24value"));
+    }
+
+    @Test
+    public void testClientWithEncodedInMethod() {
+        ClientWithEncodedInMethod client = RestClientBuilder.newBuilder()
+                .baseUri(baseUri)
+                .build(ClientWithEncodedInMethod.class);
+        assertEquals("Hello query=%24value", client.call("%24value"));
+        assertEquals("Hello subQuery=%24value", client.sub1().call("%24value"));
+        assertEquals("Hello subQuery=%24value", client.sub2().call("%24value"));
+        assertEquals("Hello subQuery=%24value", client.sub3().call("%24value"));
+    }
+
+    @Test
+    public void testClientWithEncodedInClass() {
+        ClientWithEncodedInClass client = RestClientBuilder.newBuilder()
+                .baseUri(baseUri)
+                .build(ClientWithEncodedInClass.class);
+        assertEquals("Hello query=%24value", client.call("%24value"));
+        assertEquals("Hello subQuery=%24value", client.sub().call("%24value"));
+    }
+
+    @Path("/server")
+    public interface ClientWithoutEncoded {
+        @GET
+        String call(@QueryParam("query") String query);
+    }
+
+    @Path("/server")
+    public interface ClientWithEncodedInParameter {
+        @GET
+        String call(@Encoded @QueryParam("query") String query);
+
+        @GET
+        String call(@QueryParam("query1") String query1, @Encoded @QueryParam("query2") String query2,
+                @QueryParam("query3") String query3);
+
+        @Path("/a")
+        SubClientWithEncodedInParameter sub();
+    }
+
+    @Path("/server")
+    public interface ClientWithEncodedInMethod {
+        @Encoded
+        @GET
+        String call(@QueryParam("query") String query);
+
+        @Encoded
+        @Path("/a")
+        SubClientWithoutEncoded sub1();
+
+        @Path("/a")
+        SubClientWithEncodedInMethod sub2();
+
+        @Path("/a")
+        SubClientWithEncodedInClass sub3();
+    }
+
+    @Encoded
+    @Path("/server")
+    public interface ClientWithEncodedInClass {
+        @GET
+        String call(@QueryParam("query") String query);
+
+        @Path("/a")
+        SubClientWithoutEncoded sub();
+    }
+
+    public interface SubClientWithoutEncoded {
+        @GET
+        String call(@QueryParam("subQuery") String subQuery);
+    }
+
+    @Encoded
+    public interface SubClientWithEncodedInClass {
+        @GET
+        String call(@QueryParam("subQuery") String subQuery);
+    }
+
+    public interface SubClientWithEncodedInMethod {
+        @Encoded
+        @GET
+        String call(@QueryParam("subQuery") String subQuery);
+    }
+
+    public interface SubClientWithEncodedInParameter {
+        @GET
+        String call(@Encoded @QueryParam("subQuery") String subQuery);
+    }
+
+    @Path("/server")
+    static class Resource {
+        @GET
+        public String get(@Context UriInfo uriInfo) {
+            return "Hello " + uriInfo.getRequestUri().getRawQuery();
+        }
+
+        @GET
+        @Path("/a")
+        public String getFromA(@Context UriInfo uriInfo) {
+            return "Hello " + uriInfo.getRequestUri().getRawQuery();
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamItem.java
@@ -7,7 +7,7 @@ public class BeanParamItem extends Item {
     private final String className;
 
     public BeanParamItem(String fieldName, List<Item> items, String className, ValueExtractor extractor) {
-        super(fieldName, ItemType.BEAN_PARAM, extractor);
+        super(fieldName, ItemType.BEAN_PARAM, false, extractor);
         this.items = items;
         this.className = className;
     }

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamParser.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamParser.java
@@ -2,6 +2,7 @@ package org.jboss.resteasy.reactive.client.processor.beanparam;
 
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.BEAN_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.COOKIE_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.ENCODED;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.FORM_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.HEADER_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.PATH_PARAM;
@@ -62,19 +63,23 @@ public class BeanParamParser {
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, QUERY_PARAM,
                     (annotationValue, fieldInfo) -> new QueryParamItem(fieldInfo.name(), annotationValue,
+                            fieldInfo.hasDeclaredAnnotation(ENCODED),
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString()),
                             fieldInfo.type()),
                     (annotationValue, getterMethod) -> new QueryParamItem(getterMethod.name(), annotationValue,
+                            getterMethod.hasDeclaredAnnotation(ENCODED),
                             new GetterExtractor(getterMethod),
                             getterMethod.returnType())));
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, REST_QUERY_PARAM,
                     (annotationValue, fieldInfo) -> new QueryParamItem(fieldInfo.name(),
                             annotationValue != null ? annotationValue : fieldInfo.name(),
+                            fieldInfo.hasDeclaredAnnotation(ENCODED),
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString()),
                             fieldInfo.type()),
                     (annotationValue, getterMethod) -> new QueryParamItem(getterMethod.name(),
                             annotationValue != null ? annotationValue : getterName(getterMethod),
+                            getterMethod.hasDeclaredAnnotation(ENCODED),
                             new GetterExtractor(getterMethod),
                             getterMethod.returnType())));
 
@@ -139,32 +144,33 @@ public class BeanParamParser {
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, PATH_PARAM,
                     (annotationValue, fieldInfo) -> new PathParamItem(fieldInfo.name(), annotationValue,
-                            fieldInfo.type().name().toString(),
+                            fieldInfo.type().name().toString(), fieldInfo.hasDeclaredAnnotation(ENCODED),
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString())),
                     (annotationValue, getterMethod) -> new PathParamItem(getterMethod.name(), annotationValue,
-                            getterMethod.returnType().name().toString(),
+                            getterMethod.returnType().name().toString(), getterMethod.hasDeclaredAnnotation(ENCODED),
                             new GetterExtractor(getterMethod))));
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, REST_PATH_PARAM,
                     (annotationValue, fieldInfo) -> new PathParamItem(fieldInfo.name(),
                             annotationValue != null ? annotationValue : fieldInfo.name(), fieldInfo.type().name().toString(),
+                            fieldInfo.hasDeclaredAnnotation(ENCODED),
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString())),
                     (annotationValue, getterMethod) -> new PathParamItem(getterMethod.name(),
                             annotationValue != null ? annotationValue : getterName(getterMethod),
-                            getterMethod.returnType().name().toString(),
+                            getterMethod.returnType().name().toString(), getterMethod.hasDeclaredAnnotation(ENCODED),
                             new GetterExtractor(getterMethod))));
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, FORM_PARAM,
                     (annotationValue, fieldInfo) -> new FormParamItem(fieldInfo.name(), annotationValue,
                             fieldInfo.type().name().toString(), AsmUtil.getSignature(fieldInfo.type()),
                             fieldInfo.name(),
-                            partType(fieldInfo), fileName(fieldInfo),
+                            partType(fieldInfo), fileName(fieldInfo), fieldInfo.hasDeclaredAnnotation(ENCODED),
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString())),
                     (annotationValue, getterMethod) -> new FormParamItem(getterMethod.name(), annotationValue,
                             getterMethod.returnType().name().toString(),
                             AsmUtil.getSignature(getterMethod.returnType()),
                             getterMethod.name(),
-                            partType(getterMethod), fileName(getterMethod),
+                            partType(getterMethod), fileName(getterMethod), getterMethod.hasDeclaredAnnotation(ENCODED),
                             new GetterExtractor(getterMethod))));
 
             resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, REST_FORM_PARAM,
@@ -172,14 +178,14 @@ public class BeanParamParser {
                             annotationValue != null ? annotationValue : fieldInfo.name(),
                             fieldInfo.type().name().toString(), AsmUtil.getSignature(fieldInfo.type()),
                             fieldInfo.name(),
-                            partType(fieldInfo), fileName(fieldInfo),
+                            partType(fieldInfo), fileName(fieldInfo), fieldInfo.hasDeclaredAnnotation(ENCODED),
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString())),
                     (annotationValue, getterMethod) -> new FormParamItem(getterMethod.name(),
                             annotationValue != null ? annotationValue : getterName(getterMethod),
                             getterMethod.returnType().name().toString(),
                             AsmUtil.getSignature(getterMethod.returnType()),
                             getterMethod.name(),
-                            partType(getterMethod), fileName(getterMethod),
+                            partType(getterMethod), fileName(getterMethod), getterMethod.hasDeclaredAnnotation(ENCODED),
                             new GetterExtractor(getterMethod))));
 
             return resultList;

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/CookieParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/CookieParamItem.java
@@ -5,7 +5,7 @@ public class CookieParamItem extends Item {
     private final String paramType;
 
     public CookieParamItem(String fieldName, String cookieName, ValueExtractor extractor, String paramType) {
-        super(fieldName, ItemType.COOKIE, extractor);
+        super(fieldName, ItemType.COOKIE, false, extractor);
         this.cookieName = cookieName;
         this.paramType = paramType;
     }

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/FormParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/FormParamItem.java
@@ -12,8 +12,9 @@ public class FormParamItem extends Item {
     public FormParamItem(String fieldName, String formParamName, String paramType, String paramSignature,
             String sourceName,
             String mimeType, String fileName,
+            boolean encoded,
             ValueExtractor valueExtractor) {
-        super(fieldName, ItemType.FORM_PARAM, valueExtractor);
+        super(fieldName, ItemType.FORM_PARAM, encoded, valueExtractor);
         this.formParamName = formParamName;
         this.paramType = paramType;
         this.paramSignature = paramSignature;

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/HeaderParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/HeaderParamItem.java
@@ -5,7 +5,7 @@ public class HeaderParamItem extends Item {
     private final String paramType;
 
     public HeaderParamItem(String fieldName, String headerName, ValueExtractor extractor, String paramType) {
-        super(fieldName, ItemType.HEADER_PARAM, extractor);
+        super(fieldName, ItemType.HEADER_PARAM, false, extractor);
         this.headerName = headerName;
         this.paramType = paramType;
     }

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/Item.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/Item.java
@@ -7,11 +7,13 @@ public abstract class Item {
 
     private final String fieldName;
     private final ItemType type;
+    private final boolean encoded;
     private final ValueExtractor valueExtractor;
 
-    public Item(String fieldName, ItemType type, ValueExtractor valueExtractor) {
+    public Item(String fieldName, ItemType type, boolean encoded, ValueExtractor valueExtractor) {
         this.fieldName = fieldName;
         this.type = type;
+        this.encoded = encoded;
         this.valueExtractor = valueExtractor;
     }
 
@@ -21,6 +23,10 @@ public abstract class Item {
 
     public ItemType type() {
         return type;
+    }
+
+    public boolean isEncoded() {
+        return encoded;
     }
 
     public ResultHandle extract(BytecodeCreator methodCreator, ResultHandle param) {

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/PathParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/PathParamItem.java
@@ -5,8 +5,9 @@ public class PathParamItem extends Item {
     private final String pathParamName;
     private final String paramType;
 
-    public PathParamItem(String fieldName, String pathParamName, String paramType, ValueExtractor valueExtractor) {
-        super(fieldName, ItemType.PATH_PARAM, valueExtractor);
+    public PathParamItem(String fieldName, String pathParamName, String paramType, boolean encoded,
+            ValueExtractor valueExtractor) {
+        super(fieldName, ItemType.PATH_PARAM, encoded, valueExtractor);
         this.pathParamName = pathParamName;
         this.paramType = paramType;
     }

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/QueryParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/QueryParamItem.java
@@ -7,8 +7,8 @@ public class QueryParamItem extends Item {
     private final String name;
     private final Type valueType;
 
-    public QueryParamItem(String fieldName, String name, ValueExtractor extractor, Type valueType) {
-        super(fieldName, ItemType.QUERY_PARAM, extractor);
+    public QueryParamItem(String fieldName, String name, boolean encoded, ValueExtractor extractor, Type valueType) {
+        super(fieldName, ItemType.QUERY_PARAM, encoded, extractor);
         this.name = name;
         this.valueType = valueType;
     }

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/scanning/ClientEndpointIndexer.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.client.processor.scanning;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.ENCODED;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.JSONP_JSON_ARRAY;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.JSONP_JSON_NUMBER;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.JSONP_JSON_OBJECT;
@@ -64,6 +65,7 @@ public class ClientEndpointIndexer
         try {
             RestClientInterface clazz = new RestClientInterface();
             clazz.setClassName(classInfo.name().toString());
+            clazz.setEncoded(classInfo.hasDeclaredAnnotation(ENCODED));
             if (path != null) {
                 if (!path.startsWith("/")) {
                     path = "/" + path;

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -756,6 +756,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                     .setRunOnVirtualThread(runOnVirtualThread)
                     .setSuspended(suspended)
                     .setSse(sse)
+                    .setEncoded(currentMethodInfo.hasDeclaredAnnotation(ENCODED))
                     .setStreamElementType(streamElementType)
                     .setFormParamRequired(formParamRequired)
                     .setFileFormNames(fileFormNames)

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceMethod.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceMethod.java
@@ -72,13 +72,15 @@ public class ResourceMethod {
 
     private List<ResourceMethod> subResourceMethods;
 
+    private boolean encoded;
+
     public ResourceMethod() {
     }
 
     public ResourceMethod(String httpMethod, String path, String[] produces, String streamElementType, String[] consumes,
             Set<String> nameBindingNames, String name, String returnType, String simpleReturnType, MethodParameter[] parameters,
             boolean blocking, boolean suspended, boolean isSse, boolean isFormParamRequired,
-            List<ResourceMethod> subResourceMethods) {
+            List<ResourceMethod> subResourceMethods, boolean encoded) {
         this.httpMethod = httpMethod;
         this.path = path;
         this.produces = produces;
@@ -94,6 +96,7 @@ public class ResourceMethod {
         this.isSse = isSse;
         this.isFormParamRequired = isFormParamRequired;
         this.subResourceMethods = subResourceMethods;
+        this.encoded = encoded;
     }
 
     public boolean isResourceLocator() {
@@ -242,6 +245,15 @@ public class ResourceMethod {
 
     public String getStreamElementType() {
         return streamElementType;
+    }
+
+    public boolean isEncoded() {
+        return encoded;
+    }
+
+    public ResourceMethod setEncoded(boolean encoded) {
+        this.encoded = encoded;
+        return this;
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/RestClientInterface.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/RestClientInterface.java
@@ -26,6 +26,8 @@ public class RestClientInterface {
 
     private Set<String> pathParameters = new HashSet<>();
 
+    private boolean encoded = false;
+
     public String getClassName() {
         return className;
     }
@@ -58,6 +60,15 @@ public class RestClientInterface {
 
     public RestClientInterface setPathParameters(Set<String> pathParameters) {
         this.pathParameters = pathParameters;
+        return this;
+    }
+
+    public boolean isEncoded() {
+        return encoded;
+    }
+
+    public RestClientInterface setEncoded(boolean encoded) {
+        this.encoded = encoded;
         return this;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerResourceMethod.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerResourceMethod.java
@@ -26,9 +26,10 @@ public class ServerResourceMethod extends ResourceMethod {
             Set<String> nameBindingNames, String name, String returnType, String simpleReturnType, MethodParameter[] parameters,
             boolean blocking, boolean suspended, boolean sse, boolean formParamRequired,
             List<ResourceMethod> subResourceMethods, Supplier<EndpointInvoker> invoker, Set<String> methodAnnotationNames,
-            List<HandlerChainCustomizer> handlerChainCustomizers, ParameterExtractor customerParameterExtractor) {
+            List<HandlerChainCustomizer> handlerChainCustomizers, ParameterExtractor customerParameterExtractor,
+            boolean encoded) {
         super(httpMethod, path, produces, streamElementType, consumes, nameBindingNames, name, returnType, simpleReturnType,
-                parameters, blocking, suspended, sse, formParamRequired, subResourceMethods);
+                parameters, blocking, suspended, sse, formParamRequired, subResourceMethods, encoded);
         this.invoker = invoker;
         this.methodAnnotationNames = methodAnnotationNames;
         this.handlerChainCustomizers = handlerChainCustomizers;


### PR DESCRIPTION
These changes add support for the `@Encoded` annotation for PATH and QUERY params. 

As stated in the Encoded annotation javadocs, we can use this annotation at class and method level too, so we can use it in REST Client reactive like this. 

Fix https://github.com/quarkusio/quarkus/issues/23961