### PR TITLE
Fix create app exception min java version not thrown up

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
@@ -101,7 +101,7 @@ public class CreateApp extends BaseCreateCommand {
             return CommandLine.ExitCode.SOFTWARE;
         } catch (Exception e) {
             return output.handleCommandException(e,
-                    "Unable to create project: " + e.getMessage());
+                    "Unable to create project: " + e.getLocalizedMessage());
         }
     }
 

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartPomMergeCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartPomMergeCodestartFileStrategyHandler.java
@@ -12,7 +12,7 @@ import org.apache.maven.model.Model;
 
 import io.fabric8.maven.Maven;
 import io.fabric8.maven.merge.SmartModelMerger;
-import io.quarkus.devtools.codestarts.CodestartStructureException;
+import io.quarkus.devtools.codestarts.CodestartException;
 import io.quarkus.devtools.codestarts.core.CodestartData;
 import io.quarkus.devtools.codestarts.core.reader.TargetFile;
 
@@ -32,7 +32,7 @@ final class SmartPomMergeCodestartFileStrategyHandler implements CodestartFileSt
         createDirectories(targetPath);
         CodestartData.getBuildtool(data)
                 .filter(b -> Objects.equals(b, "maven"))
-                .orElseThrow(() -> new CodestartStructureException(
+                .orElseThrow(() -> new CodestartException(
                         "something is wrong, smart-pom-merge file strategy must only be used on maven projects"));
 
         final SmartModelMerger merger = new SmartModelMerger();

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/CreateProjectCommandHandler.java
@@ -65,16 +65,11 @@ public class CreateProjectCommandHandler implements QuarkusCommandHandler {
 
         List<Extension> extensionsToAdd = computeRequiredExtensions(invocation.getExtensionsCatalog(), extensionsQuery,
                 invocation.log());
-        final List<ExtensionCatalog> extensionOrigins;
         ExtensionCatalog mainCatalog = invocation.getExtensionsCatalog(); // legacy platform initialization
+
         final String javaVersion = invocation.getStringValue(JAVA_VERSION);
-        try {
-            checkMinimumJavaVersion(javaVersion, extensionsToAdd);
-            extensionOrigins = getExtensionOrigins(mainCatalog, extensionsToAdd);
-        } catch (QuarkusCommandException e) {
-            invocation.log().error(e.getLocalizedMessage());
-            return QuarkusCommandOutcome.failure();
-        }
+        checkMinimumJavaVersion(javaVersion, extensionsToAdd);
+        final List<ExtensionCatalog> extensionOrigins = getExtensionOrigins(mainCatalog, extensionsToAdd);
 
         final List<ArtifactCoords> platformBoms = new ArrayList<>(Math.max(extensionOrigins.size(), 1));
         if (extensionOrigins.size() > 0) {

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ExtensionsAppearingInPlatformAndNonPlatformCatalogsTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ExtensionsAppearingInPlatformAndNonPlatformCatalogsTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.devtools.project.create;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.devtools.commands.CreateProject;
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
@@ -222,7 +224,8 @@ public class ExtensionsAppearingInPlatformAndNonPlatformCatalogsTest extends Mul
     @Test
     public void attemptCreateWithIncompatibleExtensions() throws Exception {
         final Path projectDir = newProjectDir("create-with-incompatible-extensions");
-        assertThat(createProject(projectDir, Arrays.asList("acme-bar", "other-five-one")).isSuccess()).isFalse();
+        assertThatExceptionOfType(QuarkusCommandException.class)
+                .isThrownBy(() -> createProject(projectDir, Arrays.asList("acme-bar", "other-five-one")));
     }
 
     @Test

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MavenProjectImportingMultipleBomsFromSinglePlatformTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MavenProjectImportingMultipleBomsFromSinglePlatformTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.devtools.project.create;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.devtools.commands.CreateProject;
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
@@ -200,7 +202,8 @@ public class MavenProjectImportingMultipleBomsFromSinglePlatformTest extends Mul
     @Test
     public void attemptCreateWithIncompatibleExtensions() throws Exception {
         final Path projectDir = newProjectDir("create-with-incompatible-extensions");
-        assertThat(createProject(projectDir, Arrays.asList("acme-bar", "other-five-one")).isSuccess()).isFalse();
+        assertThatExceptionOfType(QuarkusCommandException.class)
+                .isThrownBy(() -> createProject(projectDir, Arrays.asList("acme-bar", "other-five-one")));
     }
 
     @Test


### PR DESCRIPTION
- throw min java version so it can be displayed by code.quarkus.io
- change from CodestartStructureException to CodestartException for the smart pom merger because this is due to user input and not codestart structure.