### PR TITLE
Fix kubernetes integration tests

### DIFF
--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-existing-selectorless-manifest/verify.groovy
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-existing-selectorless-manifest/verify.groovy
@@ -13,8 +13,7 @@ kubernetesYml.withInputStream { stream ->
     KubernetesList list = Serialization.unmarshalAsList(stream)
     assert list != null
 
-    //Most probably this (the handling of QUARKUS_CONTAINER_IMAGE_TAG) is something that we need to change, but until then this is needed.
-    String version = System.getenv("QUARKUS_CONTAINER_IMAGE_TAG") != null ? System.getenv("QUARKUS_CONTAINER_IMAGE_TAG") : "0.1-SNAPSHOT"
+    String version = "0.1-SNAPSHOT"
 
     Deployment deployment = list.items.find{r -> r.kind == "Deployment" && r.metadata.name == "kubernetes-with-existing-selectorless-manifest"}
     assert deployment != null

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/minikube-with-existing-manifest/verify.groovy
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/minikube-with-existing-manifest/verify.groovy
@@ -36,8 +36,7 @@ kubernetesYml.withInputStream { stream ->
     assert container.name == "postgres"
     assert container.ports.find{p -> p.protocol = "TCP"}.containerPort == 5432
 
-    //Most probably this (the handling of QUARKUS_CONTAINER_IMAGE_TAG) is something that we need to change, but until then this is needed.
-    String version = System.getenv("QUARKUS_CONTAINER_IMAGE_TAG") != null ? System.getenv("QUARKUS_CONTAINER_IMAGE_TAG") : "0.1-SNAPSHOT"
+    String version = "0.1-SNAPSHOT"
 
     //Check that it created the application's Deployment with right labels and selector
     Deployment deployment = list.items.find{r -> r.kind == "Deployment" && r.metadata.name == "minikube-with-existing-manifest"}


### PR DESCRIPTION
Currently the invoker tests we run as part of `ci-kubernetes` contain an out of date assertion: `assuming that version label is affected by the image tag`. 

This PR deals with the obsolete assertions.