### PR TITLE
Revert "Work around https://hibernate.atlassian.net/browse/HHH-16832"

### DIFF
--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/AbstractTypedIdEntity.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/AbstractTypedIdEntity.java
@@ -9,10 +9,8 @@ import jakarta.persistence.MappedSuperclass;
 @MappedSuperclass
 public abstract class AbstractTypedIdEntity<ID extends Serializable> {
 
-    // Using package visibility instead of private visibility
-    // in order to work around https://hibernate.atlassian.net/browse/HHH-16832
     @EmbeddedId
-    ID id;
+    private ID id;
 
     protected AbstractTypedIdEntity(ID id) {
         this.id = id;


### PR DESCRIPTION
This reverts commit 823591f1e1fab10ba4a24f4c1d719a84bdb426bd.

As suggested [here](https://github.com/quarkusio/quarkus/pull/34441#issuecomment-1615692835) after the upgrade to Hibernate ORM 6.2.6.Final.