### PR TITLE
Refactor BuildTimeConfigurationReader to make it easy to initialize a config outside ExtensionLoader

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -16,6 +16,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.paths.PathCollection;
 import io.quarkus.paths.PathList;
 import io.quarkus.runtime.LaunchMode;
@@ -37,7 +38,7 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
 
     @Override
     protected boolean beforeExecute() throws MojoExecutionException, MojoFailureException {
-        if (mavenProject().getPackaging().equals("pom")) {
+        if (mavenProject().getPackaging().equals(ArtifactCoords.TYPE_POM)) {
             getLog().info("Type of the artifact is POM, skipping build goal");
             return false;
         }
@@ -86,7 +87,7 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
                     boolean.class);
             initAndRun.invoke(null, deploymentClassLoader, sourceParents,
                     generatedSourcesDir(test), buildDir().toPath(),
-                    sourceRegistrar, curatedApplication.getApplicationModel(), mavenProject().getProperties(),
+                    sourceRegistrar, curatedApplication.getApplicationModel(), getBuildSystemProperties(false),
                     launchMode.name(),
                     test);
         } catch (Exception any) {

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
@@ -2,11 +2,11 @@ package io.quarkus.maven;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.execution.MavenSession;
@@ -135,7 +135,7 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
      * The context of the execution of the plugin.
      */
     @Parameter(defaultValue = "${mojoExecution}", readonly = true, required = true)
-    private MojoExecution mojoExecution;
+    MojoExecution mojoExecution;
 
     /**
      * Application bootstrap provider ID. This parameter is not supposed to be configured by the user.
@@ -217,7 +217,7 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
      * @return list of extra dependencies that should be enforced on the application
      */
     protected List<Dependency> forcedDependencies(LaunchMode mode) {
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Deprecated(forRemoval = true)
@@ -288,5 +288,9 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
 
     protected CuratedApplication bootstrapApplication(LaunchMode mode) throws MojoExecutionException {
         return bootstrapProvider.bootstrapApplication(this, mode);
+    }
+
+    protected Properties getBuildSystemProperties(boolean quarkusOnly) throws MojoExecutionException {
+        return bootstrapProvider.bootstrapper(this).getBuildSystemProperties(this, quarkusOnly);
     }
 }


### PR DESCRIPTION
This change allows bringing the configuration used in the source code generation phase closer to the configuration used in the actual build phase.
It also opens up other possibilities such as checking whether a config has changed since previous build before launching a new one.

@radcortez and maybe @dmlloyd in case you have time to review this one, I'd appreciate it, thanks.