### PR TITLE
Add a way to configure an OpenSearch distribution for the Elasticsearch DevService

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -207,6 +207,8 @@
         <apicurio-common-rest-client.version>0.1.18.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
         <testcontainers.version>1.18.3</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
         <docker-java.version>3.3.0</docker-java.version> <!-- must be the version Testcontainers use -->
+        <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
+        <opensearch-testcontainers.version>2.0.0</opensearch-testcontainers.version>
         <com.dajudge.kindcontainer>1.3.0</com.dajudge.kindcontainer>
         <aesh.version>2.7</aesh.version>
         <aesh-readline.version>2.4</aesh-readline.version>
@@ -382,6 +384,11 @@
                         <artifactId>hamcrest-core</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.opensearch</groupId>
+                <artifactId>opensearch-testcontainers</artifactId>
+                <version>${opensearch-testcontainers.version}</version>
             </dependency>
 
             <!-- OpenTelemetry components, imported as a BOM -->

--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -13,6 +13,7 @@
 :gradle-version: ${gradle-wrapper.version}
 :elasticsearch-version: ${elasticsearch-server.version}
 :elasticsearch-image: ${elasticsearch.image}
+:opensearch-image: ${opensearch.image}
 :infinispan-version: ${infinispan.version}
 :infinispan-protostream-version: ${infinispan.protostream.version}
 :logstash-image: ${logstash.image}

--- a/docs/src/main/asciidoc/elasticsearch-dev-services.adoc
+++ b/docs/src/main/asciidoc/elasticsearch-dev-services.adoc
@@ -4,8 +4,9 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for Elasticsearch
-
 include::_attributes.adoc[]
+:categories: data
+:summary: Start Elasticsearch automatically in dev and test modes
 
 If any Elasticsearch-related extension is present (e.g. `quarkus-elasticsearch-rest-client` or `quarkus-hibernate-search-orm-elasticsearch`),
 Dev Services for Elasticsearch automatically starts an Elasticsearch server in dev mode and when running tests.
@@ -48,12 +49,28 @@ Note that the Elasticsearch hosts property is automatically configured with the 
 
 == Configuring the image
 
-Dev Services for Elasticsearch only support Elasticsearch based images, OpenSearch is not supported at the moment.
+Dev Services for Elasticsearch support distributions based on both Elasticsearch and OpenSearch images.
 
-If you need to use a different image than the default one you can configure it via:
-[source, properties]
+When using Hibernate Search, Dev Services will default to Elasticsearch or OpenSearch based on Hibernate Search configuration.
+
+Otherwise, Dev Services will default to Elasticsearch. To use OpenSearch, configure the distribution explicitly:
+[source,properties,subs="attributes"]
+----
+quarkus.elasticsearch.devservices.distribution=opensearch
+----
+
+If you need to use a different Elasticsearch or OpenSearch image than the default one you can configure it via:
+[source,properties,subs="attributes"]
 ----
 quarkus.elasticsearch.devservices.image-name={elasticsearch-image}
+----
+
+For exotic image names, Quarkus might be unable to infer the distribution (`elastic` or `opensearch`).
+In these cases starting the Dev Services will fail, and you will need to configure the distribution explicitly:
+[source,properties,subs="attributes"]
+----
+quarkus.elasticsearch.devservices.image-name=my-custom-image-with-no-clue-about-the-distribution:1.0
+quarkus.elasticsearch.devservices.distribution=elasticsearch
 ----
 
 == Current limitations

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
@@ -3,7 +3,8 @@ package io.quarkus.devservices.common;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
@@ -43,7 +44,8 @@ public final class ConfigureUtil {
         }
 
         String hostName = (hostNamePrefix + "-" + Base58.randomString(5)).toLowerCase(Locale.ROOT);
-        container.setNetworkAliases(Collections.singletonList(hostName));
+        // some containers might try to add their own aliases on start, so we want to keep this list modifiable:
+        container.setNetworkAliases(new ArrayList<>(List.of(hostName)));
 
         return hostName;
     }

