### PR TITLE
Use GraalVM CE instead of Mandrel for building static binaries

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -695,7 +695,7 @@ Sample multistage Dockerfile for building an image from `scratch`:
 [source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{mandrel-flavor} AS build
+FROM quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:{graalvm-flavor} AS build
 USER root
 RUN microdnf install make gcc
 COPY --chown=quarkus:quarkus mvnw /code/mvnw


### PR DESCRIPTION
Fix #34220 

As @cescoffier correctly pointed out, Mandrel [doesn't support static binaries with `musl`](https://github.com/graalvm/mandrel#how-does-mandrel-differ-from-graal).