### PR TITLE
Inconsistent `Bearer token  authentication` in docs

### DIFF
--- a/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
@@ -242,7 +242,7 @@ For more information, see the xref:security-openid-connect-client.adoc[OpenID Co
 The `quarkus-smallrye-jwt` extension provides a MicroProfile JSON Web Token (JWT) 2.1 implementation and multiple options to verify signed and encrypted `JWT` tokens.
 It represents them as `org.eclipse.microprofile.jwt.JsonWebToken`.
 
-`quarkus-smallrye-jwt` is an alternative to the `quarkus-oidc` Bearer authentication mechanism and verifies only `JWT` tokens by using either Privacy Enhanced Mail (PEM) keys or the refreshable `JWK` key set.
+`quarkus-smallrye-jwt` is an alternative to the `quarkus-oidc` Bearer token authentication mechanism and verifies only `JWT` tokens by using either Privacy Enhanced Mail (PEM) keys or the refreshable `JWK` key set.
 `quarkus-smallrye-jwt` also provides the JWT generation API, which you can use to easily create `signed`, `inner-signed`, and `encrypted` `JWT` tokens.
 
 For more information, see the  xref:security-jwt.adoc[Using JWT RBAC] guide.
@@ -250,7 +250,7 @@ For more information, see the  xref:security-jwt.adoc[Using JWT RBAC] guide.
 [[oauth2-authentication]]
 === OAuth2 authentication
 
-`quarkus-elytron-security-oauth2` provides an alternative to the Quarkus `quarkus-oidc` Bearer authentication mechanism extension.
+`quarkus-elytron-security-oauth2` provides an alternative to the Quarkus `quarkus-oidc` Bearer token authentication mechanism extension.
 `quarkus-elytron-security-oauth2` is based on `Elytron` and is primarily intended for introspecting opaque tokens remotely.
 For more information, see the Quarkus xref:security-oauth2.adoc[Using OAuth2] guide.
 

--- a/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
@@ -547,7 +547,7 @@ You have learned how to create and test a secure Quarkus application by combinin
 After you have completed this tutorial, explore some of the more advanced security mechanisms in Quarkus.
 Use the following information to learn how you can securely use `OpenID Connect` to provide secure single sign-on access to your Quarkus endpoints:
 
-* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication]
 * xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
 
 == References
@@ -556,7 +556,7 @@ Use the following information to learn how you can securely use `OpenID Connect`
 * xref:security-architecture.adoc[Quarkus Security architecture] 
 * xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
 * xref:security-identity-providers.adoc[Identity providers]
-* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication]
 * xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:hibernate-orm-panache.adoc[Simplified Hibernate ORM with Panache]
 * xref:hibernate-orm.adoc[Using Hibernate ORM and Jakarta Persistence]

--- a/docs/src/main/asciidoc/security-jwt-build.adoc
+++ b/docs/src/main/asciidoc/security-jwt-build.adoc
@@ -346,6 +346,6 @@ SmallRye JWT supports the following properties which can be used to customize th
 * link:https://tools.ietf.org/html/rfc7516[JSON Web Encryption]
 * link:https://tools.ietf.org/html/rfc7518[JSON Web Algorithms]
 * link:https://bitbucket.org/b_c/jose4j/wiki/Home[Jose4J]
-* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication]
 * xref:security-jwt.adoc[Using Smallrye JWT to Protect Service Applications]
 * xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -16,7 +16,7 @@ to verify https://tools.ietf.org/html/rfc7519[JSON Web Token]s, represent them a
 and provide secured access to the Quarkus HTTP endpoints using Bearer Token Authorization and https://en.wikipedia.org/wiki/Role-based_access_control[Role-Based Access Control].
 
 NOTE: Quarkus OpenID Connect `quarkus-oidc` extension also supports Bearer Token Authorization and uses `smallrye-jwt` to represent the bearer tokens as `JsonWebToken`.
-For more information, read the xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication] guide.
+For more information, read the xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication] guide.
 OpenID Connect extension has to be used if the Quarkus application needs to authenticate the users using OIDC Authorization Code Flow.
 For more information, see xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
 

