### PR TITLE
Hibernate ORM: Register TenantIdGeneration for reflection

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
@@ -64,6 +64,7 @@ public class ClassNames {
             createConstant("org.hibernate.generator.internal.GeneratedGeneration"),
             createConstant("org.hibernate.generator.internal.SourceGeneration"),
             createConstant("org.hibernate.generator.internal.VersionGeneration"),
+            createConstant("org.hibernate.generator.internal.TenantIdGeneration"),
             createConstant("org.hibernate.id.Assigned"),
             createConstant("org.hibernate.id.ForeignGenerator"),
             createConstant("org.hibernate.id.GUIDGenerator"),


### PR DESCRIPTION
This is workaround for either Quarkus or Hibernate GraalVM (need a feedback) - I am not able to test Multitenancy with discriminator column in native as `org.hibernate.generator.internal.TenantIdGeneration` constructor is missing.

Please checkout logs here https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/5438927929/jobs/9890640910?pr=1300

```bash
12:24:16,873 INFO  [app] 12:24:15,208 Failed to start application (with profile [prod]): java.lang.RuntimeException: Failed to start quarkus
12:24:16,873 INFO  [app] 	at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
12:24:16,873 INFO  [app] 	at io.quarkus.runtime.Application.start(Application.java:101)
12:24:16,874 INFO  [app] 	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:111)
12:24:16,874 INFO  [app] 	at io.quarkus.runtime.Quarkus.run(Quarkus.java:71)
12:24:16,875 INFO  [app] 	at io.quarkus.runtime.Quarkus.run(Quarkus.java:44)
12:24:16,875 INFO  [app] 	at io.quarkus.runtime.Quarkus.run(Quarkus.java:124)
12:24:16,875 INFO  [app] 	at io.quarkus.runner.GeneratedMain.main(Unknown Source)
12:24:16,876 INFO  [app] Caused by: java.lang.RuntimeException: jakarta.persistence.PersistenceException: [PersistenceUnit: fungi] Unable to build Hibernate SessionFactory
12:24:16,876 INFO  [app] 	at io.quarkus.hibernate.orm.runtime.JPAConfig.startAll(JPAConfig.java:78)
12:24:16,876 INFO  [app] 	at io.quarkus.hibernate.orm.runtime.HibernateOrmRecorder.startAllPersistenceUnits(HibernateOrmRecorder.java:101)
12:24:16,876 INFO  [app] 	at io.quarkus.deployment.steps.HibernateOrmProcessor$startPersistenceUnits1868654632.deploy_0(Unknown Source)
12:24:16,877 INFO  [app] 	at io.quarkus.deployment.steps.HibernateOrmProcessor$startPersistenceUnits1868654632.deploy(Unknown Source)
12:24:16,877 INFO  [app] 	... 7 more
12:24:16,877 INFO  [app] Caused by: jakarta.persistence.PersistenceException: [PersistenceUnit: fungi] Unable to build Hibernate SessionFactory
12:24:16,877 INFO  [app] 	at io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder.persistenceException(FastBootEntityManagerFactoryBuilder.java:126)
12:24:16,878 INFO  [app] 	at io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder.build(FastBootEntityManagerFactoryBuilder.java:86)
12:24:16,878 INFO  [app] 	at io.quarkus.hibernate.orm.runtime.FastBootHibernatePersistenceProvider.createEntityManagerFactory(FastBootHibernatePersistenceProvider.java:74)
12:24:16,878 INFO  [app] 	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:80)
12:24:16,879 INFO  [app] 	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:55)
12:24:16,879 INFO  [app] 	at io.quarkus.hibernate.orm.runtime.JPAConfig$LazyPersistenceUnit.get(JPAConfig.java:156)
12:24:16,880 INFO  [app] 	at io.quarkus.hibernate.orm.runtime.JPAConfig$1.run(JPAConfig.java:64)
12:24:16,880 INFO  [app] 	at java.base@17.0.7/java.lang.Thread.run(Thread.java:833)
12:24:16,880 INFO  [app] 	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:775)
12:24:16,880 INFO  [app] 	at org.graalvm.nativeimage.builder/com.oracle.svm.core.posix.thread.PosixPlatformThreads.pthreadStartRoutine(PosixPlatformThreads.java:203)
12:24:16,880 INFO  [app] Caused by: org.hibernate.HibernateException: Could not instantiate generator of type 'org.hibernate.generator.internal.TenantIdGeneration'
12:24:16,881 INFO  [app] 	at org.hibernate.boot.model.internal.GeneratorBinder.instantiateGenerator(GeneratorBinder.java:425)
12:24:16,881 INFO  [app] 	at org.hibernate.boot.model.internal.GeneratorBinder.lambda$generatorCreator$0(GeneratorBinder.java:362)
12:24:16,881 INFO  [app] 	at org.hibernate.mapping.Property.createGenerator(Property.java:482)
12:24:16,882 INFO  [app] 	at org.hibernate.tuple.entity.EntityMetamodel.buildGenerator(EntityMetamodel.java:479)
12:24:16,882 INFO  [app] 	at org.hibernate.tuple.entity.EntityMetamodel.<init>(EntityMetamodel.java:313)
12:24:16,882 INFO  [app] 	at org.hibernate.persister.entity.AbstractEntityPersister.<init>(AbstractEntityPersister.java:499)
12:24:16,882 INFO  [app] 	at org.hibernate.persister.entity.SingleTableEntityPersister.<init>(SingleTableEntityPersister.java:140)
12:24:16,883 INFO  [app] 	at java.base@17.0.7/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
12:24:16,883 INFO  [app] 	at java.base@17.0.7/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
12:24:16,883 INFO  [app] 	at org.hibernate.persister.internal.PersisterFactoryImpl.createEntityPersister(PersisterFactoryImpl.java:92)
12:24:16,883 INFO  [app] 	at org.hibernate.persister.internal.PersisterFactoryImpl.createEntityPersister(PersisterFactoryImpl.java:75)
12:24:16,883 INFO  [app] 	at org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl.processBootEntities(MappingMetamodelImpl.java:247)
12:24:16,883 INFO  [app] 	at org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl.finishInitialization(MappingMetamodelImpl.java:185)
12:24:16,884 INFO  [app] 	at org.hibernate.internal.SessionFactoryImpl.initializeMappingModel(SessionFactoryImpl.java:320)
12:24:16,884 INFO  [app] 	at org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:270)
12:24:16,884 INFO  [app] 	at io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder.build(FastBootEntityManagerFactoryBuilder.java:84)
12:24:16,884 INFO  [app] 	... 8 more
12:24:16,884 INFO  [app] Caused by: java.lang.InstantiationException: org.hibernate.generator.internal.TenantIdGeneration
12:24:16,885 INFO  [app] 	at java.base@17.0.7/java.lang.Class.newInstance(DynamicHub.java:639)
12:24:16,885 INFO  [app] 	at org.hibernate.boot.model.internal.GeneratorBinder.instantiateGenerator(GeneratorBinder.java:419)
12:24:16,885 INFO  [app] 	... 23 more
12:24:16,885 INFO  [app] Caused by: java.lang.NoSuchMethodException: org.hibernate.generator.internal.TenantIdGeneration.<init>()
12:24:16,885 INFO  [app] 	at java.base@17.0.7/java.lang.Class.getConstructor0(DynamicHub.java:3585)
12:24:16,886 INFO  [app] 	at java.base@17.0.7/java.lang.Class.newInstance(DynamicHub.java:626)
12:24:16,886 INFO  [app] 	... 24 more
```

@Sanne @yrodiere I'd like to proceed with my work, is this workaround acceptable for now? After reading comments in https://github.com/quarkusio/quarkus/pull/32433 I'm not sure where to create issue. Tested workaround with https://github.com/quarkus-qe/quarkus-test-suite/pull/1300.