### PR TITLE
Update builder images to jdk-17.0.7

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -39,13 +39,13 @@
         {
             "category": "Data6",
             "timeout": 90,
-            "test-modules": "elasticsearch-rest-client, elasticsearch-rest-high-level-client, elasticsearch-java-client, hibernate-search-orm-elasticsearch, hibernate-search-orm-elasticsearch-tenancy, hibernate-search-orm-opensearch, hibernate-search-orm-elasticsearch-coordination-outbox-polling, hibernate-reactive-panache, hibernate-reactive-panache-kotlin",
+            "test-modules": "elasticsearch-rest-client, elasticsearch-rest-high-level-client, elasticsearch-java-client, hibernate-search-orm-elasticsearch, hibernate-search-orm-elasticsearch-tenancy, hibernate-search-orm-opensearch, hibernate-search-orm-elasticsearch-coordination-outbox-polling",
             "os-name": "ubuntu-latest"
         },
         {
             "category": "Data7",
-            "timeout": 65,
-            "test-modules": "reactive-oracle-client, reactive-mysql-client, reactive-db2-client, hibernate-reactive-db2, hibernate-reactive-mysql",
+            "timeout": 80,
+            "test-modules": "reactive-oracle-client, reactive-mysql-client, reactive-db2-client, hibernate-reactive-db2, hibernate-reactive-mysql, hibernate-reactive-panache, hibernate-reactive-panache-kotlin",
             "os-name": "ubuntu-latest"
         },
         {
@@ -110,7 +110,7 @@
         },
         {
             "category": "Misc3",
-            "timeout": 65,
+            "timeout": 75,
             "test-modules": "kubernetes-client, openshift-client, kubernetes-service-binding-jdbc, smallrye-config, smallrye-graphql, smallrye-graphql-client, smallrye-metrics, smallrye-opentracing",
             "os-name": "ubuntu-latest"
         },

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -89,7 +89,7 @@
         <jboss-metadata-web.version>16.0.0.Final</jboss-metadata-web.version>
         <maven-toolchain.version>3.0-alpha-2</maven-toolchain.version>
         <plexus-component-annotations.version>2.1.0</plexus-component-annotations.version>
-        <graal-sdk.version>22.3.2</graal-sdk.version>
+        <graal-sdk.version>23.0.0</graal-sdk.version>
         <graal-svm.version>${graal-sdk.version}</graal-svm.version>
         <gizmo.version>1.6.1.Final</gizmo.version>
         <jackson-bom.version>2.15.2</jackson-bom.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -89,7 +89,7 @@
         <jboss-metadata-web.version>16.0.0.Final</jboss-metadata-web.version>
         <maven-toolchain.version>3.0-alpha-2</maven-toolchain.version>
         <plexus-component-annotations.version>2.1.0</plexus-component-annotations.version>
