### PR TITLE
Don't set the TCCL before every test

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -235,10 +235,6 @@ public class JunitTestRunner {
                                 startTimes.put(testIdentifier, System.currentTimeMillis());
                                 String testClassName = "";
                                 Class<?> testClass = getTestClassFromSource(testIdentifier.getSource());
-                                if (testClass != null) {
-                                    testClassName = testClass.getName();
-                                    Thread.currentThread().setContextClassLoader(testClass.getClassLoader());
-                                }
                                 for (TestRunListener listener : listeners) {
                                     listener.testStarted(testIdentifier, testClassName);
                                 }


### PR DESCRIPTION
This prevents extensions from modifying the TCCL. The correct TCCL is set at the start of the run.