### PR TITLE
Save setting the same state in the Vertx local data duplicated context

### DIFF
--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxCurrentContextFactory.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxCurrentContextFactory.java
@@ -39,7 +39,13 @@ public class VertxCurrentContextFactory implements CurrentContextFactory {
             Context context = Vertx.currentContext();
             if (context != null && VertxContext.isDuplicatedContext(context)) {
                 VertxContextSafetyToggle.setContextSafe(context, true);
-                context.putLocal(LOCAL_KEY, state);
+                // this is racy but should be fine, because DC should not be shared
+                // and never remove the existing mapping
+                var oldState = context.getLocal(LOCAL_KEY);
+                if (oldState != state) {
+                    context.putLocal(LOCAL_KEY, state);
+                }
+
             } else {
                 fallback.set(state);
             }


### PR DESCRIPTION
This is part of a bigger problem shown by some benchmarks ie https://github.com/franz1981/quarkus-reactive-beer

Feel free to try it at home, it should be able to collect flamegraphs as well and *is not* I/O bound nor using a database (that means, how much is relevant what I've found, that's a fair and separate question)

Some evidence that is a worthy change:

![image](https://github.com/quarkusio/quarkus/assets/13125299/a16cfa2f-6157-49eb-8151-f2962175a704)

In violet you can see the `VertxCurrentContext.set` calls, which set the same `io.quarkus.arc.impl.RequestContext$RequestContextState` over and over in the same context.
In my case, it happens a lot more often because it is filtering the elements (12) twice (I have observed ~50 identical `VertxCurrentContext.set`), while with a simpler one (which mimic what hibernate reactive would do while performing a query), just ~4. 
In both cases, avoiding performing `CHM::put` seems a great idea, given that would benefit card marking as mentioned already at https://github.com/quarkusio/quarkus/pull/30024

My concern now is that is now biased to make it pay more when such replacement happen instead, how much is it common? @mkouba ?

FYI the othe remaning low hanging fruit cost of context propagation is https://github.com/smallrye/smallrye-context-propagation/issues/424

**NOTE** 
this PR include some code refactoring in the caller class (performing activation) to remove from the methods the "slow paths" and makes smaller (in term of bytecode) each of the refactored methods: this would increase the chance to get inlined according to the OpenJDK inlining mechanism. It would be a great practice to always do like that, if won't harm the eyes of the readers (it shouldn't but is personal!).
