### PR TITLE
Do not make OIDC state cookie name unique if multiple code flows are not allowed

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -154,8 +154,10 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             return stateParamIsMissing(oidcTenantConfig, context, cookies, stateQueryParam.size() > 1);
         }
 
+        String stateCookieNameSuffix = oidcTenantConfig.authentication.allowMultipleCodeFlows ? "_" + stateQueryParam.get(0)
+                : "";
         final Cookie stateCookie = context.request().getCookie(
-                getStateCookieName(oidcTenantConfig) + "_" + stateQueryParam.get(0));
+                getStateCookieName(oidcTenantConfig) + stateCookieNameSuffix);
 
         if (stateCookie == null) {
             return stateCookieIsMissing(oidcTenantConfig, context, cookies);
@@ -971,8 +973,9 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             extraStateValue.setRestorePath("?" + context.request().query());
             cookieValue += (COOKIE_DELIM + encodeExtraStateValue(extraStateValue, configContext));
         }
+        String stateCookieNameSuffix = configContext.oidcConfig.authentication.allowMultipleCodeFlows ? "_" + uuid : "";
         createCookie(context, configContext.oidcConfig,
-                getStateCookieName(configContext.oidcConfig) + "_" + uuid, cookieValue, 60 * 30);
+                getStateCookieName(configContext.oidcConfig) + stateCookieNameSuffix, cookieValue, 60 * 30);
         return uuid;
     }
 

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -43,6 +43,7 @@ quarkus.oidc.tenant-jwt.client-id=quarkus-app-jwt
 quarkus.oidc.tenant-jwt.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 quarkus.oidc.tenant-jwt.token.issuer=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-jwt.authentication.redirect-path=/web-app/callback-jwt-after-redirect
+quarkus.oidc.tenant-jwt.authentication.allow-multiple-code-flows=false
 quarkus.oidc.tenant-jwt.application-type=web-app
 
 # Tenant with client which needs to use client_secret_jwt but uses client_secret_post


### PR DESCRIPTION
Fixes #34760

Quarkus OIDC enables multiple authorization code flows (multi-tab authentication) by default - a user can start a login process and without completing it open a new tab and start a new one.

State cookies are used to coordinate a given authorization code flow and for multiple code flows to be supported their names have to be unique for the state cookies not to interfere with each other.

However if such a multi-tab authentication is disabled, the state cookie should not be unique - as it prevents whitelisting supported cookies as explained in #34760.

So this PR makes a very simple fix - if multiple code flows are not allowed, do not try to make a state cookie name unique. Tests are updated to show that by default the state cookie name contains UUID, but not if the multiple code flows are not allowed.