### PR TITLE
Avoid calling OIDC UserInfo endpoint if UserInfo is cached

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -447,7 +447,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 .recoverWithUni(f -> introspectTokenUni(resolvedContext, token));
     }
 
-    private Uni<TokenVerificationResult> introspectTokenUni(TenantConfigContext resolvedContext, String token) {
+    private Uni<TokenVerificationResult> introspectTokenUni(TenantConfigContext resolvedContext, final String token) {
         TokenIntrospectionCache tokenIntrospectionCache = tenantResolver.getTokenIntrospectionCache();
         Uni<TokenIntrospection> tokenIntrospectionUni = tokenIntrospectionCache == null ? null
                 : tokenIntrospectionCache
@@ -456,7 +456,12 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             tokenIntrospectionUni = newTokenIntrospectionUni(resolvedContext, token);
         } else {
             tokenIntrospectionUni = tokenIntrospectionUni.onItem().ifNull()
-                    .switchTo(newTokenIntrospectionUni(resolvedContext, token));
+                    .switchTo(new Supplier<Uni<? extends TokenIntrospection>>() {
+                        @Override
+                        public Uni<TokenIntrospection> get() {
+                            return newTokenIntrospectionUni(resolvedContext, token);
+                        }
+                    });
         }
         return tokenIntrospectionUni.onItem().transform(t -> new TokenVerificationResult(null, t));
     }
@@ -501,10 +506,8 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
         }
 
         LOG.debug("Requesting UserInfo");
-        String accessToken = vertxContext.get(OidcConstants.ACCESS_TOKEN_VALUE);
-        if (accessToken == null) {
-            accessToken = request.getToken().getToken();
-        }
+        String contextAccessToken = vertxContext.get(OidcConstants.ACCESS_TOKEN_VALUE);
+        final String accessToken = contextAccessToken != null ? contextAccessToken : request.getToken().getToken();
 
         UserInfoCache userInfoCache = tenantResolver.getUserInfoCache();
         Uni<UserInfo> userInfoUni = userInfoCache == null ? null
@@ -513,7 +516,12 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             userInfoUni = newUserInfoUni(resolvedContext, accessToken);
         } else {
             userInfoUni = userInfoUni.onItem().ifNull()
-                    .switchTo(newUserInfoUni(resolvedContext, accessToken));
+                    .switchTo(new Supplier<Uni<? extends UserInfo>>() {
+                        @Override
+                        public Uni<UserInfo> get() {
+                            return newUserInfoUni(resolvedContext, accessToken);
+                        }
+                    });
         }
         return userInfoUni;
     }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
@@ -31,11 +31,9 @@ public class CodeFlowUserInfoResource {
     @GET
     @Path("/code-flow-user-info-only")
     public String access() {
-        int cacheSize = tokenCache.getCacheSize();
-        tokenCache.clearCache();
         return identity.getPrincipal().getName() + ":" + userInfo.getPreferredUserName() + ":" + accessToken.getName()
                 + ", cache size: "
-                + cacheSize;
+                + tokenCache.getCacheSize();
     }
 
     @GET

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -3,8 +3,10 @@ package io.quarkus.it.keycloak;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -214,9 +216,11 @@ public class CodeFlowAuthorizationTest {
         defineCodeFlowAuthorizationOauth2TokenStub();
 
         doTestCodeFlowUserInfo("code-flow-user-info-only", 300);
+        clearCache();
         doTestCodeFlowUserInfo("code-flow-user-info-github", 360);
+        clearCache();
         doTestCodeFlowUserInfo("code-flow-user-info-dynamic-github", 301);
-
+        clearCache();
         doTestCodeFlowUserInfoCashedInIdToken();
     }
 
@@ -256,6 +260,13 @@ public class CodeFlowAuthorizationTest {
             page = form.getInputByValue("login").click();
 
             assertEquals("alice:alice:alice, cache size: 1", page.getBody().asNormalizedText());
+            page = webClient.getPage("http://localhost:8081/" + tenantId);
+            assertEquals("alice:alice:alice, cache size: 1", page.getBody().asNormalizedText());
+            page = webClient.getPage("http://localhost:8081/" + tenantId);
+            assertEquals("alice:alice:alice, cache size: 1", page.getBody().asNormalizedText());
+
+            wireMockServer.verify(1, getRequestedFor(urlPathMatching("/auth/realms/quarkus/protocol/openid-connect/userinfo")));
+            wireMockServer.resetRequests();
 
             JsonObject idTokenClaims = decryptIdToken(webClient, tenantId);
             assertNull(idTokenClaims.getJsonObject(OidcUtils.USER_INFO_ATTRIBUTE));


### PR DESCRIPTION
Fixes #34104.
With thanks to Daniel-Victor Ion and Claudio Donate.

Hey Clement, Julien, I'm finding this one a bit concerning, obviously I picked up a wrong overload, I probably looked at the JavaDocs giving this example:

```
     Uni<T> upstream = ...;
     Uni<T> uni = ...;
     uni = upstream.onItem().ifNull().switchTo(another) // switch to another uni if upstream emits null
```
and incorrectly assumed I could just give it, in this case, `newUserInfoUni(resolvedContext, accessToken)` (i.e, another Uni), without wrapping it in a Supplier instance as noticed by Daniel-Victor Ion.

I'm puzzled why

```
userInfoUni.onItem().ifNull()
                    .switchTo(newUserInfoUni(resolvedContext, accessToken));
```

causes another `newUserInfoUni(resolvedContext, accessToken)` execution even though `userInfoUni.onItem().ifNull()` is `false` ? Wrapping it in a supplier instance, 

```
userInfoUni.onItem().ifNull()
                    .switchTo(() -> newUserInfoUni(resolvedContext, accessToken));
```
(PR uses Supplier directly) fixes the problem, so it looks like to me that `ifNull()` is not checked if `Uni` passed directly to `.switchTo`. Please educate me :-)

I'm happy to fix it, but what is really concerning to me is that the test I've been so happy about has been masking my mistake for a long time.

The test is [here](https://github.com/quarkusio/quarkus/blob/388cdf961a90be64ff1ad33a6a510aaf32fdcb49/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java#L487). It creates a new token 3 times, per every token it does 3 application endpoint calls, checking that there is only one UserInfo call after a given token has been used 3 times to access the endpoint.

This test depends on OIDC provider emulated by this [OidcResource](https://github.com/quarkusio/quarkus/blob/388cdf961a90be64ff1ad33a6a510aaf32fdcb49/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java) and specifically, on its [UserInfo endpoint](https://github.com/quarkusio/quarkus/blob/main/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java#L189).

I've checked that without Uni wrapped in the supplier, Quarkus OIDC will request UserInfo with every request [here](https://github.com/quarkusio/quarkus/blob/388cdf961a90be64ff1ad33a6a510aaf32fdcb49/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java#L77) but while logs will show that every test endpoint calls reaches this `OidcProviderClient#getUserInfo`, the test provider's [UserInfo endpoint](https://github.com/quarkusio/quarkus/blob/main/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java#L189). is called only once by the time the test exits - so the test passes because the userinfo call count is indeed 1 even after the test called the application endpoint 3 times - exactly what is expected in the test.

It feels like that with 

```
userInfoUni.onItem().ifNull()
                    .switchTo(newUserInfoUni(resolvedContext, accessToken));
```

Unis executed without a supplier get stuck in some queue, all but the very first one.

Can you please review the code - this is fine, I confirmed there is truly only one `UserInfo` request when a new token is used to access the application endpoint 3 times, but I'd be also interested to understand why the test is passing now even without this fix.

Thanks



