### PR TITLE
Minor clean-ups and javadoc improvements

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/DeploymentUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/DeploymentUtil.java
@@ -19,7 +19,7 @@ public class DeploymentUtil {
 
     /**
      * Get the available deployers.
-     * The list is obtained by checking for properties `quarkus.xxx.deploy`.
+     * The list is obtained by checking for properties {@code quarkus.xxx.deploy}.
      * These properties have a default value and thus they will be found regardless of the
      * actual user configuration, so we check for property names instead.
      *
@@ -28,14 +28,14 @@ public class DeploymentUtil {
     public static List<String> getDeployers() {
         Config config = ConfigProvider.getConfig();
         return StreamSupport.stream(config.getPropertyNames().spliterator(), false)
-                .map(p -> QUARKUS_DEPLOY_PATTERN.matcher(p))
+                .map(QUARKUS_DEPLOY_PATTERN::matcher)
                 .filter(Matcher::matches)
                 .map(m -> m.group(1))
                 .collect(Collectors.toList());
     }
 
     /**
-     * @return a {@link Predicate} that tests if deploye is enabled.
+     * @return a {@link Predicate} that tests if deployer is enabled.
      */
     public static Predicate<String> isDeployExplicitlyEnabled() {
         return deployer -> ConfigProvider.getConfig().getOptionalValue(String.format(DEPLOY, deployer), Boolean.class)
@@ -50,17 +50,20 @@ public class DeploymentUtil {
     }
 
     /**
-     * Check if any of the specified deployers is enabled.
+     * Check if any of the specified deployers are enabled.
      *
-     * @param the name of the speicifed deployers.
-     * @return true if the specified deploy is explicitly enabled, fasle otherwise.
+     * @param deployers name of the specified deployers.
+     * @return {@code true} if the specified deployer is explicitly enabled, {@code false} otherwise.
      */
-    public static boolean isDeploymentEnabled(String... deployer) {
-        return getDeployers().stream().filter(isDeployExplicitlyEnabled()).anyMatch(d -> Arrays.asList(deployer).contains(d));
+    public static boolean isDeploymentEnabled(String... deployers) {
+        if (deployers == null) {
+            return false;
+        }
+        return getDeployers().stream().filter(isDeployExplicitlyEnabled()).anyMatch(d -> Arrays.asList(deployers).contains(d));
     }
 
     /**
-     * @return true if deployment is explicitly enabled using: `quarkus.<deployment target>.deploy=true`.
+     * @return true if deployment is explicitly enabled using: {@code quarkus.<deployment target>.deploy=true}.
      */
     public static boolean isDeploymentEnabled() {
         return getEnabledDeployer().isPresent();

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
@@ -89,7 +89,7 @@ public class KnativeProcessor {
     public void checkKnative(ApplicationInfoBuildItem applicationInfo, KnativeConfig config,
             BuildProducer<KubernetesDeploymentTargetBuildItem> deploymentTargets,
             BuildProducer<KubernetesResourceMetadataBuildItem> resourceMeta) {
-        List<String> targets = KubernetesConfigUtil.getConfiguratedDeploymentTargets();
+        List<String> targets = KubernetesConfigUtil.getConfiguredDeploymentTargets();
         boolean knativeEnabled = targets.contains(KNATIVE);
         deploymentTargets.produce(
                 new KubernetesDeploymentTargetBuildItem(KNATIVE, KNATIVE_SERVICE, KNATIVE_SERVICE_GROUP,

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -158,7 +158,7 @@ public class KubernetesDeployer {
             ContainerImageConfig containerImageConfig) {
         final DeploymentTargetEntry selectedTarget;
 
-        List<String> userSpecifiedDeploymentTargets = KubernetesConfigUtil.getExplictilyDeploymentTargets();
+        List<String> userSpecifiedDeploymentTargets = KubernetesConfigUtil.getExplicitlyConfiguredDeploymentTargets();
         if (userSpecifiedDeploymentTargets.isEmpty()) {
             selectedTarget = targets.getEntriesSortedByPriority().get(0);
             if (targets.getEntriesSortedByPriority().size() > 1) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -140,10 +140,7 @@ class KubernetesProcessor {
             optionalProject.ifPresent(project -> {
                 Set<String> targets = new HashSet<>();
                 targets.add(COMMON);
-                targets.addAll(kubernetesDeploymentTargets.getEntriesSortedByPriority()
-                        .stream()
-                        .map(DeploymentTargetEntry::getName)
-                        .collect(Collectors.toSet()));
+                targets.addAll(deploymentTargets);
                 final Map<String, String> generatedResourcesMap;
                 final SessionWriter sessionWriter = new QuarkusFileWriter(project);
                 final SessionReader sessionReader = new SimpleFileReader(

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
@@ -86,7 +86,7 @@ public class OpenshiftProcessor {
     public void checkOpenshift(ApplicationInfoBuildItem applicationInfo, Capabilities capabilities, OpenshiftConfig config,
             BuildProducer<KubernetesDeploymentTargetBuildItem> deploymentTargets,
             BuildProducer<KubernetesResourceMetadataBuildItem> resourceMeta) {
-        List<String> targets = KubernetesConfigUtil.getConfiguratedDeploymentTargets();
+        List<String> targets = KubernetesConfigUtil.getConfiguredDeploymentTargets();
         boolean openshiftEnabled = targets.contains(OPENSHIFT);
 
         DeploymentResourceKind deploymentResourceKind = config.getDeploymentResourceKind(capabilities);

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
@@ -74,14 +74,11 @@ public class VanillaKubernetesProcessor {
             BuildProducer<KubernetesResourceMetadataBuildItem> resourceMeta) {
         String kind = config.getDeploymentResourceKind(capabilities).kind;
 
-        List<String> userSpecifiedDeploymentTargets = KubernetesConfigUtil.getConfiguratedDeploymentTargets();
+        List<String> userSpecifiedDeploymentTargets = KubernetesConfigUtil.getConfiguredDeploymentTargets();
         if (userSpecifiedDeploymentTargets.isEmpty() || userSpecifiedDeploymentTargets.contains(KUBERNETES)) {
-            // when nothing was selected by the user, we enable vanilla Kubernetes by
-            // default
-            deploymentTargets
-                    .produce(
-                            new KubernetesDeploymentTargetBuildItem(KUBERNETES, kind, DEPLOYMENT_GROUP,
-                                    DEPLOYMENT_VERSION, VANILLA_KUBERNETES_PRIORITY, true, config.deployStrategy));
+            // when nothing was selected by the user, we enable vanilla Kubernetes by default
+            deploymentTargets.produce(new KubernetesDeploymentTargetBuildItem(KUBERNETES, kind, DEPLOYMENT_GROUP,
+                    DEPLOYMENT_VERSION, VANILLA_KUBERNETES_PRIORITY, true, config.deployStrategy));
 
             String name = ResourceNameUtil.getResourceName(config, applicationInfo);
             resourceMeta.produce(new KubernetesResourceMetadataBuildItem(KUBERNETES, DEPLOYMENT_GROUP, DEPLOYMENT_VERSION,


### PR DESCRIPTION
~~The motivation for this feature is to disable manifest generation so that users could add the extension to their application but only trigger the manifest generation on demand using the `quarkus.kubernetes.enabled` property, which would be 
enabled by default to preserve the existing behavior.~~

updated to just be cleanup and javadocs.
 /cc @iocanel