### PR TITLE
Update RabbitMQ DevServices container to 3.12

### DIFF
--- a/docs/src/main/asciidoc/rabbitmq.adoc
+++ b/docs/src/main/asciidoc/rabbitmq.adoc
@@ -396,7 +396,7 @@ version: '2'
 services:
 
   rabbit:
-    image: rabbitmq:3.9-management
+    image: rabbitmq:3.12-management
     ports:
       - "5672:5672"
     networks:

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
@@ -125,7 +125,7 @@ public class RabbitMQDevServicesBuildTimeConfig {
      * Note that only official RabbitMQ images are supported.
      * Specifically, the image repository must end with {@code rabbitmq}.
      */
-    @ConfigItem(defaultValue = "rabbitmq:3.9-management")
+    @ConfigItem(defaultValue = "rabbitmq:3.12-management")
     public String imageName;
 
     /**

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsTest.java
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsTest.java
@@ -14,17 +14,17 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import io.quarkus.it.rabbitmq.RabbitMQConnectorDynCredsTest.VaultResource;
+import io.quarkus.it.rabbitmq.RabbitMQConnectorDynCredsTest.RabbitMQResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
-@QuarkusTestResource(VaultResource.class)
+@QuarkusTestResource(RabbitMQResource.class)
 public class RabbitMQConnectorDynCredsTest {
 
-    public static class VaultResource implements QuarkusTestResourceLifecycleManager {
+    public static class RabbitMQResource implements QuarkusTestResourceLifecycleManager {
 
         RabbitMQContainer rabbit;
 
@@ -33,7 +33,7 @@ public class RabbitMQConnectorDynCredsTest {
             String username = "tester";
             String password = RandomStringUtils.random(10);
 
-            rabbit = new RabbitMQContainer(DockerImageName.parse("rabbitmq:3.9-management"))
+            rabbit = new RabbitMQContainer(DockerImageName.parse("rabbitmq:3.12-management"))
                     .withNetwork(Network.SHARED)
                     .withNetworkAliases("rabbitmq")
                     .withUser(username, password)


### PR DESCRIPTION
RabbitMQ 3.9 is out of general support. This updates the dev services container to 3.12 series.

It also fixes a copy/paste error I made long ago.