-        <graal-sdk.version>23.0.0</graal-sdk.version>
+        <graal-sdk.version>22.3.2</graal-sdk.version>
         <graal-svm.version>${graal-sdk.version}</graal-svm.version>
         <gizmo.version>1.6.1.Final</gizmo.version>
         <jackson-bom.version>2.15.2</jackson-bom.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -20,8 +20,8 @@ import io.smallrye.config.WithParentName;
 @ConfigMapping(prefix = "quarkus.native")
 public interface NativeConfig {
 
-    String DEFAULT_GRAALVM_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:22.3-java17";
-    String DEFAULT_MANDREL_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17";
+    String DEFAULT_GRAALVM_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:jdk-17";
+    String DEFAULT_MANDREL_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17";
 
     /**
      * Comma-separated, additional arguments to pass to the build process.
@@ -216,7 +216,7 @@ public interface NativeConfig {
     interface BuilderImageConfig {
         /**
          * The docker image to use to do the image build. It can be one of `graalvm`, `mandrel`, or the full image path, e.g.
-         * {@code quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17}.
+         * {@code quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17}.
          */
         @WithParentName
         @WithDefault("${platform.quarkus.native.builder-image}")

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -1,8 +1,5 @@
 package io.quarkus.deployment.pkg.steps;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -200,17 +197,20 @@ public final class GraalVM {
             return this.version.compareTo(o.version);
         }
 
-        static Version of(Stream<String> lines) {
-            List<String> linesList = toList(lines); // relies on ordering of the stream
-            if (linesList.size() == 3) {
+        static Version of(Stream<String> output) {
+            List<String> lines = output
+                    .dropWhile(l -> !l.startsWith("GraalVM") && !l.startsWith("native-image"))
+                    .collect(Collectors.toUnmodifiableList());
+
+            if (lines.size() == 3) {
                 // Attempt to parse the new 3-line version scheme first.
-                Version v = VersionParseHelper.parse(linesList);
+                Version v = VersionParseHelper.parse(lines);
                 if (v != VersionParseHelper.UNKNOWN_VERSION) {
                     return v;
                 }
-            } else if (linesList.size() == 1) {
+            } else if (lines.size() == 1) {
                 // Old, single line version parsing logic
-                final String line = linesList.get(0);
+                final String line = lines.get(0);
                 final Matcher oldVersMatcher = OLD_VERS_PATTERN.matcher(line);
                 if (oldVersMatcher.find()) {
                     // GraalVM/Mandrel old, single line, version scheme:
@@ -235,12 +235,6 @@ public final class GraalVM {
             }
 
             return UNVERSIONED;
-        }
-
-        // For JDK 11 source level compatibility. stream.toList() API is JDK 16+
-        @SuppressWarnings("unchecked")
-        private static <T> List<T> toList(Stream<String> stream) {
-            return (List<T>) Collections.unmodifiableList(new ArrayList<>(Arrays.asList(stream.toArray())));
         }
 
         private static boolean isMandrel(String s) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -132,14 +132,13 @@ public final class GraalVM {
         static final Version UNVERSIONED = new Version("Undefined", "snapshot", Distribution.ORACLE);
         static final Version VERSION_21_3 = new Version("GraalVM 21.3", "21.3", Distribution.ORACLE);
         static final Version VERSION_21_3_0 = new Version("GraalVM 21.3.0", "21.3.0", Distribution.ORACLE);
-        public static final Version VERSION_22_3_2 = new Version("GraalVM 22.3.2", "22.3.2", Distribution.ORACLE);
         public static final Version VERSION_22_3_0 = new Version("GraalVM 22.3.0", "22.3.0", Distribution.ORACLE);
         public static final Version VERSION_22_2_0 = new Version("GraalVM 22.2.0", "22.2.0", Distribution.ORACLE);
         public static final Version VERSION_23_0_0 = new Version("GraalVM 23.0.0", "23.0.0", Distribution.ORACLE);
         public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", Distribution.ORACLE);
 
         public static final Version MINIMUM = VERSION_22_2_0;
-        public static final Version CURRENT = VERSION_22_3_2;
+        public static final Version CURRENT = VERSION_23_0_0;
         public static final int UNDEFINED = -1;
 
         final String fullVersion;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -780,7 +780,7 @@ public class NativeImageBuildStep {
                     nativeImageArgs.add("-H:PrintAnalysisCallTreeType=CSV");
                 }
 
-                // only available in GraalVM 22.3.0 and better.
+                // only available in GraalVM 22.3.0+.
                 if (graalVMVersion.compareTo(GraalVM.Version.VERSION_22_3_0) >= 0) {
                     if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_0_0) < 0) {
                         // Used to retrieve build time information in 22.3. Starting with 23.0 this info is included in

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/NativeConfigTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/NativeConfigTest.java
@@ -9,20 +9,20 @@ class NativeConfigTest {
     @Test
     public void testBuilderImageProperlyDetected() {
         assertThat(createConfig("graalvm").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
-                .contains("java17");
+                .contains("jdk-17");
         assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
-                .contains("java17");
+                .contains("jdk-17");
         assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
-                .contains("java17");
+                .contains("jdk-17");
         assertThat(createConfig("GRAALVM").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
-                .contains("java17");
+                .contains("jdk-17");
 
         assertThat(createConfig("mandrel").builderImage().getEffectiveImage()).contains("ubi-quarkus-mandrel-builder-image")
-                .contains("java17");
+                .contains("jdk-17");
         assertThat(createConfig("Mandrel").builderImage().getEffectiveImage()).contains("ubi-quarkus-mandrel-builder-image")
-                .contains("java17");
+                .contains("jdk-17");
         assertThat(createConfig("MANDREL").builderImage().getEffectiveImage()).contains("ubi-quarkus-mandrel-builder-image")
-                .contains("java17");
+                .contains("jdk-17");
 
         assertThat(createConfig("aRandomString").builderImage().getEffectiveImage()).isEqualTo("aRandomString");
     }

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -27,10 +27,41 @@ public class GraalVMTest {
                 Version.of(Stream.of(("native-image 17.0.6 2023-01-17\n"
                         + "GraalVM Runtime Environment Mandrel-23.0.0-dev (build 17.0.6+10)\n"
                         + "Substrate VM Mandrel-23.0.0-dev (build 17.0.6+10, serial gc)").split("\\n"))));
+        assertVersion(org.graalvm.home.Version.create(23, 0, 0), MANDREL,
+                Version.of(Stream.of(("native-image 17.0.7 2023-04-18\n"
+                        + "OpenJDK Runtime Environment Mandrel-23.0.0.0-Final (build 17.0.7+7)\n"
+                        + "OpenJDK 64-Bit Server VM Mandrel-23.0.0.0-Final (build 17.0.7+7, mixed mode)").split("\\n"))));
+        // should also work when the image is not around and we have to download it
+        assertVersion(org.graalvm.home.Version.create(23, 0, 0), MANDREL,
+                Version.of(
+                        Stream.of(("Unable to find image 'quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17' locally\n"
+                                + "jdk-17: Pulling from quarkus/ubi-quarkus-mandrel-builder-image\n"
+                                + "a49367d57626: Already exists\n"
+                                + "3a83b3d8356a: Already exists\n"
+                                + "d8dd24f2bc88: Already exists\n"
+                                + "99bd64fd6c37: Already exists\n"
+                                + "7a13281b4a63: Already exists\n"
+                                + "ae3db351551e: Already exists\n"
+                                + "eee108cfab2c: Already exists\n"
+                                + "d38abde1651d: Already exists\n"
+                                + "cac4ef5d11c0: Already exists\n"
+                                + "89e5b13e9084: Already exists\n"
+                                + "68897e59054c: Already exists\n"
+                                + "774633828afc: Already exists\n"
+                                + "6708d473f3dc: Already exists\n"
+                                + "4f4fb700ef54: Already exists\n"
+                                + "4f4fb700ef54: Already exists\n"
+                                + "Digest: sha256:2833f8ed2cdfcbdf88134a46b5ab7e4dfee8f7cbde60f819f86e59eb73c2491c\n"
+                                + "Status: Downloaded newer image for quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17\n"
+                                + "native-image 17.0.7 2023-04-18\n"
+                                + "OpenJDK Runtime Environment Mandrel-23.0.0.0-Final (build 17.0.7+7)\n"
+                                + "OpenJDK 64-Bit Server VM Mandrel-23.0.0.0-Final (build 17.0.7+7, mixed mode)")
+                                .split("\\n"))));
         assertVersion(org.graalvm.home.Version.create(23, 0), ORACLE,
                 Version.of(Stream.of(("native-image 20 2023-03-21\n"
                         + "GraalVM Runtime Environment GraalVM CE (build 20+34-jvmci-23.0-b10)\n"
                         + "Substrate VM GraalVM CE (build 20+34, serial gc)").split("\\n"))));
+
         // Older version parsing
         assertVersion(org.graalvm.home.Version.create(20, 1), ORACLE,
                 Version.of(Stream.of("GraalVM Version 20.1.0 (Java Version 11.0.7)")));

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -17,8 +17,8 @@
     <properties>
         <!-- The Graal version we suggest using in documentation - as that's
            what we work with by self downloading it: -->
-        <graal-sdk.version-for-documentation>22.3</graal-sdk.version-for-documentation>
-        <mandrel.version-for-documentation>22.3</mandrel.version-for-documentation>
+        <graal-community.version-for-documentation>jdk-17.0.7</graal-community.version-for-documentation>
+        <mandrel.version-for-documentation>jdk-17</mandrel.version-for-documentation>
 
         <assembly-maven-plugin.version>3.5.0</assembly-maven-plugin.version>
         <asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -5,8 +5,8 @@
 :quarkus-platform-groupid: io.quarkus.platform
 // .
 :maven-version: ${proposed-maven-version}
-:graalvm-version: ${graal-sdk.version-for-documentation}
-:graalvm-flavor: ${graal-sdk.version-for-documentation}-java17
+:graalvm-version: ${graal-community.version-for-documentation}
+:graalvm-flavor: ${graal-community.version-for-documentation}-java17
 :mandrel-version: ${mandrel.version-for-documentation}
 :mandrel-flavor: ${mandrel.version-for-documentation}-java17
 :surefire-version: ${version.surefire.plugin}

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -906,11 +906,11 @@ include at build time.
 
 |jvmstat
 |Adds jvmstat support
-|GraalVM 22.3 Mandrel 22.3
+|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
 
 |heapdump
 |Adds support for generating heap dumps
-|GraalVM 22.3 Mandrel 22.3
+|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
 
 |jmxclient
 |Adds support for connections to JMX servers.
@@ -918,11 +918,11 @@ include at build time.
 
 |jmxserver
 |Adds support for accepting connections from JMX clients.
-|GraalVM for JDK 17/20 Mandrel 23.0
+|GraalVM for JDK 17/20 Mandrel 23.0 (17.0.7)
 
 |all
 |Adds all monitoring options.
-|GraalVM 22.3 Mandrel 22.3
+|GraalVM 22.3, GraalVM CE 17.0.7 Mandrel 22.3 Mandrel 23.0 (17.0.7)
 |===
 
 Please see the Quarkus Native Reference Guide for more detailed information on these monitoring options.

--- a/docs/src/main/asciidoc/doc-reference.adoc
+++ b/docs/src/main/asciidoc/doc-reference.adoc
@@ -483,5 +483,5 @@ The complete list of externalized variables for use is given in the following ta
 |\{quickstarts-tree-url}|{quickstarts-tree-url}| Quickstarts URL to main source tree root; used for referencing directories.
 
 |\{graalvm-version}|{graalvm-version}| Recommended GraalVM version to use.
-|\{graalvm-flavor}|{graalvm-flavor}| The builder image tag of GraalVM to use e.g. `22.3-java17`. Use a `java17` version.
+|\{graalvm-flavor}|{graalvm-flavor}| The builder image tag of GraalVM to use e.g. `jdk-17`.
 |===

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -71,7 +71,7 @@
         <jboss-logmanager-embedded.version>1.0.11</jboss-logmanager-embedded.version>
         <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
-        <graal-sdk.version>22.3.2</graal-sdk.version>
+        <graal-sdk.version>23.0.0</graal-sdk.version>
         <plexus-classworlds.version>2.6.0</plexus-classworlds.version> <!-- not actually used but ClassRealm class is referenced from the API used in BootstrapWagonConfigurator -->
         <plexus-cipher.version>1.7</plexus-cipher.version>
         <plexus-utils.version>3.5.1</plexus-utils.version>


### PR DESCRIPTION
- Update the GraalVM Community builder image to the tag `jdk-17` / `jdk-17.0.7`
- Update the Mandrel builder image to the tag `jdk-17`(Mandrel 23.0)
- Update GraalVM SDK version to 23.0 (yes, it does not follow the same version scheme)

Note that the version scheme and name also changed: GraalVM CE -> GraalVM Community. We kept the name of the image unchanged to avoid a massive breaking change.