### PR TITLE
Fix Hibernate NoSuchMethod Exception  when TenantIdGeneration used in Quarkus 3 native mode

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
@@ -59,11 +59,11 @@ public class ClassNames {
     public static final DotName STATEMENT_INSPECTOR = createConstant("org.hibernate.resource.jdbc.spi.StatementInspector");
 
     public static final List<DotName> GENERATORS = List.of(
-            createConstant("org.hibernate.generator.internal.TenantIdGeneration"),
             createConstant("org.hibernate.generator.internal.CurrentTimestampGeneration"),
             createConstant("org.hibernate.generator.internal.GeneratedAlwaysGeneration"),
             createConstant("org.hibernate.generator.internal.GeneratedGeneration"),
             createConstant("org.hibernate.generator.internal.SourceGeneration"),
+            createConstant("org.hibernate.generator.internal.TenantIdGeneration"),
             createConstant("org.hibernate.generator.internal.VersionGeneration"),
             createConstant("org.hibernate.id.Assigned"),
             createConstant("org.hibernate.id.ForeignGenerator"),

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
@@ -59,6 +59,7 @@ public class ClassNames {
     public static final DotName STATEMENT_INSPECTOR = createConstant("org.hibernate.resource.jdbc.spi.StatementInspector");
 
     public static final List<DotName> GENERATORS = List.of(
+            createConstant("org.hibernate.generator.internal.TenantIdGeneration"),
             createConstant("org.hibernate.generator.internal.CurrentTimestampGeneration"),
             createConstant("org.hibernate.generator.internal.GeneratedAlwaysGeneration"),
             createConstant("org.hibernate.generator.internal.GeneratedGeneration"),

--- a/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/generatedvalue/CustomTenantResolver.java
+++ b/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/generatedvalue/CustomTenantResolver.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.jpa.generatedvalue;
+
+import jakarta.enterprise.context.RequestScoped;
+
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+import io.quarkus.hibernate.orm.runtime.tenant.TenantResolver;
+
+@PersistenceUnitExtension
+@RequestScoped
+public class CustomTenantResolver implements TenantResolver {
+
+    private static final String DEFAULT_TENANT = "default";
+
+    @Override
+    public String getDefaultTenantId() {
+        return DEFAULT_TENANT;
+    }
+
+    @Override
+    public String resolveTenantId() {
+        return DEFAULT_TENANT;
+    }
+
+}

--- a/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/generatedvalue/EntityWithGeneratedValues.java
+++ b/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/generatedvalue/EntityWithGeneratedValues.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.CurrentTimestamp;
 import org.hibernate.annotations.Generated;
 import org.hibernate.annotations.GeneratedColumn;
+import org.hibernate.annotations.TenantId;
 import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
@@ -18,6 +19,9 @@ public class EntityWithGeneratedValues {
     @Id
     @GeneratedValue
     public Integer id;
+
+    @TenantId
+    public String tenant;
 
     @CreationTimestamp
     public Instant creationTimestamp;

--- a/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/generatedvalue/GeneratedValueResource.java
+++ b/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/generatedvalue/GeneratedValueResource.java
@@ -26,6 +26,7 @@ public class GeneratedValueResource {
         var entity = new EntityWithGeneratedValues();
         assertThat(entity).satisfies(
                 e -> assertThat(e.id).isNull(),
+                e -> assertThat(e.tenant).isNull(),
                 e -> assertThat(e.creationTimestamp).isNull(),
                 e -> assertThat(e.updateTimestamp).isNull(),
                 e -> assertThat(e.currentTimestamp).isNull(),
@@ -35,6 +36,7 @@ public class GeneratedValueResource {
         em.flush();
         assertThat(entity).satisfies(
                 e -> assertThat(e.id).isNotNull(),
+                e -> assertThat(e.tenant).isNotNull(),
                 e -> assertThat(e.creationTimestamp).isNotNull(),
                 e -> assertThat(e.updateTimestamp).isNotNull(),
                 e -> assertThat(e.currentTimestamp).isNotNull(),

--- a/integration-tests/jpa/src/main/resources/application.properties
+++ b/integration-tests/jpa/src/main/resources/application.properties
@@ -4,3 +4,5 @@ quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-orm.metadata-builder-contributor=io.quarkus.it.jpa.defaultcatalogandschema.Schema1MetadataBuilderContributor
+
+quarkus.hibernate-orm.multitenant=DISCRIMINATOR


### PR DESCRIPTION
Fixes #34443

Uses same approach than in #32433. A more generic way should be done like proposed by @Sanne in [#32433](https://github.com/quarkusio/quarkus/pull/32433#issuecomment-1497606236) comments.