### PR TITLE
Upgrade to Hibernate Search 6.2.0.CR1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -102,7 +102,7 @@
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
         <hibernate-reactive.version>2.0.1.Final</hibernate-reactive.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
-        <hibernate-search.version>6.1.7.Final</hibernate-search.version>
+        <hibernate-search.version>6.2.0.CR1</hibernate-search.version>
         <narayana.version>6.0.1.Final</narayana.version>
         <agroal.version>2.1</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
@@ -5615,22 +5615,60 @@
                         <groupId>org.hibernate.common</groupId>
                         <artifactId>hibernate-commons-annotations</artifactId>
                     </exclusion>
+                    <!-- We don't want Jandex at runtime -->
+                    <exclusion>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>jandex</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-engine</artifactId>
                 <version>${hibernate-search.version}</version>
+                <exclusions>
+                    <!-- We don't want Jandex at runtime -->
+                    <exclusion>
+                        <groupId>org.jboss</groupId>
+                        <artifactId>jandex</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>jandex</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-mapper-pojo-base</artifactId>
                 <version>${hibernate-search.version}</version>
+                <exclusions>
+                    <!-- We don't want Jandex at runtime -->
+                    <exclusion>
+                        <groupId>org.jboss</groupId>
+                        <artifactId>jandex</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>jandex</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-util-common</artifactId>
                 <version>${hibernate-search.version}</version>
+                <exclusions>
+                    <!-- We don't want Jandex at runtime -->
+                    <exclusion>
+                        <groupId>org.jboss</groupId>
+                        <artifactId>jandex</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>jandex</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -97,11 +97,14 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.16.0</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>6.2.5.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
+        <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below),
+             as well as hibernate-orm.version-for-documentation in docs/pom.xml -->
+        <hibernate-orm.version>6.2.5.Final</hibernate-orm.version>
         <bytebuddy.version>1.12.18</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
         <hibernate-reactive.version>2.0.1.Final</hibernate-reactive.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
+        <!-- When updating, align hibernate-search.version-for-documentation in docs/pom.xml -->
         <hibernate-search.version>6.2.0.CR1</hibernate-search.version>
         <narayana.version>6.0.1.Final</narayana.version>
         <agroal.version>2.1</agroal.version>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -35,6 +35,10 @@
         <generated-dir>${project.basedir}/../target/asciidoc/generated</generated-dir>
         <code-examples-dir>${generated-dir}/examples</code-examples-dir>
         <vale.image>docker.io/jdkato/vale:v2.15.5</vale.image>
+
+        <!-- Keep these in sync with the full versions in bom/application/pom.xml -->
+        <hibernate-orm.version-for-documentation>6.2</hibernate-orm.version-for-documentation>
+        <hibernate-search.version-for-documentation>6.2</hibernate-search.version-for-documentation>
     </properties>
 
     <name>Quarkus - Documentation</name>

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -24,6 +24,8 @@
 :grpc-version: ${grpc.version}
 :protoc-version: ${protoc.version}
 :gcf-invoker-version: ${gcf-invoker.version}
+:hibernate-orm-version: ${hibernate-orm.version-for-documentation}
+:hibernate-search-version: ${hibernate-search.version-for-documentation}
 // .
 :quarkus-home-url: ${quarkus-home-url}
 :quarkus-org-url: https://github.com/quarkusio
@@ -45,6 +47,9 @@
 :quickstarts-archive-url: ${quickstarts-base-url}/archive/main.zip
 :quickstarts-blob-url: ${quickstarts-base-url}/blob/main
 :quickstarts-tree-url: ${quickstarts-base-url}/tree/main
+// .
+:hibernate-orm-docs-url: https://docs.jboss.org/hibernate/orm/{hibernate-orm-version}/userguide/html_single/Hibernate_User_Guide.html
+:hibernate-search-docs-url: https://docs.jboss.org/hibernate/search/{hibernate-search-version}/reference/en-US/html_single/
 // .
 :amazon-services-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/index.html
 :config-consul-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-config-extensions/dev/consul.html

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -763,7 +763,7 @@ If your delete query does not start with `delete`, we support the following addi
 - `<query>` will expand to `delete from EntityName where <query>`
 
 NOTE: You can also write your queries in plain
-link:https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#hql[HQL]:
+link:{hibernate-orm-docs-url}#hql[HQL]:
 
 [source,java]
 ----
@@ -869,7 +869,7 @@ You can use it to restrict which fields will be returned by the database.
 
 Hibernate will use **DTO projection** and generate a SELECT clause with the attributes from the projection class.
 This is also called **dynamic instantiation** or **constructor expression**, more info can be found on the Hibernate guide:
-link:https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql-select-clause[hql select clause]
+link:{hibernate-orm-docs-url}#hql-select-clause[hql select clause]
 
 The projection class needs to have a constructor that contains all its attributes, this constructor will be used to
 instantiate the projection DTO instead of using the entity class. This class must have a matching constructor with all the class attributes as parameters.

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -171,7 +171,7 @@ so at your application entry point boundaries like your REST endpoint controller
 [[hibernate-dialect-supported-databases]]
 ==== Supported databases
 
-For xref:datasource.adoc#default-datasource[supported databases],
+For xref:datasource.adoc#extensions-and-database-drivers-reference[supported databases],
 the link:{hibernate-orm-docs-url}#database-dialect[Hibernate ORM dialect]
 does not need to be set explicitly:
 it is selected automatically based on the datasource.

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -8,7 +8,6 @@ include::_attributes.adoc[]
 :categories: data
 :summary: Hibernate ORM is the de facto Jakarta Persistence implementation and offers you the full breath of an Object Relational Mapper. It works beautifully in Quarkus.
 :config-file: application.properties
-:orm-doc-url-prefix: https://docs.jboss.org/hibernate/orm/6.2/userguide/html_single/Hibernate_User_Guide.html
 
 Hibernate ORM is the de facto standard Jakarta Persistence (formerly known as JPA) implementation and offers you the full breadth of an Object Relational Mapper.
 It works beautifully in Quarkus.
@@ -173,7 +172,7 @@ so at your application entry point boundaries like your REST endpoint controller
 ==== Supported databases
 
 For xref:datasource.adoc#default-datasource[supported databases],
-the link:{orm-doc-url-prefix}##database-dialect[Hibernate ORM dialect]
+the link:{hibernate-orm-docs-url}#database-dialect[Hibernate ORM dialect]
 does not need to be set explicitly:
 it is selected automatically based on the datasource.
 
@@ -215,7 +214,7 @@ If the database cannot be reached, a warning will be logged but startup will pro
 
 If xref:datasource.adoc#other-databases[your database does not have a corresponding Quarkus extension],
 or if the defaults do not match your needs for some reason,
-you will need to set the link:{orm-doc-url-prefix}##database-dialect[Hibernate ORM dialect] explicitly:
+you will need to set the link:{hibernate-orm-docs-url}#database-dialect[Hibernate ORM dialect] explicitly:
 
 [source,properties]
 .`{config-file}` with an explicit `dialect`
