### PR TITLE
Support legacy property to disable OpenTelemetry in order to ensure documented behavior

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/OTelBuildConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/OTelBuildConfig.java
@@ -29,7 +29,7 @@ public interface OTelBuildConfig {
      * Defaults to <code>true</code>.
      */
     @Deprecated // TODO only use runtime (soon)
-    @WithDefault("true")
+    @WithDefault("${quarkus.opentelemetry.enabled:true}")
     boolean enabled();
 
     /**


### PR DESCRIPTION
I mentioned during review here https://github.com/quarkus-qe/quarkus-test-suite/pull/1304#pullrequestreview-1519169810 that `quarkus.opentelemetry.enabled` behaves differently than `quarkus.otel.enabled`. While `quarkus.otel.enabled` disables `OpenTelemetryProcessor` etc. at build time, `quarkus.opentelemetrye.enabled` does not after this PR https://github.com/quarkusio/quarkus/pull/32050. I understand that both properties are deprecated, but it is important to realize that we document `quarkus. opentelemetry.enabled` to work, please see https://github.com/quarkusio/quarkus/blob/89bacac0e5c7f5002f6c9d37a4d4c6f55ba6decc/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/OTelBuildConfig.java#L27