### PR TITLE
Undertow - fire context events for session context

### DIFF
--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/sessioncontext/ObservingBean.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/sessioncontext/ObservingBean.java
@@ -1,0 +1,46 @@
+package io.quarkus.undertow.test.sessioncontext;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.BeforeDestroyed;
+import jakarta.enterprise.context.Destroyed;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.enterprise.event.Observes;
+
+@ApplicationScoped
+public class ObservingBean {
+
+    int timesInitObserved = 0;
+    int timesBeforeDestroyedObserved = 0;
+    int timesDestroyedObserved = 0;
+
+    public int getTimesInitObserved() {
+        return timesInitObserved;
+    }
+
+    public int getTimesBeforeDestroyedObserved() {
+        return timesBeforeDestroyedObserved;
+    }
+
+    public int getTimesDestroyedObserved() {
+        return timesDestroyedObserved;
+    }
+
+    public void observeInit(@Observes @Initialized(SessionScoped.class) Object event) {
+        timesInitObserved++;
+    }
+
+    public void observeBeforeDestroyed(@Observes @BeforeDestroyed(SessionScoped.class) Object event) {
+        timesBeforeDestroyedObserved++;
+    }
+
+    public void observeDestroyed(@Observes @Destroyed(SessionScoped.class) Object event) {
+        timesDestroyedObserved++;
+    }
+
+    public void resetState() {
+        this.timesInitObserved = 0;
+        this.timesBeforeDestroyedObserved = 0;
+        this.timesDestroyedObserved = 0;
+    }
+}


### PR DESCRIPTION
Fixes #34332 

This is a simple implementation that any custom context could use; if we want to use some Arc's internal constructs such as [`Notifier`](https://github.com/quarkusio/quarkus/blob/main/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java#L38-L40), we'd need to expose that API publicly.