### PR TITLE
Fix duration converter with multiple units

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/DurationConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/DurationConverter.java
@@ -20,7 +20,7 @@ public class DurationConverter implements Converter<Duration>, Serializable {
     private static final String PERIOD = "P";
     private static final String PERIOD_OF_TIME = "PT";
     public static final Pattern DIGITS = Pattern.compile("^[-+]?\\d+$");
-    private static final Pattern DIGITS_AND_UNIT = Pattern.compile("^[-+]?\\d+(?:\\.\\d+)?(?i)[hms]$");
+    private static final Pattern DIGITS_AND_UNIT = Pattern.compile("^(?:[-+]?\\d+(?:\\.\\d+)?(?i)[hms])+$");
     private static final Pattern DAYS = Pattern.compile("^[-+]?\\d+(?i)d$");
     private static final Pattern MILLIS = Pattern.compile("^[-+]?\\d+(?i)ms$");
 

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/DurationConverterTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/DurationConverterTestCase.java
@@ -68,4 +68,18 @@ public class DurationConverterTestCase {
         Duration actualDuration = durationConverter.convert("2s");
         assertEquals(expectedDuration, actualDuration);
     }
+
+    @Test
+    public void testValuesWithMultipleUnits() {
+        Duration expectedDuration = Duration.ofSeconds(150);
+        Duration actualDuration = durationConverter.convert("2m30s");
+        assertEquals(expectedDuration, actualDuration);
+    }
+
+    @Test
+    public void testValuesWithMultipleUnitsSigned() {
+        Duration expectedDuration = Duration.ofSeconds(90);
+        Duration actualDuration = durationConverter.convert("+2m-30s");
+        assertEquals(expectedDuration, actualDuration);
+    }
 }


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/pull/32929 caused a minor regression when parsing durations with multiple units. This PR fixes it and adds the tests for it.