### PR TITLE
Fix AMQP Dev Services started message

### DIFF
--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
@@ -98,15 +98,6 @@ public class AmqpDevServicesProcessor {
                     devServicesConfig.timeout, !devServicesSharedNetworkBuildItem.isEmpty());
             if (newDevService != null) {
                 devService = newDevService;
-                Map<String, String> config = devService.getConfig();
-                if (newDevService.isOwner()) {
-                    log.info("Dev Services for AMQP started.");
-                    log.infof("Other Quarkus applications in dev mode will find the "
-                            + "broker automatically. For Quarkus applications in production mode, you can connect to"
-                            + " this by starting your application with -Damqp.host=%s -Damqp.port=%s -Damqp.user=%s -Damqp.password=%s",
-                            config.get(AMQP_HOST_PROP), config.get(AMQP_PORT_PROP), config.get(AMQP_USER_PROP),
-                            config.get(AMQP_PASSWORD_PROP));
-                }
             }
             if (devService == null) {
                 compressor.closeAndDumpCaptured();
@@ -138,6 +129,16 @@ public class AmqpDevServicesProcessor {
             closeBuildItem.addCloseTask(closeTask, true);
         }
         cfg = configuration;
+
+        if (devService.isOwner()) {
+            Map<String, String> config = devService.getConfig();
+            log.infof("Dev Services for AMQP started. Other Quarkus applications in dev mode will find the "
+                    + "broker automatically. For Quarkus applications in production mode, you can connect to"
+                    + " this by starting your application with -Damqp.host=%s -Damqp.port=%s -Damqp.user=%s -Damqp.password=%s",
+                    config.get(AMQP_HOST_PROP), config.get(AMQP_PORT_PROP), config.get(AMQP_USER_PROP),
+                    config.get(AMQP_PASSWORD_PROP));
+        }
+
         return devService.toBuildItem();
     }
 


### PR DESCRIPTION
This message was not printed since the compressor was still active. Also merge the messages since the second message doesn't make sense without first one.