### PR TITLE
Allow adding extra OIDC provider scopes without having to list all scopes

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -50,7 +50,9 @@ quarkus.oidc.client-id=<Client ID>
 quarkus.oidc.credentials.secret=<Secret>
 ----
 
-TIP: You can also use GitHub provider with `quarkus.oidc.application-type=service`, just set `quarkus.oidc.verify-access-token-with-user-info` configuration property to `true`.
+`quarkus.oidc.provider=github` will request `GitHub` to add a `user:email` scope to issued access tokens. For information about overriding this scope or requesting more scopes, see the  <<provider-scope>> section.
+
+TIP: You can also send access tokens issued by `GitHub` to `quarkus.oidc.application-type=service` or `quarkus.oidc.application-type=hybrid` Quarkus applications.
 
 [[google]]
 === Google
@@ -103,6 +105,10 @@ quarkus.oidc.client-id=<Client ID>
 quarkus.oidc.credentials.secret=<Secret>
 ----
 
+`quarkus.oidc.provider=google` will request `Google` to add `openid`, `email` and `profile` scopes to issued access tokens. For information about overriding these scopes or requesting more scopes, see the  <<provider-scope>> section.
+
+TIP: You can also send access tokens issued by `Google` to `quarkus.oidc.application-type=service` or `quarkus.oidc.application-type=hybrid` Quarkus applications.
+
 [[microsoft]]
 === Microsoft
 
@@ -144,6 +150,10 @@ quarkus.oidc.provider=microsoft
 quarkus.oidc.client-id=<Client ID>
 quarkus.oidc.credentials.secret=<Secret>
 ----
+
+`quarkus.oidc.provider=microsoft` will request `Microsoft` to add `openid`, `email` and `profile` scopes to issued access tokens. For information about overriding these scopes or requesting more scopes, see the  <<provider-scope>> section.
+
+TIP: You can also send access tokens issued by `Microsoft` to `quarkus.oidc.application-type=service` or `quarkus.oidc.application-type=hybrid` Quarkus applications but you may need to set `quarkus.oidc.verify-access-token-with-user-info` configuration property to `true` if access tokens issued by Microsoft are not in JWT format.
 
 [NOTE]
 ====
@@ -267,6 +277,8 @@ quarkus.oidc.credentials.jwt.issuer=<App ID Prefix>
 quarkus.oidc.credentials.jwt.subject=<Bundle ID}
 ----
 
+`quarkus.oidc.provider=apple` will request `Apple` to add `openid`, `email` and `name` scopes to issued access tokens. For information about overriding these scopes or requesting more scopes, see the  <<provider-scope>> section.
+
 [[facebook]]
 === Facebook
 
@@ -306,6 +318,8 @@ quarkus.oidc.provider=facebook
 quarkus.oidc.client-id=<App ID>
 quarkus.oidc.credentials.secret=<App secret>
 ----
+
+`quarkus.oidc.provider=facebook` will request `Facebook` to add `email` and `public_profile` scopes to issued access tokens. For information about overriding these scopes or requesting more scopes, see the  <<provider-scope>> section.
 
 [[twitter]]
 === Twitter
@@ -364,6 +378,8 @@ quarkus.oidc.client-id=<Client ID>
 quarkus.oidc.credentials.secret=<Client Secret>
 ----
 
+`quarkus.oidc.provider=twitter` will request `Twitter` to add `offline.access`, `tweet.read` and `users.read` scopes to issued access tokens. For information about overriding these scopes or requesting more scopes, see the  <<provider-scope>> section.
+
 [NOTE]
 ====
 Twitter provider requires Proof Key for Code Exchange (PKCE) which is supported by the `quarkus.oidc.provider=twitter` declaration.
@@ -392,6 +408,37 @@ You can now configure your `application.properties`:
 quarkus.oidc.provider=spotify
 quarkus.oidc.client-id=<Client ID>
 quarkus.oidc.credentials.secret=<Client Secret>
