### PR TITLE
Rename Amazon Lambda to AWS Lambda in documentation

### DIFF
--- a/docs/src/main/asciidoc/aws-lambda-http.adoc
+++ b/docs/src/main/asciidoc/aws-lambda-http.adoc
@@ -3,14 +3,14 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Amazon Lambda with RESTEasy Reactive, Undertow, or Reactive Routes
+= AWS Lambda with RESTEasy Reactive, Undertow, or Reactive Routes
 :extension-status: preview
 include::_attributes.adoc[]
 :categories: cloud
-:summary: This guide explains how you can deploy Vert.x Web, Servlet, or RESTEasy microservices as an Amazon Lambda.
+:summary: This guide explains how you can deploy Vert.x Web, Servlet, or RESTEasy microservices as an AWS Lambda.
 :devtools-no-gradle:
 
-With Quarkus you can deploy your favorite Java HTTP frameworks as Amazon Lambda's using either the https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html[AWS Gateway HTTP API]
+With Quarkus you can deploy your favorite Java HTTP frameworks as AWS Lambda's using either the https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html[AWS Gateway HTTP API]
 or https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html[AWS Gateway REST API].  This means that you can deploy your microservices written with RESTEasy Reactive (our Jakarta REST implementation),
 Undertow (servlet), Reactive Routes, xref:funqy-http.adoc[Funqy HTTP] or any other Quarkus HTTP framework as an AWS Lambda.
 
@@ -35,7 +35,7 @@ include::{includes}/prerequisites.adoc[]
 == Getting Started
 
 This guide walks you through generating an example Java project via a Maven archetype.  Later on, it walks through the structure
-of the project so you can adapt any existing projects you have to use Amazon Lambda.
+of the project so you can adapt any existing projects you have to use AWS Lambda.
 
 == Installing AWS bits
 
@@ -170,7 +170,7 @@ quarkus.lambda.mock-event-server.test-port=8083
 
 A port value of zero will result in a randomly assigned port.
 
-== Simulate Amazon Lambda Deployment with SAM CLI
+== Simulate AWS Lambda Deployment with SAM CLI
 
 The AWS SAM CLI allows you to run your lambda's locally on your laptop in a simulated Lambda environment.  This requires Docker to be installed.
 After you have built your Maven project, execute this command:
@@ -269,7 +269,7 @@ you'll see this:
             DISABLE_SIGNAL_HANDLERS: true
 ----
 
-This environment variable resolves some incompatibilities between Quarkus and the Amazon Lambda Custom Runtime environment.
+This environment variable resolves some incompatibilities between Quarkus and the AWS Lambda Custom Runtime environment.
 
 Finally, there is one specific thing for AWS Gateway REST API deployments.
 That API assumes that HTTP response bodies are text unless you explicitly tell it which media types are

--- a/docs/src/main/asciidoc/aws-lambda-snapstart.adoc
+++ b/docs/src/main/asciidoc/aws-lambda-snapstart.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Amazon Lambda SnapStart Configuration
+= AWS Lambda SnapStart Configuration
 include::_attributes.adoc[]
 :categories: cloud
 :summary: This document explains how to optimize your AWS Lambda application for SnapStart
@@ -17,7 +17,7 @@ Please check the AWS documentation to verify the eligibility of your AWS region.
 
 == Enabling / Disabling SnapStart Optimizations
 
-If you use the Quarkus Amazon Lambda extension, SnapStart optimizations are automatically enabled.
+If you use the Quarkus AWS Lambda extension, SnapStart optimizations are automatically enabled.
 However, you can enable/disable it explicitly using:
 
 [source, properties]

--- a/docs/src/main/asciidoc/aws-lambda.adoc
+++ b/docs/src/main/asciidoc/aws-lambda.adoc
@@ -3,10 +3,10 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Amazon Lambda
+= AWS Lambda
 include::_attributes.adoc[]
 :categories: cloud
-:summary: This guide explains how you can deploy Quarkus-based Amazon Lambdas.
+:summary: This guide explains how you can deploy Quarkus-based AWS Lambdas.
 
 The `quarkus-amazon-lambda` extension allows you to use Quarkus to build your AWS Lambdas.
 Your lambdas can use injection annotations from CDI or Spring and other Quarkus facilities as you need them.
