### PR TITLE
Allows receiving the channel name when using Redis Pub/Sub

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/pubsub/PubSubCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/pubsub/PubSubCommands.java
@@ -1,6 +1,7 @@
 package io.quarkus.redis.datasource.pubsub;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import io.quarkus.redis.datasource.RedisCommands;
@@ -44,6 +45,19 @@ public interface PubSubCommands<V> extends RedisCommands {
     RedisSubscriber subscribeToPattern(String pattern, Consumer<V> onMessage);
 
     /**
+     * Same as {@link #subscribeToPattern(String, Consumer)}, but instead of receiving only the message payload, it
+     * also receives the name of the channel.
+     *
+     * @param pattern the pattern
+     * @param onMessage the message consumer. Be aware that this callback is invoked for each message sent to the
+     *        channels matching the pattern, and is invoked on the <strong>I/O thread</strong>. So, you must
+     *        not block. Offload to a separate thread if needed. The first parameter is the name of the
+     *        channel. The second parameter is the payload.
+     * @return the subscriber object that lets you unsubscribe
+     */
+    RedisSubscriber subscribeToPattern(String pattern, BiConsumer<String, V> onMessage);
+
+    /**
      * Subscribes to the given patterns like {@code chan*l}.
      *
      * @param patterns the patterns
@@ -53,6 +67,19 @@ public interface PubSubCommands<V> extends RedisCommands {
      * @return the subscriber object that lets you unsubscribe
      */
     RedisSubscriber subscribeToPatterns(List<String> patterns, Consumer<V> onMessage);
+
+    /**
+     * Same as {@link #subscribeToPatterns(List, Consumer)}, but instead of only receiving the payload, it also receives
+     * the channel name.
+     *
+     * @param patterns the patterns
+     * @param onMessage the message consumer. Be aware that this callback is invoked for each message sent to the
+     *        channels matching the pattern, and is invoked on the <strong>I/O thread</strong>. So, you must
+     *        not block. Offload to a separate thread if needed. The first parameter is the channel name.
+     *        The second one if the payload.
+     * @return the subscriber object that lets you unsubscribe
+     */
+    RedisSubscriber subscribeToPatterns(List<String> patterns, BiConsumer<String, V> onMessage);
 
     /**
      * Subscribes to the given channels.
@@ -98,6 +125,23 @@ public interface PubSubCommands<V> extends RedisCommands {
             Consumer<Throwable> onException);
 
     /**
+     * Same as {@link #subscribeToPatterns(List, Consumer, Runnable, Consumer)}, but also receives the channel name.
+     *
+     * @param pattern the pattern
+     * @param onMessage the message consumer. Be aware that this callback is invoked for each message sent to the
+     *        channels matching the pattern, and is invoked on the <strong>I/O thread</strong>. So, you must
+     *        not block. Offload to a separate thread if needed. The first parameter is the name of the
+     *        channel. The second parameter is the payload.
+     * @param onEnd the end handler. Be aware that this callback is invoked on the <strong>I/O thread</strong>.
+     *        So, you must not block. Offload to a separate thread if needed.
+     * @param onException the exception handler. Be aware that this callback is invoked on the <strong>I/O thread</strong>.
+     *        So, you must not block. Offload to a separate thread if needed.
+     * @return the subscriber object that lets you unsubscribe
+     */
+    RedisSubscriber subscribeToPattern(String pattern, BiConsumer<String, V> onMessage, Runnable onEnd,
+            Consumer<Throwable> onException);
+
+    /**
      * Subscribes to the given patterns like {@code chan*l}.
      *
      * @param patterns the patterns
@@ -114,6 +158,23 @@ public interface PubSubCommands<V> extends RedisCommands {
             Consumer<Throwable> onException);
 
     /**
+     * Same as {@link #subscribeToPatterns(List, Consumer, Runnable, Consumer)}, but also receive the channel name.
+     *
+     * @param patterns the patterns
+     * @param onMessage the message consumer. Be aware that this callback is invoked for each message sent to the
+     *        channels matching the pattern, and is invoked on the <strong>I/O thread</strong>. So, you must
+     *        not block. Offload to a separate thread if needed. The first parameter is the name of the
+     *        channel. The second parameter is the payload.
+     * @param onEnd the end handler. Be aware that this callback is invoked on the <strong>I/O thread</strong>.
+     *        So, you must not block. Offload to a separate thread if needed.
+     * @param onException the exception handler. Be aware that this callback is invoked on the <strong>I/O thread</strong>.
+     *        So, you must not block. Offload to a separate thread if needed.
+     * @return the subscriber object that lets you unsubscribe
+     */
+    RedisSubscriber subscribeToPatterns(List<String> patterns, BiConsumer<String, V> onMessage, Runnable onEnd,
+            Consumer<Throwable> onException);
+
+    /**
      * Subscribes to the given channels.
      *
      * @param channels the channels
@@ -127,6 +188,23 @@ public interface PubSubCommands<V> extends RedisCommands {
      * @return the subscriber object that lets you unsubscribe
      */
     RedisSubscriber subscribe(List<String> channels, Consumer<V> onMessage, Runnable onEnd,
+            Consumer<Throwable> onException);
+
+    /**
+     * Same as {@link #subscribe(List, Consumer, Runnable, Consumer)} but also receives the channel name.
+     *
+     * @param channels the channels
+     * @param onMessage the message consumer. Be aware that this callback is invoked for each message sent to the given
+     *        channels, and is invoked on the <strong>I/O thread</strong>. So, you must not block. Offload to
+     *        a separate thread if needed. The first parameter is the name of the channel. The second
+     *        parameter is the payload.
+     * @param onEnd the end handler. Be aware that this callback is invoked on the <strong>I/O thread</strong>.
+     *        So, you must not block. Offload to a separate thread if needed.
+     * @param onException the exception handler. Be aware that this callback is invoked on the <strong>I/O thread</strong>.
+     *        So, you must not block. Offload to a separate thread if needed.
+     * @return the subscriber object that lets you unsubscribe
+     */
+    RedisSubscriber subscribe(List<String> channels, BiConsumer<String, V> onMessage, Runnable onEnd,
             Consumer<Throwable> onException);
 
     /**

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/pubsub/ReactivePubSubCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/pubsub/ReactivePubSubCommands.java
@@ -1,6 +1,7 @@
 package io.quarkus.redis.datasource.pubsub;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import io.quarkus.redis.datasource.ReactiveRedisCommands;
@@ -41,6 +42,19 @@ public interface ReactivePubSubCommands<V> extends ReactiveRedisCommands {
     Uni<ReactiveRedisSubscriber> subscribeToPattern(String pattern, Consumer<V> onMessage);
 
     /**
+     * Same as {@link #subscribeToPattern(String, Consumer)}, but instead of receiving only the message payload, it
+     * also receives the name of the channel.
+     *
+     * @param pattern the pattern
+     * @param onMessage the message consumer. Be aware that this callback is invoked for each message sent to the
+     *        channels matching the pattern, and is invoked on the <strong>I/O thread</strong>. So, you must
+     *        not block. Offload to a separate thread if needed. The first parameter is the name of the
+     *        channel. The second parameter is the payload.
+     * @return the subscriber object that lets you unsubscribe
+     */
+    Uni<ReactiveRedisSubscriber> subscribeToPattern(String pattern, BiConsumer<String, V> onMessage);
+
+    /**
      * Subscribes to the given patterns like {@code chan*l}.
      *
      * @param patterns the patterns
@@ -52,6 +66,19 @@ public interface ReactivePubSubCommands<V> extends ReactiveRedisCommands {
     Uni<ReactiveRedisSubscriber> subscribeToPatterns(List<String> patterns, Consumer<V> onMessage);
 
     /**
+     * Same as {@link #subscribeToPatterns(List, Consumer)}, but instead of only receiving the payload, it also receives
+     * the channel name.
+     *
+     * @param patterns the patterns
+     * @param onMessage the message consumer. Be aware that this callback is invoked for each message sent to the
+     *        channels matching the pattern, and is invoked on the <strong>I/O thread</strong>. So, you must
+     *        not block. Offload to a separate thread if needed. The first parameter is the channel name.
+     *        The second one if the payload.
+     * @return the subscriber object that lets you unsubscribe
+     */
+    Uni<ReactiveRedisSubscriber> subscribeToPatterns(List<String> patterns, BiConsumer<String, V> onMessage);
+
+    /**
      * Subscribes to the given channels.
      *
      * @param channels the channels
@@ -61,6 +88,19 @@ public interface ReactivePubSubCommands<V> extends ReactiveRedisCommands {
      * @return the subscriber object that lets you unsubscribe
      */
     Uni<ReactiveRedisSubscriber> subscribe(List<String> channels, Consumer<V> onMessage);
+
+    /**
+     * Same as {@link #subscribe(List, Consumer)}, but instead of just receiving the payload, it also receives the
+     * channel name.
+     *
+     * @param channels the channels
+     * @param onMessage the message consumer. Be aware that this callback is invoked for each message sent to the given
+     *        channels, and is invoked on the <strong>I/O thread</strong>. So, you must not block. Offload to
+     *        a separate thread if needed. The first parameter is the channel name. The second one if the
+     *        payload.
+     * @return the subscriber object that lets you unsubscribe
+     */
+    Uni<ReactiveRedisSubscriber> subscribe(List<String> channels, BiConsumer<String, V> onMessage);
 
     /**
      * Subscribes to a given channel.
@@ -95,6 +135,23 @@ public interface ReactivePubSubCommands<V> extends ReactiveRedisCommands {
             Consumer<Throwable> onException);
 
     /**
+     * Same as {@link #subscribeToPatterns(List, Consumer, Runnable, Consumer)}, but also receives the channel name.
+     *
+     * @param pattern the pattern
+     * @param onMessage the message consumer. Be aware that this callback is invoked for each message sent to the
+     *        channels matching the pattern, and is invoked on the <strong>I/O thread</strong>. So, you must
+     *        not block. Offload to a separate thread if needed. The first parameter is the name of the
+     *        channel. The second parameter is the payload.
+     * @param onEnd the end handler. Be aware that this callback is invoked on the <strong>I/O thread</strong>.
+     *        So, you must not block. Offload to a separate thread if needed.
+     * @param onException the exception handler. Be aware that this callback is invoked on the <strong>I/O thread</strong>.
+     *        So, you must not block. Offload to a separate thread if needed.
+     * @return the subscriber object that lets you unsubscribe
+     */
+    Uni<ReactiveRedisSubscriber> subscribeToPattern(String pattern, BiConsumer<String, V> onMessage, Runnable onEnd,
+            Consumer<Throwable> onException);
+
+    /**
      * Subscribes to the given patterns like {@code chan*l}.
      *
      * @param patterns the patterns
@@ -108,6 +165,23 @@ public interface ReactivePubSubCommands<V> extends ReactiveRedisCommands {
      * @return the subscriber object that lets you unsubscribe
      */
     Uni<ReactiveRedisSubscriber> subscribeToPatterns(List<String> patterns, Consumer<V> onMessage, Runnable onEnd,
+            Consumer<Throwable> onException);
+
+    /**
+     * Same as {@link #subscribeToPatterns(List, Consumer, Runnable, Consumer)}, but also receive the channel name.
+     *
+     * @param patterns the patterns
+     * @param onMessage the message consumer. Be aware that this callback is invoked for each message sent to the
+     *        channels matching the pattern, and is invoked on the <strong>I/O thread</strong>. So, you must
+     *        not block. Offload to a separate thread if needed. The first parameter is the name of the
+     *        channel. The second parameter is the payload.
+     * @param onEnd the end handler. Be aware that this callback is invoked on the <strong>I/O thread</strong>.
+     *        So, you must not block. Offload to a separate thread if needed.
+     * @param onException the exception handler. Be aware that this callback is invoked on the <strong>I/O thread</strong>.
+     *        So, you must not block. Offload to a separate thread if needed.
+     * @return the subscriber object that lets you unsubscribe
+     */
+    Uni<ReactiveRedisSubscriber> subscribeToPatterns(List<String> patterns, BiConsumer<String, V> onMessage, Runnable onEnd,
             Consumer<Throwable> onException);
 
     /**
@@ -127,6 +201,23 @@ public interface ReactivePubSubCommands<V> extends ReactiveRedisCommands {
             Consumer<Throwable> onException);
 
     /**
+     * Same as {@link #subscribe(List, Consumer, Runnable, Consumer)} but also receives the channel name.
+     *
+     * @param channels the channels
+     * @param onMessage the message consumer. Be aware that this callback is invoked for each message sent to the given
+     *        channels, and is invoked on the <strong>I/O thread</strong>. So, you must not block. Offload to
+     *        a separate thread if needed. The first parameter is the name of the channel. The second
+     *        parameter is the payload.
+     * @param onEnd the end handler. Be aware that this callback is invoked on the <strong>I/O thread</strong>.
+     *        So, you must not block. Offload to a separate thread if needed.
+     * @param onException the exception handler. Be aware that this callback is invoked on the <strong>I/O thread</strong>.
+     *        So, you must not block. Offload to a separate thread if needed.
+     * @return the subscriber object that lets you unsubscribe
+     */
+    Uni<ReactiveRedisSubscriber> subscribe(List<String> channels, BiConsumer<String, V> onMessage, Runnable onEnd,
+            Consumer<Throwable> onException);
+
+    /**
      * Subscribes to the given channels.
      * This method returns a {@code Multi} emitting an item of type {@code V} for each received message.
      * This emission happens on the <strong>I/O thread</strong>, so you must not block. Use {@code emitOn} to offload
@@ -138,6 +229,15 @@ public interface ReactivePubSubCommands<V> extends ReactiveRedisCommands {
     Multi<V> subscribe(String... channels);
 
     /**
+     * Same as {@link #subscribe(String...)}, but instead of receiving the message payload directly, it receives
+     * instances of {@link RedisPubSubMessage} wrapping the payload and the channel on which the message has been sent.
+     *
+     * @param channels the channels
+     * @return the stream of message
+     */
+    Multi<RedisPubSubMessage<V>> subscribeAsMessages(String... channels);
+
+    /**
      * Subscribes to the given patterns.
      * This method returns a {@code Multi} emitting an item of type {@code V} for each received message.
      * This emission happens on the <strong>I/O thread</strong>, so you must not block. Use {@code emitOn} to offload
@@ -147,6 +247,15 @@ public interface ReactivePubSubCommands<V> extends ReactiveRedisCommands {
      * @return the stream of message
      */
     Multi<V> subscribeToPatterns(String... patterns);
+
+    /**
+     * Same as {@link #subscribeToPatterns(String...)}, but instead of receiving only the message payload, it receives
+     * instances of {@link RedisPubSubMessage} containing both the payload and the name of the channel.
+     *
+     * @param patterns the patterns
+     * @return the stream of message
+     */
+    Multi<RedisPubSubMessage<V>> subscribeAsMessagesToPatterns(String... patterns);
 
     /**
      * A redis subscriber

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/pubsub/RedisPubSubMessage.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/pubsub/RedisPubSubMessage.java
@@ -1,0 +1,22 @@
+package io.quarkus.redis.datasource.pubsub;
+
+/**
+ * A structure encapsulating the Redis pub/sub payload and the channel on which the message was sent.
+ * This structure is used when using {@link ReactivePubSubCommands#subscribeAsMessages(String...)} and
+ * {@link ReactivePubSubCommands#subscribeAsMessagesToPatterns(String...)}
+ *
+ * @param <V> the type of payload
+ */
+public interface RedisPubSubMessage<V> {
+
+    /**
+     * @return the payload.
+     */
+    V getPayload();
+
+    /**
+     * @return the channel on which the message was sent.
+     */
+    String getChannel();
+
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingPubSubCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingPubSubCommandsImpl.java
@@ -4,6 +4,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import io.quarkus.redis.datasource.RedisDataSource;
@@ -69,6 +70,44 @@ public class BlockingPubSubCommandsImpl<V> extends AbstractRedisCommandGroup imp
 
     @Override
     public RedisSubscriber subscribe(List<String> channels, Consumer<V> onMessage, Runnable onEnd,
+            Consumer<Throwable> onException) {
+        return reactive.subscribe(channels, onMessage, onEnd, onException)
+                .map(r -> new BlockingRedisSubscriber(r))
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public RedisSubscriber subscribeToPattern(String pattern, BiConsumer<String, V> onMessage) {
+        return reactive.subscribeToPattern(pattern, onMessage)
+                .map(r -> new BlockingRedisSubscriber(r))
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public RedisSubscriber subscribeToPatterns(List<String> patterns, BiConsumer<String, V> onMessage) {
+        return reactive.subscribeToPatterns(patterns, onMessage)
+                .map(r -> new BlockingRedisSubscriber(r))
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public RedisSubscriber subscribeToPattern(String pattern, BiConsumer<String, V> onMessage, Runnable onEnd,
+            Consumer<Throwable> onException) {
+        return reactive.subscribeToPattern(pattern, onMessage, onEnd, onException)
+                .map(r -> new BlockingRedisSubscriber(r))
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public RedisSubscriber subscribeToPatterns(List<String> patterns, BiConsumer<String, V> onMessage, Runnable onEnd,
+            Consumer<Throwable> onException) {
+        return reactive.subscribeToPatterns(patterns, onMessage, onEnd, onException)
+                .map(r -> new BlockingRedisSubscriber(r))
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public RedisSubscriber subscribe(List<String> channels, BiConsumer<String, V> onMessage, Runnable onEnd,
             Consumer<Throwable> onException) {
         return reactive.subscribe(channels, onMessage, onEnd, onException)
                 .map(r -> new BlockingRedisSubscriber(r))

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/DefaultRedisPubSubMessage.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/DefaultRedisPubSubMessage.java
@@ -1,0 +1,24 @@
+package io.quarkus.redis.runtime.datasource;
+
+import io.quarkus.redis.datasource.pubsub.RedisPubSubMessage;
+
+public class DefaultRedisPubSubMessage<V> implements RedisPubSubMessage<V> {
+
+    private final V payload;
+    private final String channel;
+
+    public DefaultRedisPubSubMessage(V payload, String channel) {
+        this.payload = payload;
+        this.channel = channel;
+    }
+
+    @Override
+    public V getPayload() {
+        return payload;
+    }
+
+    @Override
+    public String getChannel() {
+        return channel;
+    }
+}


### PR DESCRIPTION
When using Redis Pub/Sub, receiving the message channel was impossible.
This was a problem when subscribing to multiple channels or using regexp.

This commit adds methods for receiving a bi-consumer to get the channel name and payload.
When not possible (for method returning a Multi), a dedicated structure is introduced (RedisPubSubMessage).

Fix #32979