### PR TITLE
Add configured SameSite attribute to all OIDC session cookies

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
@@ -39,13 +39,13 @@ public class DefaultTokenStateManager implements TokenStateManager {
                         oidcConfig,
                         getAccessTokenCookieName(oidcConfig),
                         encryptToken(tokens.getAccessToken(), routingContext, oidcConfig),
-                        routingContext.get(CodeAuthenticationMechanism.SESSION_MAX_AGE_PARAM));
+                        routingContext.get(CodeAuthenticationMechanism.SESSION_MAX_AGE_PARAM), true);
                 if (tokens.getRefreshToken() != null) {
                     CodeAuthenticationMechanism.createCookie(routingContext,
                             oidcConfig,
                             getRefreshTokenCookieName(oidcConfig),
                             encryptToken(tokens.getRefreshToken(), routingContext, oidcConfig),
-                            routingContext.get(CodeAuthenticationMechanism.SESSION_MAX_AGE_PARAM));
+                            routingContext.get(CodeAuthenticationMechanism.SESSION_MAX_AGE_PARAM), true);
                 }
             }
         } else if (oidcConfig.tokenStateManager.strategy == OidcTenantConfig.TokenStateManager.Strategy.ID_REFRESH_TOKENS) {

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -147,6 +147,7 @@ quarkus.oidc.tenant-split-tokens.credentials.secret=secret
 quarkus.oidc.tenant-split-tokens.token-state-manager.split-tokens=true
 quarkus.oidc.tenant-split-tokens.token-state-manager.encryption-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 quarkus.oidc.tenant-split-tokens.application-type=web-app
+quarkus.oidc.tenant-split-tokens.authentication.cookie-same-site=strict
 
 quarkus.http.auth.permission.roles1.paths=/index.html
 quarkus.http.auth.permission.roles1.policy=authenticated

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -936,12 +936,15 @@ public class CodeFlowTest {
 
             final String decryptSecret = "eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU";
             Cookie idTokenCookie = getSessionCookie(page.getWebClient(), "tenant-split-tokens");
+            assertEquals("strict", idTokenCookie.getSameSite());
             checkSingleTokenCookie(idTokenCookie, "ID", decryptSecret);
 
             Cookie atTokenCookie = getSessionAtCookie(page.getWebClient(), "tenant-split-tokens");
+            assertEquals("strict", atTokenCookie.getSameSite());
             checkSingleTokenCookie(atTokenCookie, "Bearer", decryptSecret);
 
             Cookie rtTokenCookie = getSessionRtCookie(page.getWebClient(), "tenant-split-tokens");
+            assertEquals("strict", rtTokenCookie.getSameSite());
             checkSingleTokenCookie(rtTokenCookie, "Refresh", decryptSecret);
 
             // verify all the cookies are cleared after the session timeout
@@ -1021,11 +1024,6 @@ public class CodeFlowTest {
 
             webClient.getCookieManager().clearCookies();
         }
-    }
-
-    private void checkSingleTokenCookie(Cookie tokenCookie, String type) {
-        checkSingleTokenCookie(tokenCookie, type, null);
-
     }
 
     private void checkSingleTokenCookie(Cookie tokenCookie, String type, String decryptSecret) {


### PR DESCRIPTION
Fixes #34064.

OIDC will add configured SameSite attribute to the session `q_session` cookie which by default carries 3 encrypted tokens, ID token, access token and refresh token. It can pose a challenge if the resulting cookie is larger than 4096K, so users can request that each of these tokens is saved in its own cookie:

* ID token remains in the same  `q_session` cookie
* Access token goes to  `q_session_at` cookie
* Refresh token goes to  `q_session_rt` cookie

However, in this case, the access and refresh token cookies lose the `Same-Site` property, so this PR fixes it, with the updated test confirming it.

This is a pure technical fix, nothing OIDC specific about it