### PR TITLE
Ensure Kubernetes manifests are generated in the project location

### DIFF
--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesOutputDirectoryBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesOutputDirectoryBuildItem.java
@@ -1,0 +1,20 @@
+package io.quarkus.kubernetes.spi;
+
+import java.nio.file.Path;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Contains the effective output directory where to find the generated kubernetes resources.
+ */
+public final class KubernetesOutputDirectoryBuildItem extends SimpleBuildItem {
+    private final Path outputDirectory;
+
+    public KubernetesOutputDirectoryBuildItem(Path outputDirectory) {
+        this.outputDirectory = outputDirectory;
+    }
+
+    public Path getOutputDirectory() {
+        return outputDirectory;
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -3,11 +3,8 @@ package io.quarkus.kubernetes.deployment;
 import static io.quarkus.kubernetes.deployment.Constants.CRONJOB;
 import static io.quarkus.kubernetes.deployment.Constants.DEPLOYMENT;
 import static io.quarkus.kubernetes.deployment.Constants.JOB;
-import static io.quarkus.kubernetes.deployment.Constants.KUBERNETES;
 import static io.quarkus.kubernetes.deployment.Constants.STATEFULSET;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -616,18 +613,5 @@ public class KubernetesConfig implements PlatformConfiguration {
         }
 
         return DeploymentResourceKind.Deployment;
-    }
-
-    /**
-     * Resolve the effective output directory where to generate the Kubernetes manifests.
-     * If the `quarkus.kubernetes.output-directory` property is not provided, then the default project output directory will be
-     * used.
-     *
-     * @param projectOutputDirectory The project output target.
-     * @return the effective output directory.
-     */
-    public Path getEffectiveOutputDirectory(Path projectOutputDirectory) {
-        return outputDirectory.map(d -> Paths.get("").toAbsolutePath().resolve(d))
-                .orElse(projectOutputDirectory.resolve(KUBERNETES));
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -55,6 +55,7 @@ import io.quarkus.kubernetes.spi.DeployStrategy;
 import io.quarkus.kubernetes.spi.GeneratedKubernetesResourceBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesDeploymentClusterBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesOptionalResourceDefinitionBuildItem;
+import io.quarkus.kubernetes.spi.KubernetesOutputDirectoryBuildItem;
 
 public class KubernetesDeployer {
 
@@ -110,7 +111,7 @@ public class KubernetesDeployer {
             List<KubernetesDeploymentClusterBuildItem> deploymentClusters,
             Optional<SelectedKubernetesDeploymentTargetBuildItem> selectedDeploymentTarget,
             OutputTargetBuildItem outputTarget,
-            KubernetesConfig kubernetesConfig,
+            KubernetesOutputDirectoryBuildItem outputDirectoryBuildItem,
             OpenshiftConfig openshiftConfig,
             ContainerImageConfig containerImageConfig,
             ApplicationInfoBuildItem applicationInfo,
@@ -139,7 +140,7 @@ public class KubernetesDeployer {
         try (final KubernetesClient client = kubernetesClientBuilder.buildClient()) {
             deploymentResult
                     .produce(deploy(selectedDeploymentTarget.get().getEntry(), client,
-                            kubernetesConfig.getEffectiveOutputDirectory(outputTarget.getOutputDirectory()),
+                            outputDirectoryBuildItem.getOutputDirectory(),
                             openshiftConfig, applicationInfo, optionalResourceDefinitions));
         }
     }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -55,6 +55,7 @@ import io.quarkus.kubernetes.spi.DecoratorBuildItem;
 import io.quarkus.kubernetes.spi.DekorateOutputBuildItem;
 import io.quarkus.kubernetes.spi.GeneratedKubernetesResourceBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesDeploymentTargetBuildItem;
+import io.quarkus.kubernetes.spi.KubernetesOutputDirectoryBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesPortBuildItem;
 import io.quarkus.runtime.LaunchMode;
 
@@ -113,7 +114,8 @@ class KubernetesProcessor {
             BuildProducer<DekorateOutputBuildItem> dekorateSessionProducer,
             Optional<CustomProjectRootBuildItem> customProjectRoot,
             BuildProducer<GeneratedFileSystemResourceBuildItem> generatedResourceProducer,
-            BuildProducer<GeneratedKubernetesResourceBuildItem> generatedKubernetesResourceProducer) {
+            BuildProducer<GeneratedKubernetesResourceBuildItem> generatedKubernetesResourceProducer,
+            BuildProducer<KubernetesOutputDirectoryBuildItem> outputDirectoryBuildItemBuildProducer) {
 
         List<ConfiguratorBuildItem> allConfigurators = new ArrayList<>(configurators);
         List<ConfigurationSupplierBuildItem> allConfigurationSuppliers = new ArrayList<>(configurationSuppliers);
@@ -183,7 +185,10 @@ class KubernetesProcessor {
                     }
                 });
 
-                Path targetDirectory = kubernetesConfig.getEffectiveOutputDirectory(outputTarget.getOutputDirectory());
+                Path targetDirectory = getEffectiveOutputDirectory(kubernetesConfig, project.getRoot(),
+                        outputTarget.getOutputDirectory());
+
+                outputDirectoryBuildItemBuildProducer.produce(new KubernetesOutputDirectoryBuildItem(targetDirectory));
 
                 // write the generated resources to the filesystem
                 generatedResourcesMap = session.close();
@@ -276,5 +281,20 @@ class KubernetesProcessor {
         }
 
         return buildDir.resolve(QUARKUS_RUN_JAR);
+    }
+
+    /**
+     * Resolve the effective output directory where to generate the Kubernetes manifests.
+     * If the `quarkus.kubernetes.output-directory` property is not provided, then the default project output directory will be
+     * used.
+     *
+     * @param config The Kubernetes configuration.
+     * @param projectLocation The project location.
+     * @param projectOutputDirectory The project output target.
+     * @return the effective output directory.
+     */
+    private Path getEffectiveOutputDirectory(KubernetesConfig config, Path projectLocation, Path projectOutputDirectory) {
+        return config.outputDirectory.map(d -> projectLocation.resolve(d))
+                .orElse(projectOutputDirectory.resolve(KUBERNETES));
     }
 }


### PR DESCRIPTION
... when using the `quarkus.kubernetes.output-directory`.

In gradle, when users set the output-directory property, the K8s resources were generated at `$HOME/.gradle/workers`.

I tried these changes in Maven and Gradle and now, it works. 

Fix https://github.com/quarkusio/quarkus/issues/34827