### PR TITLE
Reduce initial's Arc ManagedContext activation cost

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ArcThreadSetupAction.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ArcThreadSetupAction.java
@@ -15,9 +15,7 @@ public class ArcThreadSetupAction implements ThreadSetupAction {
 
     @Override
     public ThreadState activateInitial() {
-        managedContext.activate();
-        InjectableContext.ContextState state = managedContext.getState();
-        return toThreadState(state);
+        return toThreadState(managedContext.activate());
     }
 
     private ThreadState toThreadState(InjectableContext.ContextState state) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusCurrentRequest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusCurrentRequest.java
@@ -25,14 +25,12 @@ public class QuarkusCurrentRequest implements CurrentRequest {
     public void set(ResteasyReactiveRequestContext set) {
         if (set == null) {
             try {
-                currentVertxRequest.setOtherHttpContextObject(null);
-                currentVertxRequest.setCurrent(null);
+                currentVertxRequest.setCurrent(null, null);
             } catch (ContextNotActiveException ignored) {
                 // ignored because for HTTP pipelining it can already be closed
             }
         } else {
-            currentVertxRequest.setOtherHttpContextObject(set);
-            currentVertxRequest.setCurrent(set.unwrap(RoutingContext.class));
+            currentVertxRequest.setCurrent(set.unwrap(RoutingContext.class), set);
         }
     }
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ManagedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ManagedContext.java
@@ -10,19 +10,23 @@ public interface ManagedContext extends InjectableContext {
 
     /**
      * Activate the context with no initial state.
+     *
+     * @return the context state
      */
-    default void activate() {
-        activate(null);
+    default ContextState activate() {
+        return activate(null);
     }
 
     /**
      * Activate the context.
+     * <p>
      * If invoked with {@code null} parameter, a fresh {@link io.quarkus.arc.InjectableContext.ContextState} is
      * automatically created.
      *
      * @param initialState The initial state, may be {@code null}
+     * @return the context state
      */
-    void activate(ContextState initialState);
+    ContextState activate(ContextState initialState);
 
     /**
      * Deactivate the context - do not destoy existing contextual instances.

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
@@ -122,17 +122,20 @@ class RequestContext implements ManagedContext {
     }
 
     @Override
-    public void activate(ContextState initialState) {
+    public ContextState activate(ContextState initialState) {
         if (LOG.isTraceEnabled()) {
             traceActivate(initialState);
         }
         if (initialState == null) {
-            currentContext.set(new RequestContextState(new ConcurrentHashMap<>()));
+            RequestContextState state = new RequestContextState(new ConcurrentHashMap<>());
+            currentContext.set(state);
             // Fire an event with qualifier @Initialized(RequestScoped.class) if there are any observers for it
             fireIfNotEmpty(initializedNotifier);
+            return state;
         } else {
             if (initialState instanceof RequestContextState) {
                 currentContext.set((RequestContextState) initialState);
+                return initialState;
             } else {
                 throw new IllegalArgumentException("Invalid initial state: " + initialState.getClass().getName());
             }

--- a/independent-projects/arc/tcks/cdi-tck-porting-pkg/src/main/java/io/quarkus/arc/tck/porting/ContextsImpl.java
+++ b/independent-projects/arc/tcks/cdi-tck-porting-pkg/src/main/java/io/quarkus/arc/tck/porting/ContextsImpl.java
@@ -19,15 +19,27 @@ public class ContextsImpl implements Contexts<Context> {
 
     @Override
     public void setActive(Context context) {
-        // remove the context state we potentially stored, else use null to initiate fresh context
-        ((ManagedContext) context).activate(contextStateMap.remove(context));
+        if (context.isActive()) {
+            return;
+        }
+        if (context instanceof ManagedContext) {
+            ManagedContext managed = (ManagedContext) context;
+            // remove the context state we potentially stored, else use null to initiate fresh context
+            managed.activate(contextStateMap.remove(context));
+        }
     }
 
     @Override
     public void setInactive(Context context) {
-        // save the state of the context
-        contextStateMap.put(context, ((ManagedContext) context).getState());
-        ((ManagedContext) context).deactivate();
+        if (!context.isActive()) {
+            return;
+        }
+        if (context instanceof ManagedContext) {
+            ManagedContext managed = (ManagedContext) context;
+            // save the state of the context
+            contextStateMap.put(context, (managed.getState()));
+            managed.deactivate();
+        }
     }
 
     @Override


### PR DESCRIPTION
This is a companion of https://github.com/quarkusio/quarkus/pull/34132

On main:
- `ManagedContext`'s initial activation requires to retrieve the request context state value (ie `RequestContextState` instance freshly created) from the Vertx local context which is already known upfront ( 'cause is the first time we set it, so we know already): this pr is saving this lookup 
- `CurrentVertxRequest`'s already provide a batch set method (thanks @stuartwdouglas for it!!!) we can use to avoid proxies to perform twice a delegate lookup (which involve `io/quarkus/arc/impl/RequestContext.getIfActive` to happen twice)

