### PR TITLE
Support multiple backchannel logout tokens

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -312,12 +312,72 @@ public class OidcTenantConfig extends OidcCommonConfig {
         @ConfigItem
         public Optional<String> path = Optional.empty();
 
+        /**
+         * Maximum number of logout tokens that can be cached before they are matched against ID tokens stored in session
+         * cookies.
+         */
+        @ConfigItem(defaultValue = "10")
+        public int tokenCacheSize = 10;
+
+        /**
+         * Number of minutes a logout token can be cached for.
+         */
+        @ConfigItem(defaultValue = "10M")
+        public Duration tokenCacheTimeToLive = Duration.ofMinutes(10);
+
+        /**
+         * Token cache timer interval.
+         * If this property is set then a timer will check and remove the stale entries periodically.
+         */
+        @ConfigItem
+        public Optional<Duration> cleanUpTimerInterval = Optional.empty();
+
+        /**
+         * Logout token claim whose value will be used as a key for caching the tokens.
+         * Only `sub` (subject) and `sid` (session id) claims can be used as keys.
+         * Set it to `sid` only if ID tokens issued by the OIDC provider have no `sub` but have `sid` claim.
+         */
+        @ConfigItem(defaultValue = "sub")
+        public String logoutTokenKey = "sub";
+
         public void setPath(Optional<String> path) {
             this.path = path;
         }
 
         public Optional<String> getPath() {
             return path;
+        }
+
+        public String getLogoutTokenKey() {
+            return logoutTokenKey;
+        }
+
+        public void setLogoutTokenKey(String logoutTokenKey) {
+            this.logoutTokenKey = logoutTokenKey;
+        }
+
+        public int getTokenCacheSize() {
+            return tokenCacheSize;
+        }
+
+        public void setTokenCacheSize(int tokenCacheSize) {
+            this.tokenCacheSize = tokenCacheSize;
+        }
+
+        public Duration getTokenCacheTimeToLive() {
+            return tokenCacheTimeToLive;
+        }
+
+        public void setTokenCacheTimeToLive(Duration tokenCacheTimeToLive) {
+            this.tokenCacheTimeToLive = tokenCacheTimeToLive;
+        }
+
+        public Optional<Duration> getCleanUpTimerInterval() {
+            return cleanUpTimerInterval;
+        }
+
+        public void setCleanUpTimerInterval(Duration cleanUpTimerInterval) {
+            this.cleanUpTimerInterval = Optional.of(cleanUpTimerInterval);
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutTokenCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutTokenCache.java
@@ -1,0 +1,99 @@
+package io.quarkus.oidc.runtime;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.quarkus.oidc.OidcTenantConfig;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+
+public class BackChannelLogoutTokenCache {
+    private OidcTenantConfig oidcConfig;
+
+    private Map<String, CacheEntry> cacheMap = new ConcurrentHashMap<>();;
+    private AtomicInteger size = new AtomicInteger();
+
+    public BackChannelLogoutTokenCache(OidcTenantConfig oidcTenantConfig, Vertx vertx) {
+        this.oidcConfig = oidcTenantConfig;
+        init(vertx);
+    }
+
+    private void init(Vertx vertx) {
+        cacheMap = new ConcurrentHashMap<>();
+        if (oidcConfig.logout.backchannel.cleanUpTimerInterval.isPresent()) {
+            vertx.setPeriodic(oidcConfig.logout.backchannel.cleanUpTimerInterval.get().toMillis(), new Handler<Long>() {
+                @Override
+                public void handle(Long event) {
+                    // Remove all the entries which have expired
+                    removeInvalidEntries();
+                }
+            });
+        }
+    }
+
+    public void addTokenVerification(String token, TokenVerificationResult result) {
+        if (!prepareSpaceForNewCacheEntry()) {
+            clearCache();
+        }
+        cacheMap.put(token, new CacheEntry(result));
+    }
+
+    public TokenVerificationResult removeTokenVerification(String token) {
+        CacheEntry entry = removeCacheEntry(token);
+        return entry == null ? null : entry.result;
+    }
+
+    public void clearCache() {
+        cacheMap.clear();
+        size.set(0);
+    }
+
+    private void removeInvalidEntries() {
+        long now = now();
+        for (Iterator<Map.Entry<String, CacheEntry>> it = cacheMap.entrySet().iterator(); it.hasNext();) {
+            Map.Entry<String, CacheEntry> next = it.next();
+            if (isEntryExpired(next.getValue(), now)) {
+                it.remove();
+                size.decrementAndGet();
+            }
+        }
+    }
+
+    private boolean prepareSpaceForNewCacheEntry() {
+        int currentSize;
+        do {
+            currentSize = size.get();
+            if (currentSize == oidcConfig.logout.backchannel.tokenCacheSize) {
+                return false;
+            }
+        } while (!size.compareAndSet(currentSize, currentSize + 1));
+        return true;
+    }
+
+    private CacheEntry removeCacheEntry(String token) {
+        CacheEntry entry = cacheMap.remove(token);
+        if (entry != null) {
+            size.decrementAndGet();
+        }
+        return entry;
+    }
+
+    private boolean isEntryExpired(CacheEntry entry, long now) {
+        return entry.createdTime + oidcConfig.logout.backchannel.tokenCacheTimeToLive.toMillis() < now;
+    }
+
+    private static long now() {
+        return System.currentTimeMillis();
+    }
+
+    private static class CacheEntry {
+        volatile TokenVerificationResult result;
+        long createdTime = System.currentTimeMillis();
+
+        public CacheEntry(TokenVerificationResult result) {
+            this.result = result;
+        }
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -64,7 +64,7 @@ public class DefaultTenantConfigResolver {
 
     private volatile boolean securityEventObserved;
 
-    private ConcurrentHashMap<String, TokenVerificationResult> backChannelLogoutTokens = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<String, BackChannelLogoutTokenCache> backChannelLogoutTokens = new ConcurrentHashMap<>();
 
     @PostConstruct
     public void verifyResolvers() {
@@ -232,7 +232,7 @@ public class DefaultTenantConfigResolver {
         return enableHttpForwardedPrefix;
     }
 
-    public Map<String, TokenVerificationResult> getBackChannelLogoutTokens() {
+    public Map<String, BackChannelLogoutTokenCache> getBackChannelLogoutTokens() {
         return backChannelLogoutTokens;
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenIntrospectionUserInfoCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenIntrospectionUserInfoCache.java
@@ -5,7 +5,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.IntUnaryOperator;
 
 import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
@@ -168,19 +167,5 @@ public class DefaultTokenIntrospectionUserInfoCache implements TokenIntrospectio
         public CacheEntry(UserInfo userInfo) {
             this.userInfo = userInfo;
         }
-    }
-
-    private static class IncrementOperator implements IntUnaryOperator {
-        int maxSize;
-
-        IncrementOperator(int maxSize) {
-            this.maxSize = maxSize;
-        }
-
-        @Override
-        public int applyAsInt(int n) {
-            return n < maxSize ? n + 1 : n;
-        }
-
     }
 }

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -144,9 +144,25 @@ public class CodeFlowAuthorizationTest {
             // Session is still active
             assertNotNull(getSessionCookie(webClient, "code-flow-form-post"));
 
-            // request a back channel logout
+            // ID token subject is `123456`
+            // request a back channel logout for some other subject
             RestAssured.given()
-                    .when().contentType(ContentType.URLENC).body("logout_token=" + OidcWiremockTestResource.getLogoutToken())
+                    .when().contentType(ContentType.URLENC)
+                    .body("logout_token=" + OidcWiremockTestResource.getLogoutToken("789"))
+                    .post("/back-channel-logout")
+                    .then()
+                    .statusCode(200);
+
+            // No logout:
+            page = webClient.getPage("http://localhost:8081/code-flow-form-post");
+            assertEquals("alice", page.getBody().asNormalizedText());
+            // Session is still active
+            assertNotNull(getSessionCookie(webClient, "code-flow-form-post"));
+
+            // request a back channel logout for the same subject
+            RestAssured.given()
+                    .when().contentType(ContentType.URLENC).body("logout_token="
+                            + OidcWiremockTestResource.getLogoutToken("123456"))
                     .post("/back-channel-logout")
                     .then()
                     .statusCode(200);

--- a/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
+++ b/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
@@ -371,6 +371,17 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
                 .sign("privateKey.jwk");
     }
 
+    public static String getLogoutToken(String sub) {
+        return Jwt.issuer(TOKEN_ISSUER)
+                .audience(TOKEN_AUDIENCE)
+                .subject(sub)
+                .claim("events", createEventsClaim())
+                .claim("sid", "session-id")
+                .jws()
+                .keyId("1")
+                .sign("privateKey.jwk");
+    }
+
     private static JsonObject createEventsClaim() {
         return Json.createObjectBuilder().add("http://schemas.openid.net/event/backchannel-logout",
                 Json.createObjectBuilder().build()).build();


### PR DESCRIPTION
Fixes #34442.

Hi Pedro, finally I got to fixing this issue. 
As you know, in Quarkus, we have to cache the logout tokens, or rather their verification results done in the backchannel logout handler, so that, when the user eventually returns, it can be compared against the ID token.
The bug was I coded it initially to have a 1 to 1 relationship between the tenant id and the logout token, thanks for spotting it.

Here is a summary of changes:
* `BackChannelLogoutTokenCache` is introduced, it is a simpler version of what Stuart helped me prepare for UserInfo and TokenIntrospection cache, it is just a concurrent hash map, whose size can be controlled, whose stale entries can be removed, and optionally it can be cleaned up in the backgroud
* Each tenant has its own `BackChannelLogoutTokenCache`
* `BackChannelLogoutTokenCache` keys a given logout token by its unique `sub` claim value by default, but it can be configured to `sid` - the idea is, that only the ID token with the same `sub` would be able to match it
* When the user returns, we just get the id token `sub` (or `sid`) and use it remove the logout token if any. If the token is found, we verify as before, by matching against ID token claims as per the backchannel logout spec

All in all, PR is fairly simple, we just have to cache the logout tokens correctly
