### PR TITLE
Narayana upgrade (to 7.0.0.Final)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -105,7 +105,7 @@
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <!-- When updating, align hibernate-search.version-for-documentation in docs/pom.xml -->
         <hibernate-search.version>6.2.0.CR1</hibernate-search.version>
-        <narayana.version>6.0.1.Final</narayana.version>
+        <narayana.version>7.0.0.Final</narayana.version>
         <agroal.version>2.1</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
         <elasticsearch-opensource-components.version>8.8.2</elasticsearch-opensource-components.version>


### PR DESCRIPTION
The component upgrade brings some major updates, most notable is the re-license Narayana from LGPL to Apache-2.0 and support for JEP-444 (Virtual Threads). JEP-444 required removing the synchronized keyword from some method signatures, hence the change of the major version from 6 to 7.

Tag: https://github.com/jbosstm/narayana/releases/tag/7.0.0.Final
Diff: jbosstm/narayana@6.0.1.Final...7.0.0.Final
Release Notes: https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12310200&version=12406603