### PR TITLE
Avoid ambiguous use of 'Panache' in 'Logging with Panache'

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -59,7 +59,7 @@ In such cases, you need to use a <<logging-apis, logging adapter>> to ensure tha
 In Quarkus, the most common ways to obtain an application logger are by:
 
 * <<declaring-a-loger-field,Declaring a logger field>>
-* <<logging-with-style,Logging with style>>
+* <<simplified-logging,Simplified Logging>>
 * <<injection-of-a-configured-logger,Injecting a configured logger>>
 
 [[declaring-a-loger-field]]
@@ -87,8 +87,8 @@ public class MyService {
 <2> Invoke the desired logging methods on the `log` object.
 
 
-[[logging-with-style]]
-=== Logging with Style
+[[simplified-logging]]
+=== Simplified Logging
 
 Quarkus simplifies logging by automatically adding logger fields to classes that use `io.quarkus.logging.Log`.
 This eliminates the need for repetitive boilerplate code and enhances logging setup convenience.

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -88,7 +88,7 @@ public class MyService {
 
 
 [[simplified-logging]]
-=== Simplified Logging
+=== Simplified logging
 
 Quarkus simplifies logging by automatically adding logger fields to classes that use `io.quarkus.logging.Log`.
 This eliminates the need for repetitive boilerplate code and enhances logging setup convenience.

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -59,7 +59,7 @@ In such cases, you need to use a <<logging-apis, logging adapter>> to ensure tha
 In Quarkus, the most common ways to obtain an application logger are by:
 
 * <<declaring-a-loger-field,Declaring a logger field>>
-* <<simplified-logging,Simplified Logging>>
+* <<simplified-logging,Simplified logging>>
 * <<injection-of-a-configured-logger,Injecting a configured logger>>
 
 [[declaring-a-loger-field]]

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -59,7 +59,7 @@ In such cases, you need to use a <<logging-apis, logging adapter>> to ensure tha
 In Quarkus, the most common ways to obtain an application logger are by:
 
 * <<declaring-a-loger-field,Declaring a logger field>>
-* <<logging-with-panache,Logging with Panache>>
+* <<logging-with-style,Logging with style>>
 * <<injection-of-a-configured-logger,Injecting a configured logger>>
 
 [[declaring-a-loger-field]]
@@ -87,8 +87,8 @@ public class MyService {
 <2> Invoke the desired logging methods on the `log` object.
 
 
-[[logging-with-panache]]
-=== Logging with Panache
+[[logging-with-style]]
+=== Logging with Style
 
 Quarkus simplifies logging by automatically adding logger fields to classes that use `io.quarkus.logging.Log`.
 This eliminates the need for repetitive boilerplate code and enhances logging setup convenience.


### PR DESCRIPTION
I'm a bit unsure about the meaning of the heading in https://quarkus.io/guides/logging#logging-with-panache. 

<img width="689" alt="image" src="https://github.com/quarkusio/quarkus/assets/11509290/c16e9dcc-c28f-492a-b5a8-2d3d22a85772">

Is this a logging technique that only works if a Panache dependency is present? There's no other mention of Panache in the section. Or are we just using 'Panache' as a generic term?

I can see that the change was [introduced on September 1st, 2021](https://github.com/quarkusio/quarkus/commit/a5424aea5f96e6aa5d27eb51750f4efc11597861). I can find references to Panache in 2019, so it's not like the word 'Panache' was chosen before we had a feature called 'Panache'. 

However, I can see examples of log injection being used in projects which don't depend on Panache, for example, in the infinispan client - [usage](https://github.com/quarkusio/quarkus/blob/26cb1bd3f327606f58fe897e48d2e2c87b0198c2/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/devconsole/InfinispanJsonRPCService.java#L4) and [pom](https://github.com/quarkusio/quarkus/blob/26cb1bd3f327606f58fe897e48d2e2c87b0198c2/extensions/infinispan-client/runtime/pom.xml). 

The `logging-panache` project does depend on panache, and at least some of the tests do only seem to be testing the log injection. 

So I really can't tell:
- If we were using 'Panache' to mean something other than our data access extensions
- If Panache is an implementation detail that users can ignore, even at the dependency level (in which case maybe we don't mention it?)
- If historically we depended on Panache to make this work but now it's just in core (in which case we should remove references)
- This only works in projects with Panache, in which case we should explicitly warn people they also need Panache

I'm assuming it's one of the first three, and I've removed the Panache references. I've gone for a literal substitution of a similar word (ie, assuming the first), but we can reword if it's the second or third. 


