### PR TITLE
Deprecate fullStacktraces

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -285,8 +285,11 @@ public interface NativeConfig {
 
     /**
      * If full stack traces are enabled in the resulting image
+     *
+     * @deprecated GraalVM 23.1+ will always build with full stack traces.
      */
     @WithDefault("true")
+    @Deprecated
     boolean fullStackTraces();
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -136,6 +136,7 @@ public final class GraalVM {
         public static final Version VERSION_22_3_0 = new Version("GraalVM 22.3.0", "22.3.0", Distribution.ORACLE);
         public static final Version VERSION_22_2_0 = new Version("GraalVM 22.2.0", "22.2.0", Distribution.ORACLE);
         public static final Version VERSION_23_0_0 = new Version("GraalVM 23.0.0", "23.0.0", Distribution.ORACLE);
+        public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", Distribution.ORACLE);
 
         public static final Version MINIMUM = VERSION_22_2_0;
         public static final Version CURRENT = VERSION_22_3_2;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -900,10 +900,13 @@ public class NativeImageBuildStep {
                 } else {
                     nativeImageArgs.add("-H:-UseServiceLoaderFeature");
                 }
-                if (nativeConfig.fullStackTraces()) {
-                    nativeImageArgs.add("-H:+StackTrace");
-                } else {
-                    nativeImageArgs.add("-H:-StackTrace");
+                // This option has no effect on GraalVM 23.1+
+                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_1_0) < 0) {
+                    if (nativeConfig.fullStackTraces()) {
+                        nativeImageArgs.add("-H:+StackTrace");
+                    } else {
+                        nativeImageArgs.add("-H:-StackTrace");
+                    }
                 }
 
                 if (nativeConfig.enableDashboardDump()) {


### PR DESCRIPTION
GraalVM 23.1+ will have this option deprecated doing nothing. Deprecate it in Quarkus as well.

See for example this CI run:
https://github.com/graalvm/mandrel/actions/runs/5227497104/jobs/9439379340#step:12:140

Fixes: https://github.com/Karm/mandrel-integration-tests/issues/167