### PR TITLE
Revert to openjdk-17-runtime:1.16 images

### DIFF
--- a/extensions/container-image/container-image-docker/deployment/src/test/java/io/quarkus/container/image/docker/deployment/RedHatOpenJDKRuntimeBaseProviderTest.java
+++ b/extensions/container-image/container-image-docker/deployment/src/test/java/io/quarkus/container/image/docker/deployment/RedHatOpenJDKRuntimeBaseProviderTest.java
@@ -26,7 +26,7 @@ class RedHatOpenJDKRuntimeBaseProviderTest {
         Path path = getPath("openjdk-17-runtime");
         var result = sut.determine(path);
         assertThat(result).hasValueSatisfying(v -> {
-            assertThat(v.getBaseImage()).isEqualTo("registry.access.redhat.com/ubi8/openjdk-17-runtime:1.17");
+            assertThat(v.getBaseImage()).isEqualTo("registry.access.redhat.com/ubi8/openjdk-17-runtime:1.16");
             assertThat(v.getJavaVersion()).isEqualTo(17);
         });
     }

--- a/extensions/container-image/container-image-docker/deployment/src/test/resources/openjdk-17-runtime
+++ b/extensions/container-image/container-image-docker/deployment/src/test/resources/openjdk-17-runtime
@@ -1,5 +1,5 @@
 # Use Java 17 base image
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.17
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.16
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
@@ -16,7 +16,7 @@ public class JibConfig {
     /**
      * The base image to be used when a container image is being produced for the jar build.
      *
-     * When the application is built against Java 17 or higher, {@code registry.access.redhat.com/ubi8/openjdk-17-runtime:1.17}
+     * When the application is built against Java 17 or higher, {@code registry.access.redhat.com/ubi8/openjdk-17-runtime:1.16}
      * is used as the default.
      * Otherwise {@code registry.access.redhat.com/ubi8/openjdk-11-runtime:1.16} is used as the default.
      */

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -90,7 +90,7 @@ public class JibProcessor {
     private static final IsClassPredicate IS_CLASS_PREDICATE = new IsClassPredicate();
     private static final String BINARY_NAME_IN_CONTAINER = "application";
 
-    private static final String JAVA_17_BASE_IMAGE = "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.17";
+    private static final String JAVA_17_BASE_IMAGE = "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.16";
     private static final String JAVA_11_BASE_IMAGE = "registry.access.redhat.com/ubi8/openjdk-11-runtime:1.16";
     private static final String DEFAULT_BASE_IMAGE_USER = "185";
 


### PR DESCRIPTION
~~The 1.17 images that were available, and not published anymore...~~ ( Well, not sure anymore... might need to dig a bit more)


See
https://catalog.redhat.com/software/containers/ubi8/openjdk-17-runtime/618bdc5f843af1624c4e4ba8?architecture=amd64&container-tabs=overview

Fixes https://github.com/quarkusio/quarkus/issues/34881
