### PR TITLE
Remove "-concept" from doc filenames and IDs

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -1341,7 +1341,7 @@ public class Person {
 }
 ----
 
-Assuming security has been set up for the application (see our xref:security-overview-concept.adoc[guide] for more details), when a user with the `admin` role
+Assuming security has been set up for the application (see our xref:security-overview.adoc[guide] for more details), when a user with the `admin` role
 performs an HTTP GET on `/person/1` they will receive:
 
 [source,json]

--- a/docs/src/main/asciidoc/security-architecture.adoc
+++ b/docs/src/main/asciidoc/security-architecture.adoc
@@ -3,7 +3,7 @@ This document is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-[id="security-architecture-concept"]
+[id="security-architecture"]
 = Quarkus Security architecture
 include::_attributes.adoc[]
 :diataxis-type: concept
@@ -40,7 +40,7 @@ You can inject a `SecurityIdentity` instance for every authenticated resource to
 
 In other contexts, it is possible to have other parallel representations of the same information or parts of it, for example, `SecurityContext` for Jakarta REST or `JsonWebToken` for JSON Web Tokens (JWT).
 
-For more information, see the Quarkus xref:security-identity-providers-concept.adoc[Identity providers] guide.
+For more information, see the Quarkus xref:security-identity-providers.adoc[Identity providers] guide.
 
 === `SecurityIdentityAugmentor`
 Because Quarkus Security is customizable, for example, you can add authorization roles to `SecurityIdentity`, you can register and prioritize one or more custom security augmentors.
@@ -51,13 +51,13 @@ For more information, see the xref:security-customization.adoc#security-identity
 
 == Supported authentication mechanisms
 
-To learn more about security authentication in Quarkus and the supported mechanisms and protocols, see the Quarkus xref:security-authentication-mechanisms-concept.adoc[Authentication mechanisms in Quarkus] guide.
+To learn more about security authentication in Quarkus and the supported mechanisms and protocols, see the Quarkus xref:security-authentication-mechanisms.adoc[Authentication mechanisms in Quarkus] guide.
 
 == Proactive authentication
 
 Proactive authentication is enabled in Quarkus by default.
 The request is always authenticated if an incoming request has a credential, even if the target page does not require authentication.
-For more information, see the Quarkus xref:security-proactive-authentication-concept.adoc[Proactive authentication] guide.
+For more information, see the Quarkus xref:security-proactive-authentication.adoc[Proactive authentication] guide.
 
 == Quarkus Security customization
 
@@ -72,7 +72,7 @@ For more information about customizing Quarkus Security, including reactive secu
 
 == References
 
-* xref:security-overview-concept.adoc[Quarkus Security overview]
-* xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Other supported authentication mechanisms]
-* xref:security-identity-providers-concept.adoc[Identity providers]
+* xref:security-overview.adoc[Quarkus Security overview]
+* xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Other supported authentication mechanisms]
+* xref:security-identity-providers.adoc[Identity providers]
 * xref:security-authorize-web-endpoints-reference.adoc[Authorization of web endpoints]

--- a/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
@@ -1,4 +1,4 @@
-[id="security-authentication-mechanisms-concept"]
+[id="security-authentication-mechanisms"]
 = Authentication mechanisms in Quarkus
 include::_attributes.adoc[]
 :diataxis-type: concept
@@ -27,15 +27,15 @@ The following table maps specific authentication requirements to a supported mec
 |====
 |Authentication requirement |Authentication mechanism
 
-|Username and password |xref:security-basic-authentication-concept.adoc[Basic], <<form-auth>>
+|Username and password |xref:security-basic-authentication.adoc[Basic], <<form-auth>>
 
-|Bearer access token |xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer token authentication], xref:security-jwt.adoc[JWT], xref:security-oauth2.adoc[OAuth2]
+|Bearer access token |xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication], xref:security-jwt.adoc[JWT], xref:security-oauth2.adoc[OAuth2]
 
-|Single sign-on (SSO) |xref:security-oidc-code-flow-authentication-concept.adoc[OIDC Code Flow], <<form-auth>>
+|Single sign-on (SSO) |xref:security-oidc-code-flow-authentication.adoc[OIDC Code Flow], <<form-auth>>
 
 |Client certificate |<<mutual-tls>>
 
-|WebAuthn |xref:security-webauthn-concept.adoc[WebAuthn]
+|WebAuthn |xref:security-webauthn.adoc[WebAuthn]
 
 |Kerberos ticket |link:https://quarkiverse.github.io/quarkiverse-docs/quarkus-kerberos/dev/index.html[Kerberos]
 |====
@@ -47,7 +47,7 @@ For more information, see the following <<table>> table.
 
 Quarkus Security provides the following built-in authentication support:
 
-* xref:security-basic-authentication-concept.adoc[Basic authentication]
+* xref:security-basic-authentication.adoc[Basic authentication]
 * <<form-auth>>
 * <<mutual-tls>>
 
@@ -56,11 +56,11 @@ Quarkus Security provides the following built-in authentication support:
 You can secure your Quarkus application endpoints with the built-in HTTP Basic authentication mechanism.
 For more information, see the following documentation:
 
-* xref:security-basic-authentication-concept.adoc[Basic authentication]
+* xref:security-basic-authentication.adoc[Basic authentication]
 ** xref:security-basic-authentication-howto.adoc[Enable Basic authentication]
-* xref:security-jpa-concept.adoc[Quarkus Security with Jakarta Persistence]
+* xref:security-jpa.adoc[Quarkus Security with Jakarta Persistence]
 ** xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and Jakarta Persistence]
-* xref:security-identity-providers-concept.adoc[Identity providers]
+* xref:security-identity-providers.adoc[Identity providers]
 
 [[form-auth]]
 === Form-based authentication
@@ -167,7 +167,7 @@ Quarkus Security also supports the following authentication mechanisms through e
 
 https://webauthn.guide/[WebAuthn] is an authentication mechanism that replaces passwords.
 When you write a service for registering new users, or logging them in, instead of asking for a password, you can use WebAuthn, which replaces the password.
-For more information, see the  xref:security-webauthn-concept.adoc[Secure a Quarkus application by using the WebAuthn authentication mechanism] guide.
+For more information, see the  xref:security-webauthn.adoc[Secure a Quarkus application by using the WebAuthn authentication mechanism] guide.
 
 [[openid-connect-authentication]]
 === OpenID Connect authentication
@@ -195,8 +195,8 @@ For more information about OIDC authentication and authorization methods that yo
 [options="header"]
 |====
 |OIDC topic |Quarkus information resource
-|Bearer token authentication mechanism|xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer token authentication]
-|Authorization Code Flow authentication mechanism|xref:security-oidc-code-flow-authentication-concept.adoc[OpenID Connect (OIDC) Authorization Code Flow mechanism]
+|Bearer token authentication mechanism|xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication]
+|Authorization Code Flow authentication mechanism|xref:security-oidc-code-flow-authentication.adoc[OpenID Connect (OIDC) Authorization Code Flow mechanism]
 |Multiple tenants that can support the Bearer token authentication or Authorization Code Flow mechanisms|xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect (OIDC) multi-tenancy]
 |Securing Quarkus with commonly-used OpenID Connect providers|xref:security-openid-connect-providers.adoc[Configuring well-known OpenID Connect providers]
 |Using Keycloak to centralize authorization |xref:security-keycloak-authorization.adoc[Using OpenID Connect (OIDC) and Keycloak to centralize authorization]
@@ -358,11 +358,11 @@ Ensure that the value of the `auth-mechanism` property matches the authenticatio
 
 Proactive authentication is enabled in Quarkus by default.
 This means that if an incoming request has a credential, the request will always be authenticated, even if the target page does not require authentication.
-For more information, see the Quarkus xref:security-proactive-authentication-concept.adoc[Proactive authentication] guide.
+For more information, see the Quarkus xref:security-proactive-authentication.adoc[Proactive authentication] guide.
 
 == References
 
-* xref:security-overview-concept.adoc[Quarkus Security overview]
-* xref:security-architecture-concept.adoc[Quarkus Security architecture]
-* xref:security-identity-providers-concept.adoc[Identity providers]
+* xref:security-overview.adoc[Quarkus Security overview]
+* xref:security-architecture.adoc[Quarkus Security architecture]
+* xref:security-identity-providers.adoc[Identity providers]
 * xref:security-authorize-web-endpoints-reference.adoc[Authorization of web endpoints]

--- a/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
+++ b/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
@@ -306,7 +306,7 @@ This returns `non-null` for a secured endpoint.
 <5> The `/subject/denied` endpoint declares the `@DenyAll` annotation, disallowing all direct access to it as a REST method, regardless of the user calling it.
 The method is still invokable internally by other methods in this class.
 
-CAUTION: If you plan to use standard security annotations on the IO thread, review the information in the Quarkus xref:security-proactive-authentication-concept.adoc[Proactive Authentication] guide.
+CAUTION: If you plan to use standard security annotations on the IO thread, review the information in xref:security-proactive-authentication.adoc[Proactive Authentication].
 
 The `@RolesAllowed` annotation value supports xref:config-reference.adoc#property-expressions[property expressions] including default values and nested property expressions.
 Configuration properties used with the annotation are resolved at runtime.
