### PR TITLE
Propagate Smallrye Context when switching REST Client context

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSwitchToRequestContextRestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSwitchToRequestContextRestHandler.java
@@ -6,6 +6,7 @@ import org.jboss.resteasy.reactive.client.impl.ClientRequestContextImpl;
 import org.jboss.resteasy.reactive.client.impl.RestClientRequestContext;
 import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
 
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -29,10 +30,12 @@ public class ClientSwitchToRequestContextRestHandler implements ClientRestHandle
             requestContext.resume(new Executor() {
                 @Override
                 public void execute(Runnable command) {
+                    // This is necessary to propagate the Smallrye context which is required for OpenTelemetry
+                    Runnable decorated = Infrastructure.decorate(command);
                     captured.runOnContext(new Handler<Void>() {
                         @Override
                         public void handle(Void unused) {
-                            command.run();
+                            decorated.run();
                         }
                     });
                 }

--- a/integration-tests/opentelemetry-reactive/pom.xml
+++ b/integration-tests/opentelemetry-reactive/pom.xml
@@ -57,6 +57,11 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>

--- a/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveClientTest.java
+++ b/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveClientTest.java
@@ -7,10 +7,10 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_ROUTE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_TARGET;
+import static io.quarkus.it.opentelemetry.reactive.Utils.getSpanByKindAndParentId;
+import static io.quarkus.it.opentelemetry.reactive.Utils.getSpans;
 import static io.restassured.RestAssured.given;
-import static io.restassured.RestAssured.when;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.common.mapper.TypeRef;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpMethod;
 
@@ -112,24 +111,5 @@ public class OpenTelemetryReactiveClientTest {
         assertEquals(SpanKind.INTERNAL.toString(), internal.get("kind"));
         assertEquals("helloPost", internal.get("name"));
         assertEquals(internal.get("parentSpanId"), server.get("spanId"));
-    }
-
-    private static List<Map<String, Object>> getSpans() {
-        return when().get("/export").body().as(new TypeRef<>() {
-        });
-    }
-
-    private static Map<String, Object> getSpanByKindAndParentId(List<Map<String, Object>> spans, SpanKind kind,
-            Object parentSpanId) {
-        List<Map<String, Object>> span = getSpansByKindAndParentId(spans, kind, parentSpanId);
-        assertEquals(1, span.size());
-        return span.get(0);
-    }
-
-    private static List<Map<String, Object>> getSpansByKindAndParentId(List<Map<String, Object>> spans, SpanKind kind,
-            Object parentSpanId) {
-        return spans.stream()
-                .filter(map -> map.get("kind").equals(kind.toString()))
-                .filter(map -> map.get("parentSpanId").equals(parentSpanId)).collect(toList());
     }
 }

--- a/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveTest.java
+++ b/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveTest.java
@@ -5,10 +5,11 @@ import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_TARGET;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_URL;
+import static io.quarkus.it.opentelemetry.reactive.Utils.getSpanByKindAndParentId;
+import static io.quarkus.it.opentelemetry.reactive.Utils.getSpans;
+import static io.quarkus.it.opentelemetry.reactive.Utils.getSpansByKindAndParentId;
 import static io.restassured.RestAssured.given;
-import static io.restassured.RestAssured.when;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -24,9 +25,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.opentelemetry.api.trace.SpanKind;
 import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
 public class OpenTelemetryReactiveTest {
@@ -166,24 +165,5 @@ public class OpenTelemetryReactiveTest {
         assertEquals("/reactive?name=Goku", ((Map<?, ?>) gokuServer.get("attributes")).get(HTTP_TARGET.getKey()));
         Map<String, Object> gokuInternal = getSpanByKindAndParentId(spans, INTERNAL, gokuServer.get("spanId"));
         assertEquals("helloGet", gokuInternal.get("name"));
-    }
-
-    private static List<Map<String, Object>> getSpans() {
-        return when().get("/export").body().as(new TypeRef<>() {
-        });
-    }
-
-    private static Map<String, Object> getSpanByKindAndParentId(List<Map<String, Object>> spans, SpanKind kind,
-            Object parentSpanId) {
-        List<Map<String, Object>> span = getSpansByKindAndParentId(spans, kind, parentSpanId);
-        assertEquals(1, span.size());
-        return span.get(0);
-    }
-
-    private static List<Map<String, Object>> getSpansByKindAndParentId(List<Map<String, Object>> spans, SpanKind kind,
-            Object parentSpanId) {
-        return spans.stream()
-                .filter(map -> map.get("kind").equals(kind.toString()))
-                .filter(map -> map.get("parentSpanId").equals(parentSpanId)).collect(toList());
     }
 }

--- a/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryWithSpanAtStartupTest.java
+++ b/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryWithSpanAtStartupTest.java
@@ -1,0 +1,106 @@
+package io.quarkus.it.opentelemetry.reactive;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.quarkus.it.opentelemetry.reactive.Utils.getSpanByKindAndParentId;
+import static io.quarkus.it.opentelemetry.reactive.Utils.getSpans;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.quarkus.runtime.Startup;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTestResource(restrictToAnnotatedClass = true, value = OpenTelemetryWithSpanAtStartupTest.MyWireMockResource.class)
+@QuarkusTest
+public class OpenTelemetryWithSpanAtStartupTest {
+
+    private static final int WIREMOCK_PORT = 20001;
+    private static final String STARTUP_BEAN_ENABLED_PROPERTY = "startup.bean.enabled";
+
+    @Test
+    void testGeneratedSpansUsingRestClientReactive() {
+        List<Map<String, Object>> spans = getSpans();
+        assertEquals(2, spans.size());
+
+        // First span is the callWireMockClient method. It does not have a parent span.
+        Map<String, Object> client = getSpanByKindAndParentId(spans, INTERNAL, "0000000000000000");
+        assertEquals("StartupBean.callWireMockClient", client.get("name"));
+
+        // We should get one client span, from the internal method.
+        Map<String, Object> server = getSpanByKindAndParentId(spans, CLIENT, client.get("spanId"));
+        assertEquals("GET", server.get("name"));
+    }
+
+    @Startup
+    @ApplicationScoped
+    public static class StartupBean {
+
+        @ConfigProperty(name = STARTUP_BEAN_ENABLED_PROPERTY, defaultValue = "false")
+        boolean enabled;
+
+        @PostConstruct
+        void onStart() {
+            if (enabled) {
+                callWireMockClient();
+            }
+        }
+
+        @WithSpan
+        public void callWireMockClient() {
+            RestClientBuilder.newBuilder()
+                    .baseUri(URI.create("http://localhost:" + WIREMOCK_PORT))
+                    .build(WireMockRestClient.class)
+                    .call();
+        }
+    }
+
+    @Path("/stub")
+    public interface WireMockRestClient {
+
+        @GET
+        void call();
+    }
+
+    public static class MyWireMockResource implements QuarkusTestResourceLifecycleManager {
+
+        WireMockServer wireMockServer;
+
+        @Override
+        public Map<String, String> start() {
+            wireMockServer = new WireMockServer(WIREMOCK_PORT);
+            wireMockServer.stubFor(
+                    WireMock.get(WireMock.urlMatching("/stub"))
+                            .willReturn(ok()));
+            wireMockServer.start();
+
+            return Map.of(STARTUP_BEAN_ENABLED_PROPERTY, Boolean.TRUE.toString());
+        }
+
+        @Override
+        public synchronized void stop() {
+            if (wireMockServer != null) {
+                wireMockServer.stop();
+                wireMockServer = null;
+            }
+        }
+    }
+}

--- a/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/Utils.java
+++ b/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/Utils.java
@@ -1,0 +1,37 @@
+package io.quarkus.it.opentelemetry.reactive;
+
+import static io.restassured.RestAssured.when;
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.restassured.common.mapper.TypeRef;
+
+public final class Utils {
+
+    private Utils() {
+
+    }
+
+    public static List<Map<String, Object>> getSpans() {
+        return when().get("/export").body().as(new TypeRef<>() {
+        });
+    }
+
+    public static Map<String, Object> getSpanByKindAndParentId(List<Map<String, Object>> spans, SpanKind kind,
+            Object parentSpanId) {
+        List<Map<String, Object>> span = getSpansByKindAndParentId(spans, kind, parentSpanId);
+        assertEquals(1, span.size());
+        return span.get(0);
+    }
+
+    public static List<Map<String, Object>> getSpansByKindAndParentId(List<Map<String, Object>> spans, SpanKind kind,
+            Object parentSpanId) {
+        return spans.stream()
+                .filter(map -> map.get("kind").equals(kind.toString()))
+                .filter(map -> map.get("parentSpanId").equals(parentSpanId)).collect(toList());
+    }
+}


### PR DESCRIPTION
The problem is that Opentelemetry creates the span context in MDCEnabledContextStorage when there is no VertxContext yet. 

Then, the span context of MDCEnabledContextStorage is propagated to the VertxContext in every operator of an Uni/Multi ... action. Before the changes in https://github.com/quarkusio/quarkus/pull/32852, this was done in https://github.com/quarkusio/quarkus/pull/32852/commits/272532591b2bd437ed91dbb8e73d6336d65ea781#diff-03d3c6adcdcc01b3a1f8daccc773adc6ee1c598afa245a445a24383a77f3b3a4L92.

After the changes of https://github.com/quarkusio/quarkus/pull/32852, we're switching the context but without using any Uni/Multi/... instance, so the span context is not attached to the one that will be created later in the VertxContext, and this is why we got two spans. 

Personally, I don't like that the spancontext is being propagated only using the Uni/Multi/... instances (or at least, I could not find any other way to do it). I think we should implement a listener interface when switching of contexts (tho MDCEnabledContextStorage is an opentelemetry thing).

To mimic what Smallrye does internally when calling the Uni/Multi operators, I directly call the `Infrastructure.decorate` method which fixes the issue. 

Fix https://github.com/quarkusio/quarkus/issues/34212 Relates https://github.com/quarkusio/quarkus/pull/32852