--- a/extensions/elasticsearch-rest-client-common/deployment/pom.xml
+++ b/extensions/elasticsearch-rest-client-common/deployment/pom.xml
@@ -39,6 +39,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.opensearch</groupId>
+            <artifactId>opensearch-testcontainers</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -5,12 +5,15 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -31,6 +34,7 @@ import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerAddress;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchDevServicesBuildTimeConfig.Distribution;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
 /**
@@ -49,6 +53,9 @@ public class DevServicesElasticsearchProcessor {
 
     private static final ContainerLocator elasticsearchContainerLocator = new ContainerLocator(DEV_SERVICE_LABEL,
             ELASTICSEARCH_PORT);
+    private static final Distribution DEFAULT_DISTRIBUTION = Distribution.ELASTIC;
+    private static final String DEV_SERVICE_ELASTICSEARCH = "elasticsearch";
+    private static final String DEV_SERVICE_OPENSEARCH = "opensearch";
 
     static volatile DevServicesResultBuildItem.RunningDevService devService;
     static volatile ElasticsearchDevServicesBuildTimeConfig cfg;
@@ -171,22 +178,30 @@ public class DevServicesElasticsearchProcessor {
             return null;
         }
 
-        // We only support ELASTIC container for now
-        if (buildItemConfig.distribution == DevservicesElasticsearchBuildItem.Distribution.OPENSEARCH) {
-            throw new BuildException("Dev Services for Elasticsearch doesn't support OpenSearch", Collections.emptyList());
-        }
-
+        Distribution resolvedDistribution = resolveDistribution(config, buildItemConfig);
+        DockerImageName resolvedImageName = resolveImageName(config, resolvedDistribution);
         // Hibernate Search Elasticsearch have a version configuration property, we need to check that it is coherent
         // with the image we are about to launch
         if (buildItemConfig.version != null) {
-            String containerTag = config.imageName.substring(config.imageName.indexOf(':') + 1);
+            String containerTag = resolvedImageName.getVersionPart();
             if (!containerTag.startsWith(buildItemConfig.version)) {
                 throw new BuildException(
-                        "Dev Services for Elasticsearch detected a version mismatch, container image is " + config.imageName
-                                + " but the configured version is " + buildItemConfig.version +
-                                ". Either configure a different image or disable Dev Services for Elasticsearch.",
+                        "Dev Services for Elasticsearch detected a version mismatch."
+                                + " Consuming extensions are configured to use version " + config.imageName
+                                + " but Dev Services are configured to use version " + buildItemConfig.version +
+                                ". Either configure the same version or disable Dev Services for Elasticsearch.",
                         Collections.emptyList());
             }
+        }
+
+        if (buildItemConfig.distribution != null
+                && !buildItemConfig.distribution.equals(resolvedDistribution)) {
+            throw new BuildException(
+                    "Dev Services for Elasticsearch detected a distribution mismatch."
+                            + " Consuming extensions are configured to use distribution " + config.distribution
+                            + " but Dev Services are configured to use distribution " + buildItemConfig.distribution +
+                            ". Either configure the same distribution or disable Dev Services for Elasticsearch.",
+                    Collections.emptyList());
         }
 
         final Optional<ContainerAddress> maybeContainerAddress = elasticsearchContainerLocator.locateContainer(
@@ -196,10 +211,11 @@ public class DevServicesElasticsearchProcessor {
 
         // Starting the server
         final Supplier<DevServicesResultBuildItem.RunningDevService> defaultElasticsearchSupplier = () -> {
-            ElasticsearchContainer container = new ElasticsearchContainer(
-                    DockerImageName.parse(config.imageName)
-                            .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"));
-            ConfigureUtil.configureSharedNetwork(container, "elasticsearch");
+
+            GenericContainer<?> container = resolvedDistribution.equals(Distribution.ELASTIC)
+                    ? createElasticsearchContainer(config, resolvedImageName)
+                    : createOpensearchContainer(config, resolvedImageName);
+
             if (config.serviceName != null) {
                 container.withLabel(DEV_SERVICE_LABEL, config.serviceName);
             }
@@ -208,22 +224,14 @@ public class DevServicesElasticsearchProcessor {
             }
             timeout.ifPresent(container::withStartupTimeout);
 
-            container.addEnv("ES_JAVA_OPTS", config.javaOpts);
-            // Disable security as else we would need to configure it correctly to avoid tons of WARNING in the log
-            container.addEnv("xpack.security.enabled", "false");
-            // Disable disk-based shard allocation thresholds:
-            // in a single-node setup they just don't make sense,
-            // and lead to problems on large disks with little space left.
-            // See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
-            container.addEnv("cluster.routing.allocation.disk.threshold_enabled", "false");
-
             container.withEnv(config.containerEnv);
 
             container.start();
             return new DevServicesResultBuildItem.RunningDevService(Feature.ELASTICSEARCH_REST_CLIENT_COMMON.getName(),
                     container.getContainerId(),
                     container::close,
-                    buildPropertiesMap(buildItemConfig, container.getHttpHostAddress()));
+                    buildPropertiesMap(buildItemConfig,
+                            container.getHost() + ":" + container.getMappedPort(ELASTICSEARCH_PORT)));
         };
 
         return maybeContainerAddress
@@ -233,6 +241,77 @@ public class DevServicesElasticsearchProcessor {
                         null,
                         buildPropertiesMap(buildItemConfig, containerAddress.getUrl())))
                 .orElseGet(defaultElasticsearchSupplier);
+    }
+
+    private GenericContainer<?> createElasticsearchContainer(ElasticsearchDevServicesBuildTimeConfig config,
+            DockerImageName resolvedImageName) {
+        ElasticsearchContainer container = new ElasticsearchContainer(
+                resolvedImageName.asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"));
+        ConfigureUtil.configureSharedNetwork(container, DEV_SERVICE_ELASTICSEARCH);
+
+        // Disable security as else we would need to configure it correctly to avoid tons of WARNING in the log
+        container.addEnv("xpack.security.enabled", "false");
+        // Disable disk-based shard allocation thresholds:
+        // in a single-node setup they just don't make sense,
+        // and lead to problems on large disks with little space left.
+        // See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
+        container.addEnv("cluster.routing.allocation.disk.threshold_enabled", "false");
+        container.addEnv("ES_JAVA_OPTS", config.javaOpts);
+        return container;
+    }
+
+    private GenericContainer<?> createOpensearchContainer(ElasticsearchDevServicesBuildTimeConfig config,
+            DockerImageName resolvedImageName) {
+        OpensearchContainer container = new OpensearchContainer(
+                resolvedImageName.asCompatibleSubstituteFor("opensearchproject/opensearch"));
+        ConfigureUtil.configureSharedNetwork(container, DEV_SERVICE_OPENSEARCH);
+
+        container.addEnv("bootstrap.memory_lock", "true");
+        container.addEnv("plugins.index_state_management.enabled", "false");
+
+        container.addEnv("OPENSEARCH_JAVA_OPTS", config.javaOpts);
+        return container;
+    }
+
+    private DockerImageName resolveImageName(ElasticsearchDevServicesBuildTimeConfig config,
+            Distribution resolvedDistribution) {
+        return DockerImageName.parse(config.imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor(
+                Distribution.ELASTIC.equals(resolvedDistribution)
+                        ? DEV_SERVICE_ELASTICSEARCH
+                        : DEV_SERVICE_OPENSEARCH)));
+    }
+
+    private Distribution resolveDistribution(ElasticsearchDevServicesBuildTimeConfig config,
+            DevservicesElasticsearchBuildItemsConfiguration buildItemConfig) throws BuildException {
+        // First, let's see if it was explicitly configured:
+        if (config.distribution.isPresent()) {
+            return config.distribution.get();
+        }
+        // Now let's see if we can guess it from the image:
+        if (config.imageName.isPresent()) {
+            String imageNameRepository = DockerImageName.parse(config.imageName.get()).getRepository()
+                    .toLowerCase(Locale.ROOT);
+            if (imageNameRepository.contains(DEV_SERVICE_OPENSEARCH)) {
+                return Distribution.OPENSEARCH;
+            }
+            if (imageNameRepository.contains(DEV_SERVICE_ELASTICSEARCH)) {
+                return Distribution.ELASTIC;
+            }
+            // no luck guessing so let's ask user to be more explicit:
+            throw new BuildException(
+                    "Wasn't able to determine the distribution of the search service based on the provided image name ["
+                            + config.imageName.get()
+                            + "]. Please specify the distribution explicitly.",
+                    Collections.emptyList());
+        }
+        // Otherwise, let's see if the build item has a value available:
+        if (buildItemConfig.distribution != null) {
+            return buildItemConfig.distribution;
+        }
+        // If we didn't get an explicit distribution
+        // and no image name was provided
+        // then elastic is a default distribution:
+        return DEFAULT_DISTRIBUTION;
     }
 
     private Map<String, String> buildPropertiesMap(DevservicesElasticsearchBuildItemsConfiguration buildItemConfig,
@@ -251,7 +330,7 @@ public class DevServicesElasticsearchProcessor {
     private static class DevservicesElasticsearchBuildItemsConfiguration {
         private Set<String> hostsConfigProperties;
         private String version;
-        private DevservicesElasticsearchBuildItem.Distribution distribution;
+        private Distribution distribution;
 
         private DevservicesElasticsearchBuildItemsConfiguration(List<DevservicesElasticsearchBuildItem> buildItems)
                 throws BuildException {

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchBuildItem.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchBuildItem.java
@@ -1,5 +1,7 @@
 package io.quarkus.elasticsearch.restclient.common.deployment;
 
+import static io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchDevServicesBuildTimeConfig.Distribution;
+
 import io.quarkus.builder.item.MultiBuildItem;
 
 public final class DevservicesElasticsearchBuildItem extends MultiBuildItem {
@@ -11,7 +13,7 @@ public final class DevservicesElasticsearchBuildItem extends MultiBuildItem {
     public DevservicesElasticsearchBuildItem(String hostsConfigProperty) {
         this.hostsConfigProperty = hostsConfigProperty;
         this.version = null;
-        this.distribution = Distribution.ELASTIC;
+        this.distribution = null;
     }
 
     public DevservicesElasticsearchBuildItem(String configItemName, String version, Distribution distribution) {
@@ -32,8 +34,4 @@ public final class DevservicesElasticsearchBuildItem extends MultiBuildItem {
         return distribution;
     }
 
-    public enum Distribution {
-        ELASTIC,
-        OPENSEARCH
-    }
 }

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchDevServicesBuildTimeConfig.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchDevServicesBuildTimeConfig.java
@@ -28,11 +28,26 @@ public class ElasticsearchDevServicesBuildTimeConfig {
     public Optional<Integer> port;
 
     /**
-     * The Elasticsearch container image to use.
-     * Defaults to the elasticsearch image provided by Elastic.
+     * Defaults to a distribution inferred from the explicitly configured `image-name` (if any),
+     * or by default to the distribution configured in depending extensions (e.g. Hibernate Search),
+     * or by default to `elastic`.
+     *
+     * @asciidoclet
      */
