### PR TITLE
OIDC DEV UI - custom OIDC providers should appear on OIDC extension card and among provider tabs

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/CustomOidcDevUiProviderPageBuildItem.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/CustomOidcDevUiProviderPageBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.oidc.deployment.devservices;
+
+import java.util.Objects;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.devui.spi.page.PageBuilder;
+
+/**
+ * Replace default OIDC provider DEV UI page with one specific to your provider.
+ */
+public final class CustomOidcDevUiProviderPageBuildItem extends SimpleBuildItem {
+
+    private final PageBuilder<?> oidcProviderPage;
+
+    public CustomOidcDevUiProviderPageBuildItem(PageBuilder<?> oidcProviderPage) {
+        this.oidcProviderPage = Objects.requireNonNull(oidcProviderPage);
+    }
+
+    public PageBuilder<?> getOidcProviderPage() {
+        return oidcProviderPage;
+    }
+}

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
@@ -72,7 +72,7 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             BuildProducer<CardPageBuildItem> cardPageProducer,
             ConfigurationBuildItem configurationBuildItem,
-            OidcDevUiRecorder recorder) {
+            OidcDevUiRecorder recorder, Optional<CustomOidcDevUiProviderPageBuildItem> customProviderPage) {
         if (!isOidcTenantEnabled() || !isClientIdSet()) {
             return;
         }
@@ -161,7 +161,8 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
                     keycloakAdminUrl,
                     null,
                     null,
-                    true);
+                    true,
+                    customProviderPage.map(CustomOidcDevUiProviderPageBuildItem::getOidcProviderPage).orElse(null));
             cardPageProducer.produce(cardPage);
         }
     }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
@@ -23,6 +23,7 @@ import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.oidc.deployment.OidcBuildTimeConfig;
 import io.quarkus.oidc.deployment.devservices.AbstractDevConsoleProcessor;
+import io.quarkus.oidc.deployment.devservices.CustomOidcDevUiProviderPageBuildItem;
 import io.quarkus.oidc.deployment.devservices.OidcAuthorizationCodePostHandler;
 import io.quarkus.oidc.deployment.devservices.OidcPasswordClientCredHandler;
 import io.quarkus.oidc.deployment.devservices.OidcTestServiceHandler;
@@ -77,7 +78,8 @@ public class KeycloakDevConsoleProcessor extends AbstractDevConsoleProcessor {
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer,
             ConfigurationBuildItem configurationBuildItem,
-            Capabilities capabilities) {
+            Capabilities capabilities,
+            Optional<CustomOidcDevUiProviderPageBuildItem> customProviderPage) {
         if (configProps.isPresent() && configProps.get().getConfig().containsKey("keycloak.url")) {
             String realmUrl = configProps.get().getConfig().get("quarkus.oidc.auth-server-url");
             @SuppressWarnings("unchecked")
@@ -107,7 +109,8 @@ public class KeycloakDevConsoleProcessor extends AbstractDevConsoleProcessor {
                     keycloakAdminUrl,
                     users,
                     keycloakRealms,
-                    configProps.get().isContainerRestarted());
+                    configProps.get().isContainerRestarted(),
+                    customProviderPage.map(CustomOidcDevUiProviderPageBuildItem::getOidcProviderPage).orElse(null));
 
             // Also add Admin page
             cardPageBuildItem.addPage(Page.externalPageBuilder("Keycloak Admin")


### PR DESCRIPTION
Here https://quarkus.io/guides/security-openid-connect-dev-services#dev-services-and-ui-support-for-other-openid-connect-providers you can see that in the old DEV UI, it was possible for other extensions to add provider to OIDC card. Now it is not. This PR:

- makes it possible for any extension card to produce page for any other extension (namespace)
- rewrites relevant OIDC DEV UI docs section

@phillip-kruger problem is that when I currently just set namespace, than my custom extension page appears on extension list on custom extension card, however when I go to OIDC Keycloak provider page, I can see on the right-most tabs that there is both custom provider (from custom extension) and Keycloak provider. That is strange. However if you generally don't want to allow extensions to place its pages to other extension cards, we can create in OIDC extension build item that will enable it only for OIDC. WDYT?

/cc @sberyozkin but please don't review docs text till there is an agreement on how to do this (so that you don't waste your time!)

![custom-provider-card](https://github.com/quarkusio/quarkus/assets/43821672/e4aeb03b-02b8-46a0-b7b3-426741371c50)
![custom-provider-tabs](https://github.com/quarkusio/quarkus/assets/43821672/ade6afa2-ff63-4462-bb19-9a14fcfaf9cf)
