### PR TITLE
Simplify the way OIDC tenant id interceptors can be created

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -698,18 +698,21 @@ Next, you'll need one interceptor for each of those annotations:
 
 [source,java]
 ----
-@Interceptor
-@HrTenant
-public class HrTenantInterceptor {
-    @Inject
-    RoutingContext routingContext;
+package io.quarkus.it.keycloak;
 
-    @AroundInvoke
-    Object setTenant(InvocationContext context) throws Exception {
-        routingContext.put(OidcUtils.TENANT_ID_ATTRIBUTE, "hr");
-        return context.proceed();
+import jakarta.interceptor.Interceptor;
+
+import io.quarkus.oidc.TenantResolverInterceptor;
+
+@HrTenant
+@Interceptor
+public class HrInterceptor extends TenantResolverInterceptor {
+    @Override
+    protected String getTenantId() {
+        return "hr";
     }
 }
+
 ----
 
 Now all methods and classes carrying `@HrTenant` will be authenticated using the OIDC provider configured by

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantResolverInterceptor.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantResolverInterceptor.java
@@ -1,0 +1,21 @@
+package io.quarkus.oidc;
+
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.InvocationContext;
+
+import io.quarkus.oidc.runtime.OidcUtils;
+import io.vertx.ext.web.RoutingContext;
+
+public abstract class TenantResolverInterceptor {
+    @Inject
+    RoutingContext routingContext;
+
+    @AroundInvoke
+    public Object setTenant(InvocationContext context) throws Exception {
+        routingContext.put(OidcUtils.TENANT_ID_ATTRIBUTE, getTenantId());
+        return context.proceed();
+    }
+
+    protected abstract String getTenantId();
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/HrInterceptor.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/HrInterceptor.java
@@ -1,22 +1,16 @@
 package io.quarkus.it.keycloak;
 
-import jakarta.inject.Inject;
-import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
-import jakarta.interceptor.InvocationContext;
 
-import io.quarkus.oidc.runtime.OidcUtils;
-import io.vertx.ext.web.RoutingContext;
+import io.quarkus.oidc.TenantResolverInterceptor;
 
-@Interceptor
 @HrTenant
-public class HrInterceptor {
-    @Inject
-    RoutingContext routingContext;
+@Interceptor
+public class HrInterceptor extends TenantResolverInterceptor {
 
-    @AroundInvoke
-    Object setTenant(InvocationContext context) throws Exception {
-        routingContext.put(OidcUtils.TENANT_ID_ATTRIBUTE, "hr");
-        return context.proceed();
+    @Override
+    protected String getTenantId() {
+        return "hr";
     }
+
 }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/TenantEchoResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/TenantEchoResource.java
@@ -1,10 +1,5 @@
 package io.quarkus.it.keycloak;
 
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -13,6 +8,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.oidc.runtime.OidcUtils;
 import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
 import io.vertx.ext.web.RoutingContext;
 
 @HrTenant
@@ -23,12 +19,14 @@ public class TenantEchoResource {
     @Inject
     RoutingContext routingContext;
 
+    @Inject
+    SecurityIdentity identity;
+
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    public Map<String, String> getTenant() {
-        return Stream.of(
-                "static.tenant.id",
-                OidcUtils.TENANT_ID_ATTRIBUTE)
-                .collect(Collectors.toMap(Function.identity(), key -> "" + routingContext.get(key)));
+    public String getTenant() {
+        return OidcUtils.TENANT_ID_ATTRIBUTE + "=" + routingContext.get(OidcUtils.TENANT_ID_ATTRIBUTE)
+                + ", static.tenant.id=" + routingContext.get("static.tenant.id")
+                + ", name=" + identity.getPrincipal().getName();
     }
 }

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/AnnotationBasedTenantTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/AnnotationBasedTenantTest.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 
-import org.hamcrest.core.StringContains;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.QuarkusTestResource;
@@ -13,6 +13,7 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.RestAssured;
+import io.smallrye.jwt.build.Jwt;
 
 @QuarkusTest
 @TestProfile(AnnotationBasedTenantTest.NoProactiveAuthTestProfile.class)
@@ -20,23 +21,37 @@ import io.restassured.RestAssured;
 public class AnnotationBasedTenantTest {
     public static class NoProactiveAuthTestProfile implements QuarkusTestProfile {
         public Map<String, String> getConfigOverrides() {
-            return Map.of("quarkus.http.auth.proactive", "false");
+            return Map.of("quarkus.http.auth.proactive", "false",
+                    "quarkus.oidc.hr.auth-server-url", "http://localhost:8180/auth/realms/quarkus2/",
+                    "quarkus.oidc.hr.client-id", "quarkus-app",
+                    "quarkus.oidc.hr.credentials.secret", "secret",
+                    "quarkus.oidc.hr.token.audience", "http://hr.service");
         }
     }
 
     @Test
     public void test() {
-        String token = OidcWiremockTestResource.getAccessToken("alice", new HashSet<>(Arrays.asList("user", "admin")));
-
         // Server is starting now
         WiremockTestResource server = new WiremockTestResource();
         server.start();
         try {
+            // Audience is wrong
+            String token = OidcWiremockTestResource.getAccessToken("alice", new HashSet<>(Arrays.asList("user", "admin")));
+            RestAssured.given().auth().oauth2(token)
+                    .when().get("/api/tenant-echo")
+                    .then().statusCode(401);
+
+            token = Jwt.preferredUserName("alice")
+                    .audience("http://hr.service")
+                    .jws()
+                    .keyId("1")
+                    .sign("privateKey.jwk");
+
             RestAssured.given().auth().oauth2(token)
                     .when().get("/api/tenant-echo")
                     .then().statusCode(200)
-                    .body(StringContains.containsString("tenant-id=hr"))
-                    .body(StringContains.containsString("static.tenant.id=hr"));
+                    .body(Matchers.equalTo(("tenant-id=hr, static.tenant.id=hr, name=alice")));
+
         } finally {
             server.stop();
         }


### PR DESCRIPTION
Fixes #34692.

This PR simplifies the way custom tenant resolver interceptors can be created, now one just has to extend `quarkus.oidc.TenantResolverInterceptor` and pass it the tenant id.

Update the test to confirm the `hr` tenant configuration is picked up - this configuration adds a custom audience value - which causes `401` when the test uses a token with another (default) audience but adding an audience expected by the `hr` tenant fixes it.

This option complements 2 other options, where either `TenantResolver` or `TenantConfigResolver` can be used