### PR TITLE
Bump Vert.x Mutiny Bindings to version 3.4.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -67,7 +67,7 @@
         <smallrye-context-propagation.version>2.1.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.0</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.4.1</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.4.2</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.6.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.2.0</smallrye-stork.version>
         <jakarta.activation.version>2.1.2</jakarta.activation.version>


### PR DESCRIPTION
Fix the health check issue missing dependency reported in https://github.com/quarkusio/quarkus/issues/33835. 