### PR TITLE
Work around Gradle caching issue of AppCDS file

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
@@ -348,6 +348,11 @@ public class AppCDSBuildStep {
             return null;
         }
 
+        try {
+            appCDSPath.toFile().setWritable(true); // needed to overcome Gradle caching issue, see https://github.com/quarkusio/quarkus/issues/33842
+        } catch (Exception e) {
+            log.debug("Unable to make AppCDS file writeable.", e);
+        }
         return appCDSPath;
     }
 


### PR DESCRIPTION
Fixes: #33842

P.S. This is likely not the proper fix, but it's better than the current state.