### PR TITLE
Fix that InifispanJsonRPCService bean is only available in DEV mode when DEV profile is active

### DIFF
--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devconsole/InfinispanDevUiProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devconsole/InfinispanDevUiProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.infinispan.client.deployment.devconsole;
 
 import org.infinispan.commons.util.Version;
 
+import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
@@ -42,6 +43,6 @@ public class InfinispanDevUiProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     public JsonRPCProvidersBuildItem createJsonRPCService() {
-        return new JsonRPCProvidersBuildItem(InfinispanJsonRPCService.class);
+        return new JsonRPCProvidersBuildItem(InfinispanJsonRPCService.class, BuiltinScope.SINGLETON.getName());
     }
 }

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/devconsole/InfinispanJsonRPCService.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/devconsole/InfinispanJsonRPCService.java
@@ -1,16 +1,9 @@
 package io.quarkus.infinispan.client.runtime.devconsole;
 
-import jakarta.inject.Singleton;
-
 import io.quarkus.arc.Arc;
-import io.quarkus.arc.Unremovable;
-import io.quarkus.arc.profile.IfBuildProfile;
 import io.quarkus.logging.Log;
 import io.smallrye.common.annotation.NonBlocking;
 
-@IfBuildProfile("dev")
-@Unremovable
-@Singleton
 public class InfinispanJsonRPCService {
 
     @NonBlocking

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevJsonRpcService.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevJsonRpcService.java
@@ -5,8 +5,6 @@ import static io.quarkus.oidc.runtime.devui.OidcDevServicesUtils.getTokens;
 import java.time.Duration;
 import java.util.Map;
 
-import jakarta.enterprise.context.ApplicationScoped;
-
 import io.quarkus.arc.Arc;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.smallrye.common.annotation.NonBlocking;
@@ -14,7 +12,6 @@ import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 
-@ApplicationScoped
 public class OidcDevJsonRpcService {
 
     private final String authorizationUrl;

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/DevUIProcessor.java
@@ -241,10 +241,13 @@ public class DevUIProcessor {
 
             Class c = jsonRPCProvidersBuildItem.getJsonRPCMethodProviderClass();
             additionalIndexProducer.produce(new AdditionalIndexedClassesBuildItem(c.getName()));
+            DotName defaultBeanScope = jsonRPCProvidersBuildItem.getDefaultBeanScope() == null
+                    ? BuiltinScope.APPLICATION.getName()
+                    : jsonRPCProvidersBuildItem.getDefaultBeanScope();
 
             additionalBeanProducer.produce(AdditionalBeanBuildItem.builder()
                     .addBeanClass(c)
-                    .setDefaultScope(BuiltinScope.APPLICATION.getName())
+                    .setDefaultScope(defaultBeanScope)
                     .setUnremovable().build());
         }
 

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/JsonRPCProvidersBuildItem.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/JsonRPCProvidersBuildItem.java
@@ -1,23 +1,38 @@
 package io.quarkus.devui.spi;
 
+import org.jboss.jandex.DotName;
+
 /**
  * This allows you to register a class that will provide data during runtime for JsonRPC Requests
  */
 public final class JsonRPCProvidersBuildItem extends AbstractDevUIBuildItem {
 
     private final Class jsonRPCMethodProviderClass;
+    private final DotName defaultBeanScope;
 
     public JsonRPCProvidersBuildItem(Class jsonRPCMethodProviderClass) {
         super();
         this.jsonRPCMethodProviderClass = jsonRPCMethodProviderClass;
+        this.defaultBeanScope = null;
+    }
+
+    public JsonRPCProvidersBuildItem(Class jsonRPCMethodProviderClass, DotName defaultBeanScope) {
+        super();
+        this.jsonRPCMethodProviderClass = jsonRPCMethodProviderClass;
+        this.defaultBeanScope = defaultBeanScope;
     }
 
     public JsonRPCProvidersBuildItem(String customIdentifier, Class jsonRPCMethodProviderClass) {
         super(customIdentifier);
         this.jsonRPCMethodProviderClass = jsonRPCMethodProviderClass;
+        this.defaultBeanScope = null;
     }
 
     public Class getJsonRPCMethodProviderClass() {
         return jsonRPCMethodProviderClass;
+    }
+
+    public DotName getDefaultBeanScope() {
+        return defaultBeanScope;
     }
 }


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/33365 provides bean `InfinispanJsonRPCService` only if build profile is `dev`, however launching application in DEV mode is not a same as setting `dev` profile. We discussed it here https://github.com/quarkusio/quarkus/issues/32004 when Hibernate did same. So Quarkus QE can't test Infinispan client DEV mode for `Caused by: jakarta.enterprise.inject.UnsatisfiedResolutionException: No bean found for required type [class io.quarkus.infinispan.client.runtime.devconsole.InfinispanJsonRPCService] and qualifiers [[]]`.

I understand this is an edge case, but IMO chosen solution is incorrect one. JSON RPC services are already by default application scoped and unremoveable and they should only be produced as beans when launch mode is DEV. This PR adds an option to make RPC svc bean with different default scope. This way, we can remove build profile annotation and other qualifiers.

When debugging this, I realized I made related mistake and always produced `OidcDevJsonRpcService`, so this PR fixes it too.