### PR TITLE
Prevent NPE in Jacoco report preparation when a workspace module has no sources

### DIFF
--- a/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
+++ b/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
@@ -123,6 +123,9 @@ public class JacocoProcessor {
     private void addProjectModule(ResolvedDependency module, JacocoConfig config, ReportInfo info, String includes,
             String excludes, Set<String> classes, Set<String> sources) throws Exception {
         info.savedData.add(new File(module.getWorkspaceModule().getBuildDir(), config.dataFile).getAbsolutePath());
+        if (module.getSources() == null) {
+            return;
+        }
         for (SourceDir src : module.getSources().getSourceDirs()) {
             for (Path p : src.getSourceTree().getRoots()) {
                 sources.add(p.toAbsolutePath().toString());


### PR DESCRIPTION
Fixes #33741