### PR TITLE
Load quarkus.uuid lazily

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ConfigConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ConfigConfig.java
@@ -4,9 +4,11 @@ import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 /**
  * We don't really use this, because these are configurations for the config itself, so it causes a chicken / egg
@@ -15,27 +17,28 @@ import io.quarkus.runtime.annotations.ConfigRoot;
  * Relocation of the Config configurations to the Quarkus namespace is done in
  * {@link io.quarkus.runtime.configuration.ConfigUtils#configBuilder}.
  */
-@ConfigRoot(name = ConfigItem.PARENT, phase = ConfigPhase.RUN_TIME)
-public class ConfigConfig {
+@ConfigMapping(prefix = "quarkus")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface ConfigConfig {
     /**
      * Profile that will be active when Quarkus launches.
      */
-    @ConfigItem(name = "profile", defaultValue = "prod")
-    public Optional<String> profile;
+    @WithDefault("prod")
+    Optional<String> profile();
 
     /**
      * Accepts a single configuration profile name. If a configuration property cannot be found in the current active
      * profile, the config performs the same lookup in the profile set by this configuration.
      */
-    @ConfigItem(name = "config.profile.parent")
-    public Optional<String> profileParent;
+    @WithName("config.profile.parent")
+    Optional<String> profileParent();
 
     /**
      * Additional config locations to be loaded with the Config. The configuration support multiple locations
      * separated by a comma and each must represent a valid {@link java.net.URI}.
      */
-    @ConfigItem(name = "config.locations")
-    public Optional<List<URI>> locations;
+    @WithName("config.locations")
+    Optional<List<URI>> locations();
 
     /**
      * A property that allows accessing a generated UUID.
@@ -43,6 +46,5 @@ public class ConfigConfig {
      * <br>
      * Access this generated UUID using expressions: `${quarkus.uuid}`.
      */
-    @ConfigItem(name = "uuid")
-    public Optional<String> uuid;
+    Optional<String> uuid();
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
@@ -17,7 +17,6 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 
@@ -42,11 +41,6 @@ import io.smallrye.config.SmallRyeConfigBuilder;
  *
  */
 public final class ConfigUtils {
-
-    /**
-     * The name of the property associated with a random UUID generated at launch time.
-     */
-    static final String UUID_KEY = "quarkus.uuid";
 
     private ConfigUtils() {
     }
@@ -94,7 +88,7 @@ public final class ConfigUtils {
             builder.withSources(new RuntimeOverrideConfigSource(Thread.currentThread().getContextClassLoader()));
         }
         if (runTime || bootstrap) {
-            builder.withDefaultValue(UUID_KEY, UUID.randomUUID().toString());
+            builder.withSources(QuarkusUUIDConfigSource.INSTANCE);
         }
         if (addDiscovered) {
             builder.addDiscoveredSources();

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/QuarkusUUIDConfigSource.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/QuarkusUUIDConfigSource.java
@@ -1,0 +1,53 @@
+package io.quarkus.runtime.configuration;
+
+import java.util.Set;
+import java.util.UUID;
+
+import jakarta.annotation.Priority;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import io.smallrye.config.Priorities;
+
+@Priority(Priorities.LIBRARY)
+public class QuarkusUUIDConfigSource implements ConfigSource {
+
+    static final String QUARKUS_UUID_CONFIG_KEY = "quarkus.uuid";
+
+    public static final QuarkusUUIDConfigSource INSTANCE = new QuarkusUUIDConfigSource();
+
+    private volatile String cachedQuarkusUUID;
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return Set.of(QUARKUS_UUID_CONFIG_KEY);
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        if (!QUARKUS_UUID_CONFIG_KEY.equals(propertyName)) {
+            return null;
+        }
+
+        String localQuarkusUUID = cachedQuarkusUUID;
+
+        if (localQuarkusUUID != null) {
+            return localQuarkusUUID;
+        }
+
+        synchronized (this) {
+            localQuarkusUUID = cachedQuarkusUUID;
+
+            if (localQuarkusUUID != null) {
+                return localQuarkusUUID;
+            }
+
+            return cachedQuarkusUUID = UUID.randomUUID().toString();
+        }
+    }
+
+    @Override
+    public String getName() {
+        return QuarkusUUIDConfigSource.class.getName();
+    }
+}

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/UUIDPropertyTest.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/UUIDPropertyTest.java
@@ -2,8 +2,6 @@ package io.quarkus.runtime.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.UUID;
-
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.runtime.LaunchMode;
@@ -15,7 +13,7 @@ public class UUIDPropertyTest {
 
     private SmallRyeConfig buildConfig() {
         final SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
-        builder.withDefaultValue(ConfigUtils.UUID_KEY, UUID.randomUUID().toString());
+        builder.withSources(QuarkusUUIDConfigSource.INSTANCE);
         final SmallRyeConfig config = builder.build();
         return config;
     }
@@ -24,7 +22,7 @@ public class UUIDPropertyTest {
     void testConfigSource() {
         SmallRyeConfig config = buildConfig();
         assertThat(config.getConfigSources()).isNotEmpty();
-        ConfigValue value = config.getConfigValue(ConfigUtils.UUID_KEY);
+        ConfigValue value = config.getConfigValue(QuarkusUUIDConfigSource.QUARKUS_UUID_CONFIG_KEY);
         assertThat(value).isNotNull();
         assertThat(value.getValue()).isNotNull().isNotBlank();
     }
@@ -33,7 +31,7 @@ public class UUIDPropertyTest {
     void testBuildTimeWithDevMode() {
         SmallRyeConfig config = ConfigUtils.configBuilder(false, LaunchMode.DEVELOPMENT).build();
         assertThat(config.getConfigSources()).isNotEmpty();
-        ConfigValue value = config.getConfigValue(ConfigUtils.UUID_KEY);
+        ConfigValue value = config.getConfigValue(QuarkusUUIDConfigSource.QUARKUS_UUID_CONFIG_KEY);
         assertThat(value).isNotNull();
         assertThat(value.getValue()).isNull();
     }


### PR DESCRIPTION
It does not work yet as just having the property declared in the config actually gets the value.

@radcortez so here is a first try at trying to load `quarkus.uuid` lazily. Unfortunately, it doesn't work as soon as you have the property declared in the config. I tried to move it to `@ConfigMapping` in case it would help but it didn't.

Not sure if we should add something to SmallRye Config to allow lazy loading config property or something to somehow ignore them.

Note: having the property in the config is handy for two reasons: it documents it and it prevents the infamous `Unrecognized config property` warning.

Let me know what you think :).