### PR TITLE
Remove usages of @AlwaysInline

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/ConfigurationSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/ConfigurationSubstitutions.java
@@ -2,7 +2,6 @@ package io.quarkus.runtime.graal;
 
 import org.eclipse.microprofile.config.Config;
 
-import com.oracle.svm.core.AlwaysInline;
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
@@ -23,7 +22,6 @@ final class Target_io_smallrye_config_SmallRyeConfigProviderResolver {
     }
 
     @Substitute
-    @AlwaysInline("trivial")
     public Config getConfig(ClassLoader classLoader) {
         return getConfig();
     }

--- a/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/graal/com/microsoft/sqlserver/jdbc/SQLServerJDBCSubstitutions.java
+++ b/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/graal/com/microsoft/sqlserver/jdbc/SQLServerJDBCSubstitutions.java
@@ -9,7 +9,6 @@ import javax.net.ssl.KeyManager;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
 import com.microsoft.sqlserver.jdbc.SQLServerStatement;
 import com.microsoft.sqlserver.jdbc.SqlAuthenticationToken;
-import com.oracle.svm.core.AlwaysInline;
 import com.oracle.svm.core.annotate.Delete;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
@@ -87,7 +86,6 @@ final class SQLServerFMTQuery {
 final class DisableFMTRemove {
 
     @Substitute
-    @AlwaysInline("We need this to be constant folded")
     public final boolean getUseFmtOnly() throws SQLServerException {
         return false;//Important for this to be disabled via a constant
     }


### PR DESCRIPTION
Usages of those annotations are discouraged upstream and prevents us from changing the GraalVM dependency to graal-sdk only. See #34145 which does that.

Closes #34141