### PR TITLE
Quarkus rules for the Vale linter: Fix false positive messages and enhance regular expression of some rules

### DIFF
--- a/docs/.vale/fixtures/Quarkus/CaseSensitiveTerms/testinvalid.adoc
+++ b/docs/.vale/fixtures/Quarkus/CaseSensitiveTerms/testinvalid.adoc
@@ -88,6 +88,7 @@ IPSec
 iSeries
 iso
 iso image
+Istio Service Mesh
 Itanium2
 JBoss.org
 jetbrains

--- a/docs/.vale/fixtures/Quarkus/CaseSensitiveTerms/testvalid.adoc
+++ b/docs/.vale/fixtures/Quarkus/CaseSensitiveTerms/testvalid.adoc
@@ -26,6 +26,7 @@ Exif
 FAQ
 Fedora™ Project
 Fortran
+Fluentd
 FQDN
 GB
 Gbps
@@ -38,6 +39,7 @@ GNU
 GPL
 GraalVM
 Gradle
+Graylog
 gRPC
 GRUB
 GTK+
@@ -60,9 +62,11 @@ IPsec
 ISeries
 ISO
 ISO image
+Istio service mesh
 Itanium
 Itanium 2
 JBoss Community
+JBoss Logging
 JetBrains
 JUnit
 JVM
@@ -72,6 +76,7 @@ Kickstart
 KVM
 LAN
 Linux
+Logstash
 Mandrel
 MicroProfile
 Microsoft

--- a/docs/.vale/fixtures/Quarkus/Headings/testvalid.adoc
+++ b/docs/.vale/fixtures/Quarkus/Headings/testvalid.adoc
@@ -11,4 +11,8 @@
 == Kogito updates
 == IBM Cloud is a valid product name
 == Spotify, GraphQL, and Quiltflower are proper nouns so uppercase in headings is OK.
-= Using xDS gRPC
+== Use xDS gRPC
+== Use JBoss Logging for application logging
+== JBoss Logging API
+== A heading about Graylog, Logstash, or Fluentd open-source software
+== About the Istio service mesh

--- a/docs/.vale/fixtures/Quarkus/Spelling/testvalid.adoc
+++ b/docs/.vale/fixtures/Quarkus/Spelling/testvalid.adoc
@@ -72,11 +72,14 @@ CSVs
 Ctrl
 customizer
 Cygmon
+datasource
+datasources
 DaemonSet
 Datadog
 declaratively
 decompiler
 deserialization
+deserialized
 Dev
 dev
 devfile
@@ -117,9 +120,11 @@ Failsafe
 Fernflower
 findability
 Findability
+Fluentd
 Fortran
 Funqy
 Gbps
+Graylog
 gRPC
 GCC
 getters
@@ -154,6 +159,7 @@ Infinispan
 Inode
 Intelephense
 IntelliJ
+Istio
 Itanium
 Item
 Jakarta
@@ -189,6 +195,7 @@ libvirt
 Libvirt
 Licensor
 Liveness
+Logstash
 Lombok
 Loopback
 Makefile
@@ -241,6 +248,7 @@ OpenShift
 OpenTracing
 Operator
 osd
+OTel
 overridable
 PHP
 Podman
@@ -330,6 +338,8 @@ Subusers
 Subvolume
 Subvolumes
 Suchow
+Syslog
+syslog
 Symfony
 SVG
 Systemd

--- a/docs/.vale/styles/Quarkus/CaseSensitiveTerms.yml
+++ b/docs/.vale/styles/Quarkus/CaseSensitiveTerms.yml
@@ -9,17 +9,26 @@ action:
   name: replace
 swap:
   "(?<!/)var": VAR
