### PR TITLE
Do not refresh OIDC session if the user is requesting logout

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutTokenCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutTokenCache.java
@@ -45,6 +45,10 @@ public class BackChannelLogoutTokenCache {
         return entry == null ? null : entry.result;
     }
 
+    public boolean containsTokenVerification(String token) {
+        return cacheMap.containsKey(token);
+    }
+
     public void clearCache() {
         cacheMap.clear();
         size.set(0);

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -20,6 +20,8 @@ quarkus.oidc.code-flow.logout.extra-params.client_id=${quarkus.oidc.code-flow.cl
 quarkus.oidc.code-flow.credentials.secret=secret
 quarkus.oidc.code-flow.application-type=web-app
 quarkus.oidc.code-flow.token.audience=https://server.example.com
+quarkus.oidc.code-flow.token.refresh-expired=true
+quarkus.oidc.code-flow.token.refresh-token-time-skew=5M
 
 quarkus.oidc.code-flow-encrypted-id-token-jwk.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-encrypted-id-token-jwk.client-id=quarkus-web-app

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -6,7 +6,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -77,7 +76,7 @@ public class CodeFlowAuthorizationTest {
 
             assertEquals("alice, cache size: 0", page.getBody().asNormalizedText());
             assertNotNull(getSessionCookie(webClient, "code-flow"));
-
+            // Logout
             page = webClient.getPage("http://localhost:8081/code-flow/logout");
             assertEquals("Welcome, clientId: quarkus-web-app", page.getBody().asNormalizedText());
             assertNull(getSessionCookie(webClient, "code-flow"));


### PR DESCRIPTION
Fixes #34592.

@zeppelinux has found a hard to identify problem (reproducer has websockets, undertow, omnifaces, so enabling the debug mode with Omnifaces generates a massive log output, with SPA doing the timer pings as well, so it took me several hours today to get to the bottom of it).

The problem is that when a logout is requested from SPA (referred to as rp-initiated logout), Quarkus needs to verify the session token, before logging the user out, otherwise anyone can logout a given user with curl. 

Next, Quarkus OIDC has an option to auto-refresh the session cookie - for example, SPA, as in the reproducer, keeps pinging every min or so the endpoint, and Quarkus will auto-refresh if it finds that otherwise valid token will expire soon, for example, if OIDC refresh-token-skew is 5 mins and the token will expire in less than 5 mins, Quarkus will refresh it.

This is all works fine in general, but if the Logout is requested, with the intention to terminate the session, then, after verifying the user token, trying to auto-refresh it if it is found it will expire soon, just breaks the logout flow, whose idea is not to recreate the session but get rid of it: what happens is that Quarkus will try to refresh the session, it will succeed, it will lose track it was the logout request, assume the authentication has been successful, let the request go and since in this configuration it is a virtual path, 404 is reported.

While it was hard to identify the problem, once it was identified, the fix is straightforward: in its Token Autorefresh handler, when token has already been otherwise successfully verified - check if it is in fact a logout request and if yes - perform the same Logout call which is done in the normal path - I just had to do some minor refactoring to be able to reuse the code in two of these branches.

Minor update to the test confirming that adding the auto-refresh config does not affect the logout.
