### PR TITLE
Bump kubernetes-client-bom from 6.7.2 to 6.8.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -162,7 +162,7 @@
         <kotlin.coroutine.version>1.7.3</kotlin.coroutine.version>
         <azure.toolkit-lib.version>0.27.0</azure.toolkit-lib.version>
         <kotlin-serialization.version>1.6.0</kotlin-serialization.version>
-        <dekorate.version>3.7.0</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
+        <dekorate.version>4.0.0</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>
         <jboss-logmanager.version>3.0.2.Final</jboss-logmanager.version>

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddCronJobResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddCronJobResourceDecorator.java
@@ -26,17 +26,16 @@ public class AddCronJobResourceDecorator extends ResourceProvidingDecorator<Kube
         this.config = config;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void visit(KubernetesListFluent<?> list) {
-        CronJobBuilder builder = list.getItems().stream()
+        CronJobBuilder builder = list.buildItems().stream()
                 .filter(this::containsCronJobResource)
                 .map(replaceExistingCronJobResource(list))
                 .findAny()
                 .orElseGet(this::createCronJobResource)
                 .accept(CronJobBuilder.class, this::initCronJobResourceWithDefaults);
 
-        if (Strings.isNullOrEmpty(builder.getSpec().getSchedule())) {
+        if (Strings.isNullOrEmpty(builder.buildSpec().getSchedule())) {
             throw new IllegalArgumentException(
                     "When generating a CronJob resource, you need to specify a schedule CRON expression.");
         }
@@ -49,7 +48,7 @@ public class AddCronJobResourceDecorator extends ResourceProvidingDecorator<Kube
     }
 
     private void initCronJobResourceWithDefaults(CronJobBuilder builder) {
-        CronJobFluent.SpecNested<CronJobBuilder> spec = builder.editOrNewSpec();
+        CronJobFluent<?>.SpecNested<CronJobBuilder> spec = builder.editOrNewSpec();
 
         var jobTemplateSpec = spec
                 .editOrNewJobTemplate()
@@ -106,7 +105,7 @@ public class AddCronJobResourceDecorator extends ResourceProvidingDecorator<Kube
         };
     }
 
