### PR TITLE
Remove token customizer from OIDC Microsoft provider

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -145,6 +145,21 @@ quarkus.oidc.client-id=<Client ID>
 quarkus.oidc.credentials.secret=<Secret>
 ----
 
+[NOTE]
+====
+Some Microsoft services may issue tokens whose signatures can only be verified if the current token's `nonce` header is reset with its SHA-256 digest value.
+If your application has to deal with such tokens then please enable an Azure token customizer:
+
+[source,properties]
+----
+quarkus.oidc.provider=microsoft
+quarkus.oidc.client-id=<Client ID>
+quarkus.oidc.credentials.secret=<Secret>
+quarkus.oidc.token.customizer-name=azure-access-token-customizer
+----
+
+====
+
 [[apple]]
 === Apple
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -449,9 +449,6 @@ public final class OidcUtils {
         if (tenant.token.verifyAccessTokenWithUserInfo.isEmpty()) {
             tenant.token.verifyAccessTokenWithUserInfo = provider.token.verifyAccessTokenWithUserInfo;
         }
-        if (tenant.token.customizerName.isEmpty()) {
-            tenant.token.customizerName = provider.token.customizerName;
-        }
 
         return tenant;
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
@@ -75,7 +75,6 @@ public class KnownOidcProviders {
         ret.setAuthServerUrl("https://login.microsoftonline.com/common/v2.0");
         ret.setApplicationType(OidcTenantConfig.ApplicationType.WEB_APP);
         ret.getToken().setIssuer("any");
-        ret.getToken().setCustomizerName("azure-access-token-customizer");
         ret.getAuthentication().setScopes(List.of("openid", "email", "profile"));
         return ret;
     }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -238,7 +238,6 @@ public class OidcUtilsTest {
         assertEquals("https://login.microsoftonline.com/common/v2.0", config.getAuthServerUrl().get());
         assertEquals(List.of("openid", "email", "profile"), config.authentication.scopes.get());
         assertEquals("any", config.getToken().getIssuer().get());
-        assertEquals("azure-access-token-customizer", config.getToken().getCustomizerName().get());
     }
 
     @Test
@@ -249,7 +248,6 @@ public class OidcUtilsTest {
         tenant.setApplicationType(ApplicationType.HYBRID);
         tenant.setAuthServerUrl("http://localhost/wiremock");
         tenant.getToken().setIssuer("http://localhost/wiremock");
-        tenant.getToken().setCustomizerName("");
         tenant.authentication.setScopes(List.of("write"));
         tenant.authentication.setForceRedirectHttpsScheme(false);
 
@@ -261,7 +259,6 @@ public class OidcUtilsTest {
         assertEquals(List.of("write"), config.authentication.scopes.get());
         assertEquals("http://localhost/wiremock", config.getToken().getIssuer().get());
         assertFalse(config.authentication.forceRedirectHttpsScheme.get());
-        assertTrue(config.getToken().getCustomizerName().get().isEmpty());
     }
 
     @Test

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -131,6 +131,7 @@ quarkus.oidc.bearer-azure.application-type=service
 quarkus.oidc.bearer-azure.discovery-enabled=false
 quarkus.oidc.bearer-azure.jwks-path=${keycloak.url}/azure/jwk
 quarkus.oidc.bearer-azure.token.lifespan-grace=2147483647
+quarkus.oidc.bearer-azure.token.customizer-name=azure-access-token-customizer
 
 quarkus.oidc.bearer-role-claim-path.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.bearer-role-claim-path.client-id=quarkus-app


### PR DESCRIPTION
Fixes #34732.

I thought it would be a good idea to have `quarkus.oidc.provider=microsoft` bring an Azure token customizer by default, wrongly assuming that all tokens with `nonce` headers have to be pre-processed, but #34732 showed it was a mistake - there are  so many combinations with Azure services, API versions, that is really impossible to predict when such a customizer may be needed, and when not, so if a given token `nonce` does not need to be reset then this customizer will actually break the signature verification.

I thought I might just doc that users can disable this customizer if needed - but it would break an element of the least surprise, so I believe now it is better to show how this customizer can be configured if required but do not enable it by default 