### PR TITLE
Qute: ValueResolverGenerator optimization - reduce allocations

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/CompletedStage.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/CompletedStage.java
@@ -20,14 +20,31 @@ import java.util.function.Supplier;
  */
 public final class CompletedStage<T> implements CompletionStage<T>, Supplier<T> {
 
-    static final CompletedStage<Void> VOID = new CompletedStage<>(null, null);
+    @SuppressWarnings("rawtypes")
+    static final CompletedStage NULL = new CompletedStage<>(null, null);
 
+    @SuppressWarnings("unchecked")
     public static <T> CompletedStage<T> of(T result) {
+        if (result == null) {
+            // Use a shared constant for nulls
+            return (CompletedStage<T>) NULL;
+        }
         return new CompletedStage<T>(result, null);
     }
 
     public static <T> CompletedStage<T> failure(Throwable t) {
+        Objects.requireNonNull(t);
         return new CompletedStage<T>(null, t);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static CompletedStage<Void> ofVoid() {
+        return NULL;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static CompletedStage<Object> ofNull() {
+        return NULL;
     }
 
     private final T result;
@@ -84,7 +101,7 @@ public final class CompletedStage<T> implements CompletionStage<T>, Supplier<T> 
             } catch (Throwable e) {
                 return new CompletedStage<>(null, e);
             }
-            return VOID;
+            return ofVoid();
         }
         return new CompletedStage<>(null, exception);
     }
@@ -108,7 +125,7 @@ public final class CompletedStage<T> implements CompletionStage<T>, Supplier<T> 
             } catch (final Throwable e) {
                 return new CompletedStage<>(null, e);
             }
-            return VOID;
+            return ofVoid();
         }
         return new CompletedStage<>(null, exception);
     }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatedParams.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatedParams.java
@@ -11,7 +11,7 @@ import java.util.function.Supplier;
 
 public final class EvaluatedParams {
 
-    static final EvaluatedParams EMPTY = new EvaluatedParams(CompletedStage.VOID, new Supplier<?>[0]);
+    static final EvaluatedParams EMPTY = new EvaluatedParams(CompletedStage.ofVoid(), new Supplier<?>[0]);
 
     /**
      *
@@ -52,7 +52,7 @@ public final class EvaluatedParams {
         }
         CompletionStage<?> cs;
         if (asyncResults == null) {
-            cs = failure != null ? failure : CompletedStage.VOID;
+            cs = failure != null ? failure : CompletedStage.ofVoid();
         } else if (asyncResults.size() == 1) {
             cs = asyncResults.get(0);
         } else {
@@ -101,7 +101,7 @@ public final class EvaluatedParams {
         }
         CompletionStage<?> cs;
         if (asyncResults == null) {
-            cs = failure != null ? failure : CompletedStage.VOID;
+            cs = failure != null ? failure : CompletedStage.ofVoid();
         } else if (asyncResults.size() == 1) {
             cs = asyncResults.get(0);
         } else {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
@@ -15,7 +15,7 @@ public final class Results {
 
     public static final CompletedStage<Object> FALSE = CompletedStage.of(false);
     public static final CompletedStage<Object> TRUE = CompletedStage.of(true);
-    public static final CompletedStage<Object> NULL = CompletedStage.of(null);
+    public static final CompletedStage<Object> NULL = CompletedStage.NULL;
 
     private Results() {
     }

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/Descriptors.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/Descriptors.java
@@ -35,7 +35,7 @@ public final class Descriptors {
     public static final MethodDescriptor EVALUATE = MethodDescriptor.ofMethod(EvalContext.class, "evaluate",
             CompletionStage.class, Expression.class);
     static final MethodDescriptor LIST_GET = MethodDescriptor.ofMethod(List.class, "get", Object.class, int.class);
-    static final MethodDescriptor COMPLETED_STAGE = MethodDescriptor.ofMethod(CompletedStage.class,
+    static final MethodDescriptor COMPLETED_STAGE_OF = MethodDescriptor.ofMethod(CompletedStage.class,
             "of", CompletedStage.class, Object.class);
     public static final MethodDescriptor COMPLETABLE_FUTURE_ALL_OF = MethodDescriptor.ofMethod(CompletableFuture.class,
             "allOf",
@@ -58,6 +58,8 @@ public final class Descriptors {
             CompletionStage.class, BiConsumer.class);
     public static final MethodDescriptor BOOLEAN_LOGICAL_OR = MethodDescriptor.ofMethod(Boolean.class, "logicalOr",
             boolean.class, boolean.class, boolean.class);
+    public static final MethodDescriptor BOOLEAN_VALUE = MethodDescriptor.ofMethod(Boolean.class, "booleanValue",
+            boolean.class);
     public static final MethodDescriptor EVALUATED_PARAMS_EVALUATE = MethodDescriptor.ofMethod(EvaluatedParams.class,
             "evaluate",
             EvaluatedParams.class,
@@ -96,5 +98,7 @@ public final class Descriptors {
 
     public static final FieldDescriptor EVALUATED_PARAMS_STAGE = FieldDescriptor.of(EvaluatedParams.class, "stage",
             CompletionStage.class);
+    public static final FieldDescriptor RESULTS_TRUE = FieldDescriptor.of(Results.class, "TRUE", CompletedStage.class);
+    public static final FieldDescriptor RESULTS_FALSE = FieldDescriptor.of(Results.class, "FALSE", CompletedStage.class);
 
 }

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
@@ -261,7 +261,7 @@ public class ExtensionMethodGenerator {
             if (returnsCompletionStage) {
                 ret = result;
             } else {
-                ret = resolve.invokeStaticMethod(Descriptors.COMPLETED_STAGE, result);
+                ret = resolve.invokeStaticMethod(Descriptors.COMPLETED_STAGE_OF, result);
             }
         } else {
             ret = resolve
@@ -520,7 +520,7 @@ public class ExtensionMethodGenerator {
                                     matchScope.load(param.name));
                         }
                     }
-                    matchScope.returnValue(matchScope.invokeStaticMethod(Descriptors.COMPLETED_STAGE,
+                    matchScope.returnValue(matchScope.invokeStaticMethod(Descriptors.COMPLETED_STAGE_OF,
                             matchScope.invokeStaticMethod(MethodDescriptor.of(method), args)));
                 } else {
                     ResultHandle ret = matchScope.newInstance(MethodDescriptor.ofConstructor(CompletableFuture.class));

--- a/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/MyService.java
+++ b/independent-projects/qute/generator/src/test/java/io/quarkus/qute/generator/MyService.java
@@ -33,12 +33,16 @@ public class MyService {
         return name != null;
     }
 
-    public boolean isActive() {
+    public Boolean isActive() {
         return true;
     }
 
     public boolean hasItems() {
         return false;
+    }
+
+    public MyEnum myEnum() {
+        return MyEnum.BAR;
     }
 
     public List<String> getList(int limit, String dummy) {


### PR DESCRIPTION
- use shared constants for booleans, enums and nulls