### PR TITLE
Allow the use of HTTP2 in programmatically created REST Client

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -356,6 +356,8 @@ public class RestClientBuilderImpl implements RestClientBuilder {
 
         if (getConfiguration().hasProperty(QuarkusRestClientProperties.HTTP2)) {
             clientBuilder.http2((Boolean) getConfiguration().getProperty(QuarkusRestClientProperties.HTTP2));
+        } else if (restClientsConfig.http2) {
+            clientBuilder.http2(true);
         }
 
         Boolean enableCompression = ConfigProvider.getConfig()

--- a/integration-tests/rest-client-reactive-http2/src/main/java/io/quarkus/it/rest/client/http2/Client2.java
+++ b/integration-tests/rest-client-reactive-http2/src/main/java/io/quarkus/it/rest/client/http2/Client2.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.rest.client.http2;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("/ping")
+public interface Client2 {
+
+    @GET
+    Response ping();
+}

--- a/integration-tests/rest-client-reactive-http2/src/main/java/io/quarkus/it/rest/client/http2/Resource.java
+++ b/integration-tests/rest-client-reactive-http2/src/main/java/io/quarkus/it/rest/client/http2/Resource.java
@@ -1,22 +1,49 @@
 package io.quarkus.it.rest.client.http2;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.resteasy.reactive.client.impl.ClientResponseImpl;
 
 @Path("")
 public class Resource {
 
-    @RestClient
-    Client client;
+    private final Client client;
+    private final Client2 client2;
+
+    public Resource(@ConfigProperty(name = "test.url") String testUrl, @RestClient Client client) {
+        this.client = client;
+        try {
+            this.client2 = RestClientBuilder.newBuilder()
+                    .baseUrl(new URL(testUrl))
+                    .build(Client2.class);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     @GET
     @Path("/client/ping")
     public Response client() {
         Response response = client.ping();
+        if (((ClientResponseImpl) response).getHttpVersion().equals("HTTP_2")) {
+            return response;
+        }
+
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/client2/ping")
+    public Response client2() {
+        Response response = client2.ping();
         if (((ClientResponseImpl) response).getHttpVersion().equals("HTTP_2")) {
             return response;
         }

--- a/integration-tests/rest-client-reactive-http2/src/main/resources/application.properties
+++ b/integration-tests/rest-client-reactive-http2/src/main/resources/application.properties
@@ -4,4 +4,7 @@ quarkus.rest-client.basic-client.http2=true
 quarkus.rest-client.multipart-client.url=${test.url}
 quarkus.rest-client.multipart-client.http2=true
 
+#used for the manually created client
+quarkus.rest-client.http2=true
+
 quarkus.http.http2=true

--- a/integration-tests/rest-client-reactive-http2/src/test/java/io/quarkus/it/rest/client/http2/ResourceTest.java
+++ b/integration-tests/rest-client-reactive-http2/src/test/java/io/quarkus/it/rest/client/http2/ResourceTest.java
@@ -28,6 +28,9 @@ public class ResourceTest {
     @TestHTTPResource(value = "/client/ping")
     URL clientUrl;
 
+    @TestHTTPResource(value = "/client2/ping")
+    URL client2Url;
+
     private WebClient webClient;
 
     @BeforeEach
@@ -52,6 +55,13 @@ public class ResourceTest {
     @Test
     public void shouldReturnPongFromClient() throws Exception {
         HttpResponse<?> response = call(clientUrl);
+        // if it's empty, it's because the REST Client is not using the HTTP/2 version
+        assertEquals("pong", response.bodyAsString());
+    }
+
+    @Test
+    public void shouldReturnPongFromManuallyCreatedClient() throws Exception {
+        HttpResponse<?> response = call(client2Url);
         // if it's empty, it's because the REST Client is not using the HTTP/2 version
         assertEquals("pong", response.bodyAsString());
     }


### PR DESCRIPTION
Fixes: #34896