### PR TITLE
Fix issue of e.getCause() returns null

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/TargetAroundInvokeInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/TargetAroundInvokeInvocationContext.java
@@ -45,6 +45,11 @@ class TargetAroundInvokeInvocationContext extends InnerInvocationContext {
             }
         } catch (Exception e) {
             Throwable cause = e.getCause();
+
+            // e.getCause() may return null
+            if (cause == null) {
+                cause = e;
+            }
             if (cause instanceof Error) {
                 throw (Error) cause;
             }


### PR DESCRIPTION
In some situation, e.getCause() returns null, this cause the original exception lost when printing exception stack trace.