### PR TITLE
Add `maxLifetime` to reactive datasource configurations

### DIFF
--- a/docs/src/main/asciidoc/credentials-provider.adoc
+++ b/docs/src/main/asciidoc/credentials-provider.adoc
@@ -83,6 +83,40 @@ An alternative is to define both username and password in Vault and drop the `qu
 property from configuration. All consuming extensions do support the ability to fetch both the username
 and password from the provider, or just the password.
 
+== Time Limited Credentials
+
+A Credentials Provider may provide time limited credentials. For instance, the `vault` extension. When using
+time limited credentials, it is important to understand that consuming extensions will not have their
+credentials refreshed automatically by the Credentials Provider. Each extension must be configured to recycle its
+connections before the credentials expire.
+
+=== Datasources
+
+Datastore connections are typically pooled. When using a time limited credentials provider, the pool must be
+configured to recycle connections before each connection's credentials expire. Both JDBC and Reactive datasources
+have a `max-lifetime` configuration property that can be used to achieve this.
+
+.JDBC Datasource
+[source, properties]
+----
+quarkus.datasource.jdbc.max-lifetime=60m
+----
+
+.Reactive Datasource
+[source, properties]
+----
+quarkus.datasource.reactive.max-lifetime=60m
+----
+
+NOTE: It is the developer's responsibility to ensure that the configuration of the datasource's `max-lifetime`
+property is less than the credentials expiration time.
+
+=== RabbitMQ
+
+When using the `smallrye-reactive-messaging-rabbitmq` extension there is no configuration needed. The
+extension will automatically recycle connections before their credentials expire based on the expiration
+timestamp provided by the Credentials Provider.
+
 == Custom Credentials Provider
 
 Implementing a custom credentials provider is the only option when a vault product is not yet supported in Quarkus, or if credentials need to be retrieved from a custom store.

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -708,7 +708,7 @@ quarkus.datasource.reactive.url[1]=postgresql://host2:5432/default
 quarkus.datasource.reactive.url[2]=postgresql://host3:5432/default
 ----
 
-== Pooled Connection `idle-timeout`
+== Pooled connection `idle-timeout`
 
 Reactive datasources can be configured with an `idle-timeout`.
 It is the maximum time a connection remains unused in the pool before it is closed.

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -710,7 +710,7 @@ quarkus.datasource.reactive.url[2]=postgresql://host3:5432/default
 
 == Pooled Connection `idle-timeout`
 
-Reactive datasources can be configured with an `idle-timeout` (in milliseconds).
+Reactive datasources can be configured with an `idle-timeout`.
 It is the maximum time a connection remains unused in the pool before it is closed.
 
 NOTE: The `idle-timeout` is disabled by default.
@@ -720,6 +720,22 @@ For example, you could expire idle connections after 60 minutes:
 [source,properties]
 ----
 quarkus.datasource.reactive.idle-timeout=PT60M
+----
+
+== Pooled Connection `max-lifetime`
+
+In addition to `idle-timeout`, reactive datasources can also be configured with a `max-lifetime`.
+It is the maximum time a connection remains in the pool before it is closed and replaced as needed.
+The `max-lifetime` allows ensuring the pool has fresh connections with up-to-date configuration.
+
+NOTE: The `max-lifetime` is disabled by default but is an important configuration when using a credentials
+provider that provides time limited credentials, like the link:credentials-provider.adoc[Vault credentials provider].
+
+For example, you could ensure connections are recycled after 60 minutes:
+
+[source,properties]
+----
+quarkus.datasource.reactive.max-lifetime=PT60M
 ----
 
 == Customizing pool creation

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
@@ -122,6 +122,13 @@ public interface DataSourceReactiveRuntimeConfig {
     Optional<Duration> idleTimeout();
 
     /**
+     * The maximum time a connection remains in the pool, after which it will be closed
+     * upon return and replaced as necessary.
+     */
+    @ConfigDocDefault("no timeout")
+    Optional<Duration> maxLifetime();
+
+    /**
      * Set to true to share the pool among datasources.
      * There can be multiple shared pools distinguished by <name>name</name>, when no specific name is set,
      * the <code>__vertx.DEFAULT</code> name is used.

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/UnitisedTime.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/UnitisedTime.java
@@ -1,0 +1,53 @@
+package io.quarkus.reactive.datasource.runtime;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+public class UnitisedTime {
+
+    public final int value;
+    public final TimeUnit unit;
+
+    public UnitisedTime(int value, TimeUnit unit) {
+        this.value = value;
+        this.unit = unit;
+    }
+
+    /**
+     * Convert a {@link Duration} to a {@link UnitisedTime} with the smallest possible
+     * {@link TimeUnit} starting from {@link TimeUnit#MILLISECONDS}.
+     *
+     * @param duration Duration to convert
+     *
+     * @return UnitisedTime
+     */
+    public static UnitisedTime unitised(Duration duration) {
+        if (duration.isNegative()) {
+            throw new IllegalArgumentException("Duration cannot be negative.");
+        }
+
+        long millis = duration.toMillis();
+        if (millis < Integer.MAX_VALUE) {
+            return new UnitisedTime((int) millis, TimeUnit.MILLISECONDS);
+        }
+
+        long seconds = duration.getSeconds();
+        if (seconds < Integer.MAX_VALUE) {
+            return new UnitisedTime((int) seconds, TimeUnit.SECONDS);
+        }
+
+        long minutes = duration.toMinutes();
+        if (minutes < Integer.MAX_VALUE) {
+            return new UnitisedTime((int) minutes, TimeUnit.MINUTES);
+        }
+
+        long hours = duration.toHours();
+        if (hours < Integer.MAX_VALUE) {
+            return new UnitisedTime((int) hours, TimeUnit.HOURS);
+        }
+
+        long days = duration.toDays();
+        return new UnitisedTime((int) days, TimeUnit.DAYS);
+
+    }
+}

--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
@@ -2,6 +2,7 @@ package io.quarkus.reactive.db2.client.runtime;
 
 import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
+import static io.quarkus.reactive.datasource.runtime.UnitisedTime.unitised;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configureJksKeyCertOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configureJksTrustOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemKeyCertOptions;
@@ -11,7 +12,6 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOpt
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.inject.Instance;
@@ -108,8 +108,13 @@ public class DB2PoolRecorder {
         poolOptions.setMaxSize(dataSourceReactiveRuntimeConfig.maxSize());
 
         if (dataSourceReactiveRuntimeConfig.idleTimeout().isPresent()) {
-            int idleTimeout = Math.toIntExact(dataSourceReactiveRuntimeConfig.idleTimeout().get().toMillis());
-            poolOptions.setIdleTimeout(idleTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+            var idleTimeout = unitised(dataSourceReactiveRuntimeConfig.idleTimeout().get());
+            poolOptions.setIdleTimeout(idleTimeout.value).setIdleTimeoutUnit(idleTimeout.unit);
+        }
+
+        if (dataSourceReactiveRuntimeConfig.maxLifetime().isPresent()) {
+            var maxLifetime = unitised(dataSourceReactiveRuntimeConfig.maxLifetime().get());
+            poolOptions.setMaxLifetime(maxLifetime.value).setMaxLifetimeUnit(maxLifetime.unit);
         }
 
         if (dataSourceReactiveRuntimeConfig.shared()) {

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-changing-credentials.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-changing-credentials.properties
@@ -3,3 +3,4 @@ quarkus.datasource.credentials-provider=changing
 quarkus.datasource.reactive.url=${reactive-mssql.url}
 quarkus.datasource.reactive.max-size=1
 quarkus.datasource.reactive.idle-timeout=PT1S
+quarkus.datasource.reactive.max-lifetime=PT2s

--- a/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
+++ b/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
@@ -2,6 +2,7 @@ package io.quarkus.reactive.mssql.client.runtime;
 
 import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
+import static io.quarkus.reactive.datasource.runtime.UnitisedTime.unitised;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configureJksKeyCertOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configureJksTrustOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemKeyCertOptions;
@@ -11,7 +12,6 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOpt
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.inject.Instance;
@@ -108,8 +108,13 @@ public class MSSQLPoolRecorder {
         poolOptions.setMaxSize(dataSourceReactiveRuntimeConfig.maxSize());
 
         if (dataSourceReactiveRuntimeConfig.idleTimeout().isPresent()) {
-            int idleTimeout = Math.toIntExact(dataSourceReactiveRuntimeConfig.idleTimeout().get().toMillis());
-            poolOptions.setIdleTimeout(idleTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+            var idleTimeout = unitised(dataSourceReactiveRuntimeConfig.idleTimeout().get());
+            poolOptions.setIdleTimeout(idleTimeout.value).setIdleTimeoutUnit(idleTimeout.unit);
+        }
+
+        if (dataSourceReactiveRuntimeConfig.maxLifetime().isPresent()) {
+            var maxLifetime = unitised(dataSourceReactiveRuntimeConfig.maxLifetime().get());
+            poolOptions.setMaxLifetime(maxLifetime.value).setMaxLifetimeUnit(maxLifetime.unit);
         }
 
         if (dataSourceReactiveRuntimeConfig.shared()) {

--- a/extensions/reactive-mysql-client/deployment/src/test/resources/application-changing-credentials.properties
+++ b/extensions/reactive-mysql-client/deployment/src/test/resources/application-changing-credentials.properties
@@ -3,3 +3,4 @@ quarkus.datasource.credentials-provider=changing
 quarkus.datasource.reactive.url=${reactive-mysql.url}
 quarkus.datasource.reactive.max-size=1
 quarkus.datasource.reactive.idle-timeout=PT1S
+quarkus.datasource.reactive.max-lifetime=PT2s

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
@@ -2,6 +2,7 @@ package io.quarkus.reactive.mysql.client.runtime;
 
 import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
+import static io.quarkus.reactive.datasource.runtime.UnitisedTime.unitised;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configureJksKeyCertOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configureJksTrustOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemKeyCertOptions;
@@ -107,8 +108,13 @@ public class MySQLPoolRecorder {
         poolOptions.setMaxSize(dataSourceReactiveRuntimeConfig.maxSize());
 
         if (dataSourceReactiveRuntimeConfig.idleTimeout().isPresent()) {
-            int idleTimeout = Math.toIntExact(dataSourceReactiveRuntimeConfig.idleTimeout().get().toMillis());
-            poolOptions.setIdleTimeout(idleTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+            var idleTimeout = unitised(dataSourceReactiveRuntimeConfig.idleTimeout().get());
+            poolOptions.setIdleTimeout(idleTimeout.value).setIdleTimeoutUnit(idleTimeout.unit);
+        }
+
+        if (dataSourceReactiveRuntimeConfig.maxLifetime().isPresent()) {
+            var maxLifetime = unitised(dataSourceReactiveRuntimeConfig.maxLifetime().get());
+            poolOptions.setMaxLifetime(maxLifetime.value).setMaxLifetimeUnit(maxLifetime.unit);
         }
 
         if (dataSourceReactiveRuntimeConfig.shared()) {

--- a/extensions/reactive-oracle-client/deployment/src/test/resources/application-changing-credentials.properties
+++ b/extensions/reactive-oracle-client/deployment/src/test/resources/application-changing-credentials.properties
@@ -3,3 +3,4 @@ quarkus.datasource.credentials-provider=changing
 quarkus.datasource.reactive.url=${reactive-oracledb.url}
 quarkus.datasource.reactive.max-size=1
 quarkus.datasource.reactive.idle-timeout=PT1S
+quarkus.datasource.reactive.max-lifetime=PT2s

--- a/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/runtime/OraclePoolRecorder.java
+++ b/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/runtime/OraclePoolRecorder.java
@@ -2,10 +2,10 @@ package io.quarkus.reactive.oracle.client.runtime;
 
 import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
+import static io.quarkus.reactive.datasource.runtime.UnitisedTime.unitised;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.inject.Instance;
@@ -104,8 +104,13 @@ public class OraclePoolRecorder {
         poolOptions.setMaxSize(dataSourceReactiveRuntimeConfig.maxSize());
 
         if (dataSourceReactiveRuntimeConfig.idleTimeout().isPresent()) {
-            int idleTimeout = Math.toIntExact(dataSourceReactiveRuntimeConfig.idleTimeout().get().toMillis());
-            poolOptions.setIdleTimeout(idleTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+            var idleTimeout = unitised(dataSourceReactiveRuntimeConfig.idleTimeout().get());
+            poolOptions.setIdleTimeout(idleTimeout.value).setIdleTimeoutUnit(idleTimeout.unit);
+        }
+
+        if (dataSourceReactiveRuntimeConfig.maxLifetime().isPresent()) {
+            var maxLifetime = unitised(dataSourceReactiveRuntimeConfig.maxLifetime().get());
+            poolOptions.setMaxLifetime(maxLifetime.value).setMaxLifetimeUnit(maxLifetime.unit);
         }
 
         if (dataSourceReactiveRuntimeConfig.shared()) {

--- a/extensions/reactive-pg-client/deployment/src/test/resources/application-changing-credentials.properties
+++ b/extensions/reactive-pg-client/deployment/src/test/resources/application-changing-credentials.properties
@@ -3,3 +3,4 @@ quarkus.datasource.credentials-provider=changing
 quarkus.datasource.reactive.url=${reactive-postgres.url}
 quarkus.datasource.reactive.max-size=1
 quarkus.datasource.reactive.idle-timeout=PT1S
+quarkus.datasource.reactive.max-lifetime=PT2s

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
@@ -2,6 +2,7 @@ package io.quarkus.reactive.pg.client.runtime;
 
 import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
+import static io.quarkus.reactive.datasource.runtime.UnitisedTime.unitised;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configureJksKeyCertOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configureJksTrustOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemKeyCertOptions;
@@ -12,7 +13,6 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOpt
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.inject.Instance;
@@ -106,8 +106,13 @@ public class PgPoolRecorder {
         poolOptions.setMaxSize(dataSourceReactiveRuntimeConfig.maxSize());
 
         if (dataSourceReactiveRuntimeConfig.idleTimeout().isPresent()) {
-            int idleTimeout = Math.toIntExact(dataSourceReactiveRuntimeConfig.idleTimeout().get().toMillis());
-            poolOptions.setIdleTimeout(idleTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+            var idleTimeout = unitised(dataSourceReactiveRuntimeConfig.idleTimeout().get());
+            poolOptions.setIdleTimeout(idleTimeout.value).setIdleTimeoutUnit(idleTimeout.unit);
+        }
+
+        if (dataSourceReactiveRuntimeConfig.maxLifetime().isPresent()) {
+            var maxLifetime = unitised(dataSourceReactiveRuntimeConfig.maxLifetime().get());
+            poolOptions.setMaxLifetime(maxLifetime.value).setMaxLifetimeUnit(maxLifetime.unit);
         }
 
         if (dataSourceReactiveRuntimeConfig.shared()) {


### PR DESCRIPTION
This enables configuration of the new `maxLifetime` value provided by Vert.x `4.4.2` that ensures connections are recycled after a maximum duration.

Because `maxLifetime` could conceivable be set beyond the maximum value that milliseconds can store in an `int` (24.8 days) I created a `UnitisedTime` class. The `UnitisedTime` class has a `unitised` method that converts a `Duration` into the smallest possible `TimeUnit` that can be stored in an `int`, starting with milliseconds.

For consistency, I updated the `idleTimeout` to use the same `UnitisedTime.unitised` utitlity for conversion.

This was seemingly missed in PR #31873 and is required for use with the Vault Credentials Provider. To this end, I added a blurb about "Time Limited Credentials" to the Credentials Provider docs.