-  # Bind: BIND
+  "(?<!Business )Resource Planner|(?<!Business Resource )Planner": Business Resource Planner
+  "(?<!Microsoft )Azure": Microsoft Azure
+  "(?<!Microsoft Azure )On-Demand Marketplace": Microsoft Azure On-Demand Marketplace
+  "(?<!Red Hat )Customer Portal": Red Hat Customer Portal
+  "(?<!Red Hat )JBoss Enterprise Application Platform": Red Hat JBoss Enterprise Application Platform
+  "(?<!Red Hat )OpenStack Platform|RHOS|RH-OSP": Red Hat OpenStack Platform
+  "(?<!Red Hat JBoss )BRMS(?! engine)": inference engine
+  "(?<!Red Hat JBoss )BRMS|BRM|(?<!Red Hat )JBoss BRMS": Red Hat JBoss BRMS
+  "[dD]ay-0|day 0": Day 0
+  "[dD]ay-1|day 1": Day 1
+  "[dD]ay-2|day 2": Day 2
+  "BPMS|(?<!Red Hat )JBoss BPMS|(?<!Red Hat JBoss )BPM(?! Suite)": Red Hat JBoss BPM Suite
+  "DM(?![ -]Multipath)|directory manager": Directory Manager
+  "JBoss Broker|Red Hat Broker|The AMQ Broker": AMQ Broker
+  "JBoss Console|Red Hat Console": AMQ Console
+  "Kernel(?!-based Virtual Machine)": kernel
+  "OCM|(?<!Red Hat OpenShift )Cluster Manager|(?<!Red Hat )OpenShift Cluster Manager|the OpenShift Cluster Manager": Red Hat OpenShift Cluster Manager
+  "OD": Red Hat OpenShift Dedicated
   '(?<!\.)yaml|Yaml': YAML
-  '(?<!Business )Resource Planner|(?<!Business Resource )Planner': Business Resource Planner
-  '(?<!JBoss )EAP|(?<!Red Hat )JBoss(?!\sCommunity|\sBroker|\sClients|\sConsole|\sAMQ|\sData\sGrid|\sBRMS|\sBPMS|\sEnterprise\sApplication\sPlatform|\.org|\sInterconnect|\sEAP|\sBPM\sSuite)': JBoss EAP
-  '(?<!Microsoft Azure )On-Demand Marketplace': Microsoft Azure On-Demand Marketplace
   '(?<!Realtime )Decision\sServer': Realtime Decision Server
-  '(?<!Red Hat )Customer Portal': Red Hat Customer Portal
-  '(?<!Red Hat )JBoss Enterprise Application Platform': Red Hat JBoss Enterprise Application Platform
-  '(?<!Red Hat )OpenStack Platform|RHOS|RH-OSP': Red Hat OpenStack Platform
-  '(?<!Red Hat JBoss )BRMS(?! engine)': inference engine
-  '(?<!Red Hat JBoss )BRMS|BRM|(?<!Red Hat )JBoss BRMS': Red Hat JBoss BRMS
   '[nN]odejs|[nN]ode\.JS|node\.js': Node.js
   '\s\.Net Core|\s\.Net|\s\.NET\sCore|dotNet': .NET
   'A-MQ(?!\sBroker|\sClient|\sConsole|\sInterconnect)': AMQ
@@ -30,20 +39,14 @@ swap:
   'ack\spacket|ACK(?!\sflag)|ack': ACK flag
   'ActiveMQ\sArtemis|ActiveMQ(?!\sArtemis)': built-in messaging|JBoss EAP built-in messaging|JBoss EAP messaging
   'Admin\sPortal|webadmin\sportal|webadmin|Administrator\sPortal|Administration\sportal': Administration Portal
-  'BPMS|(?<!Red Hat )JBoss BPMS|(?<!Red Hat JBoss )BPM(?! Suite)': Red Hat JBoss BPM Suite
   'BRMS\sengine': inference engine
   'GUI\seditor|Business\sCentral\seditor': guided editor
-  'JBoss Broker|Red Hat Broker|The AMQ Broker': AMQ Broker
-  'JBoss Console|Red Hat Console': AMQ Console
   'JBoss\.org': JBoss Community
   'JBoss\sAMQ': AMQ
   'JBoss\sInterconnect': AMQ Interconnect