--- a/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
@@ -202,6 +202,6 @@ include::{generated-dir}/config/quarkus-keycloak-admin-client.adoc[leveloffset=+
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * xref:security-keycloak-authorization.adoc[Keycloak Authorization extension]
 * xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
-* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication]
 * xref:security-openid-connect-client.adoc[OpenID Connect Client and Token Propagation Quickstart]
 * xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -20,7 +20,7 @@ Use `quarkus-keycloak-authorization` only if you work with Keycloak and have Key
 
 By externalizing authorization from your application, you are allowed to protect your applications using different access control mechanisms as well as avoid re-deploying your application every time your security requirements change, where Keycloak will be acting as a centralized authorization service from where your protected resources and their associated permissions are managed.
 
-See the xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication] guide for more information about `Bearer Token` authentication mechanism. It is important to realize that it is the `Bearer Token` authentication mechanism which does the authentication and creates a security identity - while the `quarkus-keycloak-authorization` extension is responsible for applying a Keycloak Authorization Policy to this identity based on the current request path and other policy settings.
+See the xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication] guide for more information about `Bearer Token` authentication mechanism. It is important to realize that it is the `Bearer Token` authentication mechanism which does the authentication and creates a security identity - while the `quarkus-keycloak-authorization` extension is responsible for applying a Keycloak Authorization Policy to this identity based on the current request path and other policy settings.
 
 Please see https://www.keycloak.org/docs/latest/authorization_services/index.html#_enforcer_overview[Keycloak Authorization Services documentation] for more information.
 

--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -16,7 +16,7 @@ It can be used to implement an application authentication mechanism based on tok
 
 This extension provides a light-weight support for using the opaque Bearer Tokens and validating them by calling an introspection endpoint.
 
-If the OAuth2 Authentication server provides JWT Bearer Tokens, consider using either xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication] or xref:security-jwt.adoc[SmallRye JWT] extensions instead.
+If the OAuth2 Authentication server provides JWT Bearer Tokens, consider using either xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication] or xref:security-jwt.adoc[SmallRye JWT] extensions instead.
 OpenID Connect extension has to be used if the Quarkus application needs to authenticate the users using OIDC Authorization Code Flow. For more information, see the xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications] guide.
 
 include::{includes}/extension-status.adoc[]

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
@@ -4,15 +4,15 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="security-oidc-bearer-token-authentication-tutorial"]
-= Protect a service application by using OpenID Connect (OIDC) bearer authentication
+= Protect a service application by using OpenID Connect (OIDC) Bearer token authentication
 include::_attributes.adoc[]
 :diataxis-type: tutorial
 :categories: security
 
-Here, you use the Quarkus OpenID Connect (OIDC) extension to secure a Jakarta REST application using Bearer authentication.
+Here, you use the Quarkus OpenID Connect (OIDC) extension to secure a Jakarta REST application using Bearer token authentication.
 The bearer tokens are issued by OIDC and OAuth 2.0 compliant authorization servers, such as link:https://www.keycloak.org[Keycloak].
 
-To better understand OIDC Bearer authentication, see xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication].
+To better understand OIDC Bearer token authentication, see xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication].
 
 If you want to protect web applications by using OIDC Authorization Code Flow authentication, see xref:security-oidc-code-flow-authentication-concept.adoc[OIDC authorization code flow authentication].
 
@@ -269,7 +269,7 @@ See the <<keycloak-dev-mode,Running the Application in Dev mode>> section above 
 
 You can test the application launched in JVM or Native modes with `curl`.
 
-The application is using Bearer authentication and the first thing to do is obtain an access token from the Keycloak Server in order to access the application resources:
+The application is using Bearer token authentication and the first thing to do is obtain an access token from the Keycloak Server in order to access the application resources:
 
 [source,bash]
 ----
@@ -314,12 +314,12 @@ export access_token=$(\
  )
 ----
 
-Please also see the xref:security-oidc-bearer-token-authentication.adoc#integration-testing-keycloak-devservices[OIDC Bearer authentication, Dev Services for Keycloak] section, about writing the integration tests which depend on `Dev Services for Keycloak`.
+Please also see the xref:security-oidc-bearer-token-authentication.adoc#integration-testing-keycloak-devservices[OIDC Bearer token authentication, Dev Services for Keycloak] section, about writing the integration tests which depend on `Dev Services for Keycloak`.
 
 == References
 
 * xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties]
-* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication]
 * link:https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * link:https://openid.net/connect/[OpenID Connect]
 * link:https://tools.ietf.org/html/rfc7519[JSON Web Token]

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -4,26 +4,26 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="security-oidc-bearer-token-authentication"]
-= OpenID Connect (OIDC) Bearer authentication
+= OpenID Connect (OIDC) Bearer token authentication
 include::_attributes.adoc[]
 :diataxis-type: concept
 :categories: security,web
 
