### PR TITLE
Do not require custom TenantResolver when named tenants are configured

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -31,8 +31,9 @@ public class OidcTenantConfig extends OidcCommonConfig {
     /**
      * If this tenant configuration is enabled.
      *
-     * Note that the default tenant will be disabled if it is not configured
-     * but either {@link TenantResolver} or {@link TenantConfigResolver} are registered.
+     * Note that the default tenant will be disabled if it is not configured but either
+     * {@link TenantConfigResolver} which will resolve tenant configurations is registered
+     * or named tenants are configured.
      * You do not have to disable the default tenant in this case.
      */
     @ConfigItem(defaultValue = "true")

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -24,7 +24,6 @@ import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.OidcTenantConfig.Roles.Source;
 import io.quarkus.oidc.OidcTenantConfig.TokenStateManager.Strategy;
 import io.quarkus.oidc.TenantConfigResolver;
-import io.quarkus.oidc.TenantResolver;
 import io.quarkus.oidc.common.runtime.OidcCommonConfig;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.runtime.ExecutorRecorder;
@@ -115,9 +114,9 @@ public class OidcRecorder {
     }
 
     private TenantConfigContext createStaticTenantContext(Vertx vertx,
-            OidcTenantConfig oidcConfig, boolean checkTenantResolver, TlsConfig tlsConfig, String tenantId) {
+            OidcTenantConfig oidcConfig, boolean checkNamedTenants, TlsConfig tlsConfig, String tenantId) {
 
-        Uni<TenantConfigContext> uniContext = createTenantContext(vertx, oidcConfig, checkTenantResolver, tlsConfig, tenantId);
+        Uni<TenantConfigContext> uniContext = createTenantContext(vertx, oidcConfig, checkNamedTenants, tlsConfig, tenantId);
         return uniContext.onFailure()
                 .recoverWithItem(new Function<Throwable, TenantConfigContext>() {
                     @Override
@@ -152,7 +151,7 @@ public class OidcRecorder {
 
     @SuppressWarnings("resource")
     private Uni<TenantConfigContext> createTenantContext(Vertx vertx, OidcTenantConfig oidcTenantConfig,
-            boolean checkTenantResolver,
+            boolean checkNamedTenants,
             TlsConfig tlsConfig, String tenantId) {
         if (!oidcTenantConfig.tenantId.isPresent()) {
             oidcTenantConfig.tenantId = Optional.of(tenantId);
@@ -174,11 +173,10 @@ public class OidcRecorder {
                 if (OidcUtils.DEFAULT_TENANT_ID.equals(oidcConfig.tenantId.get())) {
                     ArcContainer container = Arc.container();
                     if (container != null
-                            && (container.instance(TenantConfigResolver.class).isAvailable()
-                                    || (checkTenantResolver && container.instance(TenantResolver.class).isAvailable()))) {
+                            && (container.instance(TenantConfigResolver.class).isAvailable() || checkNamedTenants)) {
                         LOG.debugf("Default tenant is not configured and will be disabled"
-                                + " because either 'TenantConfigResolver' or `TenantResolver`which will resolve"
-                                + " tenant configurations are registered");
+                                + " because either 'TenantConfigResolver' which will resolve tenant configurations is registered"
+                                + " or named tenants are configured.");
                         oidcConfig.setTenantEnabled(false);
                         return Uni.createFrom()
                                 .item(new TenantConfigContext(new OidcProvider(null, null, null, null), oidcConfig));


### PR DESCRIPTION
This is a minor follow up to #33472, which allows users to avoid having to type `quarkus.oidc.tenant-enabled=false` to disable the default tenant when either `TenantConfigResolver` which will resolves tenant configurations dynamically or when named tenant configurations are already available and `TenantResolver` is registered.

It is the very last condition,  `named tenant configurations are already available and `TenantResolver` is registered`, which needs further relaxation since now we have a default `TenantResolver` for such named tenants: #32864.

For example, right now, what will already work, if we have something like this configured:

```
quarkus.oidc.tenant-enabled=false

# tenant-id is 'spotify'
quarkus.oidc.spotify.provider=spotify
quarkus.oidc.spotify.client-id=spotify-client-id
quarkus.oidc.spotify.credentials.secret=spotify-client-secret

# tenant-id is 'twitter'
quarkus.oidc.twitter.provider=twitter
quarkus.oidc.twitter.client-id=twitter-client-id
quarkus.oidc.twitter.credentials.secret=twitter-client-secret

quarkus.http.auth.permission.login.paths=/spotify,/twitter
quarkus.http.auth.permission.login.policy=authenticated
```

Login requests ending with `/twitter` will pick up a tenant `twitter` configuration, ending with `/spotify` will pick up a tenant `spotify` configuration, and once the authentication is complete, the users accessing some application protected resources will get a tenant id picked up from the session cookie. All of it will work without users having to code a custom `TenantResolver` resolving `spotify` and `twitter` tenants.
 
So having `quarkus.oidc.tenant-enabled=false` here is totally redundant and at the demo time it does not make a lot of sense to say, oh yeah, by the way, I forgot to type `quarkus.oidc.tenant-enabled=false` after Quarkus failing to connect to the default tenant which is not even needed in this setup :-).

So this PR is just about a tiny update, to support a natural demoing or evolution of the configuration when working with named tenants without having to type something strange like `quarkus.oidc.tenant-enabled=false` 