### PR TITLE
Enable cacheability of surefire and failsafe goals

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,11 +2,11 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>1.17.1</version>
+        <version>1.18</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>common-custom-user-data-maven-extension</artifactId>
         <version>1.12</version>
     </extension>
-</extensions> 
+</extensions>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -758,6 +758,23 @@
                         </execution>
                     </executions>
                 </plugin>
+
+                <plugin>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>gradle-enterprise-maven-extension</artifactId>
+                    <configuration>
+                        <gradleEnterprise>
+                            <normalization>
+                                <systemProperties>
+                                    <ignoredKeys>
+                                        <ignore>maven.repo.local</ignore>
+                                    </ignoredKeys>
+                                </systemProperties>
+                            </normalization>
+                        </gradleEnterprise>
+                    </configuration>
+                </plugin>
+
             </plugins>
         </pluginManagement>
     </build>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -3176,6 +3176,28 @@
                 </executions>
             </plugin>
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>gradle-enterprise-maven-extension</artifactId>
+                    <configuration>
+                        <gradleEnterprise>
+                            <normalization>
+                                <systemProperties>
+                                    <ignoredKeys combine.children="append">
+                                        <ignore>vale.dir</ignore>
+                                        <ignore>git.dir</ignore>
+                                    </ignoredKeys>
+                                </systemProperties>
+                            </normalization>
+                        </gradleEnterprise>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
     </build>
 
     <profiles>
@@ -3204,7 +3226,7 @@
                                 <phase>process-resources</phase>
                                 <goals>
                                     <goal>process-asciidoc</goal>
-                                </goals> 
+                                </goals>
                                 <configuration>
                                     <skip>${skipDocs}</skip>
                                     <backend>pdf</backend>

--- a/independent-projects/arc/tcks/cdi-tck-runner/pom.xml
+++ b/independent-projects/arc/tcks/cdi-tck-runner/pom.xml
@@ -81,6 +81,26 @@
                 </configuration>
             </plugin>
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>gradle-enterprise-maven-extension</artifactId>
+                    <configuration>
+                        <gradleEnterprise>
+                            <normalization>
+                                <systemProperties>
+                                    <ignoredKeys combine.children="append">
+                                        <ignore>org.jboss.cdi.tck.libraryDirectory</ignore>
+                                    </ignoredKeys>
+                                </systemProperties>
+                            </normalization>
+                        </gradleEnterprise>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
 </project>

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -420,6 +420,23 @@
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>${version.versions.plugin}</version>
                 </plugin>
+
+                <plugin>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>gradle-enterprise-maven-extension</artifactId>
+                    <configuration>
+                        <gradleEnterprise>
+                            <normalization>
+                                <systemProperties>
+                                    <ignoredKeys>
+                                        <ignore>maven.repo.local</ignore>
+                                    </ignoredKeys>
+                                </systemProperties>
+                            </normalization>
+                        </gradleEnterprise>
+                    </configuration>
+                </plugin>
+
             </plugins>
         </pluginManagement>
     </build>

--- a/integration-tests/awt/pom.xml
+++ b/integration-tests/awt/pom.xml
@@ -166,6 +166,27 @@
                 </executions>
             </plugin>
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>gradle-enterprise-maven-extension</artifactId>
+                    <configuration>
+                        <gradleEnterprise>
+                            <normalization>
+                                <systemProperties>
+                                    <ignoredKeys combine.children="append">
+                                        <ignore>native.image.path</ignore>
+                                    </ignoredKeys>
+                                </systemProperties>
+                            </normalization>
+                        </gradleEnterprise>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
     </build>
 
 </project>

--- a/integration-tests/awt/pom.xml
+++ b/integration-tests/awt/pom.xml
@@ -147,46 +147,11 @@
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                <maven.home>${maven.home}</maven.home>
-                                <quarkus.http.host>localhost</quarkus.http.host>
-                                <quarkus.http.port>8081</quarkus.http.port>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
         </plugins>
-
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>com.gradle</groupId>
-                    <artifactId>gradle-enterprise-maven-extension</artifactId>
-                    <configuration>
-                        <gradleEnterprise>
-                            <normalization>
-                                <systemProperties>
-                                    <ignoredKeys combine.children="append">
-                                        <ignore>native.image.path</ignore>
-                                    </ignoredKeys>
-                                </systemProperties>
-                            </normalization>
-                        </gradleEnterprise>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
     </build>
 
 </project>

--- a/integration-tests/mongodb-rest-data-panache/pom.xml
+++ b/integration-tests/mongodb-rest-data-panache/pom.xml
@@ -113,6 +113,26 @@
                 </configuration>
             </plugin>
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>gradle-enterprise-maven-extension</artifactId>
+                    <configuration>
+                        <gradleEnterprise>
+                            <normalization>
+                                <systemProperties>
+                                    <ignoredKeys combine.children="append">
+                                        <ignore>quarkus.kubernetes-service-binding.root</ignore>
+                                    </ignoredKeys>
+                                </systemProperties>
+                            </normalization>
+                        </gradleEnterprise>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <profiles>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -88,29 +88,36 @@
                 </plugin>
 
                 <plugin>
