### PR TITLE
Warn extension authors if build step and recorder are in the same package

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
@@ -44,6 +44,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
@@ -375,6 +376,11 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                             processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
                                     "Class '" + parameterTypeElement.getQualifiedName()
                                             + "' is annotated with @Recorder and therefore cannot be made as a final class.");
+                        } else if (getPackageName(clazz).equals(getPackageName(parameterTypeElement))) {
+                            processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING,
+                                    "Build step class '" + clazz.getQualifiedName()
+                                            + "' and recorder '" + parameterTypeElement
+                                            + "' share the same package. This is highly discouraged as it can lead to unexpected results.");
                         }
                         hasRecorder = true;
                         break;
@@ -388,6 +394,10 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                         + "' which is annotated with '@Record' does not contain a method parameter whose type is annotated with '@Recorder'.");
             }
         }
+    }
+
+    private Name getPackageName(TypeElement clazz) {
+        return processingEnv.getElementUtils().getPackageOf(clazz).getQualifiedName();
     }
 
     private StringBuilder getRelativeBinaryName(TypeElement te, StringBuilder b) {


### PR DESCRIPTION
This is meant to guard against cases where a call to a recorder method cannot be proxied (due to packaging rules) leading to a real call to the recorder method being performed in the build step method.
For public recorder methods, the method call is always proxyable, thus by warning about same package use, we nudge extension authors towards using public methods in their recorder classes.

Note that we cannot simply reject package private
methods in recorder since these methods could very well be used in code that is not called at build time.

Relates to: #33957