@@ -524,7 +523,7 @@ difference is that you would specify your Hibernate ORM configuration in `META-I
 ----
 
 When using the `persistence.xml` configuration you are configuring Hibernate ORM directly,
-so in this case the appropriate reference is the link:{orm-doc-url-prefix}#configurations[documentation on hibernate.org].
+so in this case the appropriate reference is the link:{hibernate-orm-docs-url}#configurations[documentation on hibernate.org].
 
 Please remember these are not the same property names as the ones used in the Quarkus `{config-file}`, nor will
 the same defaults be applied.
@@ -914,9 +913,9 @@ Jump over to xref:datasource.adoc[Quarkus - Datasources] for all details.
 [[multitenancy]]
 == Multitenancy
 
-"The term multitenancy, in general, is applied to software development to indicate an architecture in which a single running instance of an application simultaneously serves multiple clients (tenants). This is highly common in SaaS solutions. Isolating information (data, customizations, etc.) pertaining to the various tenants is a particular challenge in these systems. This includes the data owned by each tenant stored in the database" (link:{orm-doc-url-prefix}#multitenacy[Hibernate User Guide]).
+"The term multitenancy, in general, is applied to software development to indicate an architecture in which a single running instance of an application simultaneously serves multiple clients (tenants). This is highly common in SaaS solutions. Isolating information (data, customizations, etc.) pertaining to the various tenants is a particular challenge in these systems. This includes the data owned by each tenant stored in the database" (link:{hibernate-orm-docs-url}#multitenacy[Hibernate User Guide]).
 
-Quarkus currently supports the link:{orm-doc-url-prefix}#multitenacy-separate-database[separate database] approach, the link:{orm-doc-url-prefix}#multitenacy-separate-schema[separate schema] approach and the link:{orm-doc-url-prefix}#multitenacy-discriminator[discriminator] approach.
+Quarkus currently supports the link:{hibernate-orm-docs-url}#multitenacy-separate-database[separate database] approach, the link:{hibernate-orm-docs-url}#multitenacy-separate-schema[separate schema] approach and the link:{hibernate-orm-docs-url}#multitenacy-discriminator[discriminator] approach.
 
 To see multitenancy in action, you can check out the {quickstarts-tree-url}/hibernate-orm-multi-tenancy-quickstart[hibernate-orm-multi-tenancy-quickstart] quickstart.
 
@@ -1179,7 +1178,7 @@ Your custom connection resolver would allow for example to read tenant informati
 [[interceptors]]
 == Interceptors
 
-You can assign an link:{orm-doc-url-prefix}#events-interceptors[`org.hibernate.Interceptor`]
+You can assign an link:{hibernate-orm-docs-url}#events-interceptors[`org.hibernate.Interceptor`]
 to your `SessionFactory` by simply defining a CDI bean with the appropriate qualifier:
 
 [source,java]

--- a/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
@@ -525,7 +525,7 @@ If your delete query does not start with `delete`, we support the following addi
 - `<query>` will expand to `delete from EntityName where <query>`
 
 NOTE: You can also write your queries in plain
-link:https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#hql[HQL]:
+link:{hibernate-orm-docs-url}#hql[HQL]:
 
 [source,java]
 ----
@@ -617,7 +617,7 @@ You can use it to restrict which fields will be returned by the database.
 
 Hibernate will use **DTO projection** and generate a SELECT clause with the attributes from the projection class.
 This is also called **dynamic instantiation** or **constructor expression**, more info can be found on the Hibernate guide:
-link:https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql-select-clause[hql select clause]
+link:{hibernate-orm-docs-url}#hql-select-clause[hql select clause]
 
 The projection class needs to be a valid Java Bean and have a constructor that contains all its attributes, this constructor will be used to
 instantiate the projection DTO instead of using the entity class. This must be the only constructor of the class.

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -5,6 +5,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Hibernate Search guide
 :hibernate-search-doc-prefix: https://docs.jboss.org/hibernate/search/6.2/reference/en-US/html_single/
+:hibernate-orm-doc-prefix: https://docs.jboss.org/hibernate/orm/6.2/userguide/html_single/Hibernate_User_Guide.html
 include::_attributes.adoc[]
 :categories: data
 :summary: Hibernate Search allows you to index your entities in an Elasticsearch cluster and easily offer full text search in all your Hibernate ORM-based applications.
@@ -895,6 +896,24 @@ and intend to xref:hibernate-orm.adoc#dev-mode[let Hibernate ORM generate your d
 then no worries: the entities required by Hibernate Search will be included in the generated schema.
 * Otherwise, you must
 link:{hibernate-search-doc-prefix}#coordination-outbox-polling-schema[manually alter your schema to add the necessary tables/sequences].
+
+[NOTE]
+====
+The database schema Hibernate Search will expect for outbox-polling coordination
+may be customized through the following configuration properties:
+
+* link:#quarkus-hibernate-search-orm-coordination-outboxpolling_quarkus.hibernate-search-orm.coordination.entity.mapping.agent.catalog[`quarkus.hibernate-search-orm.coordination.entity.mapping.agent.catalog`]
+* link:#quarkus-hibernate-search-orm-coordination-outboxpolling_quarkus.hibernate-search-orm.coordination.entity.mapping.agent.schema[`quarkus.hibernate-search-orm.coordination.entity.mapping.agent.schema`]
+* link:#quarkus-hibernate-search-orm-coordination-outboxpolling_quarkus.hibernate-search-orm.coordination.entity.mapping.agent.table[`quarkus.hibernate-search-orm.coordination.entity.mapping.agent.table`]
+* link:#quarkus-hibernate-search-orm-coordination-outboxpolling_quarkus.hibernate-search-orm.coordination.entity.mapping.agent.uuid-gen-strategy[`quarkus.hibernate-search-orm.coordination.entity.mapping.agent.uuid-gen-strategy`]
+* link:#quarkus-hibernate-search-orm-coordination-outboxpolling_quarkus.hibernate-search-orm.coordination.entity.mapping.agent.uuid-type[`quarkus.hibernate-search-orm.coordination.entity.mapping.agent.uuid-type`]
+* link:#quarkus-hibernate-search-orm-coordination-outboxpolling_quarkus.hibernate-search-orm.coordination.entity.mapping.outbox-event.catalog[`quarkus.hibernate-search-orm.coordination.entity.mapping.outbox-event.catalog`]
+* link:#quarkus-hibernate-search-orm-coordination-outboxpolling_quarkus.hibernate-search-orm.coordination.entity.mapping.outbox-event.schema[`quarkus.hibernate-search-orm.coordination.entity.mapping.outbox-event.schema`]
+* link:#quarkus-hibernate-search-orm-coordination-outboxpolling_quarkus.hibernate-search-orm.coordination.entity.mapping.outbox-event.table[`quarkus.hibernate-search-orm.coordination.entity.mapping.outbox-event.table`]
+* link:#quarkus-hibernate-search-orm-coordination-outboxpolling_quarkus.hibernate-search-orm.coordination.entity.mapping.outbox-event.uuid-gen-strategy[`quarkus.hibernate-search-orm.coordination.entity.mapping.outbox-event.uuid-gen-strategy`]
+* link:#quarkus-hibernate-search-orm-coordination-outboxpolling_quarkus.hibernate-search-orm.coordination.entity.mapping.outbox-event.uuid-type[`quarkus.hibernate-search-orm.coordination.entity.mapping.outbox-event.uuid-type`]
+
+====
 
 Once you are done with the above, you're ready to use Hibernate Search with an outbox.
 Don't change any code, and just start your application:

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Hibernate Search guide
-:hibernate-search-doc-prefix: https://docs.jboss.org/hibernate/search/6.1/reference/en-US/html_single/
+:hibernate-search-doc-prefix: https://docs.jboss.org/hibernate/search/6.2/reference/en-US/html_single/
 include::_attributes.adoc[]
 :categories: data
 :summary: Hibernate Search allows you to index your entities in an Elasticsearch cluster and easily offer full text search in all your Hibernate ORM-based applications.
@@ -566,7 +566,7 @@ quarkus.datasource.db-kind=postgresql <2>
 quarkus.hibernate-orm.sql-load-script=import.sql <3>
 
 quarkus.hibernate-search-orm.elasticsearch.version=7 <4>
-quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync <5>
+quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=sync <5>
 
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test <6>
 %prod.quarkus.datasource.username=quarkus_test
@@ -701,7 +701,7 @@ quarkus.hibernate-search-orm.elasticsearch.version=opensearch:1.2
 All other configuration options and APIs are exactly the same as with Elasticsearch.
 
 You can find more information about compatible distributions and versions of Elasticsearch in
-link:{hibernate-search-doc-prefix}#getting-started-compatibility[this section of Hibernate Search's reference documentation].
+link:{hibernate-search-doc-prefix}#compatibility[this section of Hibernate Search's reference documentation].
 
 [[multiple-persistence-units]]
 == Multiple persistence units
@@ -849,7 +849,7 @@ If you disable automatic schema creation by setting `quarkus.hibernate-search-or
 you will have to create the schema manually at some point before your application starts persisting/updating entities
 and executing search requests.
 
-See link:{hibernate-search-doc-prefix}#mapper-orm-schema-management-manager[this section of the reference documentation]
+See link:{hibernate-search-doc-prefix}#schema-management-manager[this section of the reference documentation]
 for more information.
 ====
 
@@ -876,7 +876,7 @@ These limitations are the result of Hibernate Search not coordinating between th
 In order to get rid of these limitations, you can
 link:{hibernate-search-doc-prefix}#architecture-examples-outbox-polling-elasticsearch[use the `outbox-polling` coordination strategy].
 This strategy creates an outbox table in the database to push entity change events to,
-and relies on a background processor to consume these events and perform automatic indexing.
+and relies on a background processor to consume these events and perform indexing.
 
 To enable the `outbox-polling` coordination strategy, an additional extension is required:
 
@@ -910,7 +910,7 @@ However, there is one key difference: index updates are necessarily asynchronous
 they are guaranteed to happen _eventually_, but not immediately.
 
 This means in particular that the configuration property
-link:#quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy[`quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy`]
+link:#quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy[`quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy`]
 cannot be set when using the `outbox-polling` coordination strategy:
 Hibernate Search will always behave as if this property was set to `write-sync` (the default).
 
@@ -976,7 +976,7 @@ For example `class:com.mycompany.MyClass`.
 * An arbitrary string referencing a built-in implementation.
 Available values are detailed in the documentation of each configuration property,
 such as `async`/`read-sync`/`write-sync`/`sync` for
