### PR TITLE
Remove Old Dev UI: OpenAPI

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/resources/dev-templates/embedded.html
+++ b/extensions/smallrye-openapi/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,7 +1,0 @@
-<a href="{config:http-path('quarkus.smallrye-openapi.path')}" class="badge badge-light">
-  <i class="fa fa-map-signs fa-fw"></i>
-  OpenAPI</a>
-<br>
-<a href="{config:http-path('quarkus.swagger-ui.path')}/" class="badge badge-light">
-  <i class="fa fa-map-signs fa-fw"></i>
-  Swagger UI</a>


### PR DESCRIPTION
This PR removes the old Dev UI from the OpenAPI extension