### PR TITLE
Panache: Only change field visibility and move JAXB annotations from field to getter when we actually generate the getter

### DIFF
--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/PreExistingGetterTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/PreExistingGetterTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.hibernate.orm.panache.deployment.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import jakarta.persistence.Entity;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Reproducer for https://github.com/quarkusio/quarkus/issues/33832
+ */
+public class PreExistingGetterTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(PreExistingGetterEntity.class));
+
+    @Test
+    void testDeserialization() throws IOException {
+        var objectMapper = new ObjectMapper()
+                // This module is necessary to reproduce the bug.
+                .registerModule(new JakartaXmlBindAnnotationModule());
+        PreExistingGetterEntity read = objectMapper.reader()
+                .readValue("{\"field\": \"foo\"}", PreExistingGetterEntity.class);
+        assertThat(read).isNotNull();
+        assertThat(read.getField()).isEqualTo("foo");
+    }
+
+    @Entity
+    public static class PreExistingGetterEntity extends PanacheEntity {
+        public String field;
+
+        public String getField() {
+            return field;
+        }
+
+        public void setField(String field) {
+            this.field = field;
+        }
+    }
+}


### PR DESCRIPTION
If the getter already exists, we should trust users to do the right thing.

Fixes #33832 
