### PR TITLE
Kafka Dev UI: add ACL page, set Content-Type header, support msg headers

### DIFF
--- a/extensions/kafka-client/deployment/src/main/resources/dev-static/js/pages/accessControlListPage.js
+++ b/extensions/kafka-client/deployment/src/main/resources/dev-static/js/pages/accessControlListPage.js
@@ -17,12 +17,12 @@ export default class AccessControlListPage {
         const req = {
             action: "getAclInfo"
         };
+
         toggleSpinner(this.containerId);
+
         doPost(req, (data) => {
-            setTimeout(() => {
-                this.updateInfo(data);
-                toggleSpinner(this.containerId);
-            }, 2000);
+            this.updateInfo(data);
+            toggleSpinner(this.containerId);
         }, data => {
             errorPopUp("Error getting Kafka ACL info: ", data);
         });
@@ -40,7 +40,7 @@ export default class AccessControlListPage {
             const e = acls[i];
             let tableRow = $("<tr/>");
             tableRow.append(createTableItem(e.operation));
-            tableRow.append(createTableItem(e.prinipal));
+            tableRow.append(createTableItem(e.principal));
             tableRow.append(createTableItem(e.perm));
             tableRow.append(createTableItem(e.pattern));
             aclTable.append(tableRow);

--- a/extensions/kafka-client/deployment/src/main/resources/dev-static/js/pages/nodesPage.js
+++ b/extensions/kafka-client/deployment/src/main/resources/dev-static/js/pages/nodesPage.js
@@ -16,15 +16,15 @@ export default class NodesPage {
         const req = {
             action: "getInfo"
         };
+
+        toggleSpinner(this.containerId);
+
         doPost(req, (data) => {
-            setTimeout(() => {
-                this.updateInfo(data);
-                toggleSpinner(this.containerId);
-            }, 2000);
+            this.updateInfo(data);
+            toggleSpinner(this.containerId);
         }, data => {
             errorPopUp("Error getting Kafka info: ", data);
         });
-        toggleSpinner(this.containerId);
     }
 
     updateInfo(data) {

--- a/extensions/kafka-client/deployment/src/main/resources/dev-templates/kafka-dev-ui.html
+++ b/extensions/kafka-client/deployment/src/main/resources/dev-templates/kafka-dev-ui.html
@@ -261,16 +261,9 @@ min-width: 100%;
                         </div>
                         <div class="tab-pane fade" id="headers-list-tab-pane" role="tabpanel"
                              aria-labelledby="headers-list-tab">
-                            <div class="input-group top-margin">
-                                <span class="input-group-text">1.</span>
-                                <input type="text" class="form-control" placeholder="Key"/>
-                                <input type="text" class="form-control" placeholder="Value"/>
-                                <span class="input-group-text" id="basic-addon1">
-                                    <i class="bi bi-trash"></i>
-                                </span>
-                            </div>
+
                             <div class="d-flex justify-content-end top-margin">
-                                <button type="button" class="btn btn-light" id="add-header-btn">Add</button>
+                                <button type="button" class="btn btn-light" id="add-msg-header-btn">Add</button>
                             </div>
                         </div>
                     </div>
@@ -380,7 +373,7 @@ min-width: 100%;
 
     <div class="col-md-10 content-holder" style="background-color:#ffffff;">
         <div id="topics-page" class="flex-column">
-            <div class="card d-flex flex-fill top-margin">
+            <div class="card d-flex flex-fill">
                 <table class="table table-hover pointer" id="topics-table">
                     <thead class="thead-dark">
                         <tr>
@@ -400,7 +393,7 @@ min-width: 100%;
             </button>
         </div>
         <div id="topic-messages-page" class="flex-column">
-            <div id="topic-msg-content" class="card flex-fill top-margin">
+            <div id="topic-msg-content" class="card flex-fill">
                 <div class="page d-flex align-content-center justify-content-center">
                     <div id="msg-table-holder" class="align-items-start">
                         <table class="table" id="msg-table">
@@ -445,7 +438,7 @@ min-width: 100%;
             </button>
         </div>
         <div id="consumer-groups-page">
-            <div class="card flex-fill top-margin">
+            <div class="card flex-fill">
                 <table class="table table-hover" id="consumer-groups-table">
                     <thead class="thead-dark">
                         <tr>
@@ -464,7 +457,7 @@ min-width: 100%;
         </div>
         <div id="consumer-groups-details-page">
             <div class="card flex-fill">
-                <table class="table table-hover top-margin" id="consumer-group-details-table">
+                <table class="table table-hover" id="consumer-group-details-table">
                     <thead class="thead-dark">
                         <tr>
                             <th scope="col"></th>
@@ -479,7 +472,23 @@ min-width: 100%;
                 </table>
             </div>
         </div>
-        <div id="nodes-page" class="flex-column top-margin">
+        <div id="access-control-list-page" class="flex-column">
+            <div class="card d-flex flex-fill">
+                <table class="table table-hover" id="acl-table">
+                    <thead class="thead-dark">
+                        <tr>
+                            <th scope="col">Operation</th>
+                            <th scope="col">Principal</th>
+                            <th scope="col">Permission</th>
+                            <th scope="col">Resource Pattern</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div id="nodes-page" class="flex-column">
             <div class="card d-flex flex-fill">
                 <div class="card-body">
                     <b>Kafka cluster id:&nbsp;</b><span id="cluster-id"></span><br>

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/ui/KafkaTopicClient.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/ui/KafkaTopicClient.java
@@ -2,9 +2,19 @@ package io.quarkus.kafka.client.runtime.ui;
 
 import static io.quarkus.kafka.client.runtime.ui.util.ConsumerFactory.createConsumer;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -240,9 +250,15 @@ public class KafkaTopicClient {
 
     public void createMessage(KafkaMessageCreateRequest request) {
         var record = new ProducerRecord<>(request.getTopic(), request.getPartition(), Bytes.wrap(request.getKey().getBytes()),
-                Bytes.wrap(request.getValue().getBytes())
-        //TODO: support headers
-        );
+                Bytes.wrap(request.getValue().getBytes()));
+
+        Optional.ofNullable(request.getHeaders())
+                .orElseGet(Collections::emptyMap)
+                .forEach((key, value) -> record.headers().add(
+                        key,
+                        Optional.ofNullable(value)
+                                .map(v -> v.getBytes(StandardCharsets.UTF_8))
+                                .orElse(null)));
 
         try (var producer = createProducer()) {
             producer.send(record);

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/ui/KafkaUiHandler.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/ui/KafkaUiHandler.java
@@ -13,6 +13,7 @@ import io.quarkus.kafka.client.runtime.ui.model.request.KafkaCreateTopicRequest;
 import io.quarkus.kafka.client.runtime.ui.model.request.KafkaMessageCreateRequest;
 import io.quarkus.kafka.client.runtime.ui.model.request.KafkaMessagesRequest;
 import io.quarkus.kafka.client.runtime.ui.model.request.KafkaOffsetRequest;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 
@@ -55,7 +56,7 @@ public class KafkaUiHandler extends AbstractHttpRequestHandler {
                         message = webUtils.toJson(webUtils.getTopics());
                         break;
                     case "deleteTopic":
-                        res = adminClient.deleteTopic(body.getString("key"));
+                        adminClient.deleteTopic(body.getString("key"));
                         message = "{}";
                         res = true;
                         break;
@@ -95,6 +96,7 @@ public class KafkaUiHandler extends AbstractHttpRequestHandler {
         }
 
         if (res) {
+            event.response().headers().set(HttpHeaders.CONTENT_TYPE, "application/json");
             endResponse(event, OK, message);
         } else {
             message = "ERROR: " + error;

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/ui/model/converter/KafkaModelConverter.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/ui/model/converter/KafkaModelConverter.java
@@ -1,8 +1,13 @@
 package io.quarkus.kafka.client.runtime.ui.model.converter;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.utils.Bytes;
 
 import io.quarkus.kafka.client.runtime.ui.model.response.KafkaMessage;
@@ -15,6 +20,12 @@ public class KafkaModelConverter {
                 message.offset(),
                 message.timestamp(),
                 Optional.ofNullable(message.key()).map(Bytes::toString).orElse(null),
-                Optional.ofNullable(message.value()).map(Bytes::toString).orElse(null));
+                Optional.ofNullable(message.value()).map(Bytes::toString).orElse(null),
+                headers(message));
+    }
+
+    private static Map<String, String> headers(ConsumerRecord<Bytes, Bytes> message) {
+        return StreamSupport.stream(message.headers().spliterator(), false)
+                .collect(Collectors.toMap(Header::key, header -> new String(header.value(), StandardCharsets.UTF_8)));
     }
 }

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/ui/model/request/KafkaMessageCreateRequest.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/ui/model/request/KafkaMessageCreateRequest.java
@@ -1,24 +1,27 @@
 package io.quarkus.kafka.client.runtime.ui.model.request;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties("action")
 public class KafkaMessageCreateRequest {
 
-    //TODO: add headers
     private String topic;
     private Integer partition;
     private String value;
     private String key;
+    private Map<String, String> headers;
 
     public KafkaMessageCreateRequest() {
     }
 
-    public KafkaMessageCreateRequest(String topic, Integer partition, String value, String key) {
+    public KafkaMessageCreateRequest(String topic, Integer partition, String value, String key, Map<String, String> headers) {
         this.topic = topic;
         this.partition = partition;
         this.value = value;
         this.key = key;
+        this.headers = headers;
     }
 
     public String getTopic() {
@@ -35,5 +38,9 @@ public class KafkaMessageCreateRequest {
 
     public String getKey() {
         return key;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
     }
 }

--- a/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/ui/model/response/KafkaMessage.java
+++ b/extensions/kafka-client/runtime/src/main/java/io/quarkus/kafka/client/runtime/ui/model/response/KafkaMessage.java
@@ -1,5 +1,7 @@
 package io.quarkus.kafka.client.runtime.ui.model.response;
 
+import java.util.Map;
+
 public class KafkaMessage {
     private final String topic;
     private final int partition;
@@ -7,14 +9,17 @@ public class KafkaMessage {
     private final long timestamp;
     private final String key;
     private final String value;
+    private final Map<String, String> headers;
 
-    public KafkaMessage(String topic, int partition, long offset, long timestamp, String key, String value) {
+    public KafkaMessage(String topic, int partition, long offset, long timestamp, String key, String value,
+            Map<String, String> headers) {
         this.topic = topic;
         this.partition = partition;
         this.offset = offset;
         this.timestamp = timestamp;
         this.key = key;
         this.value = value;
+        this.headers = headers;
     }
 
     public String getTopic() {
@@ -39,5 +44,9 @@ public class KafkaMessage {
 
     public String getValue() {
         return value;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
     }
 }


### PR DESCRIPTION
Fixes #34038

1. Adds support for ACL browsing
    ```shell
    $ kafka-acls.sh  --bootstrap-server localhost:49269 --add --allow-principal 'User:*' --producer --topic t1 
    Adding ACLs for resource `ResourcePattern(resourceType=TOPIC, name=t1, patternType=LITERAL)`: 
 	    (principal=User:*, host=*, operation=WRITE, permissionType=ALLOW)
            (principal=User:*, host=*, operation=DESCRIBE, permissionType=ALLOW)
            (principal=User:*, host=*, operation=CREATE, permissionType=ALLOW)
    ```
    ![image](https://github.com/quarkusio/quarkus/assets/20868526/a4e64b33-aeb3-436f-85c7-7189b6391d32)

2. Support setting headers in message create modal
    ![image](https://github.com/quarkusio/quarkus/assets/20868526/8cd8388c-8e77-4a6e-a8af-3cd28a863cf3)

3. Format message keys, values, and headers
    ![image](https://github.com/quarkusio/quarkus/assets/20868526/96fc0f38-a7e2-48d0-801f-ce353924d830)