-  'Kernel(?!-based Virtual Machine)': kernel
   'Kie(?!\sServer)': KIE
   'Kie\sServer': Intelligent Process Server
   'O\.K\.D|okd|OpenShift Kubernetes Distribution|OpenShift\sOrigin': OKD
-  'OCM|(?<!Red Hat OpenShift )Cluster Manager|(?<!Red Hat )OpenShift Cluster Manager|the OpenShift Cluster Manager': Red Hat OpenShift Cluster Manager
-  'OD': Red Hat OpenShift Dedicated
   'Red\sHat\sInterconnect': AMQ Interconnect
   'Red\sHat\sVirtualization\sHypervisor|RHV\sHost|RHV-H': Red Hat Virtualization Host
   'RHVM|RHV-M|RHV\sManager': Red Hat Virtualization Manager
@@ -116,7 +119,6 @@ swap:
   Fqdn|fqdn: FQDN
   gb|Gb: GB
   gbps|GBPS: Gbps
-  gb|Gb: GB
   GDBTK: Insight
   gid|Gid: GID
   Gimp|gimp: GIMP
@@ -139,6 +141,8 @@ swap:
   IBM z Systems: IBM Z
   Ignite|Fuse Ignite: Fuse Online|Red Hat Fuse Online|Syndesis
   ignition config: Ignition config
+  Image Builder: image builder
+  Istio Service Mesh : Istio service mesh
   INSTALL_DIR|installDir: FUSE_HOME
   Iops|IOPs: IOPS
   Ip: IP
@@ -194,13 +198,14 @@ swap:
   OCP: Red Hat OpenShift Container Platform
   ODF: Red Hat OpenShift Data Foundation
   Open InfiniBand|Infiniband: InfiniBand
-  openid connect|Openid Connect: OpenID Connect
-  Open InfiniBand|Infiniband: InfiniBand
   Open JDK|openjdk|JDK: OpenJDK
+  openid connect|Openid Connect: OpenID Connect
+  openrewrite|Openrewrite|Open Rewrite: OpenRewrite
   Openshift online|OO: Red Hat OpenShift Online
   Operating Environment: operating environment
   Operator Hub|Operator hub|Operatorhub|operatorhub: OperatorHub
   Opex|Opex|OPEX|opEx: OpEx
+  ORAN: O-RAN
   Organization administrator|Org Admin|org admin: Organization Administrator
   OS|Operating System: operating system
   Overcloud: overcloud
@@ -229,7 +234,6 @@ swap:
   Ram|ram: RAM
   RAW: raw
   Red Hat JBoss Data Grid|JDG: Red Hat Data Grid
-  Red Hat JBoss EAP: Red Hat JBoss Enterprise Application Platform
   Red Hat Network Satellite server: Red Hat Network Satellite Server
   Red Hat Proxy: Red Hat Network Proxy Server
   Red Hat Satellite Capsule server: Red Hat Satellite Capsule Server

--- a/docs/.vale/styles/Quarkus/Ellipses.yml
+++ b/docs/.vale/styles/Quarkus/Ellipses.yml
@@ -1,7 +1,7 @@
 ---
 extends: existence
 level: suggestion
-link: https://developers.google.com/style/ellipses?hl=en
+link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-reference.adoc
 message: "Avoid the ellipsis (...) except to indicate omitted words. Insert a space before and after an ellipsis."
 nonword: true
 # source: Quarkus contributor guide

--- a/docs/.vale/styles/Quarkus/Headings.yml
+++ b/docs/.vale/styles/Quarkus/Headings.yml
@@ -24,6 +24,7 @@ exceptions:
   - Azure
   - Basic authentication
   - Basic HTTP authentication
+  - BOM
   - Bierner
   - Bitbucket
   - BOM
@@ -82,8 +83,10 @@ exceptions:
   - Flathub
   - Flatpak
   - Flatpak Builder
+  - Fluentd
   - Fortran
   - Funqy
+  - gRPC
   - GCC
   - GTKplus
   - GUI
@@ -96,6 +99,7 @@ exceptions:
   - GraalVM
   - Gradle
   - GraphQL
+  - Graylog
   - Grayscale
   - GTK
   - HTTP
