### PR TITLE
Reduce the number of copies to handle Vert-x Heap Buffers

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerHttpResponse.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerHttpResponse.java
@@ -15,6 +15,12 @@ public interface ServerHttpResponse extends StreamingResponse<ServerHttpResponse
 
     boolean headWritten();
 
+    /**
+     * This method should be used to handoff a data which {@link ServerHttpResponse} cannot retain
+     * because owned by/shared with the caller.
+     */
+    ServerHttpResponse endShared(byte[] data, int offset, int length);
+
     ServerHttpResponse end(byte[] data);
 
     ServerHttpResponse end(String data);

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -360,9 +360,16 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
     }
 
     @Override
-    public ServerHttpResponse end(byte[] data) {
-        response.end(Buffer.buffer(data), null);
+    public ServerHttpResponse endShared(byte[] data, int offset, int length) {
+        var buffer = Buffer.buffer(length);
+        buffer.appendBytes(data, offset, length);
+        response.end(buffer, null);
         return this;
+    }
+
+    @Override
+    public ServerHttpResponse end(byte[] data) {
+        return endShared(data, 0, data.length);
     }
 
     @Override


### PR DESCRIPTION
I've opened this for discussion, because I see that it is something that could be addressed both on Quarkus and Vertx altogether, by changing the `Buffer`'s API and our API to be used with `ServerHttpResponse ::end`, but sadly no Vertx deps seems to be present on `ServerHttpResponse`.

I'm opened for ideas (as usual)