### PR TITLE
Fix container builds when explicitly setting `container-runtime`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -28,7 +28,7 @@ public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRu
 
     protected NativeImageBuildContainerRunner(NativeConfig nativeConfig) {
         this.nativeConfig = nativeConfig;
-        containerRuntime = nativeConfig.containerRuntime().orElseGet(ContainerRuntimeUtil::detectContainerRuntime);
+        containerRuntime = ContainerRuntimeUtil.detectContainerRuntime();
 
         this.baseContainerRuntimeArgs = new String[] { "--env", "LANG=C", "--rm" };
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
@@ -104,8 +104,7 @@ public class UpxCompressionBuildStep {
         List<String> extraArgs = nativeConfig.compression().additionalArgs().orElse(Collections.emptyList());
 
         List<String> commandLine = new ArrayList<>();
-        ContainerRuntimeUtil.ContainerRuntime containerRuntime = nativeConfig.containerRuntime()
-                .orElseGet(ContainerRuntimeUtil::detectContainerRuntime);
+        ContainerRuntimeUtil.ContainerRuntime containerRuntime = ContainerRuntimeUtil.detectContainerRuntime();
         commandLine.add(containerRuntime.getExecutableName());
 
         commandLine.add("run");


### PR DESCRIPTION
Looking at how this works right now the process is the following:

1. If the user has set `quarkus.native.container-runtime`, Quarkus uses this verbatim [1] (so if you want rootless you have to say `podman-rootless` instead of just `podman`

2. If `quarkus.native.container-runtime` is not set Quarkus next picks up the system property `quarkus-local-container-runtime` [2], this was introduced in https://github.com/quarkusio/quarkus/pull/31857 and is expected to be set by Quarkus and not the user, so the first time we try to detect the container runtime it should be unset.

3. If the system property is unset, Quarkus then checks the parameter `quarkus.native.container-runtime` (again) [3]. If it's set it uses it to test if the set runtime is available or not. If it's not available it falls back to testing first docker and then
podman [4].

As a result, removing step 1 allows Quarkus to properly check the value of `quarkus.native.container-runtime` and fully resolve the runtime.

[1] https://github.com/quarkusio/quarkus/blob/f3f97198a3a6892a828540811e0644fad7397acf/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java#L31

[2] https://github.com/quarkusio/quarkus/blob/f652f64823f4c54018344c2c941d9819ca9c3d72/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java#L43

[3] https://github.com/quarkusio/quarkus/blob/f652f64823f4c54018344c2c941d9819ca9c3d72/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java#L48

[4] https://github.com/quarkusio/quarkus/blob/f652f64823f4c54018344c2c941d9819ca9c3d72/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java#L96C1-L111

Closes: #34725