### PR TITLE
Narayana JTA: do not allow to use datasource XA transactions with JDBC object store

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -298,6 +298,7 @@ class AgroalProcessor {
             jdbcDataSource.produce(new JdbcDataSourceBuildItem(dataSourceName,
                     aggregatedBuildTimeConfigBuildItem.getDbKind(),
                     aggregatedBuildTimeConfigBuildItem.getDataSourceConfig().dbVersion,
+                    aggregatedBuildTimeConfigBuildItem.getJdbcConfig().transactions != TransactionIntegration.DISABLED,
                     aggregatedBuildTimeConfigBuildItem.isDefault()));
         }
     }

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -267,11 +267,9 @@ class AgroalProcessor {
             return;
         }
 
-        for (Map.Entry<String, DataSourceSupport.Entry> entry : getDataSourceSupport(aggregatedBuildTimeConfigBuildItems,
-                sslNativeConfig,
-                capabilities).entries.entrySet()) {
+        for (AggregatedDataSourceBuildTimeConfigBuildItem aggregatedBuildTimeConfigBuildItem : aggregatedBuildTimeConfigBuildItems) {
 
-            String dataSourceName = entry.getKey();
+            String dataSourceName = aggregatedBuildTimeConfigBuildItem.getName();
 
             SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
                     .configure(AgroalDataSource.class)
@@ -284,7 +282,7 @@ class AgroalProcessor {
                     // are created after runtime configuration has been set up
                     .createWith(recorder.agroalDataSourceSupplier(dataSourceName, dataSourcesRuntimeConfig));
 
-            if (entry.getValue().isDefault) {
+            if (aggregatedBuildTimeConfigBuildItem.isDefault()) {
                 configurator.addQualifier(Default.class);
             } else {
                 // this definitely not ideal, but 'elytron-jdbc-security' uses it (although it could be easily changed)
@@ -298,9 +296,9 @@ class AgroalProcessor {
             syntheticBeanBuildItemBuildProducer.produce(configurator.done());
 
             jdbcDataSource.produce(new JdbcDataSourceBuildItem(dataSourceName,
-                    entry.getValue().resolvedDbKind,
-                    entry.getValue().dbVersion,
-                    entry.getValue().isDefault));
+                    aggregatedBuildTimeConfigBuildItem.getDbKind(),
+                    aggregatedBuildTimeConfigBuildItem.getDataSourceConfig().dbVersion,
+                    aggregatedBuildTimeConfigBuildItem.isDefault()));
         }
     }
 

--- a/extensions/agroal/spi/src/main/java/io/quarkus/agroal/spi/JdbcDataSourceBuildItem.java
+++ b/extensions/agroal/spi/src/main/java/io/quarkus/agroal/spi/JdbcDataSourceBuildItem.java
@@ -17,12 +17,17 @@ public final class JdbcDataSourceBuildItem extends MultiBuildItem {
     private final String dbKind;
 
     private final Optional<String> dbVersion;
+
+    private final boolean transactionIntegrationEnabled;
+
     private final boolean isDefault;
 
-    public JdbcDataSourceBuildItem(String name, String kind, Optional<String> dbVersion, boolean isDefault) {
+    public JdbcDataSourceBuildItem(String name, String kind, Optional<String> dbVersion,
+            boolean transactionIntegrationEnabled, boolean isDefault) {
         this.name = name;
         this.dbKind = kind;
         this.dbVersion = dbVersion;
+        this.transactionIntegrationEnabled = transactionIntegrationEnabled;
         this.isDefault = isDefault;
     }
 
@@ -36,6 +41,10 @@ public final class JdbcDataSourceBuildItem extends MultiBuildItem {
 
     public Optional<String> getDbVersion() {
         return dbVersion;
+    }
+
+    public boolean isTransactionIntegrationEnabled() {
+        return transactionIntegrationEnabled;
     }
 
     public boolean isDefault() {

--- a/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
+++ b/extensions/narayana-jta/deployment/src/main/java/io/quarkus/narayana/jta/deployment/NarayanaJtaProcessor.java
@@ -1,12 +1,13 @@
 package io.quarkus.narayana.jta.deployment;
 
-import static io.quarkus.datasource.common.runtime.DataSourceUtil.dataSourcePropertyKeys;
 import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import jakarta.annotation.Priority;
 import jakarta.interceptor.Interceptor;
@@ -45,6 +46,7 @@ import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
 import io.quarkus.arc.deployment.SyntheticBeansRuntimeInitBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsTest;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -53,7 +55,6 @@ import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
-import io.quarkus.deployment.builditem.ConfigurationBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
@@ -155,40 +156,18 @@ class NarayanaJtaProcessor {
     @Record(RUNTIME_INIT)
     @Consume(NarayanaInitBuildItem.class)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
-    public void startRecoveryService(NarayanaJtaRecorder recorder, ConfigurationBuildItem configurationBuildItem,
+    public void startRecoveryService(NarayanaJtaRecorder recorder,
             List<JdbcDataSourceBuildItem> jdbcDataSourceBuildItems, TransactionManagerConfiguration transactions) {
-        Map<Boolean, String> namedDataSources = new HashMap<>();
+        Map<String, String> configuredDataSourcesConfigKeys = jdbcDataSourceBuildItems.stream()
+                .map(j -> j.getName())
+                .collect(Collectors.toMap(Function.identity(),
+                        n -> DataSourceUtil.dataSourcePropertyKey(n, "jdbc.transactions")));
+        Set<String> dataSourcesWithTransactionIntegration = jdbcDataSourceBuildItems.stream()
+                .filter(j -> j.isTransactionIntegrationEnabled())
+                .map(j -> j.getName())
+                .collect(Collectors.toSet());
 
-        jdbcDataSourceBuildItems.forEach(i -> namedDataSources.put(i.isDefault(), i.getName()));
-        Map<String, String> dsToConfigKey = getDsWithoutDisabledTransactions(
-                configurationBuildItem.getReadResult().getBuildTimeRunTimeValues(), namedDataSources);
-
-        recorder.startRecoveryService(transactions, namedDataSources, dsToConfigKey);
-    }
-
-    private static Map<String, String> getDsWithoutDisabledTransactions(Map<String, String> buildTimeRunTimeValues,
-            Map<Boolean, String> dataSources) {
-        Map<String, String> dsToTransactionIntegration = new HashMap<>();
-        for (String dataSourceName : dataSources.values()) {
-            List<String> transactionsPropertyKeys = dataSourcePropertyKeys(dataSourceName, "jdbc.transactions");
-            boolean propertyExplicitlyDefined = false;
-            for (String propertyKey : transactionsPropertyKeys) {
-                // get datasource 'io.quarkus.agroal.runtime.TransactionIntegration'
-                String transactionIntegration = buildTimeRunTimeValues.get(propertyKey);
-                if (transactionIntegration != null) {
-                    propertyExplicitlyDefined = true;
-                    if (!"disabled".equalsIgnoreCase(transactionIntegration)) {
-                        dsToTransactionIntegration.put(dataSourceName, propertyKey);
-                        break;
-                    }
-                }
-            }
-            if (!propertyExplicitlyDefined) {
-                // by default transaction capabilities are enabled
-                dsToTransactionIntegration.put(dataSourceName, transactionsPropertyKeys.get(0));
-            }
-        }
-        return dsToTransactionIntegration;
+        recorder.startRecoveryService(transactions, configuredDataSourcesConfigKeys, dataSourcesWithTransactionIntegration);
     }
 
     @BuildStep(onlyIf = IsTest.class)

--- a/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionJdbcObjectStoreValidationFailureTest.java
+++ b/extensions/narayana-jta/deployment/src/test/java/io/quarkus/narayana/quarkus/TransactionJdbcObjectStoreValidationFailureTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.narayana.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TransactionJdbcObjectStoreValidationFailureTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("jdbc-object-store-validation.properties", "application.properties"))
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-jdbc-h2", Version.getVersion())))
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                if (rootCause instanceof ConfigurationException) {
+                    assertTrue(rootCause.getMessage().contains(
+                            "The Narayana JTA extension is configured to use the datasource 'test' but that datasource is not configured."));
+                } else {
+                    fail(t);
+                }
+            });
+
+    @Test
+    public void test() {
+        // needs to be there in order to run test
+        Assertions.fail("Application was supposed to fail.");
+    }
+}

--- a/extensions/narayana-jta/deployment/src/test/resources/jdbc-object-store-validation.properties
+++ b/extensions/narayana-jta/deployment/src/test/resources/jdbc-object-store-validation.properties
@@ -1,0 +1,9 @@
+quarkus.transaction-manager.object-store.type=jdbc
+quarkus.transaction-manager.object-store.datasource=test
+quarkus.datasource.test.db-kind=h2
+quarkus.datasource.test.jdbc.url=jdbc:h2:mem:default
+quarkus.datasource.test.jdbc.transactions=xa
+
+# we must not start database as CI is also executed on Windows without (Docker) Linux containers
+quarkus.datasource.devservices.enabled=false
+quarkus.devservices.enabled=false

--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>quarkus-mutiny</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-datasource-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-context-propagation-jta</artifactId>
             <exclusions>

--- a/integration-tests/narayana-jta/src/main/resources/application.properties
+++ b/integration-tests/narayana-jta/src/main/resources/application.properties
@@ -11,3 +11,6 @@ quarkus.log.category."io.quarkus".level=INFO
 quarkus.datasource.db-kind=h2
 
 quarkus.transaction-manager.object-store.directory=target/tx-object-store
+
+quarkus.datasource.test.jdbc.transactions=disabled
+quarkus.datasource.test.db-kind=h2

--- a/integration-tests/narayana-jta/src/test/java/io/quarkus/narayana/jta/JdbcObjectStoreTestProfile.java
+++ b/integration-tests/narayana-jta/src/test/java/io/quarkus/narayana/jta/JdbcObjectStoreTestProfile.java
@@ -11,11 +11,10 @@ public class JdbcObjectStoreTestProfile implements QuarkusTestProfile {
         HashMap<String, String> props = new HashMap<>();
         props.put("quarkus.transaction-manager.object-store.type", "jdbc");
         props.put("quarkus.transaction-manager.object-store.create-table", "true");
+        props.put("quarkus.transaction-manager.object-store.datasource", "test");
         props.put("quarkus.transaction-manager.enable-recovery", "true");
 
-        props.put("quarkus.datasource.test.db-kind", "h2");
         props.put("quarkus.datasource.test.jdbc.url", "jdbc:h2:mem:default");
-        props.put("quarkus.datasource.test.jdbc.transactions", "xa");
 
         return props;
     }


### PR DESCRIPTION
closes: #33715

Changes in Narayana JTA integration module are down to the fact that `quarkus.datasource.test.jdbc.transactions` is build time property (and so is db-kind), so they can't be changed for integration test in test profile. It needs to be set in `application.properties` to disabled in order to use it as JDBC object store.