### PR TITLE
Introduce a way to completely customize MeterRegistry

### DIFF
--- a/docs/src/main/asciidoc/telemetry-micrometer.adoc
+++ b/docs/src/main/asciidoc/telemetry-micrometer.adoc
@@ -519,8 +519,12 @@ For example, setting
 By default, the  metrics are exported using the Prometheus format `application/openmetrics-text`,
 you can revert to the former format by specifying the `Accept` request header to `text/plain` (`curl -H "Accept: text/plain" localhost:8080/q/metrics/`).
 
+== Customizing Micrometer
+
+Quarkus provides a variety of way to customize Micrometer.
+
 [[meter-filter]]
-== Use `MeterFilter` to customize emitted tags and metrics
+=== Use `MeterFilter` to customize emitted tags and metrics
 
 Micrometer uses `MeterFilter` instances to customize the metrics emitted by `MeterRegistry` instances.
 The Micrometer extension will detect `MeterFilter` CDI beans and use them when initializing `MeterRegistry`
@@ -579,6 +583,15 @@ to all `MeterRegistry` instances.
 An application configuration property is also injected and used as a tag value.
 Additional examples of MeterFilters can be found in the
 link:https://micrometer.io/docs/concepts[official documentation].
+
+=== Use `HttpServerMetricsTagsContributor` for server HTTP requests
+
+By providing CDI beans that implement `io.quarkus.micrometer.runtime.HttpServerMetricsTagsContributor`, user code can contribute arbitrary tags based on the details of HTTP request
+
+=== Use `MeterRegistryCustomizer` for arbitrary customizations to meter registries
+
+By providing CDI beans that implement `io.quarkus.micrometer.runtime.MeterRegistryCustomizer` user code has the change to change the configuration of any `MeterRegistry` that has been activated.
+Unless an implementation is annotated with `@io.quarkus.micrometer.runtime.MeterRegistryCustomizerConstraint`, the customization applies to all `MeterRegistry` instances.
 
 [[annotations]]
 == Does Micrometer support annotations?

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
@@ -32,6 +32,7 @@ import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
@@ -163,12 +164,11 @@ public class MicrometerProcessor {
     }
 
     @BuildStep
