### PR TITLE
Avoid indefinite Uni wait in OIDC recorders

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -87,7 +87,7 @@ public class OidcClientRecorder {
 
     protected static OidcClient createOidcClient(OidcClientConfig oidcConfig, String oidcClientId,
             TlsConfig tlsConfig, Supplier<Vertx> vertx) {
-        return createOidcClientUni(oidcConfig, oidcClientId, tlsConfig, vertx).await().indefinitely();
+        return createOidcClientUni(oidcConfig, oidcClientId, tlsConfig, vertx).await().atMost(oidcConfig.connectionTimeout);
     }
 
     protected static Uni<OidcClient> createOidcClientUni(OidcClientConfig oidcConfig, String oidcClientId,

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -140,7 +140,7 @@ public class OidcRecorder {
                         throw new OIDCException(t);
                     }
                 })
-                .await().indefinitely();
+                .await().atMost(oidcConfig.getConnectionTimeout());
     }
 
     private static Throwable logTenantConfigContextFailure(Throwable t, String tenantId) {


### PR DESCRIPTION
Fixes #33993.

OIDC and OIDC Client internally use Vert.x Mutiny WebClient which is configured to fail if the connection can not be established for 10 sec (default value) and there are retries there in case of the failed connections, while the higher level OIDC code currently waits indefinitely, which has worked without problems for a long while, but  #33993 confirms it is not a good idea to keep the indefinite wait around - for some difficult to identify reasons, Uni awaiting indefinitely would not get a failure reported if the lower level OIDC code does not complete its work for up to 10 secs and it keeps hanging.

@jendib just added some logging and it stopped hanging.

The best protection we can have at the OIDC level from having the application code freezing is to never rely on the indefinite wait anywhere again. So this PR replaces the last 2 cases of indefinite wait (when either `quarkus-oidc` or `quarkus-oidc-client` tries to establish a connection) to with the timed wait using the same `connection-timeout` property that the internal Vert.x WebClient is configured with - so if, due to some reason, lower level OIDC connection/initialization code does not complete its work in 10 secs (or other configured duration) then Quarkus OIDC will just fail anyway.

That should put an end to any OIDC application freezes. 