@@ -475,7 +475,7 @@ Both resource methods `createOrUpdate` have equal authorization requirements.
 By default, string-based permission is performed by `io.quarkus.security.StringPermission`.
 <5> Permissions are not beans, therefore the only way to obtain bean instances is programmatically by using `Arc.container()`.
 
-CAUTION: If you plan to use `@PermissionsAllowed` on the IO thread, review the information in xref:security-proactive-authentication-concept.adoc[Proactive Authentication].
+CAUTION: If you plan to use the `@PermissionsAllowed` on the IO thread, review the information in xref:security-proactive-authentication.adoc[Proactive Authentication].
 
 NOTE: `@PermissionsAllowed` is not repeatable on the class level due to a limitation with Quarkus interceptors.
 For more information, see the xref:cdi-reference.adoc#repeatable-interceptor-bindings[Repeatable interceptor bindings] section of the Quarkus "CDI reference" guide.
@@ -715,8 +715,8 @@ CAUTION: Annotation permissions do not work with the custom xref:security-custom
 
 == References
 
-* xref:security-overview-concept.adoc[Quarkus Security overview]
-* xref:security-architecture-concept.adoc[Quarkus Security architecture]
-* xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Other supported authentication mechanisms]
-* xref:security-basic-authentication-concept.adoc[Basic authentication]
+* xref:security-overview.adoc[Quarkus Security overview]
+* xref:security-architecture.adoc[Quarkus Security architecture] 
+* xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
+* xref:security-basic-authentication.adoc[Basic authentication]
 * xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and Jakarta Persistence]

--- a/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
@@ -4,7 +4,7 @@ include::_attributes.adoc[]
 :diataxis-type: howto
 :categories: security
 
-Enable xref:security-basic-authentication-concept.adoc[Basic authentication] for your Quarkus project and allow users to authenticate with a username and password.
+Enable xref:security-basic-authentication.adoc[Basic authentication] for your Quarkus project and allow users to authenticate with a username and password.
 
 == Prerequisites
 
@@ -47,7 +47,7 @@ To walk through how to configure Basic authentication together with Jakarta Pers
 
 == References
 
-* xref:security-overview-concept.adoc[Quarkus Security overview]
-* xref:security-identity-providers-concept.adoc[Identity Providers]
+* xref:security-overview.adoc[Quarkus Security overview]
+* xref:security-identity-providers.adoc[Identity Providers]
 * xref:security-testing.adoc#configuring-user-information[Configuring User Information in application.properties]
-* xref:security-basic-authentication-concept.adoc[Basic authentication] 
+* xref:security-basic-authentication.adoc[Basic authentication] 

--- a/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
@@ -4,10 +4,10 @@ include::_attributes.adoc[]
 :diataxis-type: tutorial
 :categories: security,getting-started
 
-Secure your Quarkus application endpoints by combining the built-in Quarkus xref:security-basic-authentication-concept.adoc[Basic authentication] with the Jakarta Persistence identity provider to enable role-based access control (RBAC).
+Secure your Quarkus application endpoints by combining the built-in Quarkus xref:security-basic-authentication.adoc[Basic authentication] with the Jakarta Persistence identity provider to enable role-based access control (RBAC).
 The Jakarta Persistence `IdentityProvider` creates a `SecurityIdentity` instance, which is used during user authentication to verify and authorize access requests making your Quarkus application secure.
 
-For more information about Jakarta Persistence, see the xref:security-jpa-concept.adoc[Quarkus Security with Jakarta Persistence] section.
+For more information about Jakarta Persistence, see the xref:security-jpa.adoc[Quarkus Security with Jakarta Persistence] section.
 
 This tutorial prepares you for implementing more advanced security mechanisms in Quarkus, for example, how to use the OpenID Connect (OIDC) authentication mechanism.
 
@@ -250,13 +250,13 @@ Please refer to {quickstarts-tree-url}/security-jpa-reactive-quickstart/src/main
 
 === Configure the application
 
-. Enable the built-in Quarkus xref:security-basic-authentication-concept.adoc[Basic authentication] by setting the `quarkus.http.auth.basic` property to `true`:
+. Enable the built-in Quarkus xref:security-basic-authentication.adoc[Basic authentication] by setting the `quarkus.http.auth.basic` property to `true`:
 +
 `quarkus.http.auth.basic`=true`
 +
 [NOTE]
 ====
-When secure access is required and no other authentication mechanisms are enabled, the built-in xref:security-basic-authentication-concept.adoc[Basic authentication] of Quarkus is the fallback authentication mechanism.
+When secure access is required and no other authentication mechanisms are enabled, the built-in xref:security-basic-authentication.adoc[Basic authentication] of Quarkus is the fallback authentication mechanism.
 Therefore, in this tutorial, you do not need to set the property `quarkus.http.auth.basic` to `true`.
 ====
 +
@@ -542,21 +542,21 @@ user
 == What's next
 
 Congratulations!
-You have learned how to create and test a secure Quarkus application by combining the built-in xref:security-basic-authentication-concept.adoc[Basic authentication] in Quarkus with the Jakarta Persistence identity provider.
+You have learned how to create and test a secure Quarkus application by combining the built-in xref:security-basic-authentication.adoc[Basic authentication] in Quarkus with the Jakarta Persistence identity provider.
 
 After you have completed this tutorial, explore some of the more advanced security mechanisms in Quarkus.
 Use the following information to learn how you can securely use `OpenID Connect` to provide secure single sign-on access to your Quarkus endpoints:
 
-* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
-* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
+* xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
 
 == References
 
-* xref:security-overview-concept.adoc[Quarkus Security overview]
-* xref:security-architecture-concept.adoc[Quarkus Security architecture] 
-* xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
-* xref:security-identity-providers-concept.adoc[Identity providers]
-* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
-* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
+* xref:security-overview.adoc[Quarkus Security overview]
+* xref:security-architecture.adoc[Quarkus Security architecture] 
+* xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
+* xref:security-identity-providers.adoc[Identity providers]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
+* xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:hibernate-orm-panache.adoc[Simplified Hibernate ORM with Panache]
 * xref:hibernate-orm.adoc[Using Hibernate ORM and Jakarta Persistence]

--- a/docs/src/main/asciidoc/security-basic-authentication.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication.adoc
@@ -1,4 +1,4 @@
-[id="security-basic-authentication-concept"]
+[id="security-basic-authentication"]
 = Basic authentication
 include::_attributes.adoc[]
 :diataxis-type: concept
@@ -66,8 +66,8 @@ For more information, see xref:security-authorize-web-endpoints-reference.adoc[A
 
 == References
 
-* xref:security-overview-concept.adoc[Quarkus Security overview]
-* xref:security-architecture-concept.adoc[Quarkus Security architecture] 
-* xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
-* xref:security-identity-providers-concept.adoc[Identity providers]
+* xref:security-overview.adoc[Quarkus Security overview]
+* xref:security-architecture.adoc[Quarkus Security architecture] 
+* xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
+* xref:security-identity-providers.adoc[Identity providers]
 * xref:security-authorize-web-endpoints-reference.adoc[Authorization of web endpoints]

--- a/docs/src/main/asciidoc/security-csrf-prevention.adoc
+++ b/docs/src/main/asciidoc/security-csrf-prevention.adoc
@@ -291,4 +291,4 @@ include::{generated-dir}/config/quarkus-csrf-reactive.adoc[leveloffset=+1, opts=
 * https://owasp.org/www-community/attacks/csrf[OWASP Cross-Site Request Forgery]
 * xref:resteasy-reactive.adoc[RESTEasy Reactive]
 * xref:qute-reference.adoc[Qute Reference]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -175,7 +175,7 @@ public class RolesAugmentor implements SecurityIdentityAugmentor {
 }
 ----
 
-Here is another example showing how to use the client certificate available in the current xref:security-authentication-mechanisms-concept.adoc#mutual-TLS-authentication[mutual TLS (mTLS) authentication] request to add more roles:
+Here is another example showing how to use the client certificate available in the current xref:security-authentication-mechanisms.adoc#mutual-TLS-authentication[mutual TLS (mTLS) authentication] request to add more roles:
 
 [source,java]
 ----
@@ -620,7 +620,7 @@ xref:context-propagation.adoc[Context Propagation Guide].
 
 == References
 
-* xref:security-overview-concept.adoc[Quarkus Security overview]
-* xref:security-architecture-concept.adoc[Quarkus Security architecture] 
-* xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
-* xref:security-identity-providers-concept.adoc[Identity providers]
+* xref:security-overview.adoc[Quarkus Security overview]
+* xref:security-architecture.adoc[Quarkus Security architecture] 
+* xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
+* xref:security-identity-providers.adoc[Identity providers]

--- a/docs/src/main/asciidoc/security-identity-providers.adoc
+++ b/docs/src/main/asciidoc/security-identity-providers.adoc
@@ -3,7 +3,7 @@ This document is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-[id="security-identity-providers-concept"]
+[id="security-identity-providers"]
 = Identity providers
 include::_attributes.adoc[]
 :diataxis-type: concept
@@ -24,9 +24,9 @@ To get started with security in Quarkus, we recommend you combine the Quarkus bu
 
 For more information about Basic authentication, its mechanisms, and related identity providers, see the following resources:
 
-* xref:security-jpa-concept.adoc[Quarkus Security with Jakarta Persistence]
+* xref:security-jpa.adoc[Quarkus Security with Jakarta Persistence]
 ** xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and Jakarta Persistence]
-* xref:security-authentication-mechanisms-concept.adoc#form-auth[Form-based authentication]
+* xref:security-authentication-mechanisms.adoc#form-auth[Form-based authentication]
 * xref:security-jdbc.adoc[Using security with JDBC]
 * xref:security-ldap.adoc[Using security with an LDAP realm]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-jdbc.adoc
+++ b/docs/src/main/asciidoc/security-jdbc.adoc
@@ -307,4 +307,4 @@ include::{generated-dir}/config/quarkus-elytron-security-jdbc.adoc[opts=optional
 
 == References
 
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-jpa.adoc
+++ b/docs/src/main/asciidoc/security-jpa.adoc
@@ -1,9 +1,9 @@
-[id="security-jpa-concept"]
+[id="security-jpa"]
 = Quarkus Security with Jakarta Persistence
 include::_attributes.adoc[]
 :categories: security
 
-Quarkus provides a Jakarta Persistence (formerly known as JPA) identity provider, similar to the xref:security-jdbc.adoc[JDBC identity provider], suitable for use with the xref:security-basic-authentication-concept.adoc[Basic] and xref:security-authentication-mechanisms-concept.adoc#form-auth[Form-based] Quarkus Security mechanisms, which require a combination of username and password credentials.
+Quarkus provides a Jakarta Persistence (formerly known as JPA) identity provider, similar to the xref:security-jdbc.adoc[JDBC identity provider], suitable for use with the xref:security-basic-authentication.adoc[Basic] and xref:security-authentication-mechanisms.adoc#form-auth[Form-based] Quarkus Security mechanisms, which require a combination of username and password credentials.
 
 The Jakarta Persistence `IdentityProvider` creates a `SecurityIdentity` instance, which is used during user authentication to verify and authorize access requests making your Quarkus application secure.
 
@@ -176,5 +176,5 @@ However, it is possible to store passwords as plain text with the `@Password(Pas
 == References
 
 * xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and Jakarta Persistence]
