### PR TITLE
Support flattened poms

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
@@ -69,7 +69,7 @@ public class LocalProject {
             return null;
         }
         try {
-            return new LocalProject(readModel(pom), null);
+            return new LocalProject(readModel(pom), null, null);
         } catch (UnresolvedVersionException e) {
             // if a property in the version couldn't be resolved, we are trying to resolve it from the workspace
             return loadWorkspace(pom);
@@ -165,10 +165,10 @@ public class LocalProject {
         }
     }
 
-    LocalProject(Model rawModel, LocalWorkspace workspace) throws BootstrapMavenException {
+    LocalProject(Model rawModel, LocalWorkspace workspace, Path projectDirectory) throws BootstrapMavenException {
         this.modelBuildingResult = null;
         this.rawModel = rawModel;
-        this.dir = rawModel.getProjectDirectory().toPath();
+        this.dir = (projectDirectory != null) ? projectDirectory : rawModel.getProjectDirectory().toPath();
         this.workspace = workspace;
         this.key = ArtifactKey.ga(ModelUtils.getGroupId(rawModel), rawModel.getArtifactId());
 

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/WorkspaceLoader.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/WorkspaceLoader.java
@@ -146,9 +146,9 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
                 throw new BootstrapMavenException("Failed to resolve the effective model for " + pomFile, e);
             }
         } else {
-            project = new LocalProject(rawModel, workspace);
+            project = new LocalProject(rawModel, workspace, resolveProjectPath(pomFile));
         }
-        projectCache.put(pomFile.getParent(), project);
+        projectCache.put(resolveProjectPath(pomFile), project);
         return project;
     }
 
@@ -270,6 +270,13 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
         return project != null && project.getVersion().equals(versionConstraint)
                 ? project.getModelBuildingResult().getEffectiveModel()
                 : null;
+    }
+
+    private Path resolveProjectPath(Path pomFile) {
+        if (pomFile.endsWith("target/.flattened-pom.xml")) {
+            return pomFile.getParent().getParent().toAbsolutePath();
+        }
+        return pomFile.getParent().toAbsolutePath();
     }
 
     @Override


### PR DESCRIPTION
When using the `flatten-maven-plugin`, the POM file resolves to `PROJECT_DIR/target/.flattened-pom.xml`, which makes calls to `pomFile.getParent()` return the `target/` directory

- Fixes #34764
