### PR TITLE
Ignore Transfer-Encoding for lambda/azf

### DIFF
--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -115,7 +115,12 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
                         }
                         final StringBuilder sb = new StringBuilder();
                         for (Iterator<String> valueIterator = allForName.iterator(); valueIterator.hasNext();) {
-                            sb.append(valueIterator.next());
+                            String val = valueIterator.next();
+                            if (name.equalsIgnoreCase("Transfer-Encoding")
+                                    && val.equals("chunked")) {
+                                continue; // ignore transfer encoding, chunked screws up message and response
+                            }
+                            sb.append(val);
                             if (valueIterator.hasNext()) {
                                 sb.append(",");
                             }

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -97,7 +97,13 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
                     }
                     responseBuilder.setMultiValueHeaders(new Headers());
                     for (String name : res.headers().names()) {
+                        if (name.equalsIgnoreCase("Transfer-Encoding")) {
+                            continue; // ignore transfer encoding, chunked screws up message and response
+                        }
                         for (String v : res.headers().getAll(name)) {
+                            if (name.equalsIgnoreCase("Transfer-Encoding") && v.contains("chunked")) {
+                                continue;
+                            }
                             responseBuilder.getMultiValueHeaders().add(name, v);
                         }
                     }

--- a/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/BaseFunction.java
+++ b/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/BaseFunction.java
@@ -104,6 +104,11 @@ public class BaseFunction {
                     HttpResponse res = (HttpResponse) msg;
                     responseBuilder = request.createResponseBuilder(HttpStatus.valueOf(res.status().code()));
                     for (Map.Entry<String, String> entry : res.headers()) {
+                        if (entry.getKey().equalsIgnoreCase("Transfer-Encoding")
+                                && entry.getValue().contains("chunked")) {
+                            continue; // ignore transfer encoding, chunked screws up message and response
+                        }
+                        //log.info("header(" + entry.getKey() + ")=" + entry.getValue());
                         responseBuilder.header(entry.getKey(), entry.getValue());
                     }
                 }


### PR DESCRIPTION
Some http frameworks add chunked encoding formats.  Lambda and azure functions bridge is gathering all bytes and message encoding it, so chunking should not be added unless the Lambda or AZF gateway adds it themselves.

fixes: 
* https://github.com/quarkusio/quarkus/issues/31871
* https://github.com/quarkusio/quarkus/issues/25037
