### PR TITLE
Allow disabling the manifests generation for K8s/OpenShift/Knative

### DIFF
--- a/extensions/kubernetes/kind/deployment/src/main/java/io/quarkus/kind/deployment/KindProcessor.java
+++ b/extensions/kubernetes/kind/deployment/src/main/java/io/quarkus/kind/deployment/KindProcessor.java
@@ -58,6 +58,10 @@ public class KindProcessor {
     public void checkKind(ApplicationInfoBuildItem applicationInfo, KubernetesConfig config,
             BuildProducer<KubernetesDeploymentTargetBuildItem> deploymentTargets,
             BuildProducer<KubernetesResourceMetadataBuildItem> resourceMeta) {
+        if (!config.enabled) {
+            return;
+        }
+
         deploymentTargets.produce(
                 new KubernetesDeploymentTargetBuildItem(KIND, DEPLOYMENT, DEPLOYMENT_GROUP, DEPLOYMENT_VERSION,
                         KIND_PRIORITY, true, config.getDeployStrategy()));

--- a/extensions/kubernetes/minikube/deployment/src/main/java/io/quarkus/minikube/deployment/MinikubeProcessor.java
+++ b/extensions/kubernetes/minikube/deployment/src/main/java/io/quarkus/minikube/deployment/MinikubeProcessor.java
@@ -55,6 +55,10 @@ public class MinikubeProcessor {
     public void checkMinikube(ApplicationInfoBuildItem applicationInfo, KubernetesConfig config,
             BuildProducer<KubernetesDeploymentTargetBuildItem> deploymentTargets,
             BuildProducer<KubernetesResourceMetadataBuildItem> resourceMeta) {
+        if (!config.enabled) {
+            return;
+        }
+
         deploymentTargets.produce(
                 new KubernetesDeploymentTargetBuildItem(MINIKUBE, DEPLOYMENT, DEPLOYMENT_GROUP, DEPLOYMENT_VERSION,
                         MINIKUBE_PRIORITY, true, config.getDeployStrategy()));

--- a/extensions/kubernetes/openshift/deployment/src/main/java/io/quarkus/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/openshift/deployment/src/main/java/io/quarkus/openshift/deployment/OpenshiftProcessor.java
@@ -18,6 +18,9 @@ public class OpenshiftProcessor {
     public void checkOpenshift(ApplicationInfoBuildItem applicationInfo, Capabilities capabilities, OpenshiftConfig config,
             BuildProducer<KubernetesDeploymentTargetBuildItem> deploymentTargets,
             BuildProducer<KubernetesResourceMetadataBuildItem> resourceMeta) {
+        if (!config.enabled) {
+            return;
+        }
 
         DeploymentResourceKind deploymentResourceKind = config.getDeploymentResourceKind(capabilities);
         deploymentTargets

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
@@ -87,8 +87,13 @@ public class KnativeProcessor {
 
     @BuildStep
     public void checkKnative(ApplicationInfoBuildItem applicationInfo, KnativeConfig config,
+            KubernetesConfig kubernetesConfig,
             BuildProducer<KubernetesDeploymentTargetBuildItem> deploymentTargets,
             BuildProducer<KubernetesResourceMetadataBuildItem> resourceMeta) {
+        if (!kubernetesConfig.enabled) {
+            return;
+        }
+
         List<String> targets = KubernetesConfigUtil.getConfiguredDeploymentTargets();
         boolean knativeEnabled = targets.contains(KNATIVE);
         deploymentTargets.produce(

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -37,6 +37,12 @@ public class KubernetesConfig implements PlatformConfiguration {
     }
 
     /**
+     * Whether the Kubernetes extension is enabled and hence the Kubernetes manifests will be generated or not.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean enabled;
+
+    /**
      * The name of the group this component belongs too
      */
     @ConfigItem

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -65,11 +65,14 @@ public class KubernetesDeployer {
 
     @BuildStep(onlyIf = IsNormalNotRemoteDev.class)
     public void selectDeploymentTarget(ContainerImageInfoBuildItem containerImageInfo,
-            EnabledKubernetesDeploymentTargetsBuildItem targets,
+            Optional<EnabledKubernetesDeploymentTargetsBuildItem> targets,
             Capabilities capabilities,
             ContainerImageConfig containerImageConfig,
             BuildProducer<SelectedKubernetesDeploymentTargetBuildItem> selectedDeploymentTarget,
             BuildProducer<PreventImplicitContainerImagePushBuildItem> preventImplicitContainerImagePush) {
+        if (targets.isEmpty()) {
+            return;
+        }
 
         Optional<String> activeContainerImageCapability = ContainerImageCapabilitiesUtil
                 .getActiveContainerImageCapability(capabilities);
@@ -81,7 +84,7 @@ public class KubernetesDeployer {
             return;
         }
 
-        final DeploymentTargetEntry selectedTarget = determineDeploymentTarget(containerImageInfo, targets,
+        final DeploymentTargetEntry selectedTarget = determineDeploymentTarget(containerImageInfo, targets.get(),
                 containerImageConfig);
         selectedDeploymentTarget.produce(new SelectedKubernetesDeploymentTargetBuildItem(selectedTarget));
         if (MINIKUBE.equals(selectedTarget.getName()) || KIND.equals(selectedTarget.getName())) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -58,6 +58,12 @@ public class OpenshiftConfig implements PlatformConfiguration {
     }
 
     /**
+     * Whether the OpenShift extension is enabled and hence the OpenShift manifests are generated or not.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean enabled;
+
+    /**
      * The OpenShift flavor / version to use.
      * Older versions of OpenShift have minor differences in the labels and fields they support.
      * This option allows users to have their manifests automatically aligned to the OpenShift 'flavor' they use.

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
@@ -84,8 +84,13 @@ public class OpenshiftProcessor {
 
     @BuildStep
     public void checkOpenshift(ApplicationInfoBuildItem applicationInfo, Capabilities capabilities, OpenshiftConfig config,
+            KubernetesConfig kubernetesConfig,
             BuildProducer<KubernetesDeploymentTargetBuildItem> deploymentTargets,
             BuildProducer<KubernetesResourceMetadataBuildItem> resourceMeta) {
+        if (!kubernetesConfig.enabled || !config.enabled) {
+            return;
+        }
+
         List<String> targets = KubernetesConfigUtil.getConfiguredDeploymentTargets();
         boolean openshiftEnabled = targets.contains(OPENSHIFT);
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
@@ -75,6 +75,10 @@ public class VanillaKubernetesProcessor {
             KubernetesConfig config,
             BuildProducer<KubernetesDeploymentTargetBuildItem> deploymentTargets,
             BuildProducer<KubernetesResourceMetadataBuildItem> resourceMeta) {
+        if (!config.enabled) {
+            return;
+        }
+
         String kind = config.getDeploymentResourceKind(capabilities).kind;
 
         List<String> userSpecifiedDeploymentTargets = KubernetesConfigUtil.getConfiguredDeploymentTargets();

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesDisabledAndOpenshiftEnabledTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesDisabledAndOpenshiftEnabledTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesDisabledAndOpenshiftEnabledTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName("kubernetes-disabled-openshift-enabled")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .overrideConfigKey("quarkus.kubernetes.enabled", "false")
+            .overrideConfigKey("quarkus.openshift.enabled", "true")
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryNotContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryNotContaining(p -> p.getFileName().endsWith("kubernetes.yml"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.yml"));
+    }
+
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesDisabledTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesDisabledTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName("kubernetes-disabled")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .overrideConfigKey("quarkus.kubernetes.enabled", "false");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        assertThat(prodModeTestResults.getBuildDir())
+                .isDirectoryNotContaining(p -> p.toString().endsWith("kubernetes"));
+    }
+
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftDisabledTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftDisabledTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class OpenshiftDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName("openshift-disabled")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .overrideConfigKey("quarkus.kubernetes.deployment-target", "openshift")
+            .overrideConfigKey("quarkus.kubernetes.enabled", "false");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        assertThat(prodModeTestResults.getBuildDir())
+                .isDirectoryNotContaining(p -> p.toString().endsWith("kubernetes"));
+    }
+
+}


### PR DESCRIPTION
To me, it makes sense to separately enable/disable the generated resources by extension (kubernetes, knative, openshift, ...). We could disable the manifests generation for Kubernetes, but not for OpenShift for example. 

Fix https://github.com/quarkusio/quarkus/issues/34094