### PR TITLE
OIDC DEV UI - small alignment and width adjustments

### DIFF
--- a/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
+++ b/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
@@ -363,10 +363,12 @@ export class QwcOidcProvider extends QwcHotReloadElement {
         return html`
             <vaadin-vertical-layout theme="spacing padding" class="height-4xl container">
                 ${servicePathForm}
-                <vaadin-button theme="primary success"
-                               @click=${() => this._signInToService()}>
-                    Log into your Web Application
-                </vaadin-button>
+                <vaadin-vertical-layout class="margin-left-auto frm-field">
+                    <vaadin-button theme="primary success" class="full-width"
+                                   @click=${() => this._signInToService()}>
+                        Log into your Web Application
+                    </vaadin-button>
+                </vaadin-vertical-layout>
             </vaadin-vertical-layout>
         `;
     }
@@ -421,7 +423,7 @@ export class QwcOidcProvider extends QwcHotReloadElement {
                         ${keycloakRealms}
                         ${extraFields}
                         ${servicePathForm}
-                        <vaadin-horizontal-layout class="full-width">
+                        <vaadin-horizontal-layout class="margin-left-auto frm-field">
                             <vaadin-horizontal-layout class="full-width">
                                 <vaadin-button class="fill-space margin-right-auto" theme="primary" title="Test service" 
                                                @click=${testSvcFun}>
@@ -636,9 +638,9 @@ export class QwcOidcProvider extends QwcHotReloadElement {
             <vaadin-vertical-layout theme="spacing padding" class="height-4xl container" 
                                     ?hidden="${propertiesState.hideImplLoggedOut}">
                 ${keycloakRealms}
-                <vaadin-form-layout class="txt-field-form full-width">
+                <vaadin-form-layout class="margin-left-auto txt-field-form frm-field">
                         <vaadin-form-item class="full-width">
-                            <vaadin-button theme="primary success"
+                            <vaadin-button theme="primary success" class="full-width"
                                         title="Log into Single Page Application to Get Access and ID Tokens"
                                         @click=${() => this._signInToOidcProviderAndGetTokens()}>
                                 <vaadin-icon icon="font-awesome-solid:user" slot="prefix" class="btn-icon"></vaadin-icon>
@@ -749,7 +751,7 @@ export class QwcOidcProvider extends QwcHotReloadElement {
                     <vaadin-vertical-layout theme="padding">
                         ${servicePathForm}
                         <vaadin-horizontal-layout class="full-width">
-                            <vaadin-horizontal-layout class="full-width">
+                            <vaadin-horizontal-layout class="margin-left-auto frm-field">
                                 <vaadin-button class="fill-space" theme="primary" title="Test With Access Token" 
                                                @click=${() => this._testServiceWithAccessToken()}>
                                     With Access Token


### PR DESCRIPTION
1. [reproducer: use `security-openid-connect-quickstart`, run `quarkus dev` and log into SPA]: align buttons on right and limit max width as on large screens buttons are enourmous
- before
![1--before-qs-kc-provider-big-btns](https://github.com/quarkusio/quarkus/assets/43821672/abf70f11-5890-4f46-a93b-6fbb46b94185)
- after 
![1--after-qs-kc-provider-big-btns](https://github.com/quarkusio/quarkus/assets/43821672/f133f71b-4596-4e3e-bbb6-c2d6cda7477b)

2. unify login green button

  - a) [reproducer: use `security-openid-connect-quickstart`, run `quarkus dev -Dquarkus.oidc.provider=google -Dquarkus.oidc.client-id=any`]
    - before
![2-before-kc-provider-unify-btns](https://github.com/quarkusio/quarkus/assets/43821672/b3804d02-9a7a-455a-a74f-e339fd001161)

    - after
![2-after-unify-btns-google-provider](https://github.com/quarkusio/quarkus/assets/43821672/2abc1771-77de-4e97-ac0d-58c4b3398156)

  - b) [reproducer: use `security-openid-connect-quickstart`, run `quarkus dev` and log into SPA]
    - before
![2-before-kc-provider-unify-btns](https://github.com/quarkusio/quarkus/assets/43821672/24b2d3cd-06de-4968-9e0c-68eab38d91d1)

    - after
![2-after-kc-provider-unify-btns](https://github.com/quarkusio/quarkus/assets/43821672/8fb308f8-8482-493a-b575-b0a3a571e255)

3. [reproducer: use `security-openid-connect-quickstart`, run `quarkus dev -Dquarkus.oidc.devui.grant.type=password`] align test service button
  - before
![3-before-pwd-grant-test-svc-btn](https://github.com/quarkusio/quarkus/assets/43821672/1523e2e4-97fd-49bb-9900-c2d1a6b394da)
  - after
![3-after-pwd-grant-test-svc-btn](https://github.com/quarkusio/quarkus/assets/43821672/240d0e6e-390c-4e45-af71-ed38120bc1ac)


@sberyozkin changes are very subjective, feel free to say you liked previous state or suggest changes (both in what I change or other things you can think of). Point here is to have uniform appearance, but whether it will be uniform on the right or other it is up to discussion.