### PR TITLE
Virtual threads module providing executor supplier for running virtual threads

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2948,6 +2948,16 @@
                 <artifactId>quarkus-info</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-virtual-threads</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-virtual-threads-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- Quarkus test dependencies -->
             <dependency>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -2841,6 +2841,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-virtual-threads</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-webjars-locator</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -2855,6 +2855,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-virtual-threads-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-webjars-locator-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/docs/src/main/asciidoc/virtual-threads.adoc
+++ b/docs/src/main/asciidoc/virtual-threads.adoc
@@ -450,6 +450,19 @@ So, the data written in the duplicated context (and the request scope, as the re
 
 However, thread locals are not propagated.
 
+== Virtual thread names
+
+Virtual threads are created without a thread name by default, which is not practical to identify the execution for debugging and logging purposes.
+Quarkus managed virtual threads are named and prefixed with `quarkus-virtual-thread-`.
+You can customize this prefix, or disable the naming altogether configuring an empty value:
+
+[source, properties]
+----
+quarkus.virtual-threads.name-prefix=
+
+----
+
+
 == Additional references
 
 - https://dl.acm.org/doi/10.1145/3583678.3596895[Considerations for integrating virtual threads in a Java framework: a Quarkus example in a resource-constrained environment]

--- a/extensions/grpc/deployment/pom.xml
+++ b/extensions/grpc/deployment/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>quarkus-smallrye-health-deployment</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-virtual-threads-deployment</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/grpc/runtime/pom.xml
+++ b/extensions/grpc/runtime/pom.xml
@@ -45,6 +45,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-stork</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-virtual-threads</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -16,6 +16,7 @@
     <modules>
         <!-- Netty loom adaptor-->
         <module>netty-loom-adaptor</module>
+        <module>virtual-threads</module>
         <!-- Plumbing -->
         <module>arc</module>
         <module>scheduler</module>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/pom.xml
@@ -56,6 +56,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-virtual-threads-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-deployment</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/pom.xml
@@ -45,6 +45,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-virtual-threads</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -4,11 +4,8 @@ import static io.quarkus.resteasy.reactive.server.runtime.NotFoundExceptionMappe
 import static io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder.DefaultAuthFailureHandler.extractRootCause;
 
 import java.io.Closeable;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -64,9 +61,8 @@ import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder.DefaultAuthFailureHandler;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.quarkus.virtual.threads.VirtualThreadsRecorder;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.ext.web.RoutingContext;
 
 @Recorder
@@ -78,78 +74,6 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
         @Override
         public Executor get() {
             return ExecutorRecorder.getCurrent();
-        }
-    };
-    public static final Supplier<Executor> VIRTUAL_EXECUTOR_SUPPLIER = new Supplier<Executor>() {
-        Executor current = null;
-
-        /**
-         * This method is used to specify a custom executor to dispatch virtual threads on carrier threads
-         * We need reflection for both ease of use (see {@link #get() Get} method) but also because we call methods
-         * of private classes from the java.lang package.
-         *
-         * It is used for testing purposes only for now
-         */
-        private Executor setVirtualThreadCustomScheduler(Executor executor) throws ClassNotFoundException,
-                InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchMethodException {
-            var vtf = Class.forName("java.lang.ThreadBuilders").getDeclaredClasses()[0];
-            Constructor constructor = vtf.getDeclaredConstructors()[0];
-            constructor.setAccessible(true);
-            ThreadFactory tf = (ThreadFactory) constructor.newInstance(
-                    new Object[] { executor, "quarkus-virtual-factory-", 0, 0,
-                            null });
-
-            return (Executor) Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class)
-                    .invoke(this, tf);
-        }
-
-        /**
-         * This method uses reflection in order to allow developers to quickly test quarkus-loom without needing to
-         * change --release, --source, --target flags and to enable previews.
-         * Since we try to load the "Loom-preview" classes/methods at runtime, the application can even be compiled
-         * using java 11 and executed with a loom-compliant JDK.
-         * <p>
-         * IMPORTANT: we still need to use a duplicated context to have all the propagation working.
-         * Thus, the context is captured and applied/terminated in the virtual thread.
-         */
-        @Override
-        public Executor get() {
-            if (current == null) {
-                try {
-                    var virtual = (Executor) Executors.class.getMethod("newVirtualThreadPerTaskExecutor")
-                            .invoke(this);
-                    current = new Executor() {
-                        @Override
-                        public void execute(Runnable command) {
-                            var context = Vertx.currentContext();
-                            if (!(context instanceof ContextInternal)) {
-                                virtual.execute(command);
-                            } else {
-                                virtual.execute(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        final var previousContext = ((ContextInternal) context).beginDispatch();
-                                        try {
-                                            command.run();
-                                        } finally {
-                                            ((ContextInternal) context).endDispatch(previousContext);
-                                        }
-                                    }
-                                });
-                            }
-                        }
-                    };
-                } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
-                    logger.debug("Unable to invoke java.util.concurrent.Executors#newVirtualThreadPerTaskExecutor", e);
-                    //quite ugly but works
-                    logger.warnf("You weren't able to create an executor that spawns virtual threads, the default" +
-                            " blocking executor will be used, please check that your JDK is compatible with " +
-                            "virtual threads");
-                    //if for some reason a class/method can't be loaded or invoked we return the traditional EXECUTOR
-                    current = EXECUTOR_SUPPLIER.get();
-                }
-            }
-            return current;
         }
     };
 
