### PR TITLE
Support for filtering extension catalog returned from a registry by offerings

### DIFF
--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClient.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClient.java
@@ -3,6 +3,7 @@ package io.quarkus.devtools.testing.registry.client;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 
 import org.eclipse.aether.artifact.DefaultArtifact;
 
@@ -60,6 +61,15 @@ public class TestRegistryClient implements RegistryClient {
         }
         if (clientConfig.getQuarkusVersions() != null) {
             registryConfig.setQuarkusVersions(clientConfig.getQuarkusVersions());
+        }
+        if (!clientConfig.getExtra().isEmpty()) {
+            if (registryConfig.getExtra().isEmpty()) {
+                registryConfig.setExtra(clientConfig.getExtra());
+            } else {
+                for (Map.Entry<String, Object> e : clientConfig.getExtra().entrySet()) {
+                    registryConfig.getExtra().put(e.getKey(), e.getValue());
+                }
+            }
         }
 
         final Object o = clientConfig.getExtra().get("enable-maven-resolver");

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
@@ -336,6 +336,18 @@ public class TestRegistryClientBuilder {
             return this;
         }
 
+        public TestRegistryBuilder enableOfferings(String... offerings) {
+            if (offerings.length > 0) {
+                var extra = config.getExtra();
+                if (extra == null || extra.isEmpty()) {
+                    extra = new HashMap<>();
+                    config.setExtra(extra);
+                }
+                extra.put(Constants.OFFERINGS, List.of(offerings));
+            }
+            return this;
+        }
+
         public TestRegistryClientBuilder clientBuilder() {
             return parent;
         }
@@ -758,6 +770,11 @@ public class TestRegistryClientBuilder {
             }
             d.setVersion(coords.getVersion());
             pom.getDependencyManagement().addDependency(d);
+            return this;
+        }
+
+        public TestPlatformCatalogMemberBuilder setOfferings(String... offerings) {
+            extensions.getMetadata().put(Constants.OFFERINGS, List.of(offerings));
             return this;
         }
 

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ExtensionCatalogFromProvidedPlatformsTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ExtensionCatalogFromProvidedPlatformsTest.java
@@ -5,12 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
-import org.assertj.core.util.Arrays;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -18,6 +17,7 @@ import io.quarkus.bootstrap.resolver.maven.workspace.ModelUtils;
 import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.registry.ExtensionCatalogResolver;