@@ -299,7 +299,7 @@ dependencies {
 
 == Live Coding and Unit/Integration Testing
 To mirror the AWS Lambda environment as closely as possible in a dev environment,
-the Quarkus Amazon Lambda extension boots up a mock AWS Lambda event server in Quarkus Dev and Test mode.
+the Quarkus AWS Lambda extension boots up a mock AWS Lambda event server in Quarkus Dev and Test mode.
 This mock event server simulates a true AWS Lambda environment.
 
 While running in Quarkus Dev Mode, you can feed events to it by doing an HTTP POST to `http://localhost:8080`.

--- a/docs/src/main/asciidoc/funqy-aws-lambda-http.adoc
+++ b/docs/src/main/asciidoc/funqy-aws-lambda-http.adoc
@@ -3,11 +3,11 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Funqy HTTP Binding with Amazon Lambda 
+= Funqy HTTP Binding with AWS Lambda 
 :extension-status: preview
 include::_attributes.adoc[]
 :categories: cloud
-:summary: This guide explains Funqy's Amazon Lambda HTTP binding.
+:summary: This guide explains Funqy's AWS Lambda HTTP binding.
 
 If you want to allow HTTP clients to invoke on your Funqy functions on AWS Lambda, Quarkus allows you to expose multiple
 Funqy functions through HTTP deployed as one AWS Lambda.  This approach does add overhead over the
@@ -15,18 +15,18 @@ regular Funqy AWS Lambda integration and also requires you to use AWS API Gatewa
 
 include::{includes}/extension-status.adoc[]
 
-Follow the xref:amazon-lambda-http.adoc[Amazon Lambda Http Guide].  It walks through using a variety of HTTP
-frameworks on Amazon Lambda, including Funqy.
+Follow the xref:aws-lambda-http.adoc[AWS Lambda Http Guide].  It walks through using a variety of HTTP
+frameworks on AWS Lambda, including Funqy.
 
 WARNING: The Funqy HTTP + AWS Lambda binding is not a replacement for REST over HTTP.  Because Funqy
 needs to be portable across a lot of different protocols and function providers its HTTP binding
 is very minimalistic and you will lose REST features like linking and the ability to leverage
 HTTP features like cache-control and conditional GETs.  You may want to consider using Quarkus's
-Jakarta REST, Spring MVC, or Vert.x Web Reactive Route xref:amazon-lambda-http.adoc[support] instead.  They also work with Quarkus and AWS Lambda.
+Jakarta REST, Spring MVC, or Vert.x Web Reactive Route xref:aws-lambda-http.adoc[support] instead.  They also work with Quarkus and AWS Lambda.
 
 == An additional Quickstart
 
-Beyond generating an AWS project that is covered in the xref:amazon-lambda-http.adoc[Amazon Lambda Http Guide],
+Beyond generating an AWS project that is covered in the xref:aws-lambda-http.adoc[AWS Lambda Http Guide],
 there's also a quickstart for running Funqy HTTP on AWS Lambda.
 
 Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
@@ -40,7 +40,7 @@ environments and AWS Lambda is one of them.  The Java code is actually the same 
 
 == Getting Started
 
-The steps to get this quickstart running are exactly the same as defined in the xref:amazon-lambda-http.adoc[Amazon Lambda HTTP Guide].
+The steps to get this quickstart running are exactly the same as defined in the xref:aws-lambda-http.adoc[AWS Lambda HTTP Guide].
 These differences are that you are running from a quickstart and the maven dependencies are slightly different.
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]

--- a/docs/src/main/asciidoc/funqy-aws-lambda.adoc
+++ b/docs/src/main/asciidoc/funqy-aws-lambda.adoc
@@ -3,14 +3,14 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Funqy Amazon Lambda Binding
+= Funqy AWS Lambda Binding
 :extension-status: preview
 :devtools-no-gradle:
 include::_attributes.adoc[]
 :categories: cloud
-:summary: This guide explains Funqy's Amazon Lambda binding.
+:summary: This guide explains Funqy's AWS Lambda binding.
 
-The guide walks through quickstart code to show you how you can deploy Funqy functions to Amazon Lambda.
+The guide walks through quickstart code to show you how you can deploy Funqy functions to AWS Lambda.
 
 Funqy functions can be deployed using the AWS Lambda Java Runtime, or you can build a native executable and use
 Lambda Custom Runtime if you want a smaller memory footprint and faster cold boot startup time.