+----
+
+`quarkus.oidc.provider=spotiify` will request `Spotify` to add `user-read-private` and `user-read-email` scopes to issued access tokens. For information about overriding these scopes or requesting more scopes, see the  <<provider-scope>> section.
+
+[[provider-scope]]
+== Provider scopes
+
+Each provider declaration will request one or more token scopes added to access tokens issued by a given provider. For example, `quarkus.oidc.provider=google` will request `Google` to add `openid`, `email` and `profile` scopes.
+
+You can override these scopes with `quarkus.oidc.authentication.scopes` property, for example, if you work with `Google` and would not like to have an `email` scope added to access tokens:
+
+[source,properties]
+----
+quarkus.oidc.provider=google
+quarkus.oidc.authentication.scopes=oidc,profile
+----
+
+You may also want to add one or more scopes in addition to the scopes requested by default. For example, if you would like to use an access token issued by `Google` to access `Google Calendar` service, you can do it like this:
+
+[source,properties]
+----
+quarkus.oidc.provider=google
+quarkus.oidc.authentication.extra-params.scope=https://www.googleapis.com/auth/calendar
+----
+
+It is simpler than using `quarkus.oidc.authentication.scopes` to add a new scope, because `quarkus.oidc.authentication.scopes` overrides the scopes already set by the provider declaration, which is why you need to list all the required scopes in this case:
+
+[source,properties]
+----
+quarkus.oidc.provider=google
+quarkus.oidc.authentication.scopes=oidc,email,profile,https://www.googleapis.com/auth/calendar
 ----
 
 == Support for multiple providers
@@ -461,7 +508,7 @@ Finally,  you need to configure the Google Calendar address and request  the Goo
 
 [source,properties]
 ----
-quarkus.oidc.authentication.scopes=email,profile,https://www.googleapis.com/auth/calendar
+quarkus.oidc.authentication.extra-params.scope=https://www.googleapis.com/auth/calendar
 quarkus.rest-client.google-calendar-api.url=https://www.googleapis.com/calendar/v3
 ----
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -60,6 +60,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
     static final String AMP = "&";
     static final String EQ = "=";
+    static final String COMMA = ",";
     static final String UNDERSCORE = "_";
     static final String COOKIE_DELIM = "|";
     static final Pattern COOKIE_PATTERN = Pattern.compile("\\" + COOKIE_DELIM);
@@ -580,6 +581,13 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                             scopes.add(OidcConstants.OPENID_SCOPE);
                         }
                         scopes.addAll(oidcConfigScopes);
+                        // Extra scopes if any
+                        String extraScopeValue = configContext.oidcConfig.getAuthentication().getExtraParams()
+                                .get(OidcConstants.TOKEN_SCOPE);
+                        if (extraScopeValue != null) {
+                            String[] extraScopes = extraScopeValue.split(COMMA);
+                            scopes.addAll(List.of(extraScopes));
+                        }
                         codeFlowParams.append(AMP).append(OidcConstants.TOKEN_SCOPE).append(EQ)
                                 .append(OidcCommonUtils.urlEncode(String.join(" ", scopes)));
 
@@ -1197,6 +1205,9 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     private static void addExtraParamsToUri(StringBuilder builder, Map<String, String> extraParams) {
         if (extraParams != null) {
             for (Map.Entry<String, String> entry : extraParams.entrySet()) {
+                if (entry.getKey().equals(OidcConstants.TOKEN_SCOPE)) {
+                    continue;
+                }
                 builder.append(AMP).append(entry.getKey()).append(EQ).append(OidcCommonUtils.urlEncode(entry.getValue()));
             }
         }

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -2,12 +2,13 @@ quarkus.keycloak.devservices.create-realm=false
 # Default tenant configurationf
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
-quarkus.oidc.authentication.scopes=profile,email,phone
+quarkus.oidc.authentication.scopes=profile,email
 quarkus.oidc.authentication.redirect-path=/web-app
 quarkus.oidc.authentication.restore-path-after-redirect=true
 quarkus.oidc.authentication.cookie-path-header=some-header
 quarkus.oidc.authentication.cookie-domain=localhost
 quarkus.oidc.authentication.extra-params.max-age=60
+quarkus.oidc.authentication.extra-params.scope=phone
 quarkus.oidc.application-type=web-app
 quarkus.oidc.authentication.cookie-suffix=test
 quarkus.oidc.token-state-manager.encryption-required=false


### PR DESCRIPTION
Fixes #34646

Simple PR which allows to add an extra scope as a `quarkus.oidc.authentication.extra-params` Map `scope` property, which will make it simpler adding extra scopes for `quarkus.oidc.provider` declarations - at the moment one has to use `quarkus.oidc.authentication.scopes` to add some extra scope - but also list all the other scopes this provider supports by default in order not to lose them during the override.

Updated the test - moved one of the scopes to the Map property, it is asserted it still makes it to the redirect URL here: https://github.com/quarkusio/quarkus/blob/main/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java#L425, in fact I broke a few tests before I realized that after adding the this extra scope to the `scope` query parameter, it should not be duplicated when `extra-params` are processed.

Also updated the well-known providers doc with the explanation how to override provider specific scopes or just add an extra scope


