### PR TITLE
Gradle-plugin: properly handle read-only files

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -308,6 +308,7 @@ public abstract class QuarkusBuild extends QuarkusBuildTask {
         getLogger().info("Synchronizing Quarkus build for {} packaging from {} and {} into {}", packageType(),
                 appBuildDir, depBuildDir, appTargetDir);
         getFileSystemOperations().sync(sync -> {
+            sync.eachFile(new CopyActionDeleteNonWriteableTarget(appTargetDir.toPath()));
             sync.into(appTargetDir);
             sync.from(appBuildDir, depBuildDir);
         });

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -15,6 +15,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.CompileClasspath;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
@@ -60,6 +61,11 @@ public abstract class QuarkusGenerateCode extends QuarkusTask {
 
     public void setCompileClasspath(Configuration compileClasspath) {
         this.compileClasspath = compileClasspath;
+    }
+
+    @Input
+    public Map<String, String> getCachingRelevantInput() {
+        return extension().baseConfig().quarkusProperties();
     }
 
     @InputFiles


### PR DESCRIPTION
AppCDS files (`app-cds-jsa`) are created as read-only, which lets Gradle's copy+sync file operations fail, if the target file already exists (as read-only). Similar for Gradle's delete file system operation.

This change handles this case by deleting existing target files that are read-only.

Fixes #33842