### PR TITLE
Vert.x 4.4.4, Netty 4.1.94, and Mutiny Bindings 3.5.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -145,7 +145,7 @@
         <brotli4j.version>1.12.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.5.1.Final</jboss-logging.version>
-        <mutiny.version>2.2.0</mutiny.version>
+        <mutiny.version>2.3.1</mutiny.version>
         <kafka3.version>3.4.0</kafka3.version>
         <lz4.version>1.8.0</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->
         <snappy.version>1.1.10.1</snappy.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -67,7 +67,7 @@
         <smallrye-context-propagation.version>2.1.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.0</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.4.2</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.5.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.6.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.2.0</smallrye-stork.version>
         <jakarta.activation.version>2.1.2</jakarta.activation.version>
@@ -119,7 +119,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.2.1.Final</wildfly-elytron.version>
         <jboss-threads.version>3.5.0.Final</jboss-threads.version>
-        <vertx.version>4.4.3</vertx.version>
+        <vertx.version>4.4.4</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -141,8 +141,8 @@
         <infinispan.version>14.0.9.Final</infinispan.version>
         <infinispan.protostream.version>4.6.2.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>
-        <netty.version>4.1.93.Final</netty.version>
-        <brotli4j.version>1.11.0</brotli4j.version>
+        <netty.version>4.1.94.Final</netty.version>
+        <brotli4j.version>1.12.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.5.1.Final</jboss-logging.version>
         <mutiny.version>2.2.0</mutiny.version>
@@ -333,12 +333,6 @@
                 <version>${vertx.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <!-- Override the dependency on the vertx-jdbc-client, because of https://github.com/vert-x3/vertx-jdbc-client/pull/306 -->
-                <groupId>io.vertx</groupId>
-                <artifactId>vertx-jdbc-client</artifactId>
-                <version>${vertx.version}.1</version>
             </dependency>
 
             <!-- gRPC dependencies, imported as a BOM -->

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -50,7 +50,7 @@
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.0.0</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
-        <version.smallrye-mutiny>2.2.0</version.smallrye-mutiny>
+        <version.smallrye-mutiny>2.3.1</version.smallrye-mutiny>
     </properties>
 
     <modules>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -62,7 +62,7 @@
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.0.0</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <mutiny.version>2.2.0</mutiny.version>
+        <mutiny.version>2.3.1</mutiny.version>
         <smallrye-common.version>2.1.0</smallrye-common.version>
         <vertx.version>4.4.1</vertx.version>
         <rest-assured.version>5.3.0</rest-assured.version>


### PR DESCRIPTION
* Update Netty to 4.1.94 and Brotli to 1.12.0
* Update to Vert.x 4.4.4
* Update Mutiny bindings to 3.5.0

Fixes #34228

