### PR TITLE
Fix span export issue when user provided SpanProcessor beans exist

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpExporterProvider.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpExporterProvider.java
@@ -3,14 +3,11 @@ package io.quarkus.opentelemetry.runtime.exporter.otlp;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
 
-import io.quarkus.arc.DefaultBean;
-
 @Deprecated
 @Singleton
 public class OtlpExporterProvider {
     @Produces
     @Singleton
-    @DefaultBean
     public LateBoundBatchSpanProcessor batchSpanProcessorForOtlp() {
         return new LateBoundBatchSpanProcessor();
     }


### PR DESCRIPTION
`SpanProcessor` implementations are hooked into OTel in Quarkus via the `AutoConfiguredOpenTelemetrySdkBuilder#addTracerProviderCustomizer` mechanism, which in turn obtains those processor from CDI. 
However, because `LateBoundBatchSpanProcessor` (which is the one that ends up being responsible for the span export via its BatchSpanProcessor delegate) was marked as a `@DefaultBean`, when a user provided `SpanProcessor` became part of the application, the `LateBoundBatchSpanProcessor` was completely ignored.

The fix is simply to remove `@DefaultBean` and always have `LateBoundBatchSpanProcessor` be considered as a `SpanProcessor`.

Fixes: #33407

_P.S. I didn't add a test for this because I didn't see any tests that use `LateBoundBatchSpanProcessor`, I did test it however manually with a sample that was failing with `main`_