### PR TITLE
Making --verbose a global flag

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -79,6 +79,10 @@ public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
     @CommandLine.ArgGroup(exclusive = false, validate = false)
     protected PropertiesOptions propertiesOptions = new PropertiesOptions();
 
+    public OutputOptionMixin getOutput() {
+        return output;
+    }
+
     @Override
     public int run(String... args) throws Exception {
         CommandLine cmd = factory == null ? new CommandLine(this) : new CommandLine(this, factory);

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/OutputOptionMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/OutputOptionMixin.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import io.quarkus.cli.QuarkusCli;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import picocli.CommandLine;
 import picocli.CommandLine.Help.ColorScheme;
@@ -17,11 +18,10 @@ public class OutputOptionMixin implements MessageWriter {
 
     static final boolean picocliDebugEnabled = "DEBUG".equalsIgnoreCase(System.getProperty("picocli.trace"));
 
+    boolean verbose = false;
+
     @CommandLine.Option(names = { "-e", "--errors" }, description = "Print more context on errors and exceptions.")
     boolean showErrors;
-
-    @CommandLine.Option(names = { "--verbose" }, description = "Verbose mode.")
-    boolean verbose;
 
     @CommandLine.Option(names = {
             "--cli-test" }, hidden = true, description = "Manually set output streams for unit test purposes.")
@@ -70,8 +70,21 @@ public class OutputOptionMixin implements MessageWriter {
         return showErrors || picocliDebugEnabled;
     }
 
+    private static OutputOptionMixin getOutput(CommandSpec commandSpec) {
+        return ((QuarkusCli) commandSpec.root().userObject()).getOutput();
+    }
+
+    @CommandLine.Option(names = { "--verbose" }, description = "Verbose mode.")
+    public void setVerbose(boolean verbose) {
+        getOutput(mixee).verbose = verbose;
+    }
+
+    public boolean getVerbose() {
+        return getOutput(mixee).verbose;
+    }
+
     public boolean isVerbose() {
-        return verbose || picocliDebugEnabled;
+        return getVerbose() || picocliDebugEnabled;
     }
 
     public boolean isCliTest() {
@@ -157,7 +170,7 @@ public class OutputOptionMixin implements MessageWriter {
     public String toString() {
         return "OutputOptions [testMode=" + cliTestMode
                 + ", showErrors=" + showErrors
-                + ", verbose=" + verbose + "]";
+                + ", verbose=" + getVerbose() + "]";
     }
 
 }


### PR DESCRIPTION
Verbose is not a global flag. Even if it has been accepted in different locations on the command it will not work as expected.

The changes make `--verbose` a global flag which makes it possible to execute in different ways like:
`quarkus --verbose build` or `quarkus build --verbose` the result will be the same! :)

Fixes: https://github.com/quarkusio/quarkus/issues/34103 