### PR TITLE
Support OIDC authorization code flow nonce

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -469,15 +469,15 @@ link:https://datatracker.ietf.org/doc/html/rfc7636[Proof Key for Code Exchange] 
 While PKCE is of primary importance to public OpenID Connect clients, such as SPA scripts running in a browser, it can also provide an extra level of protection to Quarkus OIDC `web-app` applications. 
 With PKCE, Quarkus OIDC `web-app` applications are confidential OpenID Connect clients capable of securely storing the client secret and using it to exchange the code for the tokens.
 
-You can enable `PKCE` for your OIDC `web-app` endpoint with a `quarkus.oidc.authentication.pkce-required` property and a 32-character secret, as shown in the following example:
+You can enable `PKCE` for your OIDC `web-app` endpoint with a `quarkus.oidc.authentication.pkce-required` property and a 32-character secret which is required to encrypt the PKCE code verifier in the state cookie, as shown in the following example:
 
 [source, properties]
 ----
 quarkus.oidc.authentication.pkce-required=true
-quarkus.oidc.authentication.pkce-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
+quarkus.oidc.authentication.state-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 ----
 
-If you already have a 32-characters client secret then you do not need to set the  `quarkus.oidc.authentication.pkce-secret` property unless you prefer to use a different secret key.
+If you already have a 32-characters client secret then you do not need to set the  `quarkus.oidc.authentication.pkce-secret` property unless you prefer to use a different secret key. This secret will be auto-generated if it is not configured and if the fallback to the client secret is not possible in case of the client secret being less than 16 characters long.
 
 The secret key is required for encrypting a randomly generated `PKCE` `code_verifier` while the user is being redirected with the `code_challenge` query parameter to an OIDC provider to authenticate.
 The `code_verifier` is decrypted when the user is redirected back to Quarkus and sent to the token endpoint alongside the `code`, client secret, and other parameters to complete the code exchange. 

--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -386,7 +386,7 @@ Twitter provider requires Proof Key for Code Exchange (PKCE) which is supported 
 Quarkus has to encrypt the current PKCE code verifier in a state cookie while the authorization code flow with Twitter is in progress and it will
 generate a secure random secret key for encrypting it.
 
-You can provide your own secret key for encrypting the PKCE code verifier if you prefer with the `quarkus.oidc.authentication.pkce-secret` property but
+You can provide your own secret key for encrypting the PKCE code verifier if you prefer with the `quarkus.oidc.authentication.state-secret` property but
 note that this secret should be 32 characters long, and an error will be reported if it is less than 16 characters long.
 ====
 

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -73,4 +73,5 @@ public final class OidcConstants {
     public static final String ID_TOKEN_SID_CLAIM = "sid";
 
     public static final String OPENID_SCOPE = "openid";
+    public static final String NONCE = "nonce";
 }

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CodeFlowDevModeTestCase.java
@@ -181,14 +181,14 @@ public class CodeFlowDevModeTestCase {
                             String line = null;
                             while ((line = reader.readLine()) != null) {
                                 if (line.contains(
-                                        "Secret key for encrypting PKCE code verifier is missing, auto-generating it")) {
+                                        "Secret key for encrypting state cookie is missing, auto-generating it")) {
                                     checkPassed.set(true);
                                 }
                             }
                         }
                     }
                 });
-        assertTrue(checkPassed.get(), "Can not confirm Secret key for encrypting PKCE code verifier has been generated");
+        assertTrue(checkPassed.get(), "Can not confirm Secret key for encrypting state cookie has been generated");
     }
 
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -782,6 +782,15 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public Optional<List<String>> scopes = Optional.empty();
 
         /**
+         * Require that ID token includes `nonce` claim which must match `nonce` authentication request query parameter.
+         * Enabling this property can help mitigate replay attacks.
+         * Do not enable this property if your OpenId Connect provider does not support setting `nonce` in ID token
+         * or if you work with OAuth2 provider such as `GitHub` which does not issue ID tokens.
+         */
+        @ConfigItem(defaultValue = "false")
+        public boolean nonceRequired = false;
+
+        /**
          * Add the 'openid' scope automatically to the list of scopes. This is required for OpenId Connect providers
          * but will not work for OAuth2 providers such as Twitter OAuth2 which does not accept that scope and throws an error.
          */
