### PR TITLE
Add missing property ignore rule

### DIFF
--- a/integration-tests/test-extension/tests/pom.xml
+++ b/integration-tests/test-extension/tests/pom.xml
@@ -101,6 +101,7 @@
                       <path>application.properties</path>
                       <ignoredProperties>
                         <ignore>quarkus.bt.classpath-recording.record-file</ignore>
+                        <ignore>%test.quarkus.bt.classpath-recording.record-file</ignore>
                       </ignoredProperties>
                     </propertiesNormalization>
                   </propertiesNormalizations>


### PR DESCRIPTION
The goal `compileTest` of the module `integration-tests/test-extension/tests` defines as input an `application.properties` file containing a key `%test.quarkus.bt.classpath-recording.record-file` set to an absolute path.

This prevents from getting a build cache hit when the workspace is relocated.

![Screenshot 2023-07-07 at 4 53 54 PM](https://github.com/quarkusio/quarkus/assets/10243934/c664e108-6098-4bea-8301-7bf4a9a08809)
