### PR TITLE
Support custom claim types in quarkus-test-security-jwt and quarkus-test-security-oidc

### DIFF
--- a/test-framework/security-jwt/pom.xml
+++ b/test-framework/security-jwt/pom.xml
@@ -31,6 +31,8 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonp</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>

--- a/test-framework/security-jwt/pom.xml
+++ b/test-framework/security-jwt/pom.xml
@@ -29,6 +29,10 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-api</artifactId>
         </dependency>

--- a/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/Claim.java
+++ b/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/Claim.java
@@ -18,8 +18,10 @@ public @interface Claim {
     String value();
 
     /**
-     * Claim value type, the value will be converted to String if this type is set to Object.class.
-     * Supported types: String, Integer, int, Long, long, Boolean, boolean, jakarta.json.JsonArray, jakarta.json.JsonObject.
+     * Claim value type.
+     * If this type is set to {@link ClaimType#DEFAULT} then the value will be converted to String unless the claim
+     * is a standard claim such as `exp` (expiry), `iat` (issued at), `nbf` (not before), `auth_time` (authentication time)
+     * whose value will be converted to Long or `email_verified` whose value will be converted to Boolean.
      */
-    Class<?> type() default Object.class;
+    ClaimType type() default ClaimType.DEFAULT;
 }

--- a/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/Claim.java
+++ b/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/Claim.java
@@ -7,7 +7,19 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({})
 public @interface Claim {
+    /**
+     * Claim name
+     */
     String key();
 
+    /**
+     * Claim value
+     */
     String value();
+
+    /**
+     * Claim value type, the value will be converted to String if this type is set to Object.class.
+     * Supported types: String, Integer, int, Long, long, Boolean, boolean, jakarta.json.JsonArray, jakarta.json.JsonObject.
+     */
+    Class<?> type() default Object.class;
 }

--- a/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/ClaimType.java
+++ b/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/ClaimType.java
@@ -1,0 +1,59 @@
+package io.quarkus.test.security.jwt;
+
+import java.io.StringReader;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+public enum ClaimType {
+    LONG {
+        @Override
+        public Long convert(String value) {
+            return Long.parseLong(value);
+        }
+    },
+    INTEGER {
+        @Override
+        public Integer convert(String value) {
+            return Integer.parseInt(value);
+        }
+    },
+    BOOLEAN {
+        @Override
+        public Boolean convert(String value) {
+            return Boolean.parseBoolean(value);
+        }
+    },
+    STRING {
+        @Override
+        public String convert(String value) {
+            return value;
+        }
+    },
+    JSON_ARRAY {
+        @Override
+        public JsonArray convert(String value) {
+            try (JsonReader jsonReader = Json.createReader(new StringReader(value))) {
+                return jsonReader.readArray();
+            }
+        }
+    },
+    JSON_OBJECT {
+        @Override
+        public JsonObject convert(String value) {
+            try (JsonReader jsonReader = Json.createReader(new StringReader(value))) {
+                return jsonReader.readObject();
+            }
+        }
+    },
+    DEFAULT {
+        @Override
+        public String convert(String value) {
+            return value;
+        }
+    };
+
+    abstract Object convert(String value);
+}