@@ -945,11 +954,22 @@ public class OidcTenantConfig extends OidcCommonConfig {
         /**
          * Secret which will be used to encrypt a Proof Key for Code Exchange (PKCE) code verifier in the code flow state.
          * This secret should be at least 32 characters long.
+         *
+         * @deprecated Use {@link #stateSecret} property instead.
+         */
+        @ConfigItem
+        @Deprecated(forRemoval = true)
+        public Optional<String> pkceSecret = Optional.empty();
+
+        /**
+         * Secret which will be used to encrypt Proof Key for Code Exchange (PKCE) code verifier and/or nonce in the code flow
+         * state.
+         * This secret should be at least 32 characters long.
          * <p/>
          * If this secret is not set, the client secret configured with
          * either `quarkus.oidc.credentials.secret` or `quarkus.oidc.credentials.client-secret.value` will be checked.
          * Finally, `quarkus.oidc.credentials.jwt.secret` which can be used for `client_jwt_secret` authentication will be
-         * checked. Client secret will not be used as a PKCE code verifier encryption secret if it is less than 32 characters
+         * checked. Client secret will not be used as a state encryption secret if it is less than 32 characters
          * long.
          * </p>
          * The secret will be auto-generated if it remains uninitialized after checking all of these properties.
@@ -957,7 +977,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
          * Error will be reported if the secret length is less than 16 characters.
          */
         @ConfigItem
-        public Optional<String> pkceSecret = Optional.empty();
+        public Optional<String> stateSecret = Optional.empty();
 
         public Optional<Duration> getInternalIdTokenLifespan() {
             return internalIdTokenLifespan;
@@ -975,10 +995,12 @@ public class OidcTenantConfig extends OidcCommonConfig {
             this.pkceRequired = Optional.of(pkceRequired);
         }
 
+        @Deprecated(forRemoval = true)
         public Optional<String> getPkceSecret() {
             return pkceSecret;
         }
 
+        @Deprecated(forRemoval = true)
         public void setPkceSecret(String pkceSecret) {
             this.pkceSecret = Optional.of(pkceSecret);
         }
@@ -1157,6 +1179,22 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setAllowMultipleCodeFlows(boolean allowMultipleCodeFlows) {
             this.allowMultipleCodeFlows = allowMultipleCodeFlows;
+        }
+
+        public boolean isNonceRequired() {
+            return nonceRequired;
+        }
+
+        public void setNonceRequired(boolean nonceRequired) {
+            this.nonceRequired = nonceRequired;
+        }
+
+        public Optional<String> getStateSecret() {
+            return stateSecret;
+        }
+
+        public void setStateSecret(Optional<String> stateSecret) {
+            this.stateSecret = stateSecret;
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationStateBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationStateBean.java
@@ -6,6 +6,8 @@ public class CodeAuthenticationStateBean {
 
     private String codeVerifier;
 
+    private String nonce;
+
     public String getRestorePath() {
         return restorePath;
     }
@@ -22,8 +24,16 @@ public class CodeAuthenticationStateBean {
         this.codeVerifier = codeVerifier;
     }
 
+    public String getNonce() {
+        return nonce;
+    }
+
+    public void setNonce(String nonce) {
+        this.nonce = nonce;
+    }
+
     public boolean isEmpty() {
-        return this.restorePath == null && this.codeVerifier == null;
+        return this.restorePath == null && this.codeVerifier == null && nonce == null;
     }
 
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -11,6 +11,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
+import io.quarkus.runtime.configuration.ConfigurationException;
 
 public class TenantConfigContext {
     private static final Logger LOG = Logger.getLogger(TenantConfigContext.class);
@@ -28,7 +29,7 @@ public class TenantConfigContext {
     /**
      * PKCE Secret Key
      */
-    private final SecretKey pkceSecretKey;
+    private final SecretKey stateSecretKey;
 
     /**
      * Token Encryption Secret Key
@@ -47,39 +48,47 @@ public class TenantConfigContext {
         this.ready = ready;
 
         boolean isService = OidcUtils.isServiceApp(config);
-        pkceSecretKey = !isService && provider != null && provider.client != null ? createPkceSecretKey(config) : null;
+        stateSecretKey = !isService && provider != null && provider.client != null ? createStateSecretKey(config) : null;
         tokenEncSecretKey = !isService && provider != null && provider.client != null ? createTokenEncSecretKey(config) : null;
     }
 
-    private static SecretKey createPkceSecretKey(OidcTenantConfig config) {
-        if (config.authentication.pkceRequired.orElse(false)) {
-            String pkceSecret = null;
-            if (config.authentication.pkceSecret.isPresent()) {
-                pkceSecret = config.authentication.pkceSecret.get();
-            } else {
-                LOG.debug("'quarkus.oidc.token-state-manager.encryption-secret' is not configured, "
+    private static SecretKey createStateSecretKey(OidcTenantConfig config) {
+        if (config.authentication.pkceRequired.orElse(false) || config.authentication.nonceRequired) {
+            String stateSecret = null;
+            if (config.authentication.pkceSecret.isPresent() && config.authentication.getStateSecret().isPresent()) {
+                throw new ConfigurationException(
+                        "Both 'quarkus.oidc.authentication.state-secret' and 'quarkus.oidc.authentication.pkce-secret' are configured");
+            }
+            if (config.authentication.getStateSecret().isPresent()) {
+                stateSecret = config.authentication.getStateSecret().get();
+            } else if (config.authentication.pkceSecret.isPresent()) {
+                stateSecret = config.authentication.pkceSecret.get();
+            }
+
+            if (stateSecret == null) {
+                LOG.debug("'quarkus.oidc.authentication.state-secret' is not configured, "
                         + "trying to use the configured client secret");
                 String possiblePkceSecret = fallbackToClientSecret(config);
                 if (possiblePkceSecret != null && possiblePkceSecret.length() < 32) {
-                    LOG.debug("Client secret is less than 32 characters long, the pkce secret will be generated");
+                    LOG.debug("Client secret is less than 32 characters long, the state secret will be generated");
                 } else {
-                    pkceSecret = possiblePkceSecret;
+                    stateSecret = possiblePkceSecret;
                 }
             }
             try {
-                if (pkceSecret == null) {
-                    LOG.debug("Secret key for encrypting PKCE code verifier is missing, auto-generating it");
+                if (stateSecret == null) {
+                    LOG.debug("Secret key for encrypting state cookie is missing, auto-generating it");
                     SecretKey key = generateSecretKey();
                     return key;
                 }
-                byte[] secretBytes = pkceSecret.getBytes(StandardCharsets.UTF_8);
+                byte[] secretBytes = stateSecret.getBytes(StandardCharsets.UTF_8);
                 if (secretBytes.length < 32) {
-                    String errorMessage = "Secret key for encrypting PKCE code verifier in a state cookie should be at least 32 characters long"
+                    String errorMessage = "Secret key for encrypting state cookie should be at least 32 characters long"
                             + " for the strongest state cookie encryption to be produced."
-                            + " Please update 'quarkus.oidc.authentication.pkce-secret' or update the configured client secret.";
+                            + " Please update 'quarkus.oidc.authentication.state-secret' or update the configured client secret.";
                     if (secretBytes.length < 16) {
-                        throw new RuntimeException(
-                                "Secret key for encrypting PKCE code verifier is less than 32 characters long");
+                        throw new ConfigurationException(
+                                "Secret key for encrypting state cookie is less than 16 characters long");
                     } else {
                         LOG.debug(errorMessage);
                     }
@@ -149,8 +158,8 @@ public class TenantConfigContext {
         return oidcConfig;
     }
 
-    public SecretKey getPkceSecretKey() {
-        return pkceSecretKey;
+    public SecretKey getStateEncryptionKey() {
+        return stateSecretKey;
     }
 
     public SecretKey getTokenEncSecretKey() {

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -65,6 +65,15 @@ public class CustomTenantResolver implements TenantResolver {
             }
         }
 
+        if (path.contains("tenant-nonce")) {
+            if (context.getCookie("q_session_tenant-nonce") != null) {
+                context.put("reauthenticated", "true");
+                return context.get(OidcUtils.TENANT_ID_ATTRIBUTE);
+            } else {
+                return "tenant-nonce";
+            }
+        }
+
         if (path.contains("tenant-xhr")) {
             return "tenant-xhr";
         }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantNonce.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantNonce.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.oidc.OidcSession;
+import io.quarkus.security.Authenticated;
+import io.vertx.ext.web.RoutingContext;
+
+@Path("/tenant-nonce")
+public class TenantNonce {
+
+    @Inject
+    OidcSession session;
+    @Inject
+    RoutingContext routingContext;
+
+    @GET
+    @Authenticated
+    public String getTenant() {
+        return session.getTenantId() + (routingContext.get("reauthenticated") != null ? ":reauthenticated" : "");
+    }
+}

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -109,9 +109,19 @@ quarkus.oidc.tenant-https.authentication.force-redirect-https-scheme=true
 quarkus.oidc.tenant-https.authentication.cookie-suffix=test
 quarkus.oidc.tenant-https.authentication.error-path=/tenant-https/error
 quarkus.oidc.tenant-https.authentication.pkce-required=true
+quarkus.oidc.tenant-https.authentication.nonce-required=true
 quarkus.oidc.tenant-https.authentication.pkce-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 quarkus.oidc.tenant-https.authentication.cookie-same-site=strict
 quarkus.oidc.tenant-https.authentication.fail-on-missing-state-param=false
+
+quarkus.oidc.tenant-nonce.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc.tenant-nonce.client-id=quarkus-app
+quarkus.oidc.tenant-nonce.credentials.secret=secret
+quarkus.oidc.tenant-nonce.authentication.scopes=profile,email,phone
+quarkus.oidc.tenant-nonce.authentication.extra-params.max-age=60
+quarkus.oidc.tenant-nonce.application-type=web-app
+quarkus.oidc.tenant-nonce.authentication.nonce-required=true
+quarkus.oidc.tenant-nonce.authentication.state-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 
 quarkus.oidc.tenant-javascript.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-javascript.client-id=quarkus-app


### PR DESCRIPTION
Fixes #23580.

I've finally have looked at fixing #23580 because there is an OIDC conformance test that checks that a non-matching nonce causes a failure, but it can be a generally useful OIDC code flow hardening enhancement in any case.

From https://openid.net/specs/openid-connect-core-1_0.html#IDToken: `String value used to associate a Client session with an ID Token, and to mitigate replay attacks.`.

Quarkus will include a `nonce` query parameter in the redirect to the OIDC provider, will have a matching value securely stored in the state cookie and then when the code flow is completed - it verifies that ID token `nonce` claim matches the one in the cookie - so if the current redirect back to Quarkus has been comprimized - ID token nonce returned from the secure Keycloak/etc connection will help detecting it, and vice versa, if the connection to Keycloak has been affected.

So this PR does introduce a new OIDC feature - but it is a very simple PR - we simply store the new nonce securely in the state cookie and then check ID token claim and both values must match.

As far as storing the nonce securely in the state cookie is concerned - it depends on what has already been done for the PKCE code_verifier property - which is encrypted in the state cookie as it must not be visible in the cookie - so this PR adds a nonce property to the `CodeFlowAuthenticationBean` which captures the data which must be encrypred and then retrieves it from the state cookie, after the secured state has been decrypted.

With `nonce` we now can have either PKCE `code_verifier` or `nonce` or both of these properties having to be encrypted. More such properties may have to be secured in the state cookie. Therefore I deprecated `quarkus.oidc.authentication.pkce-secret` as this secret is not only about encrypting the (pkce) `code_verifier` but at least 2 or possibly more properties, and the new property is now called `quarkus.oidc.authentication.state-secret`. 

`quarkus.oidc.authentication.pkce-secret` will be supported for a ling while anyway I guess.

Updated tests, one of the existing test tenants, `tenant-https` has been updated to require `nonce` - this tenant also requires pkce, so 4 related tests now check that both the `code_verifier` and `nonce` are available in the decrypted state cookie.

Also added 2 tests where only `nonce` is expected, `tenant-nonce`. Positive test confirms the decrypted state cookie contains `nonce` only, and negative test - that `401` is returned if the state cookie is modified to remove the nonce from it.

So overall, the changes are not really some significant OIDC changes, but @gastaldi, @michalvavrik, we can wait for @pedroigor to review when he is back, if you'd like, thanks 