### PR TITLE
QuarkusComponentTest: convenient handling of nested classes

### DIFF
--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -156,6 +156,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-component</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-h2</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/MyComponentTest.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/MyComponentTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.it.main;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+public class MyComponentTest {
+
+    @Inject
+    @ConfigProperty // name and default value are nonbinding
+    String myProperty;
+
+    @Test
+    public void testProperty() {
+        assertEquals("foo", myProperty);
+    }
+
+    @Singleton
+    static class PropertyProducer {
+
+        // This producer would normally break all @QuarkusTest in the test suite
+        // However, since it's a static nested class declared on a @QuarkusComponentTest it's excluded from the bean discovery
+        @Produces
+        @ConfigProperty
+        String myString() {
+            return "foo";
+        }
+
+    }
+
+}

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTest.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTest.java
@@ -43,4 +43,11 @@ public @interface QuarkusComponentTest {
      * @see QuarkusComponentTestExtension#useDefaultConfigProperties()
      */
     boolean useDefaultConfigProperties() default false;
+
+    /**
+     * If set to {@code true} then all static nested classes are considered additional components under test.
+     *
+     * @see #value()
+     */
+    boolean addNestedClassesAsComponents() default true;
 }

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/MockNotSharedForClassHierarchyTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/MockNotSharedForClassHierarchyTest.java
@@ -15,7 +15,8 @@ import io.quarkus.test.InjectMock;
 public class MockNotSharedForClassHierarchyTest {
 
     @RegisterExtension
-    static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension(Component.class);
+    static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension(Component.class)
+            .ignoreNestedClasses();
 
     @Inject
     Component component;

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/MockSharedForClassHierarchyTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/MockSharedForClassHierarchyTest.java
@@ -16,7 +16,7 @@ public class MockSharedForClassHierarchyTest {
     static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension(Component.class).mock(Foo.class)
             .createMockitoMock(foo -> {
                 Mockito.when(foo.ping()).thenReturn(11);
-            });
+            }).ignoreNestedClasses();
 
     @Inject
     Component component;

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/IgnoreNestedClassesTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/IgnoreNestedClassesTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.test.component.declarative;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.Unremovable;
+import io.quarkus.test.component.QuarkusComponentTest;
+import io.quarkus.test.component.declarative.IgnoreNestedClassesTest.Alpha;
+
+@QuarkusComponentTest(value = Alpha.class, addNestedClassesAsComponents = false)
+public class IgnoreNestedClassesTest {
+
+    @Test
+    public void testComponents() {
+        assertTrue(Arc.container().instance(Alpha.class).isAvailable());
+        assertFalse(Arc.container().instance(Bravo.class).isAvailable());
+    }
+
+    @Unremovable
+    @Singleton
+    static class Alpha {
+
+    }
+
+    @Unremovable
+    @Singleton
+    static class Bravo {
+
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/InterceptorMockingTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/InterceptorMockingTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.test.component.declarative;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+import io.quarkus.test.component.beans.Charlie;
+
+@QuarkusComponentTest
+public class InterceptorMockingTest {
+
+    @Inject
+    TheComponent theComponent;
+
+    @InjectMock
+    Charlie charlie;
+
+    @Test
+    public void testPing() {
+        Mockito.when(charlie.ping()).thenReturn("ok");
+        assertEquals("ok", theComponent.ping());
+    }
+
+    @Singleton
+    static class TheComponent {
+
+        @SimpleBinding
+        String ping() {
+            return "true";
+        }
+
+    }
+
+    @Target({ TYPE, METHOD })
+    @Retention(RUNTIME)
+    @InterceptorBinding
+    public @interface SimpleBinding {
+
+    }
+
+    // This interceptor is automatically added as a tested component
+    @Priority(1)
+    @SimpleBinding
+    @Interceptor
+    static class SimpleInterceptor {
+
+        @Inject
+        Charlie charlie;
+
+        @AroundInvoke
+        Object aroundInvoke(InvocationContext context) throws Exception {
+            return Boolean.parseBoolean(context.proceed().toString()) ? charlie.ping() : "false";
+        }
+
+    }
+
+}


### PR DESCRIPTION
- add static nested classes declared on test class to the set of components under test by default
- exclude static nested classes declated on a QuarkusComponentTest from discovery during `@QuarkusTest`