### PR TITLE
Ensure Panache class transformers run before Arc's static method transformers

### DIFF
--- a/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheHibernateResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/main/java/io/quarkus/hibernate/orm/panache/deployment/PanacheHibernateResourceProcessor.java
@@ -21,6 +21,7 @@ import org.jboss.jandex.DotName;
 
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
+import io.quarkus.arc.deployment.staticmethods.InterceptedStaticMethodsTransformersRegisteredBuildItem;
 import io.quarkus.builder.BuildException;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -92,6 +93,7 @@ public final class PanacheHibernateResourceProcessor {
 
     @BuildStep
     @Consume(HibernateEnhancersRegisteredBuildItem.class)
+    @Consume(InterceptedStaticMethodsTransformersRegisteredBuildItem.class)
     void build(
             CombinedIndexBuildItem index,
             BuildProducer<BytecodeTransformerBuildItem> transformers,

--- a/extensions/panache/hibernate-reactive-panache/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/common/deployment/PanacheHibernateResourceProcessor.java
+++ b/extensions/panache/hibernate-reactive-panache/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/common/deployment/PanacheHibernateResourceProcessor.java
@@ -18,6 +18,7 @@ import org.objectweb.asm.Type;
 
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
+import io.quarkus.arc.deployment.staticmethods.InterceptedStaticMethodsTransformersRegisteredBuildItem;
 import io.quarkus.builder.BuildException;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -90,6 +91,7 @@ public final class PanacheHibernateResourceProcessor {
 
     @BuildStep
     @Consume(HibernateEnhancersRegisteredBuildItem.class)
+    @Consume(InterceptedStaticMethodsTransformersRegisteredBuildItem.class)
     void build(CombinedIndexBuildItem index,
             BuildProducer<BytecodeTransformerBuildItem> transformers,
             List<PanacheEntityClassBuildItem> entityClasses,

--- a/extensions/panache/mongodb-panache-common/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/BasePanacheMongoResourceProcessor.java
+++ b/extensions/panache/mongodb-panache-common/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/BasePanacheMongoResourceProcessor.java
@@ -30,11 +30,13 @@ import org.jboss.jandex.Type;
 
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
+import io.quarkus.arc.deployment.staticmethods.InterceptedStaticMethodsTransformersRegisteredBuildItem;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.builder.BuildException;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.bean.JavaBeanUtil;
@@ -76,6 +78,7 @@ public abstract class BasePanacheMongoResourceProcessor {
     public static final String BSON_PACKAGE = "org.bson.";
 
     @BuildStep
+    @Consume(InterceptedStaticMethodsTransformersRegisteredBuildItem.class)
     public void buildImperative(CombinedIndexBuildItem index,
             BuildProducer<BytecodeTransformerBuildItem> transformers,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
@@ -94,6 +97,7 @@ public abstract class BasePanacheMongoResourceProcessor {
     }
 
     @BuildStep
+    @Consume(InterceptedStaticMethodsTransformersRegisteredBuildItem.class)
     public void buildReactive(CombinedIndexBuildItem index,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy,

--- a/extensions/panache/panache-hibernate-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheHibernateCommonResourceProcessor.java
+++ b/extensions/panache/panache-hibernate-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheHibernateCommonResourceProcessor.java
@@ -14,6 +14,7 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 
+import io.quarkus.arc.deployment.staticmethods.InterceptedStaticMethodsTransformersRegisteredBuildItem;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -81,6 +82,7 @@ public final class PanacheHibernateCommonResourceProcessor {
 
     @BuildStep
     @Consume(HibernateEnhancersRegisteredBuildItem.class)
+    @Consume(InterceptedStaticMethodsTransformersRegisteredBuildItem.class)
     void replaceFieldAccesses(CombinedIndexBuildItem index,
             ApplicationArchivesBuildItem applicationArchivesBuildItem,
             Optional<HibernateMetamodelForFieldAccessBuildItem> modelInfoBuildItem,


### PR DESCRIPTION
Fixes #34005

Because static method transformers end up essentially changing the name of static methods (renaming them to `*_orig` and generating another method in their place), which can cause issues when Panache looks up the new name of transformed methods in Jandex (`*_orig` methods won't be in the index).