### PR TITLE
Do not generate the https in K8s unless HTTP ssl configuration is set

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -813,7 +813,6 @@ To secure the incoming connections, Kubernetes allows enabling https://kubernete
 [source,properties]
 ----
 quarkus.kubernetes.ingress.expose=true
-quarkus.kubernetes.ingress.target-port=https
 ## Ingress TLS configuration:
 quarkus.kubernetes.ingress.tls.my-secret.enabled=true
 ----

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
@@ -24,6 +24,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import io.dekorate.kubernetes.config.Annotation;
 import io.dekorate.kubernetes.config.ConfigMapVolumeBuilder;
 import io.dekorate.kubernetes.config.EnvBuilder;
@@ -169,6 +171,7 @@ public class KubernetesCommonHelper {
             String name = e.getKey();
             Port configuredPort = PortConverter.convert(e);
             Port buildItemPort = allPorts.get(name);
+
             Port combinedPort = buildItemPort == null ? configuredPort
                     : new PortBuilder()
                             .withName(name)
@@ -182,6 +185,16 @@ public class KubernetesCommonHelper {
                             .withPath(Strings.isNotNullOrEmpty(configuredPort.getPath()) ? configuredPort.getPath()
                                     : buildItemPort.getPath())
                             .build();
+
+            // Special handling for ports with name "https". We look up the container port from the Quarkus configuration.
+            if ("https".equals(name) && combinedPort.getContainerPort() == null) {
+                int containerPort = ConfigProvider.getConfig()
+                        .getOptionalValue("quarkus.http.ssl-port", Integer.class)
+                        .orElse(8443);
+
+                combinedPort = new PortBuilder(combinedPort).withContainerPort(containerPort).build();
+            }
+
             allPorts.put(name, combinedPort);
         });
         return allPorts;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BasicKubernetesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BasicKubernetesTest.java
@@ -79,7 +79,7 @@ public class BasicKubernetesTest {
                         assertThat(podSpec.getSecurityContext()).isNull();
                         assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                             assertThat(container.getImagePullPolicy()).isEqualTo("Always"); // expect the default value
-                            assertThat(container.getPorts()).hasSize(2).anySatisfy(p -> {
+                            assertThat(container.getPorts()).hasSize(1).anySatisfy(p -> {
                                 assertThat(p.getContainerPort()).isEqualTo(8080);
                             });
                         });
@@ -96,14 +96,9 @@ public class BasicKubernetesTest {
                 assertThat(spec.getSelector()).containsOnly(entry("app.kubernetes.io/name", "basic"),
                         entry("app.kubernetes.io/version", "0.1-SNAPSHOT"));
 
-                assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
+                assertThat(spec.getPorts()).hasSize(1).anySatisfy(p -> {
                     assertThat(p.getPort()).isEqualTo(80);
                     assertThat(p.getTargetPort().getIntVal()).isEqualTo(8080);
-                });
-
-                assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
-                    assertThat(p.getPort()).isEqualTo(443);
-                    assertThat(p.getTargetPort().getIntVal()).isEqualTo(8443);
                 });
             });
         });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KindWithDefaultsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KindWithDefaultsTest.java
@@ -71,7 +71,7 @@ public class KindWithDefaultsTest {
 
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("NodePort", spec.getType());
-                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
+                    assertThat(spec.getPorts()).hasSize(1).anySatisfy(p -> {
                         assertThat(p.getNodePort()).isNotNull();
                     });
                 });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesAndMinikubeWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesAndMinikubeWithApplicationPropertiesTest.java