@@ -117,14 +121,18 @@ exceptions:
   - Infinispan
   - Intelephense
   - IntelliJ
+  - Istio
   - Itanium
   - JAR file
+  - JBang
   - JUnit
   - JVM
   - Jakarta
   - Jandex
   - Java
   - Jave
+  - JBoss Log Manager
+  - JBoss Logging
   - JetBrains
   - Jira
   - Jolokia
@@ -138,6 +146,7 @@ exceptions:
   - Kubespray
   - Kylin
   - Laravel
+  - Logstash
   - Lombok
   - Makefile
   - Mandrel
@@ -167,6 +176,7 @@ exceptions:
   - OpEx
   - OpenID Connect
   - OpenJDK
+  - OpenRewrite
   - OpenShift
   - OpenTracing
   - PHP
@@ -184,7 +194,6 @@ exceptions:
   - Qt
   - Quarkiverse
   - Quarkus
-  - Quarkus Security
   - Quiltflower
   - Qute
   - RESTEasy
@@ -246,4 +255,5 @@ exceptions:
   - startx
   - vNIC
   - vNUMA
+  - xDS
   - xterm

--- a/docs/.vale/styles/Quarkus/OxfordComma.yml
+++ b/docs/.vale/styles/Quarkus/OxfordComma.yml
@@ -5,4 +5,4 @@ link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-
 message: "Use the Oxford comma in '%s'."
 # source: Quarkus contributor guide
 tokens:
-  - '(?:[^,]+,){1,}\s\w+\sand'
+  - '(?:[^\s,]+,){1,} \w+ (?:and|or) \w+[.?!]'

--- a/docs/.vale/styles/Quarkus/Spelling.yml
+++ b/docs/.vale/styles/Quarkus/Spelling.yml
@@ -1,3 +1,4 @@
+#file: noinspection IncorrectFormatting
 ---
 extends: spelling
 level: warning
@@ -17,7 +18,6 @@ filters:
   - "[bB]ackfilling"
   - "[bB]ackported"
   - "[bB]acktrace"
-  - "[bB]crypt"
   - "[bB]indable"
   - "[bB]oolean"
   - "[bB]reakpoint"
@@ -28,9 +28,11 @@ filters:
   - "[cC]olocate"
   - "[cC]onfig"
   - "[cC]ustomizer"
+  - "[dD]atasource"
   - "[dD]eclaratively"
   - "[dD]ecompiler"
   - "[dD]eserialization"
+  - "[dD]eserialized"
   - "[dD]esynchronize"
   - "[dD]esynchronized"
   - "[dD]ev"
@@ -129,6 +131,7 @@ filters:
   - "[sS]etter"
   - "[sS]harding"
   - "[sS]ysctl"
+  - "[sS]yslog"
   - "[Ss]u"
   - "[sS]ubcommand"
   - "[sS]ubcommands"
@@ -164,18 +167,24 @@ filters:
   - "[uU]ntrusted"
   - "[uU]psell"
   - "[uU]pselling"
+  - "[uU]rl"
   - "[vV]alidator"
   - "Let\\'s Encrypt"
   - adoc
+  - AGPLv
   - Agroal
   - Annobin
   - Ansible
   - Antora
   - API
+  - Applixware
+  - Asciidoctor
   - AssertJ
+  - autolink
   - aws
   - AWS
   - Azure
+  - bcrypt
   - Bierner
   - Bitbucket
   - BOM
@@ -184,7 +193,8 @@ filters:
   - btn
   - Btrfs
   - Bugzilla
-  - Camel Quarkus
+  - Camel
+  - camelCase
   - CentOS
   - Ceph
   - cephfs
@@ -198,16 +208,19 @@ filters:
   - Cloudwashing
   - CodeReady
   - ConfigMap
-  - ConfigMaps
   - Containerfile
   - Containerfiles
   - Cookiecutter
+  - CPUs
   - CR
   - CRD
   - CRDs
   - CRs
+  - CSIDriver
+  - CSINode
   - CSVs
   - Ctrl
