### PR TITLE
Bump BouncyCastle version to 1.74

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <angus-activation.version>2.0.1</angus-activation.version>
-        <bouncycastle.version>1.73</bouncycastle.version>
+        <bouncycastle.version>1.74</bouncycastle.version>
         <bouncycastle.fips.version>1.0.2.3</bouncycastle.fips.version>
         <bouncycastle.tls.fips.version>1.0.14.1</bouncycastle.tls.fips.version>
         <expressly.version>5.0.0</expressly.version>

--- a/integration-tests/bouncycastle-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleJsseTestCase.java
+++ b/integration-tests/bouncycastle-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleJsseTestCase.java
@@ -82,12 +82,12 @@ public class BouncyCastleJsseTestCase {
                             while ((line = reader.readLine()) != null) {
                                 sbLog.append(line).append("/r/n");
                                 if (!checkServerPassed && line.contains("ProvTlsServer")
-                                        && (line.contains("Server selected protocol version: TLSv1.2")
-                                                || line.contains("Server selected protocol version: TLSv1.3"))) {
+                                        && (line.contains("selected protocol version: TLSv1.2")
+                                                || line.contains("selected protocol version: TLSv1.3"))) {
                                     checkServerPassed = true;
                                 } else if (!checkClientPassed && line.contains("ProvTlsClient")
-                                        && (line.contains("Client notified of selected protocol version: TLSv1.2")
-                                                || line.contains("Client notified of selected protocol version: TLSv1.3"))) {
+                                        && (line.contains("notified of selected protocol version: TLSv1.2")
+                                                || line.contains("notified of selected protocol version: TLSv1.3"))) {
                                     checkClientPassed = true;
                                 }
                                 if (checkClientPassed && checkServerPassed) {


### PR DESCRIPTION
Bumps the version to 1.74, it now logs specific server/client instances so the test check log code had to be updated a bit.
Suggesting backports due to BC 1.74 addressing a public CVE