### PR TITLE
Fix import issues in qute documentation examples

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1830,6 +1830,9 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
 import io.quarkus.qute.TemplateInstance;
 
 @Path("hello")
@@ -2472,6 +2475,8 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.Template;

--- a/docs/src/main/asciidoc/qute.adoc
+++ b/docs/src/main/asciidoc/qute.adoc
@@ -6,7 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Qute Templating Engine
 include::_attributes.adoc[]
 :categories: miscellaneous
-:summary: Learn more about how you can use templating in your applications with the Qute template engine. 
+:summary: Learn more about how you can use templating in your applications with the Qute template engine.
 
 Qute is a templating engine designed specifically to meet the Quarkus needs.
 The usage of reflection is minimized to reduce the size of native images.
@@ -84,6 +84,8 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.Template;
@@ -102,7 +104,7 @@ public class HelloResource {
 }
 ----
 <1> If there is no `@Location` qualifier provided, the field name is used to locate the template. In this particular case, we're injecting a template with path `templates/hello.txt`.
-<2> `Template.data()` returns a new template instance that can be customized before the actual rendering is triggered. In this case, we put the name value under the key `name`. The data map is accessible during rendering. 
+<2> `Template.data()` returns a new template instance that can be customized before the actual rendering is triggered. In this case, we put the name value under the key `name`. The data map is accessible during rendering.
 <3> Note that we don't trigger the rendering - this is done automatically by a special `ContainerResponseFilter` implementation.
 
 If your application is running, you can request the endpoint:
@@ -146,6 +148,8 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.CheckedTemplate;
@@ -167,7 +171,7 @@ public class HelloResource {
 ----
 <1> This declares a template with path `templates/HelloResource/hello`.
 <2> `Templates.hello()` returns a new template instance that is returned from the resource method. Note that we don't trigger the rendering - this is done automatically by a special `ContainerResponseFilter` implementation.
- 
+
 NOTE: Once you have declared a `@CheckedTemplate` class, we will check that all its methods point to existing templates, so if you try to use a template from your Java code and you forgot to add it, we will let you know at build time :)
 
 Keep in mind this style of declaration allows you to reference templates declared in other resources too:
@@ -181,6 +185,8 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.qute.TemplateInstance;
 
@@ -217,7 +223,7 @@ public class Templates {
 <1> This declares a template with path `templates/hello`.
 
 
-== Template Parameter Declarations 
+== Template Parameter Declarations
 
 If you declare a *parameter declaration* in a template then Qute attempts to validate all expressions that reference this parameter and if an incorrect expression is found the build fails.
 
@@ -247,7 +253,7 @@ Let's start again with the template:
 </head>
 <body>
     <h1>{item.name}</h1>
-    <div>Price: {item.price}</div> <2> 
+    <div>Price: {item.price}</div> <2>
 </body>
 </html>
 ----
@@ -310,7 +316,7 @@ Let's start again with the template:
 </head>
 <body>
     <h1>{item.name}</h1>
-    <div>Price: {item.price}</div> 
+    <div>Price: {item.price}</div>
 </body>
 </html>
 ----
@@ -341,7 +347,7 @@ public class ItemResource {
 
     @Inject
     Template item; <1>
-    
+
     @GET
     @Path("{id}")
     @Produces(MediaType.TEXT_HTML)
@@ -377,7 +383,7 @@ Let's update our template:
 </head>
 <body>
     <h1>{item.name}</h1>
-    <div>Price: {item.price}</div> 
+    <div>Price: {item.price}</div>
     {#if item.price > 100} <1>
     <div>Discounted Price: {item.discountedPrice}</div> <2>
     {/if}


### PR DESCRIPTION
While walking through the Qute guide [here](https://quarkus.io/guides/qute), I found some missing imports in the code snippets that would prevent the example code from compiling if copy/pasted directly from the browser. This PR simply adds those imports that I found to be missing.