### PR TITLE
Fix for missing registry parameters in quarkus push image

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
@@ -37,6 +37,7 @@ public class Push extends BaseImageCommand {
 
     @Override
     public void populateContext(BuildToolContext context) {
+        super.populateContext(context);
         Map<String, String> properties = context.getPropertiesOptions().properties;
         registryUsername.ifPresent(u -> properties.put(QUARKUS_CONTAINER_IMAGE_USERNAME, u));
 

--- a/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageGradleTest.java
@@ -140,9 +140,10 @@ public class CliImageGradleTest {
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=false"));
         assertTrue(result.getStdout().contains("--init-script="));
 
-        // 4 image push --also-build --dry-run
-        result = CliDriver.execute(project, "image", "push", "--also-build", "--dry-run");
+        // 4 image push --also-build --dry-run --registry=quay.io
+        result = CliDriver.execute(project, "image", "push", "--also-build", "--dry-run", "--registry=quay.io");
         assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=true"));
+        assertTrue(result.getStdout().contains("-Dquarkus.container-image.registry=quay.io"));
     }
 }

--- a/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageMavenTest.java
@@ -69,10 +69,11 @@ public class CliImageMavenTest {
         assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=false"));
 
-        // 4 image push --also-build --dry-run
-        result = CliDriver.execute(project, "image", "push", "--also-build", "--dry-run");
+        // 4 image push --also-build --dry-run --registry=quay.io
+        result = CliDriver.execute(project, "image", "push", "--also-build", "--dry-run", "--registry=quay.io");
         assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=true"));
+        assertTrue(result.getStdout().contains("-Dquarkus.container-image.registry=quay.io"));
 
     }
 }


### PR DESCRIPTION
I noticed the command `quarkus image push --registry=quay.io` was ignoring the registry flag even though the --help command said it should work.  

I fixed it by adding the parent class' (BaseImageCommand) context where the registry parameters (registry, group name etc) are defined.  I also added an assertion to make sure this scenario is covered in the tests.