### PR TITLE
Invoke secured blocking Grpc methods on worker thread

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.grpc.deployment;
 
 import static io.quarkus.deployment.Feature.GRPC_SERVER;
+import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import static io.quarkus.grpc.deployment.GrpcDotNames.BLOCKING;
 import static io.quarkus.grpc.deployment.GrpcDotNames.MUTINY_SERVICE;
 import static io.quarkus.grpc.deployment.GrpcDotNames.NON_BLOCKING;
@@ -40,6 +41,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanArchivePredicateBuildItem;
+import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.CustomScopeAnnotationsBuildItem;
 import io.quarkus.arc.deployment.RecorderBeanInitializedBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -71,6 +73,7 @@ import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.grpc.GrpcService;
 import io.quarkus.grpc.auth.DefaultAuthExceptionHandlerProvider;
 import io.quarkus.grpc.auth.GrpcSecurityInterceptor;
+import io.quarkus.grpc.auth.GrpcSecurityRecorder;
 import io.quarkus.grpc.deployment.devmode.FieldDefinalizingVisitor;
 import io.quarkus.grpc.protoc.plugin.MutinyGrpcGenerator;
 import io.quarkus.grpc.runtime.GrpcContainer;
@@ -726,6 +729,28 @@ public class GrpcServerProcessor {
     @BuildStep
     UnremovableBeanBuildItem unremovableServerInterceptors() {
         return UnremovableBeanBuildItem.beanTypes(GrpcDotNames.SERVER_INTERCEPTOR);
+    }
+
+    @Consume(SyntheticBeansRuntimeInitBuildItem.class)
+    @Record(RUNTIME_INIT)
+    @BuildStep
+    void initGrpcSecurityInterceptor(List<BindableServiceBuildItem> bindables, Capabilities capabilities,
+            GrpcSecurityRecorder recorder, BeanContainerBuildItem beanContainer) {
+        if (capabilities.isPresent(Capability.SECURITY)) {
+
+            // Grpc service to blocking method
+            Map<String, List<String>> blocking = new HashMap<>();
+            for (BindableServiceBuildItem bindable : bindables) {
+                if (bindable.hasBlockingMethods()) {
+                    blocking.put(bindable.serviceClass.toString(), bindable.blockingMethods);
+                }
+            }
+
+            if (!blocking.isEmpty()) {
+                // provide GrpcSecurityInterceptor with blocking methods
+                recorder.initGrpcSecurityInterceptor(blocking, beanContainer.getValue());
+            }
+        }
     }
 
 }

--- a/extensions/grpc/deployment/src/test/proto/security.proto
+++ b/extensions/grpc/deployment/src/test/proto/security.proto
@@ -6,6 +6,8 @@ option java_package = "com.example.security";
 service SecuredService {
   rpc unaryCall(Container) returns (ThreadInfo);
   rpc streamCall(stream Container) returns (stream ThreadInfo);
+  rpc unaryCallBlocking(Container) returns (ThreadInfo);
+  rpc streamCallBlocking(stream Container) returns (stream ThreadInfo);
 }
 
 message ThreadInfo {

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/auth/GrpcSecurityRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/auth/GrpcSecurityRecorder.java
@@ -1,0 +1,46 @@
+package io.quarkus.grpc.auth;
+
+import static io.quarkus.grpc.runtime.GrpcServerRecorder.GrpcServiceDefinition.getImplementationClassName;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.grpc.BindableService;
+import io.grpc.ServerMethodDefinition;
+import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.grpc.runtime.GrpcContainer;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class GrpcSecurityRecorder {
+
+    public void initGrpcSecurityInterceptor(Map<String, List<String>> serviceClassToBlockingMethod,
+            BeanContainer container) {
+
+        // service to full method names
+        var svcToMethods = new HashMap<String, List<String>>();
+        var services = container.beanInstance(GrpcContainer.class).getServices();
+        for (BindableService service : services) {
+            var className = getImplementationClassName(service);
+            var blockingMethods = serviceClassToBlockingMethod.get(className);
+            if (blockingMethods != null && !blockingMethods.isEmpty()) {
+                var svcName = service.bindService().getServiceDescriptor().getName();
+                var methods = new ArrayList<String>();
+                for (String blockingMethod : blockingMethods) {
+                    for (ServerMethodDefinition<?, ?> method : service.bindService().getMethods()) {
+                        if (blockingMethod.equals(method.getMethodDescriptor().getBareMethodName())) {
+                            methods.add(method.getMethodDescriptor().getFullMethodName());
+                            break;
+                        }
+                    }
+                }
+                svcToMethods.put(svcName, methods);
+            }
+        }
+
+        container.beanInstance(GrpcSecurityInterceptor.class).init(svcToMethods);
+    }
+
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/GrpcServerRecorder.java
@@ -376,6 +376,10 @@ public class GrpcServerRecorder {
         }
 
         public String getImplementationClassName() {
+            return getImplementationClassName(service);
+        }
+
+        public static String getImplementationClassName(BindableService service) {
             if (service instanceof Subclass) {
                 // All intercepted services are represented by a generated subclass
                 return service.getClass().getSuperclass().getName();


### PR DESCRIPTION
fixes: #34439
fixes: #34146

We can't just rely on `Context.isOnEventLoopThread()` because when authentication executes some actions with blocking request context, we would end up on worker thread, therefore current state is correct - we check thread that should be used to invoke Grpc method before running auth, however this check is run before `BlockingServerInterceptor`, therefore before we even know whether method is blocking. This PR fixes selection of target context.