+    @Consume(BeanContainerBuildItem.class)
     @Record(ExecutionTime.STATIC_INIT)
     RootMeterRegistryBuildItem createRootRegistry(MicrometerRecorder recorder,
             MicrometerConfig config,
-            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            BeanContainerBuildItem beanContainerBuildItem) {
-        // BeanContainerBuildItem is present to indicate we call this after Arc is initialized
+            NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem) {
 
         RuntimeValue<MeterRegistry> registry = recorder.createRootRegistry(config,
                 nonApplicationRootPathBuildItem.getNonApplicationRootPath(),
@@ -177,11 +177,10 @@ public class MicrometerProcessor {
     }
 
     @BuildStep
+    @Consume(RootMeterRegistryBuildItem.class)
     @Record(ExecutionTime.STATIC_INIT)
     void registerExtensionMetrics(MicrometerRecorder recorder,
-            RootMeterRegistryBuildItem rootMeterRegistryBuildItem,
             List<MetricsFactoryConsumerBuildItem> metricsFactoryConsumerBuildItems) {
-        // RootMeterRegistryBuildItem is present to indicate we call this after the root registry has been initialized
 
         for (MetricsFactoryConsumerBuildItem item : metricsFactoryConsumerBuildItems) {
             if (item != null && item.executionTime() == ExecutionTime.STATIC_INIT) {
@@ -191,15 +190,14 @@ public class MicrometerProcessor {
     }
 
     @BuildStep
+    @Consume(RootMeterRegistryBuildItem.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void configureRegistry(MicrometerRecorder recorder,
             MicrometerConfig config,
-            RootMeterRegistryBuildItem rootMeterRegistryBuildItem,
             List<MicrometerRegistryProviderBuildItem> providerClassItems,
             List<MetricsFactoryConsumerBuildItem> metricsFactoryConsumerBuildItems,
             List<MicrometerRegistryProviderBuildItem> providerClasses,
             ShutdownContextBuildItem shutdownContextBuildItem) {
-        // RootMeterRegistryBuildItem is present to indicate we call this after the root registry has been initialized
 
         Set<Class<? extends MeterRegistry>> typeClasses = new HashSet<>();
         for (MicrometerRegistryProviderBuildItem item : providerClassItems) {

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
@@ -48,6 +48,9 @@ import io.quarkus.micrometer.runtime.ClockProvider;
 import io.quarkus.micrometer.runtime.CompositeRegistryCreator;
 import io.quarkus.micrometer.runtime.MeterFilterConstraint;
 import io.quarkus.micrometer.runtime.MeterFilterConstraints;
+import io.quarkus.micrometer.runtime.MeterRegistryCustomizer;
+import io.quarkus.micrometer.runtime.MeterRegistryCustomizerConstraint;
+import io.quarkus.micrometer.runtime.MeterRegistryCustomizerConstraints;
 import io.quarkus.micrometer.runtime.MicrometerCounted;
 import io.quarkus.micrometer.runtime.MicrometerCountedInterceptor;
 import io.quarkus.micrometer.runtime.MicrometerRecorder;
@@ -62,6 +65,7 @@ public class MicrometerProcessor {
     private static final DotName METER_REGISTRY = DotName.createSimple(MeterRegistry.class.getName());
     private static final DotName METER_BINDER = DotName.createSimple(MeterBinder.class.getName());
     private static final DotName METER_FILTER = DotName.createSimple(MeterFilter.class.getName());
+    private static final DotName METER_REGISTRY_CUSTOMIZER = DotName.createSimple(MeterRegistryCustomizer.class.getName());
     private static final DotName NAMING_CONVENTION = DotName.createSimple(NamingConvention.class.getName());
 
     private static final DotName COUNTED_ANNOTATION = DotName.createSimple(Counted.class.getName());
@@ -105,12 +109,15 @@ public class MicrometerProcessor {
                 .setUnremovable()
                 .addBeanClass(ClockProvider.class)
                 .addBeanClass(CompositeRegistryCreator.class)
+                .addBeanClass(MeterRegistryCustomizer.class)
                 .build());
 
         // Add annotations and associated interceptors
         additionalBeans.produce(AdditionalBeanBuildItem.builder()
                 .addBeanClass(MeterFilterConstraint.class)
                 .addBeanClass(MeterFilterConstraints.class)
+                .addBeanClass(MeterRegistryCustomizerConstraint.class)
+                .addBeanClass(MeterRegistryCustomizerConstraints.class)
                 .addBeanClass(TIMED_ANNOTATION.toString())
                 .addBeanClass(TIMED_INTERCEPTOR.toString())
                 .addBeanClass(COUNTED_ANNOTATION.toString())
@@ -136,7 +143,8 @@ public class MicrometerProcessor {
                         "org.HdrHistogram.ConcurrentHistogram")
                 .build());
 
-        return UnremovableBeanBuildItem.beanTypes(METER_REGISTRY, METER_BINDER, METER_FILTER, NAMING_CONVENTION);
+        return UnremovableBeanBuildItem.beanTypes(METER_REGISTRY, METER_BINDER, METER_FILTER, METER_REGISTRY_CUSTOMIZER,
+                NAMING_CONVENTION);
     }
 
     @BuildStep

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MeterRegistryCustomizer.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MeterRegistryCustomizer.java
@@ -1,0 +1,31 @@
+package io.quarkus.micrometer.runtime;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Meant to be implemented by a CDI bean that provides arbitrary customization for various {@link MeterRegistry} classes
+ * registered by Quarkus.
+ * <p>
+ * Unless an implementation is annotated with {@link MeterRegistryCustomizerConstraint}, it will apply to all
+ * {@link MeterRegistry} classes.
+ */
+public interface MeterRegistryCustomizer extends Comparable<MeterRegistryCustomizer> {
+
+    int MINIMUM_PRIORITY = Integer.MIN_VALUE;
+    // we use this priority to give a chance to other customizers to override serializers / deserializers
+    // that might have been added by the modules that Quarkus registers automatically
+    // (Jackson will keep the last registered serializer / deserializer for a given type
+    // if multiple are registered)
+    int QUARKUS_CUSTOMIZER_PRIORITY = MINIMUM_PRIORITY + 100;
+    int DEFAULT_PRIORITY = 0;
+
+    void customize(MeterRegistry registry);
+
+    default int priority() {
+        return DEFAULT_PRIORITY;
+    }
+
+    default int compareTo(MeterRegistryCustomizer o) {
+        return Integer.compare(o.priority(), priority());
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MeterRegistryCustomizerConstraint.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MeterRegistryCustomizerConstraint.java
@@ -1,0 +1,33 @@
+package io.quarkus.micrometer.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE, ElementType.PARAMETER, ElementType.FIELD })
+@Repeatable(MeterRegistryCustomizerConstraints.class)
+public @interface MeterRegistryCustomizerConstraint {
+    Class<?> applyTo();
+
+    final class Literal extends AnnotationLiteral<MeterRegistryCustomizerConstraint> implements
+            MeterRegistryCustomizerConstraint {
+        private static final long serialVersionUID = 1L;
+        private final Class<?> clazz;
+
+        public Literal(Class<?> clazz) {
+            this.clazz = clazz;
+        }
+
+        @Override
+        public Class<?> applyTo() {
+            return clazz;
+        }
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MeterRegistryCustomizerConstraints.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MeterRegistryCustomizerConstraints.java
@@ -1,0 +1,12 @@
+package io.quarkus.micrometer.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE, ElementType.PARAMETER, ElementType.FIELD })
+public @interface MeterRegistryCustomizerConstraints {
+    MeterRegistryCustomizerConstraint[] value();
+}

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/ExampleResourcesTest.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/ExampleResourcesTest.java
@@ -18,13 +18,13 @@ public class ExampleResourcesTest {
         when().get("/example/gauge/4").then().statusCode(200);
         when().get("/q/metrics").then().statusCode(200)
                 .body(containsString(
-                        "example_list_size{env=\"test\",registry=\"prometheus\"} 2.0"));
+                        "example_list_size{env=\"test\",env2=\"test\",registry=\"prometheus\"} 2.0"));
         when().get("/example/gauge/6").then().statusCode(200);
         when().get("/example/gauge/5").then().statusCode(200);
         when().get("/example/gauge/7").then().statusCode(200);
         when().get("/q/metrics").then().statusCode(200)
                 .body(containsString(
-                        "example_list_size{env=\"test\",registry=\"prometheus\"} 1.0"));
+                        "example_list_size{env=\"test\",env2=\"test\",registry=\"prometheus\"} 1.0"));
     }
 
     @Test
@@ -38,15 +38,15 @@ public class ExampleResourcesTest {
 
         when().get("/q/metrics").then().statusCode(200)
                 .body(containsString(
-                        "example_prime_number_total{env=\"test\",registry=\"prometheus\",type=\"prime\"}"))
+                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"prime\"}"))
                 .body(containsString(
-                        "example_prime_number_total{env=\"test\",registry=\"prometheus\",type=\"not-prime\"}"))
+                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"not-prime\"}"))
                 .body(containsString(
-                        "example_prime_number_total{env=\"test\",registry=\"prometheus\",type=\"one\"}"))
+                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"one\"}"))
                 .body(containsString(
-                        "example_prime_number_total{env=\"test\",registry=\"prometheus\",type=\"even\"}"))
+                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"even\"}"))
                 .body(containsString(
-                        "example_prime_number_total{env=\"test\",registry=\"prometheus\",type=\"not-natural\"}"));
+                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"not-natural\"}"));
     }
 
     @Test
