### PR TITLE
Dev UI Testing

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1865,6 +1865,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-vertx-http-dev-ui-tests</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-vertx-http-dev-ui-resources</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/extensions/hibernate-orm/deployment/pom.xml
+++ b/extensions/hibernate-orm/deployment/pom.xml
@@ -55,6 +55,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-dev-ui-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/DevUIHibernateOrmActiveFalseAndNamedPuActiveTrueTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/DevUIHibernateOrmActiveFalseAndNamedPuActiveTrueTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.hibernate.orm.devui;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.devui.namedpu.MyNamedPuEntity;
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class DevUIHibernateOrmActiveFalseAndNamedPuActiveTrueTest extends DevUIHibernateOrmTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar.addAsResource(
+                    new StringAsset("quarkus.datasource.db-kind=h2\n"
+                            + "quarkus.datasource.jdbc.url=jdbc:h2:mem:test\n"
+                            + "quarkus.datasource.\"nameddatasource\".db-kind=h2\n"
+                            + "quarkus.datasource.\"nameddatasource\".jdbc.url=jdbc:h2:mem:test2\n"
+                            // Hibernate ORM is inactive for the default PU
+                            + "quarkus.hibernate-orm.active=false\n"
+                            + "quarkus.hibernate-orm.datasource=<default>\n"
+                            + "quarkus.hibernate-orm.packages=io.quarkus.test.devconsole\n"
+                            // ... but it's (implicitly) active for a named PU
+                            + "quarkus.hibernate-orm.\"namedpu\".datasource=nameddatasource\n"
+                            + "quarkus.hibernate-orm.\"namedpu\".packages=io.quarkus.hibernate.orm.devui.namedpu\n"),
+                    "application.properties")
+                    .addClasses(MyEntity.class)
+                    .addClasses(MyNamedPuEntity.class));
+
+    public DevUIHibernateOrmActiveFalseAndNamedPuActiveTrueTest() {
+        super("namedpu", "MyNamedPuEntity", "io.quarkus.hibernate.orm.devui.namedpu.MyNamedPuEntity");
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/DevUIHibernateOrmActiveFalseTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/DevUIHibernateOrmActiveFalseTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.hibernate.orm.devui;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class DevUIHibernateOrmActiveFalseTest extends DevUIHibernateOrmTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar.addAsResource(
+                    new StringAsset("quarkus.datasource.db-kind=h2\n"
+                            + "quarkus.datasource.jdbc.url=jdbc:h2:mem:test\n"
+                            // Hibernate ORM is inactive: the dev console should be empty.
+                            + "quarkus.hibernate-orm.active=false\n"),
+                    "application.properties")
+                    .addClasses(MyEntity.class));
+
+    public DevUIHibernateOrmActiveFalseTest() {
+        super(0, 0);
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/DevUIHibernateOrmSmokeTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/DevUIHibernateOrmSmokeTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.hibernate.orm.devui;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class DevUIHibernateOrmSmokeTest extends DevUIHibernateOrmTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar.addAsResource(
+                    new StringAsset("quarkus.datasource.db-kind=h2\n"
+                            + "quarkus.datasource.jdbc.url=jdbc:h2:mem:test\n"),
+                    "application.properties")
+                    .addClasses(MyEntity.class));
+
+    public DevUIHibernateOrmSmokeTest() {
+        super("<default>", "MyEntity", "io.quarkus.hibernate.orm.devui.MyEntity");
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/DevUIHibernateOrmTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/DevUIHibernateOrmTest.java
@@ -1,0 +1,109 @@
+package io.quarkus.hibernate.orm.devui;
+
+import java.util.Iterator;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkus.devui.tests.DevUIJsonRPCTest;
+
+/**
+ * All tests test the same api call, with different configuration and different expected results
+ * This abstract class reduce the code in each test
+ */
+public abstract class DevUIHibernateOrmTest extends DevUIJsonRPCTest {
+
+    private String expectedPersistenceUnitName = null;
+    private String expectedTableName = null;
+    private String expectedClassName = null;
+    private int expectedNumberOfEntityTypes = 1;
+    private int expectedNumberOfPersistenceUnits = 1;
+
+    public DevUIHibernateOrmTest(String expectedPersistenceUnitName, String expectedTableName, String expectedClassName) {
+        this.expectedPersistenceUnitName = expectedPersistenceUnitName;
+        this.expectedTableName = expectedTableName;
+        this.expectedClassName = expectedClassName;
+    }
+
+    public DevUIHibernateOrmTest(int expectedNumberOfEntityTypes,
+            int expectedNumberOfPersistenceUnits) {
+        this.expectedNumberOfEntityTypes = expectedNumberOfEntityTypes;
+        this.expectedNumberOfPersistenceUnits = expectedNumberOfPersistenceUnits;
+    }
+
+    @Test
+    public void testGetInfo() throws Exception {
+        JsonNode getInfoResponse = super.executeJsonRPCMethod("getInfo");
+        Assertions.assertNotNull(getInfoResponse);
+
+        JsonNode persistenceUnits = getInfoResponse.get("persistenceUnits");
+        Assertions.assertNotNull(persistenceUnits);
+        Assertions.assertTrue(persistenceUnits.isArray());
+
+        if (expectedPersistenceUnitName == null) {
+            Assertions.assertEquals(0, persistenceUnits.size());
+        } else {
+            Assertions.assertEquals(1, persistenceUnits.size());
+            Iterator<JsonNode> persistenceUnitsIterator = persistenceUnits.elements();
+            while (persistenceUnitsIterator.hasNext()) {
+                JsonNode defaultPersistenceUnit = persistenceUnitsIterator.next();
+                JsonNode name = defaultPersistenceUnit.get("name");
+                Assertions.assertEquals(expectedPersistenceUnitName, name.asText());
+
+                JsonNode managedEntities = defaultPersistenceUnit.get("managedEntities");
+                Assertions.assertNotNull(managedEntities);
+                Assertions.assertTrue(managedEntities.isArray());
+
+                Iterator<JsonNode> managedEntitiesIterator = managedEntities.elements();
+                while (managedEntitiesIterator.hasNext()) {
+                    JsonNode myEntity = managedEntitiesIterator.next();
+                    Assertions.assertEquals(expectedNumberOfPersistenceUnits, persistenceUnits.size());
+
+                    String tableName = myEntity.get("tableName").asText();
+                    Assertions.assertEquals(expectedTableName, tableName);
+
+                    String className = myEntity.get("className").asText();
+                    Assertions.assertEquals(expectedClassName, className);
+
+                }
+
+                JsonNode namedQueries = defaultPersistenceUnit.get("namedQueries");
+                Assertions.assertNotNull(namedQueries);
+                Assertions.assertTrue(namedQueries.isArray());
+
+            }
+        }
+    }
+
+    @Test
+    public void testGetNumberOfPersistenceUnits() throws Exception {
+        JsonNode getNumberOfPersistenceUnitsResponse = super.executeJsonRPCMethod("getNumberOfPersistenceUnits");
+        Assertions.assertNotNull(getNumberOfPersistenceUnitsResponse);
+        Assertions.assertTrue(getNumberOfPersistenceUnitsResponse.isInt());
+        Assertions.assertEquals(expectedNumberOfPersistenceUnits, getNumberOfPersistenceUnitsResponse.asInt());
+    }
+
+    @Test
+    public void testGetNumberOfEntityTypes() throws Exception {
+        JsonNode getNumberOfEntityTypesResponse = super.executeJsonRPCMethod("getNumberOfEntityTypes");
+        Assertions.assertNotNull(getNumberOfEntityTypesResponse);
+        Assertions.assertTrue(getNumberOfEntityTypesResponse.isInt());
+        Assertions.assertEquals(expectedNumberOfEntityTypes, getNumberOfEntityTypesResponse.asInt());
+    }
+
+    @Test
+    public void testGetNumberOfNamedQueries() throws Exception {
+        JsonNode getNumberOfNamedQueriesResponse = super.executeJsonRPCMethod("getNumberOfNamedQueries");
+        Assertions.assertNotNull(getNumberOfNamedQueriesResponse);
+        Assertions.assertTrue(getNumberOfNamedQueriesResponse.isInt());
+        Assertions.assertEquals(0, getNumberOfNamedQueriesResponse.asInt());
+    }
+
+    @Override
+    protected String getNamespace() {
+        return "io.quarkus.quarkus-hibernate-orm";
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/DevUIHibernateOrmTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/DevUIHibernateOrmTest.java
@@ -22,6 +22,7 @@ public abstract class DevUIHibernateOrmTest extends DevUIJsonRPCTest {
     private int expectedNumberOfPersistenceUnits = 1;
 
     public DevUIHibernateOrmTest(String expectedPersistenceUnitName, String expectedTableName, String expectedClassName) {
+        super("io.quarkus.quarkus-hibernate-orm");
         this.expectedPersistenceUnitName = expectedPersistenceUnitName;
         this.expectedTableName = expectedTableName;
         this.expectedClassName = expectedClassName;
@@ -29,6 +30,7 @@ public abstract class DevUIHibernateOrmTest extends DevUIJsonRPCTest {
 
     public DevUIHibernateOrmTest(int expectedNumberOfEntityTypes,
             int expectedNumberOfPersistenceUnits) {
+        super("io.quarkus.quarkus-hibernate-orm");
         this.expectedNumberOfEntityTypes = expectedNumberOfEntityTypes;
         this.expectedNumberOfPersistenceUnits = expectedNumberOfPersistenceUnits;
     }
@@ -100,10 +102,4 @@ public abstract class DevUIHibernateOrmTest extends DevUIJsonRPCTest {
         Assertions.assertTrue(getNumberOfNamedQueriesResponse.isInt());
         Assertions.assertEquals(0, getNumberOfNamedQueriesResponse.asInt());
     }
-
-    @Override
-    protected String getNamespace() {
-        return "io.quarkus.quarkus-hibernate-orm";
-    }
-
 }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/MyEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/MyEntity.java
@@ -1,0 +1,16 @@
+package io.quarkus.hibernate.orm.devui;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class MyEntity {
+
+    @Id
+    Long id;
+
+    @Column
+    String field;
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/namedpu/MyNamedPuEntity.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/devui/namedpu/MyNamedPuEntity.java
@@ -1,0 +1,14 @@
+package io.quarkus.hibernate.orm.devui.namedpu;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class MyNamedPuEntity {
+
+    @Id
+    Long id;
+
+    String field;
+
+}

--- a/extensions/vertx-http/deployment/pom.xml
+++ b/extensions/vertx-http/deployment/pom.xml
@@ -117,6 +117,11 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-dev-ui-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-deployment</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/BuildMetricsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/BuildMetricsTest.java
@@ -14,6 +14,10 @@ public class BuildMetricsTest extends DevUIJsonRPCTest {
     @RegisterExtension
     static final QuarkusDevModeTest config = new QuarkusDevModeTest().withEmptyApplication();
 
+    public BuildMetricsTest() {
+        super("devui-build-metrics");
+    }
+
     @Test
     public void testGetBuildStepsMetrics() throws Exception {
         JsonNode buildStepsMetricsResponse = super.executeJsonRPCMethod("getBuildStepsMetrics");
@@ -25,10 +29,5 @@ public class BuildMetricsTest extends DevUIJsonRPCTest {
         boolean dependencyGraphsIncluded = buildStepsMetricsResponse.get("dependencyGraphs").isObject();
         Assertions.assertTrue(dependencyGraphsIncluded);
 
-    }
-
-    @Override
-    protected String getNamespace() {
-        return "devui-build-metrics";
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/BuildMetricsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/BuildMetricsTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.devui;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkus.devui.tests.DevUIJsonRPCTest;
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class BuildMetricsTest extends DevUIJsonRPCTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest().withEmptyApplication();
+
+    @Test
+    public void testGetBuildStepsMetrics() throws Exception {
+        JsonNode buildStepsMetricsResponse = super.executeJsonRPCMethod("getBuildStepsMetrics");
+        Assertions.assertNotNull(buildStepsMetricsResponse);
+
+        int duration = buildStepsMetricsResponse.get("duration").asInt();
+        Assertions.assertTrue(duration > 0);
+
+        boolean dependencyGraphsIncluded = buildStepsMetricsResponse.get("dependencyGraphs").isObject();
+        Assertions.assertTrue(dependencyGraphsIncluded);
+
+    }
+
+    @Override
+    protected String getNamespace() {
+        return "devui-build-metrics";
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/ConfigurationTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/ConfigurationTest.java
@@ -17,6 +17,10 @@ public class ConfigurationTest extends DevUIJsonRPCTest {
     static final QuarkusDevModeTest config = new QuarkusDevModeTest()
             .withEmptyApplication();
 
+    public ConfigurationTest() {
+        super("devui-configuration");
+    }
+
     @Test
     public void testLogstreamHistory() throws Exception {
 
@@ -30,10 +34,5 @@ public class ConfigurationTest extends DevUIJsonRPCTest {
         JsonNode allPropertiesResponse = super.executeJsonRPCMethod("getAllValues");
         String applicationName = allPropertiesResponse.get("quarkus.application.name").asText();
         Assertions.assertEquals("changedByTest", applicationName);
-    }
-
-    @Override
-    protected String getNamespace() {
-        return "devui-configuration";
     }
 }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/ConfigurationTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/ConfigurationTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.devui;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkus.devui.tests.DevUIJsonRPCTest;
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class ConfigurationTest extends DevUIJsonRPCTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .withEmptyApplication();
+
+    @Test
+    public void testLogstreamHistory() throws Exception {
+
+        JsonNode updatePropertyResponse = super.executeJsonRPCMethod("updateProperty",
+                Map.of(
+                        "name", "quarkus.application.name",
+                        "value", "changedByTest"));
+        Assertions.assertTrue(updatePropertyResponse.asBoolean());
+
+        // Get the properties to make sure it is changed
+        JsonNode allPropertiesResponse = super.executeJsonRPCMethod("getAllValues");
+        String applicationName = allPropertiesResponse.get("quarkus.application.name").asText();
+        Assertions.assertEquals("changedByTest", applicationName);
+    }
+
+    @Override
+    protected String getNamespace() {
+        return "devui-configuration";
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/ExtensionsTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/ExtensionsTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.devui;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkus.devui.tests.DevUIBuildTimeDataTest;
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class ExtensionsTest extends DevUIBuildTimeDataTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest().withEmptyApplication();
+
+    public ExtensionsTest() {
+        super("devui");
+    }
+
+    @Test
+    public void testGetExtensions() throws Exception {
+        JsonNode extensionsResponse = super.getBuildTimeData("extensions");
+        Assertions.assertNotNull(extensionsResponse);
+
+        JsonNode activeExtensions = extensionsResponse.get("active");
+        Assertions.assertNotNull(activeExtensions);
+        Assertions.assertTrue(activeExtensions.isArray());
+
+        JsonNode inactiveExtensions = extensionsResponse.get("inactive");
+        Assertions.assertNotNull(inactiveExtensions);
+        Assertions.assertTrue(inactiveExtensions.isArray());
+
+        log.info(extensionsResponse.toPrettyString());
+
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/LogstreamTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/LogstreamTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.devui;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkus.devui.tests.DevUIJsonRPCTest;
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class LogstreamTest extends DevUIJsonRPCTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .withEmptyApplication();
+
+    @Test
+    public void testHistory() throws Exception {
+        JsonNode historyResponse = super.executeJsonRPCMethod("history");
+        Assertions.assertNotNull(historyResponse);
+        Assertions.assertTrue(historyResponse.isArray());
+        Assertions.assertTrue(hasStartedLine(historyResponse.elements()));
+    }
+
+    @Test
+    public void testGetLoggers() throws Exception {
+        JsonNode getLoggersResponse = super.executeJsonRPCMethod("getLoggers");
+        Assertions.assertNotNull(getLoggersResponse);
+        Assertions.assertTrue(getLoggersResponse.isArray());
+    }
+
+    @Test
+    public void testUpdateLoggers() throws Exception {
+        // Get the level before
+        JsonNode getLoggerResponse = super.executeJsonRPCMethod("getLogger", Map.of("loggerName", "io.quarkus"));
+        Assertions.assertNotNull(getLoggerResponse);
+        Assertions.assertEquals("INFO", getLoggerResponse.get("effectiveLevel").asText());
+
+        // Update the level
+        JsonNode updateLogLevelResponse = super.executeJsonRPCMethod("updateLogLevel",
+                Map.of("loggerName", "io.quarkus",
+                        "levelValue", "DEBUG"));
+        Assertions.assertNotNull(updateLogLevelResponse);
+        Assertions.assertEquals("DEBUG", updateLogLevelResponse.get("effectiveLevel").asText());
+    }
+
+    @Override
+    protected String getNamespace() {
+        return "devui-logstream";
+    }
+
+    private boolean hasStartedLine(Iterator<JsonNode> elements) {
+        while (elements.hasNext()) {
+            JsonNode next = elements.next();
+            String line = next.get("formattedMessage").asText();
+
+            if (line.contains("powered by Quarkus") && line.contains(" started in ")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/LogstreamTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/devui/LogstreamTest.java
@@ -18,6 +18,10 @@ public class LogstreamTest extends DevUIJsonRPCTest {
     static final QuarkusDevModeTest config = new QuarkusDevModeTest()
             .withEmptyApplication();
 
+    public LogstreamTest() {
+        super("devui-logstream");
+    }
+
     @Test
     public void testHistory() throws Exception {
         JsonNode historyResponse = super.executeJsonRPCMethod("history");
@@ -46,11 +50,6 @@ public class LogstreamTest extends DevUIJsonRPCTest {
                         "levelValue", "DEBUG"));
         Assertions.assertNotNull(updateLogLevelResponse);
         Assertions.assertEquals("DEBUG", updateLogLevelResponse.get("effectiveLevel").asText());
-    }
-
-    @Override
-    protected String getNamespace() {
-        return "devui-logstream";
     }
 
     private boolean hasStartedLine(Iterator<JsonNode> elements) {

--- a/extensions/vertx-http/dev-ui-tests/pom.xml
+++ b/extensions/vertx-http/dev-ui-tests/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>quarkus-vertx-http-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    
+    <artifactId>quarkus-vertx-http-dev-ui-tests</artifactId>
+    <name>Quarkus - Vert.x - HTTP - Dev UI Tests</name>
+    
+    <dependencies>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-websockets-client-deployment</artifactId>
+        </dependency>
+    </dependencies>
+    
+</project>

--- a/extensions/vertx-http/dev-ui-tests/src/main/java/io/quarkus/devui/tests/DevUIBuildTimeDataTest.java
+++ b/extensions/vertx-http/dev-ui-tests/src/main/java/io/quarkus/devui/tests/DevUIBuildTimeDataTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.devui.tests;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public abstract class DevUIBuildTimeDataTest {
+
+    protected static final Logger log = Logger.getLogger(DevUIBuildTimeDataTest.class);
+
+    protected URI uri;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final JsonFactory factory = mapper.getFactory();
+
+    public DevUIBuildTimeDataTest(String namespace) {
+        String testUrl = ConfigProvider.getConfig().getValue("test.url", String.class);
+        String nonApplicationRoot = ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.http.non-application-root-path", String.class).orElse("q");
+        if (!nonApplicationRoot.startsWith("/")) {
+            nonApplicationRoot = "/" + nonApplicationRoot;
+        }
+        this.uri = URI.create(testUrl + nonApplicationRoot + "/dev-ui/" + namespace + "-data.js");
+    }
+
+    public JsonNode getBuildTimeData(String key) throws Exception {
+
+        String data = readDataFromUrl();
+        String[] kvs = data.split(CONST);
+
+        for (String kv : kvs) {
+            if (kv.startsWith(key + SPACE + EQUALS + SPACE + OPEN_CURLY_BRACKET)) {
+                String json = kv.substring(kv.indexOf(EQUALS) + 1).trim();
+                log.debug("json = " + json);
+                return toJsonNode(json);
+            }
+        }
+
+        return null;
+    }
+
+    protected JsonNode toJsonNode(String json) {
+        try {
+            JsonParser parser = factory.createParser(json);
+            return mapper.readTree(parser);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private String readDataFromUrl() throws MalformedURLException, IOException {
+        try (Scanner scanner = new Scanner(uri.toURL().openStream(),
+                StandardCharsets.UTF_8.toString())) {
+            scanner.useDelimiter("\\A");
+            return scanner.hasNext() ? scanner.next() : null;
+        }
+    }
+
+    private static final String CONST = "export const ";
+    private static final String SPACE = " ";
+    private static final String EQUALS = "=";
+    private static final String OPEN_CURLY_BRACKET = "{";
+}

--- a/extensions/vertx-http/dev-ui-tests/src/main/java/io/quarkus/devui/tests/DevUIJsonRPCTest.java
+++ b/extensions/vertx-http/dev-ui-tests/src/main/java/io/quarkus/devui/tests/DevUIJsonRPCTest.java
@@ -1,0 +1,130 @@
+package io.quarkus.devui.tests;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.websocket.ClientEndpoint;
+import jakarta.websocket.ContainerProvider;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Assertions;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public abstract class DevUIJsonRPCTest {
+
+    protected static final Logger log = Logger.getLogger(DevUIJsonRPCTest.class);
+
+    protected URI uri;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final JsonFactory factory = mapper.getFactory();
+    private final Random random = new Random();
+
+    protected abstract String getNamespace();
+
+    public DevUIJsonRPCTest() {
+        String testUrl = ConfigProvider.getConfig().getValue("test.url", String.class);
+        String nonApplicationRoot = ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.http.non-application-root-path", String.class).orElse("q");
+        if (!nonApplicationRoot.startsWith("/")) {
+            nonApplicationRoot = "/" + nonApplicationRoot;
+        }
+        this.uri = URI.create(testUrl + nonApplicationRoot + "/dev-ui/json-rpc-ws");
+    }
+
+    public JsonNode executeJsonRPCMethod(String methodName) throws Exception {
+        return executeJsonRPCMethod(methodName, null);
+    }
+
+    public JsonNode executeJsonRPCMethod(String methodName, Map<String, String> params) throws Exception {
+        try (Session session = ContainerProvider.getWebSocketContainer().connectToServer(Client.class, uri)) {
+            Assertions.assertEquals("CONNECT", MESSAGES.poll(10, TimeUnit.SECONDS));
+
+            int id = random.nextInt(Integer.MAX_VALUE);
+
+            String request = createJsonRPCRequest(id, methodName, params);
+            log.debug("request = " + request);
+            session.getAsyncRemote().sendText(request);
+
+            JsonNode response = parseJsonRPCResponse(id);
+            log.debug("response = " + response.toPrettyString());
+
+            return response;
+        }
+    }
+
+    protected JsonNode toJsonNode(String json) {
+        try {
+            JsonParser parser = factory.createParser(json);
+            return mapper.readTree(parser);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private JsonNode parseJsonRPCResponse(int id) throws InterruptedException, IOException {
+        return parseJsonRPCResponse(id, 0);
+    }
+
+    private JsonNode parseJsonRPCResponse(int id, int loopCount) throws InterruptedException, IOException {
+        String response = MESSAGES.poll(10, TimeUnit.SECONDS);
+        JsonNode jsonResponse = toJsonNode(response);
+        if (jsonResponse.isObject()) {
+            int responseId = jsonResponse.get("id").asInt();
+            if (responseId == id) {
+                return jsonResponse.get("result").get("object");
+            }
+        }
+
+        if (loopCount > 10)
+            throw new RuntimeException("Too many recursions, message not returned for id [" + id + "]");
+        return parseJsonRPCResponse(id, loopCount + 1);
+    }
+
+    private String createJsonRPCRequest(int id, String methodName, Map<String, String> params) throws IOException {
+
+        ObjectNode request = mapper.createObjectNode();
+
+        request.put("jsonrpc", "2.0");
+        request.put("id", id);
+        request.put("method", getNamespace() + "." + methodName);
+        ObjectNode jsonParams = mapper.createObjectNode();
+        if (params != null && !params.isEmpty()) {
+            for (Map.Entry<String, String> p : params.entrySet()) {
+                jsonParams.put(p.getKey(), p.getValue());
+            }
+        }
+        request.set("params", jsonParams);
+        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(request);
+    }
+
+    private static final LinkedBlockingDeque<String> MESSAGES = new LinkedBlockingDeque<>();
+
+    @ClientEndpoint
+    public static class Client {
+
+        @OnOpen
+        public void open(Session session) {
+            MESSAGES.add("CONNECT");
+        }
+
+        @OnMessage
+        void message(String msg) {
+            MESSAGES.add(msg);
+        }
+    }
+
+}

--- a/extensions/vertx-http/dev-ui-tests/src/main/java/io/quarkus/devui/tests/DevUIJsonRPCTest.java
+++ b/extensions/vertx-http/dev-ui-tests/src/main/java/io/quarkus/devui/tests/DevUIJsonRPCTest.java
@@ -33,9 +33,10 @@ public abstract class DevUIJsonRPCTest {
     private final JsonFactory factory = mapper.getFactory();
     private final Random random = new Random();
 
-    protected abstract String getNamespace();
+    private final String namespace;
 
-    public DevUIJsonRPCTest() {
+    public DevUIJsonRPCTest(String namespace) {
+        this.namespace = namespace;
         String testUrl = ConfigProvider.getConfig().getValue("test.url", String.class);
         String nonApplicationRoot = ConfigProvider.getConfig()
                 .getOptionalValue("quarkus.http.non-application-root-path", String.class).orElse("q");
@@ -100,7 +101,7 @@ public abstract class DevUIJsonRPCTest {
 
         request.put("jsonrpc", "2.0");
         request.put("id", id);
-        request.put("method", getNamespace() + "." + methodName);
+        request.put("method", this.namespace + "." + methodName);
         ObjectNode jsonParams = mapper.createObjectNode();
         if (params != null && !params.isEmpty()) {
             for (Map.Entry<String, String> p : params.entrySet()) {
@@ -122,7 +123,7 @@ public abstract class DevUIJsonRPCTest {
         }
 
         @OnMessage
-        void message(String msg) {
+        public void message(String msg) {
             MESSAGES.add(msg);
         }
     }

--- a/extensions/vertx-http/pom.xml
+++ b/extensions/vertx-http/pom.xml
@@ -21,5 +21,6 @@
         <module>deployment-spi</module>
         <module>dev-ui-spi</module>
         <module>dev-ui-resources</module>
+        <module>dev-ui-tests</module>
     </modules>
 </project>

--- a/integration-tests/devmode/pom.xml
+++ b/integration-tests/devmode/pom.xml
@@ -16,6 +16,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-dev-ui-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleHibernateOrmActiveFalseAndNamedPuActiveTrueTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleHibernateOrmActiveFalseAndNamedPuActiveTrueTest.java
@@ -52,27 +52,4 @@ public class DevConsoleHibernateOrmActiveFalseAndNamedPuActiveTrueTest {
                 .statusCode(200)
                 .body(Matchers.containsString("No named queries were found."));
     }
-
-    @Test
-    public void testPages() {
-        // TODO #31970 restore tests of the page's content as we used to do for the old Dev UI
-
-        RestAssured.get("q/dev-v1/io.quarkus.quarkus-hibernate-orm/persistence-units")
-                .then()
-                .statusCode(200);
-        //      .body(Matchers.not(Matchers.containsString("&lt;default&gt;")))
-        //      .body(Matchers.containsString("namedpu"));
-
-        RestAssured.get("q/dev-v1/io.quarkus.quarkus-hibernate-orm/managed-entities")
-                .then()
-                .statusCode(200);
-        //      .body(Matchers.not(Matchers.containsString(MyEntity.class.getName())))
-        //      .body(Matchers.containsString(MyNamedPuEntity.class.getName()));
-
-        RestAssured.get("q/dev-v1/io.quarkus.quarkus-hibernate-orm/named-queries")
-                .then()
-                .statusCode(200);
-        //      .body(Matchers.containsString("No named queries were found."));
-    }
-
 }

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleHibernateOrmActiveFalseTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleHibernateOrmActiveFalseTest.java
@@ -41,25 +41,4 @@ public class DevConsoleHibernateOrmActiveFalseTest {
                 .statusCode(200)
                 .body(Matchers.containsString("No persistence units were found"));
     }
-
-    @Test
-    public void testPages() {
-        // TODO #31970 restore tests of the page's content as we used to do for the old Dev UI
-
-        RestAssured.get("q/dev-ui/hibernate-orm/persistence-units")
-                .then()
-                .statusCode(200);
-        //        .body(Matchers.containsString("No persistence units were found"));
-
-        RestAssured.get("q/dev-ui/hibernate-orm/entity-types")
-                .then()
-                .statusCode(200);
-        //      .body(Matchers.containsString("No persistence units were found"));
-
-        RestAssured.get("q/dev-ui/hibernate-orm/named-queries")
-                .then()
-                .statusCode(200);
-        //      .body(Matchers.containsString("No persistence units were found"));
-    }
-
 }

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleHibernateOrmSmokeTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleHibernateOrmSmokeTest.java
@@ -39,25 +39,4 @@ public class DevConsoleHibernateOrmSmokeTest {
                 .statusCode(200)
                 .body(Matchers.containsString("No named queries were found."));
     }
-
-    @Test
-    public void testPages() {
-        // TODO #31970 restore tests of the page's content as we used to do for the old Dev UI
-
-        RestAssured.get("q/dev-ui/hibernate-orm/persistence-units")
-                .then()
-                .statusCode(200);
-        //      .body(Matchers.containsString("&lt;default&gt;"));
-
-        RestAssured.get("q/dev-ui/hibernate-orm/entity-types")
-                .then()
-                .statusCode(200);
-        //      .body(Matchers.containsString("io.quarkus.test.devconsole.MyEntity"));
-
-        RestAssured.get("q/dev-ui/hibernate-orm/named-queries")
-                .then()
-                .statusCode(200);
-        //      .body(Matchers.containsString("No named queries were found."));
-    }
-
 }


### PR DESCRIPTION
This PR introduce a base class that can be used to test JsonRPC and Build time data calls for Dev UI.

It also:

- Adds some JsonRPC and Build time data tests for core Dev UI
- Add Hibernate JsonRPC Tests (fix #31970)

@yrodiere - The Dev UI tests can now live in the extension (so move from integration-tests to extension). I did not move the Hibernate Search extension tests (I see the tests are skipped in the extension). Can you do the move in another PR ?