### PR TITLE
Upgrade MongoDB client to 4.10

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -173,7 +173,7 @@
         <liquibase.version>4.20.0</liquibase.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
-        <mongo-client.version>4.9.1</mongo-client.version>
+        <mongo-client.version>4.10.1</mongo-client.version>
         <mongo-crypt.version>1.8.0</mongo-crypt.version>
         <proton-j.version>0.34.1</proton-j.version>
         <javaparser.version>3.25.3</javaparser.version>

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -431,5 +431,6 @@ public class MongoClientProcessor {
     @BuildStep
     void runtimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClasses) {
         runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(ObjectId.class.getName()));
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem("com.mongodb.internal.dns.DefaultDnsResolver"));
     }
 }


### PR DESCRIPTION
@gsmet this fixes the upgrade issue with the native build.

@cescoffier starting with MongoDB client 4.10 the DefaultDnsResolver must be initialized at runtime, I don't know if it is correct as I don't know how to test it.