### PR TITLE
OIDC UserInfo request must not be made if the token verification fails

### DIFF
--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
@@ -115,8 +115,10 @@ public class OidcResource {
     @Produces("application/json")
     @Path("introspect")
     public String introspect(@FormParam("client_id") String clientId, @FormParam("client_secret") String clientSecret,
-            @HeaderParam("Authorization") String authorization) throws Exception {
+            @HeaderParam("Authorization") String authorization, @FormParam("token") String token) throws Exception {
         introspectionEndpointCallCount++;
+
+        boolean activeStatus = introspection && !token.endsWith("-invalid");
 
         String introspectionClientId = "none";
         String introspectionClientSecret = "none";
@@ -139,7 +141,7 @@ public class OidcResource {
         }
 
         return "{" +
-                "   \"active\": " + introspection + "," +
+                "   \"active\": " + activeStatus + "," +
                 "   \"scope\": \"user\"," +
                 "   \"email\": \"user@gmail.com\"," +
                 "   \"username\": \"alice\"," +

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
@@ -74,6 +74,7 @@ public class TenantResource {
             response += (",introspection_client_id:" + introspection.getString("introspection_client_id"));
             response += (",introspection_client_secret:" + introspection.getString("introspection_client_secret"));
             response += (",active:" + introspection.getBoolean("active"));
+            response += (",userinfo:" + getUserInfo().getPreferredUserName());
             response += (",cache-size:" + tokenCache.getCacheSize());
         }
 


### PR DESCRIPTION
Fixes #34993

All this PR does it does make the call order correct after it was not done in the earlier https://github.com/quarkusio/quarkus/commit/1677a8f997209c2cb134669c9c943d1d90f3cb48.

I.e - verify the primary token first, and continue with the remote UserInfo follow up call only if the token itself is valid. Right now, on `main`, it is the other way around, so if the token has expired or otherwise invalid, this UserInfo call should not go ahead.

The changes may appear massive - but it is only related to moving Uni blocks around. Also I optimized a bit the case where a null Uni representing a null UserInfo was used - but there is really no need to create an additional Uni call if simple `if/else` checks can avoid it.

Added a test confirming that if the token is invalid then no UserInfo call is made, and updated the existing test using the same tenant configuration to confirm a UserInfo call is made if the token is valid.

@gastaldi If you agree this PR is not really an OIDC logic changing PR - please review. CC @pedroigor 