### PR TITLE
Add more CORS regex tests and fix the CORS regex example

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -363,7 +363,7 @@ Here's what a full CORS filter configuration could look like, including a regula
 [source, properties]
 ----
 quarkus.http.cors=true
-quarkus.http.cors.origins=http://foo.com,http://www.bar.io,/https://([a-z0-9\\-_]+)\\.app\\.mydomain\\.com/
+quarkus.http.cors.origins=http://foo.com,http://www.bar.io,/https://([a-z0-9\\-_]+)\\\\.app\\\\.mydomain\\\\.com/
 quarkus.http.cors.methods=GET,PUT,POST
 quarkus.http.cors.headers=X-Custom
 quarkus.http.cors.exposed-headers=Content-Disposition
@@ -371,7 +371,12 @@ quarkus.http.cors.access-control-max-age=24H
 quarkus.http.cors.access-control-allow-credentials=true
 ----
 
-`/https://([a-z0-9\\-_]+)\\.app\\.mydomain\\.com/` is treated as a regular expression because it is surrounded by forward slash characters.
+`/https://([a-z0-9\\-_]+)\\\\.app\\\\.mydomain\\\\.com/` is treated as a regular expression because it is surrounded by forward slash characters.
+
+[NOTE]
+====
+If you use regular expressions in an `application.properties` file, make sure 4 backward slashes are used to represent `.` and other regular expression metadata characters as normal characters, for example, `\\\\.` represents a `.` character while `\\.` represents a metadata character allowing for any character.
+====
 
 === Support all origins in devmode
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSRegexTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSRegexTestCase.java
@@ -26,8 +26,26 @@ public class CORSRegexTestCase {
     }
 
     @Test
+    public void corsRegexValidOrigin2Test() {
+        given().header("Origin", "https://abc-123.app.mydomain.com")
+                .when()
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", "https://abc-123.app.mydomain.com");
+    }
+
+    @Test
     public void corsRegexInvalidOriginTest() {
         given().header("Origin", "https://asdfdomain.com")
+                .when()
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    @Test
+    public void corsRegexInvalidOrigin2Test() {
+        given().header("Origin", "https://abc-123app.mydomain.com")
                 .when()
                 .get("/test").then()
                 .statusCode(403)

--- a/extensions/vertx-http/deployment/src/test/resources/conf/cors-regex.properties
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/cors-regex.properties
@@ -1,2 +1,2 @@
 quarkus.http.cors=true
-quarkus.http.cors.origins=/https:\\/\\/(?:[a-z0-9\\-]+\\\\.)*domain\\\\.com/
+quarkus.http.cors.origins=/https:\\/\\/(?:[a-z0-9\\-]+\\\\.)*domain\\\\.com/,/https://([a-z0-9\\-_]+)\\\\.app\\\\.mydomain\\\\.com/

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
@@ -21,7 +21,6 @@ import io.vertx.ext.web.RoutingContext;
 public class CORSFilter implements Handler<RoutingContext> {
 
     private static final Logger LOG = Logger.getLogger(CORSFilter.class);
-    private static final Pattern COMMA_SEPARATED_SPLIT_REGEX = Pattern.compile("\\s*,\\s*");
 
     // This is set in the recorder at runtime.
     // Must be static because the filter is created(deployed) at build time and runtime config is still not available

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/cors/CORSFilterTest.java
@@ -41,6 +41,7 @@ public class CORSFilterTest {
                 Optional.of(Collections.singletonList("/https://([a-z0-9\\-_]+)\\.app\\.mydomain\\.com/")));
         Assertions.assertEquals(regexList.size(), 1);
         Assertions.assertTrue(isOriginAllowedByRegex(regexList, "https://abc-123.app.mydomain.com"));
+        Assertions.assertFalse(isOriginAllowedByRegex(regexList, "https://abc-123app.mydomain.com"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #34718.

This PR adds few more tests using the regex documented  in the docs.

Note, the same regex requires different treatment when using it directly from Java (`\\.` to represent a dot char) but `\\\\.` if the same regex is supplied from the properties.

I've proposed some text suggesting why it is the case, please tune it as required. 
CC @gsmet @dmlloyd @radcortez and everyone else is welcome to comment :-)