### PR TITLE
Fix detection of OpenTelemetry

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -204,7 +204,8 @@ public class SmallRyeGraphQLProcessor {
         serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(EventingService.class.getName()));
 
         // Add a condition for the optional eventing services
-        reflectiveClassCondition.produce(new ReflectiveClassConditionBuildItem(TracingService.class, "io.opentracing.Tracer"));
+        reflectiveClassCondition
+                .produce(new ReflectiveClassConditionBuildItem(TracingService.class, "io.opentelemetry.api.trace.Tracer"));
 
         // Use MicroProfile Config (We use the one from the CDI Module)
         serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(MicroProfileConfig.class.getName()));


### PR DESCRIPTION
this is for https://github.com/smallrye/smallrye-graphql/issues/1845 

The problem is that when an application contains OpenTracing, then during native mode compilation, this condition makes `io.smallrye.graphql.cdi.tracing.TracingService` reachable, but that class depends on stuff from OpenTelemetry, so it won't compile unless you have OpenTelemetry too.