### PR TITLE
Unlist Security JPA Common

### DIFF
--- a/extensions/security-jpa-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/security-jpa-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,14 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "Security JPA Common"
+metadata:
+  unlisted: true
+  keywords:
+  - "security"
+  - "jpa"
+  - "orm"
+  - "panache"
+  guide: "https://quarkus.io/guides/security-getting-started"
+  categories:
+  - "security"
+  status: "stable"


### PR DESCRIPTION
It is listed, moreover with an inconsistent name.
It shouldn't.