### PR TITLE
Error message when re-augmenting non-mutable Quarkus application

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/QuarkusEntryPoint.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/QuarkusEntryPoint.java
@@ -68,6 +68,11 @@ public class QuarkusEntryPoint {
 
     private static void doReaugment(Path appRoot) throws IOException, ClassNotFoundException, IllegalAccessException,
             InvocationTargetException, NoSuchMethodException {
+        if (!Files.exists(appRoot.resolve(LIB_DEPLOYMENT_DEPLOYMENT_CLASS_PATH_DAT))) {
+            System.out.println("[ERROR] Re-augmentation was requested, " +
+                    "but the application wasn't built with 'quarkus.package.type=mutable-jar'");
+            return;
+        }
         try (ObjectInputStream in = new ObjectInputStream(
                 Files.newInputStream(appRoot.resolve(LIB_DEPLOYMENT_DEPLOYMENT_CLASS_PATH_DAT)))) {
             List<String> paths = (List<String>) in.readObject();


### PR DESCRIPTION
Error message when re-augmenting non-mutable Quarkus application

Fixes https://github.com/quarkusio/quarkus/issues/34816

JBoss logging is not initialized at that phase, thus just plain stdout println.

Now:
```
java -Dquarkus.launch.rebuild=true -Dfoo=bar -jar target/quarkus-app/quarkus-run.jar
[ERROR] Re-augmentation was requested, but the application wasn't built with 'quarkus.package.type=mutable-jar'
```

Before:
```
java -Dquarkus.launch.rebuild=true -jar target/quarkus-app/quarkus-run.jar 
Exception in thread "main" java.nio.file.NoSuchFileException: /Users/rsvoboda/Downloads/code-with-quarkus/target/quarkus-app/lib/deployment/deployment-class-path.dat
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:380)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:432)
	at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:422)
	at java.base/java.nio.file.Files.newInputStream(Files.java:160)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.doReaugment(QuarkusEntryPoint.java:72)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.doRun(QuarkusEntryPoint.java:48)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.main(QuarkusEntryPoint.java:32)
```