### PR TITLE
Apply JavaPlugin on the deployment project

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
@@ -73,6 +73,7 @@ public class QuarkusExtensionPlugin implements Plugin<Project> {
             //This must be run after the extension has been configured
             Project deploymentProject = findDeploymentProject(project, quarkusExt);
             if (deploymentProject != null) {
+                deploymentProject.getPlugins().apply(JavaPlugin.class);
                 ApplicationDeploymentClasspathBuilder.initConfigurations(deploymentProject);
                 deploymentProject.getPlugins().withType(
                         JavaPlugin.class,


### PR DESCRIPTION
Apply JavaPlugin on the deployment project to solve the "Configuration with name 'annotationProcessor' not found" problem.

fixes quarkusio/quarkus#32767