### PR TITLE
Ban only unavailable config services when initializing config in CodeGenerator

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -64,7 +64,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
 
     @Test
     public void testConfigFactoryInAppModuleBannedInCodeGen() throws MavenInvocationException, IOException {
-        testDir = initProject("projects/codegen-config-factory");
+        testDir = initProject("projects/codegen-config-factory", "project/codegen-config-factory-banned");
         run(true);
         assertThat(DevModeTestUtils.getHttpResponse("/codegen-config/acme-config-factory")).isEqualTo("n/a");
         assertThat(DevModeTestUtils.getHttpResponse("/codegen-config/acme-config-provider")).isEqualTo("n/a");
@@ -76,7 +76,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
 
     @Test
     public void testConfigFactoryInAppModuleFilteredInCodeGen() throws MavenInvocationException, IOException {
-        testDir = initProject("projects/codegen-config-factory");
+        testDir = initProject("projects/codegen-config-factory", "projects/codegen-config-factory-filtered");
         run(true, "-Dconfig-factory.enabled");
         assertThat(DevModeTestUtils.getHttpResponse("/codegen-config/acme-config-factory"))
                 .isEqualTo("org.acme.config.AcmeConfigSourceFactory");


### PR DESCRIPTION
This change bans only those config services that are actually unavailable instead of assuming every service configured in the application module will not be available.
There are a couple of use-cases where this change could help:
1) if the class of a service impl configured in the application module is actually in a different module/jar and is available even in a phase before `compile`;
2) in other use-cases than `generate-code`, if the config initialization is called after the compile phase, the config service impl will be compiled and available by that time.
