### PR TITLE
Run authentication request blocking tasks on Vert.x duplicated context

### DIFF
--- a/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/BlockingSecurityExecutor.java
+++ b/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/BlockingSecurityExecutor.java
@@ -1,0 +1,42 @@
+package io.quarkus.security.spi.runtime;
+
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.UniEmitter;
+
+/**
+ * Blocking executor used for security purposes such {@link AuthenticationRequestContext#runBlocking(Supplier)}.
+ * Extensions may provide their own implementation if they need a single thread pool.
+ */
+public interface BlockingSecurityExecutor {
+
+    <T> Uni<T> executeBlocking(Supplier<? extends T> supplier);
+
+    static BlockingSecurityExecutor createBlockingExecutor(Supplier<Executor> executorSupplier) {
+        return new BlockingSecurityExecutor() {
+            @Override
+            public <T> Uni<T> executeBlocking(Supplier<? extends T> function) {
+                return Uni.createFrom().emitter(new Consumer<UniEmitter<? super T>>() {
+                    @Override
+                    public void accept(UniEmitter<? super T> uniEmitter) {
+                        executorSupplier.get().execute(new Runnable() {
+                            @Override
+                            public void run() {
+                                try {
+                                    uniEmitter.complete(function.get());
+                                } catch (Throwable t) {
+                                    uniEmitter.fail(t);
+                                }
+                            }
+                        });
+                    }
+                });
+            }
+        };
+    }
+
+}

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/IdentityProviderManagerCreator.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/IdentityProviderManagerCreator.java
@@ -1,17 +1,20 @@
 package io.quarkus.security.runtime;
 
 import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
+import io.quarkus.arc.DefaultBean;
 import io.quarkus.runtime.ExecutorRecorder;
 import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentityAugmentor;
 import io.quarkus.security.identity.request.AnonymousAuthenticationRequest;
+import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
 
 /**
  * CDI bean than manages the lifecycle of the {@link io.quarkus.security.identity.IdentityProviderManager}
@@ -24,6 +27,21 @@ public class IdentityProviderManagerCreator {
 
     @Inject
     Instance<SecurityIdentityAugmentor> augmentors;
+
+    @Inject
+    BlockingSecurityExecutor blockingExecutor;
+
+    @ApplicationScoped
+    @DefaultBean
+    @Produces
+    BlockingSecurityExecutor defaultBlockingExecutor() {
+        return BlockingSecurityExecutor.createBlockingExecutor(new Supplier<Executor>() {
+            @Override
+            public Executor get() {
+                return ExecutorRecorder.getCurrent();
+            }
+        });
+    }
 
     @Produces
     @ApplicationScoped
@@ -42,13 +60,7 @@ public class IdentityProviderManagerCreator {
         for (SecurityIdentityAugmentor i : augmentors) {
             builder.addSecurityIdentityAugmentor(i);
         }
-        builder.setBlockingExecutor(new Executor() {
-            @Override
-            public void execute(Runnable command) {
-                //TODO: should we be using vert.x blocking tasks here? We really should only have a single thread pool
-                ExecutorRecorder.getCurrent().execute(command);
-            }
-        });
+        builder.setBlockingExecutor(blockingExecutor);
         return builder.build();
     }
 

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/EnabledProactiveAuthFailedExceptionMapperHttp2Test.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/EnabledProactiveAuthFailedExceptionMapperHttp2Test.java
@@ -1,0 +1,66 @@
+package io.quarkus.jwt.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class EnabledProactiveAuthFailedExceptionMapperHttp2Test {
+
+    private static final String CUSTOMIZED_RESPONSE = "AuthenticationFailedException";
+    protected static final Class<?>[] classes = { JsonValuejectionEndpoint.class, TokenUtils.class,
+            AuthFailedExceptionMapper.class };
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(classes)
+                    .addAsResource(new StringAsset("quarkus.http.auth.proactive=true\n" +
+                            "quarkus.smallrye-jwt.blocking-authentication=true\n"), "application.properties"));
+
+    @TestHTTPResource
+    URL url;
+
+    @Test
+    public void testExMapperCustomizedResponse() throws IOException, InterruptedException, URISyntaxException {
+        var client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .build();
+
+        var response = client.send(
+                HttpRequest.newBuilder()
+                        .GET()
+                        .header("Authorization", "Bearer 12345")
+                        .uri(url.toURI())
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(401, response.statusCode());
+    }
+
+    public static class AuthFailedExceptionMapper {
+
+        @ServerExceptionMapper(value = AuthenticationFailedException.class)
+        public Response unauthorized() {
+            return Response
+                    .status(401)
+                    .entity(CUSTOMIZED_RESPONSE).build();
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.vertx.http.deployment;
 
+import static io.quarkus.arc.processor.DotNames.APPLICATION_SCOPED;
 import static org.jboss.jandex.AnnotationTarget.Kind.CLASS;
 
 import java.security.Permission;
@@ -54,6 +55,7 @@ import io.quarkus.vertx.http.runtime.security.PathMatchingHttpSecurityPolicy;
 import io.quarkus.vertx.http.runtime.security.PermitSecurityPolicy;
 import io.quarkus.vertx.http.runtime.security.RolesAllowedHttpSecurityPolicy;
 import io.quarkus.vertx.http.runtime.security.SupplierImpl;
+import io.quarkus.vertx.http.runtime.security.VertxBlockingSecurityExecutor;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.ext.web.RoutingContext;
 
@@ -261,6 +263,9 @@ public class HttpSecurityProcessor {
         }
 
         if (capabilities.isPresent(Capability.SECURITY)) {
+            beanProducer
+                    .produce(AdditionalBeanBuildItem.builder().setUnremovable()
+                            .addBeanClass(VertxBlockingSecurityExecutor.class).setDefaultScope(APPLICATION_SCOPED).build());
             beanProducer
                     .produce(AdditionalBeanBuildItem.builder().setUnremovable().addBeanClass(HttpAuthenticator.class)
                             .addBeanClass(HttpAuthorizer.class).build());

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/VertxBlockingSecurityExecutor.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/VertxBlockingSecurityExecutor.java
@@ -1,0 +1,38 @@
+package io.quarkus.vertx.http.runtime.security;
+
+import static io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.setContextSafe;
+import static io.smallrye.common.vertx.VertxContext.getOrCreateDuplicatedContext;
+
+import java.util.function.Supplier;
+
+import jakarta.inject.Inject;
+
+import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+public class VertxBlockingSecurityExecutor implements BlockingSecurityExecutor {
+
+    @Inject
+    Vertx vertx;
+
+    @Override
+    public <T> Uni<T> executeBlocking(Supplier<? extends T> supplier) {
+        Context local = getOrCreateDuplicatedContext(vertx);
+        setContextSafe(local, true);
+        return Uni
+                .createFrom()
+                .completionStage(
+                        local
+                                .executeBlocking(new Handler<Promise<T>>() {
+                                    @Override
+                                    public void handle(Promise<T> promise) {
+                                        promise.complete(supplier.get());
+                                    }
+                                })
+                                .toCompletionStage());
+    }
+}


### PR DESCRIPTION
fixes: #34912

Newly introduced blocking executor is introduced as a bean because there are 2 other places in security code where I' like to use this new blocking executor  (`io.quarkus.vertx.http.runtime.security.AbstractHttpAuthorizer#CONTEXT` and `io.quarkus.oidc.runtime.OidcRecorder#setup`), but it is not necessary change to fix this very issue. I will propose it in a separate PR if this one will be accepted. This way, it will be clear what was necessary change in order to fix this issue.