### PR TITLE
Generate/use pull secrets when possible

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -281,6 +281,41 @@ quarkus.container-image.registry=my.docker-registry.net
 By adding this property along with the rest of the container image properties of the previous section, the generated manifests will use the image `my.docker-registry.net/quarkus/demo-app:1.0`.
 The image is not the only thing that can be customized in the generated manifests, as will become evident in the following sections.
 
+
+==== Automatic generation of pull secrets
+
+When docker registries are used, users often provide credentials, so that an image is built and pushed to the specified registry during the build.
+[source,properties]
+----
+quarkus.container-image.username=myusername
+quarkus.container-image.password=mypassword
+----
+
+Kubernetes will also need these credentials when it comes to pull the image from the registry. This is where image pull secrets are used. An image pull secret is a special kind
+of secret that contains the required credentials. Quarkus can automatically generate and configure when:
+
+[source,properties]
+----
+quarkus.kubernetes.generate-image-pull-secret=true
+----
+
+More specifically a `Secret`like the one bellow is genrated:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-quarkus-app-pull-secret
+data:
+  ".dockerconfigjson": ewogCSJhdXRocyI6IHsKCQkibXkucmVnaXN0eS5vcmciOiB7CiAJCQkiYXV0aCI6ImJYbDFjMlZ5Ym1GdFpUcHRlWEJoYzNOM2IzSmsiCgkJfQoJfQp9
+type: kubernetes.io/dockerconfigjson
+
+----
+
+And also `test-quarkus-app-pull-secret is added to the `imagePullSecrets` list.
+
+
 === Labels and Annotations
 
 ==== Labels

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 
 import io.dekorate.kubernetes.decorator.AddDockerConfigJsonSecretDecorator;
-import io.dekorate.kubernetes.decorator.AddImagePullSecretDecorator;
 import io.dekorate.utils.Packaging;
 import io.dekorate.utils.Serialization;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -262,7 +261,6 @@ public class OpenshiftProcessor {
                     applicationInfo.getName(), containerImageInfo.getImage(), imagePushSecret)));
             decorator.produce(new DecoratorBuildItem(OPENSHIFT,
                     new ApplyDockerImageRepositoryToImageStream(applicationInfo.getName(), repositoryWithRegistry)));
-            decorator.produce(new DecoratorBuildItem(OPENSHIFT, new AddImagePullSecretDecorator(name, imagePushSecret)));
         });
     }
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/DevClusterHelper.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/DevClusterHelper.java
@@ -92,7 +92,7 @@ public class DevClusterHelper {
         Optional<Port> port = KubernetesCommonHelper.getPort(ports, config);
         result.addAll(KubernetesCommonHelper.createDecorators(project, clusterKind, name, config,
                 metricsConfiguration, kubernetesClientConfiguration,
-                annotations, labels, command,
+                annotations, labels, image, command,
                 port, livenessPath, readinessPath, startupPath, roles, clusterRoles, serviceAccounts, roleBindings));
 
         image.ifPresent(i -> {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
@@ -116,6 +116,13 @@ public class KnativeConfig implements PlatformConfiguration {
     Optional<List<String>> imagePullSecrets;
 
     /**
+     * Enable generation of image pull secret, when the container image username and
+     * password are provided.
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean generateImagePullSecret;
+
+    /**
      * The liveness probe
      */
     @ConfigItem
@@ -327,6 +334,10 @@ public class KnativeConfig implements PlatformConfiguration {
 
     public Optional<List<String>> getImagePullSecrets() {
         return imagePullSecrets;
+    }
+
+    public boolean isGenerateImagePullSecret() {
+        return generateImagePullSecret;
     }
 
     public ProbeConfig getLivenessProbe() {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
@@ -165,7 +165,7 @@ public class KnativeProcessor {
         Optional<Port> port = KubernetesCommonHelper.getPort(ports, config, "http");
         result.addAll(KubernetesCommonHelper.createDecorators(project, KNATIVE, name, config,
                 metricsConfiguration, kubernetesClientConfiguration, annotations,
-                labels, command, port, livenessPath, readinessPath, startupProbePath,
+                labels, image, command, port, livenessPath, readinessPath, startupProbePath,
                 roles, clusterRoles, serviceAccounts, roleBindings));
 
         image.ifPresent(i -> {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -171,6 +171,13 @@ public class KubernetesConfig implements PlatformConfiguration {
     Optional<List<String>> imagePullSecrets;
 
     /**
+     * Enable generation of image pull secret, when the container image username and
+     * password are provided.
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean generateImagePullSecret;
+
+    /**
      * The liveness probe
      */
     @ConfigItem
@@ -511,6 +518,10 @@ public class KubernetesConfig implements PlatformConfiguration {
 
     public Optional<List<String>> getImagePullSecrets() {
         return imagePullSecrets;
+    }
+
+    public boolean isGenerateImagePullSecret() {
+        return generateImagePullSecret;
     }
 
     public ProbeConfig getLivenessProbe() {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -184,6 +184,13 @@ public class OpenshiftConfig implements PlatformConfiguration {
     Optional<List<String>> imagePullSecrets;
 
     /**
+     * Enable generation of image pull secret, when the container image username and
+     * password are provided.
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean generateImagePullSecret;
+
+    /**
      * The liveness probe
      */
     @ConfigItem
@@ -410,6 +417,10 @@ public class OpenshiftConfig implements PlatformConfiguration {
 
     public Optional<List<String>> getImagePullSecrets() {
         return imagePullSecrets;
+    }
+
+    public boolean isGenerateImagePullSecret() {
+        return generateImagePullSecret;
     }
 
     public ProbeConfig getLivenessProbe() {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
@@ -222,7 +222,7 @@ public class OpenshiftProcessor {
         Optional<Port> port = KubernetesCommonHelper.getPort(ports, config, config.route.targetPort);
         result.addAll(KubernetesCommonHelper.createDecorators(project, OPENSHIFT, name, config,
                 metricsConfiguration, kubernetesClientConfiguration,
-                annotations, labels, command,
+                annotations, labels, image, command,
                 port, livenessPath, readinessPath, startupPath, roles, clusterRoles, serviceAccounts, roleBindings));
 
         if (config.flavor == v3) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PlatformConfiguration.java
@@ -46,6 +46,8 @@ public interface PlatformConfiguration extends EnvVarHolder {
 
     Optional<List<String>> getImagePullSecrets();
 
+    boolean isGenerateImagePullSecret();
+
     ProbeConfig getLivenessProbe();
 
     ProbeConfig getReadinessProbe();

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
@@ -162,7 +162,7 @@ public class VanillaKubernetesProcessor {
                 packageConfig);
         Optional<Port> port = KubernetesCommonHelper.getPort(ports, config);
         result.addAll(KubernetesCommonHelper.createDecorators(project, KUBERNETES, name, config,
-                metricsConfiguration, kubernetesClientConfiguration, annotations, labels, command, port,
+                metricsConfiguration, kubernetesClientConfiguration, annotations, labels, image, command, port,
                 livenessPath, readinessPath, startupPath,
                 roles, clusterRoles, serviceAccounts, roleBindings));
 

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BaseOpenshiftWithRemoteRegistry.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BaseOpenshiftWithRemoteRegistry.java
@@ -9,40 +9,29 @@ import java.util.List;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.openshift.api.model.BuildConfig;
-import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
 
-public class BaseOpenshiftWithRemoteRegistry {
+public class BaseOpenshiftWithRemoteRegistry extends BaseWithRemoteRegistry {
 
     public void assertGeneratedResources(String name, String tag, Path buildDir) throws IOException {
-        Path kubernetesDir = buildDir.resolve("kubernetes");
+        List<HasMetadata> resourceList = getResources("openshift", buildDir);
+        assertGeneratedResources(name, tag, resourceList);
+    }
 
-        assertThat(kubernetesDir).isDirectoryContaining(p -> p.getFileName().endsWith("openshift.json"))
-                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.yml"));
-        List<HasMetadata> openshiftList = DeserializationUtil.deserializeAsList(kubernetesDir.resolve("openshift.yml"));
+    public void assertGeneratedResources(String name, String tag, List<HasMetadata> resourceList) throws IOException {
+        super.assertGeneratedResources(name, resourceList);
 
-        assertThat(openshiftList).filteredOn(h -> "DeploymentConfig".equals(h.getKind())).singleElement().satisfies(h -> {
-            assertThat(h.getMetadata()).satisfies(m -> {
-                assertThat(m.getName()).isEqualTo(name);
-            });
-            assertThat(h).isInstanceOfSatisfying(DeploymentConfig.class, d -> {
-                assertThat(d.getSpec().getTemplate().getSpec().getImagePullSecrets()).singleElement().satisfies(l -> {
-                    assertThat(l.getName()).isEqualTo(name + "-push-secret");
+        assertThat(resourceList)
+                .filteredOn(
+                        h -> "Secret".equals(h.getKind()) && h.getMetadata().getName().equals(name + "-push-secret"))
+                .singleElement().satisfies(h -> {
+                    assertThat(h).isInstanceOfSatisfying(Secret.class, s -> {
+                        assertThat(s.getType()).isEqualTo("kubernetes.io/dockerconfigjson");
+                        assertThat(s.getData()).containsKey(".dockerconfigjson");
+                    });
                 });
-            });
-        });
 
-        assertThat(openshiftList).filteredOn(h -> "Secret".equals(h.getKind())).singleElement().satisfies(h -> {
-            assertThat(h.getMetadata()).satisfies(m -> {
-                assertThat(m.getName()).isEqualTo(name + "-push-secret");
-            });
-            assertThat(h).isInstanceOfSatisfying(Secret.class, s -> {
-                assertThat(s.getType()).isEqualTo("kubernetes.io/dockerconfigjson");
-                assertThat(s.getData()).containsKey(".dockerconfigjson");
-            });
-        });
-
-        assertThat(openshiftList).filteredOn(h -> "BuildConfig".equals(h.getKind())).singleElement().satisfies(h -> {
+        assertThat(resourceList).filteredOn(h -> "BuildConfig".equals(h.getKind())).singleElement().satisfies(h -> {
             assertThat(h.getMetadata()).satisfies(m -> {
                 assertThat(m.getName()).isEqualTo(name);
             });
@@ -52,7 +41,7 @@ public class BaseOpenshiftWithRemoteRegistry {
             });
         });
 
-        assertThat(openshiftList)
+        assertThat(resourceList)
                 .filteredOn(h -> "ImageStream".equals(h.getKind()) && h.getMetadata().getName().equals(name))
                 .singleElement().satisfies(h -> {
                     assertThat(h).isInstanceOfSatisfying(ImageStream.class, i -> {

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BaseWithRemoteRegistry.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BaseWithRemoteRegistry.java
@@ -1,0 +1,55 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.PodSpecFluent;
+import io.fabric8.kubernetes.api.model.Secret;
+
+public class BaseWithRemoteRegistry {
+
+    public void assertGeneratedResources(String name, String target, Path buildDir) throws IOException {
+        List<HasMetadata> resourceList = getResources(target, buildDir);
+        assertGeneratedResources(name, resourceList);
+    }
+
+    List<HasMetadata> getResources(String target, Path buildDir) throws IOException {
+        Path kubernetesDir = buildDir.resolve("kubernetes");
+
+        assertThat(kubernetesDir).isDirectoryContaining(p -> p.getFileName().endsWith(target + ".json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith(target + ".yml"));
+        return DeserializationUtil.deserializeAsList(kubernetesDir.resolve(target + ".yml"));
+    }
+
+    public void assertGeneratedResources(String name, List<HasMetadata> resourceList) {
+        assertThat(resourceList).satisfies(r -> {
+            KubernetesList kubernetesList = new KubernetesListBuilder()
+                    .addAllToItems(resourceList)
+                    .accept(PodSpecFluent.class, spec -> {
+                        assertThat(spec.buildImagePullSecrets()).singleElement().satisfies(e -> {
+                            assertThat(e).isInstanceOfSatisfying(LocalObjectReference.class, l -> {
+                                assertThat(l.getName()).isEqualTo(name + "-pull-secret");
+                            });
+                        });
+
+                    }).build();
+        });
+
+        assertThat(resourceList)
+                .filteredOn(
+                        h -> "Secret".equals(h.getKind()) && h.getMetadata().getName().equals(name + "-pull-secret"))
+                .singleElement().satisfies(h -> {
+                    assertThat(h).isInstanceOfSatisfying(Secret.class, s -> {
+                        assertThat(s.getType()).isEqualTo("kubernetes.io/dockerconfigjson");
+                        assertThat(s.getData()).containsKey(".dockerconfigjson");
+                    });
+                });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithImagePushTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithImagePushTest.java
@@ -12,12 +12,9 @@ import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
 
-/**
- * This is similar to OpenshiftWithRemoteRegistryPushTest, but uses `quarkus.container-image.image` instead.
- */
-public class OpenshiftWithRemoteImagePushTest extends BaseOpenshiftWithRemoteRegistry {
+public class KubernetesWithImagePushTest extends BaseWithRemoteRegistry {
 
-    private static final String APP_NAME = "openshift-with-remote-image-push";
+    private static final String APP_NAME = "kubernetes-with-remote-image-push";
 
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
@@ -28,14 +25,16 @@ public class OpenshiftWithRemoteImagePushTest extends BaseOpenshiftWithRemoteReg
             .overrideConfigKey("quarkus.container-image.image", "quay.io/user/" + APP_NAME + ":1.0")
             .overrideConfigKey("quarkus.container-image.username", "me")
             .overrideConfigKey("quarkus.container-image.password", "pass")
-            .overrideConfigKey("quarkus.openshift.generate-image-pull-secret", "true")
-            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
+            .overrideConfigKey("quarkus.kubernetes.generate-image-pull-secret", "true")
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-container-image-docker", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;
 
     @Test
     public void assertGeneratedResources() throws IOException {
-        assertGeneratedResources(APP_NAME, "1.0", prodModeTestResults.getBuildDir());
+        assertGeneratedResources(APP_NAME, "kubernetes", prodModeTestResults.getBuildDir());
     }
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRemoteRegistryPushTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRemoteRegistryPushTest.java
@@ -25,6 +25,7 @@ public class OpenshiftWithRemoteRegistryPushTest extends BaseOpenshiftWithRemote
             .overrideConfigKey("quarkus.container-image.registry", "quay.io")
             .overrideConfigKey("quarkus.container-image.username", "me")
             .overrideConfigKey("quarkus.container-image.password", "pass")
+            .overrideConfigKey("quarkus.openshift.generate-image-pull-secret", "true")
             .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
 
     @ProdBuildResults


### PR DESCRIPTION
Inspirted by @Sgitario comment on #34241 this pull request automates the generation of image pull secrets when registry and credentials are provided as part of a push operation.