+import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 
 public class ExtensionCatalogFromProvidedPlatformsTest extends MultiplePlatformBomsTestBase {
@@ -104,13 +104,12 @@ public class ExtensionCatalogFromProvidedPlatformsTest extends MultiplePlatformB
     @Test
     public void test() throws Exception {
         final ExtensionCatalog catalog = ExtensionCatalogResolver.builder().build().resolveExtensionCatalog(
-                Collections.singletonList(ArtifactCoords.fromString(MAIN_PLATFORM_KEY + ":acme-baz-bom::pom:1.0.0")));
-        assertThat(Arrays.asList(new ArtifactCoords[] {
+                List.of(ArtifactCoords.fromString(MAIN_PLATFORM_KEY + ":acme-baz-bom::pom:1.0.0")));
+        assertThat(List.of(
                 ArtifactCoords.fromString("io.quarkus:quarkus-core:1.1.2"),
                 ArtifactCoords.fromString(MAIN_PLATFORM_KEY + ":acme-foo:1.0.0"),
                 ArtifactCoords.fromString(MAIN_PLATFORM_KEY + ":acme-baz:1.0.0"),
-                ArtifactCoords.fromString("org.acme:acme-quarkus-other:5.5.5")
-        })).isEqualTo(
-                catalog.getExtensions().stream().map(e -> e.getArtifact()).collect(Collectors.toList()));
+                ArtifactCoords.fromString("org.acme:acme-quarkus-other:5.5.5")))
+                .isEqualTo(catalog.getExtensions().stream().map(Extension::getArtifact).collect(Collectors.toList()));
     }
 }

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/NoOfferringsTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/NoOfferringsTest.java
@@ -1,0 +1,133 @@
+package io.quarkus.devtools.project.create;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.registry.ExtensionCatalogResolver;
+import io.quarkus.registry.RegistryResolutionException;
+import io.quarkus.registry.catalog.Extension;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+import io.quarkus.registry.catalog.ExtensionOrigin;
+import io.quarkus.registry.catalog.PlatformStreamCoords;
+
+public class NoOfferringsTest extends MultiplePlatformBomsTestBase {
+
+    private static final String MAIN_PLATFORM_KEY = "org.acme.platform";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        TestRegistryClientBuilder.newInstance()
+                //.debug()
+                .baseDir(configDir())
+                // registry
+                .newRegistry("registry.acme.org")
+                .enableOfferings("invalid")
+                // platform key
+                .newPlatform(MAIN_PLATFORM_KEY)
+                // 2.0 STREAM
+                .newStream("2.0")
+                // 2.0.4 release
+                .newRelease("2.0.4")
+                .quarkusVersion("2.2.2")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().setOfferings("core").release()
+                // foo platform member
+                .newMember("acme-foo-bom").setOfferings("foo").addExtension("acme-foo").release()
+                .newMember("acme-baz-bom").setOfferings("baz").addExtension("acme-baz").release()
+                .stream().platform()
+                // 1.0 STREAM
+                .newStream("1.0")
+                // 1.0.1 release
+                .newRelease("1.0.1")
+                .quarkusVersion("1.1.2")
+                .addCoreMember().setOfferings("core").release()
+                .newMember("acme-foo-bom").setOfferings("foo").addExtension("acme-foo").release()
+                .newMember("acme-baz-bom").setOfferings("baz", "core").addExtension("acme-baz").release()
+                .registry()
+                .newNonPlatformCatalog("1.1.2")
+                .addExtension("org.acme", "acme-quarkus-other", "5.5.5")
+                .registry()
+                .clientBuilder()
+                .build();
+
+        enableRegistryClient();
+
+    }
+
+    protected String getMainPlatformKey() {
+        return MAIN_PLATFORM_KEY;
+    }
+
+    @Test
+    public void allEnabled() throws Exception {
+        var catalog = ExtensionCatalogResolver.builder().build().resolveExtensionCatalog();
+        assertThat(catalog.getExtensions()).hasSize(1);
+        final Map<ArtifactKey, Set<ArtifactCoords>> extensionMap = toExtensionMap(catalog);
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("org.acme:acme-quarkus-other"),
+                Set.of(ArtifactCoords.pom("io.quarkus", "quarkus-bom", "1.1.2")));
+    }
+
+    @Test
+    public void stream20() throws Exception {
+        try {
+            ExtensionCatalogResolver.builder().build().resolveExtensionCatalog(PlatformStreamCoords.fromString("2.0"));
+            fail("Should have failed");
+        } catch (RegistryResolutionException e) {
+            assertThat(e).hasMessage("Couldn't find any extension catalog for stream 2.0");
+        }
+    }
+
+    @Test
+    public void quarkusVersion222() throws Exception {
+        try {
+            ExtensionCatalogResolver.builder().build().resolveExtensionCatalog("2.2.2");
+            fail("Should have failed");
+        } catch (RegistryResolutionException e) {
+            assertThat(e).hasMessage("Quarkus extension registry registry.acme.org did not provide any extension catalog");
+        }
+    }
+
+    @Test
+    public void stream10() throws Exception {
+        try {
+            ExtensionCatalogResolver.builder().build().resolveExtensionCatalog(PlatformStreamCoords.fromString("1.0"));
+            fail("Should have failed");
+        } catch (RegistryResolutionException e) {
+            assertThat(e).hasMessage("Couldn't find any extension catalog for stream 1.0");
+        }
+    }
+
+    @Test
+    public void quarkusVersion112() throws Exception {
+        var catalog = ExtensionCatalogResolver.builder().build().resolveExtensionCatalog("1.1.2");
+        assertThat(catalog.getExtensions()).hasSize(1);
+        final Map<ArtifactKey, Set<ArtifactCoords>> extensionMap = toExtensionMap(catalog);
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("org.acme:acme-quarkus-other"),
+                Set.of(ArtifactCoords.pom("io.quarkus", "quarkus-bom", "1.1.2")));
+    }
+
+    private static Map<ArtifactKey, Set<ArtifactCoords>> toExtensionMap(ExtensionCatalog catalog) {
+        final Map<ArtifactKey, Set<ArtifactCoords>> extensionMap = new HashMap<>(catalog.getExtensions().size());
+        for (Extension e : catalog.getExtensions()) {
+            final Set<ArtifactCoords> boms = new HashSet<>(e.getOrigins().size());
+            for (ExtensionOrigin o : e.getOrigins()) {
+                boms.add(o.getBom());
+            }
+            extensionMap.put(e.getArtifact().getKey(), boms);
+        }
+        return extensionMap;
+    }
+}

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/OfferringsTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/OfferringsTest.java
@@ -1,0 +1,168 @@
+package io.quarkus.devtools.project.create;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.registry.ExtensionCatalogResolver;
+import io.quarkus.registry.catalog.Extension;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+import io.quarkus.registry.catalog.ExtensionOrigin;
+import io.quarkus.registry.catalog.PlatformStreamCoords;
+
+public class OfferringsTest extends MultiplePlatformBomsTestBase {
+
+    private static final String MAIN_PLATFORM_KEY = "org.acme.platform";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        TestRegistryClientBuilder.newInstance()
+                //.debug()
+                .baseDir(configDir())
+                // registry
+                .newRegistry("registry.acme.org")
+                .enableOfferings("core", "foo")
+                // platform key
+                .newPlatform(MAIN_PLATFORM_KEY)
+                // 2.0 STREAM
+                .newStream("2.0")
+                // 2.0.4 release
+                .newRelease("2.0.4")
+                .quarkusVersion("2.2.2")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().setOfferings("core").release()
+                // foo platform member
+                .newMember("acme-foo-bom").setOfferings("foo").addExtension("acme-foo").release()
+                .newMember("acme-baz-bom").setOfferings("baz").addExtension("acme-baz").release()
+                .stream().platform()
+                // 1.0 STREAM
+                .newStream("1.0")
+                // 1.0.1 release
+                .newRelease("1.0.1")
+                .quarkusVersion("1.1.2")
+                .addCoreMember().setOfferings("core").release()
+                .newMember("acme-foo-bom").setOfferings("foo").addExtension("acme-foo").release()
+                .newMember("acme-baz-bom").setOfferings("baz", "core").addExtension("acme-baz").release()
+                .registry()
+                .newNonPlatformCatalog("1.1.2")
+                .addExtension("org.acme", "acme-quarkus-other", "5.5.5")
+                .registry()
+                .clientBuilder()
+                .build();
+
+        enableRegistryClient();
+
+    }
+
+    protected String getMainPlatformKey() {
+        return MAIN_PLATFORM_KEY;
+    }
+
+    @Test
+    public void allEnabled() throws Exception {
+        var catalog = ExtensionCatalogResolver.builder().build().resolveExtensionCatalog();
+        assertThat(catalog.getExtensions()).hasSize(4);
+        final Map<ArtifactKey, Set<ArtifactCoords>> extensionMap = toExtensionMap(catalog);
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("io.quarkus:quarkus-core"),
+                Set.of(ArtifactCoords.pom("org.acme.platform", "quarkus-bom", "2.0.4"),
+                        ArtifactCoords.pom("org.acme.platform", "quarkus-bom", "1.0.1")));
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("org.acme.platform:acme-foo"),
+                Set.of(ArtifactCoords.pom("org.acme.platform", "acme-foo-bom", "2.0.4"),
+                        ArtifactCoords.pom("org.acme.platform", "acme-foo-bom", "1.0.1")));
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("org.acme.platform:acme-baz"),
+                Set.of(ArtifactCoords.pom("org.acme.platform", "acme-baz-bom", "1.0.1")));
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("org.acme:acme-quarkus-other"),
+                Set.of(ArtifactCoords.pom("io.quarkus", "quarkus-bom", "1.1.2")));
+    }
+
+    @Test
+    public void stream20() throws Exception {
+        var catalog = ExtensionCatalogResolver.builder().build()
+                .resolveExtensionCatalog(PlatformStreamCoords.fromString("2.0"));
+        assertThat(catalog.getExtensions()).hasSize(2);
+        final Map<ArtifactKey, Set<ArtifactCoords>> extensionMap = toExtensionMap(catalog);
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("io.quarkus:quarkus-core"),
+                Set.of(ArtifactCoords.pom("org.acme.platform", "quarkus-bom", "2.0.4")));
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("org.acme.platform:acme-foo"),
+                Set.of(ArtifactCoords.pom("org.acme.platform", "acme-foo-bom", "2.0.4")));
+    }
+
+    @Test
+    public void quarkusVersion222() throws Exception {
+        var catalog = ExtensionCatalogResolver.builder().build().resolveExtensionCatalog("2.2.2");
+        assertThat(catalog.getExtensions()).hasSize(2);
+        final Map<ArtifactKey, Set<ArtifactCoords>> extensionMap = toExtensionMap(catalog);
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("io.quarkus:quarkus-core"),
+                Set.of(ArtifactCoords.pom("org.acme.platform", "quarkus-bom", "2.0.4")));
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("org.acme.platform:acme-foo"),
+                Set.of(ArtifactCoords.pom("org.acme.platform", "acme-foo-bom", "2.0.4")));
+    }
+
+    @Test
+    public void stream10() throws Exception {
+        var catalog = ExtensionCatalogResolver.builder().build()
+                .resolveExtensionCatalog(PlatformStreamCoords.fromString("1.0"));
+        assertThat(catalog.getExtensions()).hasSize(4);
+        final Map<ArtifactKey, Set<ArtifactCoords>> extensionMap = toExtensionMap(catalog);
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("io.quarkus:quarkus-core"),
+                Set.of(ArtifactCoords.pom("org.acme.platform", "quarkus-bom", "1.0.1")));
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("org.acme.platform:acme-foo"),
+                Set.of(ArtifactCoords.pom("org.acme.platform", "acme-foo-bom", "1.0.1")));
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("org.acme.platform:acme-baz"),
+                Set.of(ArtifactCoords.pom("org.acme.platform", "acme-baz-bom", "1.0.1")));
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("org.acme:acme-quarkus-other"),
+                Set.of(ArtifactCoords.pom("io.quarkus", "quarkus-bom", "1.1.2")));
+    }
+
+    @Test
+    public void quarkusVersion112() throws Exception {
+        var catalog = ExtensionCatalogResolver.builder().build().resolveExtensionCatalog("1.1.2");
+        assertThat(catalog.getExtensions()).hasSize(4);
+        final Map<ArtifactKey, Set<ArtifactCoords>> extensionMap = toExtensionMap(catalog);
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("io.quarkus:quarkus-core"),
+                Set.of(ArtifactCoords.pom("org.acme.platform", "quarkus-bom", "1.0.1")));
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("org.acme.platform:acme-foo"),
+                Set.of(ArtifactCoords.pom("org.acme.platform", "acme-foo-bom", "1.0.1")));
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("org.acme.platform:acme-baz"),
+                Set.of(ArtifactCoords.pom("org.acme.platform", "acme-baz-bom", "1.0.1")));
+        assertThat(extensionMap).containsEntry(
+                ArtifactKey.fromString("org.acme:acme-quarkus-other"),
+                Set.of(ArtifactCoords.pom("io.quarkus", "quarkus-bom", "1.1.2")));
+    }
+
+    private static Map<ArtifactKey, Set<ArtifactCoords>> toExtensionMap(ExtensionCatalog catalog) {
+        final Map<ArtifactKey, Set<ArtifactCoords>> extensionMap = new HashMap<>(catalog.getExtensions().size());
+        for (Extension e : catalog.getExtensions()) {
+            final Set<ArtifactCoords> boms = new HashSet<>(e.getOrigins().size());
+            for (ExtensionOrigin o : e.getOrigins()) {
+                boms.add(o.getBom());
+            }
+            extensionMap.put(e.getArtifact().getKey(), boms);
+        }
+        return extensionMap;
+    }
+}

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/Constants.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/Constants.java
@@ -20,4 +20,6 @@ public interface Constants {
     String JSON = "json";
 
     String LAST_UPDATED = "last-updated";
+
+    String OFFERINGS = "offerings";
 }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
