### PR TITLE
Also support Universe BOM

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -122,7 +122,8 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
 
     private static ArtifactCoords getProjectQuarkusPlatformBOM(ProjectState currentState) {
         for (ArtifactCoords c : currentState.getPlatformBoms()) {
-            if (c.getArtifactId().equals(ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID)) {
+            if (c.getArtifactId().equals(ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID)
+                    || c.getArtifactId().equals(ToolsConstants.UNIVERSE_PLATFORM_BOM_ARTIFACT_ID)) {
                 return c;
             }
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsConstants.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsConstants.java
@@ -12,6 +12,7 @@ public interface ToolsConstants {
 
     String DEFAULT_PLATFORM_BOM_GROUP_ID = IO_QUARKUS + ".platform";
     String DEFAULT_PLATFORM_BOM_ARTIFACT_ID = "quarkus-bom";
+    String UNIVERSE_PLATFORM_BOM_ARTIFACT_ID = "quarkus-universe-bom";
 
     String PROP_QUARKUS_CORE_VERSION = "quarkus-core-version";
 


### PR DESCRIPTION
Old projects were created with the universe BOM, we need to handle updates for them too.
Also be a bit stricter about the groupId.

This is related to https://github.com/quarkusio/quarkus/issues/34817 .