### PR TITLE
Avoid race condition on adding content-length header

### DIFF
--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/ResteasyReactiveOutputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/ResteasyReactiveOutputStream.java
@@ -226,10 +226,12 @@ public class ResteasyReactiveOutputStream extends OutputStream {
         if (!committed) {
             committed = true;
             if (finished) {
-                if (buffer == null) {
-                    context.serverResponse().setResponseHeader(HttpHeaderNames.CONTENT_LENGTH, "0");
-                } else {
-                    context.serverResponse().setResponseHeader(HttpHeaderNames.CONTENT_LENGTH, "" + buffer.readableBytes());
+                if (!context.serverResponse().headWritten()) {
+                    if (buffer == null) {
+                        context.serverResponse().setResponseHeader(HttpHeaderNames.CONTENT_LENGTH, "0");
+                    } else {
+                        context.serverResponse().setResponseHeader(HttpHeaderNames.CONTENT_LENGTH, "" + buffer.readableBytes());
+                    }
                 }
             } else {
                 var contentLengthSet = contentLengthSet();


### PR DESCRIPTION
Prevent adding header if it already exists as adding it twice creates a race condition and the response is never sent

Fixes #34632