### PR TITLE
ArC: add InterceptorConfigurator#identifier() method

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -1416,6 +1416,13 @@ public class BeanDeployment {
     }
 
     void addSyntheticInterceptor(InterceptorInfo interceptor) {
+        for (InterceptorInfo i : interceptors) {
+            if (i.getIdentifier().equals(interceptor.getIdentifier())) {
+                throw new IllegalStateException(
+                        "A synthetic interceptor with identifier " + interceptor.getIdentifier() + " is already registered: "
+                                + i);
+            }
+        }
         interceptors.add(interceptor);
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorConfigurator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorConfigurator.java
@@ -11,6 +11,7 @@ import jakarta.enterprise.inject.spi.InterceptionType;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.Type;
 
+import io.quarkus.arc.InjectableInterceptor;
 import io.quarkus.arc.InterceptorCreator;
 import io.quarkus.arc.processor.InjectionPointInfo.TypeAndQualifiers;
 
@@ -24,6 +25,7 @@ public final class InterceptorConfigurator extends ConfiguratorBase<InterceptorC
     final InterceptionType type;
     final Set<TypeAndQualifiers> injectionPoints;
     final Set<AnnotationInstance> bindings;
+    String identifier;
     int priority;
 
     InterceptorConfigurator(BeanDeployment beanDeployment, InterceptionType type) {
@@ -36,6 +38,19 @@ public final class InterceptorConfigurator extends ConfiguratorBase<InterceptorC
 
     public InterceptorConfigurator priority(int priority) {
         this.priority = priority;
+        return this;
+    }
+
+    /**
+     * The identifier becomes a part of the {@link InterceptorInfo#getIdentifier()} and
+     * {@link InjectableInterceptor#getIdentifier()}. An identifier can be used to register multiple synthetic interceptors with
+     * the same {@link InterceptorCreator} class.
+     *
+     * @param identifier
+     * @return self
+     */
+    public InterceptorConfigurator identifier(String identifier) {
+        this.identifier = identifier;
         return this;
     }
 
@@ -53,7 +68,7 @@ public final class InterceptorConfigurator extends ConfiguratorBase<InterceptorC
 
     public void creator(Class<? extends InterceptorCreator> creatorClass) {
         beanDeployment.addSyntheticInterceptor(new InterceptorInfo(creatorClass, beanDeployment, bindings,
-                List.of(Injection.forSyntheticInterceptor(injectionPoints)), priority, type, params));
+                List.of(Injection.forSyntheticInterceptor(injectionPoints)), priority, type, params, identifier));
     }
 
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorInfo.java
@@ -50,7 +50,7 @@ public class InterceptorInfo extends BeanInfo implements Comparable<InterceptorI
 
     InterceptorInfo(Class<? extends InterceptorCreator> creatorClass, BeanDeployment beanDeployment,
             Set<AnnotationInstance> bindings, List<Injection> injections, int priority, InterceptionType interceptionType,
-            Map<String, Object> params) {
+            Map<String, Object> params, String identifier) {
         super(null, ClassType.create(InterceptFunction.class), null, beanDeployment, BuiltinScope.DEPENDENT.getInfo(),
                 Sets.singletonHashSet(Type.create(DotName.OBJECT_NAME, Kind.CLASS)), new HashSet<>(), injections, null,
                 null, false,
@@ -64,7 +64,7 @@ public class InterceptorInfo extends BeanInfo implements Comparable<InterceptorI
                             creatorClass.getName() + "#create() must not return null");
                     mc.returnValue(ret);
                 },
-                null, params, true, false, null, priority, creatorClass.getName());
+                null, params, true, false, null, priority, creatorClass.getName() + (identifier != null ? identifier : ""));
         this.bindings = bindings;
         this.interceptionType = interceptionType;
         this.creatorClass = creatorClass;

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInterceptorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticInterceptorTest.java
@@ -47,11 +47,12 @@ public class SyntheticInterceptorTest {
         InstanceHandle<MyBean> handle = Arc.container().instance(MyBean.class);
         assertEquals("ok", handle.get().ping());
         handle.destroy();
-        assertEquals(4, EVENTS.size());
+        assertEquals(5, EVENTS.size());
         assertEquals(TestAroundConstruct.class.getName(), EVENTS.get(0));
         assertEquals(TestPostConstruct.class.getName(), EVENTS.get(1));
-        assertEquals(TestAroundInvoke.class.getName(), EVENTS.get(2));
-        assertEquals(TestPreDestroy.class.getName(), EVENTS.get(3));
+        assertEquals(TestPostConstruct.class.getName(), EVENTS.get(2));
+        assertEquals(TestAroundInvoke.class.getName(), EVENTS.get(3));
+        assertEquals(TestPreDestroy.class.getName(), EVENTS.get(4));
     }
 
     @SimpleBinding
@@ -153,6 +154,13 @@ public class SyntheticInterceptorTest {
                     .bindings(AnnotationInstance.builder(SimpleBinding.class).build())
                     .addInjectionPoint(ParameterizedType.create(Bean.class, WildcardType.UNBOUNDED),
                             AnnotationInstance.builder(Intercepted.class).build())
+                    .creator(TestPostConstruct.class);
+
+            context.configureInterceptor(InterceptionType.POST_CONSTRUCT)
+                    .bindings(AnnotationInstance.builder(SimpleBinding.class).build())
+                    .addInjectionPoint(ParameterizedType.create(Bean.class, WildcardType.UNBOUNDED),
+                            AnnotationInstance.builder(Intercepted.class).build())
+                    .identifier("foo")
                     .creator(TestPostConstruct.class);
 
             context.configureInterceptor(InterceptionType.PRE_DESTROY)


### PR DESCRIPTION
- this makes it possible to register multiple synthetic interceptors with the same InterceptorCreator class