### PR TITLE
Dev UI Scheduler: Fix screen height

### DIFF
--- a/extensions/scheduler/deployment/src/main/resources/dev-ui/qwc-scheduler-scheduled-methods.js
+++ b/extensions/scheduler/deployment/src/main/resources/dev-ui/qwc-scheduler-scheduled-methods.js
@@ -17,6 +17,7 @@ export class QwcSchedulerScheduledMethods extends LitElement {
             display: flex;
             flex-direction: column;
             gap: 10px;
+            height: 100%;
         }
     
         .schedules-table {


### PR DESCRIPTION
Very (very !) small PR to fix the screen height in the Dev UI Scheduler screen. I stumbled across this while doing something else, so decided to do a quick fix:

Before: 
![before](https://github.com/quarkusio/quarkus/assets/6836179/64dd8a93-dbf9-4c10-bdd8-29df960ef891)

After:
![after](https://github.com/quarkusio/quarkus/assets/6836179/977a9676-b0bb-455c-af77-222f05d68c2b)