@@ -205,7 +129,7 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
         }
 
         RuntimeDeploymentManager runtimeDeploymentManager = new RuntimeDeploymentManager(info, EXECUTOR_SUPPLIER,
-                VIRTUAL_EXECUTOR_SUPPLIER,
+                VirtualThreadsRecorder::getCurrent,
                 closeTaskHandler, contextFactory, new ArcThreadSetupAction(beanContainer.requestContext()),
                 vertxConfig.rootPath);
         Deployment deployment = runtimeDeploymentManager.deploy();

--- a/extensions/smallrye-reactive-messaging/deployment/pom.xml
+++ b/extensions/smallrye-reactive-messaging/deployment/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>quarkus-vertx-deployment</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-virtual-threads-deployment</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.commonmark</groupId>
       <artifactId>commonmark</artifactId>
     </dependency>

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/SmallRyeReactiveMessagingProcessor.java
@@ -52,7 +52,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.gizmo.ClassCreator;
@@ -112,12 +111,6 @@ public class SmallRyeReactiveMessagingProcessor {
         return new AdditionalBeanBuildItem(SmallRyeReactiveMessagingLifecycle.class, Connector.class,
                 Channel.class, io.smallrye.reactive.messaging.annotations.Channel.class,
                 QuarkusWorkerPoolRegistry.class);
-    }
-
-    @BuildStep
-    void nativeRuntimeInitClasses(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitClasses) {
-        runtimeInitClasses.produce(new RuntimeInitializedClassBuildItem(
-                "io.quarkus.smallrye.reactivemessaging.runtime.QuarkusWorkerPoolRegistry$VirtualExecutorSupplier"));
     }
 
     @BuildStep

--- a/extensions/smallrye-reactive-messaging/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging/runtime/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-virtual-threads</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-messaging-provider</artifactId>
             <exclusions>

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
@@ -1,15 +1,11 @@
 package io.quarkus.smallrye.reactivemessaging.runtime;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.function.Supplier;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -21,17 +17,14 @@ import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
-import org.slf4j.LoggerFactory;
 
-import io.quarkus.runtime.ExecutorRecorder;
+import io.quarkus.virtual.threads.VirtualThreadsRecorder;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.providers.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.providers.connectors.WorkerPoolRegistry;
 import io.smallrye.reactive.messaging.providers.helpers.Validation;
-import io.vertx.core.Vertx;
 import io.vertx.core.impl.ConcurrentHashSet;
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.mutiny.core.Context;
 import io.vertx.mutiny.core.WorkerExecutor;
 
