### PR TITLE
Fix typo & minor edits to security NVD doc

### DIFF
--- a/docs/src/main/asciidoc/security-vulnerability-detection.adoc
+++ b/docs/src/main/asciidoc/security-vulnerability-detection.adoc
@@ -17,16 +17,16 @@ To view the registered Quarkus CPE names in the US NVD, use the following search
 
 https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=quarkus
 
-If the NVE database flags a CVE against a Quarkus tag, a link that provides more details about the CVE is added to the given CPE name entry.
+If the NVD database flags a CVE against a Quarkus tag, a link that provides more details about the CVE is added to the given CPE name entry.
 
 The NVD CPE team updates the list regularly, but if you encounter a false positive, report the details by creating an issue in the link:https://github.com/quarkusio/quarkus/issues/2611[quarkusio] repository.
 
-== Detecting vulnerabilities in Quarkus at build time
+== Detect vulnerabilities in Quarkus at build time
 
-You can detect the vulnerabilities at the application build time with an NVD feed by using the Maven link:https://jeremylong.github.io/DependencyCheck/dependency-check-maven/[OWASP Dependency check plugin].
+You can detect the vulnerabilities at the application build time with an NVD feed by using the Maven link:https://jeremylong.github.io/DependencyCheck/dependency-check-maven/[OWASP Dependency-check-maven plugin].
 
 
-To add the OWASP Dependency check plugin to your Quarkus Maven project, add the following XML configuration to the `pom.xml` file:
+To add the Open Worldwide Application Security Project (OWASP) Dependency-check-maven plugin to your Quarkus Maven project, add the following XML configuration to the `pom.xml` file:
 
 [source,xml]
 ----
@@ -130,9 +130,10 @@ Ensure that you review and update the suppression list regularly to ensure that 
 You can optionally apply a time limit to individual suppressions by adding an expiry attribute, as outlined in the following example:
 
 `<suppress until="2022-01-01Z">...</suppress>`
+
 You can adjust the expiry date if you need to.
 
 == References
 
 * xref:security-overview.adoc[Quarkus Security overview]
-* xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
+* xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Other supported authentication mechanisms]

--- a/docs/src/main/asciidoc/security-vulnerability-detection.adoc
+++ b/docs/src/main/asciidoc/security-vulnerability-detection.adoc
@@ -136,4 +136,4 @@ You can adjust the expiry date if you need to.
 == References
 
 * xref:security-overview.adoc[Quarkus Security overview]
-* xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Other supported authentication mechanisms]
+* xref:security-authentication-mechanisms.adoc[Authentication mechanisms in Quarkus]


### PR DESCRIPTION
This PR fixes a doc typo and an obsolete link label.

Plus enhance and apply style as per the [Quarkus docs contributor style guide](https://quarkus.io/guides/doc-reference). 