### PR TITLE
Vertx GraphQL supports graphql-transport-ws sub-protocol

### DIFF
--- a/extensions/vertx-graphql/deployment/src/main/java/io/quarkus/vertx/graphql/deployment/VertxGraphqlProcessor.java
+++ b/extensions/vertx-graphql/deployment/src/main/java/io/quarkus/vertx/graphql/deployment/VertxGraphqlProcessor.java
@@ -22,7 +22,6 @@ import io.quarkus.vertx.http.deployment.WebsocketSubProtocolsBuildItem;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.graphql.impl.GraphQLBatch;
-// import io.vertx.ext.web.handler.graphql.impl.GraphQLInputDeserializer;
 import io.vertx.ext.web.handler.graphql.impl.GraphQLQuery;
 
 class VertxGraphqlProcessor {
@@ -34,14 +33,18 @@ class VertxGraphqlProcessor {
     }
 
     @BuildStep
-    WebsocketSubProtocolsBuildItem websocketSubProtocols() {
+    WebsocketSubProtocolsBuildItem graphQLWSProtocol() {
+        return new WebsocketSubProtocolsBuildItem("graphql-transport-ws");
+    }
+
+    @BuildStep
+    WebsocketSubProtocolsBuildItem appoloWSProtocol() {
         return new WebsocketSubProtocolsBuildItem("graphql-ws");
     }
 
     @BuildStep
     List<ReflectiveClassBuildItem> registerForReflection() {
         return Arrays.asList(
-                //new ReflectiveClassBuildItem(true, true, GraphQLInputDeserializer.class.getName()),
                 ReflectiveClassBuildItem.builder(GraphQLBatch.class.getName()).methods().fields().build(),
                 ReflectiveClassBuildItem.builder(GraphQLQuery.class.getName()).methods().fields().build());
     }

--- a/integration-tests/vertx-graphql/src/main/java/io/quarkus/vertx/graphql/it/VertxGraphqlResource.java
+++ b/integration-tests/vertx-graphql/src/main/java/io/quarkus/vertx/graphql/it/VertxGraphqlResource.java
@@ -28,8 +28,8 @@ import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
-import io.vertx.ext.web.handler.graphql.ApolloWSHandler;
 import io.vertx.ext.web.handler.graphql.GraphQLHandler;
+import io.vertx.ext.web.handler.graphql.ws.GraphQLWSHandler;
 
 @ApplicationScoped
 public class VertxGraphqlResource {
@@ -50,8 +50,9 @@ public class VertxGraphqlResource {
         GraphQL graphQL = GraphQL.newGraphQL(graphQLSchema).build();
 
         router.post().handler(BodyHandler.create());
-        router.route("/graphql").handler(ApolloWSHandler.create(graphQL));
-        router.route("/graphql").handler(GraphQLHandler.create(graphQL));
+        router.route("/graphql")
+                .handler(GraphQLWSHandler.create(graphQL))
+                .handler(GraphQLHandler.create(graphQL));
     }
 
 }


### PR DESCRIPTION
The ApolloWSHandler has been deprecated in Vert.x 4 and will be removed in Vert.x 5.

The VertxGraphqlProcessor has been changed to produces a new WebsocketSubProtocolsBuildItem The VertxGraphqlTest has been updated to verify connectivity with GraphQLWSHandler