### PR TITLE
Add quarkus-grpc dependency in Kubernetes Integration Test

### DIFF
--- a/integration-tests/kubernetes/maven-invoker-way/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/pom.xml
@@ -24,6 +24,11 @@
             <artifactId>quarkus-container-image-jib</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -173,6 +178,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>


### PR DESCRIPTION
Relates to CI failures in https://github.com/quarkusio/quarkus/issues/23788