-<<quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy,`quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy`>>.
+<<quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy,`quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy`>>.
 
 Other formats are also accepted, but are only useful for advanced use cases.
 See link:{hibernate-search-doc-prefix}#configuration-bean-reference-parsing[this section of Hibernate Search's reference documentation]

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -4,8 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Hibernate Search guide
-:hibernate-search-doc-prefix: https://docs.jboss.org/hibernate/search/6.2/reference/en-US/html_single/
-:hibernate-orm-doc-prefix: https://docs.jboss.org/hibernate/orm/6.2/userguide/html_single/Hibernate_User_Guide.html
 include::_attributes.adoc[]
 :categories: data
 :summary: Hibernate Search allows you to index your entities in an Elasticsearch cluster and easily offer full text search in all your Hibernate ORM-based applications.
@@ -549,7 +547,7 @@ The Hibernate Search DSL supports a significant subset of the Elasticsearch pred
 Feel free to explore the DSL using autocompletion.
 
 When that's not enough, you can always fall back to
-link:{hibernate-search-doc-prefix}#search-dsl-predicate-extensions-elasticsearch-from-json[defining a predicate using JSON directly].
+link:{hibernate-search-docs-url}#search-dsl-predicate-extensions-elasticsearch-from-json[defining a predicate using JSON directly].
 ====
 
 == Configuring the application
@@ -691,7 +689,7 @@ and https://www.opensearch.org/[OpenSearch],
 but it assumes it is working with an Elasticsearch cluster by default.
 
 To have Hibernate Search work with an OpenSearch cluster instead,
-link:{hibernate-search-doc-prefix}#backend-elasticsearch-configuration-version[prefix the configured version with `opensearch:`],
+link:{hibernate-search-docs-url}#backend-elasticsearch-configuration-version[prefix the configured version with `opensearch:`],
 as shown below.
 
 [source,properties]
@@ -702,7 +700,7 @@ quarkus.hibernate-search-orm.elasticsearch.version=opensearch:1.2
 All other configuration options and APIs are exactly the same as with Elasticsearch.
 
 You can find more information about compatible distributions and versions of Elasticsearch in
-link:{hibernate-search-doc-prefix}#compatibility[this section of Hibernate Search's reference documentation].
+link:{hibernate-search-docs-url}#compatibility[this section of Hibernate Search's reference documentation].
 
 [[multiple-persistence-units]]
 == Multiple persistence units
