### PR TITLE
Rename OIDC Tenant annotation to TenantFeature

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1409,7 +1409,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
          * Token customizer name.
          *
          * Allows to select a tenant specific token customizer as a named bean.
-         * Prefer using {@link Tenant} qualifier when registering custom {@link TokenCustomizer}.
+         * Prefer using {@link TenantFeature} qualifier when registering custom {@link TokenCustomizer}.
          * Use this property only to refer to `TokenCustomizer` implementations provided by this extension.
          */
         @ConfigItem

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantFeature.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantFeature.java
@@ -7,11 +7,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Qualifier which can be used to associate one or more OIDC features with a named tenant.
+ * Annotation which can be used to associate one or more OIDC features with a named tenant.
  */
 @Target({ TYPE })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Tenant {
+public @interface TenantFeature {
     /**
      * Identifies an OIDC tenant to which a given feature applies.
      */

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenCustomizer.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenCustomizer.java
@@ -15,11 +15,11 @@ import jakarta.json.JsonObject;
  * have been modified by this customizer will not be possible and the signature verification will fail.
  *
  * Custom token customizers should be registered and discoverable as CDI beans.
- * They should be bound to specific OIDC tenants with a {@link Tenant} qualifier.
+ * They should be bound to specific OIDC tenants with a {@link TenantFeature} qualifier.
  * with the exception of named customizers provided by this extension which have to be selected with
  * a `quarkus.oidc.token.customizer-name` property.
  *
- * Custom token customizers without a {@link Tenant} qualifier will be bound to all OIDC tenants.
+ * Custom token customizers without a {@link TenantFeature} qualifier will be bound to all OIDC tenants.
  */
 public interface TokenCustomizer {
     /**

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TokenCustomizerFinder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TokenCustomizerFinder.java
@@ -5,7 +5,7 @@ import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcTenantConfig;
-import io.quarkus.oidc.Tenant;
+import io.quarkus.oidc.TenantFeature;
 import io.quarkus.oidc.TokenCustomizer;
 
 public class TokenCustomizerFinder {
@@ -30,7 +30,7 @@ public class TokenCustomizerFinder {
                 }
             } else {
                 for (InstanceHandle<TokenCustomizer> tokenCustomizer : container.listAll(TokenCustomizer.class)) {
-                    Tenant tenantAnn = tokenCustomizer.get().getClass().getAnnotation(Tenant.class);
+                    TenantFeature tenantAnn = tokenCustomizer.get().getClass().getAnnotation(TenantFeature.class);
                     if (tenantAnn != null && oidcConfig.tenantId.get().equals(tenantAnn.value())) {
                         return tokenCustomizer.get();
                     }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/DefaultTenantTokenCustomizer.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/DefaultTenantTokenCustomizer.java
@@ -5,11 +5,11 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 
 import io.quarkus.arc.Unremovable;
-import io.quarkus.oidc.Tenant;
+import io.quarkus.oidc.TenantFeature;
 import io.quarkus.oidc.TokenCustomizer;
 
 @Singleton
-@Tenant("bearer")
+@TenantFeature("bearer")
 @Unremovable
 public class DefaultTenantTokenCustomizer implements TokenCustomizer {
 


### PR DESCRIPTION
`quarkus.oidc.Tenant` annotation was introduced in `3.2.0` after we discussed with @geoand how we can let users associate some OIDC features with individual OIDC tenants without having to introduce new properties and rely on named beans.
At the moment `@Tenant` can only be recognized if it is added to a custom `TokenCustomizer` interface implementation. As it happens, the only real case we've had so far is related to using `TokenCustomizer` to support preprocessing some Azure tokens - but we ship `AzureTokenCustomizer` which is a named bean which can be wired in with specific tenants using a configuration property.
It is very unlikely that, since 3.2.0 was released, that there was any other, non Azure related case requiring the token customization in a multi-tenant setup. It can become more realistic with more features supported by custom beans will be introduced.

The reason I've been clarifying all of the above is that we have an enhancement request to be able to bind tenant configurations to JAX-RS classes or methods, and @michalvavrik opened a nice PR, #34833, where using `@Tenant` annotation makes perfect sense.

However, now we have a dual application of `@Tenant`:

* Effectively enhance a tenant configuration by applying `@Tenant` to some feature interface implementing bean, like `CustomTokenCustomizer`
* Use a selected tenant configuration when securing a given JAX-RS class or method - with the latter requirement also extending the `@Tenant` application to `Method` - which does not make sense for the original case where it can only be a class level annotation.

We've discussed it with @michalvavrik in #34833.

It does seem that this is the right time to rename originally misnamed `@Tenant` to `@TenantFeature` - with nearly 0% of breaking any user code at this point of time (see some reasoning above), and have `@TenantFeature` used for doing the feature binding to specific tenant configurations which is what `@Tenant` was originally meant for, while continuing using `@Tenant` but for new, better scoped purposes - apply specific tenant configuration to JAX-RS methods.

I'll add a migration note - but as I said, I'm fairly confident this technically breaking change won't affect 3.2.x users.

@geoand Can you please comment/review since we worked together on the original `@Tenant` ?