### PR TITLE
Simplify and improve OIDC PKCE secret initialization

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -343,6 +343,16 @@ quarkus.oidc.client-id=<Client ID>
 quarkus.oidc.credentials.secret=<Client Secret>
 ----
 
+[NOTE]
+====
+Twitter provider requires Proof Key for Code Exchange (PKCE) which is supported by the `quarkus.oidc.provider=twitter` declaration.
+Quarkus has to encrypt the current PKCE code verifier in a state cookie while the authorization code flow with Twitter is in progress and it will
+generate a secure random secret key for encrypting it.
+
+You can provide your own secret key for encrypting the PKCE code verifier if you prefer with the `quarkus.oidc.authentication.pkce-secret` property but
+note that this secret should be 32 characters long, and an error will be reported if it is less than 16 characters long.
+====
+
 === Spotify
 
 Create a https://developer.spotify.com/documentation/general/guides/authorization/app-settings/[Spotify application]:

--- a/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
@@ -6,5 +6,8 @@ quarkus.oidc.credentials.client-secret.provider.name=vault-secret-provider
 quarkus.oidc.credentials.client-secret.provider.key=secret-from-vault-typo
 quarkus.oidc.application-type=web-app
 quarkus.oidc.logout.path=/protected/logout
-
+quarkus.oidc.authentication.pkce-required=true
 quarkus.log.category."com.gargoylesoftware.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL
+quarkus.log.category."io.quarkus.oidc.runtime.TenantConfigContext".level=DEBUG
+quarkus.log.file.enable=true
+

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -915,8 +915,17 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         /**
          * Secret which will be used to encrypt a Proof Key for Code Exchange (PKCE) code verifier in the code flow state.
-         * This secret must be set if PKCE is required but no client secret is set.
-         * The length of the secret which will be used to encrypt the code verifier must be 32 characters long.
+         * This secret should be at least 32 characters long.
+         * <p/>
+         * If this secret is not set, the client secret configured with
+         * either `quarkus.oidc.credentials.secret` or `quarkus.oidc.credentials.client-secret.value` will be checked.
+         * Finally, `quarkus.oidc.credentials.jwt.secret` which can be used for `client_jwt_secret` authentication will be
+         * checked. Client secret will not be used as a PKCE code verifier encryption secret if it is less than 32 characters
+         * long.
+         * </p>
+         * The secret will be auto-generated if it remains uninitialized after checking all of these properties.
+         * <p/>
+         * Error will be reported if the secret length is less than 16 characters.
          */
         @ConfigItem
         public Optional<String> pkceSecret = Optional.empty();

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -38,7 +38,6 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.restassured.RestAssured;
-import io.smallrye.jwt.util.KeyUtils;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -358,8 +357,9 @@ public class CodeFlowTest {
     private void verifyCodeVerifier(Cookie stateCookie, String keycloakUrl) throws Exception {
         String encodedState = stateCookie.getValue().split("\\|")[1];
 
-        String codeVerifier = OidcUtils.decryptJson(encodedState,
-                KeyUtils.createSecretKeyFromSecret("eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU")).getString("code_verifier");
+        byte[] secretBytes = "eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU".getBytes(StandardCharsets.UTF_8);
+        SecretKey key = new SecretKeySpec(OidcUtils.getSha256Digest(secretBytes), "AES");
+        String codeVerifier = OidcUtils.decryptJson(encodedState, key).getString("code_verifier");
         String codeChallenge = Base64.getUrlEncoder().withoutPadding()
                 .encodeToString(OidcUtils.getSha256Digest(codeVerifier.getBytes(StandardCharsets.US_ASCII)));
 


### PR DESCRIPTION
Fixes #30802.

This PR follows up a report from @FroMage where he had to manually set up the 32 chars long PKCE secret for the Twitter authentication to work.

Currently, on `main`, the logic is not easy for users to deal with: the pkce secret is checked, if `null` - fallback to the client secret, in hope of it being 32 chars long, and then if the secret is less than 32 chars - fail - which is unnecessary and confusing.

This secret is required for encrypting the PKCE code verifier in a state cookie which Quarkus creates, when initiating a code flow with Twitter - after the user authenticates and returns back to Quarkus, the state cookie is decrypted, the code verifier extracted, and is used to complete the code exchange.

As opposed to the secrets required for encrypting the session cookies, PKCE state is transient, they are not expected to survive the restarts, and therefore can be generated when necessary without any side-effects,

So this PR simplifies and improves the way PKCE secret is managed:
* An attempt to fallback to the client secret is retained - but the client secret will not be used as a fallback value unless it is at least 32 chars long
* If PKCE secret is null - securely generate it
* If PKCE secret was configured but less than 32 chars: throw an error if it is very weak, less than 16 chars, inform users otherwise that for the optimal encryption output a 32 chars long secret should be used
* Finally apply SHA-256 digest
* CodeFlowTest updated to confirm SHA-256 digest is effective
* Updated dev mode test to verify  that if the pkce secret is not configured and a client secret fallback value is weak, then the PKCE secret is auto-generated by checking the log 
*  Add a note to the Twitter section in the docs