--- a/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentor.java
+++ b/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentor.java
@@ -1,0 +1,161 @@
+package io.quarkus.test.security.jwt;
+
+import java.io.StringReader;
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.test.security.TestSecurityIdentityAugmentor;
+
+public class JwtTestSecurityIdentityAugmentor implements TestSecurityIdentityAugmentor {
+    private static Converter<Long> longConverter = new LongConverter();
+    private static Converter<Integer> intConverter = new IntegerConverter();
+    private static Converter<Boolean> booleanConverter = new BooleanConverter();
+    private static Map<String, Converter<?>> standardClaimConverteres = Map.of(
+            Claims.exp.name(), longConverter,
+            Claims.iat.name(), longConverter,
+            Claims.nbf.name(), longConverter,
+            Claims.auth_time.name(), longConverter,
+            Claims.email_verified.name(), booleanConverter);
+
+    private static Map<Class<?>, Converter<?>> converters = Map.of(
+            String.class, new StringConverter(),
+            Integer.class, intConverter,
+            int.class, intConverter,
+            Long.class, longConverter,
+            long.class, longConverter,
+            Boolean.class, booleanConverter,
+            boolean.class, booleanConverter,
+            JsonArray.class, new JsonArrayConverter(),
+            JsonObject.class, new JsonObjectConverter());
+
+    @Override
+    public SecurityIdentity augment(final SecurityIdentity identity, final Annotation[] annotations) {
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
+
+        final JwtSecurity jwtSecurity = findJwtSecurity(annotations);
+        builder.setPrincipal(new JsonWebToken() {
+
+            @Override
+            public String getName() {
+                return identity.getPrincipal().getName();
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public <T> T getClaim(String claimName) {
+                if (Claims.groups.name().equals(claimName)) {
+                    return (T) identity.getRoles();
+                }
+                if (jwtSecurity != null && jwtSecurity.claims() != null) {
+                    for (Claim claim : jwtSecurity.claims()) {
+                        if (claim.key().equals(claimName)) {
+                            return convertClaimValue(claim);
+                        }
+                    }
+                }
+                return null;
+            }
+
+            @Override
+            public Set<String> getClaimNames() {
+                if (jwtSecurity != null && jwtSecurity.claims() != null) {
+                    return Arrays.stream(jwtSecurity.claims()).map(Claim::key).collect(Collectors.toSet());
+                }
+                return Collections.emptySet();
+            }
+
+        });
+
+        return builder.build();
+    }
+
+    private static JwtSecurity findJwtSecurity(Annotation[] annotations) {
+        for (Annotation ann : annotations) {
+            if (ann instanceof JwtSecurity) {
+                return (JwtSecurity) ann;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T convertClaimValue(Claim claim) {
+        if (claim.type() != Object.class) {
+            Converter<?> converter = converters.get(claim.type());
+            if (converter != null) {
+                return (T) converter.convert(claim.value());
+            } else {
+                throw new RuntimeException("Unsupported claim type: " + claim.type().getName());
+            }
+        } else if (standardClaimConverteres.containsKey(claim.key())) {
+            Converter<?> converter = standardClaimConverteres.get(claim.key());
+            return (T) converter.convert(claim.value());
+        } else {
+            return (T) claim.value();
+        }
+    }
+
+    private static interface Converter<T> {
+        T convert(String value);
+    }
+
+    private static class StringConverter implements Converter<String> {
+        @Override
+        public String convert(String value) {
+            return value;
+        }
+    }
+
+    private static class IntegerConverter implements Converter<Integer> {
+        @Override
+        public Integer convert(String value) {
+            return Integer.valueOf(value);
+        }
+    }
+
+    private static class LongConverter implements Converter<Long> {
+        @Override
+        public Long convert(String value) {
+            return Long.valueOf(value);
+        }
+    }
+
+    private static class BooleanConverter implements Converter<Boolean> {
+        @Override
+        public Boolean convert(String value) {
+            return Boolean.valueOf(value);
+        }
+    }
+
+    private static class JsonObjectConverter implements Converter<JsonObject> {
+        @Override
+        public JsonObject convert(String value) {
+            try (JsonReader jsonReader = Json.createReader(new StringReader(value))) {
+                return jsonReader.readObject();
+            }
+        }
+    }
+
+    private static class JsonArrayConverter implements Converter<JsonArray> {
+        @Override
+        public JsonArray convert(String value) {
+            try (JsonReader jsonReader = Json.createReader(new StringReader(value))) {
+                return jsonReader.readArray();
+            }
+        }
+    }
+}

--- a/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentor.java
+++ b/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentor.java
@@ -1,6 +1,5 @@
 package io.quarkus.test.security.jwt;
 
-import java.io.StringReader;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collections;
@@ -9,9 +8,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonReader;
 import jakarta.json.JsonValue;
 
 import org.eclipse.microprofile.jwt.Claims;
@@ -22,26 +18,12 @@ import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.quarkus.test.security.TestSecurityIdentityAugmentor;
 
 public class JwtTestSecurityIdentityAugmentor implements TestSecurityIdentityAugmentor {
-    private static Converter<Long> longConverter = new LongConverter();
-    private static Converter<Integer> intConverter = new IntegerConverter();
-    private static Converter<Boolean> booleanConverter = new BooleanConverter();
-    private static Map<String, Converter<?>> standardClaimConverteres = Map.of(
-            Claims.exp.name(), longConverter,
-            Claims.iat.name(), longConverter,
-            Claims.nbf.name(), longConverter,
-            Claims.auth_time.name(), longConverter,
-            Claims.email_verified.name(), booleanConverter);
-
-    private static Map<Class<?>, Converter<?>> converters = Map.of(
-            String.class, new StringConverter(),
-            Integer.class, intConverter,
-            int.class, intConverter,
-            Long.class, longConverter,
-            long.class, longConverter,
-            Boolean.class, booleanConverter,
-            boolean.class, booleanConverter,
-            JsonArray.class, new JsonArrayConverter(),
-            JsonObject.class, new JsonObjectConverter());
+    private static Map<String, ClaimType> standardClaimTypes = Map.of(
+            Claims.exp.name(), ClaimType.LONG,
+            Claims.iat.name(), ClaimType.LONG,
+            Claims.nbf.name(), ClaimType.LONG,
+            Claims.auth_time.name(), ClaimType.LONG,
+            Claims.email_verified.name(), ClaimType.BOOLEAN);
 
     @Override
     public SecurityIdentity augment(final SecurityIdentity identity, final Annotation[] annotations) {
@@ -117,70 +99,12 @@ public class JwtTestSecurityIdentityAugmentor implements TestSecurityIdentityAug
         return claimType;
     }
 
-    @SuppressWarnings("unchecked")
-    private <T> T convertClaimValue(Claim claim) {
-        if (claim.type() != Object.class) {
-            Converter<?> converter = converters.get(claim.type());
-            if (converter != null) {
-                return (T) converter.convert(claim.value());
-            } else {
-                throw new RuntimeException("Unsupported claim type: " + claim.type().getName());
-            }
-        } else if (standardClaimConverteres.containsKey(claim.key())) {
-            Converter<?> converter = standardClaimConverteres.get(claim.key());
-            return (T) converter.convert(claim.value());
-        } else {
-            return (T) claim.value();
+    private Object convertClaimValue(Claim claim) {
+        ClaimType type = claim.type();
+        if (type == ClaimType.DEFAULT && standardClaimTypes.containsKey(claim.key())) {
+            type = standardClaimTypes.get(claim.key());
         }
+        return type.convert(claim.value());
     }
 
-    private static interface Converter<T> {
-        T convert(String value);
-    }
-
-    private static class StringConverter implements Converter<String> {
-        @Override
-        public String convert(String value) {
-            return value;
-        }
-    }
-
-    private static class IntegerConverter implements Converter<Integer> {
-        @Override
-        public Integer convert(String value) {
-            return Integer.valueOf(value);
-        }
-    }
-
-    private static class LongConverter implements Converter<Long> {
-        @Override
-        public Long convert(String value) {
-            return Long.valueOf(value);
-        }
-    }
-
-    private static class BooleanConverter implements Converter<Boolean> {
-        @Override
-        public Boolean convert(String value) {
-            return Boolean.valueOf(value);
-        }
-    }
-
-    private static class JsonObjectConverter implements Converter<JsonObject> {
-        @Override
-        public JsonObject convert(String value) {
-            try (JsonReader jsonReader = Json.createReader(new StringReader(value))) {
-                return jsonReader.readObject();
-            }
-        }
-    }
-
-    private static class JsonArrayConverter implements Converter<JsonArray> {
-        @Override
-        public JsonArray convert(String value) {
-            try (JsonReader jsonReader = Json.createReader(new StringReader(value))) {
-                return jsonReader.readArray();
-            }
-        }
-    }
 }

--- a/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentorProducer.java
+++ b/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentorProducer.java
@@ -1,20 +1,9 @@
 package io.quarkus.test.security.jwt;
 
-import java.lang.annotation.Annotation;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 
-import org.eclipse.microprofile.jwt.Claims;
-import org.eclipse.microprofile.jwt.JsonWebToken;
-
 import io.quarkus.arc.Unremovable;
-import io.quarkus.security.identity.SecurityIdentity;
-import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.quarkus.test.security.TestSecurityIdentityAugmentor;
 
 @ApplicationScoped
@@ -24,58 +13,5 @@ public class JwtTestSecurityIdentityAugmentorProducer {
     @Unremovable
     public TestSecurityIdentityAugmentor produce() {
         return new JwtTestSecurityIdentityAugmentor();
-    }
-
-    private static class JwtTestSecurityIdentityAugmentor implements TestSecurityIdentityAugmentor {
-
-        @Override
-        public SecurityIdentity augment(final SecurityIdentity identity, final Annotation[] annotations) {
-            QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
-
-            final JwtSecurity jwtSecurity = findJwtSecurity(annotations);
-            builder.setPrincipal(new JsonWebToken() {
-
-                @Override
-                public String getName() {
-                    return identity.getPrincipal().getName();
-                }
-
-                @SuppressWarnings("unchecked")
-                @Override
-                public <T> T getClaim(String claimName) {
-                    if (Claims.groups.name().equals(claimName)) {
-                        return (T) identity.getRoles();
-                    }
-                    if (jwtSecurity != null && jwtSecurity.claims() != null) {
-                        for (Claim claim : jwtSecurity.claims()) {
-                            if (claim.key().equals(claimName)) {
-                                return (T) claim.value();
-                            }
-                        }
-                    }
-                    return null;
-                }
-
-                @Override
-                public Set<String> getClaimNames() {
-                    if (jwtSecurity != null && jwtSecurity.claims() != null) {
-                        return Arrays.stream(jwtSecurity.claims()).map(Claim::key).collect(Collectors.toSet());
-                    }
-                    return Collections.emptySet();
-                }
-
-            });
-
-            return builder.build();
-        }
-
-        private JwtSecurity findJwtSecurity(Annotation[] annotations) {
-            for (Annotation ann : annotations) {
-                if (ann instanceof JwtSecurity) {
-                    return (JwtSecurity) ann;
-                }
-            }
-            return null;
-        }
     }
 }

--- a/test-framework/security-jwt/src/test/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentorTest.java
+++ b/test-framework/security-jwt/src/test/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentorTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.test.security.jwt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Annotation;
+import java.security.Principal;
+import java.util.Set;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+
+public class JwtTestSecurityIdentityAugmentorTest {
+
+    @Test
+    @JwtSecurity(claims = {
+            @Claim(key = "exp", value = "123456789"),
+            @Claim(key = "iat", value = "123456788"),
+            @Claim(key = "nbf", value = "123456787"),
+            @Claim(key = "auth_time", value = "123456786"),
+            @Claim(key = "customlong", value = "123456785", type = Long.class),
+            @Claim(key = "email", value = "user@gmail.com"),
+            @Claim(key = "email_verified", value = "true"),
+            @Claim(key = "email_checked", value = "false", type = Boolean.class),
+            @Claim(key = "jsonarray_claim", value = "[\"1\", \"2\"]", type = JsonArray.class),
+            @Claim(key = "jsonobject_claim", value = "{\"a\":\"1\", \"b\":\"2\"}", type = JsonObject.class)
+    })
+    public void testClaimValues() throws Exception {
+        SecurityIdentity identity = QuarkusSecurityIdentity.builder()
+                .setPrincipal(new Principal() {
+                    @Override
+                    public String getName() {
+                        return "alice";
+                    }
+
+                })
+                .addRole("user")
+                .build();
+
+        JwtTestSecurityIdentityAugmentor augmentor = new JwtTestSecurityIdentityAugmentor();
+
+        Annotation[] annotations = JwtTestSecurityIdentityAugmentorTest.class.getMethod("testClaimValues").getAnnotations();
+        JsonWebToken jwt = (JsonWebToken) augmentor.augment(identity, annotations).getPrincipal();
+
+        assertEquals("alice", jwt.getName());
+        assertEquals(Set.of("user"), jwt.getGroups());
+
+        assertEquals(123456789, jwt.getExpirationTime());
+        assertEquals(123456788, jwt.getIssuedAtTime());
+        assertEquals(123456787, (Long) jwt.getClaim(Claims.nbf.name()));
+        assertEquals(123456786, (Long) jwt.getClaim(Claims.auth_time.name()));
+        assertEquals(123456785, (Long) jwt.getClaim("customlong"));
+        assertEquals("user@gmail.com", jwt.getClaim(Claims.email));
+        assertTrue((Boolean) jwt.getClaim(Claims.email_verified.name()));
+        assertFalse((Boolean) jwt.getClaim("email_checked"));
+
+        JsonArray array = jwt.getClaim("jsonarray_claim");
+        assertEquals("1", array.getString(0));
+        assertEquals("2", array.getString(1));
+
+        JsonObject map = jwt.getClaim("jsonobject_claim");
+        assertEquals("1", map.getString("a"));
+        assertEquals("2", map.getString("b"));
+    }
+
+}

--- a/test-framework/security-jwt/src/test/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentorTest.java
+++ b/test-framework/security-jwt/src/test/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentorTest.java
@@ -27,12 +27,12 @@ public class JwtTestSecurityIdentityAugmentorTest {
             @Claim(key = "iat", value = "123456788"),
             @Claim(key = "nbf", value = "123456787"),
             @Claim(key = "auth_time", value = "123456786"),
-            @Claim(key = "customlong", value = "123456785", type = Long.class),
+            @Claim(key = "customlong", value = "123456785", type = ClaimType.LONG),
             @Claim(key = "email", value = "user@gmail.com"),
             @Claim(key = "email_verified", value = "true"),
-            @Claim(key = "email_checked", value = "false", type = Boolean.class),
-            @Claim(key = "jsonarray_claim", value = "[\"1\", \"2\"]", type = JsonArray.class),
-            @Claim(key = "jsonobject_claim", value = "{\"a\":\"1\", \"b\":\"2\"}", type = JsonObject.class)
+            @Claim(key = "email_checked", value = "false", type = ClaimType.BOOLEAN),
+            @Claim(key = "jsonarray_claim", value = "[\"1\", \"2\"]", type = ClaimType.JSON_ARRAY),
+            @Claim(key = "jsonobject_claim", value = "{\"a\":\"1\", \"b\":\"2\"}", type = ClaimType.JSON_OBJECT)
     })
     public void testClaimValues() throws Exception {
         SecurityIdentity identity = QuarkusSecurityIdentity.builder()

--- a/test-framework/security-jwt/src/test/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentorTest.java
+++ b/test-framework/security-jwt/src/test/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentorTest.java
@@ -1,7 +1,6 @@
 package io.quarkus.test.security.jwt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.annotation.Annotation;
@@ -9,7 +8,9 @@ import java.security.Principal;
 import java.util.Set;
 
 import jakarta.json.JsonArray;
+import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 
 import org.eclipse.microprofile.jwt.Claims;
 import org.eclipse.microprofile.jwt.JsonWebToken;
@@ -57,10 +58,10 @@ public class JwtTestSecurityIdentityAugmentorTest {
         assertEquals(123456788, jwt.getIssuedAtTime());
         assertEquals(123456787, (Long) jwt.getClaim(Claims.nbf.name()));
         assertEquals(123456786, (Long) jwt.getClaim(Claims.auth_time.name()));
-        assertEquals(123456785, (Long) jwt.getClaim("customlong"));
+        assertEquals(123456785, ((JsonNumber) jwt.getClaim("customlong")).longValue());
         assertEquals("user@gmail.com", jwt.getClaim(Claims.email));
         assertTrue((Boolean) jwt.getClaim(Claims.email_verified.name()));
-        assertFalse((Boolean) jwt.getClaim("email_checked"));
+        assertEquals(JsonValue.FALSE, jwt.getClaim("email_checked"));
 
         JsonArray array = jwt.getClaim("jsonarray_claim");
         assertEquals("1", array.getString(0));

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/Claim.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/Claim.java
@@ -18,8 +18,10 @@ public @interface Claim {
     String value();
 
     /**
-     * Claim value type, the value will be converted to String if this type is set to Object.class.
-     * Supported types: String, Integer, int, Long, long, Boolean, boolean, jakarta.json.JsonArray, jakarta.json.JsonObject.
+     * Claim value type.
+     * If this type is set to {@link ClaimType#DEFAULT} then the value will be converted to String unless the claim
+     * is a standard claim such as `exp` (expiry), `iat` (issued at), `nbf` (not before), `auth_time` (authentication time)
+     * whose value will be converted to Long or `email_verified` whose value will be converted to Boolean.
      */
-    Class<?> type() default Object.class;
+    ClaimType type() default ClaimType.DEFAULT;
 }

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/Claim.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/Claim.java
@@ -7,7 +7,19 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({})
 public @interface Claim {
+    /**
+     * Claim name
+     */
     String key();
 
+    /**
+     * Claim value
+     */
     String value();
+
+    /**
+     * Claim value type, the value will be converted to String if this type is set to Object.class.
+     * Supported types: String, Integer, int, Long, long, Boolean, boolean, jakarta.json.JsonArray, jakarta.json.JsonObject.
+     */
+    Class<?> type() default Object.class;
 }

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/ClaimType.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/ClaimType.java
@@ -1,0 +1,59 @@
+package io.quarkus.test.security.oidc;
+
+import java.io.StringReader;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+public enum ClaimType {
+    LONG {
+        @Override
+        public Long convert(String value) {
+            return Long.parseLong(value);
+        }
+    },
+    INTEGER {
+        @Override
+        public Integer convert(String value) {
+            return Integer.parseInt(value);
+        }
+    },
+    BOOLEAN {
+        @Override
+        public Boolean convert(String value) {
+            return Boolean.parseBoolean(value);
+        }
+    },
+    STRING {
+        @Override
+        public String convert(String value) {
+            return value;
+        }
+    },
+    JSON_ARRAY {
+        @Override
+        public JsonArray convert(String value) {
+            try (JsonReader jsonReader = Json.createReader(new StringReader(value))) {
+                return jsonReader.readArray();
+            }
+        }
+    },
+    JSON_OBJECT {
+        @Override
+        public JsonObject convert(String value) {
+            try (JsonReader jsonReader = Json.createReader(new StringReader(value))) {
+                return jsonReader.readObject();
+            }
+        }
+    },
+    DEFAULT {
+        @Override
+        public String convert(String value) {
+            return value;
+        }
+    };
+
+    abstract Object convert(String value);
+}

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentor.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentor.java
@@ -1,6 +1,5 @@
 package io.quarkus.test.security.oidc;
 
-import java.io.StringReader;
 import java.lang.annotation.Annotation;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -12,7 +11,6 @@ import java.util.stream.Collectors;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonReader;
 
 import org.eclipse.microprofile.jwt.Claims;
 import org.eclipse.microprofile.jwt.JsonWebToken;
@@ -33,26 +31,12 @@ import io.vertx.core.json.JsonObject;
 
 public class OidcTestSecurityIdentityAugmentor implements TestSecurityIdentityAugmentor {
 
-    private static Converter<Long> longConverter = new LongConverter();
-    private static Converter<Integer> intConverter = new IntegerConverter();
-    private static Converter<Boolean> booleanConverter = new BooleanConverter();
-    private static Map<String, Converter<?>> standardClaimConverteres = Map.of(
-            Claims.exp.name(), longConverter,
-            Claims.iat.name(), longConverter,
-            Claims.nbf.name(), longConverter,
-            Claims.auth_time.name(), longConverter,
-            Claims.email_verified.name(), booleanConverter);
-
-    private static Map<Class<?>, Converter<?>> converters = Map.of(
-            String.class, new StringConverter(),
-            Integer.class, intConverter,
-            int.class, intConverter,
-            Long.class, longConverter,
-            long.class, longConverter,
-            Boolean.class, booleanConverter,
-            boolean.class, booleanConverter,
-            JsonArray.class, new JsonArrayConverter(),
-            jakarta.json.JsonObject.class, new JsonObjectConverter());
+    private static Map<String, ClaimType> standardClaimTypes = Map.of(
+            Claims.exp.name(), ClaimType.LONG,
+            Claims.iat.name(), ClaimType.LONG,
+            Claims.nbf.name(), ClaimType.LONG,
+            Claims.auth_time.name(), ClaimType.LONG,
+            Claims.email_verified.name(), ClaimType.BOOLEAN);
 
     private Optional<String> issuer;
     private PrivateKey privateKey;
@@ -170,70 +154,11 @@ public class OidcTestSecurityIdentityAugmentor implements TestSecurityIdentityAu
         return null;
     }
 
-    @SuppressWarnings("unchecked")
-    private <T> T convertClaimValue(Claim claim) {
-        if (claim.type() != Object.class) {
-            Converter<?> converter = converters.get(claim.type());
-            if (converter != null) {
-                return (T) converter.convert(claim.value());
-            } else {
-                throw new RuntimeException("Unsupported claim type: " + claim.type().getName());
-            }
-        } else if (standardClaimConverteres.containsKey(claim.key())) {
-            Converter<?> converter = standardClaimConverteres.get(claim.key());
-            return (T) converter.convert(claim.value());
-        } else {
-            return (T) claim.value();
+    private Object convertClaimValue(Claim claim) {
+        ClaimType type = claim.type();
+        if (type == ClaimType.DEFAULT && standardClaimTypes.containsKey(claim.key())) {
+            type = standardClaimTypes.get(claim.key());
         }
-    }
-
-    private static interface Converter<T> {
-        T convert(String value);
-    }
-
-    private static class StringConverter implements Converter<String> {
-        @Override
-        public String convert(String value) {
-            return value;
-        }
-    }
-
-    private static class IntegerConverter implements Converter<Integer> {
-        @Override
-        public Integer convert(String value) {
-            return Integer.valueOf(value);
-        }
-    }
-
-    private static class LongConverter implements Converter<Long> {
-        @Override
-        public Long convert(String value) {
-            return Long.valueOf(value);
-        }
-    }
-
-    private static class BooleanConverter implements Converter<Boolean> {
-        @Override
-        public Boolean convert(String value) {
-            return Boolean.valueOf(value);
-        }
-    }
-
-    private static class JsonObjectConverter implements Converter<jakarta.json.JsonObject> {
-        @Override
-        public jakarta.json.JsonObject convert(String value) {
-            try (JsonReader jsonReader = Json.createReader(new StringReader(value))) {
-                return jsonReader.readObject();
-            }
-        }
-    }
-
-    private static class JsonArrayConverter implements Converter<JsonArray> {
-        @Override
-        public JsonArray convert(String value) {
-            try (JsonReader jsonReader = Json.createReader(new StringReader(value))) {
-                return jsonReader.readArray();
-            }
-        }
+        return type.convert(claim.value());
     }
 }

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentor.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentor.java
@@ -1,0 +1,239 @@
+package io.quarkus.test.security.oidc;
+
+import java.io.StringReader;
+import java.lang.annotation.Annotation;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonReader;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jose4j.jwt.JwtClaims;
+
+import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.oidc.IdTokenCredential;
+import io.quarkus.oidc.OidcConfigurationMetadata;
+import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
+import io.quarkus.oidc.runtime.OidcUtils;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.test.security.TestSecurityIdentityAugmentor;
+import io.smallrye.jwt.build.Jwt;
+import io.smallrye.jwt.util.KeyUtils;
+import io.vertx.core.json.JsonObject;
+
+public class OidcTestSecurityIdentityAugmentor implements TestSecurityIdentityAugmentor {
+
+    private static Converter<Long> longConverter = new LongConverter();
+    private static Converter<Integer> intConverter = new IntegerConverter();
+    private static Converter<Boolean> booleanConverter = new BooleanConverter();
+    private static Map<String, Converter<?>> standardClaimConverteres = Map.of(
+            Claims.exp.name(), longConverter,
+            Claims.iat.name(), longConverter,
+            Claims.nbf.name(), longConverter,
+            Claims.auth_time.name(), longConverter,
+            Claims.email_verified.name(), booleanConverter);
+
+    private static Map<Class<?>, Converter<?>> converters = Map.of(
+            String.class, new StringConverter(),
+            Integer.class, intConverter,
+            int.class, intConverter,
+            Long.class, longConverter,
+            long.class, longConverter,
+            Boolean.class, booleanConverter,
+            boolean.class, booleanConverter,
+            JsonArray.class, new JsonArrayConverter(),
+            jakarta.json.JsonObject.class, new JsonObjectConverter());
+
+    private Optional<String> issuer;
+    private PrivateKey privateKey;
+
+    public OidcTestSecurityIdentityAugmentor(Optional<String> issuer) {
+        this.issuer = issuer;
+        try {
+            privateKey = KeyUtils.generateKeyPair(2048).getPrivate();
+        } catch (NoSuchAlgorithmException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public SecurityIdentity augment(final SecurityIdentity identity, final Annotation[] annotations) {
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
+
+        final OidcSecurity oidcSecurity = findOidcSecurity(annotations);
+
+        final boolean introspectionRequired = oidcSecurity != null && oidcSecurity.introspectionRequired();
+
+        if (!introspectionRequired) {
+            // JsonWebToken
+            JsonObjectBuilder claims = Json.createObjectBuilder();
+            claims.add(Claims.preferred_username.name(), identity.getPrincipal().getName());
+            claims.add(Claims.groups.name(),
+                    Json.createArrayBuilder(identity.getRoles().stream().collect(Collectors.toList())).build());
+            if (oidcSecurity != null && oidcSecurity.claims() != null) {
+                for (Claim claim : oidcSecurity.claims()) {
+                    Object claimValue = convertClaimValue(claim);
+                    if (claimValue instanceof String) {
+                        claims.add(claim.key(), (String) claimValue);
+                    } else if (claimValue instanceof Long) {
+                        claims.add(claim.key(), (Long) claimValue);
+                    } else if (claimValue instanceof Integer) {
+                        claims.add(claim.key(), (Integer) claimValue);
+                    } else if (claimValue instanceof Boolean) {
+                        claims.add(claim.key(), (Boolean) claimValue);
+                    } else if (claimValue instanceof JsonArray) {
+                        claims.add(claim.key(), (JsonArray) claimValue);
+                    } else if (claimValue instanceof jakarta.json.JsonObject) {
+                        claims.add(claim.key(), (jakarta.json.JsonObject) claimValue);
+                    }
+                }
+            }
+            jakarta.json.JsonObject claimsJson = claims.build();
+            String jwt = generateToken(claimsJson);
+            IdTokenCredential idToken = new IdTokenCredential(jwt);
+            AccessTokenCredential accessToken = new AccessTokenCredential(jwt);
+
+            try {
+                JsonWebToken principal = new OidcJwtCallerPrincipal(JwtClaims.parse(claimsJson.toString()), idToken);
+                builder.setPrincipal(principal);
+            } catch (Exception ex) {
+                throw new RuntimeException();
+            }
+            builder.addCredential(idToken);
+            builder.addCredential(accessToken);
+        } else {
+            JsonObjectBuilder introspectionBuilder = Json.createObjectBuilder();
+            introspectionBuilder.add(OidcConstants.INTROSPECTION_TOKEN_ACTIVE, true);
+            introspectionBuilder.add(OidcConstants.INTROSPECTION_TOKEN_USERNAME, identity.getPrincipal().getName());
+            introspectionBuilder.add(OidcConstants.TOKEN_SCOPE,
+                    identity.getRoles().stream().collect(Collectors.joining(" ")));
+
+            if (oidcSecurity != null && oidcSecurity.introspection() != null) {
+                for (TokenIntrospection introspection : oidcSecurity.introspection()) {
+                    introspectionBuilder.add(introspection.key(), introspection.value());
+                }
+            }
+
+            builder.addAttribute(OidcUtils.INTROSPECTION_ATTRIBUTE,
+                    new io.quarkus.oidc.TokenIntrospection(introspectionBuilder.build()));
+            builder.addCredential(new AccessTokenCredential(UUID.randomUUID().toString(), null));
+        }
+
+        // UserInfo
+        if (oidcSecurity != null && oidcSecurity.userinfo() != null) {
+            JsonObjectBuilder userInfoBuilder = Json.createObjectBuilder();
+            for (UserInfo userinfo : oidcSecurity.userinfo()) {
+                userInfoBuilder.add(userinfo.key(), userinfo.value());
+            }
+            builder.addAttribute(OidcUtils.USER_INFO_ATTRIBUTE, new io.quarkus.oidc.UserInfo(userInfoBuilder.build()));
+        }
+
+        // OidcConfigurationMetadata
+        JsonObject configMetadataBuilder = new JsonObject();
+        if (issuer.isPresent()) {
+            configMetadataBuilder.put("issuer", issuer.get());
+        }
+        if (oidcSecurity != null && oidcSecurity.config() != null) {
+            for (ConfigMetadata config : oidcSecurity.config()) {
+                configMetadataBuilder.put(config.key(), config.value());
+            }
+        }
+        builder.addAttribute(OidcUtils.CONFIG_METADATA_ATTRIBUTE, new OidcConfigurationMetadata(configMetadataBuilder));
+
+        return builder.build();
+    }
+
+    private String generateToken(jakarta.json.JsonObject claims) {
+        try {
+            return Jwt.claims(claims).sign(privateKey);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private static OidcSecurity findOidcSecurity(Annotation[] annotations) {
+        for (Annotation ann : annotations) {
+            if (ann instanceof OidcSecurity) {
+                return (OidcSecurity) ann;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T convertClaimValue(Claim claim) {
+        if (claim.type() != Object.class) {
+            Converter<?> converter = converters.get(claim.type());
+            if (converter != null) {
+                return (T) converter.convert(claim.value());
+            } else {
+                throw new RuntimeException("Unsupported claim type: " + claim.type().getName());
+            }
+        } else if (standardClaimConverteres.containsKey(claim.key())) {
+            Converter<?> converter = standardClaimConverteres.get(claim.key());
+            return (T) converter.convert(claim.value());
+        } else {
+            return (T) claim.value();
+        }
+    }
+
+    private static interface Converter<T> {
+        T convert(String value);
+    }
+
+    private static class StringConverter implements Converter<String> {
+        @Override
+        public String convert(String value) {
+            return value;
+        }
+    }
+
+    private static class IntegerConverter implements Converter<Integer> {
+        @Override
+        public Integer convert(String value) {
+            return Integer.valueOf(value);
+        }
+    }
+
+    private static class LongConverter implements Converter<Long> {
+        @Override
+        public Long convert(String value) {
+            return Long.valueOf(value);
+        }
+    }
+
+    private static class BooleanConverter implements Converter<Boolean> {
+        @Override
+        public Boolean convert(String value) {
+            return Boolean.valueOf(value);
+        }
+    }
+
+    private static class JsonObjectConverter implements Converter<jakarta.json.JsonObject> {
+        @Override
+        public jakarta.json.JsonObject convert(String value) {
+            try (JsonReader jsonReader = Json.createReader(new StringReader(value))) {
+                return jsonReader.readObject();
+            }
+        }
+    }
+
+    private static class JsonArrayConverter implements Converter<JsonArray> {
+        @Override
+        public JsonArray convert(String value) {
+            try (JsonReader jsonReader = Json.createReader(new StringReader(value))) {
+                return jsonReader.readArray();
+            }
+        }
+    }
+}

--- a/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentorProducer.java
+++ b/test-framework/security-oidc/src/main/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentorProducer.java
@@ -1,37 +1,15 @@
 package io.quarkus.test.security.oidc;
 
-import java.lang.annotation.Annotation;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
 import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
-import jakarta.json.Json;
-import jakarta.json.JsonObjectBuilder;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.jwt.Claims;
-import org.eclipse.microprofile.jwt.JsonWebToken;
-import org.jose4j.jwt.JwtClaims;
 
 import io.quarkus.arc.Unremovable;
-import io.quarkus.oidc.AccessTokenCredential;
-import io.quarkus.oidc.IdTokenCredential;
-import io.quarkus.oidc.OidcConfigurationMetadata;
-import io.quarkus.oidc.common.runtime.OidcConstants;
-import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
-import io.quarkus.oidc.runtime.OidcUtils;
-import io.quarkus.security.identity.SecurityIdentity;
-import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.quarkus.test.security.TestSecurityIdentityAugmentor;
-import io.smallrye.jwt.build.Jwt;
-import io.smallrye.jwt.util.KeyUtils;
-import io.vertx.core.json.JsonObject;
 
 @ApplicationScoped
 public class OidcTestSecurityIdentityAugmentorProducer {
@@ -40,109 +18,9 @@ public class OidcTestSecurityIdentityAugmentorProducer {
     @ConfigProperty(name = "quarkus.oidc.token.issuer")
     Optional<String> issuer;
 
-    PrivateKey privateKey;
-
-    @PostConstruct
-    public void init() {
-        try {
-            privateKey = KeyUtils.generateKeyPair(2048).getPrivate();
-        } catch (NoSuchAlgorithmException ex) {
-            throw new RuntimeException(ex);
-        }
-    }
-
     @Produces
     @Unremovable
     public TestSecurityIdentityAugmentor produce() {
-        return new OidcTestSecurityIdentityAugmentor();
+        return new OidcTestSecurityIdentityAugmentor(issuer);
     }
-
-    private class OidcTestSecurityIdentityAugmentor implements TestSecurityIdentityAugmentor {
-
-        @Override
-        public SecurityIdentity augment(final SecurityIdentity identity, final Annotation[] annotations) {
-            QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
-
-            final OidcSecurity oidcSecurity = findOidcSecurity(annotations);
-
-            final boolean introspectionRequired = oidcSecurity != null && oidcSecurity.introspectionRequired();
-
-            if (!introspectionRequired) {
-                // JsonWebToken
-                JwtClaims claims = new JwtClaims();
-                claims.setClaim(Claims.preferred_username.name(), identity.getPrincipal().getName());
-                claims.setClaim(Claims.groups.name(), identity.getRoles().stream().collect(Collectors.toList()));
-                if (oidcSecurity != null && oidcSecurity.claims() != null) {
-                    for (Claim claim : oidcSecurity.claims()) {
-                        claims.setClaim(claim.key(), claim.value());
-                    }
-                }
-                String jwt = generateToken(claims);
-                IdTokenCredential idToken = new IdTokenCredential(jwt);
-                AccessTokenCredential accessToken = new AccessTokenCredential(jwt);
-
-                JsonWebToken principal = new OidcJwtCallerPrincipal(claims, idToken);
-                builder.setPrincipal(principal);
-                builder.addCredential(idToken);
-                builder.addCredential(accessToken);
-            } else {
-                JsonObjectBuilder introspectionBuilder = Json.createObjectBuilder();
-                introspectionBuilder.add(OidcConstants.INTROSPECTION_TOKEN_ACTIVE, true);
-                introspectionBuilder.add(OidcConstants.INTROSPECTION_TOKEN_USERNAME, identity.getPrincipal().getName());
-                introspectionBuilder.add(OidcConstants.TOKEN_SCOPE,
-                        identity.getRoles().stream().collect(Collectors.joining(" ")));
-
-                if (oidcSecurity != null && oidcSecurity.introspection() != null) {
-                    for (TokenIntrospection introspection : oidcSecurity.introspection()) {
-                        introspectionBuilder.add(introspection.key(), introspection.value());
-                    }
-                }
-
-                builder.addAttribute(OidcUtils.INTROSPECTION_ATTRIBUTE,
-                        new io.quarkus.oidc.TokenIntrospection(introspectionBuilder.build()));
-                builder.addCredential(new AccessTokenCredential(UUID.randomUUID().toString(), null));
-            }
-
-            // UserInfo
-            if (oidcSecurity != null && oidcSecurity.userinfo() != null) {
-                JsonObjectBuilder userInfoBuilder = Json.createObjectBuilder();
-                for (UserInfo userinfo : oidcSecurity.userinfo()) {
-                    userInfoBuilder.add(userinfo.key(), userinfo.value());
-                }
-                builder.addAttribute(OidcUtils.USER_INFO_ATTRIBUTE, new io.quarkus.oidc.UserInfo(userInfoBuilder.build()));
-            }
-
-            // OidcConfigurationMetadata
-            JsonObject configMetadataBuilder = new JsonObject();
-            if (issuer.isPresent()) {
-                configMetadataBuilder.put("issuer", issuer.get());
-            }
-            if (oidcSecurity != null && oidcSecurity.config() != null) {
-                for (ConfigMetadata config : oidcSecurity.config()) {
-                    configMetadataBuilder.put(config.key(), config.value());
-                }
-            }
-            builder.addAttribute(OidcUtils.CONFIG_METADATA_ATTRIBUTE, new OidcConfigurationMetadata(configMetadataBuilder));
-
-            return builder.build();
-        }
-
-        private String generateToken(JwtClaims claims) {
-            try {
-                return Jwt.claims(claims.getClaimsMap()).sign(privateKey);
-            } catch (Exception ex) {
-                throw new RuntimeException(ex);
-            }
-        }
-
-        private OidcSecurity findOidcSecurity(Annotation[] annotations) {
-            for (Annotation ann : annotations) {
-                if (ann instanceof OidcSecurity) {
-                    return (OidcSecurity) ann;
-                }
-            }
-            return null;
-        }
-    }
-
 }

--- a/test-framework/security-oidc/src/test/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentorTest.java
+++ b/test-framework/security-oidc/src/test/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentorTest.java
@@ -28,12 +28,12 @@ public class OidcTestSecurityIdentityAugmentorTest {
             @Claim(key = "iat", value = "123456788"),
             @Claim(key = "nbf", value = "123456787"),
             @Claim(key = "auth_time", value = "123456786"),
-            @Claim(key = "customlong", value = "123456785", type = Long.class),
+            @Claim(key = "customlong", value = "123456785", type = ClaimType.LONG),
             @Claim(key = "email", value = "user@gmail.com"),
             @Claim(key = "email_verified", value = "true"),
-            @Claim(key = "email_checked", value = "false", type = Boolean.class),
-            @Claim(key = "jsonarray_claim", value = "[\"1\", \"2\"]", type = JsonArray.class),
-            @Claim(key = "jsonobject_claim", value = "{\"a\":\"1\", \"b\":\"2\"}", type = JsonObject.class)
+            @Claim(key = "email_checked", value = "false", type = ClaimType.BOOLEAN),
+            @Claim(key = "jsonarray_claim", value = "[\"1\", \"2\"]", type = ClaimType.JSON_ARRAY),
+            @Claim(key = "jsonobject_claim", value = "{\"a\":\"1\", \"b\":\"2\"}", type = ClaimType.JSON_OBJECT)
     })
     public void testClaimValues() throws Exception {
         SecurityIdentity identity = QuarkusSecurityIdentity.builder()

--- a/test-framework/security-oidc/src/test/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentorTest.java
+++ b/test-framework/security-oidc/src/test/java/io/quarkus/test/security/oidc/OidcTestSecurityIdentityAugmentorTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.test.security.oidc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Annotation;
+import java.security.Principal;
+import java.util.Optional;
+import java.util.Set;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+
+public class OidcTestSecurityIdentityAugmentorTest {
+
+    @Test
+    @OidcSecurity(claims = {
+            @Claim(key = "exp", value = "123456789"),
+            @Claim(key = "iat", value = "123456788"),
+            @Claim(key = "nbf", value = "123456787"),
+            @Claim(key = "auth_time", value = "123456786"),
+            @Claim(key = "customlong", value = "123456785", type = Long.class),
+            @Claim(key = "email", value = "user@gmail.com"),
+            @Claim(key = "email_verified", value = "true"),
+            @Claim(key = "email_checked", value = "false", type = Boolean.class),
+            @Claim(key = "jsonarray_claim", value = "[\"1\", \"2\"]", type = JsonArray.class),
+            @Claim(key = "jsonobject_claim", value = "{\"a\":\"1\", \"b\":\"2\"}", type = JsonObject.class)
+    })
+    public void testClaimValues() throws Exception {
+        SecurityIdentity identity = QuarkusSecurityIdentity.builder()
+                .setPrincipal(new Principal() {
+                    @Override
+                    public String getName() {
+                        return "alice";
+                    }
+
+                })
+                .addRole("user")
+                .build();
+
+        OidcTestSecurityIdentityAugmentor augmentor = new OidcTestSecurityIdentityAugmentor(Optional.of("https://issuer.org"));
+
+        Annotation[] annotations = OidcTestSecurityIdentityAugmentorTest.class.getMethod("testClaimValues").getAnnotations();
+        JsonWebToken jwt = (JsonWebToken) augmentor.augment(identity, annotations).getPrincipal();
+
+        assertEquals("alice", jwt.getName());
+        assertEquals(Set.of("user"), jwt.getGroups());
+
+        assertEquals(123456789, jwt.getExpirationTime());
+        assertEquals(123456788, jwt.getIssuedAtTime());
+        assertEquals(123456787, (Long) jwt.getClaim(Claims.nbf.name()));
+        assertEquals(123456786, (Long) jwt.getClaim(Claims.auth_time.name()));
+        assertEquals(123456785, ((JsonNumber) jwt.getClaim("customlong")).longValue());
+        assertEquals("user@gmail.com", jwt.getClaim(Claims.email));
+        assertTrue((Boolean) jwt.getClaim(Claims.email_verified.name()));
+        assertEquals(JsonValue.FALSE, jwt.getClaim("email_checked"));
+
+        JsonArray array = jwt.getClaim("jsonarray_claim");
+        assertEquals("1", array.getString(0));
+        assertEquals("2", array.getString(1));
+
+        JsonObject map = jwt.getClaim("jsonobject_claim");
+        assertEquals("1", map.getString("a"));
+        assertEquals("2", map.getString("b"));
+    }
+
+}


### PR DESCRIPTION
Replaces #34170 (sorry for messing it up).

Fixes #34133.
Fixes #30442.
