### PR TITLE
Fix service name in the OpenShift guide

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -115,7 +115,7 @@ So unless you've used the `quarkus.openshift.route.expose` config property to ex
 .Expose The Service - OpenShift CLI Example
 [source,bash,subs=attributes+]
 ----
-oc expose svc/greeting <1>
+oc expose svc/openshift-quickstart <1>
 oc get routes <2>
 curl http://<route>/hello <3>
 ----


### PR DESCRIPTION
After the automatic deployment, only an `openshift-quickstart` service is available.

The following section showing the manual deployment has the `greeting` service created with `oc new-app --name=greeting <project>/openshift-quickstart:1.0.0-SNAPSHOT` but initially the `greeting` service is not available