-* xref:security-identity-providers-concept.adoc[Identity providers]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-identity-providers.adoc[Identity providers]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-jwt-build.adoc
+++ b/docs/src/main/asciidoc/security-jwt-build.adoc
@@ -346,6 +346,6 @@ SmallRye JWT supports the following properties which can be used to customize th
 * link:https://tools.ietf.org/html/rfc7516[JSON Web Encryption]
 * link:https://tools.ietf.org/html/rfc7518[JSON Web Algorithms]
 * link:https://bitbucket.org/b_c/jose4j/wiki/Home[Jose4J]
-* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
 * xref:security-jwt.adoc[Using Smallrye JWT to Protect Service Applications]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -16,9 +16,9 @@ to verify https://tools.ietf.org/html/rfc7519[JSON Web Token]s, represent them a
 and provide secured access to the Quarkus HTTP endpoints using Bearer Token Authorization and https://en.wikipedia.org/wiki/Role-based_access_control[Role-Based Access Control].
 
 NOTE: Quarkus OpenID Connect `quarkus-oidc` extension also supports Bearer Token Authorization and uses `smallrye-jwt` to represent the bearer tokens as `JsonWebToken`.
-For more information, read the xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication] guide.
+For more information, read the xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication] guide.
 OpenID Connect extension has to be used if the Quarkus application needs to authenticate the users using OIDC Authorization Code Flow.
-For more information, see xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
+For more information, see xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
 
 == Prerequisites
 
@@ -804,7 +804,7 @@ Please see the xref:security-openid-connect-client.adoc#token-propagation[Token 
 [[integration-testing-wiremock]]
 ==== Wiremock
 
-If you configure `mp.jwt.verify.publickey.location` to point to HTTPS or HTTP based JsonWebKey (JWK) set then you can use the same approach as described in the xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] `Wiremock` section but only change the `application.properties` to use MP JWT configuration properties instead:
+If you configure `mp.jwt.verify.publickey.location` to point to HTTPS or HTTP based JsonWebKey (JWK) set then you can use the same approach as described in the xref:security-oidc-bearer-token-authentication.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] `Wiremock` section but only change the `application.properties` to use MP JWT configuration properties instead:
 
 [source, properties]
 ----
@@ -816,7 +816,7 @@ mp.jwt.verify.issuer=${keycloak.url}/realms/quarkus
 [[integration-testing-keycloak]]
 ==== Keycloak
 
-If you work with Keycloak and configure `mp.jwt.verify.publickey.location` to point to HTTPS or HTTP based JsonWebKey (JWK) set then you can use the same approach as described in the xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] Keycloak section but only change the `application.properties` to use MP JWT configuration properties instead:
+If you work with Keycloak and configure `mp.jwt.verify.publickey.location` to point to HTTPS or HTTP based JsonWebKey (JWK) set then you can use the same approach as described in the xref:security-oidc-bearer-token-authentication.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] Keycloak section but only change the `application.properties` to use MP JWT configuration properties instead:
 
 [source, properties]
 ----
@@ -844,7 +844,7 @@ mp.jwt.verify.issuer=${client.quarkus.oidc.auth-server-url}
 [[integration-testing-public-key]]
 ==== Local Public Key
 
-You can use the same approach as described in the xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] `Local Public Key` section but only change the `application.properties` to use MP JWT configuration properties instead:
+You can use the same approach as described in the xref:security-oidc-bearer-token-authentication.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] `Local Public Key` section but only change the `application.properties` to use MP JWT configuration properties instead:
 
 [source, properties]
 ----
@@ -977,7 +977,7 @@ quarkus.log.category."io.quarkus.smallrye.jwt.runtime.auth.MpJwtValidator".min-l
 
 === Proactive Authentication
 
-If you'd like to skip the token verification when the public endpoint methods are invoked, disable the xref:security-proactive-authentication-concept.adoc[proactive authentication].
+If you'd like to skip the token verification when the public endpoint methods are invoked, disable the xref:security-proactive-authentication.adoc[proactive authentication].
 
 Note that you can't access the injected `JsonWebToken` in the public methods if the token verification has not been done.
 
@@ -1094,5 +1094,5 @@ SmallRye JWT provides more properties which can be used to customize the token p
 * link:https://tools.ietf.org/html/rfc7516[JSON Web Encryption]
 * link:https://tools.ietf.org/html/rfc7518[JSON Web Algorithms]
 * xref:security-jwt-build.adoc[Sign and encrypt JWT tokens with SmallRye JWT Build]
-* xref:security-authentication-mechanisms-concept.adoc#combining-authentication-mechanisms[Combining authentication mechanisms]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-authentication-mechanisms.adoc#combining-authentication-mechanisms[Combining authentication mechanisms]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
@@ -201,7 +201,7 @@ include::{generated-dir}/config/quarkus-keycloak-admin-client.adoc[leveloffset=+
 
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * xref:security-keycloak-authorization.adoc[Keycloak Authorization extension]
-* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
-* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
 * xref:security-openid-connect-client.adoc[OpenID Connect Client and Token Propagation Quickstart]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -10,7 +10,7 @@ include::_attributes.adoc[]
 
 This guide demonstrates how your Quarkus application can authorize a bearer token access to protected resources using https://www.keycloak.org/docs/latest/authorization_services/index.html[Keycloak Authorization Services].
 
-The `quarkus-keycloak-authorization` extension is based on `quarkus-oidc` and provides a policy enforcer that enforces access to protected resources based on permissions managed by Keycloak and currently can only be used with the Quarkus xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC service applications].
+The `quarkus-keycloak-authorization` extension is based on `quarkus-oidc` and provides a policy enforcer that enforces access to protected resources based on permissions managed by Keycloak and currently can only be used with the Quarkus xref:security-oidc-bearer-token-authentication.adoc[OIDC service applications].
 
 It provides a flexible and dynamic authorization capability based on Resource-Based Access Control.
 
@@ -20,7 +20,7 @@ Use `quarkus-keycloak-authorization` only if you work with Keycloak and have Key
 
 By externalizing authorization from your application, you are allowed to protect your applications using different access control mechanisms as well as avoid re-deploying your application every time your security requirements change, where Keycloak will be acting as a centralized authorization service from where your protected resources and their associated permissions are managed.
 