+  - CVEs
   - Cygmon
   - DaemonSet
   - Datadog
@@ -223,24 +236,37 @@ filters:
   - Endevor
   - Endian
   - endif
+  - eServer
   - Esprima
+  - etcd
   - Exif
+  - extranet
   - Fabrice
+  - Facter
   - Failsafe
+  - FDs
   - Fernflower
+  - firewalld
   - Flathub
   - Flatpak
+  - Fluentd
   - Flyway
   - Fortran
   - Funqy
   - GCC
+  - GIDs
   - GitHub
   - GitLab
   - Gluster
-  - Gradle
-  - Grayscale
+  - GNUPro
   - GraalVM
+  - Gradle
   - GraphQL
+  - greenboot
+  - Grayscale
+  - GraphQL
+  - Graylog
+  - gRPC
   - GUI
   - Hashicorp
   - Helgrind
@@ -253,15 +279,26 @@ filters:
   - HTTPS
   - IDE
   - IDEs
+  - IKEv
   - Infinispan
   - Intelephense
   - IntelliJ
+  - IPsec
+  - ISeries
+  - Istio
+  - IPPool
+  - IPsec
+  - IPv
+  - ISVs
   - Itanium
   - Jakarta
   - Jandex
   - Java
   - Jave
+  - JBang
   - JBoss
+  - JBoss Log Manager
+  - JBoss Logging
   - Jira
   - Jolokia
   - Joyent
@@ -270,15 +307,22 @@ filters:
   - JVM
   - Kafka
   - kbd
+  - keystore
   - Kibana
   - Knative
   - Knowledgebase
   - Kogito
   - Kompose
+  - kubelet
   - Kubespray
   - Kubernetes
   - Kylin
   - Laravel
+  - LGPLv
+  - librados
+  - librbd
+  - libOSMesa
+  - Logstash
   - Lombok
   - Liquibase
   - Makefile
@@ -291,6 +335,7 @@ filters:
   - Mirantis
   - Mockito
   - MongoDB
+  - Multipath
   - MySQL
   - Nagios
   - Narayana
@@ -298,34 +343,57 @@ filters:
   - NetcoredebugOutput
   - Netty
   - Newdoc
+  - NFSv
   - Nginx
   - npm
   - NuGet
+  - Nutanix
+  - NVidia
+  - NVMe
   - OAuth
+  - objectClass
   - ocp
   - OmniSharp
   - OpenID
   - OpenJDK
+  - OpenRewrite
   - OpenShift
   - OpenTracing
+  - OSBuild
   - osd
+  - OSs
+  - PCIe
+  - PDF
   - PHP
+  - PIDs
   - Podman
   - PostgreSQL
   - PowerShell
   - Prometheus
   - proxied
   - Pytorch
+  - qdmanage
+  - qdstat
   - qeth
+  - OTel
+  - QLogic
   - Quarkiverse
   - Quarkus
-  - Qute
   - Quiltflower
+  - Qute
+  - Realtime
   - Redis
   - Redistributions
+  - relaxngDatatype
   - Restic
   - RESTEasy
+  - Restic
   - Rolfe
+  - Rollup
+  - ROMs
+  - rootful
+  - rootless
+  - RPMs
   - Sakila
   - sbt
   - SCM
@@ -336,9 +404,10 @@ filters:
   - SmallRye
   - Spotify
   - startx
+  - STMicroelectronics
   - Suchow
-  - Symfony
   - SVG
+  - Symfony
   - Tekton
   - Telekom
   - Tensorflow
@@ -346,23 +415,30 @@ filters:
   - Toolset
   - Traefik
   - Uber
+  - UIDs
   - URI
-  - URIs
-  - url
   - URL
-  - URLs
+  - USBGuard
   - Vale
   - Valgrind
+  - vDisk
   - Velero
   - Vert.x
+  - vHost
+  - VMs
+  - VMware
   - vsix
+  - vSphere
   - WebAuthn
-  - Webview
-  - Webviews
+  - Webpack
+  - WebView
   - WebSocket
   - Wildfly
   - Woopra
   - Wordpress
