### PR TITLE
URL-encode OIDC post_logout_uri query parameter

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -1134,8 +1134,8 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
         if (configContext.oidcConfig.logout.postLogoutPath.isPresent()) {
             logoutUri.append(AMP).append(configContext.oidcConfig.logout.getPostLogoutUriParam()).append(EQ).append(
-                    buildUri(context, isForceHttps(configContext.oidcConfig),
-                            configContext.oidcConfig.logout.postLogoutPath.get()));
+                    OidcCommonUtils.urlEncode(buildUri(context, isForceHttps(configContext.oidcConfig),
+                            configContext.oidcConfig.logout.postLogoutPath.get())));
             logoutUri.append(AMP).append(OidcConstants.LOGOUT_STATE).append(EQ)
                     .append(generatePostLogoutState(context, configContext));
         }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantLogout.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantLogout.java
@@ -50,6 +50,6 @@ public class TenantLogout {
         if (!postLogoutState.equals(cookie.getValue())) {
             throw new InternalServerErrorException("'state' query parameter is not equal to the q_post_logout cookie value");
         }
-        return "You were logged out";
+        return "You were logged out, please login again";
     }
 }

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -444,7 +444,7 @@ public class CodeFlowTest {
             assertNotNull(getSessionCookie(webClient, "tenant-logout"));
 
             page = webClient.getPage("http://localhost:8081/tenant-logout/logout");
-            assertTrue(page.asNormalizedText().contains("You were logged out"));
+            assertTrue(page.asNormalizedText().contains("You were logged out, please login again"));
             assertNull(getSessionCookie(webClient, "tenant-logout"));
 
             page = webClient.getPage("http://localhost:8081/tenant-logout");


### PR DESCRIPTION
Fixes #34210.

OIDC `post-logout_uri` query parameter is used to tell OIDC providers where the user should be redirected to after the user has been logged out, typically some public landing page, in the existing test it is `/tenant-logout/postLogout` supported by `TenantLogout`. So Quarkus would redirect the user to the provider's logout endpoint when the user wants to logout and will add this query parameter to the redirect uri.

Until now it has not been URL-encoded, and I'm aware of users using it, however, some providers expect it URL encoded, same way Quarkus does it for the main authorization code flow when passing a callback URI (as a `redirect_uri`), so this PR
just URL encodes this parameter too to be consistent, with a tiny test update just to show where it is being tested