### PR TITLE
Fix property "http-action-port-name" is ignored by Kubernetes

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
@@ -971,16 +971,23 @@ public class KubernetesCommonHelper {
                 .or(() -> portName.map(KubernetesProbePortNameBuildItem::getName))
                 .orElse(HTTP_PORT);
 
-        Integer port = probeConfig.httpActionPort
-                .orElse(ports.stream().filter(p -> httpPortName.equals(p.getName()))
-                        .map(KubernetesPortBuildItem::getPort).findFirst().orElse(DEFAULT_HTTP_PORT));
+        Integer port;
+        PortConfig portFromConfig = portsFromConfig.get(httpPortName);
+        if (probeConfig.httpActionPort.isPresent()) {
+            port = probeConfig.httpActionPort.get();
+        } else if (portFromConfig != null && portFromConfig.containerPort.isPresent()) {
+            port = portFromConfig.containerPort.getAsInt();
+        } else {
+            port = ports.stream().filter(p -> httpPortName.equals(p.getName()))
+                    .map(KubernetesPortBuildItem::getPort).findFirst().orElse(DEFAULT_HTTP_PORT);
+        }
 
         // Resolve scheme property from:
         String scheme;
         if (probeConfig.httpActionScheme.isPresent()) {
             // 1. User in Probe config
             scheme = probeConfig.httpActionScheme.get();
-        } else if (portsFromConfig.containsKey(httpPortName) && portsFromConfig.get(httpPortName).tls) {
+        } else if (portFromConfig != null && portFromConfig.tls) {
             // 2. User in Ports config
             scheme = SCHEME_HTTPS;
         } else if (portName.isPresent()
@@ -993,7 +1000,9 @@ public class KubernetesCommonHelper {
             scheme = port != null && (port == 443 || port == 8443) ? SCHEME_HTTPS : SCHEME_HTTP;
         }
 
-        return new DecoratorBuildItem(target, new ApplyHttpGetActionPortDecorator(name, name, port, probeKind, scheme));
+        // Applying to all deployments to mimic the same logic as the rest of probes in the method createProbeDecorators.
+        return new DecoratorBuildItem(target,
+                new ApplyHttpGetActionPortDecorator(ANY, name, httpPortName, port, probeKind, scheme));
     }
 
     /**

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithProbePortByNameTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithProbePortByNameTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithProbePortByNameTest {
+
+    private static final String NAME = "kubernetes-with-probe-port-by-name";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .overrideConfigKey("quarkus.kubernetes.ports.custom.container-port", "8888")
+            .overrideConfigKey("quarkus.kubernetes.readiness-probe.http-action-port-name", "custom")
+            .setLogFileName("k8s.log")
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-smallrye-health", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo(NAME);
+            });
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getContainers()).singleElement()
+                                .satisfies(container -> {
+                                    assertThat(container.getReadinessProbe()).isNotNull().satisfies(p -> {
+                                        assertEquals(p.getHttpGet().getPort().getIntVal(), 8888);
+                                        assertEquals(p.getHttpGet().getScheme(), "HTTP");
+                                    });
+                                });
+                    });
+                });
+            });
+        });
+    }
+}


### PR DESCRIPTION
When binding a new port:

```
quarkus.kubernetes.ports.custom.container-port=8888
```

The new port name is `custom` which port `8888`. 

Then, if we configure any probe to use the port name `custom`:

```
quarkus.kubernetes.readiness-probe.http-action-port-name=custom
```

The generated probe wrongly kept using the port name `http`.

Furthermore, we fix the support of the apply port decorators to use the correct config references.