### PR TITLE
Qute: template records

### DIFF
--- a/docs/src/main/asciidoc/mailer-reference.adoc
+++ b/docs/src/main/asciidoc/mailer-reference.adoc
@@ -154,10 +154,16 @@ When you want to reference your attachment, for instance in the `src` attribute,
 [[templates]]
 == Message Body Based on Qute Templates
 
-It's possible to inject a mail template, where the message body is created automatically using xref:qute.adoc[Qute templates].
+It's also possible to send an e-mail where the message body is created automatically using xref:qute.adoc[Qute templates].
+
+You can define a type-safe mail template in your Java code.
+Just annotate a class with `@io.quarkus.qute.CheckedTemplate` and all its `static native` methods that return `MailTemplate` will be used to define type-safe mail templates and the list of parameters they require:
 
 [source, java]
 ----
+import io.quarkus.mailer.MailTemplate;
+import io.quarkus.qute.CheckedTemplate;
+
 @Path("")
 public class MailingResource {
 
@@ -183,13 +189,43 @@ we will use the `src/main/resources/templates/MailingResource/hello.html` and `s
 <3> Create a mail template instance and set the recipient.
 <4> `MailTemplate.send()` triggers the rendering and, once finished, sends the e-mail via a `Mailer` instance.
 
-TIP: Injected mail templates are validated during build.
-The build fails if there is no matching template in `src/main/resources/templates`.
+Alternatively, use a Java record that implements `io.quarkus.mailer.MailTemplate`.
+The record components represent the template parameters.
+
+[source, java]
+----
+import io.quarkus.mailer.MailTemplate;
+import io.quarkus.qute.CheckedTemplate;
+
+@Path("")
+public class MailingResource {
+
+    record hello(String name) implements MailTemplateInstance { // <1>
+    }
+
+    @GET
+    @Path("/mail")
+    public Uni<Void> send() {
+        // the template looks like: Hello {name}! // <2>
+        return new hello("John")
+           .to("to@acme.org")  // <3>
+           .subject("Hello from Qute template")
+           .send(); // <4>
+    }
+}
+----
+<1> By convention, the enclosing class name and the record name are used to locate the template. In this particular case,
+we will use the `src/main/resources/templates/MailingResource/hello.html` and `src/main/resources/templates/MailingResource/hello.txt` templates to create the message body.
+<2> Set the data used in the template.
+<3> Create a mail template instance and set the recipient.
+<4> `MailTemplate.send()` triggers the rendering and, once finished, sends the e-mail via a `Mailer` instance.
 
 You can also do this without type-safe templates:
 
 [source, java]
 ----
+import io.quarkus.mailer.MailTemplate;
+
 @Inject
 @Location("hello")
 MailTemplate hello; // <1>
@@ -208,6 +244,9 @@ Otherwise, search for the template as the specified location. In this particular
 <2> Create a mail template instance and set the recipient.
 <3> Set the data used in the template.
 <4> `MailTemplate.send()` triggers the rendering and, once finished, sends the e-mail via a `Mailer` instance.
+
+TIP: Injected mail templates are validated during build.
+The build fails if there is no matching template in `src/main/resources/templates`.
 
 [[execution-model]]
 == Execution model

--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1751,7 +1751,18 @@ IMPORTANT: The type of a default value is not validated in <<standalone,Qute sta
  
 [[typesafe_templates]]
 === Type-safe Templates
-You can also define type-safe templates in your Java code.
+
+You can define type-safe templates in your Java code.
+Parameters of type-safe templates are automatically turned into _parameter declarations_ that are used to bind <<typesafe_expressions>>.
+The type-safe expressions are then validated at build time.
+
+There are two ways to define a type-safe template:
+
+1. Annotate a class with `@io.quarkus.qute.CheckedTemplate` and all its `static native` methods will be used to define type-safe templates and the list of parameters they require.
+2. Use a Java record that implements `io.quarkus.qute.TemplateInstance`; the record components represent the template parameters and `@io.quarkus.qute.CheckedTemplate` can be optionally used to configure the template.
+
+==== Nested Type-safe Templates
+
 If using <<resteasy_integration,templates in Jakarta REST resources>>, you can rely on the following convention:
 
 - Organise your template files in the `/src/main/resources/templates` directory, by grouping them into one directory per resource class. So, if
@@ -1845,6 +1856,41 @@ public class HelloResource {
     }
 }
 ----
+
+==== Template Records
+
+A Java record that implements `io.quarkus.qute.TemplateInstance` denotes a type-safe template.
+The record components represent the template parameters and `@io.quarkus.qute.CheckedTemplate` can be optionally used to configure the template.
+
+.HelloResource.java
+[source,java]
+----
+package org.acme.quarkus.sample;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkus.qute.TemplateInstance;
+
+@Path("hello")
+public class HelloResource {
+
+    record Hello(String name) implements TemplateInstance {} <1>
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public TemplateInstance get(@QueryParam("name") String name) {
+        return new Hello(name); <2>
+    }
+}
+----
+<1> Declares a type-safe template with the Java record.
+<2> Instantiate the record and use it as an ordinary `TemplateInstance`.
+
 
 ==== Customized Template Path
 
@@ -2793,9 +2839,13 @@ Engine::
 * First, no managed `Engine` instance is available out of the box.
 You'll need to configure a new instance via `Engine.builder()`.
 
-Templates::
+Template locators::
 * By default, no <<template-locator,template locators>> are registered, i.e. `Engine.getTemplate(String)` will not work.
 * You can register a custom template locator using `EngineBuilder.addLocator()` or parse a template manually and put the result in the cache via `Engine.putTemplate(String, Template)`.
+
+Template initializers::
+* No `TemplateInstance.Initializer` is registered by default, therefore <<global_variables,`@TemplateGlobal`>> annotations are ignored.
+* A custom `TemplateInstance.Initializer` can be registered with `EngineBuilder#addTemplateInstanceInitializer()` and initialize a template instance with any data and attributes.
 
 Sections::
 * No section helpers are registered by default.

--- a/extensions/mailer/deployment/pom.xml
+++ b/extensions/mailer/deployment/pom.xml
@@ -56,5 +56,42 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>java-17</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+
+            <properties>
+                <maven.compiler.target>17</maven.compiler.target>
+                <maven.compiler.source>17</maven.compiler.source>
+                <maven.compiler.release>17</maven.compiler.release>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-java17-directory</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>add-test-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/test/java17</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/MailTemplateLocationTest.java
+++ b/extensions/mailer/deployment/src/test/java/io/quarkus/mailer/MailTemplateLocationTest.java
@@ -27,7 +27,7 @@ public class MailTemplateLocationTest {
     MailTemplates mailTemplates;
 
     @Test
-    public void testValidationFailed() {
+    public void testLocation() {
         mailTemplates.send().await().atMost(Duration.ofSeconds(5));
     }
 

--- a/extensions/mailer/deployment/src/test/java17/io/quarkus/mailer/MailTemplateRecordTest.java
+++ b/extensions/mailer/deployment/src/test/java17/io/quarkus/mailer/MailTemplateRecordTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.mailer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.mailer.MailTemplate.MailTemplateInstance;
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.ext.mail.MailMessage;
+import jakarta.inject.Inject;
+
+public class MailTemplateRecordTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(confirmation.class)
+                    .addAsResource("mock-config.properties", "application.properties")
+                    .addAsResource(new StringAsset(""
+                            + "<html>{name}</html>"), "templates/confirmation.html"));
+
+    @Inject
+    MockMailbox mockMailbox;
+
+    @Test
+    public void testMailTemplateRecord() {
+        new confirmation("Ondrej").to("quarkus-reactive@quarkus.io").from("from-record@quarkus.io").subject("test mailer")
+                .send().await().indefinitely();
+        assertEquals(1, mockMailbox.getMailMessagesSentTo("quarkus-reactive@quarkus.io").size());
+        MailMessage message = mockMailbox.getMailMessagesSentTo("quarkus-reactive@quarkus.io").get(0);
+        assertEquals("from-record@quarkus.io", message.getFrom());
+        assertEquals("<html>Ondrej</html>", message.getHtml());
+    }
+
+    @CheckedTemplate(basePath = "")
+    record confirmation(String name) implements MailTemplateInstance {
+    }
+
+}

--- a/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
+++ b/extensions/mailer/runtime/src/main/java/io/quarkus/mailer/MailTemplate.java
@@ -36,31 +36,57 @@ public interface MailTemplate {
      */
     interface MailTemplateInstance {
 
-        MailTemplateInstance mail(Mail mail);
+        default MailTemplateInstance mail(Mail mail) {
+            throw new UnsupportedOperationException();
+        }
 
-        MailTemplateInstance to(String... to);
+        default MailTemplateInstance to(String... to) {
+            throw new UnsupportedOperationException();
+        }
 
-        MailTemplateInstance cc(String... cc);
+        default MailTemplateInstance cc(String... cc) {
+            throw new UnsupportedOperationException();
+        }
 
-        MailTemplateInstance bcc(String... bcc);
+        default MailTemplateInstance bcc(String... bcc) {
+            throw new UnsupportedOperationException();
+        }
 
-        MailTemplateInstance subject(String subject);
+        default MailTemplateInstance subject(String subject) {
+            throw new UnsupportedOperationException();
+        }
 
-        MailTemplateInstance from(String from);
+        default MailTemplateInstance from(String from) {
+            throw new UnsupportedOperationException();
+        }
 
-        MailTemplateInstance replyTo(String replyTo);
+        default MailTemplateInstance replyTo(String replyTo) {
+            throw new UnsupportedOperationException();
+        }
 
-        MailTemplateInstance replyTo(String... replyTo);
+        default MailTemplateInstance replyTo(String... replyTo) {
+            throw new UnsupportedOperationException();
+        }
 
-        MailTemplateInstance bounceAddress(String bounceAddress);
+        default MailTemplateInstance bounceAddress(String bounceAddress) {
+            throw new UnsupportedOperationException();
+        }
 
-        MailTemplateInstance addInlineAttachment(String name, File file, String contentType, String contentId);
+        default MailTemplateInstance addInlineAttachment(String name, File file, String contentType, String contentId) {
+            throw new UnsupportedOperationException();
+        }
 
-        MailTemplateInstance addInlineAttachment(String name, byte[] data, String contentType, String contentId);
+        default MailTemplateInstance addInlineAttachment(String name, byte[] data, String contentType, String contentId) {
+            throw new UnsupportedOperationException();
+        }
 
-        MailTemplateInstance addAttachment(String name, File file, String contentType);
+        default MailTemplateInstance addAttachment(String name, File file, String contentType) {
+            throw new UnsupportedOperationException();
+        }
 
-        MailTemplateInstance addAttachment(String name, byte[] data, String contentType);
+        default MailTemplateInstance addAttachment(String name, byte[] data, String contentType) {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          *
@@ -69,7 +95,9 @@ public interface MailTemplate {
          * @return self
          * @see io.quarkus.qute.TemplateInstance#data(String, Object)
          */
-        MailTemplateInstance data(String key, Object value);
+        default MailTemplateInstance data(String key, Object value) {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          *
@@ -78,7 +106,9 @@ public interface MailTemplate {
          * @return self
          * @see io.quarkus.qute.TemplateInstance#setAttribute(String, Object)
          */
-        MailTemplateInstance setAttribute(String key, Object value);
+        default MailTemplateInstance setAttribute(String key, Object value) {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          * Sends all e-mail definitions based on available template variants, i.e. {@code text/html} and {@code text/plain}
@@ -87,7 +117,9 @@ public interface MailTemplate {
          * @return a {@link Uni} indicating when the mails have been sent
          * @see ReactiveMailer#send(Mail...)
          */
-        Uni<Void> send();
+        default Uni<Void> send() {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          * The returned instance does not represent a specific template but a delegating template.
@@ -97,7 +129,9 @@ public interface MailTemplate {
          *
          * @return the underlying template instance
          */
-        TemplateInstance templateInstance();
+        default TemplateInstance templateInstance() {
+            throw new UnsupportedOperationException();
+        }
 
     }
 

--- a/extensions/qute/deployment/pom.xml
+++ b/extensions/qute/deployment/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>quarkus-qute-parent</artifactId>
@@ -81,4 +81,42 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>java-17</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+
+            <properties>
+                <maven.compiler.target>17</maven.compiler.target>
+                <maven.compiler.source>17</maven.compiler.source>
+                <maven.compiler.release>17</maven.compiler.release>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-java17-directory</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>add-test-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/test/java17</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CheckedFragmentValidationBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CheckedFragmentValidationBuildItem.java
@@ -2,27 +2,21 @@ package io.quarkus.qute.deployment;
 
 import java.util.List;
 
-import org.jboss.jandex.MethodInfo;
-
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.qute.Expression;
 
 final class CheckedFragmentValidationBuildItem extends MultiBuildItem {
 
     final String templateGeneratedId;
-    final String templateId;
-    final String fragmentId;
     final List<Expression> fragmentExpressions;
-    final MethodInfo method;
+    final CheckedTemplateBuildItem checkedTemplate;
 
-    public CheckedFragmentValidationBuildItem(String templateGeneratedId, String templateId, String fragmentId,
+    public CheckedFragmentValidationBuildItem(String templateGeneratedId,
             List<Expression> fragmentExpressions,
-            MethodInfo method) {
+            CheckedTemplateBuildItem checkedTemplate) {
         this.templateGeneratedId = templateGeneratedId;
-        this.templateId = templateId;
-        this.fragmentId = fragmentId;
         this.fragmentExpressions = fragmentExpressions;
-        this.method = method;
+        this.checkedTemplate = checkedTemplate;
     }
 
 }

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CheckedTemplateBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CheckedTemplateBuildItem.java
@@ -2,39 +2,53 @@ package io.quarkus.qute.deployment;
 
 import java.util.Map;
 
+import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.MethodInfo;
 
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
 
 /**
- * Represents a method of a class annotated with {@link CheckedTemplate}.
+ * Represents a method of a class annotated with {@link CheckedTemplate} or a Java record that implements
+ * {@link TemplateInstance}.
  */
 public final class CheckedTemplateBuildItem extends MultiBuildItem {
 
-    // A template path, potentially incomplete
+    // A template path, potentially incomplete; e.g. ItemResource/items
     public final String templateId;
     public final String fragmentId;
     public final Map<String, String> bindings;
-    public final MethodInfo method;
     public final boolean requireTypeSafeExpressions;
 
-    public CheckedTemplateBuildItem(String templateId, Map<String, String> bindings, MethodInfo method,
-            boolean requireTypeSafeExpressions) {
-        this(templateId, null, bindings, method, requireTypeSafeExpressions);
-    }
+    // native static method
+    public final MethodInfo method;
+    // record class
+    public final ClassInfo recordClass;
 
     public CheckedTemplateBuildItem(String templateId, String fragmentId, Map<String, String> bindings, MethodInfo method,
+            ClassInfo recordClass,
             boolean requireTypeSafeExpressions) {
         this.templateId = templateId;
         this.fragmentId = fragmentId;
         this.bindings = bindings;
-        this.method = method;
         this.requireTypeSafeExpressions = requireTypeSafeExpressions;
+        this.method = method;
+        this.recordClass = recordClass;
     }
 
     public boolean isFragment() {
         return fragmentId != null;
+    }
+
+    public boolean isRecord() {
+        return recordClass != null;
+    }
+
+    public String getDescription() {
+        return isRecord() ? recordClass.toString()
+                : method.declaringClass().name() + "."
+                        + method.name() + "()";
     }
 
 }

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -599,9 +599,8 @@ public class MessageBundleProcessor {
                                 } else if (checkedTemplate != null && checkedTemplate.requireTypeSafeExpressions) {
                                     incorrectExpressions.produce(new IncorrectExpressionBuildItem(expression.toOriginalString(),
                                             "Only type-safe expressions are allowed in the checked template defined via: "
-                                                    + checkedTemplate.method.declaringClass().name() + "."
-                                                    + checkedTemplate.method.name()
-                                                    + "(); an expression must be based on a checked template parameter "
+                                                    + checkedTemplate.getDescription()
+                                                    + "; an expression must be based on a checked template parameter "
                                                     + checkedTemplate.bindings.keySet()
                                                     + ", or bound via a param declaration, or the requirement must be relaxed via @CheckedTemplate(requireTypeSafeExpressions = false)",
                                             expression.getOrigin()));

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -55,6 +55,7 @@ import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.PrimitiveType;
 import org.jboss.jandex.PrimitiveType.Primitive;
+import org.jboss.jandex.RecordComponentInfo;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.TypeVariable;
 import org.jboss.logging.Logger;
@@ -92,6 +93,7 @@ import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.fs.util.ZipUtils;
 import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.panache.common.deployment.PanacheEntityClassesBuildItem;
@@ -293,14 +295,19 @@ public class QuteProcessor {
             supportedAdaptors = strbuf.append(" are supported").toString();
         }
 
-        // template path -> checked template method
-        Map<String, MethodInfo> checkedTemplateMethods = new HashMap<>();
+        // template path -> checked template method/record class
+        Map<String, AnnotationTarget> checkedTemplates = new HashMap<>();
 
+        // @CheckedTemplate static native methods
         for (AnnotationInstance annotation : index.getIndex().getAnnotations(Names.CHECKED_TEMPLATE)) {
             if (annotation.target().kind() != Kind.CLASS) {
                 continue;
             }
             ClassInfo classInfo = annotation.target().asClass();
+            if (classInfo.isRecord()) {
+                // Template records are processed separately
+                continue;
+            }
             NativeCheckedTemplateEnhancer enhancer = new NativeCheckedTemplateEnhancer();
             for (MethodInfo methodInfo : classInfo.methods()) {
                 // only keep native static methods
@@ -337,13 +344,13 @@ public class QuteProcessor {
                 String templatePath = templatePathBuilder
                         .append(getCheckedTemplateName(methodInfo, annotation, fragmentId != null)).toString();
                 String fullPath = templatePath + (fragmentId != null ? "$" + fragmentId : "");
-                MethodInfo checkedTemplateMethod = checkedTemplateMethods.putIfAbsent(fullPath, methodInfo);
-                if (checkedTemplateMethod != null) {
+                AnnotationTarget checkedTemplate = checkedTemplates.putIfAbsent(fullPath, methodInfo);
+                if (checkedTemplate != null) {
                     throw new TemplateException(
                             String.format(
-                                    "Multiple checked template methods exist for the template path %s:\n\t- %s: %s\n\t- %s: %s",
+                                    "Multiple checked templates exist for the template path %s:\n\t- %s: %s\n\t- %s",
                                     fullPath, methodInfo.declaringClass().name(), methodInfo,
-                                    checkedTemplateMethod.declaringClass().name(), checkedTemplateMethod));
+                                    checkedTemplate));
                 }
                 if (!filePaths.contains(templatePath)
                         && isNotLocatedByCustomTemplateLocator(locatorPatternsBuildItem.getLocationPatterns(),
@@ -380,7 +387,7 @@ public class QuteProcessor {
                     parameterNames.add(name);
                 }
                 AnnotationValue requireTypeSafeExpressions = annotation.value(CHECKED_TEMPLATE_REQUIRE_TYPE_SAFE);
-                ret.add(new CheckedTemplateBuildItem(templatePath, fragmentId, bindings, methodInfo,
+                ret.add(new CheckedTemplateBuildItem(templatePath, fragmentId, bindings, methodInfo, null,
                         requireTypeSafeExpressions != null ? requireTypeSafeExpressions.asBoolean() : true));
                 enhancer.implement(methodInfo, templatePath, fragmentId, parameterNames, adaptor);
             }
@@ -388,45 +395,150 @@ public class QuteProcessor {
                     enhancer));
         }
 
+        // Find all Java records that implement TemplateInstance and interfaces adapted by CheckedTemplateAdapter
+        List<DotName> recordInterfaceNames = new ArrayList<>();
+        recordInterfaceNames.add(Names.TEMPLATE_INSTANCE);
+        adaptors.keySet().forEach(recordInterfaceNames::add);
+        for (DotName recordInterfaceName : recordInterfaceNames) {
+            ClassInfo recordInterface = index.getIndex().getClassByName(recordInterfaceName);
+            if (recordInterface == null) {
+                throw new IllegalStateException(recordInterfaceName + " not found in the index");
+            }
+            Set<String> reservedNames = new HashSet<>();
+            for (MethodInfo method : recordInterface.methods()) {
+                if (method.isSynthetic() || method.isBridge() || method.parametersCount() != 0) {
+                    continue;
+                }
+                reservedNames.add(method.name());
+            }
+            for (ClassInfo recordClass : index.getIndex().getAllKnownImplementors(recordInterfaceName)) {
+                if (!recordClass.isRecord()) {
+                    continue;
+                }
+                Type[] componentTypes = recordClass.recordComponents().stream().map(RecordComponentInfo::type)
+                        .toArray(Type[]::new);
+                MethodInfo canonicalConstructor = recordClass.method(MethodDescriptor.INIT, componentTypes);
+
+                AnnotationInstance checkedTemplateAnnotation = recordClass.declaredAnnotation(Names.CHECKED_TEMPLATE);
+                String fragmentId = getCheckedFragmentId(recordClass, checkedTemplateAnnotation);
+                StringBuilder templatePathBuilder = new StringBuilder();
+                AnnotationValue basePathValue = checkedTemplateAnnotation != null
+                        ? checkedTemplateAnnotation.value(CHECKED_TEMPLATE_BASE_PATH)
+                        : null;
+                if (basePathValue != null && !basePathValue.asString().equals(CheckedTemplate.DEFAULTED)) {
+                    templatePathBuilder.append(basePathValue.asString());
+                } else if (recordClass.enclosingClass() != null) {
+                    ClassInfo enclosingClass = index.getIndex().getClassByName(recordClass.enclosingClass());
+                    templatePathBuilder.append(enclosingClass.simpleName());
+                }
+                if (templatePathBuilder.length() > 0 && templatePathBuilder.charAt(templatePathBuilder.length() - 1) != '/') {
+                    templatePathBuilder.append('/');
+                }
+                String templatePath = templatePathBuilder
+                        .append(getCheckedTemplateName(recordClass, checkedTemplateAnnotation, fragmentId != null)).toString();
+                String fullPath = templatePath + (fragmentId != null ? "$" + fragmentId : "");
+                AnnotationTarget checkedTemplate = checkedTemplates.putIfAbsent(fullPath, recordClass);
+                if (checkedTemplate != null) {
+                    throw new TemplateException(
+                            String.format(
+                                    "Multiple checked templates exist for the template path %s:\n\t- %s\n\t- %s",
+                                    fullPath, recordClass.name(), checkedTemplate));
+                }
+
+                if (!filePaths.contains(templatePath)
+                        && isNotLocatedByCustomTemplateLocator(locatorPatternsBuildItem.getLocationPatterns(),
+                                templatePath)) {
+                    List<String> startsWith = new ArrayList<>();
+                    for (String filePath : filePaths.getFilePaths()) {
+                        if (filePath.startsWith(templatePath)
+                                && filePath.charAt(templatePath.length()) == '.') {
+                            startsWith.add(filePath);
+                        }
+                    }
+                    if (startsWith.isEmpty()) {
+                        throw new TemplateException(
+                                "No template matching the path " + templatePath + " could be found for: "
+                                        + recordClass.name());
+                    } else {
+                        throw new TemplateException(
+                                startsWith + " match the path " + templatePath
+                                        + " but the file suffix is not configured via the quarkus.qute.suffixes property");
+                    }
+                }
+
+                Map<String, String> bindings = new HashMap<>();
+                List<Type> parameters = canonicalConstructor.parameterTypes();
+                List<String> parameterNames = new ArrayList<>(parameters.size());
+                for (int i = 0; i < parameters.size(); i++) {
+                    Type type = parameters.get(i);
+                    String name = canonicalConstructor.parameterName(i);
+                    if (name == null) {
+                        throw new TemplateException("Parameter names not recorded for " + recordClass.name()
+                                + ": compile the class with -parameters");
+                    }
+                    if (reservedNames.contains(name)) {
+                        throw new TemplateException("Template record component [" + name
+                                + "] conflicts with an interface method of " + recordInterface);
+                    }
+                    bindings.put(name, getCheckedTemplateParameterTypeName(type));
+                    parameterNames.add(name);
+                }
+                AnnotationValue requireTypeSafeExpressions = checkedTemplateAnnotation != null
+                        ? checkedTemplateAnnotation.value(CHECKED_TEMPLATE_REQUIRE_TYPE_SAFE)
+                        : null;
+                ret.add(new CheckedTemplateBuildItem(templatePath, fragmentId, bindings, null, recordClass,
+                        requireTypeSafeExpressions != null ? requireTypeSafeExpressions.asBoolean() : true));
+                transformers.produce(new BytecodeTransformerBuildItem(recordClass.name().toString(),
+                        new TemplateRecordEnhancer(recordInterface, recordClass, templatePath, fragmentId,
+                                canonicalConstructor.parameters(), adaptors.get(recordInterfaceName))));
+            }
+        }
+
         return ret;
     }
 
-    private String getCheckedTemplateName(MethodInfo method, AnnotationInstance checkedTemplateAnnotation,
+    private String getCheckedTemplateName(AnnotationTarget target, AnnotationInstance checkedTemplateAnnotation,
             boolean checkedFragment) {
-        AnnotationValue nameValue = checkedTemplateAnnotation.value(CHECKED_TEMPLATE_DEFAULT_NAME);
+        AnnotationValue nameValue = checkedTemplateAnnotation != null
+                ? checkedTemplateAnnotation.value(CHECKED_TEMPLATE_DEFAULT_NAME)
+                : null;
         String defaultName;
         if (nameValue == null) {
             defaultName = CheckedTemplate.ELEMENT_NAME;
         } else {
             defaultName = nameValue.asString();
         }
-        String methodName = method.name();
+        String name = target.kind() == Kind.METHOD ? target.asMethod().name() : target.asClass().simpleName();
         if (checkedFragment) {
             // the name is the part before the last occurence of a dollar sign
-            methodName = methodName.substring(0, methodName.lastIndexOf('$'));
+            name = name.substring(0, name.lastIndexOf('$'));
         }
-        return defaultedName(defaultName, methodName);
+        return defaultedName(defaultName, name);
     }
 
-    private String getCheckedFragmentId(MethodInfo method, AnnotationInstance checkedTemplateAnnotation) {
-        AnnotationValue ignoreFragmentsValue = checkedTemplateAnnotation.value(IGNORE_FRAGMENTS);
+    private String getCheckedFragmentId(AnnotationTarget target, AnnotationInstance checkedTemplateAnnotation) {
+        AnnotationValue ignoreFragmentsValue = checkedTemplateAnnotation != null
+                ? checkedTemplateAnnotation.value(IGNORE_FRAGMENTS)
+                : null;
         if (ignoreFragmentsValue != null && ignoreFragmentsValue.asBoolean()) {
             return null;
         }
-        String methodName = method.name();
+        String name = target.kind() == Kind.METHOD ? target.asMethod().name() : target.asClass().simpleName();
         // the id is the part after the last occurence of a dollar sign
-        int idx = methodName.lastIndexOf('$');
-        if (idx == -1 || idx == methodName.length()) {
+        int idx = name.lastIndexOf('$');
+        if (idx == -1 || idx == name.length()) {
             return null;
         }
-        AnnotationValue nameValue = checkedTemplateAnnotation.value(CHECKED_TEMPLATE_DEFAULT_NAME);
+        AnnotationValue nameValue = checkedTemplateAnnotation != null
+                ? checkedTemplateAnnotation.value(CHECKED_TEMPLATE_DEFAULT_NAME)
+                : null;
         String defaultName;
         if (nameValue == null) {
             defaultName = CheckedTemplate.ELEMENT_NAME;
         } else {
             defaultName = nameValue.asString();
         }
-        return defaultedName(defaultName, methodName.substring(idx + 1, methodName.length()));
+        return defaultedName(defaultName, name.substring(idx + 1, name.length()));
     }
 
     private String defaultedName(String defaultNameStrategy, String value) {
@@ -643,8 +755,7 @@ public class QuteProcessor {
                             }
                             checkedFragmentValidations
                                     .produce(new CheckedFragmentValidationBuildItem(template.getGeneratedId(),
-                                            checkedFragment.templateId,
-                                            checkedFragment.fragmentId, fragment.getExpressions(), checkedFragment.method));
+                                            fragment.getExpressions(), checkedFragment));
                         }
                     }
                 }
@@ -702,7 +813,7 @@ public class QuteProcessor {
             }
             if (matchResults == null) {
                 throw new IllegalStateException(
-                        "Match results not found for: " + validation.templateId);
+                        "Match results not found for: " + validation.checkedTemplate.templateId);
             }
 
             for (Expression expression : validation.fragmentExpressions) {
@@ -736,7 +847,7 @@ public class QuteProcessor {
                                         throw new IllegalStateException(
                                                 "Match result not found for expression [" + expression.toOriginalString()
                                                         + "] in: "
-                                                        + validation.templateId);
+                                                        + validation.checkedTemplate.templateId);
                                     }
                                     paramNamesToTypes.put(expression.getParts().get(0).getName(), match.type);
                                     break hintLoop;
@@ -749,12 +860,22 @@ public class QuteProcessor {
             if (!paramNamesToTypes.isEmpty()) {
                 for (Entry<String, Type> e : paramNamesToTypes.entrySet()) {
                     String paramName = e.getKey();
-                    MethodParameterInfo param = validation.method.parameters().stream()
+                    MethodInfo methodOrConstructor = null;
+                    if (validation.checkedTemplate.isRecord()) {
+                        Type[] componentTypes = validation.checkedTemplate.recordClass.recordComponents().stream()
+                                .map(RecordComponentInfo::type).toArray(Type[]::new);
+                        methodOrConstructor = validation.checkedTemplate.recordClass
+                                .method(MethodDescriptor.INIT, componentTypes);
+                    } else {
+                        methodOrConstructor = validation.checkedTemplate.method;
+                    }
+                    MethodParameterInfo param = methodOrConstructor.parameters().stream()
                             .filter(mp -> mp.name().equals(paramName)).findFirst().orElse(null);
                     if (param == null || !assignabilityCheck.isAssignableFrom(e.getValue(), param.type())) {
                         throw new TemplateException(
-                                validation.method.declaringClass().name().withoutPackagePrefix() + "#"
-                                        + validation.method.name() + "() must declare a parameter of name [" + paramName
+                                validation.checkedTemplate.method.declaringClass().name().withoutPackagePrefix() + "#"
+                                        + validation.checkedTemplate.method.name() + "() must declare a parameter of name ["
+                                        + paramName
                                         + "] and type [" + e.getValue() + "]");
                     }
                 }
@@ -1474,9 +1595,8 @@ public class QuteProcessor {
             } else {
                 incorrectExpressions.produce(new IncorrectExpressionBuildItem(expression.toOriginalString(),
                         "Only type-safe expressions are allowed in the checked template defined via: "
-                                + checkedTemplate.method.declaringClass().name() + "."
-                                + checkedTemplate.method.name()
-                                + "(); an expression must be based on a checked template parameter "
+                                + checkedTemplate.getDescription()
+                                + "; an expression must be based on a checked template parameter "
                                 + checkedTemplate.bindings.keySet()
                                 + ", or bound via a param declaration, or the requirement must be relaxed via @CheckedTemplate(requireTypeSafeExpressions = false)",
                         expression.getOrigin()));

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TemplateRecordEnhancer.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TemplateRecordEnhancer.java
@@ -1,0 +1,213 @@
+package io.quarkus.qute.deployment;
+
+import static org.objectweb.asm.Opcodes.ACC_FINAL;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
+import org.jboss.jandex.Type;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.deployment.util.AsmUtil;
+import io.quarkus.gizmo.DescriptorUtils;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.Gizmo;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.runtime.TemplateProducer;
+
+class TemplateRecordEnhancer implements BiFunction<String, ClassVisitor, ClassVisitor> {
+
+    private final ClassInfo interfaceToImplement;
+    private final String recordClassName;
+    private final String templateId;
+    private final String fragmentId;
+    private final List<MethodParameterInfo> parameters;
+    private final CheckedTemplateAdapter adapter;
+
+    TemplateRecordEnhancer(ClassInfo interfaceToImplement, ClassInfo recordClass, String templateId, String fragmentId,
+            List<MethodParameterInfo> parameters, CheckedTemplateAdapter adapter) {
+        this.interfaceToImplement = interfaceToImplement;
+        this.recordClassName = recordClass.name().toString();
+        this.templateId = templateId;
+        this.fragmentId = fragmentId;
+        this.parameters = parameters;
+        this.adapter = adapter;
+    }
+
+    @Override
+    public ClassVisitor apply(String className, ClassVisitor outputClassVisitor) {
+        return new TemplateRecordClassVisitor(outputClassVisitor);
+    }
+
+    class TemplateRecordClassVisitor extends ClassVisitor {
+
+        public TemplateRecordClassVisitor(ClassVisitor outputClassVisitor) {
+            super(Gizmo.ASM_API_VERSION, outputClassVisitor);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            MethodVisitor ret = super.visitMethod(access, name, descriptor, signature, exceptions);
+            if (name.equals(MethodDescriptor.INIT)) {
+                return new TemplateRecordConstructorVisitor(ret);
+            }
+            return ret;
+        }
+
+        @Override
+        public void visitEnd() {
+            String interfaceName = interfaceToImplement.name().toString();
+
+            // private final TemplateInstance qute$templateInstance;
+            FieldDescriptor quteTemplateInstanceDescriptor = FieldDescriptor.of(recordClassName, "qute$templateInstance",
+                    interfaceName);
+            FieldVisitor quteTemplateInstance = super.visitField(ACC_PRIVATE | ACC_FINAL,
+                    quteTemplateInstanceDescriptor.getName(),
+                    quteTemplateInstanceDescriptor.getType(), null, null);
+            quteTemplateInstance.visitEnd();
+
+            for (MethodInfo method : interfaceToImplement.methods()) {
+                if (method.isSynthetic() || method.isBridge()) {
+                    continue;
+                }
+                MethodDescriptor descriptor = MethodDescriptor.of(method);
+                String[] exceptions = method.exceptions().stream().map(e -> toInternalClassName(e.name().toString()))
+                        .toArray(String[]::new);
+                MethodVisitor visitor = super.visitMethod(Opcodes.ACC_PUBLIC, descriptor.getName(),
+                        descriptor.getDescriptor(), null, exceptions);
+                visitor.visitCode();
+                readQuteTemplateInstance(visitor);
+                int idx = 1;
+                for (Type paramType : method.parameterTypes()) {
+                    // Load arguments on the stack
+                    visitor.visitVarInsn(AsmUtil.getLoadOpcode(paramType), idx++);
+                }
+                invokeInterface(visitor, descriptor);
+                returnAndEnd(visitor, method.returnType());
+            }
+
+            super.visitEnd();
+        }
+
+        private void readQuteTemplateInstance(MethodVisitor methodVisitor) {
+            FieldDescriptor quteTemplateInstanceDescriptor = FieldDescriptor.of(recordClassName, "qute$templateInstance",
+                    interfaceToImplement.name().toString());
+            methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+            methodVisitor.visitFieldInsn(Opcodes.GETFIELD, quteTemplateInstanceDescriptor.getDeclaringClass(),
+                    quteTemplateInstanceDescriptor.getName(), quteTemplateInstanceDescriptor.getType());
+        }
+
+        private void returnAndEnd(MethodVisitor methodVisitor, Type returnType) {
+            methodVisitor.visitInsn(AsmUtil.getReturnInstruction(returnType));
+            methodVisitor.visitEnd();
+            methodVisitor.visitMaxs(-1, -1);
+        }
+
+    }
+
+    class TemplateRecordConstructorVisitor extends MethodVisitor {
+
+        public TemplateRecordConstructorVisitor(MethodVisitor outputVisitor) {
+            super(Gizmo.ASM_API_VERSION, outputVisitor);
+        }
+
+        @Override
+        public void visitInsn(int opcode) {
+            if (opcode != Opcodes.RETURN) {
+                super.visitInsn(opcode);
+            }
+        }
+
+        @Override
+        public void visitEnd() {
+            visitCode();
+            visitVarInsn(Opcodes.ALOAD, 0);
+
+            MethodDescriptor arcContainer = MethodDescriptor.ofMethod(Arc.class, "container", ArcContainer.class);
+            MethodDescriptor arcContainerInstance = MethodDescriptor.ofMethod(ArcContainer.class, "instance",
+                    InstanceHandle.class, Class.class, Annotation[].class);
+            MethodDescriptor instanceHandleGet = MethodDescriptor.ofMethod(InstanceHandle.class, "get", Object.class);
+            MethodDescriptor templateProducerGetInjectableTemplate = MethodDescriptor.ofMethod(TemplateProducer.class,
+                    "getInjectableTemplate", Template.class, String.class);
+            MethodDescriptor templateInstance = MethodDescriptor.ofMethod(Template.class, "instance", TemplateInstance.class);
+            MethodDescriptor templateGetFragment = MethodDescriptor.ofMethod(Template.class, "getFragment",
+                    Template.Fragment.class, String.class);
+            MethodDescriptor templateInstanceData = MethodDescriptor.ofMethod(TemplateInstance.class, "data",
+                    TemplateInstance.class, String.class, Object.class);
+
+            // Template template = Arc.container().instance(TemplateProducer.class).get().getInjectableTemplate("HelloResource/typedTemplate");
+            visitMethodInsn(Opcodes.INVOKESTATIC, arcContainer.getDeclaringClass(), arcContainer.getName(),
+                    arcContainer.getDescriptor(),
+                    false);
+            visitLdcInsn(org.objectweb.asm.Type.getType(TemplateProducer.class));
+            visitLdcInsn(0);
+            visitTypeInsn(Opcodes.ANEWARRAY, toInternalClassName(Annotation.class));
+            invokeInterface(this, arcContainerInstance);
+            invokeInterface(this, instanceHandleGet);
+            visitTypeInsn(Opcodes.CHECKCAST, toInternalClassName(TemplateProducer.class));
+            visitLdcInsn(templateId);
+            visitMethodInsn(Opcodes.INVOKEVIRTUAL, templateProducerGetInjectableTemplate.getDeclaringClass(),
+                    templateProducerGetInjectableTemplate.getName(),
+                    templateProducerGetInjectableTemplate.getDescriptor(), false);
+            if (fragmentId != null) {
+                // template = template.getFragment(id);
+                visitLdcInsn(fragmentId);
+                invokeInterface(this, templateGetFragment);
+            }
+            // templateInstance = template.instance();
+            invokeInterface(this, templateInstance);
+
+            if (adapter != null) {
+                adapter.convertTemplateInstance(this);
+                templateInstanceData = MethodDescriptor.ofMethod(adapter.templateInstanceBinaryName(), "data",
+                        adapter.templateInstanceBinaryName(), String.class, Object.class);
+            }
+
+            int slot = 1;
+            for (int i = 0; i < parameters.size(); i++) {
+                // instance = instance.data("name", value);
+                Type paramType = parameters.get(i).type();
+                visitLdcInsn(parameters.get(i).name());
+                visitVarInsn(AsmUtil.getLoadOpcode(paramType), slot);
+                AsmUtil.boxIfRequired(this, paramType);
+                invokeInterface(this, templateInstanceData);
+                slot += AsmUtil.getParameterSize(paramType);
+            }
+
+            FieldDescriptor quteTemplateInstanceDescriptor = FieldDescriptor.of(recordClassName, "qute$templateInstance",
+                    interfaceToImplement.name().toString());
+            visitFieldInsn(Opcodes.PUTFIELD, quteTemplateInstanceDescriptor.getDeclaringClass(),
+                    quteTemplateInstanceDescriptor.getName(), quteTemplateInstanceDescriptor.getType());
+            super.visitInsn(Opcodes.RETURN);
+            super.visitEnd();
+            visitMaxs(-1, -1);
+        }
+
+    }
+
+    private static void invokeInterface(MethodVisitor methodVisitor, MethodDescriptor descriptor) {
+        methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, descriptor.getDeclaringClass(), descriptor.getName(),
+                descriptor.getDescriptor(), true);
+    }
+
+    private static String toInternalClassName(Class<?> clazz) {
+        return DescriptorUtils.objectToInternalClassName(clazz);
+    }
+
+    private static String toInternalClassName(String clazzName) {
+        return DescriptorUtils.objectToInternalClassName(clazzName);
+    }
+}

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/devui/QuteDevUIProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/devui/QuteDevUIProcessor.java
@@ -182,8 +182,8 @@ public class QuteDevUIProcessor {
             CheckedTemplateBuildItem checkedTemplate = findCheckedTemplate(getBasePath(templatePath.getPath(), variants),
                     checkedTemplates);
             if (checkedTemplate != null) {
-                template.put("checkedTemplateMethod",
-                        checkedTemplate.method.declaringClass().name() + "#" + checkedTemplate.method.name() + "()");
+                template.put("checkedTemplate",
+                        checkedTemplate.getDescription());
             }
 
             TemplateAnalysis analysis = templatesAnalysis.getAnalysis().stream()

--- a/extensions/qute/deployment/src/main/resources/dev-ui/qwc-qute-templates.js
+++ b/extensions/qute/deployment/src/main/resources/dev-ui/qwc-qute-templates.js
@@ -40,7 +40,7 @@ export class QwcQuteTemplates extends LitElement {
                     </vaadin-grid-column>
                     <vaadin-grid-column auto-width
                         header="Type-safe Template Method"
-                        ${columnBodyRenderer(this._renderCheckedTemplateMethod, [])}
+                        ${columnBodyRenderer(this._renderCheckedTemplate, [])}
                         resizable>
                     </vaadin-grid-column>
                     <vaadin-grid-column auto-width
@@ -63,9 +63,9 @@ export class QwcQuteTemplates extends LitElement {
         `;
     }
     
-    _renderCheckedTemplateMethod(template) {
+    _renderCheckedTemplate(template) {
         return html`
-            <code>${template.checkedTemplateMethod}</code>
+            <code>${template.checkedTemplate}</code>
         `;
     }
     

--- a/extensions/qute/deployment/src/test/java17/io/quarkus/qute/deployment/records/TemplateRecordComponentConflictTest.java
+++ b/extensions/qute/deployment/src/test/java17/io/quarkus/qute/deployment/records/TemplateRecordComponentConflictTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.qute.deployment.records;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.assertj.core.util.Throwables;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.TemplateException;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TemplateRecordComponentConflictTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Hello.class)
+                    .addAsResource(new StringAsset("Hello {name}!"), "templates/TemplateRecordComponentConflictTest/Hello.txt"))
+            .assertException(t -> {
+                Throwable root = Throwables.getRootCause(t);
+                if (root == null) {
+                    root = t;
+                }
+                assertThat(root)
+                        .isInstanceOf(TemplateException.class)
+                        .hasMessageStartingWith("Template record component [render] conflicts with an interface method of");
+            });
+
+    @Test
+    public void testValidation() {
+        fail();
+    }
+
+    public record Hello(String render) implements TemplateInstance {
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java17/io/quarkus/qute/deployment/records/TemplateRecordConflictTest.java
+++ b/extensions/qute/deployment/src/test/java17/io/quarkus/qute/deployment/records/TemplateRecordConflictTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.qute.deployment.records;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.assertj.core.util.Throwables;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateException;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TemplateRecordConflictTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(monkFoo.class, monk_foo.class)
+                    .addAsResource(new StringAsset("Hello {name}!"), "templates/TemplateRecordConflictTest/monk_foo.txt"))
+            .assertException(t -> {
+                Throwable root = Throwables.getRootCause(t);
+                if (root == null) {
+                    root = t;
+                }
+                assertThat(root)
+                        .isInstanceOf(TemplateException.class)
+                        .hasMessageStartingWith(
+                                "Multiple checked templates exist for the template path TemplateRecordConflictTest/monk_foo");
+            });
+
+    @Test
+    public void testValidation() {
+        fail();
+    }
+
+    @CheckedTemplate(defaultName = CheckedTemplate.UNDERSCORED_ELEMENT_NAME)
+    public record monkFoo(int val) implements TemplateInstance {
+    }
+
+    public record monk_foo(String val) implements TemplateInstance {
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java17/io/quarkus/qute/deployment/records/TemplateRecordTest.java
+++ b/extensions/qute/deployment/src/test/java17/io/quarkus/qute/deployment/records/TemplateRecordTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.qute.deployment.records;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+import jakarta.inject.Inject;
+
+public class TemplateRecordTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HelloInt.class, helloWorld.class)
+                    .addAsResource(new StringAsset("Hello {val}!"),
+                            "templates/TemplateRecordTest/HelloInt.txt")
+                    .addAsResource(new StringAsset("Hello {name}!"),
+                            "templates/hello_world.txt")
+                    .addAsResource(new StringAsset("Hello {#fragment id=name}{name}{/fragment}!"),
+                            "templates/hello.txt"));
+
+    @Inject
+    Engine engine;
+
+    @Test
+    public void testTemplateRecords() throws InterruptedException, ExecutionException {
+        HelloInt helloInt = new HelloInt(1);
+        assertEquals("Hello 1!", helloInt.render());
+        assertEquals("Hello 1!", helloInt.renderAsync().toCompletableFuture().get());
+        StringBuilder builder = new StringBuilder();
+        helloInt.consume(builder::append).toCompletableFuture().get();
+        assertEquals("Hello 1!", builder.toString());
+        assertEquals("Hello 1!", helloInt.createUni().await().indefinitely());
+        Multi<String> multi = helloInt.createMulti();
+        builder = new StringBuilder();
+        CountDownLatch latch = new CountDownLatch(1);
+        multi.subscribe().with(builder::append, latch::countDown);
+        if (latch.await(2, TimeUnit.SECONDS)) {
+            assertEquals("Hello 1!", builder.toString());
+        } else {
+            fail();
+        }
+        helloInt.setAttribute("foo", true);
+        assertNotNull(helloInt.getAttribute("foo"));
+        assertEquals(engine.getTimeout(), helloInt.getTimeout());
+        assertNull(helloInt.getFragment("bar"));
+        CountDownLatch renderedLatch = new CountDownLatch(1);
+        helloInt.onRendered(() -> renderedLatch.countDown());
+        helloInt.render();
+        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        assertFalse(helloInt.getTemplate().isFragment());
+
+        assertEquals("Hello Lu!", new helloWorld("Lu").render());
+        assertEquals("Lu", new hello$name("Lu").render());
+    }
+
+    record HelloInt(int val) implements TemplateInstance {
+    }
+
+    @CheckedTemplate(basePath = "", defaultName = CheckedTemplate.UNDERSCORED_ELEMENT_NAME)
+    record helloWorld(String name) implements TemplateInstance {
+    }
+
+    @CheckedTemplate(basePath = "")
+    record hello$name(String name) implements TemplateInstance {
+    }
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/CheckedTemplate.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/CheckedTemplate.java
@@ -7,7 +7,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * If you place this annotation on a class, all its <code>native static</code> methods will be used to declare
+ * <p>
+ * <strong>IMPORTANT: This annotation only works in a fully integrated environment; such as a Quarkus application.</strong>
+ * </p>
+ *
+ * It aims to configure type-safe templates.
+ * You can annotate a class or a Java record that implements {@link TemplateInstance}.
+ *
+ * <h2>&#64;CheckedTemplate on a class</h2>
+ * If you place this annotation on a class, then all its <code>static native</code> methods will be used to declare
  * templates and the list of parameters they require.
  * <p>
  * The name of a method and the base path are used to locate the template contents.
@@ -50,17 +58,22 @@ import java.lang.annotation.Target;
  * }
  * </pre>
  *
- * <h2>Type-safe Fragments</h2>
+ * <h2>&#64;CheckedTemplate on a template record</h2>
  *
- * By default, a <code>native static</code> method with the name that contains a dollar sign {@code $} denotes a method that
- * represents a fragment of a type-safe template. It's possible to ignore the fragments and effectively disable this
- * feature via {@link CheckedTemplate#ignoreFragments()}.
+ * If you place this annotation on a Java record that implements {@link TemplateInstance}, then attributes of this annotation
+ * are used to configure the non-default values of the type-safe template denoted by this record.
+ *
+ * <h2>Type-safe fragments</h2>
+ *
+ * By default, a <code>native static</code> method or a template record with the name that contains a dollar sign {@code $}
+ * denotes a fragment of a type-safe template.
+ * It's possible to ignore the fragments and effectively disable this feature via {@link CheckedTemplate#ignoreFragments()}.
  * <p>
- * The name of the fragment is derived from the annotated method name. The part before the last occurence of a dollar sign
+ * The name of the fragment is derived from the annotated element name. The part before the last occurence of a dollar sign
  * {@code $} is the method name of the related type-safe template. The part after the last occurence of a dollar sign is the
  * fragment identifier - the strategy defined by the relevant {@link CheckedTemplate#defaultName()} is used.
  * <p>
- * Parameters of the annotated method are validated. The required names and types are derived from the relevant fragment
+ * Parameters of the annotated element are validated. The required names and types are derived from the relevant fragment
  * template.
  *
  * <pre>

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineConfiguration.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineConfiguration.java
@@ -7,6 +7,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
+ * <p>
+ * <strong>IMPORTANT: This annotation only works in a fully integrated environment; such as a Quarkus application.</strong>
+ * </p>
+ *
  * Enables registration of additional components to the preconfigured {@link Engine}.
  * <p>
  * A top-level or static nested class that implements one of the <b>supported component interface</b> and is annotated with this

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Locate.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Locate.java
@@ -10,6 +10,10 @@ import java.lang.annotation.Target;
 import io.quarkus.qute.Locate.Locates;
 
 /**
+ * <p>
+ * <strong>IMPORTANT: This annotation only works in a fully integrated environment; such as a Quarkus application.</strong>
+ * </p>
+ *
  * A custom {@link TemplateLocator}s are not available during the build time, therefore {@link Template} located by
  * the locator must disable its validation by annotating the {@link TemplateLocator} with this annotation. If
  * {@link TemplateLocator} locates {@link Template} and fails to declare the fact this way, an exception is thrown and the build

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateData.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateData.java
@@ -10,6 +10,10 @@ import java.lang.annotation.Target;
 import io.quarkus.qute.TemplateData.Container;
 
 /**
+ * <p>
+ * <strong>IMPORTANT: This annotation only works in a fully integrated environment; such as a Quarkus application.</strong>
+ * </p>
+ *
  * This annotation is used to mark a target type for which a value resolver should be automatically generated. Note that
  * non-public members, constructors, static initializers, static, synthetic and void methods are always ignored.
  * <p>

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateEnum.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateEnum.java
@@ -7,6 +7,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
+ * <p>
+ * <strong>IMPORTANT: This annotation only works in a fully integrated environment; such as a Quarkus application.</strong>
+ * </p>
+ *
  * This annotation is functionally equivalent to {@code @TemplateData(namespace = TemplateData.SIMPLENAME)}, i.e. a namespace
  * resolver is automatically generated for the target enum. The simple name of the target enum is used as the namespace. The
  * generated namespace resolver can be used to access enum constants, static methods, etc.

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateExtension.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateExtension.java
@@ -9,7 +9,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * Instructs a fully integrated environment to generate a {@link ValueResolver} for a method annotated with this annotation.
+ * <p>
+ * <strong>IMPORTANT: This annotation only works in a fully integrated environment; such as a Quarkus application.</strong>
+ * </p>
+ *
+ * Instructs to generate a {@link ValueResolver} for a method annotated with this annotation.
  * <p>
  * If declared on a class a value resolver is generated for every non-private static method declared on the class. Method-level
  * annotations override the behavior defined on the class. Methods that do not meet the following requirements are ignored.

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateGlobal.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateGlobal.java
@@ -7,6 +7,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
+ * <p>
+ * <strong>IMPORTANT: This annotation only works in a fully integrated environment; such as a Quarkus application.</strong>
+ * </p>
+ *
  * Denotes static fields and methods that supply global variables which are accessible in every template.
  * <p>
  * If a class is annotated with {@link TemplateGlobal} then every non-void non-private static method that declares no parameters

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateInstance.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateInstance.java
@@ -37,7 +37,9 @@ public interface TemplateInstance {
      * @param data
      * @return
      */
-    TemplateInstance data(Object data);
+    default TemplateInstance data(Object data) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Put the data in a map. The map will be used as the root context object during rendering. Invocation of this
@@ -47,7 +49,9 @@ public interface TemplateInstance {
      * @param data
      * @return self
      */
-    TemplateInstance data(String key, Object data);
+    default TemplateInstance data(String key, Object data) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      *
@@ -55,28 +59,36 @@ public interface TemplateInstance {
      * @param value
      * @return self
      */
-    TemplateInstance setAttribute(String key, Object value);
+    default TemplateInstance setAttribute(String key, Object value) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      *
      * @param key
      * @return the attribute or null
      */
-    Object getAttribute(String key);
+    default Object getAttribute(String key) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Triggers rendering. Note that this method blocks the current thread!
      *
      * @return the rendered template as string
      */
-    String render();
+    default String render() {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Triggers rendering.
      *
      * @return a completion stage that is completed once the rendering finished
      */
-    CompletionStage<String> renderAsync();
+    default CompletionStage<String> renderAsync() {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Create a new {@link Multi} that can be used to consume chunks of the rendered template. In particular, each item
@@ -87,7 +99,9 @@ public interface TemplateInstance {
      * @return a new Multi
      * @see Multi#subscribe()
      */
-    Multi<String> createMulti();
+    default Multi<String> createMulti() {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Create a new {@link Uni} that can be used to consume the rendered template.
@@ -97,7 +111,9 @@ public interface TemplateInstance {
      * @return a new Uni
      * @see Uni#subscribe()
      */
-    Uni<String> createUni();
+    default Uni<String> createUni() {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Triggers rendering.
@@ -105,20 +121,26 @@ public interface TemplateInstance {
      * @param consumer To consume chunks of the rendered template
      * @return a completion stage that is completed once the rendering finished
      */
-    CompletionStage<Void> consume(Consumer<String> consumer);
+    default CompletionStage<Void> consume(Consumer<String> consumer) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      *
      * @return the timeout
      * @see TemplateInstance#TIMEOUT
      */
-    long getTimeout();
+    default long getTimeout() {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      *
      * @return the original template
      */
-    Template getTemplate();
+    default Template getTemplate() {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      *
@@ -136,7 +158,9 @@ public interface TemplateInstance {
      * @param action
      * @return self
      */
-    TemplateInstance onRendered(Runnable action);
+    default TemplateInstance onRendered(Runnable action) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * This component can be used to initialize a template instance, i.e. the data and attributes.

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
@@ -191,7 +191,7 @@ public class ExtensionMethodGenerator {
         if (matchRegex != null && !matchRegex.isEmpty()) {
             patternField = valueResolver.getFieldCreator(PATTERN, Pattern.class)
                     .setModifiers(ACC_PRIVATE | ACC_FINAL).getFieldDescriptor();
-            MethodCreator constructor = valueResolver.getMethodCreator("<init>", "V");
+            MethodCreator constructor = valueResolver.getMethodCreator(MethodDescriptor.INIT, "V");
             // Invoke super()
             constructor.invokeSpecialMethod(Descriptors.OBJECT_CONSTRUCTOR, constructor.getThis());
             // Compile the regex pattern
@@ -488,7 +488,7 @@ public class ExtensionMethodGenerator {
                 this.name = resolve.invokeInterfaceMethod(Descriptors.GET_NAME, evalContext);
                 this.paramsHandle = resolve.invokeInterfaceMethod(Descriptors.GET_PARAMS, evalContext);
                 this.paramsCount = resolve.invokeInterfaceMethod(Descriptors.COLLECTION_SIZE, paramsHandle);
-                this.constructor = namespaceResolver.getMethodCreator("<init>", "V");
+                this.constructor = namespaceResolver.getMethodCreator(MethodDescriptor.INIT, "V");
                 // Invoke super()
                 this.constructor.invokeSpecialMethod(Descriptors.OBJECT_CONSTRUCTOR, constructor.getThis());
             }

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
@@ -1199,8 +1199,8 @@ public class ValueResolverGenerator {
                 return Modifier.isPublic(method.flags())
                         && !isSynthetic(method.flags())
                         && method.returnType().kind() != org.jboss.jandex.Type.Kind.VOID
-                        && !method.name().equals("<init>")
-                        && !method.name().equals("<clinit>");
+                        && !method.name().equals(MethodDescriptor.INIT)
+                        && !method.name().equals(MethodDescriptor.CLINIT);
             case FIELD:
                 FieldInfo field = target.asField();
                 return Modifier.isPublic(field.flags())


### PR DESCRIPTION
This pull request introduces an alternative syntax for type-safe templates based on Java records (kudos to @FroMage for the idea ;-). Mainly to avoid the infamous `static native` construct.

The following example:

```java
 @Path("item")
 public class ItemResource {

     @CheckedTemplate
     static class Templates {
         // defines a template at ItemResource/item, taking an Item parameter named item
         static native TemplateInstance item(Item item);
     }

     @GET
     @Path("{id}")
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance get(@PathParam("id") Integer id) {
         // instantiate that template and pass it the required template parameter
         return Templates.item(service.findItem(id));
     }
 }
```
..can be rewritten as:

```java
 @Path("item")
 public class ItemResource {

     // defines a template at ItemResource/item, taking an Item parameter named item
     record item(Item item) implements TemplateInstance {
     }

     @GET
     @Path("{id}")
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance get(@PathParam("id") Integer id) {
         // instantiate that template and pass it the required template parameter
         return new item(service.findItem(id));
     }
 }
```

TODO
- [x] docs
- [x] revisit javadoc for related classes