### PR TITLE
[3.2] Mark OIDC Tenant annotation as Experimental

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/Tenant.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/Tenant.java
@@ -6,11 +6,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import io.smallrye.common.annotation.Experimental;
+
 /**
- * Qualifier which can be used to associate one or more OIDC features with a named tenant.
+ * Annotation which can be used to associate one or more OIDC features with a named tenant.
  */
 @Target({ TYPE })
 @Retention(RetentionPolicy.RUNTIME)
+@Experimental("Tenant annnotation is experimental and may change without notice")
 public @interface Tenant {
     /**
      * Identifies an OIDC tenant to which a given feature applies.


### PR DESCRIPTION
Related to #34862 which replaces the current use of `@Tenant` with `@TenantFeature` on `main` to reflect better that it is about enhancing a given Tenant configuration with the marked feature, for `@Tenant` to continue be used but to identify tenant configurations which will be used to secure JAX-RS classes/methods.

As suggested in #34862, the possibility of users already starting using `@Tenant` in `3.2.x` is very very low because:

* At the moment `@Tenant` would only be recognized if it is applied to custom `TokenCustomizer` interfaces which preprocess token headers for the signature be verified - a rare and advanced case - but the probability will increase once more features like `TokenCustomizer` are introduced
* The only practical case we are aware of right now is the need to preprocess some of Azure tokens - which is supported by a named `AzureTokenCustomizer` which can not be selected with `@Tenant`.

Given the probability of `@Tenant` already being used is low, #34862 can be considered quite safe, but marking it as `Experimental` in the 3.2.x line, as proposed by Georgios, should help with 3.2.x users choosing to stay away from it.

