### PR TITLE
Add PR number to build scans

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -49,7 +49,6 @@ env:
   DB_PASSWORD: hibernate_orm_test
   DB_NAME: hibernate_orm_test
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-  PULL_REQUEST_NUMBER: ${{ github.event.number }}
 jobs:
   # This is a hack to work around a GitHub API limitation:
   # when the PR is coming from another fork, the pull_requests field of the

--- a/.mvn/gradle-enterprise-custom-user-data.groovy
+++ b/.mvn/gradle-enterprise-custom-user-data.groovy
@@ -1,4 +1,4 @@
-
+import groovy.json.JsonSlurper
 
 // Add mvn command line
 def mvnCommand = ''
@@ -17,11 +17,17 @@ if (System.env.GITHUB_ACTIONS) {
     buildScan.value('gh-actor', System.env.GITHUB_ACTOR)
     buildScan.value('gh-workflow', System.env.GITHUB_WORKFLOW)
 
+    if (System.env.GITHUB_EVENT_NAME == "pull_request" && System.env.GITHUB_EVENT_PATH != null) {
+        File eventJsonFile = new File(System.env.GITHUB_EVENT_PATH)
+        if (eventJsonFile.exists()) {
+            def eventJson = new JsonSlurper().parse(eventJsonFile)
+            def prNumber = eventJson.pull_request?.number
 
-    def prnumber = System.env.PULL_REQUEST_NUMBER
-    if (prnumber != null) {
-        buildScan.value('gh-pr', prnumber)
-        buildScan.tag('pr-' + prnumber)
+            if (prNumber != null) {
+                buildScan.value('gh-pr', prNumber)
+                buildScan.tag('pr-' + prNumber)
+            }
+        }
     }
 
     buildScan.buildScanPublished {  publishedBuildScan ->


### PR DESCRIPTION
The previous way of doing it didn't work: we are now extracting the value from the event.json file in the Groovy script.