@@ -54,14 +54,14 @@ public class ExampleResourcesTest {
         when().get("/example/prime/257").then().statusCode(200);
         when().get("/q/metrics").then().statusCode(200)
                 .body(containsString(
-                        "example_prime_number_test_seconds_sum{env=\"test\",prime=\"true\",registry=\"prometheus\"}"))
+                        "example_prime_number_test_seconds_sum{env=\"test\",env2=\"test\",prime=\"true\",registry=\"prometheus\"}"))
                 .body(containsString(
-                        "example_prime_number_test_seconds_max{env=\"test\",prime=\"true\",registry=\"prometheus\"}"))
+                        "example_prime_number_test_seconds_max{env=\"test\",env2=\"test\",prime=\"true\",registry=\"prometheus\"}"))
                 .body(containsString(
-                        "example_prime_number_test_seconds_count{env=\"test\",prime=\"true\",registry=\"prometheus\"} 1.0"));
+                        "example_prime_number_test_seconds_count{env=\"test\",env2=\"test\",prime=\"true\",registry=\"prometheus\"} 1.0"));
         when().get("/example/prime/7919").then().statusCode(200);
         when().get("/q/metrics").then().statusCode(200)
                 .body(containsString(
-                        "example_prime_number_test_seconds_count{env=\"test\",prime=\"true\",registry=\"prometheus\"} 2.0"));
+                        "example_prime_number_test_seconds_count{env=\"test\",env2=\"test\",prime=\"true\",registry=\"prometheus\"} 2.0"));
     }
 }

