### PR TITLE
Fail when GraalVM / Mandrel version detection fails

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -126,7 +126,6 @@ public final class GraalVM {
                 "(GraalVM|native-image)( Version)? " + VersionParseHelper.VERS_FORMAT + "(?<distro>.*?)?" +
                         "(\\(Java Version (?<jfeature>[0-9]+)(\\.(?<jinterim>[0-9]*)\\.(?<jupdate>[0-9]*))?.*)?$");
 
-        static final Version UNVERSIONED = new Version("Undefined", "snapshot", Distribution.ORACLE);
         static final Version VERSION_21_3 = new Version("GraalVM 21.3", "21.3", Distribution.ORACLE);
         static final Version VERSION_21_3_0 = new Version("GraalVM 21.3.0", "21.3.0", Distribution.ORACLE);
         public static final Version VERSION_22_3_0 = new Version("GraalVM 22.3.0", "22.3.0", Distribution.ORACLE);
@@ -158,10 +157,6 @@ public final class GraalVM {
 
         String getFullVersion() {
             return fullVersion;
-        }
-
-        boolean isDetected() {
-            return this != UNVERSIONED;
         }
 
         boolean isObsolete() {
@@ -204,10 +199,7 @@ public final class GraalVM {
 
             if (lines.size() == 3) {
                 // Attempt to parse the new 3-line version scheme first.
-                Version v = VersionParseHelper.parse(lines);
-                if (v != VersionParseHelper.UNKNOWN_VERSION) {
-                    return v;
-                }
+                return VersionParseHelper.parse(lines);
             } else if (lines.size() == 1) {
                 // Old, single line version parsing logic
                 final String line = lines.get(0);
@@ -234,7 +226,8 @@ public final class GraalVM {
                 }
             }
 
-            return UNVERSIONED;
+            throw new IllegalArgumentException(
+                    "Cannot parse version from output: " + output.collect(Collectors.joining("\n")));
         }
 
         private static boolean isMandrel(String s) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -216,12 +216,7 @@ public class NativeImageBuildStep {
 
         buildRunner.setup(processInheritIODisabled.isPresent() || processInheritIODisabledBuildItem.isPresent());
         final GraalVM.Version graalVMVersion = buildRunner.getGraalVMVersion();
-
-        if (graalVMVersion.isDetected()) {
-            checkGraalVMVersion(graalVMVersion);
-        } else {
-            log.error("Unable to get GraalVM version from the native-image binary.");
-        }
+        checkGraalVMVersion(graalVMVersion);
 
         try {
             if (nativeConfig.cleanupServer()) {
@@ -568,7 +563,7 @@ public class NativeImageBuildStep {
             private Path outputDir;
             private String runnerJarName;
             private String noPIE = "";
-            private GraalVM.Version graalVMVersion = GraalVM.Version.UNVERSIONED;
+            private GraalVM.Version graalVMVersion = null;
             private String nativeImageName;
             private boolean classpathIsBroken;
             private boolean containerBuild;

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -86,17 +86,11 @@ public class GraalVMTest {
     }
 
     static void assertVersion(org.graalvm.home.Version graalVmVersion, Distribution distro, Version version) {
-        assertThat(version.isDetected()).isEqualTo(true);
         assertThat(graalVmVersion.compareTo(version.version)).isEqualTo(0);
         assertThat(version.distribution).isEqualTo(distro);
         if (distro == MANDREL) {
             assertThat(version.isMandrel()).isTrue();
         }
-    }
-
-    @Test
-    public void testGraalVMVersionUndetected() {
-        assertThat(Version.of(Stream.of("foo bar")).isDetected()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
It's easy to miss the error message and Quarkus will assume the version is a snapshot of GraalVM making it harder to debug.

The benefits of supporting arbitrary versions from dev/snapshot builds doesn't seem to justify the above so it's better to just fail and require a proper version in dev/snapshot builds.