### PR TITLE
Remove Old Dev UI: GraphQL

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/main/resources/dev-templates/embedded.html
+++ b/extensions/smallrye-graphql/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,7 +1,0 @@
-<a href="{config:http-path('quarkus.smallrye-graphql.root-path')}/schema.graphql" class="badge badge-light">
-  <i class="fa fa-project-diagram fa-fw"></i>
-  GraphQL Schema</a>
-<br>
-<a href="{config:http-path('quarkus.smallrye-graphql.ui.root-path')}/" class="badge badge-light">
-  <i class="fa fa-project-diagram fa-fw"></i>
-  GraphQL UI</a>


### PR DESCRIPTION
This PR removes the old Dev UI from the GraphQL extension