### PR TITLE
DevServices for Keycloak should support refresh token grant

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -721,6 +721,7 @@ public class KeycloakDevServicesProcessor {
         realm.setClients(new ArrayList<>());
         realm.setAccessTokenLifespan(600);
         realm.setSsoSessionMaxLifespan(600);
+        realm.setRefreshTokenMaxReuse(10);
 
         RolesRepresentation roles = new RolesRepresentation();
         List<RoleRepresentation> realmRoles = new ArrayList<>();


### PR DESCRIPTION
I've found out, while working with the reproducer in #34592, that the first refresh token grant request from Quarkus OIDC web-app to Keycloak fails with the error not being informative, I've looked around at the OIDC tests, looks like the only option to control it from Keycloak Admin Client API is to have a non-zero usage count, which is what this PR does, and after that I was not able to reproduce the side-effect mentioned here:

https://github.com/quarkusio/quarkus/issues/34592#issuecomment-1625774699

So, when no custom realm is provided, the default realm is provided, ID token lifespan is 600 secs, 10 min. Reproducer has a 5 mins refresh skew, so with 10 refresh grants allowed, with a new ID token returned after every refresh grant, it should give about 50 mins time without any other actions on behalf of users, so this should be a reasonable enough value.

If all of it needs to be customized then users should login into Keycloak Admin Console (DevUI has a link) or register a custom ream, but out of the box it would be nice to have it working.

CC @zeppelinux 