-    private boolean containsContainerWithName(CronJobFluent.SpecNested<CronJobBuilder> spec) {
+    private boolean containsContainerWithName(CronJobFluent<?>.SpecNested<CronJobBuilder> spec) {
         var jobTemplate = spec.buildJobTemplate();
         if (jobTemplate == null
                 || jobTemplate.getSpec() == null

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddJobResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddJobResourceDecorator.java
@@ -25,10 +25,9 @@ public class AddJobResourceDecorator extends ResourceProvidingDecorator<Kubernet
         this.config = config;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void visit(KubernetesListFluent<?> list) {
-        JobBuilder builder = list.getItems().stream()
+        JobBuilder builder = list.buildItems().stream()
                 .filter(this::containsJobResource)
                 .map(replaceExistingJobResource(list))
                 .findAny()
@@ -43,7 +42,7 @@ public class AddJobResourceDecorator extends ResourceProvidingDecorator<Kubernet
     }
 
     private void initJobResourceWithDefaults(JobBuilder builder) {
-        JobFluent.SpecNested<JobBuilder> spec = builder.editOrNewSpec();
+        JobFluent<?>.SpecNested<JobBuilder> spec = builder.editOrNewSpec();
 
         spec.editOrNewSelector()
                 .endSelector()
@@ -89,7 +88,7 @@ public class AddJobResourceDecorator extends ResourceProvidingDecorator<Kubernet
         };
     }
 
-    private boolean containsContainerWithName(JobFluent.SpecNested<JobBuilder> spec) {
+    private boolean containsContainerWithName(JobFluent<?>.SpecNested<JobBuilder> spec) {
         List<Container> containers = spec.buildTemplate().getSpec().getContainers();
         return containers == null || containers.stream().anyMatch(c -> name.equals(c.getName()));
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddNodePortDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddNodePortDecorator.java
@@ -12,7 +12,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.kubernetes.api.model.ServiceSpecFluent;
 
-public class AddNodePortDecorator extends NamedResourceDecorator<ServiceSpecFluent> {
+public class AddNodePortDecorator extends NamedResourceDecorator<ServiceSpecFluent<?>> {
 
     private static final Logger log = Logger.getLogger(AddNodePortDecorator.class);
 
@@ -32,7 +32,7 @@ public class AddNodePortDecorator extends NamedResourceDecorator<ServiceSpecFlue
     @SuppressWarnings("unchecked")
     @Override
     public void andThenVisit(ServiceSpecFluent service, ObjectMeta resourceMeta) {
-        ServiceSpecFluent.PortsNested<?> editPort = service.editMatchingPort(new Predicate<ServicePortBuilder>() {
+        ServiceSpecFluent<?>.PortsNested<?> editPort = service.editMatchingPort(new Predicate<ServicePortBuilder>() {
             @Override
             public boolean test(ServicePortBuilder servicePortBuilder) {
                 return servicePortBuilder.hasName() && servicePortBuilder.getName().equals(matchingPortName);

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddStatefulSetResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddStatefulSetResourceDecorator.java
@@ -26,10 +26,9 @@ public class AddStatefulSetResourceDecorator extends ResourceProvidingDecorator<
         this.config = config;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void visit(KubernetesListFluent<?> list) {
-        StatefulSetBuilder builder = list.getItems().stream()
+        StatefulSetBuilder builder = list.buildItems().stream()
                 .filter(this::containsStatefulSetResource)
                 .map(replaceExistingStatefulSetResource(list))
                 .findAny()
@@ -44,7 +43,7 @@ public class AddStatefulSetResourceDecorator extends ResourceProvidingDecorator<
     }
 
     private void initStatefulSetResourceWithDefaults(StatefulSetBuilder builder) {
-        StatefulSetFluent.SpecNested<StatefulSetBuilder> spec = builder.editOrNewSpec();
+        StatefulSetFluent<?>.SpecNested<StatefulSetBuilder> spec = builder.editOrNewSpec();
 
         spec.editOrNewSelector()
                 .endSelector()
@@ -91,7 +90,7 @@ public class AddStatefulSetResourceDecorator extends ResourceProvidingDecorator<
         };
     }
 
-    private boolean containsContainerWithName(StatefulSetFluent.SpecNested<StatefulSetBuilder> spec) {
+    private boolean containsContainerWithName(StatefulSetFluent<?>.SpecNested<StatefulSetBuilder> spec) {
         List<Container> containers = spec.buildTemplate().getSpec().getContainers();
         return containers == null || containers.stream().anyMatch(c -> name.equals(c.getName()));
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveBuilderImageResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveBuilderImageResourceDecorator.java
@@ -20,7 +20,7 @@ public class RemoveBuilderImageResourceDecorator extends Decorator<KubernetesLis
 
     @Override
     public void visit(KubernetesListBuilder builder) {
-        List<HasMetadata> imageStreams = builder.getItems().stream()
+        List<HasMetadata> imageStreams = builder.buildItems().stream()
                 .filter(i -> i instanceof ImageStream)
                 .map(i -> (HasMetadata) i)
                 .filter(i -> i.getMetadata().getName().equalsIgnoreCase(name))

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 
         <!-- Dependency versions -->
         <jacoco.version>0.8.10</jacoco.version>
-        <kubernetes-client.version>6.7.2</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>6.8.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.57.2</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->


### PR DESCRIPTION
- Kubernetes Client 6.8.0 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v6.8.0
- Kubernetes Client 6.8.1 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v6.8.1


This will require bumping the Fabric8 Kubernetes Client version in Dekorate first.
- [x] https://github.com/dekorateio/dekorate/pull/1233
- [x] https://github.com/dekorateio/dekorate/pull/1235

The Dekorate dependency is also bumped to latest 4.0.0 which includes the 6.8.0 compatible Kubernetes Client dependency.

/cc @metacosm