### PR TITLE
Faster lookup of Vertx HTTP headers

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxUtil.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxUtil.java
@@ -46,10 +46,11 @@ public class VertxUtil {
         }
 
         // ResteasyUriInfo expects a context path to start with a "/" character
-        if (!contextPath.startsWith("/")) {
+        if (contextPath.isEmpty()) {
+            contextPath = "/";
+        } else if (contextPath.charAt(0) != '/') {
             contextPath = "/" + contextPath;
         }
-
         return new ResteasyUriInfo(uriString, contextPath);
     }
 
@@ -106,7 +107,6 @@ public class VertxUtil {
 
     public static MultivaluedMap<String, String> extractRequestHeaders(HttpServerRequest request) {
         Headers<String> requestHeaders = new Headers<String>();
-
         for (Map.Entry<String, String> header : request.headers()) {
             requestHeaders.add(header.getKey(), header.getValue());
         }


### PR DESCRIPTION
In the OpenTelemetry benchmark (run by @barreiro and @brunobat ) I've spotted some memory and cpu waste around `VertxUtil` related how we lookup for known HTTP headers and  how we parse them:
- the former is using a common `String` literal instead of a constant known `AsciiString`, which equals/hashCode computations are optimized by Netty
- the latter because we use `String::split` which create useless intermediate array objects (and `String`s) and doesn't make use of faster and intrinsified methods to find the comma/colon delimiters (which instead can be done using `String::indexOf`)


