### PR TITLE
Make jib-core a parent-first dependency

### DIFF
--- a/extensions/container-image/container-image-jib/runtime/pom.xml
+++ b/extensions/container-image/container-image-jib/runtime/pom.xml
@@ -33,6 +33,9 @@
                             <name>io.quarkus.container.image.jib</name>
                         </providesIf>
                     </capabilities>
+                    <parentFirstArtifacts>
+                        <parentFirstArtifact>com.google.cloud.tools:jib-core</parentFirstArtifact>
+                    </parentFirstArtifacts>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Done in order to avoid problems with Jib's use of
lock classes which have no effect when the lock
class is loaded from different ClassLoaders

Fixes: #11903