### PR TITLE
OpenTelemetry service name should have higher priority than app name and resource attribute service name

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryServiceNameTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static io.opentelemetry.api.trace.SpanKind.SERVER;
+import static io.quarkus.opentelemetry.deployment.common.TestSpanExporter.getSpanByKindAndParentId;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.opentelemetry.deployment.common.TestSpanExporter;
+import io.quarkus.opentelemetry.deployment.common.TestSpanExporterProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.config.SmallRyeConfig;
+
+public class OpenTelemetryServiceNameTest {
+
+    private static final String SERVICE_NAME = "FrankBullitt";
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(TestSpanExporter.class)
+                    .addClass(TestSpanExporterProvider.class)
+                    .addAsResource("resource-config/application.properties", "application.properties")
+                    .addAsResource(
+                            "META-INF/services-config/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider",
+                            "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider"))
+            .overrideRuntimeConfigKey("quarkus.otel.service.name", SERVICE_NAME);
+
+    @Inject
+    SmallRyeConfig config;
+    @Inject
+    TestSpanExporter spanExporter;
+
+    @Test
+    void testSvcNameHasPriorityOverAppNameAndResourceAttr() {
+        RestAssured.when()
+                .get("/hello").then()
+                .statusCode(200)
+                .body(is("hello"));
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems(1);
+
+        final SpanData server = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
+        assertEquals("GET /hello", server.getName());
+        assertEquals(SERVICE_NAME, server.getResource().getAttribute(AttributeKey.stringKey("service.name")));
+    }
+
+    @Path("/hello")
+    public static class HelloResource {
+        @GET
+        public String hello() {
+            return "hello";
+        }
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtil.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtil.java
@@ -1,5 +1,7 @@
 package io.quarkus.opentelemetry.runtime.tracing;
 
+import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
+
 import java.util.List;
 
 import io.opentelemetry.api.common.Attributes;
@@ -8,15 +10,25 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.quarkus.opentelemetry.runtime.OpenTelemetryUtil;
 
 public class TracerUtil {
+
     private TracerUtil() {
     }
 
-    public static Resource mapResourceAttributes(List<String> resourceAttributes) {
+    public static Resource mapResourceAttributes(List<String> resourceAttributes, String serviceName) {
         if (resourceAttributes.isEmpty()) {
             return Resource.empty();
         }
         AttributesBuilder attributesBuilder = Attributes.builder();
-        OpenTelemetryUtil.convertKeyValueListToMap(resourceAttributes).forEach(attributesBuilder::put);
+        var attrNameToValue = OpenTelemetryUtil.convertKeyValueListToMap(resourceAttributes);
+
+        // override both default (app name) and explicitly set resource attribute
+        // it needs to be done manually because OpenTelemetry correctly sets 'otel.service.name'
+        // to existing (incoming) resource, but customizer output replaces originally set service name
+        if (serviceName != null) {
+            attrNameToValue.put(SERVICE_NAME.getKey(), serviceName);
+        }
+
+        attrNameToValue.forEach(attributesBuilder::put);
         return Resource.create(attributesBuilder.build());
     }
 }

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtilTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtilTest.java
@@ -19,7 +19,7 @@ public class TracerUtilTest {
                 "service.namespace=mynamespace",
                 "service.version=1.0",
                 "deployment.environment=production");
-        Resource resource = TracerUtil.mapResourceAttributes(resourceAttributes);
+        Resource resource = TracerUtil.mapResourceAttributes(resourceAttributes, null);
         Attributes attributes = resource.getAttributes();
         Assertions.assertThat(attributes.size()).isEqualTo(4);
         Assertions.assertThat(attributes.get(ResourceAttributes.SERVICE_NAME)).isEqualTo("myservice");


### PR DESCRIPTION
fixes: #33317

When `otel.service.name` is set, it has [correctly](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#opentelemetry-resource) priority over application name and resource attribute name.

Actual state before this PR is:

- resource attribute has the highest priority (we test that: see https://github.com/quarkusio/quarkus/blob/6fde192d6ee431be23a92b7c69aef8b58a7248f5/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryResourceTest.java#L54)
- application name
- `otel.service.name` is always ignored; more precisely, OpenTelemetry sets it correctly, but than in `io.quarkus.opentelemetry.runtime.OpenTelemetryProducer#getOpenTelemetry` we add resource customizer that overrides it with resource attribute (default is app name, but user can resource attribute `service.name`)

Please see https://github.com/open-telemetry/opentelemetry-java/blob/7bd06ef1898b4d3a7068acf31893882faf8e453d/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ResourceConfiguration.java#L74 for better context.