-See the xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication] guide for more information about `Bearer Token` authentication mechanism. It is important to realize that it is the `Bearer Token` authentication mechanism which does the authentication and creates a security identity - while the `quarkus-keycloak-authorization` extension is responsible for applying a Keycloak Authorization Policy to this identity based on the current request path and other policy settings.
+See the xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication] guide for more information about `Bearer Token` authentication mechanism. It is important to realize that it is the `Bearer Token` authentication mechanism which does the authentication and creates a security identity - while the `quarkus-keycloak-authorization` extension is responsible for applying a Keycloak Authorization Policy to this identity based on the current request path and other policy settings.
 
 Please see https://www.keycloak.org/docs/latest/authorization_services/index.html#_enforcer_overview[Keycloak Authorization Services documentation] for more information.
 
@@ -361,7 +361,7 @@ Note that, depending on how many resources you have in Keycloak the time taken t
 
 In the default configuration, Keycloak is responsible for managing the roles and deciding who can access which routes.
 
-To configure the protected routes using the `@RolesAllowed` annotation or the `application.properties` file, check the xref:security-oidc-bearer-token-authentication-concept.adoc[Using OpenID Connect Adapter to Protect Jakarta REST Applications] and xref:security-authorize-web-endpoints-reference.adoc[Security Authorization] guides. For more details, check the xref:security-overview-concept.adoc[Security guide].
+To configure the protected routes using the `@RolesAllowed` annotation or the `application.properties` file, check the xref:security-oidc-bearer-token-authentication.adoc[Using OpenID Connect Adapter to Protect Jakarta REST Applications] and xref:security-authorize-web-endpoints-reference.adoc[Security Authorization] guides. For more details, check the xref:security-overview.adoc[Security guide].
 
 == Access to Public Resources
 
@@ -531,5 +531,5 @@ include::{generated-dir}/config/quarkus-keycloak-keycloak-policy-enforcer-config
 * https://www.keycloak.org/docs/latest/authorization_services/index.html[Keycloak Authorization Services Documentation]
 * https://openid.net/connect/[OpenID Connect]
 * https://tools.ietf.org/html/rfc7519[JSON Web Token]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-overview.adoc[Quarkus Security overview]
 * xref:security-keycloak-admin-client.adoc[Quarkus Keycloak Admin Client]

--- a/docs/src/main/asciidoc/security-ldap.adoc
+++ b/docs/src/main/asciidoc/security-ldap.adoc
@@ -252,4 +252,4 @@ include::{generated-dir}/config/quarkus-elytron-security-ldap.adoc[opts=optional
 == References
 
 * https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol[LDAP]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -16,8 +16,8 @@ It can be used to implement an application authentication mechanism based on tok
 
 This extension provides a light-weight support for using the opaque Bearer Tokens and validating them by calling an introspection endpoint.
 
-If the OAuth2 Authentication server provides JWT Bearer Tokens, consider using either xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication] or xref:security-jwt.adoc[SmallRye JWT] extensions instead.
-OpenID Connect extension has to be used if the Quarkus application needs to authenticate the users using OIDC Authorization Code Flow. For more information, see the xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications] guide.
+If the OAuth2 Authentication server provides JWT Bearer Tokens, consider using either xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication] or xref:security-jwt.adoc[SmallRye JWT] extensions instead.
+OpenID Connect extension has to be used if the Quarkus application needs to authenticate the users using OIDC Authorization Code Flow. For more information, see the xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications] guide.
 
 include::{includes}/extension-status.adoc[]
 
@@ -84,7 +84,7 @@ public class TokenSecuredResource {
 
 This is a basic REST endpoint that does not have any of the {extension-name} specific features, so let's add some.
 
-We will use the JSR 250 common security annotations, they are described in the xref:security-overview-concept.adoc[Using Security] guide.
+We will use the JSR 250 common security annotations, they are described in the xref:security-overview.adoc[Using Security] guide.
 
 [source,java]
 ----
@@ -451,7 +451,7 @@ class TokenSecuredResourceTest {
 == References
 
 * https://tools.ietf.org/html/rfc6749[OAuth2]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-overview.adoc[Quarkus Security overview]
 
 [[config-reference]]
 == Configuration Reference

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
@@ -12,7 +12,7 @@ include::_attributes.adoc[]
 Here, you use the Quarkus OpenID Connect (OIDC) extension to secure a Jakarta REST application using Bearer authentication.
 The bearer tokens are issued by OIDC and OAuth 2.0 compliant authorization servers, such as link:https://www.keycloak.org[Keycloak].
 
-To better understand OIDC Bearer authentication, see xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication].
+To better understand OIDC Bearer authentication, see xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication].
 
 == Prerequisites
 
@@ -312,18 +312,18 @@ export access_token=$(\
  )
 ----
 
-Please also see the xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing-keycloak-devservices[OIDC Bearer authentication, Dev Services for Keycloak] section, about writing the integration tests which depend on `Dev Services for Keycloak`.
+Please also see the xref:security-oidc-bearer-token-authentication.adoc#integration-testing-keycloak-devservices[OIDC Bearer authentication, Dev Services for Keycloak] section, about writing the integration tests which depend on `Dev Services for Keycloak`.
 
 == References
 
 * xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties]
-* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
 * link:https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * link:https://openid.net/connect/[OpenID Connect]
 * link:https://tools.ietf.org/html/rfc7519[JSON Web Token]
 * xref:security-openid-connect-client-reference.adoc[OpenID Connect and OAuth2 Client and Filters Reference Guide]
 * xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak]
 * xref:security-jwt-build.adoc[Sign and encrypt JWT tokens with SmallRye JWT Build]
-* xref:security-authentication-mechanisms-concept.adoc#combining-authentication-mechanisms[Combining authentication mechanisms]
-* xref:security-overview-concept.adoc[Quarkus Security]
+* xref:security-authentication-mechanisms.adoc#combining-authentication-mechanisms[Combining authentication mechanisms]
+* xref:security-overview.adoc[Quarkus Security]
 * xref:security-keycloak-admin-client.adoc[Quarkus Keycloak Admin Client]

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-[id="security-oidc-bearer-token-authentication-concept"]
+[id="security-oidc-bearer-token-authentication"]
 = OpenID Connect (OIDC) Bearer authentication
 include::_attributes.adoc[]
 :diataxis-type: concept
@@ -40,7 +40,7 @@ image::security-bearer-token-authorization-mechanism-2.png[alt=Bearer authentica
 3. The Client uses the access token to retrieve the service data from the Quarkus service.
 4. The Quarkus service verifies the bearer access token signature using the verification keys, checks the token expiry date and other claims, allows the request to proceed if the token is valid, and returns the service response to the Client.
 
-If you need to authenticate and authorize the users using OpenID Connect Authorization Code Flow, see xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications].
+If you need to authenticate and authorize the users using OpenID Connect Authorization Code Flow, see xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications].
 Also, if you use Keycloak and bearer tokens, see xref:security-keycloak-authorization.adoc[Using Keycloak to Centralize Authorization].
 
 For information about how to support multiple tenants, see xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect Multi-Tenancy].
@@ -317,7 +317,7 @@ Please see xref:security-openid-connect-client-reference.adoc#token-propagation[
 [[oidc-provider-authentication]]
 === Oidc Provider Client Authentication
 
-`quarkus.oidc.runtime.OidcProviderClient` is used when a remote request to an OpenID Connect Provider has to be done. If the bearer token has to be introspected then `OidcProviderClient` has to authenticate to the OpenID Connect Provider. Please see xref:security-oidc-code-flow-authentication-concept.adoc#oidc-provider-client-authentication[OidcProviderClient Authentication] for more information about all the supported authentication options.
+`quarkus.oidc.runtime.OidcProviderClient` is used when a remote request to an OpenID Connect Provider has to be done. If the bearer token has to be introspected then `OidcProviderClient` has to authenticate to the OpenID Connect Provider. Please see xref:security-oidc-code-flow-authentication.adoc#oidc-provider-client-authentication[OidcProviderClient Authentication] for more information about all the supported authentication options.
 
 [[integration-testing]]
 === Testing
@@ -920,7 +920,7 @@ Note Quarkus `web-app` applications always require `quarkus.oidc.client-id` prop
 * xref:security-openid-connect-client-reference.adoc[OpenID Connect and OAuth2 Client and Filters Reference Guide]
 * xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak]
 * xref:security-jwt-build.adoc[Sign and encrypt JWT tokens with SmallRye JWT Build]
-* xref:security-authentication-mechanisms-concept.adoc#oidc-jwt-oauth2-comparison[Choosing between OpenID Connect, SmallRye JWT, and OAuth2 authentication mechanisms]
-* xref:security-authentication-mechanisms-concept.adoc#combining-authentication-mechanisms[Combining authentication mechanisms]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-authentication-mechanisms.adoc#oidc-jwt-oauth2-comparison[Choosing between OpenID Connect, SmallRye JWT, and OAuth2 authentication mechanisms]
+* xref:security-authentication-mechanisms.adoc#combining-authentication-mechanisms[Combining authentication mechanisms]
+* xref:security-overview.adoc[Quarkus Security overview]
 * xref:security-keycloak-admin-client.adoc[Quarkus Keycloak Admin Client]

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -6,9 +6,9 @@ include::_attributes.adoc[]
 
 With the Quarkus OpenID Connect (OIDC) extension, you can protect application HTTP endpoints by using the OIDC Authorization Code Flow mechanism.
 
