### PR TITLE
Allow for minor clock skew when comparing OIDC cookie and token lifetimes

### DIFF
--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -292,7 +292,8 @@ public class CodeFlowAuthorizationTest {
 
             Cookie sessionCookie = getSessionCookie(webClient, tenantId);
             Date date = sessionCookie.getExpires();
-            assertEquals(internalIdTokenLifetime, date.toInstant().getEpochSecond() - issuedAt);
+            assertTrue(date.toInstant().getEpochSecond() - issuedAt >= internalIdTokenLifetime);
+            assertTrue(date.toInstant().getEpochSecond() - issuedAt <= internalIdTokenLifetime + 3);
 
             webClient.getCookieManager().clearCookies();
         }


### PR DESCRIPTION
#34784 failed because of of the flaky OIDC test which does a precise comparison of the session cookie token lifespans, so this PR tunes that test a bit to allow for minor clock/time related conversions