### PR TITLE
Aws lambda codestart

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/amazon-lambda-example/codestart.yml
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/amazon-lambda-example/codestart.yml
@@ -12,3 +12,5 @@ language:
       - io.quarkus:quarkus-amazon-lambda
     test-dependencies:
       - io.rest-assured:rest-assured
+output-strategy:
+  "*.sh": executable

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/amazon-lambda-example/java/pom.xml
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/amazon-lambda-example/java/pom.xml
@@ -1,0 +1,14 @@
+<project>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/aws</directory>
+        <targetPath>${project.build.directory}/aws</targetPath>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+</project>

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/amazon-lambda-example/java/src/aws/manage.sh
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/amazon-lambda-example/java/src/aws/manage.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+function cmd_create() {
+  echo Creating function
+  set -x
+  aws lambda create-function \
+    --function-name ${FUNCTION_NAME} \
+    --zip-file ${ZIP_FILE} \
+    --handler ${HANDLER} \
+    --runtime ${RUNTIME} \
+    --role ${LAMBDA_ROLE_ARN} \
+    --timeout 15 \
+    --memory-size 256 \
+    ${LAMBDA_META}
+# Enable and move this param above ${LAMBDA_META}, if using AWS X-Ray
+#    --tracing-config Mode=Active \
+}
+
+function cmd_delete() {
+  echo Deleting function
+  set -x
+  aws lambda delete-function --function-name ${FUNCTION_NAME}
+}
+
+function cmd_invoke() {
+  echo Invoking function
+
+  inputFormat=""
+  if [ $(aws --version | awk '{print substr($1,9)}' | cut -c1-1) -ge 2 ]; then inputFormat="--cli-binary-format raw-in-base64-out"; fi
+
+  set -x
+
+  aws lambda invoke response.txt \
+    ${inputFormat} \
+    --function-name ${FUNCTION_NAME} \
+    --payload file://payload.json \
+    --log-type Tail \
+    --query 'LogResult' \
+    --output text |  base64 --decode
+  { set +x; } 2>/dev/null
+  cat response.txt && rm -f response.txt
+}
+
+function cmd_update() {
+  echo Updating function
+  set -x
+  aws lambda update-function-code \
+    --function-name ${FUNCTION_NAME} \
+    --zip-file ${ZIP_FILE}
+}
+
+FUNCTION_NAME=QuarkusAwsLambdaDemo
+HANDLER=io.quarkus.amazon.lambda.runtime.QuarkusStreamHandler::handleRequest
+RUNTIME=java${maven.compiler.release}
+ZIP_FILE=fileb://${project.build.directory}/function.zip
+
+function usage() {
+  [ "_$1" == "_" ] && echo -e "\nUsage (JVM): \n$0 [create|delete|invoke]\ne.g.: $0 invoke"
+  [ "_$1" == "_" ] && echo -e "\nUsage (Native): \n$0 native [create|delete|invoke]\ne.g.: $0 native invoke"
+
+  [ "_" == "_`which aws 2>/dev/null`" ] && echo -e "\naws CLI not installed. Please see https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html"
+  [ ! -e $HOME/.aws/credentials ] && [ "_$AWS_ACCESS_KEY_ID" == "_" ] && echo -e "\naws configure not setup.  Please execute: aws configure"
+  [ "_$LAMBDA_ROLE_ARN" == "_" ] && echo -e "\nEnvironment variable must be set: LAMBDA_ROLE_ARN\ne.g.: export LAMBDA_ROLE_ARN=arn:aws:iam::123456789012:role/my-example-role"
+}
+
+if [ "_$1" == "_" ] || [ "$1" == "help" ]
+ then
+  usage
+fi
+
+if [ "$1" == "native" ]
+then
+  RUNTIME=provided
+  ZIP_FILE=fileb://${projec.build.directory}/function.zip
+  FUNCTION_NAME=QuarkusAwsLambdaDemoNative
+  LAMBDA_META="--environment Variables={DISABLE_SIGNAL_HANDLERS=true}"
+  shift
+fi
+
+while [ "$1" ]
+do
+  eval cmd_${1}
+  { set +x; } 2>/dev/null
+  shift
+done
+

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/amazon-lambda-example/java/src/aws/manage.tpl.qute.sh
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/amazon-lambda-example/java/src/aws/manage.tpl.qute.sh
@@ -4,35 +4,35 @@ function cmd_create() {
   echo Creating function
   set -x
   aws lambda create-function \
-    --function-name ${FUNCTION_NAME} \
-    --zip-file ${ZIP_FILE} \
-    --handler ${HANDLER} \
-    --runtime ${RUNTIME} \
-    --role ${LAMBDA_ROLE_ARN} \
+    --function-name $\{FUNCTION_NAME} \
+    --zip-file $\{ZIP_FILE} \
+    --handler $\{HANDLER} \
+    --runtime $\{RUNTIME} \
+    --role $\{LAMBDA_ROLE_ARN} \
     --timeout 15 \
     --memory-size 256 \
-    ${LAMBDA_META}
-# Enable and move this param above ${LAMBDA_META}, if using AWS X-Ray
+    $\{LAMBDA_META}
+# Enable and move this param above $\{LAMBDA_META}, if using AWS X-Ray
 #    --tracing-config Mode=Active \
 }
 
 function cmd_delete() {
   echo Deleting function
   set -x
-  aws lambda delete-function --function-name ${FUNCTION_NAME}
+  aws lambda delete-function --function-name $\{FUNCTION_NAME}
 }
 
 function cmd_invoke() {
   echo Invoking function
 
   inputFormat=""
-  if [ $(aws --version | awk '{print substr($1,9)}' | cut -c1-1) -ge 2 ]; then inputFormat="--cli-binary-format raw-in-base64-out"; fi
+  if [ $(aws --version | awk '\{print substr($1,9)}' | cut -c1-1) -ge 2 ]; then inputFormat="--cli-binary-format raw-in-base64-out"; fi
 
   set -x
 
   aws lambda invoke response.txt \
-    ${inputFormat} \
-    --function-name ${FUNCTION_NAME} \
+    $\{inputFormat} \
+    --function-name $\{FUNCTION_NAME} \
     --payload file://payload.json \
     --log-type Tail \
     --query 'LogResult' \
@@ -45,14 +45,14 @@ function cmd_update() {
   echo Updating function
   set -x
   aws lambda update-function-code \
-    --function-name ${FUNCTION_NAME} \
-    --zip-file ${ZIP_FILE}
+    --function-name $\{FUNCTION_NAME} \
+    --zip-file $\{ZIP_FILE}
 }
 
 FUNCTION_NAME=QuarkusAwsLambdaDemo
 HANDLER=io.quarkus.amazon.lambda.runtime.QuarkusStreamHandler::handleRequest
-RUNTIME=java${maven.compiler.release}
-ZIP_FILE=fileb://${project.build.directory}/function.zip
+RUNTIME=java$\{maven.compiler.release}
+ZIP_FILE=fileb://$\{project.build.directory}/function.zip
 
 function usage() {
   [ "_$1" == "_" ] && echo -e "\nUsage (JVM): \n$0 [create|delete|invoke]\ne.g.: $0 invoke"
@@ -71,9 +71,9 @@ fi
 if [ "$1" == "native" ]
 then
   RUNTIME=provided
-  ZIP_FILE=fileb://${projec.build.directory}/function.zip
+  ZIP_FILE=fileb://$\{projec.build.directory}/function.zip
   FUNCTION_NAME=QuarkusAwsLambdaDemoNative
-  LAMBDA_META="--environment Variables={DISABLE_SIGNAL_HANDLERS=true}"
+  LAMBDA_META="--environment Variables=\{DISABLE_SIGNAL_HANDLERS=true}"
   shift
 fi
 

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartPomMergeCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartPomMergeCodestartFileStrategyHandler.java
@@ -6,13 +6,11 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.Objects;
 
 import org.apache.maven.model.Model;
 
 import io.fabric8.maven.Maven;
 import io.fabric8.maven.merge.SmartModelMerger;
-import io.quarkus.devtools.codestarts.CodestartStructureException;
 import io.quarkus.devtools.codestarts.core.CodestartData;
 import io.quarkus.devtools.codestarts.core.reader.TargetFile;
 
@@ -26,15 +24,13 @@ final class SmartPomMergeCodestartFileStrategyHandler implements CodestartFileSt
     @Override
     public void process(Path targetDirectory, String relativePath, List<TargetFile> codestartFiles, Map<String, Object> data)
             throws IOException {
+        if (!"maven".equals(CodestartData.getBuildtool(data).orElse(""))) {
+            return;
+        }
         checkNotEmptyCodestartFiles(codestartFiles);
         final Path targetPath = targetDirectory.resolve(relativePath);
         checkTargetDoesNotExist(targetPath);
         createDirectories(targetPath);
-        CodestartData.getBuildtool(data)
-                .filter(b -> Objects.equals(b, "maven"))
-                .orElseThrow(() -> new CodestartStructureException(
-                        "something is wrong, smart-pom-merge file strategy must only be used on maven projects"));
-
         final SmartModelMerger merger = new SmartModelMerger();
         final Model targetModel = Maven.readModel(new StringReader(codestartFiles.get(0).getContent()));
         final ListIterator<TargetFile> iterator = codestartFiles.listIterator(1);


### PR DESCRIPTION
@patriot1burke WDYT about extracting the `manage.sh` and other resources from the extension to the the AWS Lambda codestart?
It would be generated in the project's resources directory and copied to `target/aws` directory with filtering enabled during the build. It would allow
* adjusting the script using properties set in the POM, such `maven.compiler.release` that would set the `runtimeXX` for the function;
* adjust and commit the script to git.