### PR TITLE
Update QuarkusIntegrationTestExtension.java

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -133,8 +133,9 @@ public class NativeTestExtension extends AbstractQuarkusTestWithContextExtension
             hasPerTestResources = testResourceManager.hasPerTestResources();
 
             Map<String, String> additionalProperties = new HashMap<>(testProfileAndProperties.properties);
-            Map<String, String> resourceManagerProps = new HashMap<>(testResourceManager.start());
-            resourceManagerProps.putAll(devServicesProps);
+            Map<String, String> resourceManagerProps = new HashMap<>(devServicesProps);
+            // Allow override of dev services props by integration test extensions
+            resourceManagerProps.putAll(testResourceManager.start());
             Map<String, String> old = new HashMap<>();
             //we also make the dev services config accessible from the test itself
             for (Map.Entry<String, String> i : resourceManagerProps.entrySet()) {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -228,9 +228,10 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
             }
 
             additionalProperties.putAll(testProfileAndProperties.properties);
-            Map<String, String> resourceManagerProps = new HashMap<>(testResourceManager.start());
             //we also make the dev services config accessible from the test itself
-            resourceManagerProps.putAll(QuarkusIntegrationTestExtension.devServicesProps);
+            Map<String, String> resourceManagerProps = new HashMap<>(QuarkusIntegrationTestExtension.devServicesProps);
+            // Allow override of dev services props by integration test extensions
+            resourceManagerProps.putAll(testResourceManager.start());
             Map<String, String> old = new HashMap<>();
             for (Map.Entry<String, String> i : resourceManagerProps.entrySet()) {
                 old.put(i.getKey(), System.getProperty(i.getKey()));

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
@@ -138,9 +138,10 @@ public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWith
                 }
 
                 additionalProperties.putAll(testProfileAndProperties.properties);
-                Map<String, String> resourceManagerProps = new HashMap<>(testResourceManager.start());
                 //also make the dev services props accessible from the test
-                resourceManagerProps.putAll(QuarkusMainIntegrationTestExtension.devServicesProps);
+                Map<String, String> resourceManagerProps = new HashMap<>(QuarkusMainIntegrationTestExtension.devServicesProps);
+                // Allow override of dev services props by integration test extensions
+                resourceManagerProps.putAll(testResourceManager.start());
                 for (Map.Entry<String, String> i : resourceManagerProps.entrySet()) {
                     old.put(i.getKey(), System.getProperty(i.getKey()));
                     if (i.getValue() == null) {


### PR DESCRIPTION
Allow override of dev services props by integration test extensions

Will enable workaround for https://github.com/quarkusio/quarkus/issues/34049