@@ -850,7 +848,7 @@ If you disable automatic schema creation by setting `quarkus.hibernate-search-or
 you will have to create the schema manually at some point before your application starts persisting/updating entities
 and executing search requests.
 
-See link:{hibernate-search-doc-prefix}#schema-management-manager[this section of the reference documentation]
+See link:{hibernate-search-docs-url}#schema-management-manager[this section of the reference documentation]
 for more information.
 ====
 
@@ -870,12 +868,12 @@ or as issues in our https://github.com/quarkusio/quarkus/issues[GitHub issue tra
 
 While it’s technically possible to use Hibernate Search and Elasticsearch in distributed applications,
 by default they suffer from
-link:{hibernate-search-doc-prefix}#architecture-examples-no-coordination-elasticsearch-pros-and-cons[a few limitations].
+link:{hibernate-search-docs-url}#architecture-examples-no-coordination-elasticsearch-pros-and-cons[a few limitations].
 
 These limitations are the result of Hibernate Search not coordinating between threads or application nodes by default.
 
 In order to get rid of these limitations, you can
-link:{hibernate-search-doc-prefix}#architecture-examples-outbox-polling-elasticsearch[use the `outbox-polling` coordination strategy].
+link:{hibernate-search-docs-url}#architecture-examples-outbox-polling-elasticsearch[use the `outbox-polling` coordination strategy].
 This strategy creates an outbox table in the database to push entity change events to,
 and relies on a background processor to consume these events and perform indexing.
 
@@ -895,7 +893,7 @@ Finally, you will need to make sure that the Hibernate ORM entities added by Hib
 and intend to xref:hibernate-orm.adoc#dev-mode[let Hibernate ORM generate your database schema],
 then no worries: the entities required by Hibernate Search will be included in the generated schema.
 * Otherwise, you must
-link:{hibernate-search-doc-prefix}#coordination-outbox-polling-schema[manually alter your schema to add the necessary tables/sequences].
+link:{hibernate-search-docs-url}#coordination-outbox-polling-schema[manually alter your schema to add the necessary tables/sequences].
 
 [NOTE]
 ====
@@ -939,7 +937,7 @@ and the recommended way of using Hibernate Search even when coordination is disa
 ====
 
 For more information about coordination in Hibernate Search,
-see link:{hibernate-search-doc-prefix}#coordination[this section of the reference documentation].
+see link:{hibernate-search-docs-url}#coordination[this section of the reference documentation].
 
 For more information about configuration options related to coordination,
 see <<configuration-reference-coordination-outbox-polling>>.
@@ -958,7 +956,7 @@ for more information.
 == Further reading
 
 If you are interested in learning more about Hibernate Search 6,
-the Hibernate team publishes link:{hibernate-search-doc-prefix}[an extensive reference documentation].
+the Hibernate team publishes link:{hibernate-search-docs-url}[an extensive reference documentation].
 
 == FAQ
 
@@ -998,7 +996,7 @@ such as `async`/`read-sync`/`write-sync`/`sync` for
 <<quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy,`quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy`>>.
 
 Other formats are also accepted, but are only useful for advanced use cases.
-See link:{hibernate-search-doc-prefix}#configuration-bean-reference-parsing[this section of Hibernate Search's reference documentation]
+See link:{hibernate-search-docs-url}#configuration-bean-reference-parsing[this section of Hibernate Search's reference documentation]
 for more information.
 ====
 

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -587,7 +587,7 @@ The `Sort` class has plenty of methods for adding columns and specifying sort di
 
 Normally, MongoDB queries are of this form: `{'firstname': 'John', 'lastname':'Doe'}`, this is what we call MongoDB native queries.
 
-You can use them if you want, but we also support what we call **PanacheQL** that can be seen as a subset of link:https://docs.oracle.com/javaee/7/tutorial/persistence-querylanguage.htm#BNBTG[JPQL] (or link:https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#hql[HQL]) and allows you to easily express a query.
+You can use them if you want, but we also support what we call **PanacheQL** that can be seen as a subset of link:https://docs.oracle.com/javaee/7/tutorial/persistence-querylanguage.htm#BNBTG[JPQL] (or link:{hibernate-orm-docs-url}#hql[HQL]) and allows you to easily express a query.
 MongoDB with Panache will then map it to a MongoDB native query.
 
 If your query does not start with `{`, we will consider it a PanacheQL query:

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
@@ -14,6 +14,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.hibernate.orm.deployment.spi.AdditionalJpaModelBuildItem;
+import io.quarkus.hibernate.search.orm.coordination.outboxpolling.runtime.HibernateSearchOutboxPollingBuildTimeConfig;
 import io.quarkus.hibernate.search.orm.coordination.outboxpolling.runtime.HibernateSearchOutboxPollingRecorder;
 import io.quarkus.hibernate.search.orm.coordination.outboxpolling.runtime.HibernateSearchOutboxPollingRuntimeConfig;
 import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem;
@@ -43,6 +44,7 @@ class HibernateSearchOutboxPollingProcessor {
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     void setStaticConfig(HibernateSearchOutboxPollingRecorder recorder,
+            HibernateSearchOutboxPollingBuildTimeConfig buildTimeConfig,
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
             BuildProducer<HibernateSearchIntegrationStaticConfiguredBuildItem> staticConfigured) {
         for (HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem configuredPersistenceUnit : configuredPersistenceUnits) {
@@ -51,7 +53,8 @@ class HibernateSearchOutboxPollingProcessor {
             }
             String puName = configuredPersistenceUnit.getPersistenceUnitName();
             staticConfigured.produce(new HibernateSearchIntegrationStaticConfiguredBuildItem(
-                    HIBERNATE_SEARCH_ORM_COORDINATION_OUTBOX_POLLING, puName, null)
+                    HIBERNATE_SEARCH_ORM_COORDINATION_OUTBOX_POLLING, puName,
+                    recorder.createStaticInitListener(buildTimeConfig, puName))
                     // Additional entities such as Agent and OutboxEvent are defined through XML
                     // (because there's no other way).
                     .setXmlMappingRequired(true));

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/test/configuration/ConfigPropertiesTest.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/test/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/test/configuration/ConfigPropertiesTest.java
@@ -9,6 +9,7 @@ import jakarta.inject.Inject;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.HibernateOrmMapperOutboxPollingSettings;
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.UuidGenerationStrategy;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,20 @@ public class ConfigPropertiesTest {
                     .addPackage(IndexedEntity.class.getPackage())
                     .addPackage(IndexedEntityForPU1.class.getPackage()))
             .withConfigurationResource("application-multiple-persistence-units.properties")
+            .overrideConfigKey("quarkus.hibernate-search-orm.coordination.entity-mapping.agent.catalog", "myagentcatalog")
+            .overrideConfigKey("quarkus.hibernate-search-orm.coordination.entity-mapping.agent.schema", "myagentschema")
+            .overrideConfigKey("quarkus.hibernate-search-orm.coordination.entity-mapping.agent.table", "myagenttable")
+            .overrideConfigKey("quarkus.hibernate-search-orm.coordination.entity-mapping.agent.uuid-gen-strategy", "random")
+            .overrideConfigKey("quarkus.hibernate-search-orm.coordination.entity-mapping.agent.uuid-type", "uuid-char")
+            .overrideConfigKey("quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.catalog",
+                    "myoutboxeventcatalog")
+            .overrideConfigKey("quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.schema",
+                    "myoutboxeventschema")
+            .overrideConfigKey("quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.table",
+                    "myoutboxeventtable")
+            .overrideConfigKey("quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.uuid-gen-strategy",
+                    "time")
+            .overrideConfigKey("quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.uuid-type", "uuid-binary")
             .overrideConfigKey("quarkus.hibernate-search-orm.coordination.event-processor.enabled", "false")
             .overrideConfigKey("quarkus.hibernate-search-orm.coordination.event-processor.shards.total-count", "10")
             .overrideConfigKey("quarkus.hibernate-search-orm.coordination.event-processor.shards.assigned", "1,2")
@@ -44,6 +59,28 @@ public class ConfigPropertiesTest {
             .overrideConfigKey("quarkus.hibernate-search-orm.coordination.mass-indexer.polling-interval", "0.048S")
             .overrideConfigKey("quarkus.hibernate-search-orm.coordination.mass-indexer.pulse-interval", "0.049S")
             .overrideConfigKey("quarkus.hibernate-search-orm.coordination.mass-indexer.pulse-expiration", "50S")
+            .overrideConfigKey("quarkus.hibernate-search-orm.coordination.mass-indexer.pulse-interval", "0.049S")
+            .overrideConfigKey("quarkus.hibernate-search-orm.coordination.mass-indexer.pulse-expiration", "50S")
+            .overrideConfigKey("quarkus.hibernate-search-orm.\"pu1\".coordination.entity-mapping.agent.catalog",
+                    "myagentcatalogpu1")
+            .overrideConfigKey("quarkus.hibernate-search-orm.\"pu1\".coordination.entity-mapping.agent.schema",
+                    "myagentschemapu1")
+            .overrideConfigKey("quarkus.hibernate-search-orm.\"pu1\".coordination.entity-mapping.agent.table",
+                    "myagenttablepu1")
+            .overrideConfigKey("quarkus.hibernate-search-orm.\"pu1\".coordination.entity-mapping.agent.uuid-gen-strategy",
+                    "time")
+            .overrideConfigKey("quarkus.hibernate-search-orm.\"pu1\".coordination.entity-mapping.agent.uuid-type",
+                    "uuid-binary")
+            .overrideConfigKey("quarkus.hibernate-search-orm.\"pu1\".coordination.entity-mapping.outbox-event.catalog",
+                    "myoutboxeventcatalogpu1")
+            .overrideConfigKey("quarkus.hibernate-search-orm.\"pu1\".coordination.entity-mapping.outbox-event.schema",
+                    "myoutboxeventschemapu1")
+            .overrideConfigKey("quarkus.hibernate-search-orm.\"pu1\".coordination.entity-mapping.outbox-event.table",
+                    "myoutboxeventtablepu1")
+            .overrideConfigKey(
+                    "quarkus.hibernate-search-orm.\"pu1\".coordination.entity-mapping.outbox-event.uuid-gen-strategy", "random")
+            .overrideConfigKey("quarkus.hibernate-search-orm.\"pu1\".coordination.entity-mapping.outbox-event.uuid-type",
+                    "uuid-char")
             .overrideConfigKey("quarkus.hibernate-search-orm.\"pu1\".coordination.event-processor.enabled", "false")
             .overrideConfigKey("quarkus.hibernate-search-orm.\"pu1\".coordination.event-processor.shards.total-count", "110")
             .overrideConfigKey("quarkus.hibernate-search-orm.\"pu1\".coordination.event-processor.shards.assigned", "11,12")
@@ -100,6 +137,24 @@ public class ConfigPropertiesTest {
     public void root() {
         assertThat(sessionFactory.getProperties())
                 .contains(
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_AGENT_CATALOG,
+                                "myagentcatalog"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_AGENT_SCHEMA,
+                                "myagentschema"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_AGENT_TABLE, "myagenttable"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_AGENT_UUID_GEN_STRATEGY,
+                                UuidGenerationStrategy.RANDOM),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_AGENT_UUID_TYPE, "uuid-char"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_CATALOG,
+                                "myoutboxeventcatalog"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_SCHEMA,
+                                "myoutboxeventschema"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_TABLE,
+                                "myoutboxeventtable"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_UUID_GEN_STRATEGY,
+                                UuidGenerationStrategy.TIME),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_UUID_TYPE,
+                                "uuid-binary"),
                         entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_EVENT_PROCESSOR_ENABLED, false),
                         entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_EVENT_PROCESSOR_SHARDS_TOTAL_COUNT, 10),
                         entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_EVENT_PROCESSOR_SHARDS_ASSIGNED,
@@ -119,6 +174,26 @@ public class ConfigPropertiesTest {
     public void perNamedPersistenceUnit() {
         assertThat(sessionFactoryForNamedPU1.getProperties())
                 .contains(
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_AGENT_CATALOG,
+                                "myagentcatalogpu1"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_AGENT_SCHEMA,
+                                "myagentschemapu1"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_AGENT_TABLE,
+                                "myagenttablepu1"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_AGENT_UUID_GEN_STRATEGY,
+                                UuidGenerationStrategy.TIME),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_AGENT_UUID_TYPE,
+                                "uuid-binary"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_CATALOG,
+                                "myoutboxeventcatalogpu1"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_SCHEMA,
+                                "myoutboxeventschemapu1"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_TABLE,
+                                "myoutboxeventtablepu1"),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_UUID_GEN_STRATEGY,
+                                UuidGenerationStrategy.RANDOM),
+                        entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_UUID_TYPE,
+                                "uuid-char"),
                         entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_EVENT_PROCESSOR_ENABLED, false),
                         entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_EVENT_PROCESSOR_SHARDS_TOTAL_COUNT, 110),
                         entry(HibernateOrmMapperOutboxPollingSettings.COORDINATION_EVENT_PROCESSOR_SHARDS_ASSIGNED,

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingBuildTimeConfig.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingBuildTimeConfig.java
@@ -1,0 +1,30 @@
+package io.quarkus.hibernate.search.orm.coordination.outboxpolling.runtime;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithParentName;
+
+@ConfigMapping(prefix = "quarkus.hibernate-search-orm")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface HibernateSearchOutboxPollingBuildTimeConfig {
+
+    /**
+     * Configuration for the default persistence unit.
+     */
+    @WithParentName
+    HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit defaultPersistenceUnit();
+
+    /**
+     * Configuration for additional named persistence units.
+     */
+    @ConfigDocSection
+    @ConfigDocMapKey("persistence-unit-name")
+    @WithParentName
+    Map<String, HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit> persistenceUnits();
+
+}

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit.java
@@ -86,7 +86,7 @@ public interface HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit {
          * The name of the Hibernate ORM basic type used for representing an UUID in the agent table.
          *
          * Refer to
-         * link:{hibernate-orm-doc-prefix}#basic-legacy-provided[this section of the Hibernate ORM documentation]
+         * link:{hibernate-orm-docs-url}#basic-legacy-provided[this section of the Hibernate ORM documentation]
          * to see the list of available UUID representations provided by Hibernate ORM.
          *
          * A user defined type can also be supplied.
@@ -145,7 +145,7 @@ public interface HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit {
          * The name of the Hibernate ORM basic type used for representing an UUID in the outbox event table.
          *
          * Refer to
-         * link:{hibernate-orm-doc-prefix}#basic-legacy-provided[this section of the Hibernate ORM documentation]
+         * link:{hibernate-orm-docs-url}#basic-legacy-provided[this section of the Hibernate ORM documentation]
          * to see the list of available UUID representations provided by Hibernate ORM.
          *
          * A user defined type can also be supplied.

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit.java
@@ -1,0 +1,163 @@
+package io.quarkus.hibernate.search.orm.coordination.outboxpolling.runtime;
+
+import java.util.Optional;
+
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.UuidGenerationStrategy;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface HibernateSearchOutboxPollingBuildTimeConfigPersistenceUnit {
+
+    /**
+     * Configuration for coordination between threads or application instances.
+     */
+    CoordinationConfig coordination();
+
+    @ConfigGroup
+    interface CoordinationConfig {
+
+        /**
+         * Configuration for the mapping of entities used for outbox-polling coordination.
+         */
+        @ConfigDocSection
+        EntityMappingConfig entityMapping();
+
+    }
+
+    @ConfigGroup
+    interface EntityMappingConfig {
+
+        /**
+         * Configuration for the "agent" entity mapping.
+         */
+        EntityMappingAgentConfig agent();
+
+        /**
+         * Configuration for the "outbox event" entity mapping.
+         */
+        EntityMappingOutboxEventConfig outboxEvent();
+
+    }
+
+    @ConfigGroup
+    interface EntityMappingAgentConfig {
+
+        /**
+         * The database catalog to use for the agent table.
+         *
+         * @asciidoclet
+         */
+        @ConfigDocDefault("Default catalog configured in Hibernate ORM")
+        Optional<String> catalog();
+
+        /**
+         * The schema catalog to use for the agent table.
+         *
+         * @asciidoclet
+         */
+        @ConfigDocDefault("Default catalog configured in Hibernate ORM")
+        Optional<String> schema();
+
+        /**
+         * The name of the agent table.
+         *
+         * @asciidoclet
+         */
+        @ConfigDocDefault("HSEARCH_AGENT")
+        Optional<String> table();
+
+        /**
+         * The UUID generator strategy used for the agent table.
+         *
+         * Available strategies:
+         *
+         * * `auto` (the default) is the same as `random` which uses `UUID#randomUUID()`.
+         * * `time` is an IP based strategy consistent with IETF RFC 4122.
+         *
+         * @asciidoclet
+         */
+        @ConfigDocDefault("auto")
+        Optional<UuidGenerationStrategy> uuidGenStrategy();
+
+        /**
+         * The name of the Hibernate ORM basic type used for representing an UUID in the agent table.
+         *
+         * Refer to
+         * link:{hibernate-orm-doc-prefix}#basic-legacy-provided[this section of the Hibernate ORM documentation]
+         * to see the list of available UUID representations provided by Hibernate ORM.
+         *
+         * A user defined type can also be supplied.
+         *
+         * Defaults to the special value `default`, which will result into one of `uuid`/`uuid-binary`/`uuid-char`
+         * depending on the database kind.
+         *
+         * @asciidoclet
+         */
+        @ConfigDocDefault("uuid/uuid-binary/uuid-char depending on the database kind")
+        Optional<String> uuidType();
+
+    }
+
+    @ConfigGroup
+    interface EntityMappingOutboxEventConfig {
+
+        /**
+         * The database catalog to use for the outbox event table.
+         *
+         * @asciidoclet
+         */
+        @ConfigDocDefault("Default catalog configured in Hibernate ORM")
+        Optional<String> catalog();
+
+        /**
+         * The schema catalog to use for the outbox event table.
+         *
+         * @asciidoclet
+         */
+        @ConfigDocDefault("Default schema configured in Hibernate ORM")
+        Optional<String> schema();
+
+        /**
+         * The name of the outbox event table.
+         *
+         * @asciidoclet
+         */
+        @ConfigDocDefault("HSEARCH_OUTBOX_EVENT")
+        Optional<String> table();
+
+        /**
+         * The UUID generator strategy used for the outbox event table.
+         *
+         * Available strategies:
+         *
+         * * `auto` (the default) is the same as `random` which uses `UUID#randomUUID()`.
+         * * `time` is an IP based strategy consistent with IETF RFC 4122.
+         *
+         * @asciidoclet
+         */
+        @ConfigDocDefault("auto")
+        Optional<UuidGenerationStrategy> uuidGenStrategy();
+
+        /**
+         * The name of the Hibernate ORM basic type used for representing an UUID in the outbox event table.
+         *
+         * Refer to
+         * link:{hibernate-orm-doc-prefix}#basic-legacy-provided[this section of the Hibernate ORM documentation]
+         * to see the list of available UUID representations provided by Hibernate ORM.
+         *
+         * A user defined type can also be supplied.
+         *
+         * Defaults to the special value `default`, which will result into one of `uuid`/`uuid-binary`/`uuid-char`
+         * depending on the database kind.
+         *
+         * @asciidoclet
+         */
+        @ConfigDocDefault("uuid/uuid-binary/uuid-char depending on the database kind")
+        Optional<String> uuidType();
+
+    }
+
+}

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingConfigUtil.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingConfigUtil.java
@@ -12,6 +12,16 @@ public final class HibernateSearchOutboxPollingConfigUtil {
     private HibernateSearchOutboxPollingConfigUtil() {
     }
 
+    public static <T> void addCoordinationConfig(BiConsumer<String, Object> propertyCollector,
+            String configPath, T value) {
+        addCoordinationConfig(propertyCollector, null, configPath, value);
+    }
+
+    public static void addCoordinationConfig(BiConsumer<String, Object> propertyCollector, String configPath,
+            Optional<?> value) {
+        addCoordinationConfig(propertyCollector, null, configPath, value);
+    }
+
     public static <T> void addCoordinationConfig(BiConsumer<String, Object> propertyCollector, String tenantId,
             String configPath, T value) {
         String key = HibernateOrmMapperOutboxPollingSettings.coordinationKey(tenantId, configPath);

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/runtime/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/runtime/HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit.java
@@ -66,7 +66,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * for example to dedicate some nodes to HTTP request processing and other nodes to event processing.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#coordination-outbox-polling-event-processor[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#coordination-outbox-polling-event-processor[this section of the reference documentation]
          * for more information.
          *
          * @asciidoclet
@@ -88,7 +88,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * but will increase the stress on the database when there are no new events.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#coordination-outbox-polling-event-processor[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#coordination-outbox-polling-event-processor[this section of the reference documentation]
          * for more information.
          *
          * @asciidoclet
@@ -118,7 +118,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * but less stress on the database because of less frequent checks of the list of agents.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#coordination-outbox-polling-event-processor[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#coordination-outbox-polling-event-processor[this section of the reference documentation]
          * for more information.
          *
          * @asciidoclet
@@ -145,7 +145,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * because an event processor is incorrectly considered disconnected.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#coordination-outbox-polling-event-processor[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#coordination-outbox-polling-event-processor[this section of the reference documentation]
          * for more information.
          *
          * @asciidoclet
@@ -163,7 +163,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * but will increase memory usage and in extreme cases may lead to ``OutOfMemoryError``s.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#coordination-outbox-polling-event-processor[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#coordination-outbox-polling-event-processor[this section of the reference documentation]
          * for more information.
          *
          * @asciidoclet
@@ -182,7 +182,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * If this happens, set a higher transaction timeout for event processing using this property.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#coordination-outbox-polling-event-processor[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#coordination-outbox-polling-event-processor[this section of the reference documentation]
          * for more information.
          *
          * @asciidoclet
@@ -197,7 +197,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * Use the value `0S` to reprocess failed events as soon as possible, with no delay.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#coordination-outbox-polling-event-processor[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#coordination-outbox-polling-event-processor[this section of the reference documentation]
          * for more information.
          *
          * @asciidoclet
@@ -222,7 +222,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * is necessary.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#coordination-outbox-polling-event-processor-sharding[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#coordination-outbox-polling-event-processor-sharding[this section of the reference documentation]
          * for more information about event processor sharding.
          *
          * @asciidoclet
@@ -246,7 +246,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * by setting `shards.assigned` to a comma-separated list, e.g. `0,3`.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#coordination-outbox-polling-event-processor-sharding[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#coordination-outbox-polling-event-processor-sharding[this section of the reference documentation]
          * for more information about event processor sharding.
          *
          * @asciidoclet
@@ -273,7 +273,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * but will reduce the stress on the database while the mass indexer agent is actively waiting.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#coordination-outbox-polling-mass-indexer[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#coordination-outbox-polling-mass-indexer[this section of the reference documentation]
          * for more information.
          *
          * @asciidoclet
@@ -301,7 +301,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * but less stress on the database because of less frequent updates of the mass indexer agent's entry in the agent table.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#coordination-outbox-polling-mass-indexer[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#coordination-outbox-polling-mass-indexer[this section of the reference documentation]
          * for more information.
          *
          * @asciidoclet
@@ -328,7 +328,7 @@ public interface HibernateSearchOutboxPollingRuntimeConfigPersistenceUnit {
          * because a mass indexer agent is incorrectly considered disconnected.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#coordination-outbox-polling-mass-indexer[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#coordination-outbox-polling-mass-indexer[this section of the reference documentation]
          * for more information.
          *
          * @asciidoclet

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/ClassNames.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/ClassNames.java
@@ -9,4 +9,9 @@ class ClassNames {
     static final DotName INDEXED = DotName
             .createSimple("org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed");
 
+    static final DotName ROOT_MAPPING = DotName
+            .createSimple("org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.RootMapping");
+    static final DotName PROJECTION_CONSTRUCTOR = DotName
+            .createSimple("org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor");
+
 }

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -26,6 +26,7 @@ import org.hibernate.search.backend.elasticsearch.gson.spi.GsonClasses;
 import org.hibernate.search.backend.elasticsearch.index.layout.IndexLayoutStrategy;
 import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategy;
+import org.hibernate.search.mapper.pojo.work.IndexingPlanSynchronizationStrategy;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.IndexView;
@@ -167,7 +168,7 @@ class HibernateSearchElasticsearchProcessor {
 
         // Some user-injectable beans are retrieved programmatically and shouldn't be removed
         unremovableBean.produce(UnremovableBeanBuildItem.beanTypes(FailureHandler.class,
-                AutomaticIndexingSynchronizationStrategy.class,
+                AutomaticIndexingSynchronizationStrategy.class, IndexingPlanSynchronizationStrategy.class,
                 ElasticsearchAnalysisConfigurer.class, IndexLayoutStrategy.class));
     }
 

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -1,6 +1,8 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.deployment;
 
 import static io.quarkus.hibernate.search.orm.elasticsearch.deployment.ClassNames.INDEXED;
+import static io.quarkus.hibernate.search.orm.elasticsearch.deployment.ClassNames.PROJECTION_CONSTRUCTOR;
+import static io.quarkus.hibernate.search.orm.elasticsearch.deployment.ClassNames.ROOT_MAPPING;
 import static io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig.backendPropertyKey;
 import static io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig.defaultBackendPropertyKeys;
 import static io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig.elasticsearchVersionPropertyKey;
@@ -29,6 +31,7 @@ import org.hibernate.search.mapper.orm.automaticindexing.session.AutomaticIndexi
 import org.hibernate.search.mapper.pojo.work.IndexingPlanSynchronizationStrategy;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.logging.Logger;
 
@@ -46,6 +49,7 @@ import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
+import io.quarkus.deployment.util.JandexUtil;
 import io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchBuildItem;
 import io.quarkus.hibernate.orm.deployment.PersistenceUnitDescriptorBuildItem;
 import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRuntimeConfiguredBuildItem;
@@ -175,6 +179,7 @@ class HibernateSearchElasticsearchProcessor {
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     void setStaticConfig(RecorderContext recorderContext, HibernateSearchElasticsearchRecorder recorder,
+            CombinedIndexBuildItem combinedIndexBuildItem,
             List<HibernateSearchIntegrationStaticConfiguredBuildItem> integrationStaticConfigBuildItems,
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
             HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig,
@@ -182,6 +187,9 @@ class HibernateSearchElasticsearchProcessor {
         // Make it possible to record the settings as bytecode:
         recorderContext.registerSubstitution(ElasticsearchVersion.class,
                 String.class, ElasticsearchVersionSubstitution.class);
+
+        IndexView index = combinedIndexBuildItem.getIndex();
+        Set<String> rootAnnotationMappedClassNames = collectRootAnnotationMappedClassNames(index);
 
         for (HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem configuredPersistenceUnit : configuredPersistenceUnits) {
             String puName = configuredPersistenceUnit.getPersistenceUnitName();
@@ -204,9 +212,35 @@ class HibernateSearchElasticsearchProcessor {
                                     // we cannot pass a config group to a recorder so passing the whole config
                                     recorder.createStaticInitListener(puName, buildTimeConfig,
                                             configuredPersistenceUnit.getBackendAndIndexNamesForSearchExtensions(),
+                                            rootAnnotationMappedClassNames,
                                             integrationStaticInitListeners))
                             .setXmlMappingRequired(xmlMappingRequired));
         }
+    }
+
+    private static Set<String> collectRootAnnotationMappedClassNames(IndexView index) {
+        // Look for classes annotated with annotations meta-annotated with @RootMapping:
+        // those classes will have their annotations processed on every persistence unit.
+        // At the moment only @ProjectionConstructor is meta-annotated with @RootMapping.
+        Set<DotName> rootMappingAnnotationNames = new LinkedHashSet<>();
+        // This is built into Hibernate Search, which may not be part of the index.
+        rootMappingAnnotationNames.add(PROJECTION_CONSTRUCTOR);
+        // Users can theoretically declare their own root mapping annotations
+        // (replacements for @ProjectionConstructor, for example),
+        // so we need to consider those as well.
+        for (AnnotationInstance rootMappingAnnotationInstance : index.getAnnotations(ROOT_MAPPING)) {
+            rootMappingAnnotationNames.add(rootMappingAnnotationInstance.target().asClass().name());
+        }
+
+        // We'll collect all classes annotated with "root mapping" annotations
+        // anywhere (type level, constructor, ...)
+        Set<String> rootAnnotationMappedClassNames = new LinkedHashSet<>();
+        for (DotName rootMappingAnnotationName : rootMappingAnnotationNames) {
+            for (AnnotationInstance annotation : index.getAnnotations(rootMappingAnnotationName)) {
+                rootAnnotationMappedClassNames.add(JandexUtil.getEnclosingClass(annotation).name().toString());
+            }
+        }
+        return rootAnnotationMappedClassNames;
     }
 
     @BuildStep

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-multiple-persistence-units.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-multiple-persistence-units.properties
@@ -17,7 +17,7 @@ quarkus.hibernate-search-orm.elasticsearch.version=7
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.elasticsearch.protocol=${elasticsearch.protocol:http}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
-quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync
+quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=sync
 
 quarkus.hibernate-orm."pu1".database.generation=drop-and-create
 quarkus.hibernate-orm."pu1".datasource=data1
@@ -26,7 +26,7 @@ quarkus.hibernate-search-orm."pu1".elasticsearch.version=7
 quarkus.hibernate-search-orm."pu1".elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm."pu1".elasticsearch.protocol=${elasticsearch.protocol:http}
 quarkus.hibernate-search-orm."pu1".schema-management.strategy=drop-and-create-and-drop
-quarkus.hibernate-search-orm."pu1".automatic-indexing.synchronization.strategy=sync
+quarkus.hibernate-search-orm."pu1".indexing.plan.synchronization.strategy=sync
 
 quarkus.hibernate-orm."pu2".database.generation=drop-and-create
 quarkus.hibernate-orm."pu2".datasource=data2
@@ -35,7 +35,7 @@ quarkus.hibernate-search-orm."pu2".elasticsearch.version=7
 quarkus.hibernate-search-orm."pu2".elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm."pu2".elasticsearch.protocol=${elasticsearch.protocol:http}
 quarkus.hibernate-search-orm."pu2".schema-management.strategy=drop-and-create-and-drop
-quarkus.hibernate-search-orm."pu2".automatic-indexing.synchronization.strategy=sync
+quarkus.hibernate-search-orm."pu2".indexing.plan.synchronization.strategy=sync
 
 quarkus.hibernate-orm."pu3".database.generation=drop-and-create
 quarkus.hibernate-orm."pu3".datasource=data3

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application.properties
@@ -7,4 +7,4 @@ quarkus.hibernate-search-orm.elasticsearch.version=7
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.elasticsearch.protocol=${elasticsearch.protocol:http}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
-quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync
+quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=sync

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
@@ -209,7 +209,7 @@ public interface HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
          * this strategy will create an index named `myindex`, and will not use any alias.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#backend-elasticsearch-indexlayout[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#backend-elasticsearch-indexlayout[this section of the reference documentation]
          * for more information.
          *
          * [NOTE]

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
@@ -1,6 +1,7 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.runtime;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -165,12 +166,12 @@ public interface HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface AnalysisConfig {
+    interface AnalysisConfig {
         /**
-         * A xref:hibernate-search-orm-elasticsearch.adoc#bean-reference-note-anchor[bean reference] to the component
-         * used to configure full text analysis (e.g. analyzers, normalizers).
+         * One or more xref:hibernate-search-orm-elasticsearch.adoc#bean-reference-note-anchor[bean references]
+         * to the component(s) used to configure full text analysis (e.g. analyzers, normalizers).
          *
-         * The referenced bean must implement `ElasticsearchAnalysisConfigurer`.
+         * The referenced beans must implement `ElasticsearchAnalysisConfigurer`.
          *
          * See xref:hibernate-search-orm-elasticsearch.adoc#analysis-configurer[Setting up the analyzers] for more
          * information.
@@ -178,14 +179,14 @@ public interface HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
          * [NOTE]
          * ====
          * Instead of setting this configuration property,
-         * you can simply annotate your custom `ElasticsearchAnalysisConfigurer` implementation with `@SearchExtension`
+         * you can simply annotate your custom `ElasticsearchAnalysisConfigurer` implementations with `@SearchExtension`
          * and leave the configuration property unset: Hibernate Search will use the annotated implementation automatically.
          * If this configuration property is set, it takes precedence over any `@SearchExtension` annotation.
          * ====
          *
          * @asciidoclet
          */
-        Optional<String> configurer();
+        Optional<List<String>> configurer();
     }
 
     @ConfigGroup

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -286,7 +286,7 @@ public class HibernateSearchElasticsearchRecorder {
             // Settings that may default to a @SearchExtension-annotated-bean
             addBackendIndexConfig(propertyCollector, backendName, indexName,
                     ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
-                    HibernateSearchBeanUtil.singleExtensionBeanReferenceFor(
+                    HibernateSearchBeanUtil.multiExtensionBeanReferencesFor(
                             indexConfig == null ? Optional.empty() : indexConfig.analysis().configurer(),
                             ElasticsearchAnalysisConfigurer.class, persistenceUnitName, backendName, indexName));
         }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
@@ -353,7 +353,7 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          * to a custom implementations of `IndexingPlanSynchronizationStrategy`.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#indexing-plan-synchronization[this section of the reference documentation]
+         * link:{hibernate-search-docs-url}#indexing-plan-synchronization[this section of the reference documentation]
          * for more information.
          *
          * [NOTE]

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
@@ -67,8 +67,16 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     SearchQueryLoadingConfig queryLoading();
 
     /**
-     * Configuration for the automatic indexing.
+     * Configuration for indexing.
      */
+    IndexingConfig indexing();
+
+    /**
+     * Configuration for automatic indexing.
+     *
+     * @deprecated Use {@link #indexing()} instead.
+     */
+    @Deprecated
     AutomaticIndexingConfig automaticIndexing();
 
     /**
@@ -256,31 +264,41 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     }
 
     @ConfigGroup
-    public interface AutomaticIndexingConfig {
+    interface IndexingConfig {
 
         /**
-         * Configuration for synchronization with the index when indexing automatically.
+         * Configuration for indexing plans.
          */
-        AutomaticIndexingSynchronizationConfig synchronization();
+        IndexingPlanConfig plan();
 
-        /**
-         * Whether to check if dirty properties are relevant to indexing before actually reindexing an entity.
-         *
-         * When enabled, re-indexing of an entity is skipped if the only changes are on properties that are not used when
-         * indexing.
-         *
-         * @asciidoclet
-         */
-        @WithDefault("true")
-        boolean enableDirtyCheck();
     }
 
+    // Having a dedicated config group class feels a bit unnecessary
+    // because we could just use @WithName("plan.synchronization.strategy")
+    // but that leads to bugs
+    // see https://github.com/quarkusio/quarkus/pull/34251#issuecomment-1611273375
     @ConfigGroup
-    public interface AutomaticIndexingSynchronizationConfig {
+    interface IndexingPlanConfig {
+
+        /**
+         * Configuration for indexing plan synchronization.
+         */
+        IndexingPlanSynchronizationConfig synchronization();
+
+    }
+
+    // Having a dedicated config group class feels a bit unnecessary
+    // because we could just use @WithName("plan.synchronization.strategy")
+    // but that leads to bugs
+    // see https://github.com/quarkusio/quarkus/pull/34251#issuecomment-1611273375
+    @ConfigGroup
+    interface IndexingPlanSynchronizationConfig {
 
         // @formatter:off
         /**
-         * The synchronization strategy to use when indexing automatically.
+         * How to synchronize between application threads and indexing,
+         * in particular when relying on (implicit) listener-triggered indexing on entity change,
+         * but also when using a `SearchIndexingPlan` explicitly.
          *
          * Defines how complete indexing should be before resuming the application thread
          * after a database transaction is committed.
@@ -332,21 +350,62 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          * !===
          *
          * This property also accepts a xref:hibernate-search-orm-elasticsearch.adoc#bean-reference-note-anchor[bean reference]
-         * to a custom implementations of `AutomaticIndexingSynchronizationStrategy`.
+         * to a custom implementations of `IndexingPlanSynchronizationStrategy`.
          *
          * See
-         * link:{hibernate-search-doc-prefix}#mapper-orm-indexing-automatic-synchronization[this section of the reference documentation]
+         * link:{hibernate-search-doc-prefix}#indexing-plan-synchronization[this section of the reference documentation]
          * for more information.
          *
          * [NOTE]
          * ====
          * Instead of setting this configuration property,
-         * you can simply annotate your custom `AutomaticIndexingSynchronizationStrategy` implementation with `@SearchExtension`
+         * you can simply annotate your custom `IndexingPlanSynchronizationStrategy` implementation with `@SearchExtension`
          * and leave the configuration property unset: Hibernate Search will use the annotated implementation automatically.
          * If this configuration property is set, it takes precedence over any `@SearchExtension` annotation.
          * ====
          *
          * @asciidoclet
+         */
+        // @formatter:on
+        @ConfigDocDefault("write-sync")
+        Optional<String> strategy();
+
+    }
+
+    @ConfigGroup
+    @Deprecated
+    public interface AutomaticIndexingConfig {
+
+        /**
+         * Configuration for synchronization with the index when indexing automatically.
+         *
+         * @deprecated Use {@code quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy} instead.
+         */
+        AutomaticIndexingSynchronizationConfig synchronization();
+
+        /**
+         * Whether to check if dirty properties are relevant to indexing before actually reindexing an entity.
+         * <p>
+         * When enabled, re-indexing of an entity is skipped if the only changes are on properties that are not used when
+         * indexing.
+         *
+         * @deprecated This property is deprecated with no alternative to replace it.
+         *             In the future, a dirty check will always be performed when considering whether to trigger reindexing.
+         */
+        @WithDefault("true")
+        @Deprecated
+        boolean enableDirtyCheck();
+    }
+
+    @ConfigGroup
+    @Deprecated
+    public interface AutomaticIndexingSynchronizationConfig {
+
+        // @formatter:off
+        /**
+         * The synchronization strategy to use when indexing automatically.
+         *
+         * @deprecated Use {@code quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy} instead.
          */
         // @formatter:on
         @ConfigDocDefault("write-sync")

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/bean/ArcBeanReference.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/bean/ArcBeanReference.java
@@ -4,24 +4,25 @@ import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
 
-import io.quarkus.arc.InjectableInstance;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
 
 final class ArcBeanReference<T> implements BeanReference<T> {
 
-    private final InjectableInstance<T> delegate;
+    private final InjectableBean<T> bean;
 
-    public ArcBeanReference(InjectableInstance<T> delegate) {
-        this.delegate = delegate;
+    public ArcBeanReference(InjectableBean<T> bean) {
+        this.bean = bean;
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "[" + delegate.toString() + "]";
+        return getClass().getSimpleName() + "[" + bean.toString() + "]";
     }
 
     @Override
     public BeanHolder<T> resolve(BeanResolver beanResolver) {
-        return new ArcBeanHolder<>(delegate.getHandle());
+        return new ArcBeanHolder<>(Arc.container().instance(bean));
     }
 
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/graal/Substitute_JandexBehavior.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/graal/Substitute_JandexBehavior.java
@@ -1,0 +1,20 @@
+package io.quarkus.hibernate.search.orm.elasticsearch.runtime.graal;
+
+import org.hibernate.search.util.common.jar.spi.JandexBehavior;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * Disallow the use of Jandex so that relevant code can be DCEd
+ * (otherwise compilation would fail as Jandex is not available at runtime).
+ */
+@TargetClass(className = "org.hibernate.search.util.common.jar.spi.JandexBehavior")
+final class Substitute_JandexBehavior {
+
+    @Substitute
+    public static <T> T doWithJandex(JandexBehavior.JandexOperation operation) {
+        throw new IllegalStateException("Jandex should not be used at runtime.");
+    }
+
+}

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/mapping/QuarkusHibernateOrmSearchMappingConfigurer.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/mapping/QuarkusHibernateOrmSearchMappingConfigurer.java
@@ -1,9 +1,17 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.runtime.mapping;
 
+import java.util.Set;
+
 import org.hibernate.search.mapper.orm.mapping.HibernateOrmMappingConfigurationContext;
 import org.hibernate.search.mapper.orm.mapping.HibernateOrmSearchMappingConfigurer;
 
 public class QuarkusHibernateOrmSearchMappingConfigurer implements HibernateOrmSearchMappingConfigurer {
+    private final Set<Class<?>> rootAnnotationMappedClasses;
+
+    public QuarkusHibernateOrmSearchMappingConfigurer(Set<Class<?>> rootAnnotationMappedClasses) {
+        this.rootAnnotationMappedClasses = rootAnnotationMappedClasses;
+    }
+
     @Override
     public void configure(HibernateOrmMappingConfigurationContext context) {
         // Jandex is not available at runtime in Quarkus,
@@ -11,5 +19,9 @@ public class QuarkusHibernateOrmSearchMappingConfigurer implements HibernateOrmS
         context.annotationMapping()
                 .discoverJandexIndexesFromAddedTypes(false)
                 .buildMissingDiscoveredJandexIndexes(false);
+
+        // ... but we do better: we perform classpath scanning during the build,
+        // and propagate the result here.
+        context.annotationMapping().add(rootAnnotationMappedClasses);
     }
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/mapping/QuarkusHibernateOrmSearchMappingConfigurer.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/mapping/QuarkusHibernateOrmSearchMappingConfigurer.java
@@ -1,0 +1,15 @@
+package io.quarkus.hibernate.search.orm.elasticsearch.runtime.mapping;
+
+import org.hibernate.search.mapper.orm.mapping.HibernateOrmMappingConfigurationContext;
+import org.hibernate.search.mapper.orm.mapping.HibernateOrmSearchMappingConfigurer;
+
+public class QuarkusHibernateOrmSearchMappingConfigurer implements HibernateOrmSearchMappingConfigurer {
+    @Override
+    public void configure(HibernateOrmMappingConfigurationContext context) {
+        // Jandex is not available at runtime in Quarkus,
+        // so Hibernate Search cannot perform classpath scanning on startup.
+        context.annotationMapping()
+                .discoverJandexIndexesFromAddedTypes(false)
+                .buildMissingDiscoveredJandexIndexes(false);
+    }
+}

--- a/integration-tests/hibernate-search-orm-elasticsearch-tenancy/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-orm-elasticsearch-tenancy/src/main/resources/application.properties
@@ -10,4 +10,4 @@ quarkus.hibernate-search-orm.elasticsearch.version=7
 quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 quarkus.hibernate-search-orm.elasticsearch.protocol=${elasticsearch.protocol:http}
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
-quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync
+quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=sync

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/analysis/AnalysisTestResource.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/analysis/AnalysisTestResource.java
@@ -13,8 +13,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+import org.hibernate.search.engine.common.EntityReference;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.mapper.orm.common.EntityReference;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.jboss.resteasy.annotations.jaxrs.QueryParam;
 
@@ -65,7 +65,7 @@ public class AnalysisTestResource {
     public List<Class<?>> findTypesMatching(@QueryParam String field, @QueryParam String term) {
         SearchSession searchSession = Search.session(entityManager);
         return searchSession.search(AnalysisTestingEntityBase.class)
-                .<Class<?>> select(f -> f.composite(EntityReference::type, f.entityReference()))
+                .<Class<?>> select(f -> f.composite().from(f.entityReference()).as(EntityReference::type))
                 .where(f -> f.match().field(field).matching(term).skipAnalysis())
                 .fetchAllHits();
     }

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/search/AddressDTO.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/search/AddressDTO.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.hibernate.search.orm.elasticsearch.search;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor;
+
+// Ideally we'd use records, but Quarkus still has to compile with JDK 11 at the moment.
+public class AddressDTO {
+    public final String city;
+
+    @ProjectionConstructor
+    public AddressDTO(String city) {
+        this.city = city;
+    }
+
+    @Override
+    public String toString() {
+        return "AddressDTO{" +
+                "city='" + city + '\'' +
+                '}';
+    }
+}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/search/HibernateSearchTestResource.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/search/HibernateSearchTestResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.hibernate.search.orm.elasticsearch.search;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -64,6 +65,25 @@ public class HibernateSearchTestResource {
         assertEquals(4 + 2000, searchSession.search(Person.class)
                 .where(f -> f.matchAll())
                 .fetchTotalHitCount());
+
+        return "OK";
+    }
+
+    @GET
+    @Path("/search-projection")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String testSearchWithProjection() {
+        SearchSession searchSession = Search.session(entityManager);
+
+        assertThat(searchSession.search(Person.class)
+                .select(PersonDTO.class)
+                .where(f -> f.match().field("name").matching("john"))
+                .sort(f -> f.field("name_sort"))
+                .fetchHits(20))
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(
+                        new PersonDTO(4, "John Grisham", new AddressDTO("Oxford")),
+                        new PersonDTO(1, "John Irving", new AddressDTO("Burlington")));
 
         return "OK";
     }

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/search/HibernateSearchTestResource.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/search/HibernateSearchTestResource.java
@@ -54,8 +54,7 @@ public class HibernateSearchTestResource {
         assertEquals("John Irving", person.get(1).getName());
 
         person = searchSession.search(Person.class)
-                .where(f -> f.nested().objectField("address").nest(
-                        f.match().field("address.city").matching("london")))
+                .where(f -> f.match().field("address.city").matching("london"))
                 .sort(f -> f.field("name_sort"))
                 .fetchHits(20);
 

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/search/PersonDTO.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/search/PersonDTO.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.hibernate.search.orm.elasticsearch.search;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IdProjection;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor;
+
+// Ideally we'd use records, but Quarkus still has to compile with JDK 11 at the moment.
+public class PersonDTO {
+    public final long id;
+    public final String name;
+    public final AddressDTO address;
+
+    @ProjectionConstructor
+    public PersonDTO(@IdProjection long id, String name, AddressDTO address) {
+        this.id = id;
+        this.name = name;
+        this.address = address;
+    }
+
+    @Override
+    public String toString() {
+        return "PersonDTO{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", address=" + address +
+                '}';
+    }
+}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/resources/application.properties
@@ -12,7 +12,7 @@ quarkus.hibernate-search-orm.elasticsearch.indexes.Analysis2TestingEntity.analys
 quarkus.hibernate-search-orm.elasticsearch.indexes.Analysis3TestingEntity.analysis.configurer=io.quarkus.it.hibernate.search.orm.elasticsearch.analysis.IndexAnalysis3Configurer
 quarkus.hibernate-search-orm.elasticsearch.indexes.Analysis4TestingEntity.analysis.configurer=index-analysis-4
 quarkus.hibernate-search-orm.elasticsearch.indexes.Analysis5TestingEntity.analysis.configurer=io.quarkus.it.hibernate.search.orm.elasticsearch.analysis.IndexAnalysis5Configurer
-quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync
+quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=sync
 
 # Use drop-and-create instead of drop-and-create-and-drop
 # so we can differentiate between the value we set here

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/HibernateSearchTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/HibernateSearchTest.java
@@ -11,11 +11,15 @@ import io.restassured.RestAssured;
 public class HibernateSearchTest {
 
     @Test
-    public void testSearch() throws Exception {
+    public void testSearch() {
         RestAssured.when().put("/test/hibernate-search/init-data").then()
                 .statusCode(204);
 
         RestAssured.when().get("/test/hibernate-search/search").then()
+                .statusCode(200)
+                .body(is("OK"));
+
+        RestAssured.when().get("/test/hibernate-search/search-projection").then()
                 .statusCode(200)
                 .body(is("OK"));
 

--- a/integration-tests/hibernate-search-orm-opensearch/src/main/java/io/quarkus/it/hibernate/search/orm/opensearch/search/HibernateSearchTestResource.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/main/java/io/quarkus/it/hibernate/search/orm/opensearch/search/HibernateSearchTestResource.java
@@ -54,8 +54,7 @@ public class HibernateSearchTestResource {
         assertEquals("John Irving", person.get(1).getName());
 
         person = searchSession.search(Person.class)
-                .where(f -> f.nested().objectField("address").nest(
-                        f.match().field("address.city").matching("london")))
+                .where(f -> f.match().field("address.city").matching("london"))
                 .sort(f -> f.field("name_sort"))
                 .fetchHits(20);
 

--- a/integration-tests/hibernate-search-orm-opensearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-orm-opensearch/src/main/resources/application.properties
@@ -11,4 +11,4 @@ quarkus.hibernate-search-orm.elasticsearch.hosts=${opensearch.hosts:localhost:92
 quarkus.hibernate-search-orm.elasticsearch.protocol=${opensearch.protocol:http}
 quarkus.hibernate-search-orm.elasticsearch.analysis.configurer=bean:backend-analysis
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
-quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync
+quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=sync


### PR DESCRIPTION
~~Creating as draft, because we will need to release Hibernate Search 6.2.0.CR1 (soon) first. Currently, to test this you'd need to build Hibernate Search locally and change the version of the Hibernate Search dependency in this PR to 6.2.0-SNAPSHOT.~~ => [Hibernate Search 6.2.0.CR1 is out](https://in.relation.to/2023/06/26/hibernate-search-6-2-0-CR1/), we can upgrade.

I checked locally that we could run `integration-tests/hibernate-search-orm-elasticsearch`, including in native mode, but I didn't run many more tests.

@marko-bekhta would you have a look, please?