### PR TITLE
Revert "Bump h2 from 2.1.214 to 2.2.220 in /bom/application"

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -127,7 +127,7 @@
         <httpasync.version>4.1.5</httpasync.version>
         <cronutils.version>9.2.1</cronutils.version>
         <quartz.version>2.3.2</quartz.version>
-        <h2.version>2.2.220</h2.version> <!-- When updating, needs to be matched in io.quarkus.hibernate.orm.runtime.config.DialectVersions -->
+        <h2.version>2.1.214</h2.version> <!-- When updating, needs to be matched in io.quarkus.hibernate.orm.runtime.config.DialectVersions -->
         <postgresql-jdbc.version>42.6.0</postgresql-jdbc.version>
         <mariadb-jdbc.version>3.1.4</mariadb-jdbc.version>
         <mysql-jdbc.version>8.0.30</mysql-jdbc.version>

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/config/DialectVersions.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/config/DialectVersions.java
@@ -22,7 +22,7 @@ public final class DialectVersions {
         public static final String ORACLE = "12";
 
         // This must be aligned on the H2 version in the Quarkus BOM
-        public static final String H2 = "2.1.210";
+        public static final String H2 = "2.1.214";
 
         private Defaults() {
         }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/config/DialectVersions.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/config/DialectVersions.java
@@ -22,7 +22,7 @@ public final class DialectVersions {
         public static final String ORACLE = "12";
 
         // This must be aligned on the H2 version in the Quarkus BOM
-        public static final String H2 = "2.2.220";
+        public static final String H2 = "2.1.210";
 
         private Defaults() {
         }


### PR DESCRIPTION
Temporarily reverts #34615 which broke the whole build, until we can find the proper way to make the upgrade work.

See https://github.com/quarkusio/quarkus/pull/34615#issuecomment-1661613280