### PR TITLE
Bump dekorate.version from 3.6.1 to 3.7.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -162,7 +162,7 @@
         <azure.toolkit-lib.version>0.27.0</azure.toolkit-lib.version>
         <kotlin.coroutine.version>1.6.4</kotlin.coroutine.version>
         <kotlin-serialization.version>1.5.1</kotlin-serialization.version>
-        <dekorate.version>3.6.1</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
+        <dekorate.version>3.7.0</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>
         <jboss-logmanager.version>1.1.1</jboss-logmanager.version>


### PR DESCRIPTION
Changes: https://github.com/dekorateio/dekorate/releases/tag/3.7.0