### PR TITLE
Add OpenAPI to management interface if enabled, with option to exclude

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/devui/SmallRyeGraphQLDevUIProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/devui/SmallRyeGraphQLDevUIProcessor.java
@@ -18,17 +18,16 @@ public class SmallRyeGraphQLDevUIProcessor {
         CardPageBuildItem cardPageBuildItem = new CardPageBuildItem();
 
         // Generated GraphQL Schema
+        String schemaPath = "/" + graphQLConfig.rootPath + "/schema.graphql";
         PageBuilder schemaPage = Page.externalPageBuilder("GraphQL Schema")
                 .icon("font-awesome-solid:diagram-project")
-                .url("/" + graphQLConfig.rootPath + "/schema.graphql");
+                .url(schemaPath, schemaPath);
 
         // GraphiQL UI
         String uiPath = nonApplicationRootPathBuildItem.resolvePath(graphQLConfig.ui.rootPath);
         PageBuilder uiPage = Page.externalPageBuilder("GraphQL UI")
                 .icon("font-awesome-solid:table-columns")
-                .staticLabel("<a style='color: var(--lumo-contrast-80pct);' href='" + uiPath
-                        + "' target='_blank'><vaadin-icon class='icon' icon='font-awesome-solid:up-right-from-square'></vaadin-icon></a>")
-                .url(uiPath + "/index.html?embed=true");
+                .url(uiPath + "/index.html?embed=true", uiPath);
 
         // Learn
         PageBuilder learnLink = Page.externalPageBuilder("Learn more about GraphQL")

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthConfig.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthConfig.java
@@ -73,6 +73,13 @@ public class SmallRyeHealthConfig {
     Optional<String> defaultHealthGroup;
 
     /**
+     * If management interface is turned on the health endpoints and ui will be published under the management interface. This
+     * allows you to exclude Health from management by setting the value to false
+     */
+    @ConfigItem(name = "management.enabled", defaultValue = "true")
+    public boolean managementEnabled;
+
+    /**
      * SmallRye Health UI configuration
      */
     @ConfigItem

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthDevUiProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthDevUiProcessor.java
@@ -25,16 +25,19 @@ public class SmallRyeHealthDevUiProcessor {
             SmallRyeHealthRecorder unused) {
         CardPageBuildItem pageBuildItem = new CardPageBuildItem();
 
-        var path = nonApplicationRootPathBuildItem.resolveManagementPath(config.rootPath,
-                managementInterfaceBuildTimeConfig, launchModeBuildItem);
+        String path = nonApplicationRootPathBuildItem.resolveManagementPath(config.rootPath,
+                managementInterfaceBuildTimeConfig, launchModeBuildItem, config.managementEnabled);
+
         pageBuildItem.addPage(Page.externalPageBuilder("Health")
                 .icon("font-awesome-solid:heart-circle-bolt")
-                .url(path)
+                .url(path, path)
                 .isJsonContent());
 
+        String uipath = nonApplicationRootPathBuildItem.resolveManagementPath(config.ui.rootPath,
+                managementInterfaceBuildTimeConfig, launchModeBuildItem, config.managementEnabled);
         pageBuildItem.addPage(Page.externalPageBuilder("Health UI")
                 .icon("font-awesome-solid:stethoscope")
-                .url(nonApplicationRootPathBuildItem.resolvePath(config.ui.rootPath))
+                .url(uipath, uipath)
                 .isHtmlContent());
 
         return pageBuildItem;

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -208,7 +208,7 @@ class SmallRyeHealthProcessor {
 
         // Register the health handler
         routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
-                .management()
+                .management("quarkus.smallrye-health.management.enabled")
                 .route(healthConfig.rootPath)
                 .routeConfigKey("quarkus.smallrye-health.root-path")
                 .handler(new SmallRyeHealthHandler())
@@ -218,7 +218,7 @@ class SmallRyeHealthProcessor {
 
         // Register the liveness handler
         routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
-                .management()
+                .management("quarkus.smallrye-health.management.enabled")
                 .nestedRoute(healthConfig.rootPath, healthConfig.livenessPath)
                 .handler(new SmallRyeLivenessHandler())
                 .displayOnNotFoundPage()
@@ -227,7 +227,7 @@ class SmallRyeHealthProcessor {
 
         // Register the readiness handler
         routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
-                .management()
+                .management("quarkus.smallrye-health.management.enabled")
                 .nestedRoute(healthConfig.rootPath, healthConfig.readinessPath)
                 .handler(new SmallRyeReadinessHandler())
                 .displayOnNotFoundPage()
@@ -249,7 +249,7 @@ class SmallRyeHealthProcessor {
 
         // Register the health group handlers
         routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
-                .management()
+                .management("quarkus.smallrye-health.management.enabled")
                 .nestedRoute(healthConfig.rootPath, healthConfig.groupPath)
                 .handler(new SmallRyeHealthGroupHandler())
                 .displayOnNotFoundPage()
@@ -258,7 +258,7 @@ class SmallRyeHealthProcessor {
 
         SmallRyeIndividualHealthGroupHandler handler = new SmallRyeIndividualHealthGroupHandler();
         routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
-                .management()
+                .management("quarkus.smallrye-health.management.enabled")
                 .nestedRoute(healthConfig.rootPath, healthConfig.groupPath + "/*")
                 .handler(handler)
                 .displayOnNotFoundPage()
@@ -267,7 +267,7 @@ class SmallRyeHealthProcessor {
 
         // Register the wellness handler
         routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
-                .management()
+                .management("quarkus.smallrye-health.management.enabled")
                 .nestedRoute(healthConfig.rootPath, healthConfig.wellnessPath)
                 .handler(new SmallRyeWellnessHandler())
                 .displayOnNotFoundPage()
@@ -276,7 +276,7 @@ class SmallRyeHealthProcessor {
 
         // Register the startup handler
         routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
-                .management()
+                .management("quarkus.smallrye-health.management.enabled")
                 .nestedRoute(healthConfig.rootPath, healthConfig.startupPath)
                 .handler(new SmallRyeStartupHandler())
                 .displayOnNotFoundPage()
@@ -443,8 +443,9 @@ class SmallRyeHealthProcessor {
 
             Handler<RoutingContext> handler = recorder.uiHandler(result.getFinalDestination(),
                     healthUiPath, result.getWebRootConfigurations(), runtimeConfig, shutdownContext);
-            // The health ui is not a management route.
+
             routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
+                    .management("quarkus.smallrye-health.management.enabled")
                     .route(healthConfig.ui.rootPath)
                     .displayOnNotFoundPage("Health UI")
                     .routeConfigKey("quarkus.smallrye-health.ui.root-path")
@@ -452,6 +453,7 @@ class SmallRyeHealthProcessor {
                     .build());
 
             routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
+                    .management("quarkus.smallrye-health.management.enabled")
                     .route(healthConfig.ui.rootPath + "*")
                     .handler(handler)
                     .build());

--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -38,6 +38,13 @@ public final class SmallRyeOpenApiConfig {
     public boolean ignoreStaticDocument;
 
     /**
+     * If management interface is turned on the openapi schema document will be published under the management interface. This
+     * allows you to exclude OpenAPI from management by setting the value to false
+     */
+    @ConfigItem(name = "management.enabled", defaultValue = "true")
+    public boolean managementEnabled;
+
+    /**
      * A list of local directories that should be scanned for yaml and/or json files to be included in the static model.
      * Example: `META-INF/openapi/`
      */

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/devui/OpenApiDevUIProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/devui/OpenApiDevUIProcessor.java
@@ -2,37 +2,44 @@ package io.quarkus.smallrye.openapi.deployment.devui;
 
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.swaggerui.deployment.SwaggerUiConfig;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
+import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
 
 public class OpenApiDevUIProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     public CardPageBuildItem pages(NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            SwaggerUiConfig swaggerUiConfig, SmallRyeOpenApiConfig openApiConfig) {
+            ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
+            LaunchModeBuildItem launchModeBuildItem,
+            SwaggerUiConfig swaggerUiConfig,
+            SmallRyeOpenApiConfig openApiConfig) {
 
-        String uiPath = nonApplicationRootPathBuildItem.resolvePath(swaggerUiConfig.path);
-        String schemaPath = nonApplicationRootPathBuildItem.resolvePath(openApiConfig.path);
+        String uiPath = nonApplicationRootPathBuildItem.resolveManagementPath(swaggerUiConfig.path,
+                managementInterfaceBuildTimeConfig, launchModeBuildItem, openApiConfig.managementEnabled);
+
+        String schemaPath = nonApplicationRootPathBuildItem.resolveManagementPath(openApiConfig.path,
+                managementInterfaceBuildTimeConfig, launchModeBuildItem, openApiConfig.managementEnabled);
 
         CardPageBuildItem cardPageBuildItem = new CardPageBuildItem();
 
         cardPageBuildItem.addPage(Page.externalPageBuilder("Schema yaml")
-                .url(nonApplicationRootPathBuildItem.resolvePath(schemaPath))
+                .url(schemaPath, schemaPath)
                 .isYamlContent()
                 .icon("font-awesome-solid:file-lines"));
 
+        String jsonSchema = schemaPath + "?format=json";
         cardPageBuildItem.addPage(Page.externalPageBuilder("Schema json")
-                .url(nonApplicationRootPathBuildItem.resolvePath(schemaPath) + "?format=json")
+                .url(jsonSchema, jsonSchema)
                 .isJsonContent()
                 .icon("font-awesome-solid:file-code"));
 
         cardPageBuildItem.addPage(Page.externalPageBuilder("Swagger UI")
-                .url(uiPath + "/index.html?embed=true")
-                .staticLabel("<a style='color: var(--lumo-contrast-80pct);' href='" + uiPath
-                        + "' target='_blank'><vaadin-icon class='icon' icon='font-awesome-solid:up-right-from-square'></vaadin-icon></a>")
+                .url(uiPath + "/index.html?embed=true", uiPath)
                 .isHtmlContent()
                 .icon("font-awesome-solid:signs-post"));
 

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/AutoServerFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/AutoServerFilter.java
@@ -14,7 +14,6 @@ import io.smallrye.openapi.api.models.servers.ServerImpl;
  */
 public class AutoServerFilter implements OASFilter {
 
-    private static final String DESCRIPTION = "Auto generated value";
     private static final String HTTP = "http";
     private static final String ZEROS = "0.0.0.0";
     private static final String LOCALHOST = "localhost";
@@ -23,8 +22,9 @@ public class AutoServerFilter implements OASFilter {
     private final String defaultScheme;
     private final String defaultHost;
     private final int defaultPort;
+    private final String description;
 
-    public AutoServerFilter(String defaultScheme, String defaultHost, int defaultPort) {
+    public AutoServerFilter(String defaultScheme, String defaultHost, int defaultPort, String description) {
         if (defaultScheme == null) {
             defaultScheme = HTTP;
         }
@@ -34,6 +34,7 @@ public class AutoServerFilter implements OASFilter {
         this.defaultScheme = defaultScheme;
         this.defaultHost = defaultHost;
         this.defaultPort = defaultPort;
+        this.description = description;
     }
 
     @Override
@@ -47,13 +48,13 @@ public class AutoServerFilter implements OASFilter {
             if (this.defaultHost.equals(ZEROS)) {
                 ServerImpl localhost = new ServerImpl();
                 localhost.setUrl(getUrl(this.defaultScheme, LOCALHOST, this.defaultPort));
-                localhost.setDescription(DESCRIPTION);
+                localhost.setDescription(this.description);
                 servers.add(localhost);
             }
 
             ServerImpl serverImpl = new ServerImpl();
             serverImpl.setUrl(getUrl(this.defaultScheme, this.defaultHost, this.defaultPort));
-            serverImpl.setDescription(DESCRIPTION);
+            serverImpl.setDescription(this.description);
             servers.add(serverImpl);
 
             openAPI.setServers(servers);

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -120,6 +120,7 @@ public class SwaggerUiProcessor {
             }
 
             String openApiPath = nonApplicationRootPathBuildItem.resolvePath(openapi.path);
+
             String swaggerUiPath = nonApplicationRootPathBuildItem.resolvePath(swaggerUiConfig.path);
             ThemeHref theme = swaggerUiConfig.theme.orElse(ThemeHref.feeling_blue);
 
@@ -180,6 +181,7 @@ public class SwaggerUiProcessor {
                     runtimeConfig, shutdownContext);
 
             routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
+                    .management("quarkus.smallrye-openapi.management.enabled")
                     .route(swaggerUiConfig.path)
                     .displayOnNotFoundPage("Open API UI")
                     .routeConfigKey("quarkus.swagger-ui.path")
@@ -187,6 +189,7 @@ public class SwaggerUiProcessor {
                     .build());
 
             routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
+                    .management("quarkus.smallrye-openapi.management.enabled")
                     .route(swaggerUiConfig.path + "*")
                     .handler(handler)
                     .build());

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpRootPathBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpRootPathBuildItem.java
@@ -225,6 +225,12 @@ public final class HttpRootPathBuildItem extends SimpleBuildItem {
         }
 
         @Override
+        public Builder management(String managementConfigKey) {
+            super.management(managementConfigKey);
+            return this;
+        }
+
+        @Override
         protected NotFoundPageDisplayableEndpointBuildItem getNotFoundEndpoint() {
             return super.getNotFoundEndpoint();
         }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItem.java
@@ -169,15 +169,15 @@ public final class NonApplicationRootPathBuildItem extends SimpleBuildItem {
 
     public String resolveManagementPath(String path, ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
             LaunchModeBuildItem mode) {
+        return resolveManagementPath(path, managementInterfaceBuildTimeConfig, mode, true);
+    }
+
+    public String resolveManagementPath(String path, ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
+            LaunchModeBuildItem mode, boolean extensionOverride) {
         if (path == null || path.trim().isEmpty()) {
             throw new IllegalArgumentException("Specified path can not be empty");
         }
-        if (!managementInterfaceBuildTimeConfig.enabled) {
-            if (managementRootPath != null) {
-                return UriNormalizationUtil.normalizeWithBase(managementRootPath, path, false).getPath();
-            }
-            return UriNormalizationUtil.normalizeWithBase(nonApplicationRootPath, path, false).getPath();
-        } else {
+        if (managementInterfaceBuildTimeConfig.enabled && extensionOverride) {
             // Best effort
             String prefix = getManagementUrlPrefix(mode);
             if (managementRootPath != null) {
@@ -185,6 +185,11 @@ public final class NonApplicationRootPathBuildItem extends SimpleBuildItem {
             } else {
                 return prefix + path;
             }
+        } else {
+            if (managementRootPath != null) {
+                return UriNormalizationUtil.normalizeWithBase(managementRootPath, path, false).getPath();
+            }
+            return UriNormalizationUtil.normalizeWithBase(nonApplicationRootPath, path, false).getPath();
         }
     }
 
@@ -411,6 +416,11 @@ public final class NonApplicationRootPathBuildItem extends SimpleBuildItem {
             return this;
         }
 
+        @Override
+        public Builder management(String managementConfigKey) {
+            super.management(managementConfigKey);
+            return this;
+        }
     }
 
     /**

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
@@ -5,6 +5,9 @@ import static io.quarkus.vertx.http.deployment.RouteBuildItem.RouteType.APPLICAT
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.console.ConfiguredPathInfo;
@@ -210,8 +213,21 @@ public final class RouteBuildItem extends MultiBuildItem {
         }
 
         public Builder management() {
-            this.isManagement = true;
+            return management(null);
+        }
+
+        public Builder management(String managementConfigKey) {
+            if (managementConfigKey == null || shouldInclude(managementConfigKey)) {
+                this.isManagement = true;
+            } else {
+                this.isManagement = false;
+            }
             return this;
+        }
+
+        private boolean shouldInclude(String managementConfigKey) {
+            Config config = ConfigProvider.getConfig();
+            return config.getValue(managementConfigKey, boolean.class);
         }
 
         public RouteBuildItem build() {

--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-external-page.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-external-page.js
@@ -109,7 +109,7 @@ export class QwcExternalPage extends LitElement {
                 let currentPath = window.location.pathname;
                 currentPath = currentPath.substring(0, currentPath.indexOf('/dev'));
                 return html`<div class="codeBlock">
-                            <span class="download" @click="${this._download}">
+                            <span class="download" @click="${this._download}" title="${this._externalUrl}">
                                 <vaadin-icon class="icon" icon="font-awesome-solid:download"></vaadin-icon>
                                 Download
                             </span>

--- a/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/ExternalPageBuilder.java
+++ b/extensions/vertx-http/dev-ui-spi/src/main/java/io/quarkus/devui/spi/page/ExternalPageBuilder.java
@@ -21,10 +21,18 @@ public class ExternalPageBuilder extends PageBuilder<ExternalPageBuilder> {
     }
 
     public ExternalPageBuilder url(String url) {
+        return url(url, null);
+    }
+
+    public ExternalPageBuilder url(String url, String externalLink) {
         if (url == null || url.isEmpty()) {
             throw new RuntimeException("Invalid external URL, can not be empty");
         }
         super.metadata.put(EXTERNAL_URL, url);
+        if (externalLink != null) {
+            return staticLabel("<a style='color: var(--lumo-contrast-80pct);' href='" + externalLink
+                    + "' target='_blank'><vaadin-icon class='icon' icon='font-awesome-solid:up-right-from-square'></vaadin-icon></a>");
+        }
         return this;
     }
 


### PR DESCRIPTION
Fix #34353

Now, when management is enabled, OpenAPI schema and UI will also be published under the management interface, with the option to exclude that for open api using a config (`quarkus.smallrye-openapi.management.enabled=false`)

In dev mode, we will automatically set CORS to true (if not already true) and add the management host to the origins list (if not already there). This is so that swagger-ui can make tests calls to the endpoints. This is equivalent to set
```
quarkus.http.cors=true
quarkus.http.cors.origins=http://0.0.0.0:9000
```
in application.properties

In dev mode, we will automatically set the servers for openapi (if not already set) to include http://localhost:8080. This is so that swagger-ui knows where the endpoints are (as they are not on the same hosts). This is equivalent to set
```
quarkus.smallrye-openapi.servers=http://localhost:8080
```
in application.properties

Below: Everything on management interface
![management](https://github.com/quarkusio/quarkus/assets/6836179/e9406b94-8407-48b7-b36a-17f16d9b1cb1)


Below: Everything on management except OpenAPI
![management_exclude_openapi](https://github.com/quarkusio/quarkus/assets/6836179/849656bd-625d-4029-b907-77ae217ca039)

