### PR TITLE
Make the creation of the Tracer bean lazy

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/cdi/TracerProducer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/cdi/TracerProducer.java
@@ -2,6 +2,7 @@ package io.quarkus.opentelemetry.runtime.tracing.cdi;
 
 import static io.quarkus.opentelemetry.runtime.config.build.OTelBuildConfig.INSTRUMENTATION_NAME;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
@@ -22,7 +23,7 @@ public class TracerProducer {
     }
 
     @Produces
-    @Singleton
+    @ApplicationScoped
     @DefaultBean
     public Tracer getTracer() {
         return GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);


### PR DESCRIPTION
This is needed to avoid a timing issue
that can lead to `java.lang.IllegalStateException: GlobalOpenTelemetry.set has already been called`

In rare cases this could happen in our tests that do have an `@Inject Tracer tracer` injection point