-Secure HTTP access to Jakarta REST (formerly known as JAX-RS) endpoints in your application with Bearer authentication by using the Quarkus OpenID Connect (OIDC) extension.
+Secure HTTP access to Jakarta REST (formerly known as JAX-RS) endpoints in your application with Bearer token authentication by using the Quarkus OpenID Connect (OIDC) extension.
 
-== Overview of the Bearer authentication mechanism in Quarkus
+== Overview of the Bearer token authentication mechanism in Quarkus
 
-Quarkus supports the Bearer authentication mechanism through the Quarkus OpenID Connect (OIDC) extension.
+Quarkus supports the Bearer token authentication mechanism through the Quarkus OpenID Connect (OIDC) extension.
 
 The bearer tokens are issued by OIDC and OAuth 2.0 compliant authorization servers, such as link:https://www.keycloak.org[Keycloak].
 
-Bearer authentication is the process of authorizing HTTP requests based on the existence and validity of a bearer token.
+Bearer token authentication is the process of authorizing HTTP requests based on the existence and validity of a bearer token.
 The bearer token provides information about the subject of the call, which is used to determine whether or not an HTTP resource can be accessed.
 
-The following diagrams outline the Bearer authentication mechanism in Quarkus:
+The following diagrams outline the Bearer token authentication mechanism in Quarkus:
 
-.Bearer authentication mechanism in Quarkus with Single-page application
-image::security-bearer-token-authorization-mechanism-1.png[alt=Bearer authentication, width="60%", align=center]
+.Bearer token authentication mechanism in Quarkus with Single-page application
+image::security-bearer-token-authorization-mechanism-1.png[alt=Bearer token authentication, width="60%", align=center]
 
 1. The Quarkus service retrieves verification keys from the OpenID Connect provider. The verification keys are used to verify the bearer access token signatures.
 2. The Quarkus user accesses the Single-page application.
@@ -32,8 +32,8 @@ image::security-bearer-token-authorization-mechanism-1.png[alt=Bearer authentica
 5. The Quarkus service verifies the bearer access token signature using the verification keys, checks the token expiry date and other claims, allows the request to proceed if the token is valid, and returns the service response to the Single-page application.
 6. The Single-page application returns the same data to the Quarkus user.
 
-.Bearer authentication mechanism in Quarkus with Java or command line client
-image::security-bearer-token-authorization-mechanism-2.png[alt=Bearer authentication, width="60%", align=center]
+.Bearer token authentication mechanism in Quarkus with Java or command line client
+image::security-bearer-token-authorization-mechanism-2.png[alt=Bearer token authentication, width="60%", align=center]
 
 1. The Quarkus service retrieves verification keys from the OpenID Connect provider. The verification keys are used to verify the bearer access token signatures.
 2. The Client uses `client_credentials` that requires client ID and secret or password grant, which also requires client ID, secret, user name, and password to retrieve the access token from the OpenID Connect provider.
@@ -43,7 +43,7 @@ image::security-bearer-token-authorization-mechanism-2.png[alt=Bearer authentica
 If you need to authenticate and authorize the users using OpenID Connect Authorization Code Flow, see xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications].
 Also, if you use Keycloak and bearer tokens, see xref:security-keycloak-authorization.adoc[Using Keycloak to Centralize Authorization].
 
-To learn about how you can protect service applications by using OIDC Bearer authentication, see xref:security-oidc-bearer-token-authentication-tutorial.adoc[OIDC Bearer authentication tutorial].
+To learn about how you can protect service applications by using OIDC Bearer token authentication, see xref:security-oidc-bearer-token-authentication-tutorial.adoc[OIDC Bearer token authentication tutorial].
 
 If you want to protect web applications by using OIDC authorization code flow authentication, see xref:security-oidc-code-flow-authentication-concept.adoc[OIDC authorization code flow authentication].
 
@@ -915,8 +915,8 @@ Note Quarkus `web-app` applications always require `quarkus.oidc.client-id` prop
 == References
 
 * xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties]
