### PR TITLE
Allow JSON serialization customization in ORM

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -32,10 +32,12 @@ public interface Capability {
     String LRA_PARTICIPANT = QUARKUS_PREFIX + ".lra.participant";
 
     String JACKSON = QUARKUS_PREFIX + ".jackson";
+    String JSONB = QUARKUS_PREFIX + ".jsonb";
+
+    String JAXB = QUARKUS_PREFIX + ".jaxb";
+    String JAXP = QUARKUS_PREFIX + ".jaxp";
 
     String KOTLIN = QUARKUS_PREFIX + ".kotlin";
-
-    String JSONB = QUARKUS_PREFIX + ".jsonb";
 
     String HAL = QUARKUS_PREFIX + ".hal";
 

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1242,3 +1242,82 @@ to tell Quarkus it should be used in the default persistence unit.
 +
 For <<multiple-persistence-units,named persistence units>>, use `@PersistenceUnitExtension("nameOfYourPU")`
 <2> Implement `org.hibernate.engine.jdbc.spi.StatementInspector`.
+
+[[json_xml_serialization_deserialization]]
+== Customizing JSON/XML serialization/deserialization
+
+By default, Quarkus will try to automatically configure format mappers depending on available extensions.
+Globally configured `ObjectMapper` (or `Jsonb`) will be used for serialization/deserialization operations when Jackson (or JSON-B) is available.
+Jackson will take precedence if both Jackson and JSON-B are available at the same time.
+
+JSON and XML serialization/deserialization in Hibernate ORM can be customized by implementing a `org.hibernate.type.format.FormatMapper`
+and annotating the implementation with the appropriate qualifiers:
+
+[source,java]
+----
+@JsonFormat // <1>
+@PersistenceUnitExtension // <2>
+public class MyJsonFormatMapper implements FormatMapper { // <3>
+    @Override
+    public String inspect(String sql) {
+        // ...
+        return sql;
+    }
+    @Override
+    public <T> T fromString(CharSequence charSequence, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+        // ...
+    }
+
+    @Override
+    public <T> String toString(T value, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+       // ...
+    }
+}
+----
+<1> Annotate the format mapper implementation with the `@JsonFormat` qualifier
+to tell Quarkus that this mapper is specific to JSON serialization/deserialization.
++
+<2> Annotate the format mapper implementation with the `@PersistenceUnitExtension` qualifier
+to tell Quarkus it should be used in the default persistence unit.
++
+For <<multiple-persistence-units,named persistence units>>, use `@PersistenceUnitExtension("nameOfYourPU")`
+<3> Implement `org.hibernate.type.format.FormatMapper`.
+
+In case of a custom XML format mapper, a different CDI qualifier must be applied:
+
+[source,java]
+----
+@XmlFormat // <1>
+@PersistenceUnitExtension // <2>
+public class MyJsonFormatMapper implements FormatMapper { // <3>
+    @Override
+    public String inspect(String sql) {
+        // ...
+        return sql;
+    }
+    @Override
+    public <T> T fromString(CharSequence charSequence, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+        // ...
+    }
+
+    @Override
+    public <T> String toString(T value, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+       // ...
+    }
+}
+----
+<1> Annotate the format mapper implementation with the `@XmlFormat` qualifier
+to tell Quarkus that this mapper is specific to XML serialization/deserialization.
++
+<2> Annotate the format mapper implementation with the `@PersistenceUnitExtension` qualifier
+to tell Quarkus it should be used in the default persistence unit.
++
+For <<multiple-persistence-units,named persistence units>>, use `@PersistenceUnitExtension("nameOfYourPU")`
+<3> Implement `org.hibernate.type.format.FormatMapper`.
+
+[NOTE]
+====
+Format mappers *must* have both `@PersistenceUnitExtension` and either `@JsonFormat` or `@XmlFormat` CDI qualifiers applied.
+
+Having multiple JSON (or XML) format mappers registered for the same persistence unit will result in an exception, because of the ambiguity.
+====

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/ClassNames.java
@@ -57,6 +57,9 @@ public class ClassNames {
 
     public static final DotName INTERCEPTOR = createConstant("org.hibernate.Interceptor");
     public static final DotName STATEMENT_INSPECTOR = createConstant("org.hibernate.resource.jdbc.spi.StatementInspector");
+    public static final DotName FORMAT_MAPPER = createConstant("org.hibernate.type.format.FormatMapper");
+    public static final DotName JSON_FORMAT = createConstant("io.quarkus.hibernate.orm.JsonFormat");
+    public static final DotName XML_FORMAT = createConstant("io.quarkus.hibernate.orm.XmlFormat");
 
     public static final List<DotName> GENERATORS = List.of(
             createConstant("org.hibernate.generator.internal.CurrentTimestampGeneration"),

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmCdiProcessor.java
@@ -61,7 +61,8 @@ public class HibernateOrmCdiProcessor {
             ClassNames.TENANT_RESOLVER,
             ClassNames.TENANT_CONNECTION_RESOLVER,
             ClassNames.INTERCEPTOR,
-            ClassNames.STATEMENT_INSPECTOR);
+            ClassNames.STATEMENT_INSPECTOR,
+            ClassNames.FORMAT_MAPPER);
 
     @BuildStep
     AnnotationsTransformerBuildItem convertJpaResourceAnnotationsToQualifier(
@@ -247,11 +248,13 @@ public class HibernateOrmCdiProcessor {
     @BuildStep
     void registerAnnotations(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<BeanDefiningAnnotationBuildItem> beanDefiningAnnotations) {
-        // add the @PersistenceUnit and @PersistenceUnitExtension classes
+        // add the @PersistenceUnit, @PersistenceUnitExtension, @JsonFormat and @XmlFormat classes
         // otherwise they won't be registered as qualifiers
         additionalBeans.produce(AdditionalBeanBuildItem.builder()
                 .addBeanClasses(ClassNames.QUARKUS_PERSISTENCE_UNIT.toString(),
-                        ClassNames.PERSISTENCE_UNIT_EXTENSION.toString())
+                        ClassNames.PERSISTENCE_UNIT_EXTENSION.toString(),
+                        ClassNames.JSON_FORMAT.toString(),
+                        ClassNames.XML_FORMAT.toString())
                 .build());
 
         // Register the default scope for @PersistenceUnitExtension and make such beans unremovable by default

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -326,7 +326,7 @@ public final class HibernateOrmProcessor {
                                     hibernateOrmConfig.database.ormCompatibilityVersion, Collections.emptyMap()),
                             null,
                             jpaModel.getXmlMappings(persistenceXmlDescriptorBuildItem.getDescriptor().getName()),
-                            false, true));
+                            false, true, capabilities));
         }
 
         if (impliedPU.shouldGenerateImpliedBlockingPersistenceUnit()) {
@@ -1124,7 +1124,7 @@ public final class HibernateOrmProcessor {
                                 persistenceUnitConfig.unsupportedProperties),
                         persistenceUnitConfig.multitenantSchemaDatasource.orElse(null),
                         xmlMappings,
-                        false, false));
+                        false, false, capabilities));
     }
 
     private static void collectDialectConfig(String persistenceUnitName,

--- a/extensions/hibernate-orm/runtime/pom.xml
+++ b/extensions/hibernate-orm/runtime/pom.xml
@@ -143,6 +143,21 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-caffeine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonb</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxb</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/JsonFormat.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/JsonFormat.java
@@ -1,0 +1,37 @@
+package io.quarkus.hibernate.orm;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+import org.hibernate.type.format.FormatMapper;
+
+/**
+ * CDI qualifier for beans implementing a {@link FormatMapper}.
+ * <p>
+ * This mapper will be used by Hibernate ORM for serialization and deserialization of JSON properties.
+ * <p>
+ * <strong>Must</strong> be used in a combination with a {@link PersistenceUnitExtension} qualifier to define the persistence
+ * unit the mapper should be associated with.
+ */
+@Target({ TYPE, FIELD, METHOD, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Qualifier
+public @interface JsonFormat {
+    class Literal extends AnnotationLiteral<JsonFormat> implements JsonFormat {
+        public static JsonFormat INSTANCE = new Literal();
+
+        private Literal() {
+        }
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/XmlFormat.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/XmlFormat.java
@@ -1,0 +1,37 @@
+package io.quarkus.hibernate.orm;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+import org.hibernate.type.format.FormatMapper;
+
+/**
+ * CDI qualifier for beans implementing a {@link FormatMapper}.
+ * <p>
+ * This mapper will be used by Hibernate ORM for serialization and deserialization of XML properties.
+ * <p>
+ * <strong>Must</strong> be used in a combination with a {@link PersistenceUnitExtension} qualifier to define the persistence
+ * unit the mapper should be associated with.
+ */
+@Target({ TYPE, FIELD, METHOD, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Qualifier
+public @interface XmlFormat {
+    class Literal extends AnnotationLiteral<XmlFormat> implements XmlFormat {
+        public static XmlFormat INSTANCE = new Literal();
+
+        private Literal() {
+        }
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
@@ -30,8 +30,11 @@ import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.tool.schema.spi.CommandAcceptanceException;
 import org.hibernate.tool.schema.spi.DelayedDropRegistryNotAvailableImpl;
 import org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator;
+import org.hibernate.type.format.FormatMapper;
 
 import io.quarkus.arc.InjectableInstance;
+import io.quarkus.hibernate.orm.JsonFormat;
+import io.quarkus.hibernate.orm.XmlFormat;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.orm.runtime.RuntimeSettings;
 import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
@@ -210,6 +213,17 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
                 .singleExtensionInstanceForPersistenceUnit(StatementInspector.class, persistenceUnitName);
         if (!statementInspectorInstance.isUnsatisfied()) {
             options.applyStatementInspector(statementInspectorInstance.get());
+        }
+
+        InjectableInstance<FormatMapper> jsonFormatMapper = PersistenceUnitUtil.singleExtensionInstanceForPersistenceUnit(
+                FormatMapper.class, persistenceUnitName, JsonFormat.Literal.INSTANCE);
+        if (!jsonFormatMapper.isUnsatisfied()) {
+            options.applyJsonFormatMapper(jsonFormatMapper.get());
+        }
+        InjectableInstance<FormatMapper> xmlFormatMapper = PersistenceUnitUtil.singleExtensionInstanceForPersistenceUnit(
+                FormatMapper.class, persistenceUnitName, XmlFormat.Literal.INSTANCE);
+        if (!xmlFormatMapper.isUnsatisfied()) {
+            options.applyXmlFormatMapper(xmlFormatMapper.get());
         }
     }
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -399,6 +399,15 @@ public class FastBootMetadataBuilder {
             }
         }
 
+        // If there's any mapping lib that we can work with available we'll set the default mapper:
+        if (puDefinition.getJsonMapperCreator().isPresent()) {
+            cfg.put(AvailableSettings.JSON_FORMAT_MAPPER, puDefinition.getJsonMapperCreator().get().create());
+        }
+        // If there's any mapping lib that we can work with available we'll set the default mapper:
+        if (puDefinition.getXmlMapperCreator().isPresent()) {
+            cfg.put(AvailableSettings.XML_FORMAT_MAPPER, puDefinition.getXmlMapperCreator().get().create());
+        }
+
         return mergedSettings;
     }
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/QuarkusPersistenceUnitDefinition.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/QuarkusPersistenceUnitDefinition.java
@@ -2,10 +2,12 @@ package io.quarkus.hibernate.orm.runtime.boot;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.hibernate.jpa.boot.spi.PersistenceUnitDescriptor;
 
 import io.quarkus.hibernate.orm.runtime.boot.xml.RecordableXmlMapping;
+import io.quarkus.hibernate.orm.runtime.customized.FormatMapperKind;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationStaticDescriptor;
 import io.quarkus.hibernate.orm.runtime.recording.RecordedConfig;
 import io.quarkus.runtime.annotations.RecordableConstructor;
@@ -21,12 +23,16 @@ public final class QuarkusPersistenceUnitDefinition {
     private final List<RecordableXmlMapping> xmlMappings;
     private final boolean isReactive;
     private final boolean fromPersistenceXml;
+    private final Optional<FormatMapperKind> jsonMapperCreator;
+    private final Optional<FormatMapperKind> xmlMapperCreator;
     private final List<HibernateOrmIntegrationStaticDescriptor> integrationStaticDescriptors;
 
     public QuarkusPersistenceUnitDefinition(PersistenceUnitDescriptor persistenceUnitDescriptor,
             String configurationName, RecordedConfig config,
             List<RecordableXmlMapping> xmlMappings,
             boolean isReactive, boolean fromPersistenceXml,
+            Optional<FormatMapperKind> jsonMapperCreator,
+            Optional<FormatMapperKind> xmlMapperCreator,
             List<HibernateOrmIntegrationStaticDescriptor> integrationStaticDescriptors) {
         Objects.requireNonNull(persistenceUnitDescriptor);
         Objects.requireNonNull(config);
@@ -36,6 +42,8 @@ public final class QuarkusPersistenceUnitDefinition {
         this.xmlMappings = xmlMappings;
         this.isReactive = isReactive;
         this.fromPersistenceXml = fromPersistenceXml;
+        this.jsonMapperCreator = jsonMapperCreator;
+        this.xmlMapperCreator = xmlMapperCreator;
         this.integrationStaticDescriptors = integrationStaticDescriptors;
     }
 
@@ -45,6 +53,8 @@ public final class QuarkusPersistenceUnitDefinition {
             List<RecordableXmlMapping> xmlMappings,
             boolean reactive,
             boolean fromPersistenceXml,
+            Optional<FormatMapperKind> jsonMapperCreator,
+            Optional<FormatMapperKind> xmlMapperCreator,
             List<HibernateOrmIntegrationStaticDescriptor> integrationStaticDescriptors) {
         Objects.requireNonNull(actualHibernateDescriptor);
         Objects.requireNonNull(config);
@@ -53,6 +63,8 @@ public final class QuarkusPersistenceUnitDefinition {
         this.xmlMappings = xmlMappings;
         this.isReactive = reactive;
         this.fromPersistenceXml = fromPersistenceXml;
+        this.jsonMapperCreator = jsonMapperCreator;
+        this.xmlMapperCreator = xmlMapperCreator;
         this.integrationStaticDescriptors = integrationStaticDescriptors;
     }
 
@@ -79,6 +91,14 @@ public final class QuarkusPersistenceUnitDefinition {
 
     public boolean isFromPersistenceXml() {
         return fromPersistenceXml;
+    }
+
+    public Optional<FormatMapperKind> getJsonMapperCreator() {
+        return jsonMapperCreator;
+    }
+
+    public Optional<FormatMapperKind> getXmlMapperCreator() {
+        return xmlMapperCreator;
     }
 
     public List<HibernateOrmIntegrationStaticDescriptor> getIntegrationStaticDescriptors() {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/FormatMapperKind.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/FormatMapperKind.java
@@ -1,0 +1,38 @@
+package io.quarkus.hibernate.orm.runtime.customized;
+
+import jakarta.json.bind.Jsonb;
+
+import org.hibernate.type.format.FormatMapper;
+import org.hibernate.type.format.jackson.JacksonJsonFormatMapper;
+import org.hibernate.type.format.jakartajson.JsonBJsonFormatMapper;
+import org.hibernate.type.format.jaxb.JaxbXmlFormatMapper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.arc.Arc;
+
+public enum FormatMapperKind {
+    JACKSON {
+        @Override
+        public FormatMapper create() {
+            // NOTE: we are not creating a Jackson based XML mapper since that one
+            // requires an additional lib (jackson-dataformat-xml-2.15.2) being available
+            // as well as an XmlMapper instance instead of an ObjectMapper...
+            return new JacksonJsonFormatMapper(Arc.container().instance(ObjectMapper.class).get());
+        }
+    },
+    JSONB {
+        @Override
+        public FormatMapper create() {
+            return new JsonBJsonFormatMapper(Arc.container().instance(Jsonb.class).get());
+        }
+    },
+    JAXB {
+        @Override
+        public FormatMapper create() {
+            return new JaxbXmlFormatMapper();
+        }
+    };
+
+    public abstract FormatMapper create();
+}

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -40,6 +40,7 @@ import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
 import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
@@ -131,6 +132,7 @@ public final class HibernateReactiveProcessor {
             ApplicationArchivesBuildItem applicationArchivesBuildItem,
             LaunchModeBuildItem launchMode,
             JpaModelBuildItem jpaModel,
+            Capabilities capabilities,
             BuildProducer<SystemPropertyBuildItem> systemProperties,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResources,
             BuildProducer<HotDeploymentWatchedFileBuildItem> hotDeploymentWatchedFiles,
@@ -191,7 +193,7 @@ public final class HibernateReactiveProcessor {
                             persistenceUnitConfig.unsupportedProperties),
                     null,
                     jpaModel.getXmlMappings(reactivePU.getName()),
-                    true, false));
+                    true, false, capabilities));
         }
     }
 

--- a/extensions/jaxb/runtime/pom.xml
+++ b/extensions/jaxb/runtime/pom.xml
@@ -53,6 +53,9 @@
                         <excludedArtifact>javax.xml.bind:jaxb-api</excludedArtifact>
                         <excludedArtifact>org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec</excludedArtifact>
                     </excludedArtifacts>
+                    <capabilities>
+                        <provides>io.quarkus.jaxb</provides>
+                    </capabilities>
                 </configuration>
             </plugin>
             <plugin>

--- a/extensions/jaxp/runtime/pom.xml
+++ b/extensions/jaxp/runtime/pom.xml
@@ -24,6 +24,11 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkus.jaxp</provides>
+                    </capabilities>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/integration-tests/jpa-postgresql-withxml/pom.xml
+++ b/integration-tests/jpa-postgresql-withxml/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-integration-test-jpa-postgresql-withxml</artifactId>
-    <name>Quarkus - Integration Tests - JPA - PostgreSQL</name>
+    <name>Quarkus - Integration Tests - JPA - PostgreSQL with XML</name>
     <description>Module that contains JPA related tests running with the PostgreSQL database</description>
 
     <properties>
@@ -29,6 +29,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxb</artifactId>
         </dependency>
 
         <!-- test dependencies -->
@@ -73,6 +77,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jaxb-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/EntityWithXml.java
+++ b/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/EntityWithXml.java
@@ -1,0 +1,74 @@
+package io.quarkus.it.jpa.postgresql;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@Entity
+public class EntityWithXml {
+    @Id
+    @GeneratedValue
+    Long id;
+
+    @JdbcTypeCode(SqlTypes.SQLXML)
+    ToBeSerializedWithDateTime xml;
+
+    public EntityWithXml() {
+    }
+
+    public EntityWithXml(ToBeSerializedWithDateTime data) {
+        this.xml = data;
+    }
+
+    @Override
+    public String toString() {
+        return "EntityWithXml{" +
+                "id=" + id +
+                ", xml=" + xml +
+                '}';
+    }
+
+    @RegisterForReflection
+    @XmlRootElement
+    public static class ToBeSerializedWithDateTime {
+        @XmlElement
+        @XmlJavaTypeAdapter(value = LocalDateXmlAdapter.class)
+        LocalDate date;
+
+        public ToBeSerializedWithDateTime() {
+        }
+
+        public ToBeSerializedWithDateTime(LocalDate date) {
+            this.date = date;
+        }
+
+        @Override
+        public String toString() {
+            return "ToBeSerializedWithDateTime{" +
+                    "date=" + date +
+                    '}';
+        }
+    }
+
+    @RegisterForReflection
+    public static class LocalDateXmlAdapter extends XmlAdapter<String, LocalDate> {
+        public LocalDate unmarshal(String string) {
+            return string == null ? null : LocalDate.parse(string);
+        }
+
+        public String marshal(LocalDate localDate) {
+            return localDate == null ? null : localDate.toString();
+        }
+    }
+}

--- a/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/otherpu/EntityWithXmlOtherPU.java
+++ b/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/otherpu/EntityWithXmlOtherPU.java
@@ -1,0 +1,57 @@
+
+package io.quarkus.it.jpa.postgresql.otherpu;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@Entity
+public class EntityWithXmlOtherPU {
+    @Id
+    @GeneratedValue
+    Long id;
+
+    @JdbcTypeCode(SqlTypes.SQLXML)
+    ToBeSerializedWithDateTime xml;
+
+    public EntityWithXmlOtherPU() {
+    }
+
+    public EntityWithXmlOtherPU(ToBeSerializedWithDateTime data) {
+        this.xml = data;
+    }
+
+    @Override
+    public String toString() {
+        return "EntityWithXmlOtherPU{" +
+                "id=" + id +
+                ", xml" + xml +
+                '}';
+    }
+
+    @RegisterForReflection
+    public static class ToBeSerializedWithDateTime {
+        LocalDate date;
+
+        public ToBeSerializedWithDateTime() {
+        }
+
+        public ToBeSerializedWithDateTime(LocalDate date) {
+            this.date = date;
+        }
+
+        @Override
+        public String toString() {
+            return "ToBeSerializedWithDateTime{" +
+                    "date=" + date +
+                    '}';
+        }
+    }
+}

--- a/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/otherpu/XmlFormatMapper.java
+++ b/integration-tests/jpa-postgresql-withxml/src/main/java/io/quarkus/it/jpa/postgresql/otherpu/XmlFormatMapper.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.jpa.postgresql.otherpu;
+
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.format.FormatMapper;
+
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+import io.quarkus.hibernate.orm.XmlFormat;
+
+@XmlFormat
+@PersistenceUnitExtension("other")
+public class XmlFormatMapper implements FormatMapper {
+
+    @Override
+    public <T> T fromString(CharSequence charSequence, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+        throw new UnsupportedOperationException("I cannot convert anything from XML.");
+    }
+
+    @Override
+    public <T> String toString(T value, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+        throw new UnsupportedOperationException("I cannot convert anything to XML.");
+    }
+}

--- a/integration-tests/jpa-postgresql-withxml/src/main/resources/application.properties
+++ b/integration-tests/jpa-postgresql-withxml/src/main/resources/application.properties
@@ -3,6 +3,7 @@ quarkus.datasource.password=hibernate_orm_test
 quarkus.datasource.jdbc.url=${postgres.url}
 quarkus.datasource.jdbc.max-size=8
 
+quarkus.hibernate-orm.packages=io.quarkus.it.jpa.postgresql
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 #Necessary for assertions in JPAFunctionalityInGraalITCase:
@@ -10,3 +11,7 @@ quarkus.native.enable-reports=true
 
 #Useful to get some more insight in the trigger:
 quarkus.native.additional-build-args=-J-Dio.quarkus.jdbc.postgresql.graalvm.diagnostics=true
+
+# Define non-default PU so that we can configure a custom XML format mapper. The default PU is using the default mapper.
+quarkus.hibernate-orm."other".datasource=<default>
+quarkus.hibernate-orm."other".packages=io.quarkus.it.jpa.postgresql.otherpu

--- a/integration-tests/jpa-postgresql/pom.xml
+++ b/integration-tests/jpa-postgresql/pom.xml
@@ -30,6 +30,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-postgresql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>
@@ -83,6 +87,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/EntityWithJson.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/EntityWithJson.java
@@ -1,0 +1,59 @@
+package io.quarkus.it.jpa.postgresql;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@Entity
+public class EntityWithJson {
+    @Id
+    @GeneratedValue
+    Long id;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    ToBeSerializedWithDateTime json;
+
+    public EntityWithJson() {
+    }
+
+    public EntityWithJson(ToBeSerializedWithDateTime data) {
+        this.json = data;
+    }
+
+    @Override
+    public String toString() {
+        return "EntityWithJson{" +
+                "id=" + id +
+                ", json=" + json +
+                '}';
+    }
+
+    @RegisterForReflection
+    public static class ToBeSerializedWithDateTime {
+        @JsonProperty
+        LocalDate date;
+
+        public ToBeSerializedWithDateTime() {
+        }
+
+        public ToBeSerializedWithDateTime(LocalDate date) {
+            this.date = date;
+        }
+
+        @Override
+        public String toString() {
+            return "ToBeSerializedWithDateTime{" +
+                    "date=" + date +
+                    '}';
+        }
+    }
+}

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/otherpu/EntityWithJsonOtherPU.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/otherpu/EntityWithJsonOtherPU.java
@@ -1,0 +1,60 @@
+
+package io.quarkus.it.jpa.postgresql.otherpu;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@Entity
+public class EntityWithJsonOtherPU {
+    @Id
+    @GeneratedValue
+    Long id;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    ToBeSerializedWithDateTime json;
+
+    public EntityWithJsonOtherPU() {
+    }
+
+    public EntityWithJsonOtherPU(ToBeSerializedWithDateTime data) {
+        this.json = data;
+    }
+
+    @Override
+    public String toString() {
+        return "EntityWithJsonOtherPU{" +
+                "id=" + id +
+                ", json=" + json +
+                '}';
+    }
+
+    @RegisterForReflection
+    public static class ToBeSerializedWithDateTime {
+        @JsonProperty
+        LocalDate date;
+
+        public ToBeSerializedWithDateTime() {
+        }
+
+        public ToBeSerializedWithDateTime(LocalDate date) {
+            this.date = date;
+        }
+
+        @Override
+        public String toString() {
+            return "ToBeSerializedWithDateTime{" +
+                    "date=" + date +
+                    '}';
+        }
+    }
+}

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/otherpu/JsonFormatMapper.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/otherpu/JsonFormatMapper.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.jpa.postgresql.otherpu;
+
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.format.FormatMapper;
+
+import io.quarkus.hibernate.orm.JsonFormat;
+import io.quarkus.hibernate.orm.PersistenceUnitExtension;
+
+@JsonFormat
+@PersistenceUnitExtension("other")
+public class JsonFormatMapper implements FormatMapper {
+
+    @Override
+    public <T> T fromString(CharSequence charSequence, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+        throw new UnsupportedOperationException("I cannot convert anything from JSON.");
+    }
+
+    @Override
+    public <T> String toString(T value, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+        throw new UnsupportedOperationException("I cannot convert anything to JSON.");
+    }
+}

--- a/integration-tests/jpa-postgresql/src/main/resources/application.properties
+++ b/integration-tests/jpa-postgresql/src/main/resources/application.properties
@@ -3,8 +3,12 @@ quarkus.datasource.password=hibernate_orm_test
 quarkus.datasource.jdbc.url=${postgres.url}
 quarkus.datasource.jdbc.max-size=8
 
+quarkus.hibernate-orm.packages=io.quarkus.it.jpa.postgresql
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.database.generation.create-schemas=true
+# Define non-default PU so that we can configure a custom JSON format mapper. The default PU is using the default mapper.
+quarkus.hibernate-orm."other".datasource=<default>
+quarkus.hibernate-orm."other".packages=io.quarkus.it.jpa.postgresql.otherpu
 
 #Necessary for assertions in JPAFunctionalityInGraalITCase:
 quarkus.native.enable-reports=true


### PR DESCRIPTION
- add `@JsonFormat`/`@XmlFormat` annotations to apply to custom FormatMapper implementations for JSON/XML formatting (must also use `@PersistenceUnitExtension`)
- use a Quarkus-configured FormatMapping if Jackson/JSONB/Jaxb is present, and the user did not specify a format mapper

Closes: https://github.com/quarkusio/quarkus/issues/32029