### PR TITLE
DevMojo warnIfBuildGoalMissing parameter to be able to supress the warning about missing build goal

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -336,6 +336,9 @@ public class DevMojo extends AbstractMojo {
     @Parameter(defaultValue = "${quarkus.enforceBuildGoal}")
     private boolean enforceBuildGoal = true;
 
+    @Parameter(property = "quarkus.warnIfBuildGoalMissing")
+    boolean warnIfBuildGoalMissing = true;
+
     @Component
     private WorkspaceReader wsReader;
 
@@ -399,13 +402,18 @@ public class DevMojo extends AbstractMojo {
             final PluginDescriptor pluginDescr = getPluginDescriptor();
             final Plugin pluginDef = getConfiguredPluginOrNull(pluginDescr.getGroupId(), pluginDescr.getArtifactId());
             if (!isGoalConfigured(pluginDef, "build")) {
-                var currentGoal = getCurrentGoal();
-                getLog().warn(
-                        "The quarkus-maven-plugin build goal was not configured for this project, skipping " +
-                                currentGoal + " as this is assumed to be a support library. If you want to run " + currentGoal +
-                                " on this project make sure the quarkus-maven-plugin is configured with the build goal" +
-                                " or disable the enforceBuildGoal flag (via plugin configuration or via" +
-                                " -Dquarkus.enforceBuildGoal=false).");
+                if (warnIfBuildGoalMissing) {
+                    var currentGoal = getCurrentGoal();
+                    getLog().warn(
+                            "Skipping " + currentGoal + " as this is assumed to be a support library." +
+                                    " To disable this warning set warnIfBuildGoalMissing parameter to false."
+                                    + System.lineSeparator() +
+                                    "To enable " + currentGoal +
+                                    " for this module, make sure the quarkus-maven-plugin configuration includes the build goal"
+                                    +
+                                    " or disable the enforceBuildGoal flag (via plugin configuration or via" +
+                                    " -Dquarkus.enforceBuildGoal=false).");
+                }
                 return;
             }
         }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -1192,7 +1192,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
                 .atMost(30, TimeUnit.SECONDS)
-                .until(() -> running.log().contains("skipping quarkus:dev as this is assumed to be a support library"));
+                .until(() -> running.log().contains("Skipping quarkus:dev as this is assumed to be a support library"));
     }
 
     @Test
@@ -1200,7 +1200,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         testDir = initProject("projects/classic-no-build", "projects/classic-no-build-not-enforced");
         runAndCheck("-Dquarkus.enforceBuildGoal=false");
 
-        assertThat(running.log()).doesNotContain("skipping quarkus:dev as this is assumed to be a support library");
+        assertThat(running.log()).doesNotContain("Skipping quarkus:dev as this is assumed to be a support library");
     }
 
     @Test


### PR DESCRIPTION
Following a discussion in https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Warning.20message.20from.20the.20quarus-maven-plugin/near/374093875