### PR TITLE
Skip flaky jms virtual threads until fix

### DIFF
--- a/integration-tests/virtual-threads/jms-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/jms-virtual-threads/pom.xml
@@ -144,6 +144,18 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Flaky test -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <!-- Flaky test -->
+                    <skip>true</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
jms-virtual-threads IT introduced in #35018 is flaky.

This PR skips the tests for that module.

Probably due to a bug in RM JMS connector :
```
2023-07-28 15:07:04,415 ERROR [io.sma.rea.mes.provider] (quarkus-virtual-thread-55) SRMSG00201: Error caught while processing a message in method io.quarkus.it.vthreads.jms.PriceConsumer#consume: java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.CompletableFuture$AsyncRun@17571b45 rejected from java.util.concurrent.ThreadPoolExecutor@74109346[Running, pool size = 10, active threads = 9, queued tasks = 0, completed tasks = 69]
	at java.base@20.0.1/java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2081)
	at java.base@20.0.1/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:841)
	at java.base@20.0.1/java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1376)
	at java.base@20.0.1/java.util.concurrent.CompletableFuture.asyncRunStage(CompletableFuture.java:1818)
	at java.base@20.0.1/java.util.concurrent.CompletableFuture.runAsync(CompletableFuture.java:2033)
	at io.smallrye.reactive.messaging.jms.IncomingJmsMessage.ack(IncomingJmsMessage.java:113)
	at io.smallrye.reactive.messaging.providers.SubscriberMediator.lambda$handleInvocationResult$11(SubscriberMediator.java:197)
	at io.smallrye.context.impl.wrappers.SlowContextualBiFunction.apply(SlowContextualBiFunction.java:21)
	at io.smallrye.mutiny.operators.uni.UniOnItemOrFailureFlatMap$UniOnItemOrFailureFlatMapProcessor.performInnerSubscription(UniOnItemOrFailureFlatMap.java:86)
	at io.smallrye.mutiny.operators.uni.UniOnItemOrFailureFlatMap$UniOnItemOrFailureFlatMapProcessor.onItem(UniOnItemOrFailureFlatMap.java:54)
	at io.smallrye.mutiny.operators.uni.UniOnItemOrFailureFlatMap$UniOnItemOrFailureFlatMapProcessor.onItem(UniOnItemOrFailureFlatMap.java:56)
	at io.smallrye.mutiny.operators.uni.builders.DefaultUniEmitter.complete(DefaultUniEmitter.java:37)
	at io.quarkus.smallrye.reactivemessaging.runtime.QuarkusWorkerPoolRegistry.lambda$runOnVirtualThread$7(QuarkusWorkerPoolRegistry.java:105)
	at io.smallrye.context.impl.wrappers.SlowContextualConsumer.accept(SlowContextualConsumer.java:21)
	at io.smallrye.mutiny.operators.uni.builders.UniCreateWithEmitter.subscribe(UniCreateWithEmitter.java:22)
	at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:36)
	at io.smallrye.mutiny.operators.uni.UniOnItemOrFailureFlatMap$UniOnItemOrFailureFlatMapProcessor.performInnerSubscription(UniOnItemOrFailureFlatMap.java:99)
	at io.smallrye.mutiny.operators.uni.UniOnItemOrFailureFlatMap$UniOnItemOrFailureFlatMapProcessor.onItem(UniOnItemOrFailureFlatMap.java:54)
	at io.smallrye.mutiny.operators.uni.UniOperatorProcessor.onItem(UniOperatorProcessor.java:47)
	at io.smallrye.mutiny.operators.uni.builders.DefaultUniEmitter.complete(DefaultUniEmitter.java:37)
	at io.smallrye.reactive.messaging.providers.AbstractMediator.lambda$invokeBlocking$11(AbstractMediator.java:175)
	at io.smallrye.context.impl.wrappers.SlowContextualConsumer.accept(SlowContextualConsumer.java:21)
	at io.smallrye.mutiny.operators.uni.builders.UniCreateWithEmitter.subscribe(UniCreateWithEmitter.java:22)
	at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:36)
	at io.smallrye.mutiny.operators.uni.UniRunSubscribeOn.lambda$subscribe$0(UniRunSubscribeOn.java:27)
	at java.base@20.0.1/java.util.concurrent.ThreadPerTaskExecutor$TaskRunner.run(ThreadPerTaskExecutor.java:314)
	at java.base@20.0.1/java.lang.VirtualThread.runWith(VirtualThread.java:335)
	at java.base@20.0.1/java.lang.VirtualThread.run(VirtualThread.java:305)
	at java.base@20.0.1/java.lang.VirtualThread$VThreadContinuation.lambda$new$0(VirtualThread.java:177)
	at java.base@20.0.1/jdk.internal.vm.Continuation.enter(Continuation.java:169)
```