--- a/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
+++ b/integration-tests/micrometer-prometheus/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
@@ -118,61 +118,61 @@ class PrometheusMetricsRegistryTest {
                 .body(containsString("uri=\"/message/match/{other}\""))
 
                 .body(containsString(
-                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",foo=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/template/path/{value}\""))
+                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",env2=\"test\",foo=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/template/path/{value}\""))
 
                 // Verify Hibernate Metrics
                 .body(containsString(
-                        "hibernate_sessions_open_total{entityManagerFactory=\"<default>\",env=\"test\",registry=\"prometheus\",} 2.0"))
+                        "hibernate_sessions_open_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\",} 2.0"))
                 .body(containsString(
-                        "hibernate_sessions_closed_total{entityManagerFactory=\"<default>\",env=\"test\",registry=\"prometheus\",} 2.0"))
+                        "hibernate_sessions_closed_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\",} 2.0"))
                 .body(containsString(
-                        "hibernate_connections_obtained_total{entityManagerFactory=\"<default>\",env=\"test\",registry=\"prometheus\",}"))
+                        "hibernate_connections_obtained_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\",}"))
                 .body(containsString(
-                        "hibernate_entities_inserts_total{entityManagerFactory=\"<default>\",env=\"test\",registry=\"prometheus\",} 3.0"))
+                        "hibernate_entities_inserts_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\",} 3.0"))
                 .body(containsString(
-                        "hibernate_flushes_total{entityManagerFactory=\"<default>\",env=\"test\",registry=\"prometheus\",} 1.0"))
+                        "hibernate_flushes_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\",} 1.0"))
 
                 // Annotated counters
                 .body(not(containsString("metric_none")))
                 .body(containsString(
-                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"none\",extra=\"tag\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"success\",} 1.0"))
+                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"success\",} 1.0"))
                 .body(containsString(
-                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"failure\",} 1.0"))
+                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"failure\",} 1.0"))
                 .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"NullPointerException\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"failure\",} 1.0"))
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"failure\",} 1.0"))
                 .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"none\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"success\",} 1.0"))
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"success\",} 1.0"))
                 .body(not(containsString("async_none")))
                 .body(containsString(
-                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"failure\",} 1.0"))
+                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"failure\",} 1.0"))
                 .body(containsString(
-                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"none\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"success\",} 1.0"))
+                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"success\",} 1.0"))
                 .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"NullPointerException\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"failure\",} 1.0"))
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"failure\",} 1.0"))
                 .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"none\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"success\",} 1.0"))
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"success\",} 1.0"))
 
                 // Annotated Timers
                 .body(containsString(
-                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"call\",registry=\"prometheus\",} 1.0"))
+                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"call\",registry=\"prometheus\",} 1.0"))
                 .body(containsString(
-                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"none\",extra=\"tag\",method=\"call\",registry=\"prometheus\",}"))
+                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"call\",registry=\"prometheus\",}"))
                 .body(containsString(
-                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\",} 1.0"))
+                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\",} 1.0"))
                 .body(containsString(
-                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"none\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\",} 1.0"))
+                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\",} 1.0"))
                 .body(containsString(
-                        "longCall_seconds_active_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",extra=\"tag\",method=\"longCall\",registry=\"prometheus\",}"))
+                        "longCall_seconds_active_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",extra=\"tag\",method=\"longCall\",registry=\"prometheus\",}"))
                 .body(containsString(
-                        "async_longCall_seconds_duration_sum{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",extra=\"tag\",method=\"longAsyncCall\",registry=\"prometheus\",} 0.0"))
+                        "async_longCall_seconds_duration_sum{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",extra=\"tag\",method=\"longAsyncCall\",registry=\"prometheus\",} 0.0"))
 
                 // Configured median, 95th percentile and histogram buckets
                 .body(containsString(
-                        "prime_number_test_seconds{env=\"test\",registry=\"prometheus\",quantile=\"0.5\",}"))
+                        "prime_number_test_seconds{env=\"test\",env2=\"test\",registry=\"prometheus\",quantile=\"0.5\",}"))
                 .body(containsString(
-                        "prime_number_test_seconds{env=\"test\",registry=\"prometheus\",quantile=\"0.95\",}"))
+                        "prime_number_test_seconds{env=\"test\",env2=\"test\",registry=\"prometheus\",quantile=\"0.95\",}"))
                 .body(containsString(
-                        "prime_number_test_seconds_bucket{env=\"test\",registry=\"prometheus\",le=\"0.001\",}"))
+                        "prime_number_test_seconds_bucket{env=\"test\",env2=\"test\",registry=\"prometheus\",le=\"0.001\",}"))
 
                 // this was defined by a tag to a non-matching registry, and should not be found
                 .body(not(containsString("class-should-not-match")))