-To learn more about the OIDC authorization code flow mechanism, see xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications].
+To learn more about the OIDC authorization code flow mechanism, see xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications].
 To learn about how well-known social providers such as Google, GitHub, Microsoft, Twitter, Apple, Facebook, and Spotify can be used with Quarkus OIDC, see xref:security-openid-connect-providers.adoc[Configuring Well-Known OpenID Connect Providers].
-See also, xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus].
+See also, xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus].
 
 == Prerequisites
 
@@ -243,22 +243,22 @@ To authenticate to the application, type the following credentials when at the K
 
 After clicking the `Login` button, you are redirected back to the application.
 
-For more information about writing the integration tests that depend on `Dev Services for Keycloak`, see the <<security-oidc-code-flow-authentication-concept.adoc#integration-testing-keycloak-devservices, Dev Services for Keycloak>> section.
+For more information about writing the integration tests that depend on `Dev Services for Keycloak`, see the <<security-oidc-code-flow-authentication.adoc#integration-testing-keycloak-devservices, Dev Services for Keycloak>> section.
 
 == Summary
 
 Congratulations!
 You have learned how to set up and use the OIDC authorization code flow mechanism to protect and test application HTTP endpoints.
-After you have completed this tutorial, explore xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication] and xref:security-authentication-mechanisms-concept.adoc[other authentication mechanisms].
+After you have completed this tutorial, explore xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication] and xref:security-authentication-mechanisms.adoc[other authentication mechanisms].
 
 == References
-* xref:security-overview-concept.adoc[Quarkus Security overview]
-* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
+* xref:security-overview.adoc[Quarkus Security overview]
+* xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:security-openid-connect-providers.adoc[Configuring well-known OpenID Connect Providers]
 * xref:security-openid-connect-client-reference.adoc[OpenID Connect and OAuth2 Client and Filters Reference Guide]
 * xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak]
 * xref:security-jwt-build.adoc[Sign and encrypt JWT tokens with SmallRye JWT Build]
-* xref:security-authentication-mechanisms-concept.adoc#oidc-jwt-oauth2-comparison[Choosing between OpenID Connect, SmallRye JWT, and OAuth2 authentication mechanisms]
+* xref:security-authentication-mechanisms.adoc#oidc-jwt-oauth2-comparison[Choosing between OpenID Connect, SmallRye JWT, and OAuth2 authentication mechanisms]
 * xref:security-keycloak-admin-client.adoc[Quarkus Keycloak Admin Client]
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * https://openid.net/connect/[OpenID Connect]

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -3,7 +3,7 @@ This document is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-[id="security-oidc-code-flow-authentication-concept"]
+[id="security-oidc-code-flow-authentication"]
 = OpenID Connect authorization code flow mechanism for protecting web applications
 include::_attributes.adoc[]
 :diataxis-type: concept
@@ -42,7 +42,7 @@ See also the xref:security-oidc-configuration-properties-reference.adoc[OIDC con
 
 To learn about how you can protect web applications by using the OIDC authorization code flow mechanism, see xref:security-oidc-code-flow-authentication-tutorial.adoc[Protect a web application by using OIDC authorization code flow]
 
-If you want to protect your applications by using Bearer Token authentication, see xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication].
+If you want to protect your applications by using Bearer Token authentication, see xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication].
 For information about how to support multiple tenants, see xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect Multi-Tenancy].
 
 == Using the authorization code flow mechanism
@@ -414,7 +414,7 @@ The default tenant's `OidcConfigurationMetadata` is injected if the endpoint is 
 [[token-claims-roles]]
 ==== Mapping token claims and `SecurityIdentity` roles
 
-The way the roles are mapped to the SecurityIdentity roles from the verified tokens is identical to how it is done for the xref:security-oidc-bearer-token-authentication-concept.adoc[Bearer tokens] with the only difference being that https://openid.net/specs/openid-connect-core-1_0.html#IDToken[ID Token] is used as a source of the roles by default.
+The way the roles are mapped to the SecurityIdentity roles from the verified tokens is identical to how it is done for the xref:security-oidc-bearer-token-authentication.adoc[Bearer tokens] with the only difference being that https://openid.net/specs/openid-connect-core-1_0.html#IDToken[ID Token] is used as a source of the roles by default.
 
 [NOTE]
 ====
@@ -438,7 +438,7 @@ This is done by ensuring tokens are trustable.
 [[token-verification-introspection]]
 ==== Token verification and introspection
 
-The verification process of OIDC authorization code flow tokens follows the bearer authentication token verification and introspection logic. For more information, see the xref:security-oidc-bearer-token-authentication-concept.adoc#token-verification-introspection[Token Verification And Introspection] section of the "Quarkus OpenID Connect (OIDC) Bearer authentication" guide.
+The verification process of OIDC authorization code flow tokens follows the bearer authentication token verification and introspection logic. For more information, see the xref:security-oidc-bearer-token-authentication.adoc#token-verification-introspection[Token Verification And Introspection] section of the "Quarkus OpenID Connect (OIDC) Bearer authentication" guide.
 
 [NOTE]
 --
@@ -453,12 +453,12 @@ Code flow access tokens are not introspected unless they are expected to be the 
 They will however be used to get `UserInfo`.
 There will be one or two remote calls with the code flow access token, if the token introspection and/or `UserInfo` are required.
 
-Please see xref:security-oidc-bearer-token-authentication-concept.adoc#token-introspection-userinfo-cache[Token Introspection and UserInfo cache] for more information about using a default token cache or registering a custom cache implementation.
+Please see xref:security-oidc-bearer-token-authentication.adoc#token-introspection-userinfo-cache[Token Introspection and UserInfo cache] for more information about using a default token cache or registering a custom cache implementation.
 
 [[jwt-claim-verification]]
 ==== JSON web token claim verification
 
-Please see xref:security-oidc-bearer-token-authentication-concept.adoc#jwt-claim-verification[JSON Web Token Claim verification] section about the claim verification, including the `iss` (issuer) claim.
+Please see xref:security-oidc-bearer-token-authentication.adoc#jwt-claim-verification[JSON Web Token Claim verification] section about the claim verification, including the `iss` (issuer) claim.
 It applies to ID tokens but also to access tokens in a JWT format if the `web-app` application has requested the access token verification.
 
 ==== Further security with Proof Key for Code Exchange (PKCE)
@@ -804,7 +804,7 @@ If set to `true`, when the current ID token expires, a refresh token grant will 
 
 [TIP]
 --
-If you have a xref:security-oidc-bearer-token-authentication-concept.adoc#single-page-applications[single page application for service applications] where your OIDC provider script such as `keycloak.js` is managing an authorization code flow then that script will also control the SPA authentication session lifespan.
+If you have a xref:security-oidc-bearer-token-authentication.adoc#single-page-applications[single page application for service applications] where your OIDC provider script such as `keycloak.js` is managing an authorization code flow then that script will also control the SPA authentication session lifespan.
 --
 
 If you work with a Quarkus OIDC `web-app` application, then it is the Quarkus OIDC code authentication mechanism that is managing the user session lifespan.
@@ -884,7 +884,7 @@ For GitHub, since it does not have an introspection endpoint, requesting the Use
 ====
 Requiring <<user-info,UserInfo>> involves making a remote call on every request.
 Therefore, you might want to consider caching `UserInfo` data.
-For more information, see the xref:security-oidc-bearer-token-authentication-concept.adoc#token-introspection-userinfo-cache[Token Introspection and UserInfo cache] section of the "OpenID Connect (OIDC) Bearer authentication" guide.
+For more information, see the xref:security-oidc-bearer-token-authentication.adoc#token-introspection-userinfo-cache[Token Introspection and UserInfo cache] section of the "OpenID Connect (OIDC) Bearer authentication" guide.
 
 Alternatively, you may want to request that `UserInfo` is embedded into the internal generated `IdToken` with the `quarkus.oidc.cache-user-info-in-idtoken=true` property - the advantage of this approach is that by default no cached `UserInfo` state will be kept with the endpoint - instead it will be stored in a session cookie. You may also want to consider encrypting `IdToken` in this case if `UserInfo` contains sensitive data. For more information, see <<token-state-manager,Encrypt tokens with TokenStateManager>>.
 ====
@@ -1066,7 +1066,7 @@ This section discusses these considerations.
 
 === Single-page applications
 