@@ -3,6 +3,7 @@ package io.quarkus.registry;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import io.quarkus.devtools.messagewriter.MessageWriter;
@@ -24,21 +25,35 @@ class RegistryExtensionResolver {
     private final RegistryConfig config;
     private final RegistryClient extensionResolver;
     private final int index;
+    private final MessageWriter log;
 
     private final Pattern recognizedQuarkusVersions;
     private final Collection<String> recognizedGroupIds;
+
+    private final Set<String> offerings;
 
     RegistryExtensionResolver(RegistryClient extensionResolver,
             MessageWriter log, int index) throws RegistryResolutionException {
         this.extensionResolver = Objects.requireNonNull(extensionResolver, "Registry extension resolver is null");
         this.config = extensionResolver.resolveRegistryConfig();
         this.index = index;
+        this.log = log;
 
         final String versionExpr = config.getQuarkusVersions() == null ? null
                 : config.getQuarkusVersions().getRecognizedVersionsExpression();
         recognizedQuarkusVersions = versionExpr == null ? null : Pattern.compile(GlobUtil.toRegexPattern(versionExpr));
         this.recognizedGroupIds = config.getQuarkusVersions() == null ? Collections.emptyList()
                 : config.getQuarkusVersions().getRecognizedGroupIds();
+
+        var offerings = config.getExtra().get(Constants.OFFERINGS);
+        if (offerings == null) {
+            this.offerings = Set.of();
+        } else if (offerings instanceof Collection) {
+            this.offerings = Set.copyOf((Collection<String>) offerings);
+        } else {
+            log.warn("Offerings for " + config.getId() + " are not configured as a list but " + offerings);
+            this.offerings = Set.of();
+        }
     }
 
     String getId() {
@@ -95,10 +110,28 @@ class RegistryExtensionResolver {
     }
 
     ExtensionCatalog.Mutable resolvePlatformExtensions(ArtifactCoords platform) throws RegistryResolutionException {
-        return extensionResolver.resolvePlatformExtensions(platform);
+        var catalog = extensionResolver.resolvePlatformExtensions(platform);
+        if (offerings.isEmpty()) {
+            return catalog;
+        }
+        var o = catalog.getMetadata().get(Constants.OFFERINGS);
+        if (o == null) {
+            return null;
+        }
+        if (!(o instanceof Collection)) {
+            log.warn("Offerings from " + catalog.getBom().toCompactCoords() + " are not a collection but " + o);
+            return null;
+        }
+        for (var offering : (Collection<?>) o) {
+            if (offerings.contains(offering.toString())) {
+                return catalog;
+            }
+        }
+        return null;
     }
 
     void clearCache() throws RegistryResolutionException {
         extensionResolver.clearCache();
     }
+
 }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/PlatformStreamCoords.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/PlatformStreamCoords.java
@@ -31,4 +31,13 @@ public class PlatformStreamCoords {
                 ", streamId='" + streamId + '\'' +
                 '}';
     }
+
+    /**
+     * Returns a compact string representation of a stream following the format [platform-key:]stream-id
+     *
+     * @return compact string representation of a stream following the format [platform-key:]stream-id
+     */
+    public String toCompactString() {
+        return platformKey == null || platformKey.isEmpty() ? streamId : platformKey + ":" + streamId;
+    }
 }


### PR DESCRIPTION
This is based on the assumption that platform member extension catalogs may include `offerings` metadata in their extension catalogs, that would be a list of offering names they are a part of.

For example, a member extension catalog could look like:
```
{
  "id" : "org.acme.platform:acme-baz-bom-quarkus-platform-descriptor:1.0.1:json:1.0.1",
  "platform" : true,
  "bom" : "org.acme.platform:acme-baz-bom::pom:1.0.1",
  "quarkus-core-version" : "1.1.2",
  "extensions" : [ {
    "name" : "acme-baz",
    "artifact" : "org.acme.platform:acme-baz::jar:1.0.1",
    "origins" : [ "org.acme.platform:acme-baz-bom-quarkus-platform-descriptor:1.0.1:json:1.0.1" ]
  } ],
  "metadata" : {
    "offerings" : [ "baz", "core" ],
```
and the `.quarkus/config.yaml` could be configured as
```
registries:
- registry.acme.org:
    offerings:
    - "core"
    - "foo"
```