### PR TITLE
Downgrade `maven-shade-plugin` to 3.2.1

### DIFF
--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -34,7 +34,7 @@
         <version.nexus-staging.plugin>1.6.13</version.nexus-staging.plugin>
         <version.release.plugin>3.0.0</version.release.plugin>
         <version.resources.plugin>3.3.1</version.resources.plugin>
-        <version.shade.plugin>3.4.1</version.shade.plugin>
+        <version.shade.plugin>3.2.1</version.shade.plugin>
         <version.source.plugin>3.2.1</version.source.plugin>
         <version.surefire.plugin>${version.failsafe.plugin}</version.surefire.plugin>
         <version.versions.plugin>2.15.0</version.versions.plugin>


### PR DESCRIPTION
The latest version is causing problems when building https://github.com/quarkusio/quarkus/tree/main/extensions/grpc/protoc and https://github.com/quarkusio/quarkus/tree/main/extensions/opentelemetry/deployment:

```
[INFO] Building protoc plugin: quarkus-grpc-protoc-plugin
[INFO] Compiling 2 proto file(s) to /Users/bbaptist/devel/projects/another-version/quarkus/extensions/opentelemetry/deployment/target/generated-test-sources/protobuf/java
[ERROR] PROTOC FAILED: Error: Could not find or load main class io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator
Caused by: java.lang.NoClassDefFoundError: com/salesforce/jprotoc/Generator
--quarkus-grpc-protoc-plugin_out: protoc-gen-quarkus-grpc-protoc-plugin: Plugin failed with status code 1.

[ERROR] /Users/bbaptist/devel/projects/another-version/quarkus/extensions/opentelemetry/deployment/src/test/proto/streaming.proto [0:0]: Error: Could not find or load main class io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator
Caused by: java.lang.NoClassDefFoundError: com/salesforce/jprotoc/Generator
--quarkus-grpc-protoc-plugin_out: protoc-gen-quarkus-grpc-protoc-plugin: Plugin failed with status code 1.

[ERROR] /Users/bbaptist/devel/projects/another-version/quarkus/extensions/opentelemetry/deployment/src/test/proto/hello.proto [0:0]: Error: Could not find or load main class io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator
Caused by: java.lang.NoClassDefFoundError: com/salesforce/jprotoc/Generator
--quarkus-grpc-protoc-plugin_out: protoc-gen-quarkus-grpc-protoc-plugin: Plugin failed with status code 1.
```

Also see https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/quarkus-grpc-protoc-plugin/near/361962387 for more context