### PR TITLE
Change how actual DB version is checked

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -200,8 +200,9 @@ but must be lower than or equal to the version of any database your application 
 
 [NOTE]
 ====
-When a version is set explicitly,
-Quarkus will try to check this version against the actual database version on startup,
+As described above, the version can either be preconfigured explicitly via a `quarkus.datasource.db-version` configuration property,
+or implicitly set by the Quarkus build process to a minimum supported version of the database.
+Quarkus will try to check this preconfigured version against the actual database version on startup,
 leading to a startup failure when the actual version is lower.
 
 This is because Hibernate ORM may generate SQL that is invalid

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusRuntimeInitDialectFactory.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusRuntimeInitDialectFactory.java
@@ -29,13 +29,13 @@ public class QuarkusRuntimeInitDialectFactory implements DialectFactory {
     private final String persistenceUnitName;
     private final Dialect dialect;
     private final Optional<String> datasourceName;
-    private final Optional<DatabaseVersion> buildTimeDbVersion;
+    private final DatabaseVersion buildTimeDbVersion;
 
     private boolean triedToRetrieveDbVersion = false;
     private Optional<DatabaseVersion> actualDbVersion = Optional.empty();
 
     public QuarkusRuntimeInitDialectFactory(String persistenceUnitName, Dialect dialect,
-            Optional<String> datasourceName, Optional<DatabaseVersion> buildTimeDbVersion) {
+            Optional<String> datasourceName, DatabaseVersion buildTimeDbVersion) {
         this.persistenceUnitName = persistenceUnitName;
         this.dialect = dialect;
         this.datasourceName = datasourceName;
@@ -45,29 +45,25 @@ public class QuarkusRuntimeInitDialectFactory implements DialectFactory {
     @Override
     public Dialect buildDialect(Map<String, Object> configValues, DialectResolutionInfoSource resolutionInfoSource)
             throws HibernateException {
-        if (buildTimeDbVersion.isPresent() && actualDbVersion.isEmpty()) {
+        if (actualDbVersion.isEmpty()) {
             this.actualDbVersion = retrieveDbVersion(resolutionInfoSource);
         }
         return dialect;
     }
 
     public void checkActualDbVersion() {
-        if (buildTimeDbVersion.isEmpty()) {
-            // Nothing to check
-            return;
-        }
         if (!triedToRetrieveDbVersion) {
             LOG.warnf("Persistence unit %1$s: Could not retrieve the database version to check it is at least %2$s",
-                    persistenceUnitName, DialectVersions.toString(buildTimeDbVersion.get()));
+                    persistenceUnitName, DialectVersions.toString(buildTimeDbVersion));
             return;
         }
-        if (actualDbVersion.isPresent() && buildTimeDbVersion.get().isAfter(actualDbVersion.get())) {
+        if (actualDbVersion.isPresent() && buildTimeDbVersion.isAfter(actualDbVersion.get())) {
             throw new ConfigurationException(String.format(Locale.ROOT,
                     "Persistence unit '%1$s' was configured to run with a database version"
                             + " of at least '%2$s', but the actual version is '%3$s'."
                             + " Consider upgrading your database.",
                     persistenceUnitName,
-                    DialectVersions.toString(buildTimeDbVersion.get()), DialectVersions.toString(actualDbVersion.get()))
+                    DialectVersions.toString(buildTimeDbVersion), DialectVersions.toString(actualDbVersion.get()))
                     // It shouldn't be possible to reach this code if datasourceName is empty,
                     // but just let's be safe...
                     + (datasourceName.isEmpty() ? ""
@@ -93,7 +89,7 @@ public class QuarkusRuntimeInitDialectFactory implements DialectFactory {
                     databaseMetadata.getDatabaseMinorVersion()));
         } catch (RuntimeException | SQLException e) {
             LOG.warnf(e, "Persistence unit %1$s: Could not retrieve the database version to check it is at least %2$s",
-                    persistenceUnitName, buildTimeDbVersion.get());
+                    persistenceUnitName, buildTimeDbVersion);
             return Optional.empty();
         }
     }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusRuntimeInitDialectFactoryInitiator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/QuarkusRuntimeInitDialectFactoryInitiator.java
@@ -16,17 +16,16 @@ public class QuarkusRuntimeInitDialectFactoryInitiator implements StandardServic
     private final String persistenceUnitName;
     private final Dialect dialect;
     private final Optional<String> datasourceName;
-    private final Optional<DatabaseVersion> buildTimeDbVersion;
+    private final DatabaseVersion buildTimeDbVersion;
 
     public QuarkusRuntimeInitDialectFactoryInitiator(String persistenceUnitName, Dialect dialect,
             RecordedConfig recordedConfig) {
         this.persistenceUnitName = persistenceUnitName;
         this.dialect = dialect;
         this.datasourceName = recordedConfig.getDataSource();
-        this.buildTimeDbVersion = recordedConfig.getDbVersion().isPresent()
-                // This is the same version, but parsed in a dialect-specific way.
-                ? Optional.of(dialect.getVersion())
-                : Optional.empty();
+        // We set the version from the dialect since if it wasn't provided explicitly through the `recordedConfig.getDbVersion()`
+        // then the version from `DialectVersions.Defaults` will be used:
+        this.buildTimeDbVersion = dialect.getVersion();
     }
 
     @Override


### PR DESCRIPTION
This came up while looking into https://github.com/quarkusio/quarkus/issues/34754

In that scenario, the actual DB version is 5.5, but because of the `DialectVersions.Defaults`, the version is set to 8.0 😨🥲, which I guess may lead to problems in runtime...
And `checkActualDbVersion() ` call never got further than the first if statement. It seems safe to say that `buildTimeDbVersion` is whatever the driver version got initialized to...

With these changes, the app would first fail with:
```
Persistence unit '<default>' was configured to run with a database version of at least '8.0.0', but the actual version is '5.5.0'. Consider upgrading your database. Alternatively, rebuild your application with 'quarkus.datasource.db-version=5.5.0' (but this may disable some features and/or impact performance negatively).
```
and then if the db-version is configured:
```
WARN: HHH000511: The 5.5.0 version for [org.hibernate.dialect.MySQLDialect] is no longer supported, hence certain features may not work properly. The minimum supported version is 5.7.0. Check the community dialects project for available legacy versions.
```
ORM will warn the user about the unsupported version. 