### PR TITLE
Remove duplicate property kotlin.coroutine.version from application BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -160,7 +160,6 @@
         <kotlin.version>1.8.22</kotlin.version>
         <kotlin.coroutine.version>1.7.1</kotlin.coroutine.version>
         <azure.toolkit-lib.version>0.27.0</azure.toolkit-lib.version>
-        <kotlin.coroutine.version>1.6.4</kotlin.coroutine.version>
         <kotlin-serialization.version>1.5.1</kotlin-serialization.version>
         <dekorate.version>3.7.0</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>


### PR DESCRIPTION
There is a newer `kotlin.coroutine.version` two lines up.