### PR TITLE
Generated docs should generate mvn create app command with Quarkus version and not stream version

### DIFF
--- a/docs/src/main/asciidoc/_includes/devtools/create-app.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/create-app.adoc
@@ -62,7 +62,7 @@ _For more information about how to install the Quarkus CLI and use it, please re
 ----
 mvn {quarkus-platform-groupid}:quarkus-maven-plugin:{quarkus-version}:create \
 ifdef::create-app-stream[]
-    -DplatformVersion={create-app-stream} \
+    -DplatformVersion={quarkus-version} \
 endif::[]
     -DprojectGroupId={create-app-group-id} \
 ifdef::create-app-extensions[]


### PR DESCRIPTION
I tried https://quarkus.io/version/2.13/guides/maven-tooling on Maven tab and this is suggested command to create app:
```
mvn io.quarkus.platform:quarkus-maven-plugin:2.13.8.Final:create \
    -DplatformVersion=2.13 \
    -DprojectGroupId=my-groupId \
    -DprojectArtifactId=my-artifactId
```
so platformVersion is set to 
https://github.com/quarkusio/quarkusio.github.io/blob/ca55ed96950f7ae303865507c4ec86daa2bf2981/_versions/2.13/guides/_attributes-local.adoc#L8
however `platformVersion` should be `2.13.8.Final`
https://github.com/quarkusio/quarkus/blob/197c9219df4ec331ccc5c39a6c6e4b3b1d09b5d4/devtools/maven/src/main/java/io/quarkus/maven/CreateProjectMojo.java#LL101C32-L101C32
so command fails:
```
Execution default-cli of goal io.quarkus.platform:quarkus-maven-plugin:2.13.8.Final:create failed: Failed to resolve extension catalog for io.quarkus.platform:quarkus-bom:pom:2.13. Make sure the groupId, artifactId and version are spelled correctly and the relevant Maven repositories are configured
```
while following pass:
```
mvn io.quarkus.platform:quarkus-maven-plugin:2.13.8.Final:create \
    -DplatformVersion=2.13.8.Final \
    -DprojectGroupId=my-groupId \
    -DprojectArtifactId=my-artifactId
```
but we should still only append it when quarkusio.github.io repo actually defines `create-app-stream`.