### PR TITLE
Fix notifications when reindexing the default PU through the dev UI

### DIFF
--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/resources/dev-ui/hibernate-search-orm-elasticsearch-indexed-entity-types.js
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/resources/dev-ui/hibernate-search-orm-elasticsearch-indexed-entity-types.js
@@ -121,16 +121,27 @@ export class HibernateSearchOrmElasticsearchIndexedEntitiesComponent extends Lit
                 const msg = response.result;
                 if (msg === "started") {
                     notifier.showInfoMessage("Requested reindexing of " + selected.length
-                            + " entity types for persistence unit '" + puName + "'.");
+                            + " entity types for persistence unit '" + this._escapeHTML(puName) + "'.");
                 } else if (msg === "success") {
                     notifier.showSuccessMessage("Successfully reindexed " + selected.length
-                            + " entity types for persistence unit '" + puName + "'.");
+                            + " entity types for persistence unit '" + this._escapeHTML(puName) + "'.");
                 } else {
                     notifier.showErrorMessage("An error occurred while reindexing " + selected.length
-                            + " entity types for persistence unit '" + puName + "':\n" + msg);
+                            + " entity types for persistence unit '" + this._escapeHTML(puName) + "':\n" + msg);
                 }
             });
     }
 
+    _escapeHTML(text) {
+        var fn=function(char) {
+            var replacementMap = {
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;'
+            };
+            return replacementMap[char] || char;
+        }
+        return text.replace(/[&<>]/g, fn);
+    }
 }
 customElements.define('hibernate-search-orm-elasticsearch-indexed-entity-types', HibernateSearchOrmElasticsearchIndexedEntitiesComponent);


### PR DESCRIPTION
Without this patch, the PU name `<default>` is interpreted as an HTML tag and rendered incorrectly.

Also, I did look for half an hour and didn't find a cleaner way to do this. Vaadin's `` html`...` `` didn't work either. So I'm giving up and resorting to this.