### PR TITLE
Add another hint how to decrease OIDC session cookie size

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -870,7 +870,9 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                                             + " to have the ID, access and refresh tokens stored in separate cookies."
                                                             + " 2. Set 'quarkus.oidc.token-state-manager.strategy=id-refresh-tokens' if you do not need to use the access token"
                                                             + " as a source of roles or to request UserInfo or propagate it to the downstream services."
-                                                            + " 3. Register a custom 'quarkus.oidc.TokenStateManager' CDI bean with the alternative priority set to 1.",
+                                                            + " 3. Decrease the session cookie's length by disabling its encryption with 'quarkus.oidc.token-state-manager.encryption-required=false'"
+                                                            + " but only if it is considered to be safe in your application's network."
+                                                            + " 4. Register a custom 'quarkus.oidc.TokenStateManager' CDI bean with the alternative priority set to 1.",
                                                     configContext.oidcConfig.tenantId.get(),
                                                     MAX_COOKIE_VALUE_LENGTH);
                                         }


### PR DESCRIPTION
Now that session cookies are encrypted by default a warning that the session cookie length is exceeding 4096 bytes is shown quite regularly, with 3 options offered how to avoid this warning.
Adding another hint showing how to disable the cookie encryption may help users who run it securely over HTTPS