-    @ConfigItem(defaultValue = "docker.elastic.co/elasticsearch/elasticsearch:8.8.2")
-    public String imageName;
+    @ConfigItem
+    public Optional<Distribution> distribution;
+
+    /**
+     * The Elasticsearch container image to use.
+     * Defaults depend on the configured `distribution`:
+     *
+     * * For the `elastic` distribution: {elasticsearch-image}
+     * * For the `opensearch` distribution: {opensearch-image}
+     *
+     * @asciidoclet
+     */
+    @ConfigItem
+    public Optional<String> imageName;
 
     /**
      * The value for the ES_JAVA_OPTS env variable.
@@ -84,6 +99,7 @@ public class ElasticsearchDevServicesBuildTimeConfig {
         return Objects.equals(shared, that.shared)
                 && Objects.equals(enabled, that.enabled)
                 && Objects.equals(port, that.port)
+                && Objects.equals(distribution, that.distribution)
                 && Objects.equals(imageName, that.imageName)
                 && Objects.equals(javaOpts, that.javaOpts)
                 && Objects.equals(serviceName, that.serviceName)
@@ -92,6 +108,11 @@ public class ElasticsearchDevServicesBuildTimeConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(enabled, port, imageName, javaOpts, shared, serviceName, containerEnv);
+        return Objects.hash(enabled, port, distribution, imageName, javaOpts, shared, serviceName, containerEnv);
+    }
+
+    public enum Distribution {
+        ELASTIC,
+        OPENSEARCH
     }
 }

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/elasticsearch-devservice.properties
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/elasticsearch-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${elasticsearch.image}

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/opensearch-devservice.properties
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/resources/opensearch-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${opensearch.image}

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.deployment;
 
+import static io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchDevServicesBuildTimeConfig.Distribution;
 import static io.quarkus.hibernate.search.orm.elasticsearch.deployment.ClassNames.INDEXED;
 import static io.quarkus.hibernate.search.orm.elasticsearch.deployment.ClassNames.PROJECTION_CONSTRUCTOR;
 import static io.quarkus.hibernate.search.orm.elasticsearch.deployment.ClassNames.ROOT_MAPPING;
@@ -402,7 +403,7 @@ class HibernateSearchElasticsearchProcessor {
                 "hosts");
         return new DevservicesElasticsearchBuildItem(hostsPropertyKey,
                 version.versionString(),
-                DevservicesElasticsearchBuildItem.Distribution.valueOf(version.distribution().toString().toUpperCase()));
+                Distribution.valueOf(version.distribution().toString().toUpperCase()));
     }
 
     @BuildStep(onlyIfNot = IsNormal.class)

--- a/integration-tests/hibernate-search-orm-elasticsearch/README.md
+++ b/integration-tests/hibernate-search-orm-elasticsearch/README.md
@@ -7,12 +7,12 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with Elasticsearch started in the JVM, you can run the following command:
 
 ```
-mvn clean install -Dtest-containers
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-containers -Dnative
+mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 

--- a/integration-tests/hibernate-search-orm-opensearch/README.md
+++ b/integration-tests/hibernate-search-orm-opensearch/README.md
@@ -7,12 +7,12 @@ By default, the tests of this module are disabled.
 To run the tests in a standard JVM with OpenSearch started in the JVM, you can run the following command:
 
 ```
-mvn clean install -Dtest-containers
+mvn clean install -Dtest-containers -Dstart-containers
 ```
 
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean install -Dtest-containers -Dnative
+mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 

--- a/integration-tests/hibernate-search-orm-opensearch/src/main/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchDevServicesTestResource.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/main/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchDevServicesTestResource.java
@@ -1,0 +1,71 @@
+package io.quarkus.it.hibernate.search.orm.opensearch.devservices;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.search.mapper.orm.schema.management.SchemaManagementStrategyName;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+
+@Path("/test/dev-services")
+public class HibernateSearchDevServicesTestResource {
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Inject
+    Session session;
+
+    @Inject
+    SearchSession searchSession;
+
+    @GET
+    @Path("/hosts")
+    @Transactional
+    @SuppressWarnings("unchecked")
+    public String hosts() {
+        return ((List<String>) sessionFactory.getProperties().get("hibernate.search.backend.hosts")).iterator().next();
+    }
+
+    @GET
+    @Path("/schema-management-strategy")
+    @Transactional
+    public String schemaManagementStrategy() {
+        var strategy = ((SchemaManagementStrategyName) sessionFactory.getProperties()
+                .get("hibernate.search.schema_management.strategy"));
+        return strategy == null ? null : strategy.externalRepresentation();
+    }
+
+    @PUT
+    @Path("/init-data")
+    @Transactional
+    public void initData() {
+        IndexedEntity entity = new IndexedEntity("John Irving");
+        session.persist(entity);
+    }
+
+    @PUT
+    @Path("/refresh")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String refresh() {
+        searchSession.workspace().refresh();
+        return "OK";
+    }
+
+    @GET
+    @Path("/count")
+    @Produces(MediaType.TEXT_PLAIN)
+    public long count() {
+        return searchSession.search(IndexedEntity.class)
+                .where(f -> f.matchAll())
+                .fetchTotalHitCount();
+    }
+}

--- a/integration-tests/hibernate-search-orm-opensearch/src/main/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/IndexedEntity.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/main/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/IndexedEntity.java
@@ -1,0 +1,47 @@
+package io.quarkus.it.hibernate.search.orm.opensearch.devservices;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
+
+@Entity
+@Indexed
+public class IndexedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "personSeq")
+    private Long id;
+
+    @FullTextField(analyzer = "standard")
+    @KeywordField(name = "name_sort", normalizer = "lowercase", sortable = Sortable.YES)
+    private String name;
+
+    public IndexedEntity() {
+    }
+
+    public IndexedEntity(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/integration-tests/hibernate-search-orm-opensearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-orm-opensearch/src/main/resources/application.properties
@@ -7,8 +7,14 @@ quarkus.datasource.jdbc.max-size=8
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-search-orm.elasticsearch.version=opensearch:1.2
-quarkus.hibernate-search-orm.elasticsearch.hosts=${opensearch.hosts:localhost:9200}
-quarkus.hibernate-search-orm.elasticsearch.protocol=${opensearch.protocol:http}
 quarkus.hibernate-search-orm.elasticsearch.analysis.configurer=bean:backend-analysis
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
 quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=sync
+
+# Use drop-and-create instead of drop-and-create-and-drop
+# so we can differentiate between the value we set here
+# and the value set automatically by the extension when using dev services
+# See io.quarkus.it.hibernate.search.orm.opensearch.devservices.HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.testHibernateSearch
+%test.quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create
+%test.quarkus.hibernate-search-orm.elasticsearch.hosts=${opensearch.hosts:localhost:9200}
+%test.quarkus.hibernate-search-orm.elasticsearch.protocol=${opensearch.protocol:http}

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/DevServicesContextSpy.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/DevServicesContextSpy.java
@@ -1,0 +1,32 @@
+package io.quarkus.it.hibernate.search.orm.opensearch.devservices;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class DevServicesContextSpy implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
+
+    DevServicesContext devServicesContext;
+
+    @Override
+    public void setIntegrationTestContext(DevServicesContext context) {
+        this.devServicesContext = context;
+    }
+
+    @Override
+    public Map<String, String> start() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+        testInjector.injectIntoFields(devServicesContext, f -> f.getType().isAssignableFrom(DevServicesContext.class));
+    }
+
+    @Override
+    public void stop() {
+
+    }
+}

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchElasticsearchDevServicesConfiguredExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchElasticsearchDevServicesConfiguredExplicitlyTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.it.hibernate.search.orm.opensearch.devservices;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@DisabledOnOs(OS.WINDOWS)
+@TestProfile(HibernateSearchElasticsearchDevServicesConfiguredExplicitlyTest.Profile.class)
+public class HibernateSearchElasticsearchDevServicesConfiguredExplicitlyTest {
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.elasticsearch.devservices.enabled", "true",
+                    "quarkus.elasticsearch.devservices.image-name", "docker.io/opensearchproject/opensearch:2.6.0",
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2");
+        }
+
+        @Override
+        public String getConfigProfile() {
+            // Don't use %test properties;
+            // that way, we can control whether quarkus.hibernate-search-orm.elasticsearch.hosts is set or not.
+            // In this test, we do NOT set quarkus.hibernate-search-orm.elasticsearch.hosts.
+            return "someotherprofile";
+        }
+
+        @Override
+        public List<TestResourceEntry> testResources() {
+            // Enables injection of DevServicesContext
+            return List.of(new TestResourceEntry(DevServicesContextSpy.class));
+        }
+    }
+
+    DevServicesContext context;
+
+    @Test
+    public void testDevServicesProperties() {
+        assertThat(context.devServicesProperties())
+                .containsKey("quarkus.hibernate-search-orm.elasticsearch.hosts");
+        assertThat(context.devServicesProperties().get("quarkus.hibernate-search-orm.elasticsearch.hosts"))
+                .isNotEmpty()
+                .isNotEqualTo("localhost:9200");
+    }
+
+    @Test
+    public void testHibernateSearch() {
+        RestAssured.when().get("/test/dev-services/hosts").then()
+                .statusCode(200)
+                .body(is(context.devServicesProperties().get("quarkus.hibernate-search-orm.elasticsearch.hosts")));
+
+        RestAssured.when().get("/test/dev-services/schema-management-strategy").then()
+                .statusCode(200)
+                // If the value is drop-and-create, this would indicate we're using the %test profile:
+                // that would be a bug in this test (see the Profile class above).
+                .body(is("drop-and-create-and-drop"));
+
+        RestAssured.when().get("/test/dev-services/count").then()
+                .statusCode(200)
+                .body(is("0"));
+
+        RestAssured.when().put("/test/dev-services/init-data").then()
+                .statusCode(204);
+
+        RestAssured.when().put("/test/hibernate-search/refresh").then()
+                .statusCode(200)
+                .body(is("OK"));
+
+        RestAssured.when().get("/test/dev-services/count").then()
+                .statusCode(200)
+                .body(is("1"));
+    }
+}

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.it.hibernate.search.orm.opensearch.devservices;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@DisabledOnOs(OS.WINDOWS)
+@TestProfile(HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.Profile.class)
+public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            Map<String, String> config = new HashMap<>(); // Cannot use Map.of, we need nulls
+            // Even if quarkus.hibernate-search-orm.elasticsearch.hosts is not set,
+            // Quarkus won't start Elasticsearch dev-services because of this explicit setting:
+            config.put("quarkus.elasticsearch.devservices.enabled", "false");
+            // Ensure we can work offline, because without dev-services,
+            // we won't have an Elasticsearch instance to talk to.
+            config.putAll(Map.of(
+                    "quarkus.hibernate-search-orm.schema-management.strategy", "none",
+                    // This version does not matter as long as it's supported by Hibernate Search:
+                    // it won't be checked in this test anyway.
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.9.0",
+                    "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false"));
+            return config;
+        }
+
+        @Override
+        public String getConfigProfile() {
+            // Don't use %test properties;
+            // that way, we can control whether quarkus.hibernate-search-orm.elasticsearch.hosts is set or not.
+            // In this test, we do NOT set quarkus.hibernate-search-orm.elasticsearch.hosts.
+            return "someotherprofile";
+        }
+
+        @Override
+        public List<TestResourceEntry> testResources() {
+            // Enables injection of DevServicesContext
+            return List.of(new TestResourceEntry(DevServicesContextSpy.class));
+        }
+    }
+
+    DevServicesContext context;
+
+    @Test
+    public void testDevServicesProperties() {
+        assertThat(context.devServicesProperties())
+                .doesNotContainKey("quarkus.hibernate-search-orm.elasticsearch.hosts");
+    }
+
+    @Test
+    public void testHibernateSearch() {
+        RestAssured.when().get("/test/dev-services/hosts").then()
+                .statusCode(200)
+                .body(is("localhost:9200")); // This is the default
+
+        // We don't test Hibernate Search features (indexing, search) here,
+        // because we're not sure that there is a host that Hibernate Search can talk to.
+        // It's fine, though: we checked that Hibernate Search is configured as intended.
+    }
+}

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.it.hibernate.search.orm.opensearch.devservices;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@DisabledOnOs(OS.WINDOWS)
+@TestProfile(HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.Profile.class)
+public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
+    private static final String EXPLICIT_HOSTS = "mycompany.com:4242";
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    // Make sure quarkus.hibernate-search-orm.elasticsearch.hosts is set,
+                    // so that Quarkus detects disables Elasticsearch dev-services implicitly.
+                    "quarkus.hibernate-search-orm.elasticsearch.hosts", EXPLICIT_HOSTS,
+                    // Ensure we can work offline, because the host we set just above does not actually exist.
+                    "quarkus.hibernate-search-orm.schema-management.strategy", "none",
+                    // This version does not matter as long as it's supported by Hibernate Search:
+                    // it won't be checked in this test anyway.
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.9.0",
+                    "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false");
+        }
+
+        @Override
+        public String getConfigProfile() {
+            // Don't use %test properties;
+            // that way, we can control whether quarkus.hibernate-search-orm.elasticsearch.hosts is set or not.
+            // In this test, we DO set quarkus.hibernate-search-orm.elasticsearch.hosts (see above).
+            return "someotherprofile";
+        }
+
+        @Override
+        public List<TestResourceEntry> testResources() {
+            // Enables injection of DevServicesContext
+            return List.of(new TestResourceEntry(DevServicesContextSpy.class));
+        }
+    }
+
+    DevServicesContext context;
+
+    @Test
+    public void testDevServicesProperties() {
+        assertThat(context.devServicesProperties())
+                .doesNotContainKey("quarkus.hibernate-search-orm.elasticsearch.hosts");
+    }
+
+    @Test
+    public void testHibernateSearch() {
+        RestAssured.when().get("/test/dev-services/hosts").then()
+                .statusCode(200)
+                .body(is(EXPLICIT_HOSTS));
+
+        // We don't test Hibernate Search features (indexing, search) here,
+        // because we're not sure that there is a host that Hibernate Search can talk to.
+        // It's fine, though: we checked that Hibernate Search is configured as intended.
+    }
+}

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.it.hibernate.search.orm.opensearch.devservices;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@DisabledOnOs(OS.WINDOWS)
+@TestProfile(HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.Profile.class)
+public class HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest {
+    public static class Profile implements QuarkusTestProfile {
+
+        @Override
+        public String getConfigProfile() {
+            // Don't use %test properties;
+            // that way, we can control whether quarkus.hibernate-search-orm.elasticsearch.hosts is set or not.
+            // In this test, we do NOT set quarkus.hibernate-search-orm.elasticsearch.hosts.
+            return "someotherprofile";
+        }
+
+        @Override
+        public List<TestResourceEntry> testResources() {
+            // Enables injection of DevServicesContext
+            return List.of(new TestResourceEntry(DevServicesContextSpy.class));
+        }
+    }
+
+    DevServicesContext context;
+
+    @Test
+    public void testDevServicesProperties() {
+        assertThat(context.devServicesProperties())
+                .containsKey("quarkus.hibernate-search-orm.elasticsearch.hosts");
+        assertThat(context.devServicesProperties().get("quarkus.hibernate-search-orm.elasticsearch.hosts"))
+                .isNotEmpty()
+                .isNotEqualTo("localhost:9200");
+    }
+
+    @Test
+    public void testHibernateSearch() {
+        RestAssured.when().get("/test/dev-services/hosts").then()
+                .statusCode(200)
+                .body(is(context.devServicesProperties().get("quarkus.hibernate-search-orm.elasticsearch.hosts")));
+
+        RestAssured.when().get("/test/dev-services/schema-management-strategy").then()
+                .statusCode(200)
+                // If the value is drop-and-create, this would indicate we're using the %test profile:
+                // that would be a bug in this test (see the Profile class above).
+                .body(is("drop-and-create-and-drop"));
+
+        RestAssured.when().get("/test/dev-services/count").then()
+                .statusCode(200)
+                .body(is("0"));
+
+        RestAssured.when().put("/test/dev-services/init-data").then()
+                .statusCode(204);
+
+        RestAssured.when().put("/test/hibernate-search/refresh").then()
+                .statusCode(200)
+                .body(is("OK"));
+
+        RestAssured.when().get("/test/dev-services/count").then()
+                .statusCode(200)
+                .body(is("1"));
+    }
+}


### PR DESCRIPTION
Fixes #23906

This was among the things Yoann suggested to look into. While doing so, I noticed that the guide had property placeholders instead of values -- fixed that.

Also, I wanted to better understand the logic behind the used Elasticsearch/OpenSearch image versions, but couldn't figure it out 😃 so any pointers are appreciated. `elasticsearch-server.version` version that we have in POM (`7.16.3`) and is used for testing doesn't match the default we have in the config for dev services (`7.17.0`) and the ES client is `8.8.2` (while `7.10.2` for proprietary components, which is expected). As for OpenSearch, `opensearch-server.version` is `1.2.3` while there's already a 2.8.0. At least, I'd expect that the version we are testing against and the version of dev services would match...