### PR TITLE
Allow Type Reference in the Redis data source

### DIFF
--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -21,7 +21,7 @@ Typically, we recommend:
 
 This extension provides imperative and reactive APIs and low-level and high-level (type-safe) clients.
 
-== Installation
+== Use the Redis Client
 
 If you want to use this extension, you need to add the `io.quarkus:quarkus-redis` extension first.
 In your `pom.xml` file, add:
@@ -85,7 +85,7 @@ To help you select the suitable API for you, here are some recommendations:
 * If you have existing Vert.x code, use `io.vertx.redis.client.RedisAPI`
 * If you need to emit custom commands, you can either use the data sources (reactive or imperative) or the `io.vertx.mutiny.redis.client.Redis`.
 
-== Default and named clients
+== Inject the default and named clients
 
 This extension lets you configure a _default_ Redis client/data sources or _named_ ones.
 The latter is essential when you need to connect to multiple Redis instances.
@@ -135,7 +135,7 @@ public class RedisExample {
 
 TIP: You can omit the `@Inject` annotation when using `@RedisClientName`.
 
-== Connection to Redis
+== Connect to the Redis server
 
 The Redis extension can operate in 4 distinct modes:
 
@@ -151,7 +151,7 @@ The connection url is configured with the `quarkus.redis.hosts` (or `quarkus.red
 quarkus.redis.hosts=redis://[:password@]host[:port][/db-number]
 ----
 
-=== Unix Socket
+=== Use Unix Socket
 
 When using unix-socket, you need:
 
@@ -160,7 +160,7 @@ When using unix-socket, you need:
 quarkus.redis.hosts=unix://[:password@]/domain/docker.sock[?select=db-number]
 ----
 
-=== Sentinel Mode
+=== Use the Sentinel Mode
 
 When using Sentinel, you need to pass multiple _host urls_ and configure the client type to `sentinel`:
 
@@ -174,7 +174,7 @@ quarkus.redis.master-name=my-sentinel # Default is my-master
 quarkus.redis.role=master # master is the default
 ----
 
-=== Cluster Mode
+=== Use the Cluster Mode
 
 When using Redis in cluster mode, you need to pass multiple _host urls_, configure the client type to `cluster` and configure the `replicas` mode:
 
@@ -185,7 +185,7 @@ quarkus.redis.client-type=cluster
 quarkus.redis.replicas=share
 ----
 
-=== Replication Mode
+=== Use the replication Mode
 
 When using the replication mode, you need to pass a single host url and configure the type to be `replication`:
 
@@ -195,7 +195,7 @@ quarkus.redis.hosts=redis://localhost:7000
 quarkus.redis.client-type=replication
 ----
 
-=== Redis Cloud
+=== Connect to Redis Cloud
 
 To connect to redis cloud, you need the following properties:
 
@@ -205,14 +205,21 @@ quarkus.redis.hosts=<the redis cloud url such as redis://redis-12436.c14.us-east
 quarkus.redis.password=<the password>
 ----
 
-=== Authentication
+=== Use TLS
+
+To use TLS, you need to:
+
+1. Set the `quarkus.redis.tls.enabled=true` property
+2. Make sure that your URL starts with `rediss://` (with two `s`)
+
+=== Configure the authentication
 
 The Redis password can be set in the `redis://` URL or with the `quarkus.redis.password` property.
 We recommend the latter, and if possible, using secrets or an environment variable to configure the password.
 
 The associated environment variable is `QUARKUS_REDIS_PASSWORD`, or `QUARKUS_REDIS_<NAME>_PASSWORD` for named clients.
 
-== Quarkus client API for data sources
+== Use Redis data sources
 
 Quarkus exposes a high-level API on top of Redis.
 This API is type-safe and structured around the notion of _group_, inherited from the https://redis.io/commands/command-docs/[Redis command organization].
@@ -264,7 +271,6 @@ The `ReactiveRedisDataSource` is implemented on top of the `io.vertx.mutiny.redi
 As mentioned above, the API is divided into groups:
 
 - bitmap - `.bitmap()`
-- bitmap - `.bitmap()`
 - key (generic) - `.key()`
 - geo - `.geo(memberType)`
 - hash - `.hash(`valueType)`
@@ -282,7 +288,8 @@ As mentioned above, the API is divided into groups:
 - count-min - `.countmin()` (requires the https://redis.com/modules/redis-bloom/[RedisBloom] module on the server side, which also provides the count-min filter commands)
 - top-k - `.topk()` (requires the https://redis.com/modules/redis-bloom/[RedisBloom] module on the server side, which also provides the top-k filter commands)
 - graph - `.graph()` (requires the https://redis.com/modules/redis-graph/[RedisGraph] module on the server side).
-These commands are marked as experimental, as we would need feedback before making them stable.
+These commands are marked as experimental.
+Also the module has been declared _end of life_ by https://redis.com/blog/redisgraph-eol/[Redis].
 - search - `.search()` (requires the https://redis.com/modules/redis-search/[RedisSearch] module on the server side).
 - auto-suggest - `.autosuggest()` (requires the https://redis.com/modules/redis-search/[RedisSearch] module on the server side).
 - time-series - `.timeseries()` (requires the https://redis.com/modules/redis-timeseries/[Redis Time Series] module on the server side).
@@ -321,7 +328,7 @@ This object has three type parameters: the type of the key, the type of the fiel
 <3> Use the created `commands` to associate the field `field` with the value `value`
 <4> Use the created `commands` to retrieve the field `field` value.
 
-=== Serialization and Deserialization
+=== Serializing and Deserializing data
 
 The data source APIs handle the serialization and deserialization automatically.
 By default, non-standard types are serialized into JSON and deserialized from JSON.
@@ -370,7 +377,37 @@ The `canHandle` method is called to check if the codec can handle a specific typ
 The parameter received in the `encode` method matches that type.
 The object returned by the `decode` method must also match that type.
 
-=== The `value` group
+=== Use type reference
+
+Each group can be configured with `Class`, or with `TypeReference` objects.
+`TypeReference` are useful when dealing with Java generics:
+
+[source,java]
+----
+@ApplicationScoped
+public class MyRedisService {
+
+    private static final String MY_KEY = "my-key";
+
+    private final HashCommands<String, String, List<Person>> commands;
+
+    public MyRedisService(RedisDataSource ds) {
+        commands = ds.hash(new TypeReference<List<Person>>(){});
+    }
+
+    public void set(String field, List<Person> value) {
+        commands.hset(MY_KEY, field, value);
+    }
+
+    public List<Person> get(String field) {
+        return commands.hget(MY_KEY, field);
+    }
+}
+----
+
+IMPORTANT: You cannot use type references when using transaction. This is a known limitation.
+
+=== Manipulate cached and binary data with the `value` group
 
 The `value` group is used to manipulate https://redis.io/docs/manual/data-types/#strings[Redis Strings].
 Thus, this group is not limited to Java Strings but can be used for integers (like a counter) or binary content (like images).
@@ -563,7 +600,7 @@ public static class MyCache {
 }
 ----
 
-==== Redis transactions
+==== Use Redis transactions
 
 Redis transactions are slightly different from relational database transactions.
 Redis transactions are a batch of commands executed altogether.
@@ -627,7 +664,7 @@ TransactionResult result = ds.withTransaction(tx -> {
 
 IMPORTANT: You cannot use the pub/sub feature from within a transaction.
 
-==== Optimistic locking
+==== Implement the optimistic locking pattern
 
 To use optimistic locking, you need to use a variant of the `withTransaction` method, allowing the execution of code before the transaction starts.
 In other words, it will be executed as follows:
@@ -702,7 +739,7 @@ NOTE: You can also execute custom command in a transaction.
 
 On startup, you can configure the Redis client to preload data into the Redis database.
 
-=== Load scripts
+=== Configure the load scripts
 
 Specify the _load script_ you want to load using:
 
@@ -717,7 +754,7 @@ IMPORTANT: `load-script` is a build time property than cannot be overridden at r
 Note that each client can have a different script, even a list of scripts.
 In the case of a list, the data is imported in the list order (for example, first `actors.redis`, then `movies.redis` for the `my-redis` client).
 
-=== Load Script format
+=== Write load scripts
 
 The `.redis` file follows a _one command per line_ format:
 
@@ -750,7 +787,7 @@ INCR counter
 EXEC
 ----
 
-=== Configuration
+=== Configure the pre-loading
 
 The data is loaded when the application starts.
 By default, it drops the whole database before importing.
@@ -759,7 +796,7 @@ You can prevent this using `quarkus.redis.flush-before-load=false`.
 Also, the import process only runs if the database is empty (no key).
 You can force to import even if there is data using the `quarkus.redis.load-only-if-empty=false`
 
-=== Dev/Test vs. Prod
+=== Distinguish dev/test vs. prod when pre-loading
 
 As mentioned above, in dev and test modes, Quarkus tries to import data by looking for the `src/main/resources/import.redis`.
 This behavior is disabled in _prod_ mode, and if you want to import even in production, add:
@@ -773,20 +810,12 @@ Before importing in _prod_ mode, make sure you configured `quarkus.redis.flush-b
 
 IMPORTANT: In dev mode, to reload the content of the `.redis` load scripts, you need to add: `%dev.quarkus.vertx.caching=false`
 
-== Vert.x Redis Client
+== Use the Vert.x redis client
 
 In addition to the high-level API, you can use the Vertx Redis clients directly in your code.
 The documentation of the Vert.x Redis Client is available on the https://vertx.io/docs/vertx-redis-client/java/[Vert.x Web Site].
 
-== Redis Health Check
-
-If you are using the `quarkus-smallrye-health` extension, `quarkus-redis` will automatically add a readiness health check to validate the connection to the Redis server.
-
-So when you access the `/q/health/ready` endpoint of your application you will have information about the connection validation status.
-
-This behavior can be disabled by setting the `quarkus.redis.health.enabled` property to `false` in your `application.properties`.
-
-== Programmatic Redis Hosts
+== Configure Redis hosts programmatically
 
 The `RedisHostsProvider` programmatically provides redis hosts.
 This allows for configuration of properties like redis connection password coming from other sources.
@@ -839,13 +868,21 @@ public static class MyExampleCustomizer implements RedisOptionsCustomizer {
 }
 ----
 
-=== Dev Services
+=== Use the Redis Dev Services
 
 See xref:redis-dev-services.adoc[Redis Dev Service].
 
-== Redis client metrics
+== Configure Redis observability
 
-=== Enable metrics collection
+=== Enable the health checks
+
+If you are using the `quarkus-smallrye-health` extension, `quarkus-redis` will automatically add a readiness health check to validate the connection to the Redis server.
+
+So when you access the `/q/health/ready` endpoint of your application you will have information about the connection validation status.
+
+This behavior can be disabled by setting the `quarkus.redis.health.enabled` property to `false` in your `application.properties`.
+
+=== Enable metrics
 
 Redis client metrics are automatically enabled when the application also uses the xref:telemetry-micrometer.adoc[`quarkus-micrometer`] extension.
 Micrometer collects the metrics of all the Redis clients implemented by the application.
@@ -905,7 +942,7 @@ The Redis client name can be found in the _tags_.
 
 The metrics contain both the Redis connection pool metrics (`redis_pool_*`) and the metrics about the command execution (`redis_commands_*`) such as the number of command, successes, failures, and durations.
 
-=== Disable metrics collection
+=== Disable metrics
 
 To disable the Redis client metrics when `quarkus-micrometer` is used, add the following property to the application configuration:
 

--- a/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheImpl.java
+++ b/extensions/redis-cache/runtime/src/main/java/io/quarkus/cache/redis/runtime/RedisCacheImpl.java
@@ -283,7 +283,7 @@ public class RedisCacheImpl extends AbstractCache implements RedisCache {
     @Override
     public Uni<Void> invalidateIf(Predicate<Object> predicate) {
         return redis.send(Request.cmd(Command.KEYS).arg(getKeyPattern()))
-                .map(response -> marshaller.decodeAsList(response, String.class))
+                .<List<String>> map(response -> marshaller.decodeAsList(response, String.class))
                 .chain(new Function<List<String>, Uni<?>>() {
                     @Override
                     public Uni<?> apply(List<String> listOfKeys) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
@@ -1,7 +1,11 @@
 package io.quarkus.redis.datasource;
 
+import static io.quarkus.redis.runtime.datasource.Marshaller.STRING_TYPE_REFERENCE;
+
 import java.util.function.BiFunction;
 import java.util.function.Function;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import io.quarkus.redis.datasource.autosuggest.ReactiveAutoSuggestCommands;
 import io.quarkus.redis.datasource.bitmap.ReactiveBitMapCommands;
@@ -166,6 +170,25 @@ public interface ReactiveRedisDataSource {
     <K, F, V> ReactiveHashCommands<K, F, V> hash(Class<K> redisKeyType, Class<F> fieldType, Class<V> valueType);
 
     /**
+     * Gets the object to execute commands manipulating hashes (a.k.a. {@code Map&lt;F, V&gt;}).
+     * <p>
+     * If you want to use a hash of {@code &lt;String -> Person&gt;} stored using String identifier, you would use:
+     * {@code hash(String.class, String.class, Person.class)}.
+     * If you want to use a hash of {@code &lt;String -> Person&gt;} stored using UUID identifier, you would use:
+     * {@code hash(UUID.class, String.class, Person.class)}.
+     *
+     * @param redisKeyType the class of the keys
+     * @param fieldType the class of the fields
+     * @param valueType the class of the values
+     * @param <K> the type of the redis key
+     * @param <F> the type of the fields (map's keys)
+     * @param <V> the type of the value
+     * @return the object to execute commands manipulating hashes (a.k.a. {@code Map&lt;K, V&gt;}).
+     */
+    <K, F, V> ReactiveHashCommands<K, F, V> hash(TypeReference<K> redisKeyType, TypeReference<F> fieldType,
+            TypeReference<V> valueType);
+
+    /**
      * Gets the object to execute commands manipulating hashes (a.k.a. {@code Map&lt;String, V&gt;}).
      * <p>
      * This is a shortcut on {@code hash(String.class, String.class, V)}
@@ -176,6 +199,19 @@ public interface ReactiveRedisDataSource {
      */
     default <V> ReactiveHashCommands<String, String, V> hash(Class<V> typeOfValue) {
         return hash(String.class, String.class, typeOfValue);
+    }
+
+    /**
+     * Gets the object to execute commands manipulating hashes (a.k.a. {@code Map&lt;String, V&gt;}).
+     * <p>
+     * This is a shortcut on {@code hash(String.class, String.class, V)}
+     *
+     * @param typeOfValue the class of the values
+     * @param <V> the type of the value
+     * @return the object to execute commands manipulating hashes (a.k.a. {@code Map&lt;String, V&gt;}).
+     */
+    default <V> ReactiveHashCommands<String, String, V> hash(TypeReference<V> typeOfValue) {
+        return hash(STRING_TYPE_REFERENCE, STRING_TYPE_REFERENCE, typeOfValue);
     }
 
     /**
@@ -196,12 +232,38 @@ public interface ReactiveRedisDataSource {
      * <p>
      * {@code V} represents the type of the member, i.e. the localized <em>thing</em>.
      *
+     * @param redisKeyType the class of the keys
+     * @param memberType the class of the members
+     * @param <K> the type of the redis key
+     * @param <V> the type of the member
+     * @return the object to execute geo commands.
+     */
+    <K, V> ReactiveGeoCommands<K, V> geo(TypeReference<K> redisKeyType, TypeReference<V> memberType);
+
+    /**
+     * Gets the object to execute commands manipulating geo items (a.k.a. {@code {longitude, latitude, member}}).
+     * <p>
+     * {@code V} represents the type of the member, i.e. the localized <em>thing</em>.
+     *
      * @param memberType the class of the members
      * @param <V> the type of the member
      * @return the object to execute geo commands.
      */
     default <V> ReactiveGeoCommands<String, V> geo(Class<V> memberType) {
         return geo(String.class, memberType);
+    }
+
+    /**
+     * Gets the object to execute commands manipulating geo items (a.k.a. {@code {longitude, latitude, member}}).
+     * <p>
+     * {@code V} represents the type of the member, i.e. the localized <em>thing</em>.
+     *
+     * @param memberType the class of the members
+     * @param <V> the type of the member
+     * @return the object to execute geo commands.
+     */
+    default <V> ReactiveGeoCommands<String, V> geo(TypeReference<V> memberType) {
+        return geo(STRING_TYPE_REFERENCE, memberType);
     }
 
     /**
@@ -212,6 +274,15 @@ public interface ReactiveRedisDataSource {
      * @return the object to execute commands manipulating keys.
      */
     <K> ReactiveKeyCommands<K> key(Class<K> redisKeyType);
+
+    /**
+     * Gets the object to execute commands manipulating keys and expiration times.
+     *
+     * @param redisKeyType the type of the keys
+     * @param <K> the type of the key
+     * @return the object to execute commands manipulating keys.
+     */
+    <K> ReactiveKeyCommands<K> key(TypeReference<K> redisKeyType);
 
     /**
      * Gets the object to execute commands manipulating keys and expiration times.
@@ -236,12 +307,34 @@ public interface ReactiveRedisDataSource {
     /**
      * Gets the object to execute commands manipulating sorted sets.
      *
+     * @param redisKeyType the type of the keys
+     * @param valueType the type of the value sorted in the sorted sets
+     * @param <K> the type of the key
+     * @param <V> the type of the value
+     * @return the object to manipulate sorted sets.
+     */
+    <K, V> ReactiveSortedSetCommands<K, V> sortedSet(TypeReference<K> redisKeyType, TypeReference<V> valueType);
+
+    /**
+     * Gets the object to execute commands manipulating sorted sets.
+     *
      * @param valueType the type of the value sorted in the sorted sets
      * @param <V> the type of the value
      * @return the object to manipulate sorted sets.
      */
     default <V> ReactiveSortedSetCommands<String, V> sortedSet(Class<V> valueType) {
         return sortedSet(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to execute commands manipulating sorted sets.
+     *
+     * @param valueType the type of the value sorted in the sorted sets
+     * @param <V> the type of the value
+     * @return the object to manipulate sorted sets.
+     */
+    default <V> ReactiveSortedSetCommands<String, V> sortedSet(TypeReference<V> valueType) {
+        return sortedSet(STRING_TYPE_REFERENCE, valueType);
     }
 
     /**
@@ -264,12 +357,40 @@ public interface ReactiveRedisDataSource {
      * <strong>NOTE:</strong> Instead of {@code string}, this group is named {@code value} to avoid the confusion with the
      * Java String type. Indeed, Redis strings can be strings, numbers, byte arrays...
      *
+     * @param redisKeyType the type of the keys
+     * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
+     * @param <K> the type of the key
+     * @param <V> the type of the value
+     * @return the object to manipulate stored strings.
+     */
+    <K, V> ReactiveValueCommands<K, V> value(TypeReference<K> redisKeyType, TypeReference<V> valueType);
+
+    /**
+     * Gets the object to execute commands manipulating stored strings.
+     * <p>
+     * <strong>NOTE:</strong> Instead of {@code string}, this group is named {@code value} to avoid the confusion with the
+     * Java String type. Indeed, Redis strings can be strings, numbers, byte arrays...
+     *
      * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
      * @param <V> the type of the value
      * @return the object to manipulate stored strings.
      */
     default <V> ReactiveValueCommands<String, V> value(Class<V> valueType) {
         return value(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to execute commands manipulating stored strings.
+     * <p>
+     * <strong>NOTE:</strong> Instead of {@code string}, this group is named {@code value} to avoid the confusion with the
+     * Java String type. Indeed, Redis strings can be strings, numbers, byte arrays...
+     *
+     * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
+     * @param <V> the type of the value
+     * @return the object to manipulate stored strings.
+     */
+    default <V> ReactiveValueCommands<String, V> value(TypeReference<V> valueType) {
+        return value(STRING_TYPE_REFERENCE, valueType);
     }
 
     /**
@@ -312,12 +433,34 @@ public interface ReactiveRedisDataSource {
     /**
      * Gets the object to execute commands manipulating sets.
      *
+     * @param redisKeyType the type of the keys
+     * @param memberType the type of the member stored in each set
+     * @param <K> the type of the key
+     * @param <V> the type of the member
+     * @return the object to manipulate sets.
+     */
+    <K, V> ReactiveSetCommands<K, V> set(TypeReference<K> redisKeyType, TypeReference<V> memberType);
+
+    /**
+     * Gets the object to execute commands manipulating sets.
+     *
      * @param memberType the type of the member stored in each set
      * @param <V> the type of the member
      * @return the object to manipulate sets.
      */
     default <V> ReactiveSetCommands<String, V> set(Class<V> memberType) {
         return set(String.class, memberType);
+    }
+
+    /**
+     * Gets the object to execute commands manipulating sets.
+     *
+     * @param memberType the type of the member stored in each set
+     * @param <V> the type of the member
+     * @return the object to manipulate sets.
+     */
+    default <V> ReactiveSetCommands<String, V> set(TypeReference<V> memberType) {
+        return set(STRING_TYPE_REFERENCE, memberType);
     }
 
     /**
@@ -343,6 +486,28 @@ public interface ReactiveRedisDataSource {
     }
 
     /**
+     * Gets the object to execute commands manipulating lists.
+     *
+     * @param redisKeyType the type of the keys
+     * @param memberType the type of the member stored in each list
+     * @param <K> the type of the key
+     * @param <V> the type of the member
+     * @return the object to manipulate sets.
+     */
+    <K, V> ReactiveListCommands<K, V> list(TypeReference<K> redisKeyType, TypeReference<V> memberType);
+
+    /**
+     * Gets the object to execute commands manipulating lists.
+     *
+     * @param memberType the type of the member stored in each list
+     * @param <V> the type of the member
+     * @return the object to manipulate sets.
+     */
+    default <V> ReactiveListCommands<String, V> list(TypeReference<V> memberType) {
+        return list(STRING_TYPE_REFERENCE, memberType);
+    }
+
+    /**
      * Gets the object to execute commands manipulating hyperloglog data structures.
      *
      * @param redisKeyType the type of the keys
@@ -356,12 +521,34 @@ public interface ReactiveRedisDataSource {
     /**
      * Gets the object to execute commands manipulating hyperloglog data structures.
      *
+     * @param redisKeyType the type of the keys
+     * @param memberType the type of the member stored in the data structure
+     * @param <K> the type of the key
+     * @param <V> the type of the member
+     * @return the object to manipulate hyper log log data structures.
+     */
+    <K, V> ReactiveHyperLogLogCommands<K, V> hyperloglog(TypeReference<K> redisKeyType, TypeReference<V> memberType);
+
+    /**
+     * Gets the object to execute commands manipulating hyperloglog data structures.
+     *
      * @param memberType the type of the member stored in the data structure
      * @param <V> the type of the member
      * @return the object to manipulate hyper log log data structures.
      */
     default <V> ReactiveHyperLogLogCommands<String, V> hyperloglog(Class<V> memberType) {
         return hyperloglog(String.class, memberType);
+    }
+
+    /**
+     * Gets the object to execute commands manipulating hyperloglog data structures.
+     *
+     * @param memberType the type of the member stored in the data structure
+     * @param <V> the type of the member
+     * @return the object to manipulate hyper log log data structures.
+     */
+    default <V> ReactiveHyperLogLogCommands<String, V> hyperloglog(TypeReference<V> memberType) {
+        return hyperloglog(STRING_TYPE_REFERENCE, memberType);
     }
 
     /**
@@ -372,6 +559,15 @@ public interface ReactiveRedisDataSource {
      * @return the object to manipulate bitmap data structures.
      */
     <K> ReactiveBitMapCommands<K> bitmap(Class<K> redisKeyType);
+
+    /**
+     * Gets the object to execute commands manipulating bitmap data structures.
+     *
+     * @param redisKeyType the type of the keys
+     * @param <K> the type of the key
+     * @return the object to manipulate bitmap data structures.
+     */
+    <K> ReactiveBitMapCommands<K> bitmap(TypeReference<K> redisKeyType);
 
     /**
      * Gets the object to execute commands manipulating bitmap data structures.
@@ -396,6 +592,20 @@ public interface ReactiveRedisDataSource {
     <K, F, V> ReactiveStreamCommands<K, F, V> stream(Class<K> redisKeyType, Class<F> fieldType, Class<V> valueType);
 
     /**
+     * Gets the object to execute commands manipulating streams.
+     *
+     * @param redisKeyType the class of the keys
+     * @param fieldType the class of the fields included in the message exchanged on the streams
+     * @param valueType the class of the values included in the message exchanged on the streams
+     * @param <K> the type of the redis key
+     * @param <F> the type of the fields (map's keys)
+     * @param <V> the type of the value
+     * @return the object to execute commands manipulating streams.
+     */
+    <K, F, V> ReactiveStreamCommands<K, F, V> stream(TypeReference<K> redisKeyType, TypeReference<F> fieldType,
+            TypeReference<V> valueType);
+
+    /**
      * Gets the object to execute commands manipulating streams, using a string key, and string fields.
      *
      * @param <V> the type of the value
@@ -406,6 +616,16 @@ public interface ReactiveRedisDataSource {
     }
 
     /**
+     * Gets the object to execute commands manipulating streams, using a string key, and string fields.
+     *
+     * @param <V> the type of the value
+     * @return the object to execute commands manipulating streams.
+     */
+    default <V> ReactiveStreamCommands<String, String, V> stream(TypeReference<V> typeOfValue) {
+        return stream(STRING_TYPE_REFERENCE, STRING_TYPE_REFERENCE, typeOfValue);
+    }
+
+    /**
      * Gets the object to publish and receive messages.
      *
      * @param messageType the type of message
@@ -413,6 +633,15 @@ public interface ReactiveRedisDataSource {
      * @return the object to publish and subscribe to Redis channels
      */
     <V> ReactivePubSubCommands<V> pubsub(Class<V> messageType);
+
+    /**
+     * Gets the object to publish and receive messages.
+     *
+     * @param messageType the type of message
+     * @param <V> the type of message
+     * @return the object to publish and subscribe to Redis channels
+     */
+    <V> ReactivePubSubCommands<V> pubsub(TypeReference<V> messageType);
 
     /**
      * Gets the object to manipulate JSON values.
@@ -434,6 +663,15 @@ public interface ReactiveRedisDataSource {
     <K> ReactiveJsonCommands<K> json(Class<K> redisKeyType);
 
     /**
+     * Gets the object to manipulate JSON values.
+     * This group requires the <a href="https://redis.io/docs/stack/json/">RedisJSON module</a>.
+     *
+     * @param <K> the type of keys
+     * @return the object to manipulate JSON values.
+     */
+    <K> ReactiveJsonCommands<K> json(TypeReference<K> redisKeyType);
+
+    /**
      * Gets the object to manipulate Bloom filters.
      * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a>.
      *
@@ -448,11 +686,32 @@ public interface ReactiveRedisDataSource {
      * Gets the object to manipulate Bloom filters.
      * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a>.
      *
+     * @param <V> the type of the values added into the Bloom filter
+     * @return the object to manipulate bloom values.
+     */
+    default <V> ReactiveBloomCommands<String, V> bloom(TypeReference<V> valueType) {
+        return bloom(STRING_TYPE_REFERENCE, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Bloom filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a>.
+     *
      * @param <K> the type of keys
      * @param <V> the type of the values added into the Bloom filter
      * @return the object to manipulate bloom values.
      */
     <K, V> ReactiveBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Bloom filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a>.
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the Bloom filter
+     * @return the object to manipulate bloom values.
+     */
+    <K, V> ReactiveBloomCommands<K, V> bloom(TypeReference<K> redisKeyType, TypeReference<V> valueType);
 
     /**
      * Gets the object to manipulate Cuckoo filters.
@@ -471,11 +730,34 @@ public interface ReactiveRedisDataSource {
      * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the Cuckoo
      * filter support).
      *
+     * @param <V> the type of the values added into the Cuckoo filter
+     * @return the object to manipulate Cuckoo values.
+     */
+    default <V> ReactiveCuckooCommands<String, V> cuckoo(TypeReference<V> valueType) {
+        return cuckoo(STRING_TYPE_REFERENCE, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Cuckoo filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the Cuckoo
+     * filter support).
+     *
      * @param <K> the type of keys
      * @param <V> the type of the values added into the Cuckoo filter
      * @return the object to manipulate Cuckoo values.
      */
     <K, V> ReactiveCuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Cuckoo filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the Cuckoo
+     * filter support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the Cuckoo filter
+     * @return the object to manipulate Cuckoo values.
+     */
+    <K, V> ReactiveCuckooCommands<K, V> cuckoo(TypeReference<K> redisKeyType, TypeReference<V> valueType);
 
     /**
      * Gets the object to manipulate Count-Min sketches.
@@ -494,11 +776,34 @@ public interface ReactiveRedisDataSource {
      * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
      * sketches support).
      *
+     * @param <V> the type of the values added into the count-min sketches
+     * @return the object to manipulate count-min sketches.
+     */
+    default <V> ReactiveCountMinCommands<String, V> countmin(TypeReference<V> valueType) {
+        return countmin(STRING_TYPE_REFERENCE, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Count-Min sketches.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
+     * sketches support).
+     *
      * @param <K> the type of keys
      * @param <V> the type of the values added into the count-min sketches
      * @return the object to manipulate count-min sketches.
      */
     <K, V> ReactiveCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Count-Min sketches.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
+     * sketches support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the count-min sketches
+     * @return the object to manipulate count-min sketches.
+     */
+    <K, V> ReactiveCountMinCommands<K, V> countmin(TypeReference<K> redisKeyType, TypeReference<V> valueType);
 
     /**
      * Gets the object to manipulate Top-K list.
@@ -517,11 +822,34 @@ public interface ReactiveRedisDataSource {
      * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the top-k
      * list support).
      *
+     * @param <V> the type of the values added into the top-k lists
+     * @return the object to manipulate top-k lists.
+     */
+    default <V> ReactiveTopKCommands<String, V> topk(TypeReference<V> valueType) {
+        return topk(STRING_TYPE_REFERENCE, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Top-K list.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the top-k
+     * list support).
+     *
      * @param <K> the type of keys
      * @param <V> the type of the values added into the top-k lists
      * @return the object to manipulate top-k lists.
      */
     <K, V> ReactiveTopKCommands<K, V> topk(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Top-K list.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the top-k
+     * list support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the top-k lists
+     * @return the object to manipulate top-k lists.
+     */
+    <K, V> ReactiveTopKCommands<K, V> topk(TypeReference<K> redisKeyType, TypeReference<V> valueType);
 
     /**
      * Gets the object to manipulate graphs.
@@ -550,8 +878,10 @@ public interface ReactiveRedisDataSource {
      *
      * @param <K> the type of keys
      * @return the object to search documents
+     * @deprecated Use the variant without parameter, as the index name must be a string.
      */
     @Experimental("The Redis search support is experimental")
+    @Deprecated
     <K> ReactiveSearchCommands<K> search(Class<K> redisKeyType);
 
     /**
@@ -579,6 +909,16 @@ public interface ReactiveRedisDataSource {
      * Gets the object to emit commands from the {@code auto-suggest} group.
      * This group requires the <a href="https://redis.io/docs/stack/search/">RedisSearch module</a>.
      *
+     * @param <K> the type of keys
+     * @return the object to get suggestions
+     */
+    @Experimental("The Redis auto-suggest support is experimental")
+    <K> ReactiveAutoSuggestCommands<K> autosuggest(TypeReference<K> redisKeyType);
+
+    /**
+     * Gets the object to emit commands from the {@code auto-suggest} group.
+     * This group requires the <a href="https://redis.io/docs/stack/search/">RedisSearch module</a>.
+     *
      * @return the object to get suggestions
      */
     @Experimental("The Redis auto-suggest support is experimental")
@@ -595,6 +935,16 @@ public interface ReactiveRedisDataSource {
      */
     @Experimental("The Redis time series support is experimental")
     <K> ReactiveTimeSeriesCommands<K> timeseries(Class<K> redisKeyType);
+
+    /**
+     * Gets the object to emit commands from the {@code time series} group.
+     * This group requires the <a href="https://redis.io/docs/stack/timeseries/">Redis Time Series module</a>.
+     *
+     * @param <K> the type of keys
+     * @return the object to manipulate time series
+     */
+    @Experimental("The Redis time series support is experimental")
+    <K> ReactiveTimeSeriesCommands<K> timeseries(TypeReference<K> redisKeyType);
 
     /**
      * Gets the object to emit commands from the {@code time series} group.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/codecs/Codecs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/codecs/Codecs.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.datasource.codecs;
 
+import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -7,8 +8,12 @@ import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.jackson.DatabindCodec;
 
 public class Codecs {
 
@@ -39,11 +44,24 @@ public class Codecs {
     }
 
     public static class JsonCodec implements Codec {
-
-        private final Type clazz;
+        private final TypeReference<?> type;
+        private final Class<?> clazz;
+        private final ObjectMapper mapper;
 
         public JsonCodec(Type clazz) {
-            this.clazz = clazz;
+            if (clazz instanceof Class) {
+                this.clazz = (Class<?>) clazz;
+                this.type = null;
+            } else {
+                this.type = new TypeReference<>() {
+                    @Override
+                    public Type getType() {
+                        return clazz;
+                    }
+                };
+                this.clazz = null;
+            }
+            this.mapper = DatabindCodec.mapper();
         }
 
         @Override
@@ -58,8 +76,15 @@ public class Codecs {
 
         @Override
         public Object decode(byte[] payload) {
-            // TODO This would need to be revisited when we use TypeReference.
-            return Json.decodeValue(Buffer.buffer(payload), (Class<?>) clazz);
+            try {
+                if (clazz != null) {
+                    return Json.decodeValue(Buffer.buffer(payload), clazz);
+                } else {
+                    return mapper.readValue(payload, type);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractAutoSuggestCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractAutoSuggestCommands.java
@@ -3,6 +3,8 @@ package io.quarkus.redis.runtime.datasource;
 import static io.quarkus.redis.runtime.datasource.Validation.notNullOrBlank;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
+
 import io.quarkus.redis.datasource.autosuggest.GetArgs;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Command;
@@ -10,7 +12,7 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class AbstractAutoSuggestCommands<K> extends AbstractRedisCommands {
 
-    AbstractAutoSuggestCommands(RedisCommandExecutor redis, Class<K> k) {
+    AbstractAutoSuggestCommands(RedisCommandExecutor redis, Type k) {
         super(redis, new Marshaller(k));
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractBitMapCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractBitMapCommands.java
@@ -4,6 +4,7 @@ import static io.quarkus.redis.runtime.datasource.Validation.isBit;
 import static io.quarkus.redis.runtime.datasource.Validation.notNullOrEmpty;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.util.List;
 
 import io.quarkus.redis.datasource.bitmap.BitFieldArgs;
@@ -13,7 +14,7 @@ import io.vertx.mutiny.redis.client.Response;
 
 class AbstractBitMapCommands<K> extends AbstractRedisCommands {
 
-    AbstractBitMapCommands(RedisCommandExecutor redis, Class<K> k) {
+    AbstractBitMapCommands(RedisCommandExecutor redis, Type k) {
         super(redis, new Marshaller(k));
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractBloomCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractBloomCommands.java
@@ -3,6 +3,8 @@ package io.quarkus.redis.runtime.datasource;
 import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
+
 import io.quarkus.redis.datasource.bloom.BfInsertArgs;
 import io.quarkus.redis.datasource.bloom.BfReserveArgs;
 import io.smallrye.mutiny.Uni;
@@ -11,7 +13,7 @@ import io.vertx.mutiny.redis.client.Response;
 
 class AbstractBloomCommands<K, V> extends AbstractRedisCommands {
 
-    AbstractBloomCommands(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    AbstractBloomCommands(RedisCommandExecutor redis, Type k, Type v) {
         super(redis, new Marshaller(k, v));
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCountMinCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCountMinCommands.java
@@ -4,6 +4,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.isNotEmpty;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 
@@ -13,7 +14,7 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class AbstractCountMinCommands<K, V> extends AbstractRedisCommands {
 
-    AbstractCountMinCommands(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    AbstractCountMinCommands(RedisCommandExecutor redis, Type k, Type v) {
         super(redis, new Marshaller(k, v));
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCuckooCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCuckooCommands.java
@@ -3,6 +3,8 @@ package io.quarkus.redis.runtime.datasource;
 import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
+
 import io.quarkus.redis.datasource.cuckoo.CfInsertArgs;
 import io.quarkus.redis.datasource.cuckoo.CfReserveArgs;
 import io.smallrye.mutiny.Uni;
@@ -11,7 +13,7 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class AbstractCuckooCommands<K, V> extends AbstractRedisCommands {
 
-    AbstractCuckooCommands(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    AbstractCuckooCommands(RedisCommandExecutor redis, Type k, Type v) {
         super(redis, new Marshaller(k, v));
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractGeoCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractGeoCommands.java
@@ -7,6 +7,7 @@ import static io.quarkus.redis.runtime.datasource.Validation.validateLongitude;
 import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalDouble;
@@ -31,13 +32,13 @@ import io.vertx.mutiny.redis.client.Response;
 
 class AbstractGeoCommands<K, V> extends AbstractRedisCommands {
 
-    protected final Class<V> typeOfValue;
+    protected final Type typeOfValue;
     protected final Codec keyCodec;
     protected final Codec valueCodec;
 
     private static final Pattern NOISE_REMOVER_PATTERN = Pattern.compile("[^a-zA-Z0-9\\.]");
 
-    AbstractGeoCommands(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    AbstractGeoCommands(RedisCommandExecutor redis, Type k, Type v) {
         super(redis, new Marshaller(k, v));
         this.typeOfValue = v;
         this.keyCodec = Codecs.getDefaultCodecFor(k);

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractGraphCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractGraphCommands.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.runtime.datasource;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.time.Duration;
 
 import io.smallrye.mutiny.Uni;
@@ -10,7 +11,7 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class AbstractGraphCommands<K> extends AbstractRedisCommands {
 
-    AbstractGraphCommands(RedisCommandExecutor redis, Class<K> k) {
+    AbstractGraphCommands(RedisCommandExecutor redis, Type k) {
         super(redis, new Marshaller(k));
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractHashCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractHashCommands.java
@@ -5,6 +5,7 @@ import static io.quarkus.redis.runtime.datasource.Validation.positive;
 import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -16,10 +17,10 @@ import io.vertx.mutiny.redis.client.Response;
 
 class AbstractHashCommands<K, F, V> extends AbstractRedisCommands {
 
-    protected final Class<V> typeOfValue;
-    protected final Class<F> typeOfField;
+    protected final Type typeOfValue;
+    protected final Type typeOfField;
 
-    AbstractHashCommands(RedisCommandExecutor redis, Class<K> k, Class<F> f, Class<V> v) {
+    AbstractHashCommands(RedisCommandExecutor redis, Type k, Type f, Type v) {
         super(redis, new Marshaller(k, f, v));
         this.typeOfField = f;
         this.typeOfValue = v;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractHyperLogLogCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractHyperLogLogCommands.java
@@ -4,13 +4,15 @@ import static io.quarkus.redis.runtime.datasource.Validation.notNullOrEmpty;
 import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
+
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Response;
 
 class AbstractHyperLogLogCommands<K, V> extends AbstractRedisCommands {
 
-    AbstractHyperLogLogCommands(RedisCommandExecutor api, Class<K> k, Class<V> v) {
+    AbstractHyperLogLogCommands(RedisCommandExecutor api, Type k, Type v) {
         super(api, new Marshaller(k, v));
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractJsonCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractJsonCommands.java
@@ -4,6 +4,7 @@ import static io.quarkus.redis.runtime.datasource.Validation.notNullOrBlank;
 import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,7 +19,7 @@ import io.vertx.mutiny.redis.client.Response;
 public class AbstractJsonCommands<K> extends AbstractRedisCommands {
     private static final JsonSetArgs JSON_SET_DEFAULT = new JsonSetArgs();
 
-    public AbstractJsonCommands(RedisCommandExecutor api, Class<K> k) {
+    public AbstractJsonCommands(RedisCommandExecutor api, Type k) {
         super(api, new Marshaller(k));
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractKeyCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractKeyCommands.java
@@ -8,6 +8,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.positiveOrZero;
 import static io.vertx.mutiny.redis.client.Command.EXPIRETIME;
 import static io.vertx.mutiny.redis.client.Command.PEXPIRETIME;
 
+import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -24,9 +25,9 @@ import io.vertx.mutiny.redis.client.Response;
 
 class AbstractKeyCommands<K> extends AbstractRedisCommands {
 
-    protected final Class<K> typeOfKey;
+    protected final Type typeOfKey;
 
-    AbstractKeyCommands(RedisCommandExecutor redis, Class<K> k) {
+    AbstractKeyCommands(RedisCommandExecutor redis, Type k) {
         super(redis, new Marshaller(k));
         this.typeOfKey = k;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractListCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractListCommands.java
@@ -6,6 +6,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
 import static io.smallrye.mutiny.helpers.ParameterValidation.validate;
 
+import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,15 +21,15 @@ import io.vertx.mutiny.redis.client.Response;
 
 class AbstractListCommands<K, V> extends ReactiveSortable<K, V> {
 
-    protected final Class<V> typeOfValue;
-    protected final Class<K> typeOfKey;
+    protected final Type typeOfValue;
+    protected final Type typeOfKey;
 
     protected static final LPosArgs DEFAULT_INSTANCE = new LPosArgs();
 
     public static final Command LMPOP = Command.create("lmpop");
     public static final Command BLMPOP = Command.create("blmpop");
 
-    AbstractListCommands(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    AbstractListCommands(RedisCommandExecutor redis, Type k, Type v) {
         super(redis, new Marshaller(k, v), v);
         this.typeOfKey = k;
         this.typeOfValue = v;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSearchCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSearchCommands.java
@@ -7,6 +7,8 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
 import static io.smallrye.mutiny.helpers.ParameterValidation.positiveOrZero;
 
+import java.lang.reflect.Type;
+
 import io.quarkus.redis.datasource.search.AggregateArgs;
 import io.quarkus.redis.datasource.search.CreateArgs;
 import io.quarkus.redis.datasource.search.IndexedField;
@@ -18,7 +20,7 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class AbstractSearchCommands<K> extends AbstractRedisCommands {
 
-    AbstractSearchCommands(RedisCommandExecutor redis, Class<K> k) {
+    AbstractSearchCommands(RedisCommandExecutor redis, Type k) {
         super(redis, new Marshaller(k));
     }
 
@@ -82,10 +84,6 @@ public class AbstractSearchCommands<K> extends AbstractRedisCommands {
                 .put("ADD")
                 .putArgs(field);
         return execute(cmd);
-    }
-
-    Uni<Response> _ftAlter(String index, IndexedField field) {
-        return _ftAlter(index, field, false);
     }
 
     Uni<Response> _ftCreate(String index, CreateArgs args) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSetCommands.java
@@ -5,6 +5,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Set;
 
@@ -14,11 +15,11 @@ import io.vertx.mutiny.redis.client.Response;
 
 class AbstractSetCommands<K, V> extends ReactiveSortable<K, V> {
 
-    protected final Class<V> typeOfValue;
+    protected final Type typeOfValue;
 
     public static final Command SINTERCARD = Command.create("sintercard");
 
-    AbstractSetCommands(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    AbstractSetCommands(RedisCommandExecutor redis, Type k, Type v) {
         super(redis, new Marshaller(k, v), v);
         this.typeOfValue = v;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSortedSetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractSortedSetCommands.java
@@ -9,6 +9,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.validate;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.POSITIVE_INFINITY;
 
+import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,8 +33,8 @@ import io.vertx.redis.client.ResponseType;
 
 class AbstractSortedSetCommands<K, V> extends ReactiveSortable<K, V> {
 
-    protected final Class<V> typeOfValue;
-    protected final Class<K> typeOfKey;
+    protected final Type typeOfValue;
+    protected final Type typeOfKey;
 
     protected static final ZAggregateArgs DEFAULT_INSTANCE_AGG = new ZAggregateArgs();
     protected static final ZRangeArgs DEFAULT_INSTANCE_RANGE = new ZRangeArgs();
@@ -42,7 +43,7 @@ class AbstractSortedSetCommands<K, V> extends ReactiveSortable<K, V> {
     public static final Command ZMPOP = Command.create("zmpop");
     public static final Command BZMPOP = Command.create("bzmpop");
 
-    AbstractSortedSetCommands(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    AbstractSortedSetCommands(RedisCommandExecutor redis, Type k, Type v) {
         super(redis, new Marshaller(k, v), v);
         this.typeOfValue = v;
         this.typeOfKey = k;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractStreamCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractStreamCommands.java
@@ -6,6 +6,7 @@ import static io.quarkus.redis.runtime.datasource.Validation.positive;
 import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +28,7 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class AbstractStreamCommands<K, F, V> extends AbstractRedisCommands {
 
-    AbstractStreamCommands(RedisCommandExecutor redis, Class<K> k, Class<F> m, Class<V> v) {
+    AbstractStreamCommands(RedisCommandExecutor redis, Type k, Type m, Type v) {
         super(redis, new Marshaller(k, m, v));
     }
 
@@ -318,7 +319,7 @@ public class AbstractStreamCommands<K, F, V> extends AbstractRedisCommands {
         return execute(cmd);
     }
 
-    private <K> void writeStreamsAndIds(Map<K, String> lastIdsPerStream, RedisCommand cmd) {
+    private void writeStreamsAndIds(Map<K, String> lastIdsPerStream, RedisCommand cmd) {
         List<String> ids = new ArrayList<>();
         for (Map.Entry<K, String> entry : lastIdsPerStream.entrySet()) {
             cmd.put(marshaller.encode(entry.getKey()));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractStringCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractStringCommands.java
@@ -6,6 +6,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
 import static io.smallrye.mutiny.helpers.ParameterValidation.positiveOrZero;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 import io.quarkus.redis.datasource.string.GetExArgs;
@@ -16,11 +17,11 @@ import io.vertx.mutiny.redis.client.Response;
 
 class AbstractStringCommands<K, V> extends AbstractRedisCommands {
 
-    protected final Class<V> typeOfValue;
+    protected final Type typeOfValue;
 
     public static final Command LCS = Command.create("lcs");
 
-    AbstractStringCommands(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    AbstractStringCommands(RedisCommandExecutor redis, Type k, Type v) {
         super(redis, new Marshaller(k, v));
         this.typeOfValue = v;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTimeSeriesCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTimeSeriesCommands.java
@@ -4,6 +4,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
 
+import java.lang.reflect.Type;
 import java.time.Duration;
 
 import io.quarkus.redis.datasource.timeseries.AddArgs;
@@ -23,7 +24,7 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class AbstractTimeSeriesCommands<K> extends AbstractRedisCommands {
 
-    AbstractTimeSeriesCommands(RedisCommandExecutor redis, Class<K> k) {
+    AbstractTimeSeriesCommands(RedisCommandExecutor redis, Type k) {
         super(redis, new Marshaller(k));
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTopKCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTopKCommands.java
@@ -5,6 +5,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.isNotEmpty;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 import io.smallrye.mutiny.Uni;
@@ -13,7 +14,7 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class AbstractTopKCommands<K, V> extends AbstractRedisCommands {
 
-    AbstractTopKCommands(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    AbstractTopKCommands(RedisCommandExecutor redis, Type k, Type v) {
         super(redis, new Marshaller(k, v));
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
@@ -7,6 +7,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.autosuggest.AutoSuggestCommands;
@@ -187,7 +189,18 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
     }
 
     @Override
+    public <K, F, V> HashCommands<K, F, V> hash(TypeReference<K> redisKeyType, TypeReference<F> typeOfField,
+            TypeReference<V> typeOfValue) {
+        return new BlockingHashCommandsImpl<>(this, reactive.hash(redisKeyType, typeOfField, typeOfValue), timeout);
+    }
+
+    @Override
     public <K1, V1> GeoCommands<K1, V1> geo(Class<K1> redisKeyType, Class<V1> memberType) {
+        return new BlockingGeoCommandsImpl<>(this, reactive.geo(redisKeyType, memberType), timeout);
+    }
+
+    @Override
+    public <K1, V1> GeoCommands<K1, V1> geo(TypeReference<K1> redisKeyType, TypeReference<V1> memberType) {
         return new BlockingGeoCommandsImpl<>(this, reactive.geo(redisKeyType, memberType), timeout);
     }
 
@@ -197,7 +210,17 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
     }
 
     @Override
+    public <K1> KeyCommands<K1> key(TypeReference<K1> redisKeyType) {
+        return new BlockingKeyCommandsImpl<>(this, reactive.key(redisKeyType), timeout);
+    }
+
+    @Override
     public <K1, V1> SortedSetCommands<K1, V1> sortedSet(Class<K1> redisKeyType, Class<V1> valueType) {
+        return new BlockingSortedSetCommandsImpl<>(this, reactive.sortedSet(redisKeyType, valueType), timeout);
+    }
+
+    @Override
+    public <K1, V1> SortedSetCommands<K1, V1> sortedSet(TypeReference<K1> redisKeyType, TypeReference<V1> valueType) {
         return new BlockingSortedSetCommandsImpl<>(this, reactive.sortedSet(redisKeyType, valueType), timeout);
     }
 
@@ -212,7 +235,17 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
     }
 
     @Override
+    public <K, V> ValueCommands<K, V> value(TypeReference<K> redisKeyType, TypeReference<V> valueType) {
+        return new BlockingStringCommandsImpl<>(this, reactive.value(redisKeyType, valueType), timeout);
+    }
+
+    @Override
     public <K1, V1> SetCommands<K1, V1> set(Class<K1> redisKeyType, Class<V1> memberType) {
+        return new BlockingSetCommandsImpl<>(this, reactive.set(redisKeyType, memberType), timeout);
+    }
+
+    @Override
+    public <K1, V1> SetCommands<K1, V1> set(TypeReference<K1> redisKeyType, TypeReference<V1> memberType) {
         return new BlockingSetCommandsImpl<>(this, reactive.set(redisKeyType, memberType), timeout);
     }
 
@@ -222,7 +255,17 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
     }
 
     @Override
+    public <K1, V1> ListCommands<K1, V1> list(TypeReference<K1> redisKeyType, TypeReference<V1> memberType) {
+        return new BlockingListCommandsImpl<>(this, reactive.list(redisKeyType, memberType), timeout);
+    }
+
+    @Override
     public <K1, V1> HyperLogLogCommands<K1, V1> hyperloglog(Class<K1> redisKeyType, Class<V1> memberType) {
+        return new BlockingHyperLogLogCommandsImpl<>(this, reactive.hyperloglog(redisKeyType, memberType), timeout);
+    }
+
+    @Override
+    public <K1, V1> HyperLogLogCommands<K1, V1> hyperloglog(TypeReference<K1> redisKeyType, TypeReference<V1> memberType) {
         return new BlockingHyperLogLogCommandsImpl<>(this, reactive.hyperloglog(redisKeyType, memberType), timeout);
     }
 
@@ -232,7 +275,18 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
     }
 
     @Override
+    public <K> BitMapCommands<K> bitmap(TypeReference<K> redisKeyType) {
+        return new BlockingBitmapCommandsImpl<>(this, reactive.bitmap(redisKeyType), timeout);
+    }
+
+    @Override
     public <K, F, V> StreamCommands<K, F, V> stream(Class<K> redisKeyType, Class<F> fieldType, Class<V> valueType) {
+        return new BlockingStreamCommandsImpl<>(this, reactive.stream(redisKeyType, fieldType, valueType), timeout);
+    }
+
+    @Override
+    public <K, F, V> StreamCommands<K, F, V> stream(TypeReference<K> redisKeyType, TypeReference<F> fieldType,
+            TypeReference<V> valueType) {
         return new BlockingStreamCommandsImpl<>(this, reactive.stream(redisKeyType, fieldType, valueType), timeout);
     }
 
@@ -242,7 +296,17 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
     }
 
     @Override
+    public <K> JsonCommands<K> json(TypeReference<K> redisKeyType) {
+        return new BlockingJsonCommandsImpl<>(this, reactive.json(redisKeyType), timeout);
+    }
+
+    @Override
     public <K, V> BloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType) {
+        return new BlockingBloomCommandsImpl<>(this, reactive.bloom(redisKeyType, valueType), timeout);
+    }
+
+    @Override
+    public <K, V> BloomCommands<K, V> bloom(TypeReference<K> redisKeyType, TypeReference<V> valueType) {
         return new BlockingBloomCommandsImpl<>(this, reactive.bloom(redisKeyType, valueType), timeout);
     }
 
@@ -252,12 +316,27 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
     }
 
     @Override
+    public <K, V> CuckooCommands<K, V> cuckoo(TypeReference<K> redisKeyType, TypeReference<V> valueType) {
+        return new BlockingCuckooCommandsImpl<>(this, reactive.cuckoo(redisKeyType, valueType), timeout);
+    }
+
+    @Override
     public <K, V> CountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType) {
         return new BlockingCountMinCommandsImpl<>(this, reactive.countmin(redisKeyType, valueType), timeout);
     }
 
     @Override
+    public <K, V> CountMinCommands<K, V> countmin(TypeReference<K> redisKeyType, TypeReference<V> valueType) {
+        return new BlockingCountMinCommandsImpl<>(this, reactive.countmin(redisKeyType, valueType), timeout);
+    }
+
+    @Override
     public <K, V> TopKCommands<K, V> topk(Class<K> redisKeyType, Class<V> valueType) {
+        return new BlockingTopKCommandsImpl<>(this, reactive.topk(redisKeyType, valueType), timeout);
+    }
+
+    @Override
+    public <K, V> TopKCommands<K, V> topk(TypeReference<K> redisKeyType, TypeReference<V> valueType) {
         return new BlockingTopKCommandsImpl<>(this, reactive.topk(redisKeyType, valueType), timeout);
     }
 
@@ -277,12 +356,27 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
     }
 
     @Override
+    public <K> AutoSuggestCommands<K> autosuggest(TypeReference<K> redisKeyType) {
+        return new BlockingAutoSuggestCommandsImpl<>(this, reactive.autosuggest(redisKeyType), timeout);
+    }
+
+    @Override
     public <K> TimeSeriesCommands<K> timeseries(Class<K> redisKeyType) {
         return new BlockingTimeSeriesCommandsImpl<>(this, reactive.timeseries(redisKeyType), timeout);
     }
 
     @Override
+    public <K> TimeSeriesCommands<K> timeseries(TypeReference<K> redisKeyType) {
+        return new BlockingTimeSeriesCommandsImpl<>(this, reactive.timeseries(redisKeyType), timeout);
+    }
+
+    @Override
     public <V> PubSubCommands<V> pubsub(Class<V> messageType) {
+        return new BlockingPubSubCommandsImpl<>(this, reactive.pubsub(messageType), timeout);
+    }
+
+    @Override
+    public <V> PubSubCommands<V> pubsub(TypeReference<V> messageType) {
         return new BlockingPubSubCommandsImpl<>(this, reactive.pubsub(messageType), timeout);
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/HScanReactiveCursorImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/HScanReactiveCursorImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -14,13 +15,13 @@ import io.vertx.mutiny.redis.client.Response;
 public class HScanReactiveCursorImpl<F, V> extends AbstractRedisCommands implements ReactiveHashScanCursor<F, V> {
 
     private final byte[] key;
-    private final Class<F> typeOfField;
-    private final Class<V> typeOfValue;
+    private final Type typeOfField;
+    private final Type typeOfValue;
     private long cursor;
     private final List<String> extra = new ArrayList<>();
 
-    public <K> HScanReactiveCursorImpl(RedisCommandExecutor redis, K key, Marshaller marshaller, Class<F> typeOfField,
-            Class<V> typeOfValue,
+    public <K> HScanReactiveCursorImpl(RedisCommandExecutor redis, K key, Marshaller marshaller, Type typeOfField,
+            Type typeOfValue,
             List<String> extra) {
         super(redis, marshaller);
         this.key = marshaller.encode(key);

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveAutoSuggestCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveAutoSuggestCommandsImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,7 +17,7 @@ public class ReactiveAutoSuggestCommandsImpl<K> extends AbstractAutoSuggestComma
 
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveAutoSuggestCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k) {
+    public ReactiveAutoSuggestCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k) {
         super(redis, k);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveBitMapCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveBitMapCommandsImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.util.List;
 
 import io.quarkus.redis.datasource.ReactiveRedisCommands;
@@ -14,7 +15,7 @@ public class ReactiveBitMapCommandsImpl<K> extends AbstractBitMapCommands<K>
 
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveBitMapCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k) {
+    public ReactiveBitMapCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k) {
         super(redis, k);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveBloomCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveBloomCommandsImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,7 +16,7 @@ public class ReactiveBloomCommandsImpl<K, V> extends AbstractBloomCommands<K, V>
 
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveBloomCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+    public ReactiveBloomCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k, Type v) {
         super(redis, k, v);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveCountMinCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveCountMinCommandsImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -16,7 +17,7 @@ public class ReactiveCountMinCommandsImpl<K, V> extends AbstractCountMinCommands
 
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveCountMinCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+    public ReactiveCountMinCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k, Type v) {
         super(redis, k, v);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveCuckooCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveCuckooCommandsImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.util.List;
 
 import io.quarkus.redis.datasource.ReactiveRedisCommands;
@@ -15,7 +16,7 @@ public class ReactiveCuckooCommandsImpl<K, V> extends AbstractCuckooCommands<K, 
 
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveCuckooCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+    public ReactiveCuckooCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k, Type v) {
         super(redis, k, v);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveGeoCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveGeoCommandsImpl.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.runtime.datasource;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Set;
 
@@ -24,7 +25,7 @@ public class ReactiveGeoCommandsImpl<K, V> extends AbstractGeoCommands<K, V> imp
     static final GeoAddArgs DEFAULT_INSTANCE = new GeoAddArgs();
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveGeoCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+    public ReactiveGeoCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k, Type v) {
         super(redis, k, v);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveHashCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveHashCommandsImpl.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.runtime.datasource;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -17,7 +18,7 @@ public class ReactiveHashCommandsImpl<K, F, V> extends AbstractHashCommands<K, F
 
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveHashCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<F> f, Class<V> v) {
+    public ReactiveHashCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k, Type f, Type v) {
         super(redis, k, f, v);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveHyperLogLogCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveHyperLogLogCommandsImpl.java
@@ -1,5 +1,7 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
+
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.hyperloglog.ReactiveHyperLogLogCommands;
 import io.smallrye.mutiny.Uni;
@@ -10,7 +12,7 @@ public class ReactiveHyperLogLogCommandsImpl<K, V> extends AbstractHyperLogLogCo
 
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveHyperLogLogCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+    public ReactiveHyperLogLogCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k, Type v) {
         super(redis, k, v);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveJsonCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveJsonCommandsImpl.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.runtime.datasource;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,7 +20,7 @@ public class ReactiveJsonCommandsImpl<K> extends AbstractJsonCommands<K> impleme
 
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveJsonCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k) {
+    public ReactiveJsonCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k) {
         super(redis, k);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveKeyCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveKeyCommandsImpl.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.runtime.datasource;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
@@ -21,7 +22,7 @@ public class ReactiveKeyCommandsImpl<K> extends AbstractKeyCommands<K> implement
 
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveKeyCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k) {
+    public ReactiveKeyCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k) {
         super(redis, k);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveListCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveListCommandsImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.List;
 
@@ -15,7 +16,7 @@ public class ReactiveListCommandsImpl<K, V> extends AbstractListCommands<K, V> i
 
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveListCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+    public ReactiveListCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k, Type v) {
         super(redis, k, v);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactivePubSubCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactivePubSubCommandsImpl.java
@@ -4,6 +4,7 @@ import static io.quarkus.redis.runtime.datasource.Validation.notNullOrEmpty;
 import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -30,11 +31,11 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class ReactivePubSubCommandsImpl<V> extends AbstractRedisCommands implements ReactivePubSubCommands<V> {
 
-    private final Class<V> classOfMessage;
+    private final Type classOfMessage;
     private final Redis client;
     private final ReactiveRedisDataSourceImpl datasource;
 
-    public ReactivePubSubCommandsImpl(ReactiveRedisDataSourceImpl ds, Class<V> classOfMessage) {
+    public ReactivePubSubCommandsImpl(ReactiveRedisDataSourceImpl ds, Type classOfMessage) {
         super(ds, new Marshaller(classOfMessage));
         this.client = ds.redis;
         this.datasource = ds;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.autosuggest.ReactiveAutoSuggestCommands;
 import io.quarkus.redis.datasource.bitmap.ReactiveBitMapCommands;
@@ -105,7 +107,6 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
         return redis.connect()
                 .onItem().transformToUni(connection -> {
                     ReactiveRedisDataSourceImpl singleConnectionDS = new ReactiveRedisDataSourceImpl(vertx, redis, connection);
-                    List<String> watched = List.of(keys);
                     TransactionHolder th = new TransactionHolder();
                     return watch(connection, keys) // WATCH keys
                             .chain(() -> connection.send(Request.cmd(Command.MULTI))
@@ -243,8 +244,19 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     }
 
     @Override
+    public <K, F, V> ReactiveHashCommands<K, F, V> hash(TypeReference<K> redisKeyType, TypeReference<F> fieldType,
+            TypeReference<V> valueType) {
+        return new ReactiveHashCommandsImpl<>(this, redisKeyType.getType(), fieldType.getType(), valueType.getType());
+    }
+
+    @Override
     public <K, V> ReactiveGeoCommands<K, V> geo(Class<K> redisKeyType, Class<V> memberType) {
         return new ReactiveGeoCommandsImpl<>(this, redisKeyType, memberType);
+    }
+
+    @Override
+    public <K, V> ReactiveGeoCommands<K, V> geo(TypeReference<K> redisKeyType, TypeReference<V> memberType) {
+        return new ReactiveGeoCommandsImpl<>(this, redisKeyType.getType(), memberType.getType());
     }
 
     @Override
@@ -253,8 +265,18 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     }
 
     @Override
+    public <K> ReactiveKeyCommands<K> key(TypeReference<K> redisKeyType) {
+        return new ReactiveKeyCommandsImpl<>(this, redisKeyType.getType());
+    }
+
+    @Override
     public <K, V> ReactiveSortedSetCommands<K, V> sortedSet(Class<K> redisKeyType, Class<V> valueType) {
         return new ReactiveSortedSetCommandsImpl<>(this, redisKeyType, valueType);
+    }
+
+    @Override
+    public <K, V> ReactiveSortedSetCommands<K, V> sortedSet(TypeReference<K> redisKeyType, TypeReference<V> valueType) {
+        return new ReactiveSortedSetCommandsImpl<>(this, redisKeyType.getType(), valueType.getType());
     }
 
     @Override
@@ -268,8 +290,18 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     }
 
     @Override
+    public <K, V> ReactiveValueCommands<K, V> value(TypeReference<K> redisKeyType, TypeReference<V> valueType) {
+        return new ReactiveStringCommandsImpl<>(this, redisKeyType.getType(), valueType.getType());
+    }
+
+    @Override
     public <K, V> ReactiveSetCommands<K, V> set(Class<K> redisKeyType, Class<V> memberType) {
         return new ReactiveSetCommandsImpl<>(this, redisKeyType, memberType);
+    }
+
+    @Override
+    public <K, V> ReactiveSetCommands<K, V> set(TypeReference<K> redisKeyType, TypeReference<V> memberType) {
+        return new ReactiveSetCommandsImpl<>(this, redisKeyType.getType(), memberType.getType());
     }
 
     @Override
@@ -278,8 +310,18 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     }
 
     @Override
+    public <K, V> ReactiveListCommands<K, V> list(TypeReference<K> redisKeyType, TypeReference<V> memberType) {
+        return new ReactiveListCommandsImpl<>(this, redisKeyType.getType(), memberType.getType());
+    }
+
+    @Override
     public <K, V> ReactiveHyperLogLogCommands<K, V> hyperloglog(Class<K> redisKeyType, Class<V> memberType) {
         return new ReactiveHyperLogLogCommandsImpl<>(this, redisKeyType, memberType);
+    }
+
+    @Override
+    public <K, V> ReactiveHyperLogLogCommands<K, V> hyperloglog(TypeReference<K> redisKeyType, TypeReference<V> memberType) {
+        return new ReactiveHyperLogLogCommandsImpl<>(this, redisKeyType.getType(), memberType.getType());
     }
 
     @Override
@@ -288,8 +330,19 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     }
 
     @Override
+    public <K> ReactiveBitMapCommands<K> bitmap(TypeReference<K> redisKeyType) {
+        return new ReactiveBitMapCommandsImpl<>(this, redisKeyType.getType());
+    }
+
+    @Override
     public <K, F, V> ReactiveStreamCommands<K, F, V> stream(Class<K> redisKeyType, Class<F> fieldType, Class<V> valueType) {
         return new ReactiveStreamCommandsImpl<>(this, redisKeyType, fieldType, valueType);
+    }
+
+    @Override
+    public <K, F, V> ReactiveStreamCommands<K, F, V> stream(TypeReference<K> redisKeyType, TypeReference<F> fieldType,
+            TypeReference<V> valueType) {
+        return new ReactiveStreamCommandsImpl<>(this, redisKeyType.getType(), fieldType.getType(), valueType.getType());
     }
 
     @Override
@@ -298,8 +351,18 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     }
 
     @Override
+    public <K> ReactiveJsonCommands<K> json(TypeReference<K> redisKeyType) {
+        return new ReactiveJsonCommandsImpl<>(this, redisKeyType.getType());
+    }
+
+    @Override
     public <K, V> ReactiveBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType) {
         return new ReactiveBloomCommandsImpl<>(this, redisKeyType, valueType);
+    }
+
+    @Override
+    public <K, V> ReactiveBloomCommands<K, V> bloom(TypeReference<K> redisKeyType, TypeReference<V> valueType) {
+        return new ReactiveBloomCommandsImpl<>(this, redisKeyType.getType(), valueType.getType());
     }
 
     @Override
@@ -308,13 +371,28 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     }
 
     @Override
+    public <K, V> ReactiveCuckooCommands<K, V> cuckoo(TypeReference<K> redisKeyType, TypeReference<V> valueType) {
+        return new ReactiveCuckooCommandsImpl<>(this, redisKeyType.getType(), valueType.getType());
+    }
+
+    @Override
     public <K, V> ReactiveCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType) {
         return new ReactiveCountMinCommandsImpl<>(this, redisKeyType, valueType);
     }
 
     @Override
+    public <K, V> ReactiveCountMinCommands<K, V> countmin(TypeReference<K> redisKeyType, TypeReference<V> valueType) {
+        return new ReactiveCountMinCommandsImpl<>(this, redisKeyType.getType(), valueType.getType());
+    }
+
+    @Override
     public <K, V> ReactiveTopKCommands<K, V> topk(Class<K> redisKeyType, Class<V> valueType) {
         return new ReactiveTopKCommandsImpl<>(this, redisKeyType, valueType);
+    }
+
+    @Override
+    public <K, V> ReactiveTopKCommands<K, V> topk(TypeReference<K> redisKeyType, TypeReference<V> valueType) {
+        return new ReactiveTopKCommandsImpl<>(this, redisKeyType.getType(), valueType.getType());
     }
 
     @Override
@@ -328,6 +406,11 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     }
 
     @Override
+    public <V> ReactivePubSubCommands<V> pubsub(TypeReference<V> messageType) {
+        return new ReactivePubSubCommandsImpl<>(this, messageType.getType());
+    }
+
+    @Override
     public <K> ReactiveSearchCommands<K> search(Class<K> redisKeyType) {
         return new ReactiveSearchCommandsImpl<>(this, redisKeyType);
     }
@@ -338,8 +421,18 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     }
 
     @Override
+    public <K> ReactiveAutoSuggestCommands<K> autosuggest(TypeReference<K> redisKeyType) {
+        return new ReactiveAutoSuggestCommandsImpl<>(this, redisKeyType.getType());
+    }
+
+    @Override
     public <K> ReactiveTimeSeriesCommands<K> timeseries(Class<K> redisKeyType) {
         return new ReactiveTimeSeriesCommandsImpl<>(this, redisKeyType);
+    }
+
+    @Override
+    public <K> ReactiveTimeSeriesCommands<K> timeseries(TypeReference<K> redisKeyType) {
+        return new ReactiveTimeSeriesCommandsImpl<>(this, redisKeyType.getType());
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSearchCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSearchCommandsImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,9 +31,9 @@ public class ReactiveSearchCommandsImpl<K> extends AbstractSearchCommands<K>
         implements ReactiveSearchCommands<K>, ReactiveRedisCommands {
 
     private final ReactiveRedisDataSource reactive;
-    protected final Class<K> keyType;
+    protected final Type keyType;
 
-    public ReactiveSearchCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k) {
+    public ReactiveSearchCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k) {
         super(redis, k);
         this.reactive = redis;
         this.keyType = k;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSetCommandsImpl.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.runtime.datasource;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -17,7 +18,7 @@ public class ReactiveSetCommandsImpl<K, V> extends AbstractSetCommands<K, V> imp
 
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveSetCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+    public ReactiveSetCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k, Type v) {
         super(redis, k, v);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSortable.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSortable.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.runtime.datasource;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.util.List;
 
 import io.quarkus.redis.datasource.SortArgs;
@@ -11,11 +12,11 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class ReactiveSortable<K, V> extends AbstractRedisCommands {
 
-    private final Class<V> typeOfValue;
+    private final Type typeOfValue;
 
     private static final SortArgs DEFAULT_INSTANCE = new SortArgs();
 
-    public ReactiveSortable(RedisCommandExecutor redis, Marshaller marshaller, Class<V> typeOfValue) {
+    public ReactiveSortable(RedisCommandExecutor redis, Marshaller marshaller, Type typeOfValue) {
         super(redis, marshaller);
         this.typeOfValue = typeOfValue;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSortedSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSortedSetCommandsImpl.java
@@ -3,6 +3,7 @@ package io.quarkus.redis.runtime.datasource;
 
 import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 
+import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -27,7 +28,7 @@ public class ReactiveSortedSetCommandsImpl<K, V> extends AbstractSortedSetComman
 
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveSortedSetCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+    public ReactiveSortedSetCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k, Type v) {
         super(redis, k, v);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStreamCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStreamCommandsImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -30,11 +31,11 @@ public class ReactiveStreamCommandsImpl<K, F, V> extends AbstractStreamCommands<
         implements ReactiveStreamCommands<K, F, V>, ReactiveRedisCommands {
 
     private final ReactiveRedisDataSource reactive;
-    private final Class<V> typeOfValue;
-    private final Class<F> typeOfField;
-    private final Class<K> typeOfKey;
+    private final Type typeOfValue;
+    private final Type typeOfField;
+    private final Type typeOfKey;
 
-    public ReactiveStreamCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<F> f, Class<V> v) {
+    public ReactiveStreamCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k, Type f, Type v) {
         super(redis, k, f, v);
         this.typeOfKey = k;
         this.typeOfField = f;
@@ -97,7 +98,7 @@ public class ReactiveStreamCommandsImpl<K, F, V> extends AbstractStreamCommands<
         if (r == null) {
             return List.of();
         }
-        var actualKey = marshaller.decode(typeOfKey, r.get(0));
+        K actualKey = marshaller.decode(typeOfKey, r.get(0));
         var listOfMessages = r.get(1);
         List<StreamMessage<K, F, V>> list = new ArrayList<>();
         for (int i = 0; i < listOfMessages.size(); i++) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStringCommandsImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
@@ -15,7 +16,7 @@ public class ReactiveStringCommandsImpl<K, V> extends AbstractStringCommands<K, 
 
     private final ReactiveRedisDataSource reactive;
 
-    public ReactiveStringCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+    public ReactiveStringCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k, Type v) {
         super(redis, k, v);
         this.reactive = redis;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTimeSeriesCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTimeSeriesCommandsImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,9 +32,9 @@ public class ReactiveTimeSeriesCommandsImpl<K> extends AbstractTimeSeriesCommand
         implements ReactiveTimeSeriesCommands<K>, ReactiveRedisCommands {
 
     private final ReactiveRedisDataSource reactive;
-    protected final Class<K> keyType;
+    protected final Type keyType;
 
-    public ReactiveTimeSeriesCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k) {
+    public ReactiveTimeSeriesCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k) {
         super(redis, k);
         this.keyType = k;
         this.reactive = redis;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTopKCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTopKCommandsImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -15,9 +16,9 @@ public class ReactiveTopKCommandsImpl<K, V> extends AbstractTopKCommands<K, V>
         implements ReactiveTopKCommands<K, V>, ReactiveRedisCommands {
 
     private final ReactiveRedisDataSource reactive;
-    final Class<V> typeOfValue;
+    final Type typeOfValue;
 
-    public ReactiveTopKCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+    public ReactiveTopKCommandsImpl(ReactiveRedisDataSourceImpl redis, Type k, Type v) {
         super(redis, k, v);
         this.typeOfValue = v;
         this.reactive = redis;
@@ -31,7 +32,7 @@ public class ReactiveTopKCommandsImpl<K, V> extends AbstractTopKCommands<K, V>
     @Override
     public Uni<V> topkAdd(K key, V item) {
         return super._topkAdd(key, item)
-                .map(r -> marshaller.decodeAsList(r, typeOfValue).get(0));
+                .map(r -> marshaller.<V> decodeAsList(r, typeOfValue).get(0));
     }
 
     @Override
@@ -43,7 +44,7 @@ public class ReactiveTopKCommandsImpl<K, V> extends AbstractTopKCommands<K, V>
     @Override
     public Uni<V> topkIncrBy(K key, V item, int increment) {
         return super._topkIncrBy(key, item, increment)
-                .map(r -> marshaller.decodeAsList(r, typeOfValue).get(0));
+                .map(r -> marshaller.<V> decodeAsList(r, typeOfValue).get(0));
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/SScanReactiveCursorImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/SScanReactiveCursorImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,13 +14,13 @@ import io.vertx.mutiny.redis.client.Response;
 public class SScanReactiveCursorImpl<V> extends AbstractRedisCommands implements ReactiveSScanCursor<V> {
 
     private final byte[] key;
-    private final Class<V> typeOfValue;
+    private final Type typeOfValue;
     private final Marshaller marshaller;
     private long cursor;
     private final List<String> extra = new ArrayList<>();
 
     public <K> SScanReactiveCursorImpl(RedisCommandExecutor redis, K key, Marshaller marshaller,
-            Class<V> typeOfValue, List<String> extra) {
+            Type typeOfValue, List<String> extra) {
         super(redis, marshaller);
         this.key = marshaller.encode(key);
         this.cursor = ReactiveCursor.INITIAL_CURSOR_ID;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ScanReactiveCursorImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ScanReactiveCursorImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -12,11 +13,11 @@ import io.vertx.mutiny.redis.client.Command;
 
 public class ScanReactiveCursorImpl<K> extends AbstractRedisCommands implements ReactiveKeyScanCursor<K> {
 
-    private final Class<K> typeOfKey;
+    private final Type typeOfKey;
     private long cursor;
     private final List<String> extra = new ArrayList<>();
 
-    public ScanReactiveCursorImpl(RedisCommandExecutor redis, Marshaller marshaller, Class<K> typeOfKey, List<String> extra) {
+    public ScanReactiveCursorImpl(RedisCommandExecutor redis, Marshaller marshaller, Type typeOfKey, List<String> extra) {
         super(redis, marshaller);
         this.cursor = ReactiveCursor.INITIAL_CURSOR_ID;
         this.typeOfKey = typeOfKey;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ZScanReactiveCursorImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ZScanReactiveCursorImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,11 +14,11 @@ import io.vertx.mutiny.redis.client.Response;
 public class ZScanReactiveCursorImpl<V> extends AbstractRedisCommands implements ReactiveZScanCursor<V> {
 
     private final byte[] key;
-    private final Class<V> typeOfValue;
+    private final Type typeOfValue;
     private long cursor;
     private final List<String> extra = new ArrayList<>();
 
-    public <K> ZScanReactiveCursorImpl(RedisCommandExecutor redis, K key, Marshaller marshaller, Class<V> typeOfValue,
+    public <K> ZScanReactiveCursorImpl(RedisCommandExecutor redis, K key, Marshaller marshaller, Type typeOfValue,
             List<String> extra) {
         super(redis, marshaller);
         this.key = marshaller.encode(key);

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/AutoSuggestCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/AutoSuggestCommandsTest.java
@@ -4,10 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
+import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import io.quarkus.redis.datasource.autosuggest.AutoSuggestCommands;
 import io.quarkus.redis.datasource.autosuggest.GetArgs;
@@ -41,6 +44,60 @@ public class AutoSuggestCommandsTest extends DatasourceTestBase {
 
     @Test
     void testSuggestions() {
+        assertThat(auto.ftSugAdd(key, "hello world", 1)).isEqualTo(1L);
+        assertThat(auto.ftSugAdd(key, "hello world", 3, true)).isEqualTo(1L);
+
+        assertThat(auto.ftSugAdd(key, "bonjour", 3)).isEqualTo(2L);
+        assertThat(auto.ftSugAdd(key, "bonjourno", 1)).isEqualTo(3L);
+
+        assertThat(auto.ftSugLen(key)).isEqualTo(3L);
+        assertThat(auto.ftSugDel(key, "bonjourno")).isTrue();
+        assertThat(auto.ftSugDel(key, "missing")).isFalse();
+
+        assertThat(auto.ftSugLen(key)).isEqualTo(2L);
+
+        assertThat(auto.ftSugAdd(key, "hell", 3)).isEqualTo(3L);
+
+        assertThat(auto.ftSugGet(key, "hell")).hasSize(2)
+                .anySatisfy(s -> assertThat(s.suggestion()).isEqualTo("hell"))
+                .anySatisfy(s -> assertThat(s.suggestion()).isEqualTo("hello world"));
+
+        assertThat(auto.ftSugGet(key, "hel", new GetArgs().max(1).withScores())).hasSize(1)
+                .anySatisfy(s -> {
+                    assertThat(s.suggestion()).isEqualTo("hell");
+                    assertThat(s.score()).isGreaterThan(0.0);
+                });
+
+        assertThat(auto.ftSugAdd(key, "hill", 3)).isEqualTo(4L);
+
+        assertThat(auto.ftSugGet(key, "hell", new GetArgs().fuzzy())).hasSize(3)
+                .anySatisfy(s -> assertThat(s.suggestion()).isEqualTo("hell"))
+                .anySatisfy(s -> assertThat(s.suggestion()).isEqualTo("hello world"))
+                .anySatisfy(s -> assertThat(s.suggestion()).isEqualTo("hill"));
+
+        assertThat(auto.ftSugGet(key, "hell", new GetArgs().fuzzy().withScores())).hasSize(3)
+                .anySatisfy(s -> {
+                    assertThat(s.suggestion()).isEqualTo("hell");
+                    assertThat(s.score()).isGreaterThan(0.0);
+                })
+                .anySatisfy(s -> {
+                    assertThat(s.suggestion()).isEqualTo("hello world");
+                    assertThat(s.score()).isGreaterThan(0.0);
+                })
+                .anySatisfy(s -> {
+                    assertThat(s.suggestion()).isEqualTo("hill");
+                    assertThat(s.score()).isGreaterThan(0.0);
+                });
+    }
+
+    @Test
+    void testSuggestionsWithTypeReference() {
+        var auto = ds.autosuggest(new TypeReference<List<Person>>() {
+            // Empty on purpose.
+        });
+
+        List<Person> key = List.of(Person.person0);
+
         assertThat(auto.ftSugAdd(key, "hello world", 1)).isEqualTo(1L);
         assertThat(auto.ftSugAdd(key, "hello world", 3, true)).isEqualTo(1L);
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/BitMapCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/BitMapCommandsTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import io.quarkus.redis.datasource.bitmap.BitFieldArgs;
 import io.quarkus.redis.datasource.bitmap.BitMapCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
@@ -207,5 +209,21 @@ public class BitMapCommandsTest extends DatasourceTestBase {
     void setbit() {
         assertThat(bitmap.setbit(key, 0, 1)).isEqualTo(0);
         assertThat(bitmap.setbit(key, 0, 0)).isEqualTo(1);
+    }
+
+    @Test
+    void bitcountWithTypeReference() {
+        var bitmap = ds.bitmap(new TypeReference<List<String>>() {
+            // Empty on purpose
+        });
+        List<String> key = List.of("a", "b", "c");
+        assertThat(bitmap.bitcount(key)).isEqualTo(0);
+
+        bitmap.setbit(key, 0L, 1);
+        bitmap.setbit(key, 1L, 1);
+        bitmap.setbit(key, 2L, 1);
+
+        assertThat(bitmap.bitcount(key)).isEqualTo(3);
+        assertThat(bitmap.bitcount(key, 3, -1)).isEqualTo(0);
     }
 }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/GeoCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/GeoCommandsTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.offset;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.OptionalDouble;
 import java.util.Set;
 
@@ -14,6 +15,8 @@ import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import io.quarkus.redis.datasource.geo.GeoAddArgs;
 import io.quarkus.redis.datasource.geo.GeoCommands;
@@ -88,6 +91,31 @@ public class GeoCommandsTest extends DatasourceTestBase {
 
         added = geo.geoadd(key, GeoItem.of(Place.suze, SUZE_LONGITUDE, SUZE_LATITUDE));
         assertThat(added).isTrue();
+    }
+
+    @Test
+    void geoaddUsingTypeReferences() {
+        var g = ds.geo(new TypeReference<Map<String, Place>>() {
+            // Empty on purpose
+        });
+
+        boolean added = g.geoadd(key, 44.9396, CRUSSOL_LATITUDE, Map.of("a", Place.crussol));
+        assertThat(added).isTrue();
+
+        added = g.geoadd(key, 44.9396, CRUSSOL_LATITUDE, Map.of("a", Place.crussol));
+        assertThat(added).isFalse();
+
+        added = g.geoadd(key, GeoPosition.of(GRIGNAN_LONGITUDE, GRIGNAN_LATITUDE), Map.of("a", Place.grignan));
+        assertThat(added).isTrue();
+
+        added = g.geoadd(key, GeoItem.of(Map.of("a", Place.suze), SUZE_LONGITUDE, SUZE_LATITUDE));
+        assertThat(added).isTrue();
+
+        List<GeoValue<Map<String, Place>>> list = g.geosearch(key, new GeoSearchArgs<Map<String, Place>>()
+                .byRadius(60, GeoUnit.KM).fromMember(Map.of("a", Place.crussol)).ascending().withDistance());
+        assertThat(list).hasSize(2);
+        assertThat(list.get(0).member).isEqualTo(Map.of("a", Place.crussol));
+        assertThat(list.get(1).member).isEqualTo(Map.of("a", Place.grignan)); // 58 Km from crussol
     }
 
     @Test

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HashCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HashCommandsTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import io.quarkus.redis.datasource.hash.HashCommands;
 import io.quarkus.redis.datasource.hash.HashScanCursor;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
@@ -51,6 +53,34 @@ public class HashCommandsTest extends DatasourceTestBase {
 
         assertThat(hash.hdel("my-hash", "field1")).isEqualTo(1);
         person = hash.hget("my-hash", "field1");
+        assertThat(person).isNull();
+    }
+
+    @Test
+    void HSetWithTypeReference() {
+        var h = ds.hash(new TypeReference<List<Person>>() {
+            // Empty on purpose.
+        });
+        h.hset("my-hash", "l1", List.of(Person.person1, Person.person2));
+        List<Person> person = h.hget("my-hash", "l1");
+        assertThat(person).containsExactly(Person.person1, Person.person2);
+
+        assertThat(h.hdel("my-hash", "l1")).isEqualTo(1);
+        person = h.hget("my-hash", "l1");
+        assertThat(person).isNull();
+    }
+
+    @Test
+    void HSetWithTypeReferenceUsingMaps() {
+        var h = ds.hash(new TypeReference<Map<String, Person>>() {
+            // Empty on purpose.
+        });
+        h.hset("my-hash", "l1", Map.of("a", Person.person1, "b", Person.person2));
+        Map<String, Person> person = h.hget("my-hash", "l1");
+        assertThat(person).containsOnly(entry("a", Person.person1), entry("b", Person.person2));
+
+        assertThat(h.hdel("my-hash", "l1")).isEqualTo(1);
+        person = h.hget("my-hash", "l1");
         assertThat(person).isNull();
     }
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HyperLogLogCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HyperLogLogCommandsTest.java
@@ -4,11 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import io.quarkus.redis.datasource.hyperloglog.HyperLogLogCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
@@ -114,6 +117,19 @@ public class HyperLogLogCommandsTest extends DatasourceTestBase {
         hll.pfmerge(k2, k0, k1);
 
         assertThat(hll.pfcount(k2)).isEqualTo(3);
+    }
+
+    @Test
+    void pfaddWithTypeReference() {
+        String k = getKey();
+        var hll = ds.hyperloglog(new TypeReference<List<Person>>() {
+            // Empty on purpose
+        });
+        var l1 = List.of(Person.person1, Person.person2);
+        var l2 = List.of(Person.person3, Person.person2);
+        assertThat(hll.pfadd(k, l1, l2)).isTrue();
+        assertThat(hll.pfadd(k, l1, l1)).isFalse();
+        Assertions.assertThat(hll.pfadd(k, l1)).isFalse();
     }
 
 }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/KeyCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/KeyCommandsTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import io.quarkus.redis.datasource.keys.CopyArgs;
 import io.quarkus.redis.datasource.keys.ExpireArgs;
 import io.quarkus.redis.datasource.keys.KeyCommands;
@@ -190,6 +192,30 @@ public class KeyCommandsTest extends DatasourceTestBase {
         assertThat(k).hasSize(2);
         assertThat(k.contains("one")).isTrue();
         assertThat(k.contains("two")).isTrue();
+    }
+
+    @Test
+    void keysWithTypeReferences() {
+        var v = ds.value(new TypeReference<List<String>>() {
+            // Empty on purpose
+        }, new TypeReference<Person>() {
+            // Empty on purpose
+        });
+        var k = ds.key(new TypeReference<List<String>>() {
+            // Empty on purpose
+        });
+
+        assertThat(k.keys("*")).isEqualTo(List.of());
+        Map<List<String>, Person> map = new LinkedHashMap<>();
+        map.put(List.of("one"), Person.person1);
+        map.put(List.of("two"), Person.person2);
+        map.put(List.of("three"), Person.person3);
+        v.mset(map);
+        var l = k.keys("*o*");
+        assertThat(l).hasSize(2);
+        assertThat(l.contains(List.of("one"))).isTrue();
+        assertThat(l.contains(List.of("two"))).isTrue();
+        assertThat(l.contains(List.of("three"))).isFalse();
     }
 
     @Test

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ListCommandTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ListCommandTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import io.quarkus.redis.datasource.list.KeyValue;
 import io.quarkus.redis.datasource.list.LPosArgs;
@@ -354,6 +355,19 @@ public class ListCommandTest extends DatasourceTestBase {
 
         assertThat(commands.lpop("dest1", 100)).containsExactly("a", "b", "e", "f");
         assertThat(commands.lpop("dest2", 100)).containsExactly("1", "2", "3", "4", "5", "5", "6", "7", "8", "9");
+    }
+
+    @Test
+    void testListWithTypeReference() {
+        var lists = ds.list(new TypeReference<List<Person>>() {
+            // Empty on purpose
+        });
+
+        var l1 = List.of(Person.person1, Person.person2);
+        var l2 = List.of(Person.person1, Person.person3);
+
+        lists.rpush(key, l1, l2);
+        assertThat(lists.blpop(Duration.ofSeconds(1), "one", key)).isEqualTo(KeyValue.of(key, l1));
     }
 
     @Test

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SetCommandsTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import io.quarkus.redis.datasource.list.ListCommands;
 import io.quarkus.redis.datasource.set.SScanCursor;
 import io.quarkus.redis.datasource.set.SetCommands;
@@ -331,6 +333,19 @@ public class SetCommandsTest extends DatasourceTestBase {
         ListCommands<String, String> listCommands = ds.list(String.class, String.class);
         assertThat(listCommands.lrange("dest1", 0, -1)).containsExactly("a", "b", "e", "f");
         assertThat(listCommands.lpop("dest2", 100)).containsExactly("1", "2", "3", "4", "5", "6", "7", "8", "9");
+    }
+
+    @Test
+    void testSetWithTypeReference() {
+        var sets = ds.set(new TypeReference<List<Person>>() {
+            // Empty on purpose.
+        });
+        assertThat(sets.sadd(key, List.of(person1, person2))).isEqualTo(1L);
+        assertThat(sets.sadd(key, List.of(person1, person2))).isEqualTo(0);
+        assertThat(sets.smembers(key)).isEqualTo(Set.of(List.of(person1, person2)));
+        assertThat(sets.sadd(key, List.of(person2, person3), List.of(person4))).isEqualTo(2);
+        assertThat(sets.smembers(key)).containsExactlyInAnyOrder(List.of(person1, person2), List.of(person2, person3),
+                List.of(person4));
     }
 
 }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TopKCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TopKCommandsTest.java
@@ -5,11 +5,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import io.quarkus.redis.datasource.topk.TopKCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
@@ -72,6 +75,39 @@ public class TopKCommandsTest extends DatasourceTestBase {
         topk.topkReserve(key + "1", 100, 2, 4, 0.5);
         assertThatThrownBy(() -> topk.topkReserve(key, 100, 3, 4, .01));
         assertThatThrownBy(() -> topk.topkReserve(key + "1", 20));
+    }
+
+    @Test
+    void topKWithTypeReference() {
+        var l1 = List.of(new Person("luke", "skywalker"), new Person("leia", "ordana"));
+        var l2 = List.of(new Person("leia", "ordana"));
+        var l3 = List.of(new Person("anakin", "skywalker"));
+
+        var topk = ds.topk(new TypeReference<List<Person>>() {
+            // Empty on purpose
+        });
+
+        assertThatThrownBy(() -> topk.topkAdd(key, l1))
+                .hasMessageContaining("TopK");
+
+        topk.topkReserve(key, 2);
+        assertThat(topk.topkAdd(key, l1)).isEmpty();
+        assertThat(topk.topkAdd(key, l1)).isEmpty();
+        assertThat(topk.topkAdd(key, l2)).isEmpty();
+        assertThat(topk.topkAdd(key, l3)).contains(l2);
+
+        assertThat(topk.topkAdd(key, l1, l1, l2, l2, l2, l1)).containsExactly(null, null, l3, null, null, null);
+
+        assertThat(topk.topkList(key)).containsExactly(l1, l2);
+        assertThat(topk.topkListWithCount(key)).contains(entry(l1, 5), entry(l2, 4));
+
+        assertThat(topk.topkIncrBy(key, l3, 6)).contains(l2);
+        assertThat(topk.topkListWithCount(key)).contains(entry(l3, 7), entry(l1, 5));
+
+        assertThat(topk.topkIncrBy(key, Map.of(l2, 20, l1, 20))).hasSize(2);
+        assertThat(topk.topkQuery(key, l3)).isFalse();
+        assertThat(topk.topkQuery(key, l1)).isTrue();
+        assertThat(topk.topkQuery(key, l1, l2, l3)).containsExactly(true, true, false);
     }
 
 }


### PR DESCRIPTION
Allows configuring the Redis data source with type references

The Redis data source used Class<?> to configure the type safety. Unfortunately, it didn't work with generics. 

This commit adds methods using (Jackson) TypeReference to configure the various groups. Thus, generics are now supported.

Also:

- deprecate the graph group, as Redis declared it is as end-of-life ( :-( )
- deprecate search(Class<K> keyType) as the index must be a string
- re-structure a bit the Redis reference guide 

Fix https://github.com/quarkusio/quarkus/issues/34554
Fix https://github.com/quarkusio/quarkus/issues/29865
