### PR TITLE
Use tag provided by quarkus.container-image.image property

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
@@ -335,31 +335,28 @@ public class OpenshiftProcessor {
                 ports,
                 config.ports));
 
-        // Handle non-openshift builds
-        if (deploymentKind == DeploymentResourceKind.DeploymentConfig
-                && !OpenshiftConfig.isOpenshiftBuildEnabled(containerImageConfig, capabilities)) {
-            image.ifPresent(i -> {
-                String registry = i.registry
-                        .or(() -> containerImageConfig.registry)
-                        .orElse(fallbackRegistry.map(f -> f.getRegistry()).orElse(DOCKERIO_REGISTRY));
-                String repositoryWithRegistry = registry + "/" + i.getRepository();
-                ImageConfiguration imageConfiguration = new ImageConfigurationBuilder()
-                        .withName(name)
-                        .withRegistry(registry)
-                        .build();
+        image.ifPresent(i -> {
+            String registry = i.registry
+                    .or(() -> containerImageConfig.registry)
+                    .orElse(fallbackRegistry.map(f -> f.getRegistry()).orElse(DOCKERIO_REGISTRY));
+            String repositoryWithRegistry = registry + "/" + i.getRepository();
+            ImageConfiguration imageConfiguration = new ImageConfigurationBuilder()
+                    .withName(name)
+                    .withRegistry(registry)
+                    .build();
 
+            String imageStreamWithTag = name + ":" + i.getTag();
+            if (deploymentKind == DeploymentResourceKind.DeploymentConfig
+                    && !OpenshiftConfig.isOpenshiftBuildEnabled(containerImageConfig, capabilities)) {
                 result.add(new DecoratorBuildItem(OPENSHIFT,
                         new AddDockerImageStreamResourceDecorator(imageConfiguration, repositoryWithRegistry)));
-                String imageStreamWithTag = name + ":" + i.getTag();
-                result.add(new DecoratorBuildItem(OPENSHIFT, new ApplyContainerImageDecorator(name, imageStreamWithTag)));
-                // remove the default trigger which has a wrong version
-                result.add(new DecoratorBuildItem(OPENSHIFT, new RemoveDeploymentTriggerDecorator(name)));
-                // re-add the trigger with the correct version
-                result.add(new DecoratorBuildItem(OPENSHIFT, new ChangeDeploymentTriggerDecorator(name, imageStreamWithTag)));
-            });
-        } else if (image.isPresent()) {
-            result.add(new DecoratorBuildItem(OPENSHIFT, new ApplyContainerImageDecorator(name, image.get().getImage())));
-        }
+            }
+            result.add(new DecoratorBuildItem(OPENSHIFT, new ApplyContainerImageDecorator(name, i.getImage())));
+            // remove the default trigger which has a wrong version
+            result.add(new DecoratorBuildItem(OPENSHIFT, new RemoveDeploymentTriggerDecorator(name)));
+            // re-add the trigger with the correct version
+            result.add(new DecoratorBuildItem(OPENSHIFT, new ChangeDeploymentTriggerDecorator(name, imageStreamWithTag)));
+        });
 
         // Handle remote debug configuration
         if (config.remoteDebug.enabled) {


### PR DESCRIPTION
Currently when `quarkus.container-image.image` is specified the Openshift resources ignore the tag as of the provided image and use application version instead. 

This pull request addresses that.