### PR TITLE
Configurable strategy to control GraalVM build image pulling

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -88,7 +88,9 @@ public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRu
                 final ProcessBuilder pb = new ProcessBuilder(
                         Arrays.asList(containerRuntime.getExecutableName(), "pull", effectiveBuilderImage));
                 pullProcess = ProcessUtil.launchProcess(pb, processInheritIODisabled);
-                pullProcess.waitFor();
+                if (pullProcess.waitFor() != 0) {
+                    throw new RuntimeException("Failed to pull builder image '" + effectiveBuilderImage + "'");
+                }
             } catch (IOException | InterruptedException e) {
                 throw new RuntimeException("Failed to pull builder image '" + effectiveBuilderImage + "'", e);
             } finally {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -149,7 +149,7 @@ public class NativeImageBuildStep {
             Files.writeString(outputDir.resolve("native-image.args"), String.join(" ", command));
             Files.writeString(outputDir.resolve("graalvm.version"), GraalVM.Version.CURRENT.version.toString());
             if (nativeImageRunner.isContainerBuild()) {
-                Files.writeString(outputDir.resolve("native-builder.image"), nativeConfig.getEffectiveBuilderImage());
+                Files.writeString(outputDir.resolve("native-builder.image"), nativeConfig.builderImage().getEffectiveImage());
             }
         } catch (IOException | RuntimeException e) {
             throw new RuntimeException("Failed to build native image sources", e);

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
@@ -44,7 +44,7 @@ public class UpxCompressionBuildStep {
             return;
         }
 
-        String effectiveBuilderImage = nativeConfig.getEffectiveBuilderImage();
+        String effectiveBuilderImage = nativeConfig.builderImage().getEffectiveImage();
         Optional<File> upxPathFromSystem = getUpxFromSystem();
         if (upxPathFromSystem.isPresent()) {
             log.debug("Running UPX from system path");

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/NativeConfigTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/NativeConfigTest.java
@@ -8,23 +8,23 @@ class NativeConfigTest {
 
     @Test
     public void testBuilderImageProperlyDetected() {
-        assertThat(createConfig("graalvm").getEffectiveBuilderImage()).contains("ubi-quarkus-graalvmce-builder-image")
+        assertThat(createConfig("graalvm").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
                 .contains("java17");
-        assertThat(createConfig("GraalVM").getEffectiveBuilderImage()).contains("ubi-quarkus-graalvmce-builder-image")
+        assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
                 .contains("java17");
-        assertThat(createConfig("GraalVM").getEffectiveBuilderImage()).contains("ubi-quarkus-graalvmce-builder-image")
+        assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
                 .contains("java17");
-        assertThat(createConfig("GRAALVM").getEffectiveBuilderImage()).contains("ubi-quarkus-graalvmce-builder-image")
-                .contains("java17");
-
-        assertThat(createConfig("mandrel").getEffectiveBuilderImage()).contains("ubi-quarkus-mandrel-builder-image")
-                .contains("java17");
-        assertThat(createConfig("Mandrel").getEffectiveBuilderImage()).contains("ubi-quarkus-mandrel-builder-image")
-                .contains("java17");
-        assertThat(createConfig("MANDREL").getEffectiveBuilderImage()).contains("ubi-quarkus-mandrel-builder-image")
+        assertThat(createConfig("GRAALVM").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
                 .contains("java17");
 
-        assertThat(createConfig("aRandomString").getEffectiveBuilderImage()).isEqualTo("aRandomString");
+        assertThat(createConfig("mandrel").builderImage().getEffectiveImage()).contains("ubi-quarkus-mandrel-builder-image")
+                .contains("java17");
+        assertThat(createConfig("Mandrel").builderImage().getEffectiveImage()).contains("ubi-quarkus-mandrel-builder-image")
+                .contains("java17");
+        assertThat(createConfig("MANDREL").builderImage().getEffectiveImage()).contains("ubi-quarkus-mandrel-builder-image")
+                .contains("java17");
+
+        assertThat(createConfig("aRandomString").builderImage().getEffectiveImage()).isEqualTo("aRandomString");
     }
 
     private NativeConfig createConfig(String builderImage) {

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/TestNativeConfig.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/TestNativeConfig.java
@@ -8,10 +8,18 @@ import io.quarkus.runtime.util.ContainerRuntimeUtil;
 
 public class TestNativeConfig implements NativeConfig {
 
-    private final String builderImage;
+    private final NativeConfig.BuilderImageConfig builderImage;
 
     public TestNativeConfig(String builderImage) {
-        this.builderImage = builderImage;
+        this(builderImage, ImagePullStrategy.ALWAYS);
+    }
+
+    public TestNativeConfig(ImagePullStrategy builderImagePull) {
+        this("mandrel", builderImagePull);
+    }
+
+    public TestNativeConfig(String builderImage, ImagePullStrategy builderImagePull) {
+        this.builderImage = new TestBuildImageConfig(builderImage, builderImagePull);
     }
 
     @Override
@@ -135,7 +143,7 @@ public class TestNativeConfig implements NativeConfig {
     }
 
     @Override
-    public String builderImage() {
+    public BuilderImageConfig builderImage() {
         return builderImage;
     }
 
@@ -202,5 +210,25 @@ public class TestNativeConfig implements NativeConfig {
     @Override
     public Compression compression() {
         return null;
+    }
+
+    private class TestBuildImageConfig implements BuilderImageConfig {
+        private final String image;
+        private final ImagePullStrategy pull;
+
+        TestBuildImageConfig(String image, ImagePullStrategy pull) {
+            this.image = image;
+            this.pull = pull;
+        }
+
+        @Override
+        public String image() {
+            return image;
+        }
+
+        @Override
+        public ImagePullStrategy pull() {
+            return pull;
+        }
     }
 }

--- a/integration-tests/maven/src/test/resources-filtered/projects/platform-properties-overrides/ext/deployment/src/main/java/org/acme/quarkus/sample/extension/deployment/AcmeExtensionProcessor.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/platform-properties-overrides/ext/deployment/src/main/java/org/acme/quarkus/sample/extension/deployment/AcmeExtensionProcessor.java
@@ -26,7 +26,7 @@ class AcmeExtensionProcessor {
     SyntheticBeanBuildItem syntheticBean(ConfigReportRecorder recorder, NativeConfig nativeConfig) {
        return SyntheticBeanBuildItem.configure(ConfigReport.class)
     		   .scope(Singleton.class)
-    		   .runtimeValue(recorder.configReport(nativeConfig.builderImage()))
+    		   .runtimeValue(recorder.configReport(nativeConfig.builderImage().image()))
     		   .done();
     }
 }


### PR DESCRIPTION
Fixes #33691

With this patch, you can set the environment variable `QUARKUS_NATIVE_BUILDER_IMAGE_PULL` to e.g. `missing`, and Quarkus will only ever pull the image if it's not available in the local docker/podman registry.

I'd appreciate if someone could test with podman as I don't have it locally, and from what I understand CI does not run against podman (yet).

I tested locally with the Hibernate ORM [quickstart](https://github.com/quarkusio/quarkus-quickstarts):

```
cd hibernate-orm-quickstart
# Will pull and build
mvn install -Dnative -DskipTests
# Will display "Found builder image [...] locally", will not pull and will build
QUARKUS_NATIVE_BUILDER_IMAGE_PULL=missing mvn install -Dnative -DskipTests
# Will display "Could not find builder image [...] locally", will pull and will build (and fail, obviously, since postgres is not a valid builder image)
QUARKUS_NATIVE_BUILDER_IMAGE_PULL=missing mvn install -Dnative -DskipTests -Dquarkus.native.builder-image=postgres:15.2
```