### PR TITLE
Remove the `bufferEntity` invocation in the default exception mapper

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/DefaultMicroprofileRestClientExceptionMapper.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/DefaultMicroprofileRestClientExceptionMapper.java
@@ -9,11 +9,6 @@ import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 public class DefaultMicroprofileRestClientExceptionMapper implements ResponseExceptionMapper {
 
     public Throwable toThrowable(Response response) {
-        try {
-            response.bufferEntity();
-        } catch (Exception var3) {
-        }
-
         return new WebApplicationException(
                 String.format("%s, status code %d", response.getStatusInfo().getReasonPhrase(), response.getStatus()),
                 response);


### PR DESCRIPTION
This method seems to do nothing and it causes a performance cost.