### PR TITLE
Support marshalling of JAXBElements in REST Client and Server Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/SimpleXmlTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/SimpleXmlTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.StringWriter;
 
+import javax.xml.namespace.QName;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.ws.rs.Consumes;
@@ -18,6 +20,7 @@ import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.xml.bind.JAXB;
+import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -178,6 +181,19 @@ public class SimpleXmlTest {
                 .body(is("bb"));
     }
 
+    @Test
+    public void testSupportReturningJaxbElement() {
+        Person response = RestAssured
+                .get("/simple/person-as-jaxb-element")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.XML)
+                .extract().as(Person.class);
+
+        assertEquals("Bob", response.getFirst());
+        assertEquals("Builder", response.getLast());
+    }
+
     private String toXml(Object person) {
         StringWriter sw = new StringWriter();
         JAXB.marshal(person, sw);
@@ -244,6 +260,13 @@ public class SimpleXmlTest {
             person.setFirst("Bob");
             person.setLast("Builder");
             return person;
+        }
+
+        @GET
+        @Produces(MediaType.APPLICATION_XML)
+        @Path("/person-as-jaxb-element")
+        public JAXBElement<Person> getPersonAsJaxbElement() {
+            return new JAXBElement<>(new QName("person"), Person.class, getPerson());
         }
 
         @POST

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/runtime/src/main/java/io/quarkus/resteasy/reactive/jaxb/runtime/serialisers/ServerJaxbMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/runtime/src/main/java/io/quarkus/resteasy/reactive/jaxb/runtime/serialisers/ServerJaxbMessageBodyWriter.java
@@ -55,11 +55,15 @@ public class ServerJaxbMessageBodyWriter extends ServerMessageBodyWriter.AllWrit
 
     protected void marshal(Object o, OutputStream outputStream) {
         try {
-            Object jaxbObject = o;
             Class<?> clazz = o.getClass();
-            XmlRootElement jaxbElement = clazz.getAnnotation(XmlRootElement.class);
-            if (jaxbElement == null) {
-                jaxbObject = new JAXBElement(new QName(Introspector.decapitalize(clazz.getSimpleName())), clazz, o);
+            Object jaxbObject = o;
+            if (o instanceof JAXBElement) {
+                clazz = ((JAXBElement<?>) o).getDeclaredType();
+            } else {
+                XmlRootElement jaxbElement = clazz.getAnnotation(XmlRootElement.class);
+                if (jaxbElement == null) {
+                    jaxbObject = new JAXBElement(new QName(Introspector.decapitalize(clazz.getSimpleName())), clazz, o);
+                }
             }
 
             getMarshall(clazz).marshal(jaxbObject, outputStream);

--- a/extensions/resteasy-reactive/rest-client-reactive-jaxb/runtime/src/main/java/io/quarkus/rest/client/reactive/jaxb/runtime/ClientMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/rest-client-reactive-jaxb/runtime/src/main/java/io/quarkus/rest/client/reactive/jaxb/runtime/ClientMessageBodyWriter.java
@@ -46,11 +46,13 @@ public class ClientMessageBodyWriter implements MessageBodyWriter<Object> {
 
     protected void marshal(Object o, OutputStream outputStream) {
         try {
-            Object jaxbObject = o;
             Class<?> clazz = o.getClass();
-            XmlRootElement jaxbElement = clazz.getAnnotation(XmlRootElement.class);
-            if (jaxbElement == null) {
-                jaxbObject = new JAXBElement(new QName(Introspector.decapitalize(clazz.getSimpleName())), clazz, o);
+            Object jaxbObject = o;
+            if (!(o instanceof JAXBElement)) {
+                XmlRootElement jaxbElement = clazz.getAnnotation(XmlRootElement.class);
+                if (jaxbElement == null) {
+                    jaxbObject = new JAXBElement(new QName(Introspector.decapitalize(clazz.getSimpleName())), clazz, o);
+                }
             }
 
             marshaller.marshal(jaxbObject, outputStream);


### PR DESCRIPTION
I made also this change in the server, even though I think it's a niche use case here, but just to keep the server and client writers synced. 

Also, I discarded the idea of returning JAXBElements which would be a more complex scenario. 

Fix https://github.com/quarkusio/quarkus/issues/33875