@@ -26,7 +26,7 @@ include::{includes}/prerequisites.adoc[]
 * https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html[AWS CLI]
 * https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html[AWS SAM CLI], for local testing
 
-NOTE: Funqy Amazon Lambdas build off of our xref:amazon-lambda.adoc[Quarkus Amazon Lambda support].
+NOTE: Funqy AWS Lambdas build off of our xref:aws-lambda.adoc[Quarkus AWS Lambda support].
 
 == Installing AWS bits
 
@@ -47,7 +47,7 @@ environments and AWS Lambda is one of them.  The Java code is actually the same 
 [[choose]]
 == Choose Your Function
 
-Only one Funqy function can be exported per Amazon Lambda deployment.  If you have multiple functions defined
+Only one Funqy function can be exported per AWS Lambda deployment.  If you have multiple functions defined
 within your project, then you will need to choose the function within your Quarkus `application.properties`:
 
 [source,properties,subs=attributes+]
@@ -57,7 +57,7 @@ quarkus.funqy.export=greet
 
 You can see how the quickstart has done it within its own {quickstarts-tree-url}/funqy-quickstarts/funqy-amazon-lambda-quickstart/src/main/resources/application.properties[application.properties].
 
-Alternatively, you can set the `QUARKUS_FUNQY_EXPORT` environment variable when you create the Amazon Lambda using the `aws` cli.
+Alternatively, you can set the `QUARKUS_FUNQY_EXPORT` environment variable when you create the AWS Lambda using the `aws` cli.
 
 == Deploy to AWS Lambda Java Runtime
 
@@ -230,7 +230,7 @@ as a dependency.  The extension automatically generates everything you might nee
 
 == Integration Testing
 
-Funqy Amazon Lambda support leverages the Quarkus AWS Lambda test framework so that you can unit tests your Funqy functions.
+Funqy AWS Lambda support leverages the Quarkus AWS Lambda test framework so that you can unit tests your Funqy functions.
 This is true for both JVM and native modes.
 This test framework provides similar functionality to the SAM CLI, without the overhead of Docker.
 

--- a/docs/src/main/asciidoc/funqy.adoc
+++ b/docs/src/main/asciidoc/funqy.adoc
@@ -179,12 +179,12 @@ developers will be ok with that as many won't be using these REST/HTTP features 
 have to make the decision on what camp you are in.  Quarkus does support REST integration (through Jakarta REST,
  Spring MVC, Vert.x Web, and Servlet) with
 various cloud/function providers, but there are some disadvantages of using that approach as well.  For example,
-if you want to do xref:amazon-lambda-http.adoc[HTTP with AWS Lambda], this requires you to use the AWS API Gateway which may
+if you want to do xref:aws-lambda-http.adoc[HTTP with AWS Lambda], this requires you to use the AWS API Gateway which may
 slow down deployment and cold start time or even cost you more.
 
 The purpose of Funqy is to allow you to write cross-provider functions so that you can move
 off of your current function provider if, for instance, they start charging you a lot more for their
 service.  Another reason you might not want to use Funqy is if you need access specific APIs of the
 target function environment.  For example, developers often want access to the AWS Context on
-Lambda.  In this case, we tell them they may be better off using the xref:amazon-lambda.adoc[Quarkus Amazon Lambda] integration instead.
+Lambda.  In this case, we tell them they may be better off using the xref:aws-lambda.adoc[Quarkus AWS Lambda] integration instead.
 

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -987,7 +987,7 @@ Note that you can't access the injected `JsonWebToken` in the public methods if 
 To <<jwt-parser,parse and verify JsonWebToken with JWTParser>>, use `smallrye-jwt` instead of `quarkus-smallrye-jwt` directly for the following situations:
 
 * You work with Quarkus extensions that do not support `HTTP`, such as `Quarkus GRPC`.
-* You provide an extension-specific `HTTP`, the support of which conflicts with the support of those offered by `quarkus-smallrye-jwt` and `Vert.x HTTP`, such as `Quarkus Amazon Lambda`.
+* You provide an extension-specific `HTTP`, the support of which conflicts with the support of those offered by `quarkus-smallrye-jwt` and `Vert.x HTTP`, such as `Quarkus AWS Lambda`.
 
 Start with adding the `smallrye-jwt` dependency:
 


### PR DESCRIPTION
Fixes #34279

/cc @aloubyansky 

I think we will need to rename the extensions too but probably for another day.