### PR TITLE
Fix failing tests after removing the HTTPS port in Kubernetes

### DIFF
--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesExposingManagementInterfaceTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesExposingManagementInterfaceTest.java
@@ -47,9 +47,8 @@ public class KubernetesExposingManagementInterfaceTest {
         });
 
         assertThat(service.getSpec()).satisfies(spec -> {
-            assertThat(spec.getPorts()).hasSize(3);
+            assertThat(spec.getPorts()).hasSize(2);
             assertThat(spec.getPorts()).satisfiesOnlyOnce(port -> assertThat(port.getName()).isEqualTo("http"));
-            assertThat(spec.getPorts()).satisfiesOnlyOnce(port -> assertThat(port.getName()).isEqualTo("https"));
             assertThat(spec.getPorts()).satisfiesOnlyOnce(port -> assertThat(port.getName()).isEqualTo("management"));
         });
     }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthUsingManagementInterfaceTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthUsingManagementInterfaceTest.java
@@ -102,9 +102,8 @@ public class KubernetesWithHealthUsingManagementInterfaceTest {
             });
 
             assertThat(s.getSpec()).satisfies(spec -> {
-                assertThat(spec.getPorts()).hasSize(2);
+                assertThat(spec.getPorts()).hasSize(1);
                 assertThat(spec.getPorts()).satisfiesOnlyOnce(port -> assertThat(port.getName()).isEqualTo("http"));
-                assertThat(spec.getPorts()).satisfiesOnlyOnce(port -> assertThat(port.getName()).isEqualTo("https"));
             });
         });
     }


### PR DESCRIPTION
After https://github.com/quarkusio/quarkus/pull/33696 being merged, the port https is no longer bound by default. The problem is that I merged https://github.com/quarkusio/quarkus/pull/33694 without rebasing and these two tests needed to be updated.