### PR TITLE
Add support for absolute paths for jacoco exec and report

### DIFF
--- a/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
+++ b/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 
@@ -35,6 +36,9 @@ import io.quarkus.maven.dependency.ResolvedDependency;
 
 public class JacocoProcessor {
 
+    public static final String JACOCO_QUARKUS_EXEC = "jacoco-quarkus.exec";
+    public static final String JACOCO_REPORT = "jacoco-report";
+
     @BuildStep(onlyIf = IsTest.class)
     FeatureBuildItem feature() {
         return new FeatureBuildItem("jacoco");
@@ -53,10 +57,8 @@ public class JacocoProcessor {
             return;
         }
 
-        String dataFile = outputTargetBuildItem.getOutputDirectory().toAbsolutePath().toString() + File.separator
-                + config.dataFile;
-        System.setProperty("jacoco-agent.destfile",
-                dataFile);
+        String dataFile = getFilePath(config.dataFile, outputTargetBuildItem.getOutputDirectory(), JACOCO_QUARKUS_EXEC);
+        System.setProperty("jacoco-agent.destfile", dataFile);
         if (!config.reuseDataFile) {
             Files.deleteIfExists(Paths.get(dataFile));
         }
@@ -95,8 +97,7 @@ public class JacocoProcessor {
             info.dataFile = dataFile;
 
             File targetdir = new File(
-                    outputTargetBuildItem.getOutputDirectory().toAbsolutePath().toString() + File.separator
-                            + config.reportLocation);
+                    getFilePath(config.reportLocation, outputTargetBuildItem.getOutputDirectory(), JACOCO_REPORT));
             info.reportDir = targetdir.getAbsolutePath();
             String includes = String.join(",", config.includes);
             String excludes = String.join(",", config.excludes.orElse(Collections.emptyList()));
@@ -122,7 +123,8 @@ public class JacocoProcessor {
 
     private void addProjectModule(ResolvedDependency module, JacocoConfig config, ReportInfo info, String includes,
             String excludes, Set<String> classes, Set<String> sources) throws Exception {
-        info.savedData.add(new File(module.getWorkspaceModule().getBuildDir(), config.dataFile).getAbsolutePath());
+        String dataFile = getFilePath(config.dataFile, module.getWorkspaceModule().getBuildDir().toPath(), JACOCO_QUARKUS_EXEC);
+        info.savedData.add(new File(dataFile).getAbsolutePath());
         if (module.getSources() == null) {
             return;
         }
@@ -139,5 +141,9 @@ public class JacocoProcessor {
                 }
             }
         }
+    }
+
+    private String getFilePath(Optional<String> path, Path outputDirectory, String defaultRelativePath) {
+        return path.orElse(outputDirectory.toAbsolutePath() + File.separator + defaultRelativePath);
     }
 }

--- a/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
+++ b/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
@@ -11,10 +11,11 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class JacocoConfig {
 
     /**
-     * The jacoco data file
+     * The jacoco data file. By default this will be target/jacoco-quarkus.exec.
+     * The path can be relative (to the module) or absolute.
      */
-    @ConfigItem(defaultValue = "jacoco-quarkus.exec")
-    public String dataFile;
+    @ConfigItem
+    public Optional<String> dataFile;
 
     /**
      * Whether to reuse ({@code true}) or delete ({@code false}) the jacoco
@@ -82,8 +83,9 @@ public class JacocoConfig {
     public Optional<List<String>> excludes;
 
     /**
-     * The location of the report files.
+     * The location of the report files. By default this will be target/jacoco-report.
+     * The path can be relative (to the module) or absolute.
      */
-    @ConfigItem(defaultValue = "jacoco-report")
-    public String reportLocation;
+    @ConfigItem
+    public Optional<String> reportLocation;
 }


### PR DESCRIPTION
This changes the `data-file` and `report-location` config parameters to allow paths that are not relative to the build directory.
we need this to be able to point to a common location for all modules in a multi module project.
today, if we specify a `data-file=jacoco/jacoco-quarkus.exec` in module foo, the `data-file` passed to jacoco will be `<project root>/foo/target/jacoco/jacoco-quarkus.exec`
in a multi-module project, we need the path to be something like <project root>/target/jacoco/jacoco-quarkus.exec
the only option we have right now is to use an expression such as `data-file=../target/jacoco/jacoco-quarkus.exec`.
but that works only for modules that are at the first level. if we have deeper sub-modules (which is the case in extensions), then we have to customize the number of `../../..` for each module.
This PR allows to configure `data-file=${maven.multiModuleProjectDirectory}/target/jacoco/jacoco-quarkus.exec`

this is a breaking change on the configuration, since existing configuration `data-file=foo` would end up with `./foo` instead of `./target/foo`. if accepted this will need to be properly documented in the migration guide.
another option would be to add an additional config parameter `relative-to-multi-module-project-directory=true|false(false by default)`.

see [zulip Multi Module Code Coverage With Jacoco](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Multi.20Module.20Code.20Coverage.20With.20Jacoco) and https://github.com/quarkusio/quarkus/issues/32254