### PR TITLE
Implement expire-after-access for the redis cache

### DIFF
--- a/docs/src/main/asciidoc/cache-redis-reference.adoc
+++ b/docs/src/main/asciidoc/cache-redis-reference.adoc
@@ -101,13 +101,13 @@ You can also configure the time to live of the cached entries:
 [source, properties]
 ----
 # Default configuration
-quarkus.cache.redis.ttl=10s
+quarkus.cache.redis.expire-after-write=10s
 
 # Configuration for `expensiveResourceCache`
-quarkus.cache.redis.expensiveResourceCache.ttl=1h
+quarkus.cache.redis.expensiveResourceCache.expire-after-write=1h
 ----
 
-If the `ttl` is not configured, the entry won't be evicted.
+If the `expire-after-write` is not configured, the entry won't be evicted.
 You would need to invalidate the values using the `@CacheInvalidateAll` or `@CacheInvalidate` annotations.
 
 The following table lists the supported properties:

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheBuildRecorder.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheBuildRecorder.java
@@ -51,7 +51,7 @@ public class RedisCacheBuildRecorder {
                                 if (LOGGER.isDebugEnabled()) {
                                     LOGGER.debugf(
                                             "Building Redis cache [%s] with [ttl=%s], [prefix=%s], [classOfItems=%s]",
-                                            cacheInfo.name, cacheInfo.ttl, cacheInfo.prefix,
+                                            cacheInfo.name, cacheInfo.expireAfterAccess, cacheInfo.prefix,
                                             cacheInfo.valueType);
                                 }
 

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheInfo.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheInfo.java
@@ -13,7 +13,12 @@ public class RedisCacheInfo {
     /**
      * The default time to live of the item stored in the cache
      */
-    public Optional<Duration> ttl = Optional.empty();
+    public Optional<Duration> expireAfterAccess = Optional.empty();
+
+    /**
+     * The default time to live to add to the item once read
+     */
+    public Optional<Duration> expireAfterWrite = Optional.empty();
 
     /**
      * the key prefix allowing to identify the keys belonging to the cache.

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheInfoBuilder.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheInfoBuilder.java
@@ -23,10 +23,23 @@ public class RedisCacheInfoBuilder {
                 RedisCacheRuntimeConfig defaultRuntimeConfig = runtimeConfig.defaultConfig;
                 RedisCacheRuntimeConfig namedRuntimeConfig = runtimeConfig.cachesConfig.get(cacheInfo.name);
 
+                if (namedRuntimeConfig != null && namedRuntimeConfig.expireAfterAccess.isPresent()) {
+                    cacheInfo.expireAfterAccess = namedRuntimeConfig.expireAfterAccess;
+                } else if (defaultRuntimeConfig.expireAfterAccess.isPresent()) {
+                    cacheInfo.expireAfterAccess = defaultRuntimeConfig.expireAfterAccess;
+                }
+
+                if (namedRuntimeConfig != null && namedRuntimeConfig.expireAfterWrite.isPresent()) {
+                    cacheInfo.expireAfterWrite = namedRuntimeConfig.expireAfterWrite;
+                } else if (defaultRuntimeConfig.expireAfterAccess.isPresent()) {
+                    cacheInfo.expireAfterWrite = defaultRuntimeConfig.expireAfterWrite;
+                }
+
+                // Handle the deprecated TTL
                 if (namedRuntimeConfig != null && namedRuntimeConfig.ttl.isPresent()) {
-                    cacheInfo.ttl = namedRuntimeConfig.ttl;
+                    cacheInfo.expireAfterWrite = namedRuntimeConfig.ttl;
                 } else if (defaultRuntimeConfig.ttl.isPresent()) {
-                    cacheInfo.ttl = defaultRuntimeConfig.ttl;
+                    cacheInfo.expireAfterWrite = defaultRuntimeConfig.ttl;
                 }
 
                 if (namedRuntimeConfig != null && namedRuntimeConfig.prefix.isPresent()) {

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheRuntimeConfig.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheRuntimeConfig.java
@@ -9,10 +9,27 @@ import io.quarkus.runtime.annotations.ConfigItem;
 @ConfigGroup
 public class RedisCacheRuntimeConfig {
     /**
-     * The default time to live of the item stored in the cache
+     * The default time to live of the item stored in the cache.
+     *
+     * @deprecated Use {@link #expireAfterWrite} instead.
      */
     @ConfigItem
+    @Deprecated
     public Optional<Duration> ttl;
+
+    /**
+     * Specifies that each entry should be automatically removed from the cache once a fixed duration has elapsed after
+     * the entry's creation, or the most recent replacement of its value.
+     */
+    @ConfigItem
+    Optional<Duration> expireAfterWrite;
+
+    /**
+     * Specifies that each entry should be automatically removed from the cache once a fixed duration has elapsed after
+     * the last access of its value.
+     */
+    @ConfigItem
+    Optional<Duration> expireAfterAccess;
 
     /**
      * the key prefix allowing to identify the keys belonging to the cache.


### PR DESCRIPTION
Also rename the ttl property to expire-after-write to align the configuration with the Caffeine cache.

Fix https://github.com/quarkusio/quarkus/issues/33615
