### PR TITLE
Document @IfBuildProfile in the Kafka and AMQP reference guides

### DIFF
--- a/docs/src/main/asciidoc/amqp-reference.adoc
+++ b/docs/src/main/asciidoc/amqp-reference.adoc
@@ -817,3 +817,18 @@ Type: _string_ | false |
 Type: _string_ | false |
 
 |===
+
+=== Conditionally configure channels
+
+You can configure the channels using a specific profile.
+Thus, the channels are only configured (and added to the application) when the specified profile is enabled.
+
+To achieve this, you need:
+
+1. Prefix the `mp.messaging.[incoming|outgoing].$channel` entries with `%my-profile` such as `%my-profile.mp.messaging.[incoming|outgoing].$channel.key=value`
+2. Use the `@IfBuildProfile("my-profile")` on the CDI beans containing `@Incoming(channel)` and `@Outgoing(channel)` annotations that need only to be enabled when the profile is enabled.
+
+Note that reactive messaging verifies that the graph is complete.
+So, when using such a conditional configuration, ensure the application works with and without the profile enabled.
+
+Note that this approach can also be used to change the channel configuration based on a profile.

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -2320,6 +2320,21 @@ Attribute values are resolved as follows:
 2. if not set, the connector looks for a `Map` with the channel name or the configured `kafka-configuration` (if set) and the value is retrieved from that `Map`
 3. If the resolved `Map` does not contain the value the default `Map` is used (exposed with the `default-kafka-broker` name)
 
+=== Conditionally configure channels
+
+You can configure the channels using a specific profile.
+Thus, the channels are only configured (and added to the application) when the specified profile is enabled.
+
+To achieve this, you need:
+
+1. Prefix the `mp.messaging.[incoming|outgoing].$channel` entries with `%my-profile` such as `%my-profile.mp.messaging.[incoming|outgoing].$channel.key=value`
+2. Use the `@IfBuildProfile("my-profile")` on the CDI beans containing `@Incoming(channel)` and `@Outgoing(channel)` annotations that need only to be enabled when the profile is enabled.
+
+Note that reactive messaging verifies that the graph is complete.
+So, when using such a conditional configuration, ensure the application works with and without the profile enabled.
+
+Note that this approach can also be used to change the channel configuration based on a profile.
+
 == Integrating with Kafka - Common patterns
 
 === Writing to Kafka from an HTTP endpoint


### PR DESCRIPTION
Add a section about BuildIfProfile and conditional channel configuration in the amqp and kafka reference guides.

Fix #29837