-* xref:security-oidc-bearer-token-authentication-tutorial.adoc[Protect a service application by using OIDC Bearer authentication]
-* xref:security-protect-service-applications-by-using-oidc-bearer-authentication-how-to.adoc[Protect service applications by using OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication-tutorial.adoc[Protect a service application by using OIDC Bearer token authentication]
+* xref:security-protect-service-applications-by-using-oidc-bearer-authentication-how-to.adoc[Protect service applications by using OIDC Bearer token authentication]
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * https://openid.net/connect/[OpenID Connect]
 * https://tools.ietf.org/html/rfc7519[JSON Web Token]

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -11,7 +11,7 @@ To learn more about the OIDC authorization code flow mechanism, see xref:securit
 To learn about how well-known social providers such as Google, GitHub, Microsoft, Twitter, Apple, Facebook, and Spotify can be used with Quarkus OIDC, see xref:security-openid-connect-providers.adoc[Configuring Well-Known OpenID Connect Providers].
 See also, xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus].
 
-If you want to protect your service applications by using OIDC Bearer authentication, see xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer authentication].
+If you want to protect your service applications by using OIDC Bearer token authentication, see xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer token authentication].
 
 == Prerequisites
 
@@ -252,7 +252,7 @@ For more information about writing the integration tests that depend on `Dev Ser
 
 Congratulations!
 You have learned how to set up and use the OIDC authorization code flow mechanism to protect and test application HTTP endpoints.
-After you have completed this tutorial, explore xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication] and xref:security-authentication-mechanisms.adoc[other authentication mechanisms].
+After you have completed this tutorial, explore xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication] and xref:security-authentication-mechanisms.adoc[other authentication mechanisms].
 
 == References
 * xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -42,7 +42,7 @@ See also the xref:security-oidc-configuration-properties-reference.adoc[OIDC con
 
 To learn about how you can protect web applications by using the OIDC authorization code flow mechanism, see xref:security-oidc-code-flow-authentication-tutorial.adoc[Protect a web application by using OIDC authorization code flow]
 
-If you want to protect service applications by using OIDC Bearer authentication, see xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication].
+If you want to protect service applications by using OIDC Bearer token authentication, see xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication].
 
 For information about how to support multiple tenants, see xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect Multi-Tenancy].
 
@@ -439,7 +439,7 @@ This is done by ensuring tokens are trustable.
 [[token-verification-introspection]]
 ==== Token verification and introspection
 
-The verification process of OIDC authorization code flow tokens follows the bearer authentication token verification and introspection logic. For more information, see the xref:security-oidc-bearer-token-authentication.adoc#token-verification-introspection[Token Verification And Introspection] section of the "Quarkus OpenID Connect (OIDC) Bearer authentication" guide.
+The verification process of OIDC authorization code flow tokens follows the Bearer token authentication token verification and introspection logic. For more information, see the xref:security-oidc-bearer-token-authentication.adoc#token-verification-introspection[Token Verification And Introspection] section of the "Quarkus OpenID Connect (OIDC) Bearer token authentication" guide.
 
 [NOTE]
 --
@@ -885,7 +885,7 @@ For GitHub, since it does not have an introspection endpoint, requesting the Use
 ====
 Requiring <<user-info,UserInfo>> involves making a remote call on every request.
 Therefore, you might want to consider caching `UserInfo` data.
-For more information, see the xref:security-oidc-bearer-token-authentication.adoc#token-introspection-userinfo-cache[Token Introspection and UserInfo cache] section of the "OpenID Connect (OIDC) Bearer authentication" guide.
+For more information, see the xref:security-oidc-bearer-token-authentication.adoc#token-introspection-userinfo-cache[Token Introspection and UserInfo cache] section of the "OpenID Connect (OIDC) Bearer token authentication" guide.
 
 Alternatively, you may want to request that `UserInfo` is embedded into the internal generated `IdToken` with the `quarkus.oidc.cache-user-info-in-idtoken=true` property - the advantage of this approach is that by default no cached `UserInfo` state will be kept with the endpoint - instead it will be stored in a session cookie. You may also want to consider encrypting `IdToken` in this case if `UserInfo` contains sensitive data. For more information, see <<token-state-manager,Encrypt tokens with TokenStateManager>>.
 ====
@@ -1067,7 +1067,7 @@ This section discusses these considerations.
 
 === Single-page applications
 
-You can check if implementing single-page applications (SPAs) the way it is suggested in the xref:security-oidc-bearer-token-authentication.adoc#single-page-applications[Single-page applications] section of the "OpenID Connect (OIDC) Bearer authentication" guide meets your requirements.
+You can check if implementing single-page applications (SPAs) the way it is suggested in the xref:security-oidc-bearer-token-authentication.adoc#single-page-applications[Single-page applications] section of the "OpenID Connect (OIDC) Bearer token authentication" guide meets your requirements.
 
 If you prefer to use SPAs and JavaScript APIs such as `Fetch` or `XMLHttpRequest`(XHR) with Quarkus web applications, be aware that OpenID Connect providers might not support cross-origin resource sharing (CORS) for authorization endpoints where the users are authenticated after a redirect from Quarkus. 
 This will lead to authentication failures if the Quarkus application and the OpenID Connect provider are hosted on different HTTP domains, ports, or both.

--- a/docs/src/main/asciidoc/security-oidc-configuration-properties-reference.adoc
+++ b/docs/src/main/asciidoc/security-oidc-configuration-properties-reference.adoc
@@ -15,8 +15,8 @@ include::{generated-dir}/config/quarkus-oidc.adoc[opts=optional, leveloffset=+1]
 
 == References
 
-* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
-* xref:security-oidc-bearer-token-authentication-tutorial.adoc[Protect a service application by using OpenID Connect (OIDC) bearer authentication]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication]
+* xref:security-oidc-bearer-token-authentication-tutorial.adoc[Protect a service application by using OpenID Connect (OIDC) Bearer token authentication]
 // * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * https://openid.net/connect/[OpenID Connect]
 // * https://tools.ietf.org/html/rfc7519[JSON Web Token]

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -1109,6 +1109,6 @@ However, these features may be added in the future.
 == References
 
 * xref:security-openid-connect-client.adoc[OpenID Connect Client and Token Propagation Quickstart]
-* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication]
 * xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -12,7 +12,7 @@ This quickstart demonstrates how to use `OpenID Connect Client Reactive Filter` 
 
 Please check xref:security-openid-connect-client-reference.adoc[OpenID Connect Client and Token Propagation Reference Guide] for all the information related to `Oidc Client` and `Token Propagation` support in Quarkus.
 
-Please also read xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication] guide if you need to protect your applications using Bearer Token Authorization.
+Please also read xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication] guide if you need to protect your applications using Bearer Token Authorization.
 
 == Prerequisites
 
@@ -501,5 +501,5 @@ will return `403` status code.
 == References
 
 * xref:security-openid-connect-client-reference.adoc[OpenID Connect Client and Token Propagation Reference Guide]
-* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication]
 * xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -413,6 +413,6 @@ This document refers to the `http://localhost:8080/q/dev-v1` Dev UI URL in sever
 * xref:dev-ui.adoc[Dev UI]
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * https://openid.net/connect/[OpenID Connect]
-* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication]
+* xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication]
 * xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications]
 * xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -12,7 +12,7 @@ This guide demonstrates how your OpenID Connect (OIDC) application can support m
 
 When serving multiple customers from the same application (e.g.: SaaS), each customer is a tenant. By enabling multi-tenancy support to your applications you are allowed to also support distinct authentication policies for each tenant even though if that means authenticating against different OpenID Providers, such as Keycloak and Google.
 
