### PR TITLE
Don't strip stack trace on startup failures

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -194,7 +194,7 @@ public class ApplicationLifecycleManager {
                     System.err.println(rootCause.getMessage());
                 } else {
                     // If it is not a ConfigurationException it should be safe to call ConfigProvider.getConfig here
-                    applicationLogger.errorv(rootCause, "Failed to start application (with profile {0})",
+                    applicationLogger.errorv(e, "Failed to start application (with profile {0})",
                             ConfigUtils.getProfiles());
                     ensureConsoleLogsDrained();
                 }

--- a/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayExtensionRepairAtStartTest.java
+++ b/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayExtensionRepairAtStartTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.runtime.util.ExceptionUtil;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
@@ -45,7 +46,8 @@ public class FlywayExtensionRepairAtStartTest {
         await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
             assertThat(config.getLogRecords()).anySatisfy(r -> {
                 assertThat(r.getMessage()).contains("Failed to start application");
-                assertThat(r.getThrown().getMessage()).contains("Migration checksum mismatch for migration version 1.0.0");
+                assertThat(ExceptionUtil.getRootCause(r.getThrown()).getMessage())
+                        .contains("Migration checksum mismatch for migration version 1.0.0");
             });
             RestAssured.get("/flyway/current-version").then().statusCode(500);
         });


### PR DESCRIPTION
Resolves: #32763

From what I see in the source of `ApplicationLifecycleManager` we detect the root cause to check if its:
- PreventFurtherStepException
- ConfigurationException
- etc

However, we should use the original exception for logging, so that the context is not stripped and the error message makes sense. This PR does that.