### PR TITLE
Add more links between OIDC bearer and code flow authentication docs

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
@@ -14,6 +14,8 @@ The bearer tokens are issued by OIDC and OAuth 2.0 compliant authorization serve
 
 To better understand OIDC Bearer authentication, see xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication].
 
+If you want to protect web applications by using OIDC Authorization Code Flow authentication, see xref:security-oidc-code-flow-authentication-concept.adoc[OIDC authorization code flow authentication].
+
 == Prerequisites
 
 :prerequisites-docker:

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -43,8 +43,11 @@ image::security-bearer-token-authorization-mechanism-2.png[alt=Bearer authentica
 If you need to authenticate and authorize the users using OpenID Connect Authorization Code Flow, see xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications].
 Also, if you use Keycloak and bearer tokens, see xref:security-keycloak-authorization.adoc[Using Keycloak to Centralize Authorization].
 
-For information about how to support multiple tenants, see xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect Multi-Tenancy].
+To learn about how you can protect service applications by using OIDC Bearer authentication, see xref:security-oidc-bearer-token-authentication-tutorial.adoc[OIDC Bearer authentication tutorial].
 
+If you want to protect web applications by using OIDC authorization code flow authentication, see xref:security-oidc-code-flow-authentication-concept.adoc[OIDC authorization code flow authentication].
+
+For information about how to support multiple tenants, see xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect Multi-Tenancy].
 
 === Accessing JWT claims
 

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -7,8 +7,11 @@ include::_attributes.adoc[]
 With the Quarkus OpenID Connect (OIDC) extension, you can protect application HTTP endpoints by using the OIDC Authorization Code Flow mechanism.
 
 To learn more about the OIDC authorization code flow mechanism, see xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications].
+
 To learn about how well-known social providers such as Google, GitHub, Microsoft, Twitter, Apple, Facebook, and Spotify can be used with Quarkus OIDC, see xref:security-openid-connect-providers.adoc[Configuring Well-Known OpenID Connect Providers].
 See also, xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus].
+
+If you want to protect your service applications by using OIDC Bearer authentication, see xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication].
 
 == Prerequisites
 

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -10,7 +10,7 @@ include::_attributes.adoc[]
 :categories: security,web
 :toclevels: 4
 
-To protect your web applications, you can use the industry-standard authorization code flow mechanism provided by the Quarkus OpenID Connect (OIDC) extension.
+To protect your web applications, you can use the industry-standard OpenID Connect (OIDC) Authorization Code Flow mechanism provided by the Quarkus OIDC extension.
 
 == Overview of the OIDC authorization code flow mechanism
 
@@ -42,7 +42,8 @@ See also the xref:security-oidc-configuration-properties-reference.adoc[OIDC con
 
 To learn about how you can protect web applications by using the OIDC authorization code flow mechanism, see xref:security-oidc-code-flow-authentication-tutorial.adoc[Protect a web application by using OIDC authorization code flow]
 
-If you want to protect your applications by using Bearer Token authentication, see xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication].
+If you want to protect service applications by using OIDC Bearer authentication, see xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication].
+
 For information about how to support multiple tenants, see xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect Multi-Tenancy].
 
 == Using the authorization code flow mechanism


### PR DESCRIPTION
This PR adds more links between bearer authentication tutorial and concept docs and code flow authentication tutorial and concept docs, for the users, irrespective of which document they find first, be able to quickly get to the OIDC tutorial or concept doc they may need.

Also removed one link to the other non-OIDC mechanisms in one of the introductions, as users can follow Reference links if needed  