### PR TITLE
Prevent build failure when @Blocking on Application

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -15,6 +15,7 @@ import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.*;
 import static org.jboss.resteasy.reactive.common.processor.EndpointIndexer.CDI_WRAPPER_SUFFIX;
 import static org.jboss.resteasy.reactive.common.processor.JandexUtil.isImplementorOf;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.APPLICATION;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.BLOCKING;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REQUEST_SCOPED;
 import static org.jboss.resteasy.reactive.common.processor.scanning.ResteasyReactiveScanner.BUILTIN_HTTP_ANNOTATIONS_TO_METHOD;
@@ -523,7 +524,7 @@ class RestClientReactiveProcessor {
         for (AnnotationInstance registerBlockingClass : registerBlockingClasses) {
             AnnotationTarget target = registerBlockingClass.target();
             if (target.kind() == AnnotationTarget.Kind.CLASS
-                    && isImplementorOf(index, target.asClass(), RESPONSE_EXCEPTION_MAPPER)) {
+                    && isImplementorOf(index, target.asClass(), RESPONSE_EXCEPTION_MAPPER, Set.of(APPLICATION))) {
                 // Watch for @Blocking annotations in classes that implements ResponseExceptionMapper:
                 blockingClassNames.add(target.asClass().toString());
             } else if (target.kind() == AnnotationTarget.Kind.METHOD

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/JandexUtil.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/JandexUtil.java
@@ -373,6 +373,20 @@ public final class JandexUtil {
      * @throws RuntimeException if one of the superclasses is not indexed.
      */
     public static boolean isImplementorOf(IndexView index, ClassInfo info, DotName name) {
+        return isImplementorOf(index, info, name, Collections.emptySet());
+    }
+
+    /**
+     * Returns true if the given Jandex ClassInfo is a subclass of or inherits the given <tt>name</tt>.
+     *
+     * @param index the index to use to look up super classes.
+     * @param info the ClassInfo we want to check.
+     * @param name the name of the superclass or interface we want to find.
+     * @param additionalIgnoredSuperClasses return false if the class has any of these as a superclass.
+     * @throws RuntimeException if one of the superclasses is not indexed.
+     */
+    public static boolean isImplementorOf(IndexView index, ClassInfo info, DotName name,
+            Set<DotName> additionalIgnoredSuperClasses) {
         // Check interfaces
         List<DotName> interfaceNames = info.interfaceNames();
         for (DotName interfaceName : interfaceNames) {
@@ -382,7 +396,9 @@ public final class JandexUtil {
         }
 
         // Check direct hierarchy
-        if (info.superName().equals(DOTNAME_OBJECT) || info.superName().equals(DOTNAME_RECORD)) {
+        DotName superDotName = info.superName();
+        if (superDotName.equals(DOTNAME_OBJECT) || superDotName.equals(DOTNAME_RECORD)
+                || additionalIgnoredSuperClasses.contains(superDotName)) {
             return false;
         }
         if (info.superName().equals(name)) {
@@ -393,10 +409,10 @@ public final class JandexUtil {
         Type superType = info.superClassType();
         ClassInfo superClass = index.getClassByName(superType.name());
         if (superClass == null) {
-            // this can happens if the parent is not inside the Jandex index
+            // this can happen if the parent is not inside the Jandex index
             throw new RuntimeException("The class " + superType.name() + " is not inside the Jandex index");
         }
-        return isImplementorOf(index, superClass, name);
+        return isImplementorOf(index, superClass, name, additionalIgnoredSuperClasses);
     }
 
 }


### PR DESCRIPTION
This would happen when @Blocking was used on a class that extended Jakarta REST's Application class
and the Reactive REST Client extension was present

The issue was originally reported [here](https://github.com/redhat-developer-demos/quarkus-petclinic/pull/23)