@@ -41,7 +34,8 @@ import io.vertx.mutiny.core.WorkerExecutor;
 // TODO: create a different entry for WorkerPoolRegistry than `analyzeWorker` and drop this class
 public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
 
-    private static final Logger logger = Logger.getLogger(QuarkusWorkerPoolRegistry.class);
+    private static final Logger log = Logger.getLogger(WorkerPoolRegistry.class);
+
     private static final String WORKER_CONFIG_PREFIX = "smallrye.messaging.worker";
     private static final String WORKER_CONCURRENCY = "max-concurrency";
     public static final String DEFAULT_VIRTUAL_THREAD_WORKER = "<virtual-thread>";
@@ -57,61 +51,6 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
         Set<String> set = new ConcurrentHashSet<>();
         set.add(DEFAULT_VIRTUAL_THREAD_WORKER);
         return set;
-    }
-
-    private enum VirtualExecutorSupplier implements Supplier<Executor> {
-        Instance;
-
-        private final Executor executor;
-
-        /**
-         * This method uses reflection in order to allow developers to quickly test quarkus-loom without needing to
-         * change --release, --source, --target flags and to enable previews.
-         * Since we try to load the "Loom-preview" classes/methods at runtime, the application can even be compiled
-         * using java 11 and executed with a loom-compliant JDK.
-         */
-        VirtualExecutorSupplier() {
-            Executor actual;
-            try {
-                var virtual = (Executor) Executors.class.getMethod("newVirtualThreadPerTaskExecutor")
-                        .invoke(this);
-                actual = new Executor() {
-                    @Override
-                    public void execute(Runnable command) {
-                        var context = Vertx.currentContext();
-                        if (!(context instanceof ContextInternal)) {
-                            virtual.execute(command);
-                        } else {
-                            ContextInternal contextInternal = (ContextInternal) context;
-                            virtual.execute(new Runnable() {
-                                @Override
-                                public void run() {
-                                    final var previousContext = contextInternal.beginDispatch();
-                                    try {
-                                        command.run();
-                                    } finally {
-                                        contextInternal.endDispatch(previousContext);
-                                    }
-                                }
-                            });
-                        }
-                    }
-                };
-            } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
-                //quite ugly but works
-                logger.warnf(e, "You weren't able to create an executor that spawns virtual threads, the default" +
-                        " blocking executor will be used, please check that your JDK is compatible with " +
-                        "virtual threads");
-                //if for some reason a class/method can't be loaded or invoked we return the traditional EXECUTOR
-                actual = ExecutorRecorder.getCurrent();
-            }
-            this.executor = actual;
-        }
-
-        @Override
-        public Executor get() {
-            return this.executor;
-        }
     }
 
     public void terminate(
@@ -151,7 +90,7 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
     }
 
     private <T> Uni<T> runOnVirtualThread(Context currentContext, Uni<T> uni) {
-        return uni.runSubscriptionOn(VirtualExecutorSupplier.Instance.get())
+        return uni.runSubscriptionOn(VirtualThreadsRecorder.getCurrent())
                 .onItemOrFailure().transformToUni((item, failure) -> {
                     return Uni.createFrom().emitter(emitter -> {
                         if (currentContext != null) {
@@ -186,9 +125,8 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
                     if (executor == null) {
                         executor = executionHolder.vertx().createSharedWorkerExecutor(workerName,
                                 workerConcurrency.get(workerName));
-                        LoggerFactory.getLogger(WorkerPoolRegistry.class)
-                                .info("Created worker pool named " + workerName + " with concurrency of "
-                                        + workerConcurrency.get(workerName));
+                        log.info("Created worker pool named " + workerName + " with concurrency of "
+                                + workerConcurrency.get(workerName));
                         workerExecutors.put(workerName, executor);
                     }
                 }

--- a/extensions/virtual-threads/deployment/pom.xml
+++ b/extensions/virtual-threads/deployment/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-virtual-threads-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-virtual-threads-deployment</artifactId>
+    <name>Quarkus - Virtual Threads - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-virtual-threads</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-deployment</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/virtual-threads/deployment/src/main/java/io/quarkus/virtual/threads/VirtualThreadsProcessor.java
+++ b/extensions/virtual-threads/deployment/src/main/java/io/quarkus/virtual/threads/VirtualThreadsProcessor.java
@@ -1,0 +1,19 @@
+package io.quarkus.virtual.threads;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+
+public class VirtualThreadsProcessor {
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    public void setup(VirtualThreadsConfig config, VirtualThreadsRecorder recorder,
+            ShutdownContextBuildItem shutdownContextBuildItem,
+            LaunchModeBuildItem launchModeBuildItem) {
+        recorder.setupVirtualThreads(config, shutdownContextBuildItem, launchModeBuildItem.getLaunchMode());
+    }
+
+}

--- a/extensions/virtual-threads/pom.xml
+++ b/extensions/virtual-threads/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-virtual-threads-parent</artifactId>
+    <name>Quarkus - Virtual Threads</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+
+</project>

--- a/extensions/virtual-threads/runtime/pom.xml
+++ b/extensions/virtual-threads/runtime/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-virtual-threads-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-virtual-threads</artifactId>
+    <name>Quarkus - Virtual Threads - Runtime</name>
+    <description>Virtual Threads Executor</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <argLine>--enable-preview</argLine>
+                    </configuration>
+                </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/ContextPreservingExecutorService.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/ContextPreservingExecutorService.java
@@ -1,0 +1,105 @@
+package io.quarkus.virtual.threads;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+
+/**
+ * Delegating executor service implementation preserving the Vert.x context on {@link #execute(Runnable)}
+ */
+class ContextPreservingExecutorService implements ExecutorService {
+    private final ExecutorService delegate;
+
+    ContextPreservingExecutorService(final ExecutorService delegate) {
+        this.delegate = delegate;
+    }
+
+    public void execute(final Runnable command) {
+        var context = Vertx.currentContext();
+        if (!(context instanceof ContextInternal)) {
+            delegate.execute(command);
+        } else {
+            ContextInternal contextInternal = (ContextInternal) context;
+            delegate.execute(new Runnable() {
+                @Override
+                public void run() {
+                    final var previousContext = contextInternal.beginDispatch();
+                    try {
+                        command.run();
+                    } finally {
+                        contextInternal.endDispatch(previousContext);
+                    }
+                }
+            });
+        }
+    }
+
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(task, result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(task);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        return delegate.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate.invokeAny(tasks, timeout, unit);
+    }
+
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    public String toString() {
+        return delegate.toString();
+    }
+}

--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsConfig.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsConfig.java
@@ -1,0 +1,32 @@
+package io.quarkus.virtual.threads;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public class VirtualThreadsConfig {
+
+    /**
+     * Virtual thread name prefix. If left blank virtual threads will be unnamed.
+     */
+    @ConfigItem(defaultValue = "quarkus-virtual-thread-")
+    Optional<String> namePrefix;
+
+    /**
+     * The shutdown timeout. If all pending work has not been completed by this time
+     * then any pending tasks will be interrupted, and the shutdown process will continue
+     */
+    @ConfigItem(defaultValue = "1M")
+    public Duration shutdownTimeout;
+
+    /**
+     * The frequency at which the status of the executor service should be checked during shutdown.
+     * Setting this key to an empty value disables the shutdown check interval.
+     */
+    @ConfigItem(defaultValue = "5s")
+    public Optional<Duration> shutdownCheckInterval;
+}

--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsRecorder.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsRecorder.java
@@ -1,0 +1,166 @@
+package io.quarkus.virtual.threads;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.ShutdownContext;
+import io.quarkus.runtime.annotations.Recorder;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+
+@Recorder
+public class VirtualThreadsRecorder {
+
+    private static final Logger logger = Logger.getLogger("io.quarkus.virtual-threads");
+
+    static VirtualThreadsConfig config = new VirtualThreadsConfig();
+
+    private static volatile Executor current;
+    private static final Object lock = new Object();
+
+    public void setupVirtualThreads(VirtualThreadsConfig c, ShutdownContext shutdownContext, LaunchMode launchMode) {
+        config = c;
+        if (launchMode == LaunchMode.DEVELOPMENT) {
+            shutdownContext.addLastShutdownTask(new Runnable() {
+                @Override
+                public void run() {
+                    Executor executor = current;
+                    if (executor instanceof ExecutorService) {
+                        ((ExecutorService) executor).shutdownNow();
+                    }
+                    current = null;
+                }
+            });
+        } else {
+            shutdownContext.addLastShutdownTask(new Runnable() {
+                @Override
+                public void run() {
+                    Executor executor = current;
+                    if (executor instanceof ExecutorService) {
+                        ExecutorService service = (ExecutorService) executor;
+                        service.shutdown();
+
+                        final long timeout = config.shutdownTimeout.toNanos();
+                        final long interval = config.shutdownCheckInterval.orElse(config.shutdownTimeout).toNanos();
+
+                        long start = System.nanoTime();
+                        int loop = 1;
+                        long elapsed = 0;
+                        for (;;) {
+                            // This log can be very useful when debugging problems
+                            logger.debugf("Await termination loop: %s, remaining: %s", loop++, timeout - elapsed);
+                            try {
+                                if (!service.awaitTermination(Math.min(timeout, interval), NANOSECONDS)) {
+                                    elapsed = System.nanoTime() - start;
+                                    if (elapsed >= timeout) {
+                                        service.shutdownNow();
+                                        break;
+                                    }
+                                } else {
+                                    return;
+                                }
+                            } catch (InterruptedException ignored) {
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    public static Executor getCurrent() {
+        Executor executor = current;
+        if (executor != null) {
+            return executor;
+        }
+        synchronized (lock) {
+            if (current == null) {
+                current = createExecutor();
+            }
+            return current;
+        }
+    }
+
+    static ExecutorService newVirtualThreadPerTaskExecutorWithName(String prefix)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, ClassNotFoundException {
+        Method ofVirtual = Thread.class.getMethod("ofVirtual");
+        Object vtb = ofVirtual.invoke(VirtualThreadsRecorder.class);
+        Class<?> vtbClass = Class.forName("java.lang.Thread$Builder$OfVirtual");
+        Method name = vtbClass.getMethod("name", String.class, long.class);
+        vtb = name.invoke(vtb, prefix, 0);
+        Method factory = vtbClass.getMethod("factory");
+        ThreadFactory tf = (ThreadFactory) factory.invoke(vtb);
+
+        return (ExecutorService) Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class)
+                .invoke(VirtualThreadsRecorder.class, tf);
+    }
+
+    static ExecutorService newVirtualThreadPerTaskExecutor()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        return (ExecutorService) Executors.class.getMethod("newVirtualThreadPerTaskExecutor")
+                .invoke(VirtualThreadsRecorder.class);
+    }
+
+    static ExecutorService newVirtualThreadExecutor()
+            throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        try {
+            Optional<String> namePrefix = config.namePrefix;
+            return namePrefix.isPresent() ? newVirtualThreadPerTaskExecutorWithName(namePrefix.get())
+                    : newVirtualThreadPerTaskExecutor();
+        } catch (ClassNotFoundException e) {
+            logger.warn("Unable to invoke java.util.concurrent.Executors#newThreadPerTaskExecutor" +
+                    " with VirtualThreadFactory, falling back to unnamed virtual threads", e);
+            return newVirtualThreadPerTaskExecutor();
+        }
+    }
+
+    /**
+     * This method uses reflection in order to allow developers to quickly test quarkus-loom without needing to
+     * change --release, --source, --target flags and to enable previews.
+     * Since we try to load the "Loom-preview" classes/methods at runtime, the application can even be compiled
+     * using java 11 and executed with a loom-compliant JDK.
+     */
+    private static Executor createExecutor() {
+        try {
+            return new ContextPreservingExecutorService(newVirtualThreadExecutor());
+        } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+            logger.debug("Unable to invoke java.util.concurrent.Executors#newVirtualThreadPerTaskExecutor", e);
+            //quite ugly but works
+            logger.warn("You weren't able to create an executor that spawns virtual threads, the default" +
+                    " blocking executor will be used, please check that your JDK is compatible with " +
+                    "virtual threads");
+            //if for some reason a class/method can't be loaded or invoked we return the traditional executor,
+            // wrapping executeBlocking.
+            return new Executor() {
+                @Override
+                public void execute(Runnable command) {
+                    var context = Vertx.currentContext();
+                    if (!(context instanceof ContextInternal)) {
+                        Infrastructure.getDefaultWorkerPool().execute(command);
+                    } else {
+                        context.executeBlocking(fut -> {
+                            try {
+                                command.run();
+                                fut.complete(null);
+                            } catch (Exception e) {
+                                fut.fail(e);
+                            }
+                        }, false);
+                    }
+                }
+            };
+        }
+    }
+
+}

--- a/extensions/virtual-threads/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/virtual-threads/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,10 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "Virtual Threads Support"
+metadata:
+  keywords:
+  - "virtual-threads"
+  - "loom"
+  unlisted: true
+  config:
+  - "quarkus.virtual-threads."

--- a/extensions/virtual-threads/runtime/src/test/java/io/quarkus/virtual/threads/VirtualThreadExecutorSupplierTest.java
+++ b/extensions/virtual-threads/runtime/src/test/java/io/quarkus/virtual/threads/VirtualThreadExecutorSupplierTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.virtual.threads;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.concurrent.Executor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+
+class VirtualThreadExecutorSupplierTest {
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_20, disabledReason = "Virtual Threads are a preview feature starting from Java 20")
+    void virtualThreadCustomScheduler()
+            throws ClassNotFoundException, InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+        Executor executor = VirtualThreadsRecorder.newVirtualThreadPerTaskExecutorWithName("vthread-");
+        var assertSubscriber = Uni.createFrom().emitter(e -> {
+            assertThat(Thread.currentThread().getName()).isNotEmpty()
+                    .startsWith("vthread-");
+            assertThatItRunsOnVirtualThread();
+            e.complete(null);
+        }).runSubscriptionOn(executor)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        assertSubscriber.awaitItem(Duration.ofSeconds(1)).assertCompleted();
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_20, disabledReason = "Virtual Threads are a preview feature starting from Java 20")
+    void execute() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        Executor executor = VirtualThreadsRecorder.newVirtualThreadPerTaskExecutor();
+        var assertSubscriber = Uni.createFrom().emitter(e -> {
+            assertThat(Thread.currentThread().getName()).isEmpty();
+            assertThatItRunsOnVirtualThread();
+            e.complete(null);
+        }).runSubscriptionOn(executor)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        assertSubscriber.awaitItem(Duration.ofSeconds(1)).assertCompleted();
+    }
+
+    public static void assertThatItRunsOnVirtualThread() {
+        // We cannot depend on a Java 20.
+        try {
+            Method isVirtual = Thread.class.getMethod("isVirtual");
+            isVirtual.setAccessible(true);
+            boolean virtual = (Boolean) isVirtual.invoke(Thread.currentThread());
+            if (!virtual) {
+                throw new AssertionError("Thread " + Thread.currentThread() + " is not a virtual thread");
+            }
+        } catch (Exception e) {
+            throw new AssertionError(
+                    "Thread " + Thread.currentThread() + " is not a virtual thread - cannot invoke Thread.isVirtual()", e);
+        }
+    }
+}


### PR DESCRIPTION
Replaces ad-hoc virtual thread executors in resteasy-reactive, grpc and reactive messaging
Handles executor service close on shutdown hook
Creates named virtual threads
Introduces config options:
- `quarkus.virtual-threads.name-prefix` default `quarkus-virtual-thread-`
- `quarkus.virtual-threads.shutdown-timeout` default 1 minute
- `quarkus.virtual-threads.shutdown-check-interval` default 5 seconds