### PR TITLE
Do not bind the Management port into the generated Service resource

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
@@ -217,13 +217,13 @@ public class KubernetesCommonHelper {
         result.addAll(createCommandDecorator(project, target, name, config, command));
         result.addAll(createArgsDecorator(project, target, name, config, command));
 
-        //Handle Probes
+        // Handle Probes
         if (!port.isEmpty()) {
             result.addAll(createProbeDecorators(name, target, config.getLivenessProbe(), config.getReadinessProbe(),
                     config.getStartupProbe(), livenessProbePath, readinessProbePath, startupPath));
         }
 
-        //Handle RBAC
+        // Handle RBAC
         result.addAll(createRbacDecorators(name, target, config, kubernetesClientConfiguration, roles, clusterRoles,
                 serviceAccounts, roleBindings));
         return result;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfigUtil.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfigUtil.java
@@ -22,6 +22,11 @@ import io.quarkus.deployment.util.DeploymentUtil;
 
 public class KubernetesConfigUtil {
 
+    /**
+     * It should be the same name as in VertxHttpProcessor.kubernetesForManagement.
+     */
+    public static final String MANAGEMENT_PORT_NAME = "management";
+
     private static final String DEKORATE_PREFIX = "dekorate.";
     private static final Pattern QUARKUS_DEPLOY_PATTERN = Pattern.compile("quarkus\\.([^\\.]+)\\.deploy");
 
@@ -109,6 +114,10 @@ public class KubernetesConfigUtil {
         result.putAll(quarkusPrefixed);
         result.putAll(toS2iProperties(quarkusPrefixed));
         return result;
+    }
+
+    public static boolean managementPortIsEnabled() {
+        return ConfigProvider.getConfig().getOptionalValue("quarkus.management.enabled", Boolean.class).orElse(false);
     }
 
     private static Map<String, Object> toS2iProperties(Map<String, Object> map) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemovePortFromServiceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemovePortFromServiceDecorator.java
@@ -1,0 +1,29 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.kubernetes.decorator.AddServiceResourceDecorator;
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.fabric8.kubernetes.api.model.ServiceSpecFluent;
+
+public class RemovePortFromServiceDecorator extends NamedResourceDecorator<ServiceSpecFluent> {
+
+    private final String portNameToRemove;
+
+    public RemovePortFromServiceDecorator(String name, String portNameToRemove) {
+        super(name);
+        this.portNameToRemove = portNameToRemove;
+    }
+
+    @Override
+    public void andThenVisit(ServiceSpecFluent service, ObjectMeta resourceMeta) {
+        service.removeMatchingFromPorts(p -> ((ServicePortBuilder) p).getName().equals(portNameToRemove));
+    }
+
+    @Override
+    public Class<? extends Decorator>[] after() {
+        return new Class[] { AddServiceResourceDecorator.class };
+    }
+
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesExposingManagementInterfaceTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesExposingManagementInterfaceTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Service;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesExposingManagementInterfaceTest {
+
+    private static final String NAME = "kubernetes-exposing-management";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .overrideConfigKey("quarkus.management.enabled", "true")
+            .overrideConfigKey("quarkus.kubernetes.ingress.expose", "true")
+            .overrideConfigKey("quarkus.kubernetes.ingress.target-port", "management");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        Service service = kubernetesList.stream().filter(Service.class::isInstance).map(Service.class::cast).findFirst().get();
+
+        assertThat(service.getMetadata()).satisfies(m -> {
+            assertThat(m.getName()).isEqualTo(NAME);
+        });
+
+        assertThat(service.getSpec()).satisfies(spec -> {
+            assertThat(spec.getPorts()).hasSize(3);
+            assertThat(spec.getPorts()).satisfiesOnlyOnce(port -> assertThat(port.getName()).isEqualTo("http"));
+            assertThat(spec.getPorts()).satisfiesOnlyOnce(port -> assertThat(port.getName()).isEqualTo("https"));
+            assertThat(spec.getPorts()).satisfiesOnlyOnce(port -> assertThat(port.getName()).isEqualTo("management"));
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthUsingManagementInterfaceTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthUsingManagementInterfaceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.quarkus.builder.Version;
 import io.quarkus.maven.dependency.Dependency;
@@ -92,6 +93,18 @@ public class KubernetesWithHealthUsingManagementInterfaceTest {
                         });
                     });
                 });
+            });
+        });
+
+        assertThat(kubernetesList.get(1)).isInstanceOfSatisfying(Service.class, s -> {
+            assertThat(s.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo(NAME);
+            });
+
+            assertThat(s.getSpec()).satisfies(spec -> {
+                assertThat(spec.getPorts()).hasSize(2);
+                assertThat(spec.getPorts()).satisfiesOnlyOnce(port -> assertThat(port.getName()).isEqualTo("http"));
+                assertThat(spec.getPorts()).satisfiesOnlyOnce(port -> assertThat(port.getName()).isEqualTo("https"));
             });
         });
     }


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/issues/33307, task 4.

Yet if users set the "target-port" to "management", this port won't be unbound. I wanted to open this possibility to users that for some reason do want to expose the management port, so let me know what you think about this @iocanel @cescoffier 