### PR TITLE
Add optional native flag to build PIE binaries

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -199,6 +199,15 @@ public interface NativeConfig {
     Optional<Boolean> containerBuild();
 
     /**
+     * Explicit configuration option to generate a native Position Independent Executable (PIE) for Linux.
+     * If the system supports PIE generation, the default behaviour is to disable it for
+     * <a href="https://www.redhat.com/en/blog/position-independent-executable-pie-performance">performance reasons</a>.
+     * However, some systems can only run position-independent executables,
+     * so this option enables the generation of such native executables.
+     */
+    Optional<Boolean> pie();
+
+    /**
      * If this build is done using a remote docker daemon.
      */
     @WithDefault("false")

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/TestNativeConfig.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/TestNativeConfig.java
@@ -138,6 +138,11 @@ public class TestNativeConfig implements NativeConfig {
     }
 
     @Override
+    public Optional<Boolean> pie() {
+        return Optional.empty();
+    }
+
+    @Override
     public boolean remoteContainerBuild() {
         return false;
     }


### PR DESCRIPTION
Closes #33524. Adds `quarkus.native.pie` configuration option. Usage and verification:

```
$ mvn package -Dquarkus.native.pie=true -Dnative
...
file getting-started/target/getting-started-1.0.0-SNAPSHOT-runner
getting-started/target/getting-started-1.0.0-SNAPSHOT-runner: ELF 64-bit LSB pie executable, ...
```

Compared with:

```
$ mvn package -Dnative
file getting-started/target/getting-started-1.0.0-SNAPSHOT-runner
getting-started/target/getting-started-1.0.0-SNAPSHOT-runner: ELF 64-bit LSB executable, ...
```

Commits need squashing once review passes.

@zakkak is away so maybe @Karm or @jerboaa can review?