### PR TITLE
Add more documentation to @RestHeader

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/RestHeader.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/RestHeader.java
@@ -7,6 +7,11 @@ import java.lang.annotation.Target;
 
 /**
  * Equivalent of HeaderParam but with optional name.
+ * <p>
+ * When the name is not specified, then the parameter name is converted to kebab case
+ * while the first letter of every part of the kebab is made uppercase.
+ * <p>
+ * For example {@code @RestHeader String iAmTheParam} results in the value of the HTTP header {@code I-Am-The-Param} being used.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.PARAMETER })


### PR DESCRIPTION
This is needed because otherwise users
can get confused about what the actual
HTTP header being used

Closes: #33861