### PR TITLE
Fix missing bits in Flyway Dev UI migration

### DIFF
--- a/extensions/flyway/deployment/src/main/resources/dev-ui/qwc-flyway-datasources.js
+++ b/extensions/flyway/deployment/src/main/resources/dev-ui/qwc-flyway-datasources.js
@@ -136,9 +136,11 @@ export class QwcFlywayDatasources extends QwcHotReloadElement {
     }
 
     _clean(ds) {
-        this.jsonRpc.clean({ds: ds.name}).then(jsonRpcResponse => {
-            this._showResultNotification(jsonRpcResponse.result);
-        });
+        if (confirm('This will drop all objects (tables, views, procedures, triggers, ...) in the configured schema. Do you want to continue?')) {
+            this.jsonRpc.clean({ds: ds.name}).then(jsonRpcResponse => {
+                this._showResultNotification(jsonRpcResponse.result);
+            });
+        }
     }
     
     _migrate(ds) {

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/devui/FlywayJsonRpcService.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/devui/FlywayJsonRpcService.java
@@ -153,7 +153,7 @@ public class FlywayJsonRpcService {
                     return new FlywayActionResponse("success",
                             "Initial migration created, Flyway will now manage this datasource");
                 } catch (Throwable t) {
-                    new FlywayActionResponse("error", t.getMessage());
+                    return new FlywayActionResponse("error", t.getMessage());
                 }
             }
             return errorNoScript(ds);
@@ -184,7 +184,7 @@ public class FlywayJsonRpcService {
         return null;
     }
 
-    static class FlywayDatasource {
+    public static class FlywayDatasource {
         public String name;
         public boolean hasMigrations;
         public boolean createPossible;
@@ -199,7 +199,7 @@ public class FlywayJsonRpcService {
         }
     }
 
-    static class FlywayActionResponse {
+    public static class FlywayActionResponse {
         public String type;
         public String message;
         public int number;


### PR DESCRIPTION
- Follow up for #35073

This PR: 

- Adds a missing `return` statement and fixes IDE warnings by making classes from public methods also public;
- Confirms before cleaning (as introduced in #18080)
