### PR TITLE
Undertow correct path when building on Windows to Docker

### DIFF
--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/KnownPathResourceManager.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/KnownPathResourceManager.java
@@ -86,7 +86,7 @@ public class KnownPathResourceManager implements ResourceManager {
         }
 
         private String evaluatePath(String path) {
-            return IS_WINDOWS ? path.replaceAll("\\\\", "/") : path;
+            return path.replaceAll("\\\\", "/");
         }
 
         @Override


### PR DESCRIPTION
As part of the ongoing saga of #28028 it was reported to me on Quarkus Faces the issue here:

https://github.com/melloware/quarkus-faces/issues/282

I was able to verify the issue and fix it so it now works on either Linux or Windows