@@ -72,7 +72,7 @@ public class KubernetesAndMinikubeWithApplicationPropertiesTest {
             assertThat(i).isInstanceOfSatisfying(Service.class, s -> {
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("ClusterIP", spec.getType());
-                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
+                    assertThat(spec.getPorts()).hasSize(1).anySatisfy(p -> {
                         assertThat(p.getNodePort()).isNull();
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(9090);
@@ -109,7 +109,7 @@ public class KubernetesAndMinikubeWithApplicationPropertiesTest {
             assertThat(i).isInstanceOfSatisfying(Service.class, s -> {
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("NodePort", spec.getType());
-                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
+                    assertThat(spec.getPorts()).hasSize(1).anySatisfy(p -> {
                         assertThat(p.getNodePort()).isNotNull();
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(9090);

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesServiceMappingTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesServiceMappingTest.java
@@ -55,7 +55,7 @@ public class KubernetesServiceMappingTest {
                 assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         List<ContainerPort> ports = podSpec.getContainers().get(0).getPorts();
-                        assertThat(ports.size()).isEqualTo(3);
+                        assertThat(ports.size()).isEqualTo(2);
                         assertTrue(ports.stream().anyMatch(port -> "http".equals(port.getName())
                                 && port.getContainerPort() == 8080
                                 && "TCP".equals(port.getProtocol())),
@@ -74,7 +74,7 @@ public class KubernetesServiceMappingTest {
                 assertThat(m.getName()).isEqualTo("kubernetes-service-mapping");
             });
             assertThat(s.getSpec()).satisfies(serviceSpec -> {
-                assertThat(serviceSpec.getPorts().size()).isEqualTo(3);
+                assertThat(serviceSpec.getPorts().size()).isEqualTo(2);
                 assertTrue(serviceSpec.getPorts().stream().anyMatch(port -> "http".equals(port.getName())
                         && port.getTargetPort().getIntVal() == 8080
                         && "TCP".equals(port.getProtocol())

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithApplicationPropertiesTest.java
@@ -93,7 +93,7 @@ public class KubernetesWithApplicationPropertiesTest {
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("NodePort", spec.getType());
                     assertThat(spec.getSelector()).containsOnly(entry("app.kubernetes.io/name", "test-it"));
-                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
+                    assertThat(spec.getPorts()).hasSize(1).anySatisfy(p -> {
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(9090);
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithCustomResourcesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithCustomResourcesTest.java
@@ -89,7 +89,7 @@ public class KubernetesWithCustomResourcesTest {
                         assertThat(spec.getSelector()).containsOnly(entry("app.kubernetes.io/name", "custom-resources"),
                                 entry("app.kubernetes.io/version", "0.1-SNAPSHOT"));
 
-                        assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
+                        assertThat(spec.getPorts()).hasSize(1).anySatisfy(p -> {
                             assertThat(p.getPort()).isEqualTo(80);
                             assertThat(p.getTargetPort().getIntVal()).isEqualTo(8080);
                         });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMultiplePortsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMultiplePortsTest.java
@@ -50,11 +50,9 @@ public class KubernetesWithMultiplePortsTest {
                     assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
                         assertThat(t.getSpec()).satisfies(podSpec -> {
                             assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
-                                assertThat(container.getPorts()).hasSize(3);
+                                assertThat(container.getPorts()).hasSize(2);
                                 assertThat(container.getPorts()).filteredOn(cp -> cp.getContainerPort() == 8080).singleElement()
                                         .satisfies(c -> assertThat(c.getName()).isEqualTo("http"));
-                                assertThat(container.getPorts()).filteredOn(cp -> cp.getContainerPort() == 8443).singleElement()
-                                        .satisfies(c -> assertThat(c.getName()).isEqualTo("https"));
                                 assertThat(container.getPorts()).filteredOn(cp -> cp.getContainerPort() == 5005).singleElement()
                                         .satisfies(c -> assertThat(c.getName()).isEqualTo("remote"));
                             });
@@ -68,7 +66,7 @@ public class KubernetesWithMultiplePortsTest {
             assertThat(i).isInstanceOfSatisfying(Service.class, s -> {
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("NodePort", spec.getType());
-                    assertThat(spec.getPorts()).hasSize(3);
+                    assertThat(spec.getPorts()).hasSize(2);
                     assertThat(spec.getPorts()).filteredOn(sp -> sp.getPort() == 8080).singleElement().satisfies(p -> {
                         assertThat(p.getNodePort()).isEqualTo(30000);
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithApplicationPropertiesTest.java
@@ -72,7 +72,7 @@ public class MinikubeWithApplicationPropertiesTest {
 
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("NodePort", spec.getType());
-                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
+                    assertThat(spec.getPorts()).hasSize(1).anySatisfy(p -> {
                         assertThat(p.getNodePort()).isEqualTo(31999);
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(9090);

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithDefaultsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithDefaultsTest.java
@@ -70,14 +70,10 @@ public class MinikubeWithDefaultsTest {
 
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertEquals("NodePort", spec.getType());
-                    assertThat(spec.getPorts()).hasSize(2);
+                    assertThat(spec.getPorts()).hasSize(1);
                     assertThat(spec.getPorts()).anySatisfy(p -> {
                         assertThat(p.getName()).isEqualTo("http");
                         assertThat(p.getNodePort()).isNotNull();
-                    });
-                    assertThat(spec.getPorts()).anySatisfy(p -> {
-                        assertThat(p.getName()).isEqualTo("https");
-                        assertThat(p.getNodePort()).isNull();
                     });
                 });
             });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithApplicationPropertiesTest.java
@@ -72,7 +72,7 @@ public class OpenshiftWithApplicationPropertiesTest {
 
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertThat(spec.getSelector()).containsOnly(entry("app.kubernetes.io/name", "test-it"));
-                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
+                    assertThat(spec.getPorts()).hasSize(1).anySatisfy(p -> {
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(9090);
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRoutePropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRoutePropertiesTest.java
@@ -45,7 +45,7 @@ public class OpenshiftWithRoutePropertiesTest {
 
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertThat(spec.getSelector()).contains(entry("app.kubernetes.io/name", "test-it"));
-                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
+                    assertThat(spec.getPorts()).hasSize(1).anySatisfy(p -> {
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(9090);
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithS2iTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithS2iTest.java
@@ -102,7 +102,7 @@ public class OpenshiftWithS2iTest {
         assertThat(openshiftList).filteredOn(h -> "Service".equals(h.getKind())).singleElement().satisfies(h -> {
             assertThat(h).isInstanceOfSatisfying(Service.class, s -> {
                 assertThat(s.getSpec()).satisfies(spec -> {
-                    assertThat(spec.getPorts()).hasSize(2).anySatisfy(p -> {
+                    assertThat(spec.getPorts()).hasSize(1).anySatisfy(p -> {
                         assertThat(p.getPort()).isEqualTo(80);
                         assertThat(p.getTargetPort().getIntVal()).isEqualTo(8080);
                     });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-ingress-target-port.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-ingress-target-port.properties
@@ -1,2 +1,4 @@
+quarkus.http.ssl-port=7777
+quarkus.kubernetes.ports.https.tls=true
 quarkus.kubernetes.ingress.expose=true
 quarkus.kubernetes.ingress.target-port=https


### PR DESCRIPTION
For the HTTP TLS configuration, add a new property quarkus.kubernetes.ports.https.tls=true with default value false. If users set it to true, then the container port HTTPS will be bound to the application container and to the service resource. If false, we will check whether the quarkus.http.ssl.* runtime properties were set at build time using the ConfigProvider API, and bind the container HTTPS accordingly.

Related to https://github.com/quarkusio/quarkus/issues/33307, task 1.