@@ -210,61 +210,61 @@ class PrometheusMetricsRegistryTest {
                 .body(containsString("uri=\"/message/match/{other}\""))
 
                 .body(containsString(
-                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",foo=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/template/path/{value}\""))
+                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",env2=\"test\",foo=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/template/path/{value}\""))
 
                 // Verify Hibernate Metrics
                 .body(containsString(
-                        "hibernate_sessions_open_total{entityManagerFactory=\"<default>\",env=\"test\",registry=\"prometheus\"} 2.0"))
+                        "hibernate_sessions_open_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 2.0"))
                 .body(containsString(
-                        "hibernate_sessions_closed_total{entityManagerFactory=\"<default>\",env=\"test\",registry=\"prometheus\"} 2.0"))
+                        "hibernate_sessions_closed_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 2.0"))
                 .body(containsString(
-                        "hibernate_connections_obtained_total{entityManagerFactory=\"<default>\",env=\"test\",registry=\"prometheus\"}"))
+                        "hibernate_connections_obtained_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"}"))
                 .body(containsString(
-                        "hibernate_entities_inserts_total{entityManagerFactory=\"<default>\",env=\"test\",registry=\"prometheus\"} 3.0"))
+                        "hibernate_entities_inserts_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 3.0"))
                 .body(containsString(
-                        "hibernate_flushes_total{entityManagerFactory=\"<default>\",env=\"test\",registry=\"prometheus\"} 1.0"))
+                        "hibernate_flushes_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 1.0"))
 
                 // Annotated counters
                 .body(not(containsString("metric_none")))
                 .body(containsString(
-                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"none\",extra=\"tag\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"success\"} 1.0 # {span_id="))
+                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"success\"} 1.0 # {span_id="))
                 .body(containsString(
-                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"failure\"} 1.0"))
+                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"failure\"} 1.0"))
                 .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"NullPointerException\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"failure\"} 1.0 # {span_id="))
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"failure\"} 1.0 # {span_id="))
                 .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"none\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"success\"} 1.0"))
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"success\"} 1.0"))
                 .body(not(containsString("async_none")))
                 .body(containsString(
-                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"failure\"} 1.0"))
+                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"failure\"} 1.0"))
                 .body(containsString(
-                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"none\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"success\"} 1.0"))
+                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"success\"} 1.0"))
                 .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"NullPointerException\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"failure\"} 1.0"))
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"failure\"} 1.0"))
                 .body(containsString(
-                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"none\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"success\"} 1.0"))
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"success\"} 1.0"))
 
                 // Annotated Timers
                 .body(containsString(
-                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"call\",registry=\"prometheus\"} 1.0"))
+                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"call\",registry=\"prometheus\"} 1.0"))
                 .body(containsString(
-                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"none\",extra=\"tag\",method=\"call\",registry=\"prometheus\"}"))
+                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"call\",registry=\"prometheus\"}"))
                 .body(containsString(
-                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\"} 1.0"))
+                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\"} 1.0"))
                 .body(containsString(
-                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",exception=\"none\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\"} 1.0"))
+                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\"} 1.0"))
                 .body(containsString(
-                        "longCall_seconds_active_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",extra=\"tag\",method=\"longCall\",registry=\"prometheus\"}"))
+                        "longCall_seconds_active_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",extra=\"tag\",method=\"longCall\",registry=\"prometheus\"}"))
                 .body(containsString(
-                        "async_longCall_seconds_duration_sum{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",extra=\"tag\",method=\"longAsyncCall\",registry=\"prometheus\"} 0.0"))
+                        "async_longCall_seconds_duration_sum{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",extra=\"tag\",method=\"longAsyncCall\",registry=\"prometheus\"} 0.0"))
 
                 // Configured median, 95th percentile and histogram buckets
                 .body(containsString(
-                        "prime_number_test_seconds{env=\"test\",registry=\"prometheus\",quantile=\"0.5\"}"))
+                        "prime_number_test_seconds{env=\"test\",env2=\"test\",registry=\"prometheus\",quantile=\"0.5\"}"))
                 .body(containsString(
-                        "prime_number_test_seconds{env=\"test\",registry=\"prometheus\",quantile=\"0.95\"}"))
+                        "prime_number_test_seconds{env=\"test\",env2=\"test\",registry=\"prometheus\",quantile=\"0.95\"}"))
                 .body(containsString(
-                        "prime_number_test_seconds_bucket{env=\"test\",registry=\"prometheus\",le=\"0.001\"}"))
+                        "prime_number_test_seconds_bucket{env=\"test\",env2=\"test\",registry=\"prometheus\",le=\"0.001\"}"))
 
                 // this was defined by a tag to a non-matching registry, and should not be found
                 .body(not(containsString("class-should-not-match")))


### PR DESCRIPTION
This is done via the new `MeterRegistryCustomizer` interface
the implementations of which are meant to be registered as
CDI beans.

Closes: https://github.com/quarkusio/quarkus/issues/32996

_P.S. The customizer pattern is heavily used in Quarkus while the qualifier constraint pattern 
is the same idea as used for `MeterFilter` classes._