### PR TITLE
Add smallrye-jwt test confirming RSA-OAEP encrypted token with RSA 1_5 set in headers is rejected

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/WrongEncryptionAlgHeaderUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/WrongEncryptionAlgHeaderUnitTest.java
@@ -1,0 +1,30 @@
+package io.quarkus.jwt.test;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class WrongEncryptionAlgHeaderUnitTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DefaultGroupsEndpoint.class)
+                    .addAsResource("rsa-oaep.jwk")
+                    .addAsResource("applicationEncryptWrongAlgorithm.properties", "application.properties"));
+
+    @Test
+    public void echoGroups() {
+        String token = "eyJhbGciOiJSU0ExXzUiLCJlbmMiOiJBMTI4R0NNIn0"
+                + ".CuUuY9PH2wWjuLXd5O9LLFanwyt5-y-NzEpy9rC3A63tFsvdp8GWP1kRt1d3zd0bGqakwls623VQxzxqQ25j5gdHh8dKMl67xTLHt1Qlg36nI9Ukn7syq25VrzfrRRwy0k7isqMncHpzuBQlmfzPrszW7d13z7_ex0Uha869RaP-W2NNBfHYw26xIXcCSVIPg8jTLA7h6QmOetEej-NXXcWrRKQgBRapYy4iWrij9Vr3JzAGSHVtIID74tFOm01FdJj4s1M4IXegDbvAdQb6Vao1Ln5GolnTki4IGvH5FDssDHz6MS2JG5QBcITzfuXU81vDC00xzNEuMat0AngmOw"
+                + ".UjPQbnakkZYUdoDa"
+                + ".vcbS"
+                + ".WQ_bOPiGKjPSq-qyGOIfjA";
+        RestAssured.given().auth()
+                .oauth2(token)
+                .get("/endp/echo")
+                .then().assertThat().statusCode(401).body(Matchers.emptyString());
+    }
+}

--- a/extensions/smallrye-jwt/deployment/src/test/resources/applicationEncryptWrongAlgorithm.properties
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/applicationEncryptWrongAlgorithm.properties
@@ -1,0 +1,5 @@
+smallrye.jwt.decrypt.key.location=/rsa-oaep.jwk
+mp.jwt.verify.issuer=https://server.example.com
+
+quarkus.log.category."io.quarkus.smallrye.jwt.runtime.auth.MpJwtValidator".min-level=TRACE
+quarkus.log.category."io.quarkus.smallrye.jwt.runtime.auth.MpJwtValidator".level=TRACE

--- a/extensions/smallrye-jwt/deployment/src/test/resources/rsa-oaep.jwk
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/rsa-oaep.jwk
@@ -1,0 +1,14 @@
+{
+        "alg": "RSA-OAEP",
+        "use": "enc",
+        "n": "kqGboBfAWttWPCA-0cGRgsY6SaYoIARt0B_PkaEcIq9HPYNdu9n6UuWHuuTHrjF_ZoQW97r5HaAorNvrMEGTGdxCHZdEtkHvNVVmrtxTBLiQCbCozXhFoIrVcr3qUBrdGnNn_M3jJi7Wg7p_-x62nS5gNG875oyheRkutHsQXikFZwsN3q_TsPNOVlCiHy8mxzaFTUQGm-X8UYexFyAivlDSjgDJLAZSWfxd7k9Gxuwa3AUfQqQcVcegmgKGCaErQ3qQbh1x7WB6iopE3_-GZ8HMAVtR9AmrVscqYsnjhaCehfAI0iKKs8zXr8tISc0ORbaalrkk03H1ZrsEnDKEWQ",
+        "e": "AQAB",
+        "d": "YsfIRYN6rDqSz5KRf1E9q7HK1o6-_UK-j7S-asb0Y1FdVs1GuiRQhMPoOjmhY3Io93EI3_7vj8uzWzAUMsAaTxOY3sJnIbktYuqTcD0xGD8VmdGPBkx963db8B6M2UYfqZARf7dbzP9EuB1N1miMcTsqyGgfHGOk7CXQ1vkIv8Uww38KMtEdJ3iB8r-f3qcu-UJjE7Egw9CxKOMjArOXxZEr4VnoIXrImrcTxBfjdY8GbzXGATiPQLur5GT99ZDW78falsir-b5Ean6HNyOeuaJuceT-yjgCXn57Rd3oIHD94CrjNtjBusoLdjbr489L8K9ksCh1gynzLGkeeWgVGQ",
+        "p": "0xalbl1PJbSBGD4XOjIYJLwMYyHMiM06SBauMGzBfCask5DN5jH68Kw1yPS4wkLpx4ltGLuy0X5mMaZzrSOkBGb27-NizBgB2-L279XotznWeh2jbF05Kqzkoz3VaX_7dRhCHEhOopMQh619hA1bwaJyW1k8aNlLPTl3BotkP4M",
+        "q": "sdQsQVz3tI7hmisAgiIjppOssEnZaZO0ONeRRDxBHGLe3BCo1FJoMMQryOAlglayjQnnWjQ-BpwUpa0r9YQhVLweoNEIig6Beph7iYRZgOHEiiTTgUIGgXAL6xhsby1PueUfT0xsN1Y7qt5f5EwOfu7tnFqNyJXIp9W1NQgU6fM",
+        "dp": "kEpEnuJNfdqa-_VFb1RayJF6bjDmXQTcN_a47wUIZVMSWHR9KkMz41v0D_-oY7HVl73Kw0NagnVCaeH75HgeX5v6ZBQsrpIigynr3hl8T_LLNwIXebVnpFI2n5de0BTZ0DraxfZvOhYJEJV43NE8zWm7fdHLx2fxVFJ5mBGkXv0",
+        "dq": "U_xJCnXF51iz5AP7MXq-K6YDIR8_t0UzEMV-riNm_OkVKAoWMnDZFG8R3sU98djQaxwKT-fsg2KjvbuTz1igBUzzijAvQESpkiUB82i2fNAj6rqJybpNKESq3FWkoL1dsgYsS19knJ31gDWWRFRHZFujjPyXiexz4BBmjK1Mc1E",
+        "qi": "Uvb84tWiJF3fB-U9wZSPi7juGgrzeXS_LYtf5fcdV0fZg_h_5nSVpXyYyQ-PK218qEC5MlDkaHKRD9wBOe_eU_zJTNoXzB2oAcgl2MapBWUMytbiF84ghP_2K9UD63ZVsyrorSZhmsJIBBuqQjrmk0tIdpMdlMxLYhrbYwFxUqc",
+        "kid": "kid-rsa-enc-oaep",
+        "kty": "RSA"
+}


### PR DESCRIPTION
Simple test confirming `401` with no error details is returned when an `RSA-OAEP` encrypted token has the headers modified attempting to mislead that the encryption algorithm is `RSA_1_5`.