-                <!-- config to avoid unbind-executions confuses gradle enterprise caching-->
-                <groupId>com.gradle</groupId>
-                <artifactId>gradle-enterprise-maven-extension</artifactId>
-                <configuration>
-                    <gradleEnterprise>
-                        <plugins>
-                            <plugin>
-                                <artifactId>maven-compiler-plugin</artifactId>
-                                <inputs>
-                                    <fileSets combine.children="append">
-                                        <fileSet>
-                                            <name>specs</name>
-                                            <paths>
-                                                <path>${project.basedir}/disable-unbind-executions</path>
-                                            </paths>
-                                            <normalization>RELATIVE_PATH</normalization>
-                                        </fileSet>
-                                    </fileSets>
-                                </inputs>
-                            </plugin>
-                        </plugins>
-                    </gradleEnterprise>
-                </configuration>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>gradle-enterprise-maven-extension</artifactId>
+                    <configuration>
+                        <gradleEnterprise>
+                            <normalization>
+                                <systemProperties>
+                                    <ignoredKeys combine.children="append">
+                                        <ignore>native.image.path</ignore>
+                                    </ignoredKeys>
+                                </systemProperties>
+                            </normalization>
+                            <!-- config to avoid unbind-executions confuses gradle enterprise caching-->
+                            <plugins>
+                                <plugin>
+                                    <artifactId>maven-compiler-plugin</artifactId>
+                                    <inputs>
+                                        <fileSets combine.children="append">
+                                            <fileSet>
+                                                <name>specs</name>
+                                                <paths>
+                                                    <path>${project.basedir}/disable-unbind-executions</path>
+                                                </paths>
+                                                <normalization>RELATIVE_PATH</normalization>
+                                            </fileSet>
+                                        </fileSets>
+                                    </inputs>
+                                </plugin>
+                            </plugins>
+                        </gradleEnterprise>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -93,22 +93,22 @@
                 <artifactId>gradle-enterprise-maven-extension</artifactId>
                 <configuration>
                     <gradleEnterprise>
-                    <plugins>
-                        <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <inputs>
-                            <fileSets>
-                            <fileSet>
-                                <name>specs</name>
-                                <paths>
-                                <path>${project.basedir}/disable-unbind-executions</path>
-                                </paths>
-                                <normalization>RELATIVE_PATH</normalization>
-                            </fileSet>
-                            </fileSets>
-                        </inputs>
-                        </plugin>
-                    </plugins>
+                        <plugins>
+                            <plugin>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <inputs>
+                                    <fileSets combine.children="append">
+                                        <fileSet>
+                                            <name>specs</name>
+                                            <paths>
+                                                <path>${project.basedir}/disable-unbind-executions</path>
+                                            </paths>
+                                            <normalization>RELATIVE_PATH</normalization>
+                                        </fileSet>
+                                    </fileSets>
+                                </inputs>
+                            </plugin>
+                        </plugins>
                     </gradleEnterprise>
                 </configuration>
                 </plugin>

--- a/integration-tests/rest-client/pom.xml
+++ b/integration-tests/rest-client/pom.xml
@@ -200,6 +200,27 @@
                 </configuration>
             </plugin>
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>gradle-enterprise-maven-extension</artifactId>
+                    <configuration>
+                        <gradleEnterprise>
+                            <normalization>
+                                <systemProperties>
+                                    <ignoredKeys combine.children="append">
+                                        <ignore>javax.net.ssl.trustStore</ignore>
+                                        <ignore>rest-client.trustStore</ignore>
+                                    </ignoredKeys>
+                                </systemProperties>
+                            </normalization>
+                        </gradleEnterprise>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <profiles>

--- a/integration-tests/test-extension/tests/pom.xml
+++ b/integration-tests/test-extension/tests/pom.xml
@@ -94,9 +94,14 @@
           <artifactId>gradle-enterprise-maven-extension</artifactId>
           <configuration>
             <gradleEnterprise>
-              <normalization combine.children="append">
+              <normalization>
+                <systemProperties>
+                  <ignoredKeys combine.children="append">
+                    <ignore>classpathEntriesRecordingFile</ignore>
+                  </ignoredKeys>
+                </systemProperties>
                 <runtimeClassPath>
-                  <propertiesNormalizations>
+                  <propertiesNormalizations combine.children="append">
                     <propertiesNormalization>
                       <path>application.properties</path>
                       <ignoredProperties>


### PR DESCRIPTION
### Issue
Most of the _maven-surefire-plugin_ and _maven-failsafe-plugin_ test goal executions rely on `SystemPropertiesVariables` with paths as values, see [here](https://github.com/quarkusio/quarkus/blob/3f5257be5a82e7376c97b28e7dd43fc9abc03ae9/independent-projects/parent/pom.xml#L384) for an example.
If not declared as [inputs](https://docs.gradle.com/enterprise/maven-extension/#using_system_properties) or [ignored](https://docs.gradle.com/enterprise/maven-extension/#ignoring_system_properties_by_keys), the goal is marked as not cacheable.

![Screenshot 2023-07-26 at 2 26 39 PM](https://github.com/quarkusio/quarkus/assets/10243934/61aa9635-a896-4013-851f-15dcf3ff75aa)

**The cost is 1h17mn of CPU time in my local experiment for surefire and 7mn42s for failsafe**

![Screenshot 2023-07-26 at 2 49 04 PM](https://github.com/quarkusio/quarkus/assets/10243934/06cf8af4-0b89-46dc-a6e7-e0385f49e196)

### Fix
Configure the test goal executions to ignore the _SystemPropertiesVariables_ `maven.repo.local`. The local repository can't be identical across builds if running `install` goal, and fingerprinting it would lead to very large build scans (not even considering the time it would take).
The same goes for `git.dir` which does not make sense to add as an input.

### To be discussed
Some other inputs have been ignored but could be added as inputs, this can be discussed case by case while reviewing the PR. The question being, is it ok to get a cache hit (meaning not re-execute the tests) if something changed in one of those folders:
- `vale.dir`
- `org.jboss.cdi.tck.libraryDirectory`
- `native.image.path`
- `quarkus.kubernetes-service-binding.root`
- `javax.net.ssl.trustStore`
- `rest-client.trustStore`
- `classpathEntriesRecordingFile`