### PR TITLE
Fix parameter validation issue in classic rest-client

### DIFF
--- a/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/ClassicRestClientBuilderFactoryTest.java
+++ b/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/ClassicRestClientBuilderFactoryTest.java
@@ -14,7 +14,7 @@ public class ClassicRestClientBuilderFactoryTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar.addClasses(EchoClientWithoutAnnotation.class, EchoClientWithConfigKey.class,
-                    EchoResource.class))
+                    EchoClientWithEmptyPath.class, EchoResource.class))
             .withConfigurationResource("factory-test-application.properties");
 
     @Test
@@ -32,5 +32,14 @@ public class ClassicRestClientBuilderFactoryTest {
         EchoClientWithoutAnnotation restClient = restClientBuilder.build(EchoClientWithoutAnnotation.class);
 
         assertThat(restClient.echo("Hello")).contains("Hello");
+    }
+
+    @Test
+    public void testEmptyPathAnnotationOnClass() {
+        RestClientBuilder restClientBuilder = RestClientBuilderFactory.getInstance()
+                .newBuilder(EchoClientWithEmptyPath.class);
+        EchoClientWithEmptyPath restClient = restClientBuilder.build(EchoClientWithEmptyPath.class);
+
+        assertThat(restClient.echo("echo", "Hello")).contains("Hello");
     }
 }

--- a/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/EchoClientWithEmptyPath.java
+++ b/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/EchoClientWithEmptyPath.java
@@ -1,0 +1,23 @@
+package io.quarkus.restclient.configuration;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("")
+@RegisterRestClient(configKey = "echo-client")
+public interface EchoClientWithEmptyPath {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Path("/{id}")
+    String echo(@PathParam("id") String id, @QueryParam("message") String message);
+
+}

--- a/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/QuarkusRestClientBuilder.java
+++ b/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/QuarkusRestClientBuilder.java
@@ -588,11 +588,12 @@ public class QuarkusRestClientBuilder implements RestClientBuilder {
         for (Method method : methods) {
             Path methodPathAnno = method.getAnnotation(Path.class);
             if (methodPathAnno != null) {
-                template = classPathAnno == null ? (ResteasyUriBuilder) new ResteasyUriBuilderImpl().uri(methodPathAnno.value())
+                template = classPathAnno == null
+                        ? (ResteasyUriBuilder) new ResteasyUriBuilderImpl().path(methodPathAnno.value())
                         : (ResteasyUriBuilder) new ResteasyUriBuilderImpl()
-                                .uri(classPathAnno.value() + "/" + methodPathAnno.value());
+                                .path(classPathAnno.value() + "/" + methodPathAnno.value());
             } else if (classPathAnno != null) {
-                template = (ResteasyUriBuilder) new ResteasyUriBuilderImpl().uri(classPathAnno.value());
+                template = (ResteasyUriBuilder) new ResteasyUriBuilderImpl().path(classPathAnno.value());
             } else {
                 template = null;
             }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ConfigurationTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ConfigurationTest.java
@@ -23,11 +23,15 @@ public class ConfigurationTest {
 
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
-            .withApplicationRoot(jar -> jar.addClasses(HelloClientWithBaseUri.class, EchoResource.class))
+            .withApplicationRoot(
+                    jar -> jar.addClasses(HelloClientWithBaseUri.class, EchoResource.class, EchoClientWithEmptyPath.class))
             .withConfigurationResource("configuration-test-application.properties");
 
     @RestClient
     HelloClientWithBaseUri client;
+
+    @RestClient
+    EchoClientWithEmptyPath echoClientWithEmptyPath;
 
     @Test
     void shouldHaveSingletonScope() {
@@ -60,6 +64,11 @@ public class ConfigurationTest {
 
         clientConfig = RestClientConfig.load("mp-client-prefix");
         verifyClientConfig(clientConfig, false);
+    }
+
+    @Test
+    void emptyPathAnnotationShouldWork() {
+        assertThat(echoClientWithEmptyPath.echo("hello", "hello world")).isEqualTo("hello world");
     }
 
     private void verifyClientConfig(RestClientConfig clientConfig, boolean checkExtraProperties) {

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/EchoClientWithEmptyPath.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/EchoClientWithEmptyPath.java
@@ -1,0 +1,22 @@
+package io.quarkus.rest.client.reactive;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("")
+@RegisterRestClient
+public interface EchoClientWithEmptyPath {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Path("/{id}")
+    String echo(@PathParam("id") String id, @QueryParam("message") String message);
+
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/configuration/EchoResource.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/configuration/EchoResource.java
@@ -1,9 +1,11 @@
 package io.quarkus.rest.client.reactive.configuration;
 
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
@@ -20,5 +22,10 @@ public class EchoResource {
         var suffix = httpHeaders.getHeaderString("suffix");
         return (message != null ? message : "hello") + (comma != null ? comma : "_") + " " + name
                 + (suffix != null ? suffix : "");
+    }
+
+    @GET
+    public String echoQueryParam(@QueryParam("message") String message) {
+        return message;
     }
 }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/configuration-test-application.properties
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/configuration-test-application.properties
@@ -18,6 +18,7 @@ quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".kee
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".max-redirects=5
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".headers.message=hi
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".headers.suffix=!
+quarkus.rest-client."io.quarkus.rest.client.reactive.EchoClientWithEmptyPath".url=http://localhost:${quarkus.http.test-port:8081}/
 
 # client identified by a configKey
 quarkus.rest-client.client-prefix.url=http://localhost:${quarkus.http.test-port:8081}/hello


### PR DESCRIPTION
URL parsing inside of `QuarkusRestClientBuilder.verifyInterface` used `ResteasyUriBuilderImpl.uri`, which works for most cases, but parsed in subtly wrong ways when the constructed path started with `//`. For example, a path of `//{id}` parses `{id}` as the hostname. Such a path was possible to trigger by a couple of scenarios:

1. Interface has `@Path("")`, and a method-level `@Path` value starting with `/`.
2. Interface has `@Path("/")`, and a method-level `@Path` value not starting with `/`.

Furthermore, if the first path component contained a path param, then it would not be counted, leading to incorrect validation results.

Fixes: #33915