### PR TITLE
Fix join message in websocket quickstart

### DIFF
--- a/docs/src/main/asciidoc/websockets.adoc
+++ b/docs/src/main/asciidoc/websockets.adoc
@@ -95,6 +95,7 @@ public class ChatSocket {
 
     @OnOpen
     public void onOpen(Session session, @PathParam("username") String username) {
+        broadcast("User " + username + " joined");
         sessions.put(username, session);
     }
 
@@ -112,11 +113,7 @@ public class ChatSocket {
 
     @OnMessage
     public void onMessage(String message, @PathParam("username") String username) {
-        if (message.equalsIgnoreCase("_ready_")) {
-            broadcast("User " + username + " joined");
-        } else {
-            broadcast(">> " + username + ": " + message);
-        }
+        broadcast(">> " + username + ": " + message);
     }
 
     private void broadcast(String message) {


### PR DESCRIPTION
There should be a "joined" message on user joining, but no message is acctually sent.

No "ready" message is generated on user joining,
so move this message to user incoming.

Relates to https://github.com/quarkusio/quarkus-quickstarts/pull/1309