### PR TITLE
Revert "Remove unnecessary synchronization when creating Resource instances

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/InstanceHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/InstanceHandler.java
@@ -10,6 +10,7 @@ public class InstanceHandler implements ServerRestHandler {
      * CDI Manages the lifecycle
      *
      */
+    private volatile Object instance;
     private final BeanFactory<Object> factory;
 
     public InstanceHandler(BeanFactory<Object> factory) {
@@ -18,7 +19,14 @@ public class InstanceHandler implements ServerRestHandler {
 
     @Override
     public void handle(ResteasyReactiveRequestContext requestContext) throws Exception {
-        requestContext.requireCDIRequestScope();
-        requestContext.setEndpointInstance(factory.createInstance().getInstance());
+        if (instance == null) {
+            synchronized (this) {
+                if (instance == null) {
+                    requestContext.requireCDIRequestScope();
+                    instance = factory.createInstance().getInstance();
+                }
+            }
+        }
+        requestContext.setEndpointInstance(instance);
     }
 }


### PR DESCRIPTION
Turns out that #34339 is worse for performance...

Verified by @franz1981.

The reason is that the creation of the `BeanInstance ` costs more than the volatile read