-You can check if implementing single-page applications (SPAs) the way it is suggested in the xref:security-oidc-bearer-token-authentication-concept.adoc#single-page-applications[Single-page applications] section of the "OpenID Connect (OIDC) Bearer authentication" guide meets your requirements.
+You can check if implementing single-page applications (SPAs) the way it is suggested in the xref:security-oidc-bearer-token-authentication.adoc#single-page-applications[Single-page applications] section of the "OpenID Connect (OIDC) Bearer authentication" guide meets your requirements.
 
 If you prefer to use SPAs and JavaScript APIs such as `Fetch` or `XMLHttpRequest`(XHR) with Quarkus web applications, be aware that OpenID Connect providers might not support cross-origin resource sharing (CORS) for authorization endpoints where the users are authenticated after a redirect from Quarkus. 
 This will lead to authentication failures if the Quarkus application and the OpenID Connect provider are hosted on different HTTP domains, ports, or both.
@@ -1379,7 +1379,7 @@ Default realm name is `quarkus` and client id - `quarkus-web-app` - set `keycloa
 [[integration-testing-security-annotation]]
 === TestSecurity annotation
 
-See xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing-security-annotation[Use TestingSecurity with injected JsonWebToken] section for more information about using `@TestSecurity` and `@OidcSecurity` annotations for testing the `web-app` application endpoint code which depends on the injected ID and access `JsonWebToken` as well as `UserInfo` and `OidcConfigurationMetadata`.
+See xref:security-oidc-bearer-token-authentication.adoc#integration-testing-security-annotation[Use TestingSecurity with injected JsonWebToken] section for more information about using `@TestSecurity` and `@OidcSecurity` annotations for testing the `web-app` application endpoint code which depends on the injected ID and access `JsonWebToken` as well as `UserInfo` and `OidcConfigurationMetadata`.
 
 === Checking errors in the logs
 
@@ -1407,9 +1407,9 @@ You can also from `quarkus dev` console hit `j` to change the application global
 * xref:security-openid-connect-providers.adoc[Configuring well-known OpenID Connect Providers]
 * xref:security-openid-connect-client-reference.adoc[OpenID Connect and OAuth2 Client and Filters Reference Guide]
 * xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak]
-* xref:security-authentication-mechanisms-concept.adoc#oidc-jwt-oauth2-comparison[Choosing between OpenID Connect, SmallRye JWT, and OAuth2 authentication mechanisms]
-* xref:security-authentication-mechanisms-concept.adoc#combining-authentication-mechanisms[Combining authentication mechanisms]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-authentication-mechanisms.adoc#oidc-jwt-oauth2-comparison[Choosing between OpenID Connect, SmallRye JWT, and OAuth2 authentication mechanisms]
+* xref:security-authentication-mechanisms.adoc#combining-authentication-mechanisms[Combining authentication mechanisms]
+* xref:security-overview.adoc[Quarkus Security overview]
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * https://openid.net/connect/[OpenID Connect]
 * https://tools.ietf.org/html/rfc7519[JSON Web Token]

--- a/docs/src/main/asciidoc/security-oidc-configuration-properties-reference.adoc
+++ b/docs/src/main/asciidoc/security-oidc-configuration-properties-reference.adoc
@@ -15,7 +15,7 @@ include::{generated-dir}/config/quarkus-oidc.adoc[opts=optional, leveloffset=+1]
 
 == References
 
-* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
 * xref:security-oidc-bearer-token-authentication-tutorial.adoc[Protect a service application by using OpenID Connect (OIDC) bearer authentication]
 // * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * https://openid.net/connect/[OpenID Connect]
@@ -23,8 +23,8 @@ include::{generated-dir}/config/quarkus-oidc.adoc[opts=optional, leveloffset=+1]
 * xref:security-openid-connect-client-reference.adoc[OpenID Connect and OAuth2 Client and Filters Reference Guide]
 // * xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak]
 // * xref:security-jwt-build.adoc[Sign and encrypt JWT tokens with SmallRye JWT Build]
-* xref:security-authentication-mechanisms-concept.adoc#oidc-jwt-oauth2-comparison[Choosing between OpenID Connect, SmallRye JWT, and OAuth2 authentication mechanisms]
-* xref:security-authentication-mechanisms-concept.adoc#combining-authentication-mechanisms[Combining authentication mechanisms]
-* xref:security-overview-concept.adoc[Quarkus Security]
+* xref:security-authentication-mechanisms.adoc#oidc-jwt-oauth2-comparison[Choosing between OpenID Connect, SmallRye JWT, and OAuth2 authentication mechanisms]
+* xref:security-authentication-mechanisms.adoc#combining-authentication-mechanisms[Combining authentication mechanisms]
+* xref:security-overview.adoc[Quarkus Security]
 // * xref:security-keycloak-admin-client.adoc[Quarkus Keycloak Admin Client]
 // TASK - Select some references and eliminate the rest.

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -125,7 +125,7 @@ and then you can use `OidcClient.refreshTokens` method with a provided refresh t
 
 Using the `urn:ietf:params:oauth:grant-type:token-exchange` or `urn:ietf:params:oauth:grant-type:jwt-bearer` grants may be required if you are building a complex microservices application and would like to avoid the same `Bearer` token be propagated to and used by more than one service. Please see <<token-propagation-reactive,Token Propagation in MicroProfile RestClient Reactive filter>> and <<token-propagation,Token Propagation in MicroProfile RestClient filter>> for more details.
 
-Using `OidcClient` to support the `authorization code` grant might be required if for some reason you cannot use the xref:security-oidc-code-flow-authentication-concept.adoc[Quarkus OIDC extension] to support Authorization Code Flow. If there is a very good reason for you to implement Authorization Code Flow then you can configure `OidcClient` as follows:
+Using `OidcClient` to support the `authorization code` grant might be required if for some reason you cannot use the xref:security-oidc-code-flow-authentication.adoc[Quarkus OIDC extension] to support Authorization Code Flow. If there is a very good reason for you to implement Authorization Code Flow then you can configure `OidcClient` as follows:
 
 [source,properties]
 ----
@@ -838,7 +838,7 @@ and finally write the test code. Given the Wiremock-based resource above, the fi
 
 ==== Keycloak
 
-If you work with Keycloak then you can use the same approach as described in the xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing-keycloak[OpenID Connect Bearer Token Integration testing] Keycloak section.
+If you work with Keycloak then you can use the same approach as described in the xref:security-oidc-bearer-token-authentication.adoc#integration-testing-keycloak[OpenID Connect Bearer Token Integration testing] Keycloak section.
 
 === How to check the errors in the logs
 
@@ -861,7 +861,7 @@ quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".min-lev
 [[token-propagation-reactive]]
 == Token Propagation Reactive
 
-The `quarkus-oidc-token-propagation-reactive` extension provides RestEasy Reactive Client `io.quarkus.oidc.token.propagation.reactive.AccessTokenRequestReactiveFilter` that simplifies the propagation of authentication information by propagating the xref:security-oidc-bearer-token-authentication-concept.adoc[Bearer token] present in the current active request or the token acquired from the xref:security-oidc-code-flow-authentication-concept.adoc[Authorization code flow mechanism], as the HTTP `Authorization` header's `Bearer` scheme value.
+The `quarkus-oidc-token-propagation-reactive` extension provides RestEasy Reactive Client `io.quarkus.oidc.token.propagation.reactive.AccessTokenRequestReactiveFilter` that simplifies the propagation of authentication information by propagating the xref:security-oidc-bearer-token-authentication.adoc[Bearer token] present in the current active request or the token acquired from the xref:security-oidc-code-flow-authentication.adoc[Authorization code flow mechanism], as the HTTP `Authorization` header's `Bearer` scheme value.
 
 You can selectively register `AccessTokenRequestReactiveFilter` by using either `io.quarkus.oidc.token.propagation.AccessToken` or `org.eclipse.microprofile.rest.client.annotation.RegisterProvider` annotation, for example:
 
@@ -937,7 +937,7 @@ quarkus.oidc-token-propagation-reactive.exchange-token=true
 == Token Propagation
 
 The `quarkus-oidc-token-propagation` extension provides two Jakarta REST `jakarta.ws.rs.client.ClientRequestFilter` class implementations that simplify the propagation of authentication information.
-`io.quarkus.oidc.token.propagation.AccessTokenRequestFilter` propagates the xref:security-oidc-bearer-token-authentication-concept.adoc[Bearer token] present in the current active request or the token acquired from the xref:security-oidc-code-flow-authentication-concept.adoc[Authorization code flow mechanism], as the HTTP `Authorization` header's `Bearer` scheme value.
+`io.quarkus.oidc.token.propagation.AccessTokenRequestFilter` propagates the xref:security-oidc-bearer-token-authentication.adoc[Bearer token] present in the current active request or the token acquired from the xref:security-oidc-code-flow-authentication.adoc[Authorization code flow mechanism], as the HTTP `Authorization` header's `Bearer` scheme value.
 The `io.quarkus.oidc.token.propagation.JsonWebTokenRequestFilter` provides the same functionality, but in addition provides support for JWT tokens.
 
 When you need to propagate the current Authorization Code Flow access token then the immediate token propagation will work well - as the code flow access tokens (as opposed to ID tokens) are meant to be propagated for the current Quarkus endpoint to access the remote services on behalf of the currently authenticated user.
@@ -1085,7 +1085,7 @@ As already noted above, please use `AccessTokenRequestFilter` if you work with K
 [[integration-testing-token-propagation]]
 === Testing
 
-You can generate the tokens as described in xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] section.
+You can generate the tokens as described in xref:security-oidc-bearer-token-authentication.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] section.
 Prepare the REST test endpoints, you can have the test frontend endpoint which uses the injected MP REST client with a registered token propagation filter to invoke on the downstream endpoint, for example, see the `integration-tests/oidc-token-propagation` in the `main` Quarkus repository.
 
 [[reactive-token-propagation]]
@@ -1109,6 +1109,6 @@ However, these features may be added in the future.
 == References
 
 * xref:security-openid-connect-client.adoc[OpenID Connect Client and Token Propagation Quickstart]
-* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
-* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
+* xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -12,7 +12,7 @@ This quickstart demonstrates how to use `OpenID Connect Client Reactive Filter` 
 
 Please check xref:security-openid-connect-client-reference.adoc[OpenID Connect Client and Token Propagation Reference Guide] for all the information related to `Oidc Client` and `Token Propagation` support in Quarkus.
 
-Please also read xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication] guide if you need to protect your applications using Bearer Token Authorization.
+Please also read xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication] guide if you need to protect your applications using Bearer Token Authorization.
 
 == Prerequisites
 
@@ -501,5 +501,5 @@ will return `403` status code.
 == References
 
 * xref:security-openid-connect-client-reference.adoc[OpenID Connect Client and Token Propagation Reference Guide]
-* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -67,7 +67,7 @@ Click on the `Provider: Keycloak` link, and you will see a Keycloak page which w
 [[develop-service-applications]]
 === Developing Service Applications
 
-By default, the Keycloak page can be used to support the development of a xref:security-oidc-bearer-token-authentication-concept.adoc[Quarkus OIDC service application].
+By default, the Keycloak page can be used to support the development of a xref:security-oidc-bearer-token-authentication.adoc[Quarkus OIDC service application].
 
 [[keycloak-authorization-code-grant]]
 ==== Authorization Code Grant
@@ -179,7 +179,7 @@ Select a realm, enter the client id and secret, a relative service endpoint path
 [[develop-web-app-applications]]
 === Developing OpenID Connect Web App Applications
 
-If you develop a xref:security-oidc-code-flow-authentication-concept.adoc[Quarkus OIDC web-app application], then you should set `quarkus.oidc.application-type=web-app` in `application.properties` before starting the application.
+If you develop a xref:security-oidc-code-flow-authentication.adoc[Quarkus OIDC web-app application], then you should set `quarkus.oidc.application-type=web-app` in `application.properties` before starting the application.
 
 You will see a screen like this one:
 
@@ -217,7 +217,7 @@ It will ensure that if you access the application from the browser in dev mode, 
 You can run the tests against a Keycloak container started in a test mode in a xref:continuous-testing.adoc[Continuous Testing] mode.
 
 It is also recommended to run the integration tests against Keycloak using `Dev Services for Keycloak`.
-For more information, see xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing-keycloak-devservices[Testing OpenID onnect Service Applications with Dev Services] and xref:security-oidc-code-flow-authentication-concept.adoc#integration-testing-keycloak-devservices[Testing OpenID Connect WebApp Applications with Dev Services].
+For more information, see xref:security-oidc-bearer-token-authentication.adoc#integration-testing-keycloak-devservices[Testing OpenID onnect Service Applications with Dev Services] and xref:security-oidc-code-flow-authentication.adoc#integration-testing-keycloak-devservices[Testing OpenID Connect WebApp Applications with Dev Services].
 
 [[keycloak-initialization]]
 === Keycloak Initialization
@@ -317,7 +317,7 @@ If you work with other providers then a Dev UI experience described in the <<key
 The current access token is used by default to test the service with `Swagger UI` or `GrapghQL UI`. If the provider (other than Keycloak) returns a binary access token then it will be used with `Swagger UI` or `GrapghQL UI` only if this provider has a token introspection endpoint otherwise an `IdToken` which is always in a JWT format will be passed to `Swagger UI` or `GrapghQL UI`. In such cases you can verify with the manual Dev UI test that `401` will always be returned for the current binary access token. Also note that using `IdToken` as a fallback with either of these UIs is only possible with the authorization code flow.
 ====
 
-Some providers such as `Auth0` do not support a standard RP initiated logout so the provider specific logout properties will have to be configured for a logout option be visible. For more information, see xref:security-oidc-code-flow-authentication-concept.adoc#user-initiated-logout[OpenID Connect User-Initiated Logout].
+Some providers such as `Auth0` do not support a standard RP initiated logout so the provider specific logout properties will have to be configured for a logout option be visible. For more information, see xref:security-oidc-code-flow-authentication.adoc#user-initiated-logout[OpenID Connect User-Initiated Logout].
 
 Similarly, if you'd like to use a `password` or `client_credentials` grant for Dev UI to acquire the tokens then you may have to configure some extra provider specific properties, for example:
 
@@ -413,6 +413,6 @@ This document refers to the `http://localhost:8080/q/dev-v1` Dev UI URL in sever
 * xref:dev-ui.adoc[Dev UI]
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * https://openid.net/connect/[OpenID Connect]
-* xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication]
-* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
+* xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -12,9 +12,9 @@ This guide demonstrates how your OpenID Connect (OIDC) application can support m
 
 When serving multiple customers from the same application (e.g.: SaaS), each customer is a tenant. By enabling multi-tenancy support to your applications you are allowed to also support distinct authentication policies for each tenant even though if that means authenticating against different OpenID Providers, such as Keycloak and Google.
 
