### PR TITLE
add default main method for IDE launches

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/grpc-codestart/java/src/main/java/org/acme/HelloGrpcService.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/grpc-codestart/java/src/main/java/org/acme/HelloGrpcService.java
@@ -13,4 +13,7 @@ public class HelloGrpcService implements HelloGrpc {
                 .map(msg -> HelloReply.newBuilder().setMessage(msg).build());
     }
 
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/picocli-codestart/java/src/main/java/org/acme/GreetingCommand.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/picocli-codestart/java/src/main/java/org/acme/GreetingCommand.java
@@ -16,4 +16,7 @@ public class GreetingCommand implements Runnable {
         System.out.printf("Hello %s, go go commando!\n", name);
     }
 
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-messaging-codestart/java/src/main/java/org/acme/MyReactiveMessagingApplication.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-messaging-codestart/java/src/main/java/org/acme/MyReactiveMessagingApplication.java
@@ -40,4 +40,8 @@ public class MyReactiveMessagingApplication {
     public void sink(String word) {
         System.out.println(">> " + word);
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/java/src/main/java/org/acme/MyDeclarativeRoutes.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/reactive-routes-codestart/java/src/main/java/org/acme/MyDeclarativeRoutes.java
@@ -13,4 +13,8 @@ public class MyDeclarativeRoutes {
     void helloRoute(RoutingExchange ex) { 
         ex.ok("Hello " + ex.getParam("name").orElse("Reactive Route") +" !!");
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/rest-client-codestart/java/src/main/java/org/acme/MyRemoteService.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/rest-client-codestart/java/src/main/java/org/acme/MyRemoteService.java
@@ -34,4 +34,8 @@ public interface MyRemoteService {
         public String shortName;
         public List<String> keywords;
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
@@ -20,4 +20,8 @@ public class {resource.class-name} {
     public String hello() {
         return "{resource.response}";
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-qute-codestart/java/src/main/java/org/acme/SomePage.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-qute-codestart/java/src/main/java/org/acme/SomePage.java
@@ -25,4 +25,7 @@ public class SomePage {
         return page.data("name", name);
     }
 
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
@@ -13,4 +13,8 @@ public class {resource.class-name} {
     public String hello() {
         return "{resource.response}";
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-qute-codestart/java/src/main/java/org/acme/SomePage.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-qute-codestart/java/src/main/java/org/acme/SomePage.java
@@ -26,4 +26,7 @@ public class SomePage {
         return page.data("name", name);
     }
 
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/smallrye-graphql-codestart/java/src/main/java/org/acme/HelloGraphQLResource.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/smallrye-graphql-codestart/java/src/main/java/org/acme/HelloGraphQLResource.java
@@ -13,4 +13,8 @@ public class HelloGraphQLResource {
     public String sayHello(@DefaultValue("World") String name) {
         return "Hello " + name;
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/smallrye-health-codestart/java/src/main/java/org/acme/MyLivenessCheck.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/smallrye-health-codestart/java/src/main/java/org/acme/MyLivenessCheck.java
@@ -12,4 +12,7 @@ public class MyLivenessCheck implements HealthCheck {
         return HealthCheckResponse.up("alive");
     }
 
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
@@ -12,4 +12,8 @@ public class {resource.class-name} {
     public String hello() {
         return "{resource.response}";
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/websockets-codestart/java/src/main/java/org/acme/StartWebSocket.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/websockets-codestart/java/src/main/java/org/acme/StartWebSocket.java
@@ -36,4 +36,8 @@ public class StartWebSocket {
     public void onMessage(String message, @PathParam("name") String name) {
         System.out.println("onMessage> " + name + ": " + message);
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/GrpcCodestartTest/testContent/src_main_java_ilove_quark_us_HelloGrpcService.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/GrpcCodestartTest/testContent/src_main_java_ilove_quark_us_HelloGrpcService.java
@@ -13,4 +13,7 @@ public class HelloGrpcService implements HelloGrpc {
                 .map(msg -> HelloReply.newBuilder().setMessage(msg).build());
     }
 
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/PicocliCodestartTest/testContent/src_main_java_ilove_quark_us_GreetingCommand.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/PicocliCodestartTest/testContent/src_main_java_ilove_quark_us_GreetingCommand.java
@@ -16,4 +16,7 @@ public class GreetingCommand implements Runnable {
         System.out.printf("Hello %s, go go commando!\n", name);
     }
 
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/RESTClientCodestartTest/testContent/src_main_java_ilove_quark_us_MyRemoteService.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/RESTClientCodestartTest/testContent/src_main_java_ilove_quark_us_MyRemoteService.java
@@ -34,4 +34,8 @@ public interface MyRemoteService {
         public String shortName;
         public List<String> keywords;
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyQuteCodestartTest/testContent/src_main_java_ilove_quark_us_SomePage.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyQuteCodestartTest/testContent/src_main_java_ilove_quark_us_SomePage.java
@@ -25,4 +25,7 @@ public class SomePage {
         return page.data("name", name);
     }
 
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveCodestartsTest/testContent/src_main_java_ilove_quark_us_GreetingResource.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveCodestartsTest/testContent/src_main_java_ilove_quark_us_GreetingResource.java
@@ -13,4 +13,8 @@ public class GreetingResource {
     public String hello() {
         return "Hello from RESTEasy Reactive";
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveCodestartsTest/testContent/src_main_java_ilove_quark_us_SomePage.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveCodestartsTest/testContent/src_main_java_ilove_quark_us_SomePage.java
@@ -26,4 +26,7 @@ public class SomePage {
         return page.data("name", name);
     }
 
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testAMQPContent/src_main_java_ilove_quark_us_MyReactiveMessagingApplication.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testAMQPContent/src_main_java_ilove_quark_us_MyReactiveMessagingApplication.java
@@ -40,4 +40,8 @@ public class MyReactiveMessagingApplication {
     public void sink(String word) {
         System.out.println(">> " + word);
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testKafkaContent/src_main_java_ilove_quark_us_MyReactiveMessagingApplication.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveMessagingCodestartIT/testKafkaContent/src_main_java_ilove_quark_us_MyReactiveMessagingApplication.java
@@ -40,4 +40,8 @@ public class MyReactiveMessagingApplication {
     public void sink(String word) {
         System.out.println(">> " + word);
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveRoutesCodestartTest/testContent/src_main_java_ilove_quark_us_MyDeclarativeRoutes.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/ReactiveRoutesCodestartTest/testContent/src_main_java_ilove_quark_us_MyDeclarativeRoutes.java
@@ -13,4 +13,8 @@ public class MyDeclarativeRoutes {
     void helloRoute(RoutingExchange ex) { 
         ex.ok("Hello " + ex.getParam("name").orElse("Reactive Route") +" !!");
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/SmallRyeGraphQLCodestartTest/testContent/src_main_java_ilove_quark_us_HelloGraphQLResource.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/SmallRyeGraphQLCodestartTest/testContent/src_main_java_ilove_quark_us_HelloGraphQLResource.java
@@ -13,4 +13,8 @@ public class HelloGraphQLResource {
     public String sayHello(@DefaultValue("World") String name) {
         return "Hello " + name;
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/SmallRyeHealthCodestartTest/testContent/src_main_java_ilove_quark_us_MyLivenessCheck.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/SmallRyeHealthCodestartTest/testContent/src_main_java_ilove_quark_us_MyLivenessCheck.java
@@ -12,4 +12,7 @@ public class MyLivenessCheck implements HealthCheck {
         return HealthCheckResponse.up("alive");
     }
 
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/WebSocketsCodestartTest/testContent/src_main_java_ilove_quark_us_StartWebSocket.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/WebSocketsCodestartTest/testContent/src_main_java_ilove_quark_us_StartWebSocket.java
@@ -36,4 +36,8 @@ public class StartWebSocket {
     public void onMessage(String message, @PathParam("name") String name) {
         System.out.println("onMessage> " + name + ": " + message);
     }
+
+    // Use in IDE: Starts the app for development. Not used in production.
+    public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }
+
 }


### PR DESCRIPTION
we have feedback that users can't run the quarkus project from the IDE as easy as they can other projects.
Turns out that other frameworks requires a main method and thus naturally have such main method the IDE can launch without using any build tool or custom plugin.

This is first (naive) attempt on adding a main method to codestarts.

I simply added this to every java based codestarter I could find:

`public static void main(String... args) { io.quarkus.runtime.Quarkus.run(args); }`

One line so minimal footprint, no extra imports needed, easy to delete while also easy to run.

I'm wondering if instead of verbatim have this in every codestart wether we should have codestart define a property, ie. `java_mainmethod` which codestarts can then insert if that key is present. Similar for `kotlin_mainmethod` etc.

Then we can more easily tweak it if we would want to adjust with some comment/noob help in future.

wdyt?