### PR TITLE
Remove Old Dev UI: Health

### DIFF
--- a/extensions/smallrye-health/deployment/src/main/resources/dev-templates/embedded.html
+++ b/extensions/smallrye-health/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,7 +1,0 @@
-<a href="{config:http-path('quarkus.smallrye-health.root-path')}" class="badge badge-light">
-  <i class="fa fa-stethoscope fa-fw"></i>
-  Health</a>
-<br>
-<a href="{config:http-path('quarkus.smallrye-health.ui.root-path')}/" class="badge badge-light">
-  <i class="fa fa-stethoscope fa-fw"></i>
-  Health UI</a>


### PR DESCRIPTION
This PR removes the old Dev UI from the Health extension