### PR TITLE
Replace references of s2i with openshift

### DIFF
--- a/docs/src/main/asciidoc/container-image.adoc
+++ b/docs/src/main/asciidoc/container-image.adoc
@@ -6,13 +6,13 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Container Images
 include::_attributes.adoc[]
 :categories: cloud
-:summary: Learn how to build and push container images with Jib, S2I or Docker as part of the Quarkus build.
+:summary: Learn how to build and push container images with Jib, OpenShift or Docker as part of the Quarkus build.
 
 Quarkus provides extensions for building (and pushing) container images. Currently, it supports:
 
 - <<#jib,Jib>>
 - <<#docker,Docker>>
-- <<#s2i,S2I>>
+- <<#openshift,OpenShift>>
 - <<#buildpack,Buildpack>>
 
 == Container Image extensions
@@ -118,20 +118,20 @@ The `quarkus-container-image-docker` extension is capable of https://docs.docker
 
 NOTE: `docker buildx build` ONLY supports https://docs.docker.com/engine/reference/commandline/buildx_build/#load[loading the result of a build] to `docker images` when building for a single platform. Therefore, if you specify more than one argument in the `quarkus.docker.buildx.platform` property, the resulting images will not be loaded into `docker images`. If `quarkus.docker.buildx.platform` is omitted or if only a single platform is specified, it will then be loaded into `docker images`.
 
-[#s2i]
-=== S2I
+[#openshift]
+=== OpenShift
 
-The extension `quarkus-container-image-s2i` is using S2I binary builds in order to perform container builds inside the OpenShift cluster.
+The extension `quarkus-container-image-openshift` is using OpenShift binary builds in order to perform container builds inside the OpenShift cluster.
 The idea behind the binary build is that you just upload the artifact and its dependencies to the cluster and during the build they will be merged to a builder image (defaults to `fabric8/s2i-java`).
 
 The benefit of this approach, is that it can be combined with OpenShift's `DeploymentConfig` that makes it easy to roll out changes to the cluster.
 
 To use this feature, add the following extension to your project.
 
-:add-extension-extensions: container-image-s2i
+:add-extension-extensions: container-image-openshift
 include::{includes}/devtools/extension-add.adoc[]
 
-S2I builds require creating a `BuildConfig` and two `ImageStream` resources, one for the builder image and one for the output image.
+OpenShift builds require creating a `BuildConfig` and two `ImageStream` resources, one for the builder image and one for the output image.
 The creation of such objects is being taken care of by the Quarkus Kubernetes extension.
 
 
@@ -202,7 +202,7 @@ NOTE: If no registry is set (using `quarkus.container-image.registry`) then `doc
 
 It does not make sense to use multiple extension as part of the same build. When multiple container image extensions are present, an error will be raised to inform the user. The user can either remove the unneeded extensions or select one using `application.properties`.
 
-For example, if both `container-image-docker` and `container-image-s2i` are present and the user needs to use `container-image-docker`:
+For example, if both `container-image-docker` and `container-image-openshift` are present and the user needs to use `container-image-docker`:
 
 [source,properties]
 ----
@@ -253,8 +253,8 @@ In addition to the generic container image options, the `container-image-docker`
 
 include::{generated-dir}/config/quarkus-container-image-docker.adoc[opts=optional, leveloffset=+1]
 
-=== S2I  Options
+=== OpenShift  Options
 
-In addition to the generic container image options, the `container-image-s2i` also provides the following options:
+In addition to the generic container image options, the `container-image-openshift` also provides the following options:
 
-include::{generated-dir}/config/quarkus-container-image-s2i.adoc[opts=optional, leveloffset=+1]
+include::{generated-dir}/config/quarkus-container-image-openshift.adoc[opts=optional, leveloffset=+1]


### PR DESCRIPTION
The `container-image-s2i` extension has long been deprecated in favor of `container-image-openshift`. However, our container image documentation is still using the old one. 

This pull requests changes that.