### PR TITLE
Keep maven-repo artifact 7 days instead of 1

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -180,7 +180,7 @@ jobs:
         with:
           name: maven-repo
           path: maven-repo.tgz
-          retention-days: 1
+          retention-days: 7
       - name: Delete Local Artifacts From Cache
         shell: bash
         run: rm -r ~/.m2/repository/io/quarkus


### PR DESCRIPTION
This is useful when we want to restart a failed build. It usually happens in the next few days and we need the artifact to be around.