### PR TITLE
Use postgresql db kind for Google Cloud deployments

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
+++ b/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
@@ -248,22 +248,18 @@ Finally, you need to configure your datasource specifically to use the socket fa
 
 [source, properties]
 ----
-quarkus.datasource.db-kind=other <1>
-quarkus.datasource.jdbc.url=jdbc:postgresql:///mydatabase <2>
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.jdbc.url=jdbc:postgresql:///mydatabase <1>
 quarkus.datasource.jdbc.driver=org.postgresql.Driver
 quarkus.datasource.username=quarkus
 quarkus.datasource.password=quarkus
-quarkus.datasource.jdbc.additional-jdbc-properties.cloudSqlInstance=project-id:gcp-region:instance <3>
-quarkus.datasource.jdbc.additional-jdbc-properties.socketFactory=com.google.cloud.sql.postgres.SocketFactory <4>
+quarkus.datasource.jdbc.additional-jdbc-properties.cloudSqlInstance=project-id:gcp-region:instance <2>
+quarkus.datasource.jdbc.additional-jdbc-properties.socketFactory=com.google.cloud.sql.postgres.SocketFactory <3>
 ----
-<1> Database kind must be 'other' as we need to skip Quarkus auto-configuration.
-<2> The JDBC URL should not include the hostname / IP of the database.
-<3> We add the `cloudSqlInstance` additional JDBC property to configure the instance id.
-<4> We add the `socketFactory` additional JDBC property to configure the socket factory used to connect to Cloud SQL,
+<1> The JDBC URL should not include the hostname / IP of the database.
+<2> We add the `cloudSqlInstance` additional JDBC property to configure the instance id.
+<3> We add the `socketFactory` additional JDBC property to configure the socket factory used to connect to Cloud SQL,
 this one is coming from the `postgres-socket-factory` dependency.
-
-NOTE: If you use Hibernate ORM, you also need to configure `quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect`
-as Hibernate ORM would not be able to automatically detect the dialect of your database.
 
 WARNING: Using a PostgreSQL socket factory is not possible in dev mode at the moment
 due to issue link:https://github.com/quarkusio/quarkus/issues/15782[#15782].

--- a/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
+++ b/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
@@ -262,7 +262,7 @@ quarkus.datasource.jdbc.additional-jdbc-properties.socketFactory=com.google.clou
 <4> We add the `socketFactory` additional JDBC property to configure the socket factory used to connect to Cloud SQL,
 this one is coming from the `postgres-socket-factory` dependency.
 
-NOTE: If you use Hibernate ORM, you also need to configure `quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQL10Dialect`
+NOTE: If you use Hibernate ORM, you also need to configure `quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect`
 as Hibernate ORM would not be able to automatically detect the dialect of your database.
 
 WARNING: Using a PostgreSQL socket factory is not possible in dev mode at the moment


### PR DESCRIPTION
[`PostgreSQL10Dialect`](https://docs.jboss.org/hibernate/orm/6.2/javadocs/org/hibernate/dialect/PostgreSQL10Dialect.html) is desprecated; deprecation note says [`PostgreSQLDialect`](https://docs.jboss.org/hibernate/orm/6.2/javadocs/org/hibernate/dialect/PostgreSQLDialect.html) shall be used.

