### PR TITLE
Disable build scan publication for test builds

### DIFF
--- a/.mvn/gradle-enterprise-custom-user-data.groovy
+++ b/.mvn/gradle-enterprise-custom-user-data.groovy
@@ -1,4 +1,16 @@
 
+// Configure build scan publication
+boolean publish = true
+if(session?.getRequest()?.getBaseDirectory() != null) {
+    def testBuildPaths = [ '/target/codestart-test/', '/target/it/', '/target/test-classes/', '/target/test-project/']
+    publish = testBuildPaths.every {testBuildPath -> !session.getRequest().getBaseDirectory().contains(testBuildPath) }
+    if(!publish) {
+        // do not publish a build scan for test builds
+        log.debug("Disabling build scan publication for " + session.getRequest().getBaseDirectory())
+    }
+}
+buildScan.publishAlwaysIf(publish)
+buildScan.publishIfAuthenticated()
 
 // Add mvn command line
 def mvnCommand = ''
@@ -14,8 +26,8 @@ if (System.env.GITHUB_ACTIONS) {
     buildScan.value('gh-ref-name', System.env.GITHUB_REF_NAME)
     buildScan.value('gh-actor', System.env.GITHUB_ACTOR)
     buildScan.value('gh-workflow', System.env.GITHUB_WORKFLOW)
-    
-   
+
+
     def prnumber = System.env.PULL_REQUEST_NUMBER
     if (prnumber != null) {
         buildScan.value('gh-pr', prnumber)

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -5,15 +5,12 @@
      </server>
     <buildScan>
         <!-- adjust conditions ?
-        mvn gradle-enterprise:provision-access-key 
+        mvn gradle-enterprise:provision-access-key
         https://docs.gradle.com/enterprise/maven-extension/#publishing_based_on_criteria
          -->
-        <!-- only publish test runs when failure (no option to completely avoid it)-->
-        <publish>#{basedir.contains('test-classes') ? 'ON_FAILURE' : 'ALWAYS'}</publish>
-        <!-- tag which builds are tests vs real -->
-        <tags>
-          <tag>#{basedir.contains('test-classes') ? 'TEST-BUILD' : 'MAIN-BUILD'}</tag>
-        </tags>
+        <!-- build scan publication is configured in gradle-enterprise-custom-user-data.groovy
+        to leverage options to disable build scan publication for test builds
+        -->
         <obfuscation>
           <!-- Don't share ip addresses-->
           <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
@@ -23,7 +20,6 @@
         </capture>
         <!-- https://docs.gradle.com/enterprise/maven-extension/#manual_access_key_configuration -->
         <backgroundBuildScanUpload>#{env['CI'] == null}</backgroundBuildScanUpload>
-        <publishIfAuthenticated>true</publishIfAuthenticated>
     </buildScan>
     <buildCache>
         <local><enabled>false</enabled></local>


### PR DESCRIPTION
### Issue
The Quarkus build is comprised of many test builds which by default publish some build scans to [Gradle Enterprise](https://ge.quarkus.io).
The [current approach](https://github.com/quarkusio/quarkus/blob/3bb78204c2992acd25a988eb83bb363a0afc459f/.mvn/gradle-enterprise.xml#L12) only publishes those test builds when failing. This is however not sufficient as some tests are expecting builds to fail.

### Fix
Leverage [the programmatic approach](https://docs.gradle.com/enterprise/maven-extension/api/com/gradle/maven/extension/api/scan/BuildScanApi.html#publishAlwaysIf(boolean)) which allows to fully disable publication

This PR is replacing https://github.com/quarkusio/quarkus/pull/34158 with a simpler approach