-Please read the xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication] guide if you need to authorize a tenant using Bearer Token Authorization.
+Please read the xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication] guide if you need to authorize a tenant using Bearer Token Authorization.
 
-If you need to authenticate and authorize a tenant using OpenID Connect Authorization Code Flow, read the xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications] guide.
+If you need to authenticate and authorize a tenant using OpenID Connect Authorization Code Flow, read the xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications] guide.
 
 Also see the xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties] reference guide.
 
@@ -588,7 +588,7 @@ annotation per tenant ID other than default:
 
 [NOTE]
 ====
-Proactive HTTP authentication must be disabled (`quarkus.http.auth.proactive=false`) for this to work. For more information, see xref:security-proactive-authentication-concept.adoc[Proactive authentication].
+Proactive HTTP authentication must be disabled (`quarkus.http.auth.proactive=false`) for this to work. For more information, see xref:security-proactive-authentication.adoc[Proactive authentication].
 ====
 
 [source,java]
@@ -753,4 +753,4 @@ Note that tenant specific configurations can also be disabled, for example: `qua
 * https://openid.net/connect/[OpenID Connect]
 * https://tools.ietf.org/html/rfc7519[JSON Web Token]
 * https://developers.google.com/identity/protocols/OpenIDConnect[Google OpenID Connect]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -9,9 +9,9 @@ include::_attributes.adoc[]
 
 == Introduction
 
-If you use xref:security-oidc-code-flow-authentication-concept.adoc[OpenID Connect Authorization Code Flow] to protect Quarkus endpoints, then you need to configure Quarkus to tell it how to connect to OpenID Connect providers, how to authenticate to such providers, which scopes to use, and so on.
+If you use xref:security-oidc-code-flow-authentication.adoc[OpenID Connect Authorization Code Flow] to protect Quarkus endpoints, then you need to configure Quarkus to tell it how to connect to OpenID Connect providers, how to authenticate to such providers, which scopes to use, and so on.
 
-Sometimes you need to use the configuration to work around the fact that some providers do not implement OpenID Connect completely or when they are in fact xref:security-oidc-code-flow-authentication-concept.adoc#oauth2[OAuth2 providers only].
+Sometimes you need to use the configuration to work around the fact that some providers do not implement OpenID Connect completely or when they are in fact xref:security-oidc-code-flow-authentication.adoc#oauth2[OAuth2 providers only].
 
 The configuration of such providers can become complex, very technical and difficult to understand.
 
@@ -364,5 +364,5 @@ quarkus.oidc.credentials.secret=<Client Secret>
 
 == References
 
-* xref:security-oidc-code-flow-authentication-concept.adoc[OIDC code flow mechanism for protecting web applications]
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-overview.adoc
+++ b/docs/src/main/asciidoc/security-overview.adoc
@@ -1,4 +1,4 @@
-[id="security-overview-concept"]
+[id="security-overview"]
 = Quarkus Security overview
 include::_attributes.adoc[]
 :diataxis-type: concept
@@ -6,21 +6,21 @@ include::_attributes.adoc[]
 
 Quarkus Security is a framework that provides the architecture, multiple authentication and authorization mechanisms, and other tools for you to build secure and production-quality Java applications.
 
-Before building security into your Quarkus applications, learn about the xref:security-architecture-concept.adoc[Quarkus Security architecture] and the different authentication mechanisms and features that you can use.
+Before building security into your Quarkus applications, learn about the xref:security-architecture.adoc[Quarkus Security architecture] and the different authentication mechanisms and features that you can use.
 
 == Key features of Quarkus Security
 
 The Quarkus Security framework provides built-in security authentication mechanisms for Basic, Form-based, and mutual TLS (mTLS) authentication.
-You can also use other well-known xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[authentication mechanisms], such as OpenID Connect (OIDC) and WebAuthn.
+You can also use other well-known xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[authentication mechanisms], such as OpenID Connect (OIDC) and WebAuthn.
 
-Authentication mechanisms depend on xref:security-identity-providers-concept.adoc[Identity providers] to verify the authentication credentials and map them to a `SecurityIdentity` instance, which has the username, roles, original authentication credentials, and other attributes.
+Authentication mechanisms depend on xref:security-identity-providers.adoc[Identity providers] to verify the authentication credentials and map them to a `SecurityIdentity` instance, which has the username, roles, original authentication credentials, and other attributes.
 
 {project-name} also includes built-in security to allow for role-based access control (RBAC) based on the common security annotations @RolesAllowed, @DenyAll, @PermitAll on REST endpoints, and CDI beans.
 For more information, see the Quarkus xref:security-authorize-web-endpoints-reference.adoc[Authorization of web endpoints] guide.
 
 Quarkus Security also supports the following features:
 
-* xref:security-proactive-authentication-concept.adoc[Proactive authentication]
+* xref:security-proactive-authentication.adoc[Proactive authentication]
 * xref:http-reference.adoc#ssl[Secure connections with SSL/TLS]
 * <<cross-origin-resource-sharing>>
 * <<csrf-prevention>>
@@ -28,17 +28,17 @@ Quarkus Security also supports the following features:
 * <<secrets-engines>>
 * <<rest-data-panache>>
 * <<secure-serialization>>
-* xref:security-vulnerability-detection-concept.adoc[Security vulnerability detection and National Vulnerability Database (NVD) registration]
+* xref:security-vulnerability-detection.adoc[Security vulnerability detection and National Vulnerability Database (NVD) registration]
 
 Quarkus Security is also highly customizable.
 For more information, see the Quarkus xref:security-customization.adoc[Security tips and tricks] guide.
 
 == Getting started with Quarkus Security
 
-To get started with security in Quarkus, consider combining the Quarkus built-in xref:security-basic-authentication-concept.adoc[Basic authentication] with the Jakarta Persistence identity provider to enable role-based access control (RBAC).
+To get started with security in Quarkus, consider combining the Quarkus built-in xref:security-basic-authentication.adoc[Basic authentication] with the Jakarta Persistence identity provider to enable role-based access control (RBAC).
 Complete the steps in the xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication] tutorial.
 
-After successfully securing your Quarkus application with Basic authentication, you can increase the security further by adding more advanced authentication mechanisms, for example, the xref:security-oidc-code-flow-authentication-concept.adoc[OpenID Connect (OIDC) authorization code flow mechanism].
+After successfully securing your Quarkus application with Basic authentication, you can increase the security further by adding more advanced authentication mechanisms, for example, the xref:security-oidc-code-flow-authentication.adoc[OpenID Connect (OIDC) authorization code flow mechanism].
 
 == Quarkus Security testing
 
@@ -86,7 +86,7 @@ For more information, see the xref:rest-data-panache.adoc#securing-endpoints[Sec
 == Security vulnerability detection
 
 Most Quarkus tags get reported in the US link:https://nvd.nist.gov[National Vulnerability Database (NVD)].
-For information about security vulnerabilities, see the xref:security-vulnerability-detection-concept.adoc[Security vulnerability detection and reporting in Quarkus] guide.
+For information about security vulnerabilities, see the xref:security-vulnerability-detection.adoc[Security vulnerability detection and reporting in Quarkus] guide.
 
 == References
 

--- a/docs/src/main/asciidoc/security-proactive-authentication.adoc
+++ b/docs/src/main/asciidoc/security-proactive-authentication.adoc
@@ -3,7 +3,7 @@ This document is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-[id="security-proactive-authentication-concept"]
+[id="security-proactive-authentication"]
 = Proactive authentication
 include::_attributes.adoc[]
 :diataxis-type: concept
@@ -152,7 +152,7 @@ public class AuthenticationFailedExceptionHandler {
 
 == References
 
-* xref:security-overview-concept.adoc[Quarkus Security overview]
-* xref:security-architecture-concept.adoc[Quarkus Security architecture] 
-* xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
-* xref:security-identity-providers-concept.adoc[Identity providers]
+* xref:security-overview.adoc[Quarkus Security overview]
+* xref:security-architecture.adoc[Quarkus Security architecture] 
+* xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
+* xref:security-identity-providers.adoc[Identity providers]

--- a/docs/src/main/asciidoc/security-properties.adoc
+++ b/docs/src/main/asciidoc/security-properties.adoc
@@ -150,4 +150,4 @@ quarkus.security.users.embedded.roles.noadmin=user
 
 == References
 
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-testing.adoc
+++ b/docs/src/main/asciidoc/security-testing.adoc
@@ -89,7 +89,7 @@ This will run the test with an identity with the given username and roles. Note 
 disable authorization while also providing an identity to run the test under, which can be useful if the endpoint expects an
 identity to be present.
 
-See xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing-security-annotation[OpenID Connect Bearer Token Integration testing], xref:security-oidc-code-flow-authentication-concept.adoc#integration-testing-security-annotation[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-security-annotation[SmallRye JWT Integration testing] for more details about testing the endpoint code which depends on the injected `JsonWebToken`.
+See xref:security-oidc-bearer-token-authentication.adoc#integration-testing-security-annotation[OpenID Connect Bearer Token Integration testing], xref:security-oidc-code-flow-authentication.adoc#integration-testing-security-annotation[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-security-annotation[SmallRye JWT Integration testing] for more details about testing the endpoint code which depends on the injected `JsonWebToken`.
 
 [WARNING]
 ====
@@ -122,8 +122,8 @@ for example by setting `quarkus.http.auth.basic=true` or `%test.quarkus.http.aut
 == Use Wiremock for Integration Testing
 
 You can also use Wiremock to mock the authorization OAuth2 and OIDC services:
