### PR TITLE
Fix Keycloak token address in OIDC DevUI script

### DIFF
--- a/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
+++ b/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
@@ -854,7 +854,7 @@ export class QwcOidcProvider extends QwcHotReloadElement {
         let address;
         let state;
         if (propertiesState.keycloakAdminUrl && propertiesState.keycloakRealms?.length > 0) {
-            address = this._getKeycloakTokenUrl();
+            address = this._getKeycloakAuthorizationUrl();
             state = QwcOidcProvider._makeId() + "_" + this._selectedRealm + "_" + clientId;
         } else {
             address = propertiesState.authorizationUrl ?? '';
@@ -1225,6 +1225,10 @@ export class QwcOidcProvider extends QwcHotReloadElement {
     }
 
     _getKeycloakTokenUrl() {
+        return propertiesState.keycloakAdminUrl + "/realms/" + this._selectedRealm + "/protocol/openid-connect/token";
+    }
+    
+    _getKeycloakAuthorizationUrl() {
         return propertiesState.keycloakAdminUrl + "/realms/" + this._selectedRealm + "/protocol/openid-connect/auth";
     }
 }


### PR DESCRIPTION
Fixes #35029.

I have confirmed the code flow works as expected, and that the client credentials grant request succeeds - the client cred token itself is not accepted in the demo but that is an unrelated issue (Keycloak reports an inactive token for this token) 