### PR TITLE
ArC: prevent removing the final flag from records

### DIFF
--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -90,6 +90,41 @@
 
     <profiles>
         <profile>
+            <id>java-17</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+
+            <properties>
+                <maven.compiler.target>17</maven.compiler.target>
+                <maven.compiler.source>17</maven.compiler.source>
+                <maven.compiler.release>17</maven.compiler.release>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-java17-directory</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>add-test-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/test/java17</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>kotlin-tests</id>
             <activation>
                 <property>

--- a/independent-projects/arc/tests/src/test/java17/io/quarkus/arc/test/java17/records/DependentRecordTest.java
+++ b/independent-projects/arc/tests/src/test/java17/io/quarkus/arc/test/java17/records/DependentRecordTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.arc.test.java17.records;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.DeploymentException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DependentRecordTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(DependentRecord.class);
+
+    @Test
+    public void test() {
+        assertNotNull(Arc.container().select(DependentRecord.class).get());
+    }
+
+    @Dependent
+    record DependentRecord() {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java17/io/quarkus/arc/test/java17/records/InterceptedRecordTest.java
+++ b/independent-projects/arc/tests/src/test/java17/io/quarkus/arc/test/java17/records/InterceptedRecordTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.arc.test.java17.records;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.interceptors.targetclass.mixed.AroundInvokeOnTargetClassAndOutsideAndManySuperclassesWithOverridesTest;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class InterceptedRecordTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(DependentRecord.class, MyInterceptorBinding.class, MyInterceptor.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DeploymentException.class, error);
+        assertTrue(error.getMessage().contains("records are always final"));
+    }
+
+    @Dependent
+    record DependentRecord() {
+        @MyInterceptorBinding
+        String hello() {
+            return "hello";
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    static class MyInterceptor {
+        @AroundInvoke
+        Object intercept(InvocationContext ctx) throws Exception {
+            return "intercepted: " + ctx.proceed();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java17/io/quarkus/arc/test/java17/records/NormalScopedRecordProducerTest.java
+++ b/independent-projects/arc/tests/src/test/java17/io/quarkus/arc/test/java17/records/NormalScopedRecordProducerTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.arc.test.java17.records;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DeploymentException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class NormalScopedRecordProducerTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Producer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DeploymentException.class, error);
+        assertTrue(error.getMessage().contains("records are always final"));
+    }
+
+    @Dependent
+    static class Producer {
+        @Produces
+        @ApplicationScoped
+        MyRecord produce() {
+            return new MyRecord();
+        }
+    }
+
+    record MyRecord() {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java17/io/quarkus/arc/test/java17/records/NormalScopedRecordTest.java
+++ b/independent-projects/arc/tests/src/test/java17/io/quarkus/arc/test/java17/records/NormalScopedRecordTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.arc.test.java17.records;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.DeploymentException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class NormalScopedRecordTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(NormalScopedRecord.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void trigger() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertInstanceOf(DeploymentException.class, error);
+        assertTrue(error.getMessage().contains("records are always final"));
+    }
+
+    @ApplicationScoped
+    record NormalScopedRecord() {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java17/io/quarkus/arc/test/java17/records/SingletonRecordProducerTest.java
+++ b/independent-projects/arc/tests/src/test/java17/io/quarkus/arc/test/java17/records/SingletonRecordProducerTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.arc.test.java17.records;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SingletonRecordProducerTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Producer.class);
+
+    @Test
+    public void test() {
+        assertNotNull(Arc.container().select(MyRecord.class).get());
+    }
+
+    @Dependent
+    static class Producer {
+        @Produces
+        @Singleton
+        MyRecord produce() {
+            return new MyRecord();
+        }
+    }
+
+    record MyRecord() {
+    }
+}


### PR DESCRIPTION
Record classes must always be `final`, even the `Class.isRecord()` method checks that. Therefore, the bytecode transformation that removes the `final` flag from a class is invalid for records.

With this commit, ArC will no longer blindly remove the `final` flag from records; a deployment problem occurs instead. This means that records cannot be used to define normal scoped beans and cannot be intercepted or decorated.

Fixes #33810