### PR TITLE
Add SSL Support to integration test

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1396,6 +1396,7 @@ An example use of this could be the following Maven command, that forces `@Quark
 ./mvnw verify -Dquarkus.http.test-host=1.2.3.4 -Dquarkus.http.test-port=4321
 ----
 
+To test against a running instance that only accepts SSL/TLS connection (example: `https://1.2.3.4:4321`) set the system property `quarkus.http.test-ssl-enabled` to `true`.
 
 == Mixing `@QuarkusTest` with other type of tests
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestHostLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestHostLauncher.java
@@ -28,7 +28,7 @@ public class TestHostLauncher implements ArtifactLauncher {
 
     @Override
     public boolean listensOnSsl() {
-        return false;
+        return Boolean.parseBoolean(System.getProperty("quarkus.http.test-ssl-enabled", "false"));
     }
 
     @Override


### PR DESCRIPTION
This adds support for running integration tests against a running instance that only support HTTPS requests.

- Fixes https://github.com/quarkusio/quarkus/issues/34502