+  - XString
+  - XWayland
   - Yana
   - Yeoman
+  - ZCentral
   - Zowe

--- a/docs/.vale/styles/Quarkus/TermsSuggestions.yml
+++ b/docs/.vale/styles/Quarkus/TermsSuggestions.yml
@@ -8,13 +8,13 @@ message: "Depending on the context, consider using '%s' rather than '%s'."
 action:
   name: replace
 swap:
-  ", that": ", which (non restrictive clause preceded by a comma)|that (restrictive clause without a comma)"
   "(?<!,) which": ", which (non restrictive clause preceded by a comma)|that (restrictive clause without a comma)"
+  "(?<!by) using": by using|that uses
+  "(?<!such )as": because|while
+  ", that": ", which (non restrictive clause preceded by a comma)|that (restrictive clause without a comma)"
+  "[Bb]are metal|[Bb]are-metal(?! clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| machines?| media| nodes?| provisioning| servers?| workers?)": bare metal (noun)|bare-metal (adjective)
+  "shell(?! prompt| script)": shell prompt
   and so on: "appropriate descriptive wording, unless you list a clear sequence of elements"
-  bare metal|bare-metal: bare metal (noun)|bare-metal (adjective)
   Bps|bps: Bps (bytes per second)|bps (bits per second)
   CD|cd: cd (change directory command)|CD (compact disc)
-  between: " - ' to indicate a 'range of numbers"
-  refer to: see (For more information, see...)
-  thru|through: "' - ' (range)|by using|finished|completed"
   Navigate|navigate: '"click", "select", "browse", or "go to"'

--- a/docs/.vale/styles/Quarkus/TermsWarnings.yml
+++ b/docs/.vale/styles/Quarkus/TermsWarnings.yml
@@ -3,7 +3,7 @@ extends: substitution
 ignorecase: true
 level: warning
 link: https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/doc-reference.adoc
-message: "Consider using '%s' rather than '%s' unless updating existing content that uses it."
+message: "Consider using '%s' rather than '%s' unless updating existing content that uses the term."
 # source: Quarkus contributor guide
 action:
   name: replace
@@ -44,6 +44,8 @@ swap:
   command-language: command language
   deinstall: uninstall
   deinstallation: uninstallation
+  entitlement: repository|subscription
+  host name: hostname
   in order to: to
   in other words: for example|that is
   in spite of: regardless of|despite
@@ -63,6 +65,7 @@ swap:
   may: might (for possiblity)|can (for ability)
   OK button: OK
   okay: OK
+  on-premises|on-prem|on premise: on-premise|on-site|in-house
   openshift: OpenShift
   open-source|OpenSource|opensource: open source
   organise: organize
@@ -79,6 +82,7 @@ swap:
   recognise: recognize
   right double-click: double right-click
   right-hand: right
+  sane: accurate|valid|verified
   sanity check: test|evaluate|validate|verify
   sanity test: test|evaluate|validate|verify
   shift-click: press Shift and click
@@ -95,7 +99,7 @@ swap:
   upward compatible: compatible with later versions
   utilize: use
   versus|vs: compared to
-  via: through
+  via: through|by|from|on|by using
   wish: want
   wish|would like: want
   xsite: cross-site replication


### PR DESCRIPTION
The PR contains fixes and enhancements to the Vale linter rules for Quarkus, including:

- Adds exceptions for the following proper noun (product, service, component or other names) to the spelling, headings, and in some cases where needed the case-sensitive terms rules:
  - datasources
  - deserialized/Deserialized
  - Fluentd
  - Graylog
  - Istio (service mesh)
  - JBoss Logging
  - Logstash
  - syslog/Syslog
  - OTel (the correct abbreviation for OpenTelemetry)
- Works around a vale bug in heading capitalization rules with terms `xDS` and `gRPC`.
-  Improves the regular expression for detecting non-compliance to the Oxford comma rule and some other fixes leveraged from the `vale-at-red-hat` repo
- Removes some low-priority grammar rules that were flagged as churn by some community members
  