-See xref:security-oauth2.adoc#integration-testing[OAuth2 Integration testing], xref:security-oidc-bearer-token-authentication-concept.adoc#integration-testing-wiremock[OpenID Connect Bearer Token Integration testing], xref:security-oidc-code-flow-authentication-concept.adoc#integration-testing-wiremock[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-wiremock[SmallRye JWT Integration testing] for more details.
+See xref:security-oauth2.adoc#integration-testing[OAuth2 Integration testing], xref:security-oidc-bearer-token-authentication.adoc#integration-testing-wiremock[OpenID Connect Bearer Token Integration testing], xref:security-oidc-code-flow-authentication.adoc#integration-testing-wiremock[OpenID Connect Authorization Code Flow Integration testing] and xref:security-jwt.adoc#integration-testing-wiremock[SmallRye JWT Integration testing] for more details.
 
 == References
 
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-vulnerability-detection.adoc
+++ b/docs/src/main/asciidoc/security-vulnerability-detection.adoc
@@ -3,7 +3,7 @@ This document is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-[id="security-vulnerability-detection-concept"]
+[id="security-vulnerability-detection"]
 = Security vulnerability detection and reporting in Quarkus
 include::_attributes.adoc[]
 :diataxis-type: concept
@@ -134,5 +134,5 @@ You can adjust the expiry date if you need to.
 
 == References
 
-* xref:security-overview-concept.adoc[Quarkus Security overview]
-* xref:security-authentication-mechanisms-concept.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
+* xref:security-overview.adoc[Quarkus Security overview]
+* xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]

--- a/docs/src/main/asciidoc/security-webauthn.adoc
+++ b/docs/src/main/asciidoc/security-webauthn.adoc
@@ -3,7 +3,7 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-[id="security-webauthn-concept"]
+[id="security-webauthn"]
 = Using Security with WebAuthn
 :extension-status: preview
 
@@ -1306,4 +1306,4 @@ include::{generated-dir}/config/quarkus-security-webauthn.adoc[opts=optional, le
 
 == References
 
-* xref:security-overview-concept.adoc[Quarkus Security overview]
+* xref:security-overview.adoc[Quarkus Security overview]


### PR DESCRIPTION
Adding concept adds little value. This change helps to reduce some of the lengthy security docs, as discussed with @sberyozkin and as per the new doc header content type attribute (`:diataxis-type:`) introduced by @ebullient in PR #33619.

- `-concept` removed from security doc filenames and IDs in header.
-  xrefs in all applicable topics updated with new filename  - (Note, no other edits are in scope for these touched topics in this PR.)
- The URL redirects of renamed adocs are created in the [quarkusio.github.io](https://github.com/quarkusio/quarkusio.github.io/tree/develop/_redirects/guides) repo in PR https://github.com/quarkusio/quarkusio.github.io/pull/1735



