### PR TITLE
Allow customizing ObjectReader via `@CustomDeserialization` in Resteasy

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -1425,12 +1425,12 @@ public User userPrivate() {
 When the result the `userPublic` method is serialized, the `id` field will not be contained in the response as the `Public` view does not include it.
 The result of `userPrivate` however will include the `id` as expected when serialized.
 
-===== Completely customized per method serialization
+===== Completely customized per method serialization/deserialization
 
-There are times when you need to completely customize the serialization of a POJO on a per Jakarta REST method basis. For such use cases, the `@io.quarkus.resteasy.reactive.jackson.CustomSerialization` annotation
-is a great tool, as it allows you to configure a per-method `com.fasterxml.jackson.databind.ObjectWriter` which can be configured at will.
+There are times when you need to completely customize the serialization/deserialization of a POJO on a per Jakarta REST method basis. For such use cases, the `@io.quarkus.resteasy.reactive.jackson.CustomSerialization` and `@io.quarkus.resteasy.reactive.jackson.CustomDeserialization` annotations.
+is a great tool, as it allows you to configure a per-method `com.fasterxml.jackson.databind.ObjectWriter`/`com.fasterxml.jackson.databind.ObjectReader` which can be configured at will.
 
-Here is an example use case:
+Here is an example use case to customize the `com.fasterxml.jackson.databind.ObjectWriter`:
 
 [source,java]
 ----
@@ -1458,6 +1458,31 @@ public static class UnquotedFields implements BiFunction<ObjectMapper, Type, Obj
 Essentially what this class does is force Jackson to not include quotes in the field names.
 
 It is important to note that this customization is only performed for the serialization of the Jakarta REST methods that use `@CustomSerialization(UnquotedFields.class)`.
+
+Following the previous example, let's now customize the `com.fasterxml.jackson.databind.ObjectReader` to read JSON requests with unquoted field names:
+
+[source,java]
+----
+@CustomDeserialization(SupportUnquotedFields.class)
+@POST
+@Path("/use-of-custom-deserializer")
+public void useOfCustomSerializer(User request) {
+    // ...
+}
+----
+
+where `SupportUnquotedFields` is a `BiFunction` defined as so:
+
+[source,java]
+----
+public static class SupportUnquotedFields implements BiFunction<ObjectMapper, Type, ObjectReader> {
+
+    @Override
+    public ObjectReader apply(ObjectMapper objectMapper, Type type) {
+        return objectMapper.reader().with(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES);
+    }
+}
+----
 
 === XML serialisation
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonFeatureBuildItem.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/JacksonFeatureBuildItem.java
@@ -19,6 +19,7 @@ public final class JacksonFeatureBuildItem extends MultiBuildItem {
 
     public enum Feature {
         JSON_VIEW,
-        CUSTOM_SERIALIZATION
+        CUSTOM_SERIALIZATION,
+        CUSTOM_DESERIALIZATION
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/CustomDeserialization.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/CustomDeserialization.java
@@ -1,0 +1,43 @@
+package io.quarkus.resteasy.reactive.jackson;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Type;
+import java.util.function.BiFunction;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import io.smallrye.common.annotation.Experimental;
+
+/**
+ * Annotation that can be used on RESTEasy Reactive Resource method to allow users to configure Jackson deserialization
+ * for that method only, without affecting the global Jackson configuration.
+ */
+@Experimental(value = "Remains to be determined if this is the best possible API for users to configure per Resource Method Deserialization")
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD })
+public @interface CustomDeserialization {
+
+    /**
+     * A {@code BiFunction} that converts the global {@code ObjectMapper} and type for which a custom {@code ObjectReader} is
+     * needed
+     * (this type will be a generic type if the method returns such a generic type) and returns the instance of the custom
+     * {@code ObjectReader}.
+     * <p>
+     * Quarkus will construct one instance of this {@code BiFunction} for each JAX-RS resource method that is annotated with
+     * {@code CustomDeserialization} and once an instance is created it will be cached for subsequent usage by that resource
+     * method.
+     * <p>
+     * The {@code BiFunction} MUST contain a no-args constructor.
+     * <p>
+     * Furthermore, it is advisable that it contains no state that is updated outside
+     * its constructor.
+     * <p>
+     * Finally and most importantly, the {@code ObjectMapper} should NEVER be changed any way as it is the global ObjectMapper
+     * that is accessible to the entire Quarkus application.
+     */
+    Class<? extends BiFunction<ObjectMapper, Type, ObjectReader>> value();
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/ResteasyReactiveServerJacksonRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/ResteasyReactiveServerJacksonRecorder.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
 import io.quarkus.runtime.ShutdownContext;
@@ -16,6 +17,7 @@ public class ResteasyReactiveServerJacksonRecorder {
 
     private static final Map<String, Class<?>> jsonViewMap = new HashMap<>();
     private static final Map<String, Class<?>> customSerializationMap = new HashMap<>();
+    private static final Map<String, Class<?>> customDeserializationMap = new HashMap<>();
 
     public void recordJsonView(String methodId, String className) {
         jsonViewMap.put(methodId, loadClass(className));
@@ -25,12 +27,17 @@ public class ResteasyReactiveServerJacksonRecorder {
         customSerializationMap.put(methodId, loadClass(className));
     }
 
+    public void recordCustomDeserialization(String methodId, String className) {
+        customDeserializationMap.put(methodId, loadClass(className));
+    }
+
     public void configureShutdown(ShutdownContext shutdownContext) {
         shutdownContext.addShutdownTask(new Runnable() {
             @Override
             public void run() {
                 jsonViewMap.clear();
                 customSerializationMap.clear();
+                customDeserializationMap.clear();
             }
         });
     }
@@ -42,6 +49,12 @@ public class ResteasyReactiveServerJacksonRecorder {
     @SuppressWarnings("unchecked")
     public static Class<? extends BiFunction<ObjectMapper, Type, ObjectWriter>> customSerializationForMethod(String methodId) {
         return (Class<? extends BiFunction<ObjectMapper, Type, ObjectWriter>>) customSerializationMap.get(methodId);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Class<? extends BiFunction<ObjectMapper, Type, ObjectReader>> customDeserializationForMethod(
+            String methodId) {
+        return (Class<? extends BiFunction<ObjectMapper, Type, ObjectReader>>) customDeserializationMap.get(methodId);
     }
 
     private Class<?> loadClass(String className) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyReader.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyReader.java
@@ -1,11 +1,14 @@
 package io.quarkus.resteasy.reactive.jackson.runtime.serialisers;
 
+import static org.jboss.resteasy.reactive.server.jackson.JacksonMessageBodyWriterUtil.setNecessaryJsonFactoryConfig;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import jakarta.inject.Inject;
@@ -17,6 +20,7 @@ import jakarta.ws.rs.ext.ContextResolver;
 import jakarta.ws.rs.ext.Providers;
 
 import org.jboss.resteasy.reactive.common.util.StreamUtil;
+import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
 import org.jboss.resteasy.reactive.server.jackson.JacksonBasicMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
@@ -29,15 +33,20 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.quarkus.resteasy.reactive.jackson.runtime.ResteasyReactiveServerJacksonRecorder;
+
 public class FullyFeaturedServerJacksonMessageBodyReader extends JacksonBasicMessageBodyReader
         implements ServerMessageBodyReader<Object> {
 
+    private final ObjectMapper originalMapper;
     private final Providers providers;
+    private final ConcurrentMap<String, ObjectReader> perMethodReader = new ConcurrentHashMap<>();
     private final ConcurrentMap<ObjectMapper, ObjectReader> contextResolverMap = new ConcurrentHashMap<>();
 
     @Inject
     public FullyFeaturedServerJacksonMessageBodyReader(ObjectMapper mapper, Providers providers) {
         super(mapper);
+        this.originalMapper = mapper;
         this.providers = providers;
     }
 
@@ -93,7 +102,7 @@ public class FullyFeaturedServerJacksonMessageBodyReader extends JacksonBasicMes
             return null;
         }
         try {
-            ObjectReader reader = getEffectiveReader(type, responseMediaType);
+            ObjectReader reader = getEffectiveReader(type, genericType, responseMediaType);
             return reader.forType(reader.getTypeFactory().constructType(genericType != null ? genericType : type))
                     .readValue(entityStream);
         } catch (MismatchedInputException e) {
@@ -109,23 +118,50 @@ public class FullyFeaturedServerJacksonMessageBodyReader extends JacksonBasicMes
         return e.getMessage().startsWith("No content");
     }
 
-    private ObjectReader getEffectiveReader(Class<Object> type, MediaType responseMediaType) {
-        ObjectMapper effectiveMapper = getObjectMapperFromContext(type, responseMediaType);
-        if (effectiveMapper == null) {
-            return getEffectiveReader();
+    private ObjectReader getEffectiveReader(Class<Object> type, Type genericType, MediaType responseMediaType) {
+        ObjectMapper effectiveMapper = getEffectiveMapper(type, responseMediaType);
+        ObjectReader effectiveReader = defaultReader;
+        if (effectiveMapper != originalMapper) {
+            // Effective reader based on the context
+            effectiveReader = contextResolverMap.computeIfAbsent(effectiveMapper, new Function<>() {
+                @Override
+                public ObjectReader apply(ObjectMapper objectMapper) {
+                    return objectMapper.reader();
+                }
+            });
         }
 
-        return contextResolverMap.computeIfAbsent(effectiveMapper, new Function<>() {
-            @Override
-            public ObjectReader apply(ObjectMapper objectMapper) {
-                return objectMapper.reader();
+        // Get object reader from context if configured
+        ServerRequestContext context = CurrentRequestManager.get();
+        if (context != null) {
+            ResteasyReactiveResourceInfo resourceInfo = context.getResteasyReactiveResourceInfo();
+            if (resourceInfo != null) {
+                String methodId = resourceInfo.getMethodId();
+                var customDeserializationValue = ResteasyReactiveServerJacksonRecorder.customDeserializationForMethod(methodId);
+                if (customDeserializationValue != null) {
+                    ObjectReader objectReader = perMethodReader.computeIfAbsent(methodId,
+                            new MethodObjectReaderFunction(customDeserializationValue, genericType, effectiveMapper));
+                    Class<?> jsonViewValue = ResteasyReactiveServerJacksonRecorder.jsonViewForMethod(methodId);
+                    if (jsonViewValue != null) {
+                        objectReader = objectReader.withView(jsonViewValue);
+                    }
+
+                    return objectReader;
+                }
+
+                Class<?> jsonViewValue = ResteasyReactiveServerJacksonRecorder.jsonViewForMethod(methodId);
+                if (jsonViewValue != null) {
+                    return effectiveReader.withView(jsonViewValue);
+                }
             }
-        });
+        }
+
+        return effectiveReader;
     }
 
-    private ObjectMapper getObjectMapperFromContext(Class<Object> type, MediaType responseMediaType) {
+    private ObjectMapper getEffectiveMapper(Class<Object> type, MediaType responseMediaType) {
         if (providers == null) {
-            return null;
+            return originalMapper;
         }
 
         ContextResolver<ObjectMapper> contextResolver = providers.getContextResolver(ObjectMapper.class,
@@ -138,6 +174,31 @@ public class FullyFeaturedServerJacksonMessageBodyReader extends JacksonBasicMes
             return contextResolver.getContext(type);
         }
 
-        return null;
+        return originalMapper;
+    }
+
+    private static class MethodObjectReaderFunction implements Function<String, ObjectReader> {
+        private final Class<? extends BiFunction<ObjectMapper, Type, ObjectReader>> clazz;
+        private final Type genericType;
+        private final ObjectMapper originalMapper;
+
+        public MethodObjectReaderFunction(Class<? extends BiFunction<ObjectMapper, Type, ObjectReader>> clazz, Type genericType,
+                ObjectMapper originalMapper) {
+            this.clazz = clazz;
+            this.genericType = genericType;
+            this.originalMapper = originalMapper;
+        }
+
+        @Override
+        public ObjectReader apply(String methodId) {
+            try {
+                BiFunction<ObjectMapper, Type, ObjectReader> biFunctionInstance = clazz.getDeclaredConstructor().newInstance();
+                ObjectReader objectReader = biFunctionInstance.apply(originalMapper, genericType);
+                setNecessaryJsonFactoryConfig(objectReader.getFactory());
+                return objectReader;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }


### PR DESCRIPTION
To customize the `com.fasterxml.jackson.databind.ObjectReader` to read JSON requests with unquoted field names:

```java
@CustomDeserialization(SupportUnquotedFields.class)
@POST
@Path("/use-of-custom-deserializer")
public void useOfCustomSerializer(User request) {
    // ...
}
```

where `SupportUnquotedFields` is a `BiFunction` defined as so:

```java
public static class SupportUnquotedFields implements BiFunction<ObjectMapper, Type, ObjectReader> {

    @Override
    public ObjectReader apply(ObjectMapper objectMapper, Type type) {
        return objectMapper.reader().with(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES);
    }
}
```

Fix https://github.com/quarkusio/quarkus/issues/35122