-Please read the xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer authentication] guide if you need to authorize a tenant using Bearer Token Authorization.
+Please read the xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication] guide if you need to authorize a tenant using Bearer Token Authorization.
 
 If you need to authenticate and authorize a tenant using OpenID Connect Authorization Code Flow, read the xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications] guide.
 

--- a/docs/src/main/asciidoc/security-overview.adoc
+++ b/docs/src/main/asciidoc/security-overview.adoc
@@ -92,4 +92,4 @@ For information about security vulnerabilities, see the xref:security-vulnerabil
 
 * xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and Jakarta Persistence]
 * xref:security-oidc-code-flow-authentication-tutorial.adoc[Protect a web application by using OIDC authorization code flow]
-* xref:security-oidc-bearer-token-authentication-tutorial.adoc[Protect a service application by using OIDC bearer authentication]
+* xref:security-oidc-bearer-token-authentication-tutorial.adoc[Protect a service application by using OIDC Bearer token authentication]


### PR DESCRIPTION
This PR does a blanket find `Bearer authentication` and replaces it with `Bearer token authentication` so that the docs are as consistent as possible.

**Why?**

- Referring to the same 'thing' using two slightly different terms can cause confusion.
- SME also requested the emphasis on token, as this variation of the term is likely to be more familiar with Quarkus developers.

This relates to a discussion that began in a related 3.2 Security docs PR: https://github.com/quarkusio/quarkus/pull/33794