### PR TITLE
Force Linux line endings for mvnw

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # ./mvnw fails on Windows in git bash if -Xmx in that file has a trailing CRLF
 .mvn/jvm.config		text eol=lf
+mvnw	text eol=lf
 *.xml	text eol=lf
 *.java	text diff=java eol=lf
 *.kt	text diff=kotlin eol=lf


### PR DESCRIPTION
Without this fix, executing `mvnw` on Windows in a Cygwin environment fails:

```shell
$ ./mvnw validate
./mvnw: line 20: $'\r': command not found
./mvnw: line 35: $'\r': command not found
./mvnw: line 56: syntax error near unexpected token `$'in\r''
'/mvnw: line 56: `case "$(uname)" in
```

Execution is successful if .mvnw has Linux line endings.