### PR TITLE
Force reachability handlers to run concurrently in GraalVM 23.0

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -792,6 +792,11 @@ public class NativeImageBuildStep {
                     nativeImageArgs.add("-H:BuildOutputJSONFile=" + nativeImageName + "-build-output-stats.json");
                 }
 
+                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_0_0) == 0) {
+                    // Serial reachability handler is broken in 23.0.0, see https://github.com/oracle/graal/issues/6904
+                    nativeImageArgs.add("-H:+RunReachabilityHandlersConcurrently");
+                }
+
                 /*
                  * Any parameters following this call are forced over the user provided parameters in
                  * quarkus.native.additional-build-args. So if you need a parameter to be overridable through


### PR DESCRIPTION
Serial reachability handler is broken in 23.0.0, see https://github.com/oracle/graal/issues/6904

Needed to fix https://github.com/apache/camel-quarkus/issues/5006

Note that:
* this just enforces the default GraalVM behavior when a dependency passes `-H:-RunReachabilityHandlersConcurrently`.
* users are still able to explicitly pass the same flag through `quarkus.native.additional-build-args`.