### PR TITLE
Remove com.typesafe.netty:netty-reactive-streams exclusion from org.asynchttpclient:async-http-client

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5924,10 +5924,6 @@
                         <groupId>com.sun.activation</groupId>
                         <artifactId>jakarta.activation</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>com.typesafe.netty</groupId>
-                        <artifactId>netty-reactive-streams</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
From what I can tell, `netty-reactive-streams` is not optional for the `async-http-client`:

https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-project-2.12.3/client/pom.xml#L67-L70

In a few extensions that use it in Camel Quarkus I see:

```
2023-07-19 07:18:50,060 DEBUG [org.asy.net.han.HttpHandler] (AsyncHttpClient-3-1) Unexpected I/O exception on channel [id: 0x9ed333da, L:/127.0.0.1:49290 - R:localhost/127.0.0.1:37861]: java.lang.ClassNotFoundException: com.typesafe.netty.HandlerPublisher
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
        at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:516)
        at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:466)
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1012)
        at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:506)
        at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:466)
        at org.asynchttpclient.netty.handler.AsyncHttpClientHandler.isHandledByReactiveStreams(AsyncHttpClientHandler.java:228)
        at org.asynchttpclient.netty.handler.AsyncHttpClientHandler.channelReadComplete(AsyncHttpClientHandler.java:220)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelReadComplete(AbstractChannelHandlerContext.java:486)
```