### PR TITLE
Remove unnecessary ImageID resolution in DockerProcessor

### DIFF
--- a/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
+++ b/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
@@ -6,10 +6,6 @@ import static io.quarkus.container.image.deployment.util.EnablementUtil.pushCont
 import static io.quarkus.container.util.PathsUtil.findMainSourcesRoot;
 import static io.quarkus.runtime.util.ContainerRuntimeUtil.detectContainerRuntime;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -19,8 +15,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
@@ -106,8 +100,7 @@ public class DockerProcessor {
             log.info("Starting (local) container image build for jar using docker.");
         }
 
-        ImageIdReader reader = new ImageIdReader();
-        String builtContainerImage = createContainerImage(containerImageConfig, dockerConfig, containerImageInfo, out, reader,
+        String builtContainerImage = createContainerImage(containerImageConfig, dockerConfig, containerImageInfo, out,
                 false,
                 buildContainerImage,
                 pushContainerImage, packageConfig);
@@ -151,8 +144,7 @@ public class DockerProcessor {
 
         log.info("Starting (local) container image build for native binary using docker.");
 
-        ImageIdReader reader = new ImageIdReader();
-        String builtContainerImage = createContainerImage(containerImageConfig, dockerConfig, containerImage, out, reader, true,
+        String builtContainerImage = createContainerImage(containerImageConfig, dockerConfig, containerImage, out, true,
                 buildContainerImage,
                 pushContainerImage, packageConfig);
 
@@ -166,7 +158,7 @@ public class DockerProcessor {
 
     private String createContainerImage(ContainerImageConfig containerImageConfig, DockerConfig dockerConfig,
             ContainerImageInfoBuildItem containerImageInfo,
-            OutputTargetBuildItem out, ImageIdReader reader, boolean forNative, boolean buildContainerImage,
+            OutputTargetBuildItem out, boolean forNative, boolean buildContainerImage,
             boolean pushContainerImage,
             PackageConfig packageConfig) {
 
@@ -201,8 +193,7 @@ public class DockerProcessor {
             final String executableName = dockerConfig.executableName.orElse(detectContainerRuntime(true).getExecutableName());
             log.infof("Executing the following command to build docker image: '%s %s'", executableName,
                     String.join(" ", dockerArgs));
-            boolean buildSuccessful = ExecUtil.exec(out.getOutputDirectory().toFile(), reader, executableName,
-                    dockerArgs);
+            boolean buildSuccessful = ExecUtil.exec(out.getOutputDirectory().toFile(), executableName, dockerArgs);
             if (!buildSuccessful) {
                 throw dockerException(executableName, dockerArgs);
             }
@@ -212,8 +203,7 @@ public class DockerProcessor {
                     .ifPresentOrElse(
                             platform -> log.infof("Built container image %s (%s platform(s))\n", containerImageInfo.getImage(),
                                     String.join(",", platform)),
-                            () -> log.infof("Built container image %s (%s)\n", containerImageInfo.getImage(),
-                                    reader.getImageId()));
+                            () -> log.infof("Built container image %s\n", containerImageInfo.getImage()));
 
         }
 
@@ -368,41 +358,6 @@ public class DockerProcessor {
             } else {
                 return DockerfileDetectionResult.detect(DOCKERFILE_JVM, outputDirectory);
             }
-        }
-    }
-
-    /**
-     * A function that creates a command output reader, that reads and holds the image id from the docker build output.
-     */
-    private static class ImageIdReader implements Function<InputStream, Runnable> {
-
-        private final AtomicReference<String> id = new AtomicReference<>();
-
-        public String getImageId() {
-            return id.get();
-        }
-
-        @Override
-        public Runnable apply(InputStream t) {
-            return new Runnable() {
-                @Override
-                public void run() {
-                    try (InputStreamReader isr = new InputStreamReader(t);
-                            BufferedReader reader = new BufferedReader(isr)) {
-
-                        for (String line = reader.readLine(); line != null; line = reader.readLine()) {
-                            if (line.startsWith("Successfully built")) {
-                                String[] parts = line.split(" ");
-                                if (parts.length == 3)
-                                    id.set(parts[2]);
-                            }
-                            log.info(line);
-                        }
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            };
         }
     }
 

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker/verify.groovy
@@ -1,14 +1,12 @@
 import io.quarkus.deployment.util.ExecUtil
 
-ExecUtil.useSystemLogging() //prevents stack overflow issues
-
 try {
-    ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
+    ExecUtil.execWithSystemLogging("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {
     println "Docker not found"
     return
 }
 
 String group = System.getProperty("user.name")
-assert ExecUtil.exec("docker", "images", group + "/container-build-docker")
-assert ExecUtil.exec("docker", "rmi", group + "/container-build-docker:0.1-SNAPSHOT")
+assert ExecUtil.execWithSystemLogging("docker", "images", group + "/container-build-docker")
+assert ExecUtil.execWithSystemLogging("docker", "rmi", group + "/container-build-docker:0.1-SNAPSHOT")

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-appcds/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-appcds/verify.groovy
@@ -2,21 +2,20 @@ import io.quarkus.deployment.util.ExecUtil
 
 import java.util.concurrent.ThreadLocalRandom
 
-ExecUtil.useSystemLogging() //prevents stack overflow issues
 try {
-    ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
+    ExecUtil.execWithSystemLogging("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {
     return
 }
 
 String image = "${System.getProperty("user.name")}/container-build-jib-appcds:0.1-SNAPSHOT"
-assert ExecUtil.exec("docker", "images", image)
+assert ExecUtil.execWithSystemLogging("docker", "images", image)
 
 String containerName = "container-build-jib-appcds-" + ThreadLocalRandom.current().nextInt(10000)
 int maxTimesToCheck = 10
 int i = 0
 int hostPort = 12345
-assert ExecUtil.exec("docker", "run", "-d", "-p", "$hostPort:8080", "--name", containerName, image)
+assert ExecUtil.execWithSystemLogging("docker", "run", "-d", "-p", "$hostPort:8080", "--name", containerName, image)
 
 while (true) {
     try {
@@ -33,6 +32,6 @@ while (true) {
         }
     }
 }
-assert ExecUtil.exec("docker", "stop", containerName)
-assert ExecUtil.exec("docker", "rm", containerName)
-assert ExecUtil.exec("docker", "rmi", image)
+assert ExecUtil.execWithSystemLogging("docker", "stop", containerName)
+assert ExecUtil.execWithSystemLogging("docker", "rm", containerName)
+assert ExecUtil.execWithSystemLogging("docker", "rmi", image)

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-inherit/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-inherit/verify.groovy
@@ -2,22 +2,21 @@ import io.quarkus.deployment.util.ExecUtil
 
 import java.util.concurrent.ThreadLocalRandom
 
-ExecUtil.useSystemLogging() //prevents stack overflow issues
 
 try {
-    ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
+    ExecUtil.execWithSystemLogging("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {
     return
 }
 
 String image = "${System.getProperty("user.name")}/container-build-jib-inherit:0.1-SNAPSHOT"
-assert ExecUtil.exec("docker", "images", image)
+assert ExecUtil.execWithSystemLogging("docker", "images", image)
 
 String containerName = "container-build-jib-inherit-" + ThreadLocalRandom.current().nextInt(10000)
 int maxTimesToCheck = 10
 int i = 0
 int hostPort = 12345
-assert ExecUtil.exec("docker", "run", "-d", "-p", "$hostPort:8080", "--name", containerName, image)
+assert ExecUtil.execWithSystemLogging("docker", "run", "-d", "-p", "$hostPort:8080", "--name", containerName, image)
 
 while (true) {
     try {
@@ -34,6 +33,6 @@ while (true) {
         }
     }
 }
-assert ExecUtil.exec("docker", "stop", containerName)
-assert ExecUtil.exec("docker", "rm", containerName)
-assert ExecUtil.exec("docker", "rmi", image)
+assert ExecUtil.execWithSystemLogging("docker", "stop", containerName)
+assert ExecUtil.execWithSystemLogging("docker", "rm", containerName)
+assert ExecUtil.execWithSystemLogging("docker", "rmi", image)

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib/verify.groovy
@@ -4,16 +4,15 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
-ExecUtil.useSystemLogging() //prevents stack overflow issues
 try {
-    ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
+    ExecUtil.execWithSystemLogging("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {
     println "Docker not found"
     return
 }
 
-assert ExecUtil.exec("docker", "images", "container-build-jib")
-assert ExecUtil.exec("docker", "rmi", "container-build-jib:0.1-SNAPSHOT")
+assert ExecUtil.execWithSystemLogging("docker", "images", "container-build-jib")
+assert ExecUtil.execWithSystemLogging("docker", "rmi", "container-build-jib:0.1-SNAPSHOT")
 
 
 Path pathInIT = Paths.get("target", "it", "container-build-jib", "target")

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-docker/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-docker/verify.groovy
@@ -1,15 +1,14 @@
 import io.quarkus.deployment.util.ExecUtil
 
-ExecUtil.useSystemLogging() //prevents stack overflow issues
 try {
-    ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
+    ExecUtil.execWithSystemLogging("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {
     println "Docker not found"
     return
 }
 
 String group = System.getProperty("user.name")
-assert ExecUtil.exec("docker", "images", group + "/container-build-multiple-tags-docker")
-assert ExecUtil.exec("docker", "rmi", group + "/container-build-multiple-tags-docker:foo")
-assert ExecUtil.exec("docker", "rmi", group + "/container-build-multiple-tags-docker:bar")
-assert ExecUtil.exec("docker", "rmi", group + "/container-build-multiple-tags-docker:baz")
+assert ExecUtil.execWithSystemLogging("docker", "images", group + "/container-build-multiple-tags-docker")
+assert ExecUtil.execWithSystemLogging("docker", "rmi", group + "/container-build-multiple-tags-docker:foo")
+assert ExecUtil.execWithSystemLogging("docker", "rmi", group + "/container-build-multiple-tags-docker:bar")
+assert ExecUtil.execWithSystemLogging("docker", "rmi", group + "/container-build-multiple-tags-docker:baz")

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-jib/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-jib/verify.groovy
@@ -1,15 +1,14 @@
 import io.quarkus.deployment.util.ExecUtil
 
-ExecUtil.useSystemLogging() //prevents stack overflow issues
 try {
-    ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
+    ExecUtil.execWithSystemLogging("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {
     println "Docker not found"
     return
 }
 
 String group = System.getProperty("user.name")
-assert ExecUtil.exec("docker", "images", group + "/container-build-multiple-tags-jib")
-assert ExecUtil.exec("docker", "rmi", group + "/container-build-multiple-tags-jib:foo")
-assert ExecUtil.exec("docker", "rmi", group + "/container-build-multiple-tags-jib:bar")
-assert ExecUtil.exec("docker", "rmi", group + "/container-build-multiple-tags-jib:baz")
+assert ExecUtil.execWithSystemLogging("docker", "images", group + "/container-build-multiple-tags-jib")
+assert ExecUtil.execWithSystemLogging("docker", "rmi", group + "/container-build-multiple-tags-jib:foo")
+assert ExecUtil.execWithSystemLogging("docker", "rmi", group + "/container-build-multiple-tags-jib:bar")
+assert ExecUtil.execWithSystemLogging("docker", "rmi", group + "/container-build-multiple-tags-jib:baz")

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-image-push/setup.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-image-push/setup.groovy
@@ -1,11 +1,10 @@
 import io.quarkus.deployment.util.ExecUtil
 
-ExecUtil.useSystemLogging() //prevents stack overflow issues
 try {
-    ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
+    ExecUtil.execWithSystemLogging("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {
     println "Docker not found"
     return
 }
 
-assert ExecUtil.exec("docker", "run", "--rm", "-p", "5000:5000", "-d", "--name", "registry" ,"registry:2");
+assert ExecUtil.execWithSystemLogging("docker", "run", "--rm", "-p", "5000:5000", "-d", "--name", "registry" ,"registry:2");

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-image-push/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-image-push/verify.groovy
@@ -3,9 +3,8 @@ import io.quarkus.deployment.util.ExecUtil
 import static io.restassured.RestAssured.get
 import static org.hamcrest.Matchers.containsString
 
-ExecUtil.useSystemLogging() //prevents stack overflow issues
 try {
-    ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")
+    ExecUtil.execWithSystemLogging("docker", "version", "--format", "'{{.Server.Version}}'")
 } catch (Exception ignored) {
     println "Docker not found"
     return
@@ -15,4 +14,4 @@ get("http://localhost:5000/v2/_catalog")
         .then()
         .body(containsString("container-image-push"))
 
-assert ExecUtil.exec("docker", "stop", "registry")
+assert ExecUtil.execWithSystemLogging("docker", "stop", "registry")


### PR DESCRIPTION
The process is longer used for anything except logging
and it doesn't even work properly with new Docker versions
as the output has changed

For example, a run I did yielded:

```
[INFO] [io.quarkus.container.image.docker.deployment.DockerProcessor] Built container image gandrian/getting-started-command-mode:1.0.0-SNAPSHOT (null)
```

because my Docker version no longer has the line starting with `Successfully built`.

P.S. The first commit isn't strictly necessary, but I think we should include it as it both fixes the default logging of `ExecUtil`
and also removes an unused and unsafe API