### PR TITLE
Encode multi char code points correctly in RestEasy Reactive

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/Encode.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/Encode.java
@@ -389,6 +389,12 @@ public class Encode {
                 result.append(currentChar);
                 continue;
             }
+            if (Character.isHighSurrogate(currentChar)) {
+                String part = segment.substring(i, i + 2);
+                result.append(URLEncoder.encode(part, StandardCharsets.UTF_8));
+                ++i;
+                continue;
+            }
             String encoding = encode(currentChar, encodingMap);
             if (encoding == null) {
                 result.append(currentChar);

--- a/independent-projects/resteasy-reactive/common/runtime/src/test/java/org/jboss/resteasy/reactive/common/util/EncodeTest.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/test/java/org/jboss/resteasy/reactive/common/util/EncodeTest.java
@@ -1,0 +1,18 @@
+package org.jboss.resteasy.reactive.common.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+class EncodeTest {
+    @Test
+    void encodeEmoji() {
+        String emoji = "\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00";
+        String encodedEmoji = URLEncoder.encode(emoji, StandardCharsets.UTF_8);
+        assertEquals(encodedEmoji, Encode.encodePath(emoji));
+        assertEquals(encodedEmoji, Encode.encodeQueryParam(emoji));
+    }
+}


### PR DESCRIPTION
- Fixes #10134
- Cherry-picks the commit from RestEasy Classic: https://github.com/resteasy/resteasy/commit/a02582028726bc4ce89d61b8ccb5c3ccafbe9444