### PR TITLE
Remove unnecessary --pull parameter when running builder images

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -495,20 +495,14 @@ public interface NativeConfig {
         /**
          * Always pull the most recent image.
          */
-        ALWAYS("always"),
+        ALWAYS,
         /**
          * Only pull the image if it's missing locally.
          */
-        MISSING("missing"),
+        MISSING,
         /**
          * Never pull any image; fail if the image is missing locally.
          */
-        NEVER("never");
-
-        public final String commandLineParamValue;
-
-        ImagePullStrategy(String commandLineParamValue) {
-            this.commandLineParamValue = commandLineParamValue;
-        }
+        NEVER
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -30,8 +30,7 @@ public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRu
         this.nativeConfig = nativeConfig;
         containerRuntime = nativeConfig.containerRuntime().orElseGet(ContainerRuntimeUtil::detectContainerRuntime);
 
-        this.baseContainerRuntimeArgs = new String[] { "--env", "LANG=C", "--rm",
-                "--pull", nativeConfig.builderImage().pull().commandLineParamValue };
+        this.baseContainerRuntimeArgs = new String[] { "--env", "LANG=C", "--rm" };
 
         containerName = "build-native-" + RandomStringUtils.random(5, true, false);
     }


### PR DESCRIPTION
Follows up on #33749.

I forgot to remove this code that was just a remainder of an earlier approach which didn't go anywhere
(https://github.com/quarkusio/quarkus/issues/33691#issuecomment-1570453108).

Keeping this code could in theory lead to extra pulls when using quarkus.native.build-image.pull='always' (the default) and the image gets updated right while we're building, but more importantly it could lead to extra, unecessary queries to quay.io, so let's avoid that.