### PR TITLE
Properly use internal links to point to other guides

### DIFF
--- a/docs/src/main/asciidoc/azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/azure-functions-http.adoc
@@ -160,7 +160,7 @@ The `quarkus-azure-functions-http` extension handles all the work to deploy to A
 Quarkus will use the Azure CLI in the background to authenticate and deploy to Azure.  If you have
 multiple subscriptions associated with your account, you must set the `quarkus.azure-functions.subscription-id`
 property in your `application.properties` file to the subscription you want to use.
-For other authentication mechanisms and deployment options see our config properties https://quarkus.io/guides/all-config[here].
+For other authentication mechanisms and deployment options see our config properties xref:all-config.adoc[here].
 
 To run the deploy, after you build your project execute:
 

--- a/docs/src/main/asciidoc/azure-functions.adoc
+++ b/docs/src/main/asciidoc/azure-functions.adoc
@@ -177,7 +177,7 @@ The `quarkus-azure-functions` extension handles all the work to deploy to Azure.
 Quarkus will use the Azure CLI in the background to authenticate and deploy to Azure.  If you have
 multiple subscriptions associated with your account, you must set the `quarkus.azure-functions.subscription-id`
 property in your `application.properties` file to the subscription you want to use.
-For other authentication mechanisms and deployment options see our config properties https://quarkus.io/guides/all-config[here].
+For other authentication mechanisms and deployment options see our config properties xref:all-config.adoc[here].
 
 To run the deploy, after you build your project execute:
 

--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -903,7 +903,7 @@ From an application developer perspective, a Quarkus platform is represented as 
 
 link:https://github.com/quarkiverse[Quarkiverse Hub] is the GitHub organization that provides repository hosting (including build, CI and release publishing setup) for Quarkus extension projects contributed by the community.
 
-In case you are wondering about creating a new Quarkus extension and adding it to the Quarkus ecosystem so that the Quarkus community can discover it using the Quarkus dev tools (including the https://quarkus.io/guides/cli-tooling[Quarkus CLI] and https://code.quarkus.io[code.quarkus.io]), the https://github.com/quarkiverse[Quarkiverse Hub] GitHub organization will be a good home for it.
+In case you are wondering about creating a new Quarkus extension and adding it to the Quarkus ecosystem so that the Quarkus community can discover it using the Quarkus dev tools (including the xref:cli-tooling.adoc[Quarkus CLI] and https://code.quarkus.io[code.quarkus.io]), the https://github.com/quarkiverse[Quarkiverse Hub] GitHub organization will be a good home for it.
 
 You can get started by creating an link:https://github.com/quarkusio/quarkus/issues/new/choose[Extension Request] issue (check first if one wasn't already submitted link:https://github.com/quarkusio/quarkus/labels/kind%2Fextension-proposal[here]) and asking to lead it.
 

--- a/docs/src/main/asciidoc/cassandra.adoc
+++ b/docs/src/main/asciidoc/cassandra.adoc
@@ -789,8 +789,7 @@ until your application actually connects and hits the database for the first tim
 
 == Running in native mode
 
-If you installed GraalVM, you can link:https://quarkus.io/guides/building-native-image[build a
-native image] using:
+If you installed GraalVM, you can xref:building-native-image.adoc[build a native image] using:
 
 [source,shell]
 ----
@@ -830,8 +829,8 @@ that needs to interact with the Cassandra database.
 
 Using lazy initialization speeds up your application startup time, and avoids startup failures if
 the Cassandra database is not available. However, it could also prove dangerous if your code is
-fully non-blocking, for example if it uses https://quarkus.io/guides/reactive-routes[reactive
-routes]. Indeed, the lazy initialization could accidentally happen on a thread that is not allowed
+fully non-blocking, for example if it uses xref:reactive-routes.adoc[reactive routes].
+Indeed, the lazy initialization could accidentally happen on a thread that is not allowed
 to block, such as a Vert.x event loop thread. Therefore, setting `quarkus.cassandra.init.eager-init`
 to `false` and injecting `QuarkusCqlSession` should be avoided in these contexts.
 

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -398,7 +398,7 @@ Both `quarkus create` and `quarkus extension list` allow you to explicitly speci
 
 1. Specify a specific Platform Release BOM
 +
-A https://quarkus.io/guides/platform#quarkus-platform-bom[Quarkus Platform release BOM] is identified by `groupId:artifactId:version` (GAV) coordinates. When specifying a platform release BOM, you may use empty segments to fall back to default values (shown with `quarkus create app --help`). If you specify only one segment (no `:`), it is assumed to be a version.
+A xref:platform.adoc#quarkus-platform-bom[Quarkus Platform release BOM] is identified by `groupId:artifactId:version` (GAV) coordinates. When specifying a platform release BOM, you may use empty segments to fall back to default values (shown with `quarkus create app --help`). If you specify only one segment (no `:`), it is assumed to be a version.
 +
 `{quarkus-platform-groupid}` is the default `groupId`. Specifying `-P :quarkus-bom:` is equivalent to `-P {quarkus-platform-groupid}:quarkus-bom:{quarkus-version}`. Note that you need to specify the `groupId` to work with a snapshot, e.g. `-P io.quarkus::999-SNAPSHOT` is equivalent to `-P io.quarkus:quarkus-bom:999-SNAPSHOT`.
 +

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -407,7 +407,7 @@ To exclude only a particular datasource from the health check, use:
 
 === Datasource metrics
 
-If you are using the link:https://quarkus.io/guides/micrometer[`quarkus-micrometer`] or link:https://quarkus.io/guides/smallrye-metrics[`quarkus-smallrye-metrics`] extension, `quarkus-agroal` can contribute some datasource-related metrics to the metric registry.
+If you are using the xref:micrometer.adoc[`quarkus-micrometer`] or xref:smallrye-metrics.adoc[`quarkus-smallrye-metrics`] extension, `quarkus-agroal` can contribute some datasource-related metrics to the metric registry.
 This can be activated by setting the `quarkus.datasource.metrics.enabled` property to `true`.
 
 For the exposed metrics to contain any actual values, a metric collection must be enabled internally by the Agroal mechanisms.

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -236,7 +236,7 @@ You can provide the arguments that will be used by the Kubernetes Job via the pr
 
 Finally, the Kubernetes job will be launched every time it is installed in Kubernetes. You can know more about how to run Kubernetes jobs in this https://kubernetes.io/docs/concepts/workloads/controllers/job/#running-an-example-job[link].
 
-You can configure the rest of the Kubernetes Job configuration using the properties under `quarkus.kubernetes.job.xxx` (see https://quarkus.io/guides/deploying-to-kubernetes#quarkus-kubernetes-kubernetes-config_quarkus.kubernetes.job.parallelism-parallelism[link]).
+You can configure the rest of the Kubernetes Job configuration using the properties under `quarkus.kubernetes.job.xxx` (see xref:deploying-to-kubernetes.adoc#quarkus-kubernetes-kubernetes-config_quarkus.kubernetes.job.parallelism[link]).
 
 ==== Generating CronJob resources
 
@@ -251,7 +251,7 @@ quarkus.kubernetes.cron-job.schedule=0 * * * *
 
 IMPORTANT: CronJob resources require the https://en.wikipedia.org/wiki/Cron[Cron] expression to specify when to launch the job via the property `quarkus.kubernetes.cron-job.schedule`. If not provide, the build will fail.
 
-You can configure the rest of the Kubernetes CronJob configuration using the properties under `quarkus.kubernetes.cron-job.xxx` (see https://quarkus.io/guides/deploying-to-kubernetes#quarkus-kubernetes-kubernetes-config_quarkus.kubernetes.cron-job.parallelism-parallelism[link]).
+You can configure the rest of the Kubernetes CronJob configuration using the properties under `quarkus.kubernetes.cron-job.xxx` (see xref:deploying-to-kubernetes.adoc#quarkus-kubernetes-kubernetes-config_quarkus.kubernetes.cron-job.parallelism[link]).
 
 === Namespace
 

--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -91,7 +91,7 @@ include::{includes}/devtools/build.adoc[]
 TIP: If you want to test your application immediately then set the `quarkus.openshift.route.expose` config property to `true` to <<exposing_routes,expose the service automatically>>, e.g. add `-Dquarkus.openshift.route.expose=true` to the command above.
 
 [#re-deploy-with-service-binding]
-NOTE: When using `DeploymentConfig` and https://quarkus.io/guides/deploying-to-kubernetes#service_binding[Service Binding], re-deploying might remove the configuration added by OpenShift to allow service discovery. A new container image build will trigger a refresh of the Quarkus app in OpenShift: `-Dquarkus.container-image.build=true` which might be enough in most situations. If you need to update the OpenShift resources, you need to delete the binding first to create it again after new deployment.
+NOTE: When using `DeploymentConfig` and xref:deploying-to-kubernetes.adoc#service_binding[Service Binding], re-deploying might remove the configuration added by OpenShift to allow service discovery. A new container image build will trigger a refresh of the Quarkus app in OpenShift: `-Dquarkus.container-image.build=true` which might be enough in most situations. If you need to update the OpenShift resources, you need to delete the binding first to create it again after new deployment.
 
 This command will build your application locally, then trigger a container image build and finally apply the generated OpenShift resources automatically.
 The generated resources use OpenShift's `DeploymentConfig` that is configured to automatically trigger a redeployment when a change in the `ImageStream` is noticed.
@@ -147,7 +147,7 @@ During the build you may find the `Caused by: javax.net.ssl.SSLHandshakeExceptio
 quarkus.kubernetes-client.trust-certs=true
 ----
 
-For more information, see link:https://quarkus.io/guides/deploying-to-kubernetes#client-connection-configuration[deploying to Kubernetes].
+For more information, see xref:deploying-to-kubernetes.adoc#client-connection-configuration[deploying to Kubernetes].
 ====
 
 Once the build is done we can create a new application from the relevant `ImageStream`.
@@ -415,7 +415,7 @@ You can provide the arguments that will be used by the Kubernetes Job via the pr
 
 Finally, the Kubernetes job will be launched every time that is installed in OpenShift. You can know more about how to run Kubernetes jobs in this https://kubernetes.io/docs/concepts/workloads/controllers/job/#running-an-example-job[link].
 
-You can configure the rest of the Kubernetes Job configuration using the properties under `quarkus.openshift.job.xxx` (see https://quarkus.io/guides/deploying-to-openshift#quarkus-openshift-openshift-config_quarkus.openshift.job.parallelism[link]).
+You can configure the rest of the Kubernetes Job configuration using the properties under `quarkus.openshift.job.xxx` (see xref:deploying-to-openshift#quarkus-openshift-openshift-config_quarkus.openshift.job.parallelism[link]).
 
 ===== Generating CronJob resources
 
@@ -430,7 +430,7 @@ quarkus.openshift.cron-job.schedule=0 * * * *
 
 IMPORTANT: CronJob resources require the https://en.wikipedia.org/wiki/Cron[Cron] expression to specify when to launch the job via the property `quarkus.openshift.cron-job.schedule`. If not provide, the build will fail.
 
-You can configure the rest of the Kubernetes CronJob configuration using the properties under `quarkus.openshift.cron-job.xxx` (see https://quarkus.io/guides/deploying-to-openshift#quarkus-openshift-openshift-config_quarkus.openshift.cron-job.parallelism[link]).
+You can configure the rest of the Kubernetes CronJob configuration using the properties under `quarkus.openshift.cron-job.xxx` (see xref:deploying-to-openshift.adoc#quarkus-openshift-openshift-config_quarkus.openshift.cron-job.parallelism[link]).
 
 ==== Validation
 

--- a/docs/src/main/asciidoc/extension-registry-user.adoc
+++ b/docs/src/main/asciidoc/extension-registry-user.adoc
@@ -8,7 +8,7 @@ include::_attributes.adoc[]
 :categories: architecture
 :summary: Learn more about the notion of extension registry and how you can use your own.
 
-The Quarkus dev tools, such as the https://quarkus.io/guides/cli-tooling[Quarkus CLI], the https://quarkus.io/guides/maven-tooling[Maven] and the https://quarkus.io/guides/gradle-tooling[Gradle] plugins, or https://code.quarkus.io[code.quarkus.io] can be used to list and search the Quarkus ecosystem for extensions that match a certain criteria. That includes the https://quarkus.io/guides/platform[Quarkus platform] extensions and various other extensions contributed by the community, many of which are hosted on the https://github.com/quarkiverse[Quarkiverse Hub].
+The Quarkus dev tools, such as the xref:cli-tooling.adoc[Quarkus CLI], the xref:maven-tooling.adoc[Maven] and the xref:gradle-tooling.adoc[Gradle] plugins, or https://code.quarkus.io[code.quarkus.io] can be used to list and search the Quarkus ecosystem for extensions that match a certain criteria. That includes the xref:platform.adoc[Quarkus platform] extensions and various other extensions contributed by the community, many of which are hosted on the https://github.com/quarkiverse[Quarkiverse Hub].
 
 The information about all the available Quarkus extensions is provided to the dev tools by __Quarkus extension registries__.
 
@@ -76,7 +76,7 @@ When the Quarkus dev tools are launched, a search for the registry client config
 
 === Configuring multiple registries
 
-The <<registry.quarkus.io,registry.quarkus.io>> is the default Quarkus community extension registry, but it is not meant to be always the only registry. Other organizations may find it useful to create their own Quarkus extension registries to provide their own https://quarkus.io/guides/platform[Quarkus platforms] and/or individual (non-platform) Quarkus extensions. Users wishing to enable custom Quarkus extension registries in their environment would need to add them to the registry client configuration file.
+The <<registry.quarkus.io,registry.quarkus.io>> is the default Quarkus community extension registry, but it is not meant to be always the only registry. Other organizations may find it useful to create their own Quarkus extension registries to provide their own xref:platform.adoc[Quarkus platforms] and/or individual (non-platform) Quarkus extensions. Users wishing to enable custom Quarkus extension registries in their environment would need to add them to the registry client configuration file.
 
 The registry client configuration file is a simple YAML file which contains a list of registries, for example:
 

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -788,7 +788,7 @@ Quarkus provides following state store implementations:
 
 - `quarkus-redis`: Uses the xref:redis-reference.adoc[`quarkus-redis-client`] extension to persist processing states. 
 Jackson is used to serialize processing state in Json. For complex objects it is required to configure the `checkpoint.state-type` property with the class name of the object.
-By default, the state store uses the default redis client, but if a link:https://quarkus.io/guides/redis-reference#default-and-named-clients[named client] is to be used, the client name can be specified using the `mp.messaging.incoming.[channel-name].checkpoint.quarkus-redis.client-name` property.
+By default, the state store uses the default redis client, but if a xref:redis-reference.adoc#default-and-named-clients[named client] is to be used, the client name can be specified using the `mp.messaging.incoming.[channel-name].checkpoint.quarkus-redis.client-name` property.
 Processing states will be stored in Redis using the key naming scheme `[consumer-group-id]:[topic]:[partition]`.
 
 For example the configuration of the previous code would be the following:
@@ -1300,7 +1300,7 @@ While a transaction is in progress, subsequent calls to the `withTransaction`, i
 
 Note that in Reactive Messaging, the execution of processing methods, is already serialized, unless `@Blocking(ordered = false)` is used.
 If `withTransaction` can be called concurrently, for example from a REST endpoint, it is recommended to limit the concurrency of the execution.
-This can be done using the `@Bulkhead` annotation from link:https://quarkus.io/guides/smallrye-fault-tolerance[_Microprofile Fault Tolerance_].
+This can be done using the `@Bulkhead` annotation from xref:smallrye-fault-tolerance.adoc[_Microprofile Fault Tolerance_].
 
 An example usage can be found in <<chaining-kafka-transactions-with-hibernate-reactive-transactions>>.
 ====

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -59,7 +59,7 @@ If you are using the Maven command, the following table lists the attributes you
 | The artifact id of the target platform BOM.
 
 | `platformVersion`
-| The version currently recommended by the https://quarkus.io/guides/extension-registry-user[Quarkus Extension Registry]
+| The version currently recommended by the xref:extension-registry-user.adoc[Quarkus Extension Registry]
 | The version of the platform you want the project to use. It can also accept a version range, in which case the latest from the specified range will be used.
 
 | `javaVersion`

--- a/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
@@ -334,7 +334,7 @@ As a result, the `security-jpa` defaults to using bcrypt-hashed passwords.
 
 == Test your application by using Dev Services for PostgreSQL
 
-Complete the integration testing of your application in JVM and native modes by using xref:https://quarkus.io/guides/dev-services#databases[Dev Services for PostgreSQL] before you run your application in production mode.
+Complete the integration testing of your application in JVM and native modes by using xref:dev-services.adoc#databases[Dev Services for PostgreSQL] before you run your application in production mode.
 
 To run your application in dev mode:
 

--- a/docs/src/main/asciidoc/security-jpa.adoc
+++ b/docs/src/main/asciidoc/security-jpa.adoc
@@ -17,7 +17,7 @@ Quarkus security offers a Jakarta Persistence integration to collect usernames, 
 The following Jakarta Persistence entity specification demonstrates how users' information needs to be stored in a Jakarta Persistence entity and properly mapped so that Quarkus can retrieve this information from a database.
 
 
-* The `@UserDefinition` annotation must be present on a Jakarta Persistence entity, regardless of whether link:https://quarkus.io/guides/hibernate-orm-panache[simplified Hibernate ORM with Panache] is used or not.
+* The `@UserDefinition` annotation must be present on a Jakarta Persistence entity, regardless of whether xref:hibernate-orm-panache.adoc[simplified Hibernate ORM with Panache] is used or not.
 
 * The `@Username` and `@Password` field types are always `String`.
 

--- a/docs/src/main/asciidoc/stork-kubernetes.adoc
+++ b/docs/src/main/asciidoc/stork-kubernetes.adoc
@@ -108,7 +108,7 @@ implementation("io.quarkus:quarkus-container-image-jib")
 
 Let's start with the very beginning: the service we will discover, select and call.
 
-The Red and Blue are two simple REST services serving an endpoint responding `Hello from Red!` and `Hello from Blue!` respectively. The code of both applications has been developed following the https://quarkus.io/guides/getting-started[Getting Started Guide].
+The Red and Blue are two simple REST services serving an endpoint responding `Hello from Red!` and `Hello from Blue!` respectively. The code of both applications has been developed following the xref:getting-started.adoc[Getting Started Guide].
 
 As the goal of this guide is to show how to use Stork Kubernetes service discovery, we won't provide the specifics steps for the Red and Blue services. Their container images are already built and available in a public registry:
 
@@ -409,7 +409,7 @@ The `quarkus.container-image.registry` contains the container registry to use.
 The `quarkus.kubernetes.ingress.expose` indicates that the service will be accessible from the outside of the cluster.
 The `quarkus.kubernetes.ingress.host` contains the url to access the service. We are using https://nip.io/[nip.io] wildcard for IP address mappings.
 
-For a more customized configuration you can check the https://quarkus.io/guides/deploying-to-kubernetes[Deploying to Kubernetes guide]
+For a more customized configuration you can check the xref:deploying-to-kubernetes.adoc[Deploying to Kubernetes guide]
 
 == Build and push the container image
 

--- a/docs/src/main/asciidoc/update-quarkus.adoc
+++ b/docs/src/main/asciidoc/update-quarkus.adoc
@@ -36,7 +36,7 @@ include::{includes}/prerequisites.adoc[]
 
 . Create a working branch for your project by using your version control system.
 
-. To use the Quarkus CLI in the next step, link:https://quarkus.io/guides/cli-tooling#installing-the-cli[install the latest version of the Quarkus CLI].
+. To use the Quarkus CLI in the next step, xref:cli-tooling.adoc#installing-the-cli[install the latest version of the Quarkus CLI].
 Confirm the version number using `quarkus -v`.
 
 . Go to the project directory and update the project to the latest stream:

--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -82,7 +82,7 @@ Check the associated documentation to learn how to use them.
 
 |AMQP Client
 |`io.quarkus:quarkus-smallrye-reactive-messaging-amqp` (extension)
-|https://quarkus.io/guides/amqp
+|xref:amqp.adoc
 
 |Circuit Breaker
 |`io.smallrye.reactive:smallrye-mutiny-vertx-circuit-breaker` (external dependency)
@@ -94,15 +94,15 @@ Check the associated documentation to learn how to use them.
 
 |DB2 Client
 |`io.quarkus:quarkus-reactive-db2-client` (extension)
-|https://quarkus.io/guides/reactive-sql-clients
+|xref:reactive-sql-clients.adoc
 
 |Kafka Client
 |`io.quarkus:quarkus-smallrye-reactive-messaging-kafka` (extension)
-|https://quarkus.io/guides/kafka
+|xref:kafka.adoc
 
 |Mail Client
 |`io.quarkus:quarkus-mailer` (extension)
-|https://quarkus.io/guides/mailer
+|xref:mailer.adoc
 
 |MQTT Client
 |`io.quarkus:quarkus-smallrye-reactive-messaging-mqtt` (extension)
@@ -110,19 +110,19 @@ Check the associated documentation to learn how to use them.
 
 |MS SQL Client
 |`io.quarkus:quarkus-reactive-mssql-client` (extension)
-|https://quarkus.io/guides/reactive-sql-clients
+|xref:reactive-sql-clients.adoc
 
 |MySQL Client
 |`io.quarkus:quarkus-reactive-mysql-client` (extension)
-|https://quarkus.io/guides/reactive-sql-clients
+|xref:reactive-sql-clients.adoc
 
 |Oracle Client
 |`io.quarkus:quarkus-reactive-oracle-client` (extension)
-|https://quarkus.io/guides/reactive-sql-clients
+|xref:reactive-sql-clients.adoc
 
 |PostgreSQL Client
 |`io.quarkus:quarkus-reactive-pg-client` (extension)
-|https://quarkus.io/guides/reactive-sql-clients
+|xref:reactive-sql-clients.adoc
 
 |RabbitMQ Client
 |`io.smallrye.reactive:smallrye-mutiny-vertx-rabbitmq-client` (external dependency)
@@ -130,7 +130,7 @@ Check the associated documentation to learn how to use them.
 
 |Redis Client
 |`io.quarkus:quarkus-redis-client` (extension)
-|https://quarkus.io/guides/redis
+|xref:redis.adoc
 
 |Web Client
 |`io.smallrye.reactive:smallrye-mutiny-vertx-web-client` (external dependency)

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerImageJibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/ContainerImageJibConfig.java
@@ -9,8 +9,8 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
-public class JibConfig {
+@ConfigRoot(name = "jib", phase = ConfigPhase.BUILD_TIME)
+public class ContainerImageJibConfig {
 
     public static final String DEFAULT_WORKING_DIR = "/home/jboss";
     /**

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ContainerImageOpenshiftConfig.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/ContainerImageOpenshiftConfig.java
@@ -12,8 +12,8 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
-public class OpenshiftConfig {
+@ConfigRoot(name = "openshift", phase = ConfigPhase.BUILD_TIME)
+public class ContainerImageOpenshiftConfig {
 
     public static final String DEFAULT_BASE_JVM_JDK11_IMAGE = "registry.access.redhat.com/ubi8/openjdk-11:1.16";
     public static final String DEFAULT_BASE_JVM_JDK17_IMAGE = "registry.access.redhat.com/ubi8/openjdk-17:1.16";

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftUtils.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftUtils.java
@@ -87,14 +87,15 @@ public class OpenshiftUtils {
     }
 
     /**
-     * Merges {@link OpenshiftConfig} with {@link S2iConfig} prioritizing in the former.
+     * Merges {@link ContainerImageOpenshiftConfig} with {@link S2iConfig} prioritizing in the former.
      *
      * @param openshiftConfig the Openshift config
      * @param s2iConfig the s2i config
-     * @return an instance of {@link OpenshiftConfig} with the merged configuration.
+     * @return an instance of {@link ContainerImageOpenshiftConfig} with the merged configuration.
      */
-    public static OpenshiftConfig mergeConfig(OpenshiftConfig openshiftConfig, S2iConfig s2iConfig) {
-        OpenshiftConfig result = openshiftConfig != null ? openshiftConfig : new OpenshiftConfig();
+    public static ContainerImageOpenshiftConfig mergeConfig(ContainerImageOpenshiftConfig openshiftConfig,
+            S2iConfig s2iConfig) {
+        ContainerImageOpenshiftConfig result = openshiftConfig != null ? openshiftConfig : new ContainerImageOpenshiftConfig();
         if (s2iConfig == null) {
             return result;
         }

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/ContainerImageS2iConfig.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/ContainerImageS2iConfig.java
@@ -10,8 +10,8 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
-public class S2iConfig {
+@ConfigRoot(name = "s2i", phase = ConfigPhase.BUILD_TIME)
+public class ContainerImageS2iConfig {
 
     public static final String DEFAULT_BASE_JVM_JDK11_IMAGE = "registry.access.redhat.com/ubi8/openjdk-11";
     public static final String DEFAULT_BASE_JVM_JDK17_IMAGE = "registry.access.redhat.com/ubi8/openjdk-17";

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
@@ -82,7 +82,7 @@ public class S2iProcessor {
     }
 
     @BuildStep(onlyIf = { IsNormalNotRemoteDev.class, S2iBuild.class }, onlyIfNot = NativeBuild.class)
-    public void s2iRequirementsJvm(S2iConfig s2iConfig,
+    public void s2iRequirementsJvm(ContainerImageS2iConfig s2iConfig,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             OutputTargetBuildItem out,
             PackageConfig packageConfig,
@@ -104,7 +104,8 @@ public class S2iProcessor {
         String jarFileName = s2iConfig.jarFileName.orElse(outputJarFileName);
         String jarDirectory = s2iConfig.jarDirectory;
         String pathToJar = concatUnixPaths(jarDirectory, jarFileName);
-        String baseJvmImage = s2iConfig.baseJvmImage.orElse(S2iConfig.getDefaultJvmImage(compiledJavaVersion.getJavaVersion()));
+        String baseJvmImage = s2iConfig.baseJvmImage
+                .orElse(ContainerImageS2iConfig.getDefaultJvmImage(compiledJavaVersion.getJavaVersion()));
 
         builderImageProducer.produce(new BaseImageInfoBuildItem(baseJvmImage));
         Optional<S2iBaseJavaImage> baseImage = S2iBaseJavaImage.findMatching(baseJvmImage);
@@ -128,7 +129,7 @@ public class S2iProcessor {
     }
 
     @BuildStep(onlyIf = { IsNormalNotRemoteDev.class, S2iBuild.class, NativeBuild.class })
-    public void s2iRequirementsNative(S2iConfig s2iConfig,
+    public void s2iRequirementsNative(ContainerImageS2iConfig s2iConfig,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
             OutputTargetBuildItem out,
             PackageConfig packageConfig,
@@ -137,7 +138,7 @@ public class S2iProcessor {
             BuildProducer<BaseImageInfoBuildItem> builderImageProducer,
             BuildProducer<KubernetesCommandBuildItem> commandProducer) {
 
-        boolean usingDefaultBuilder = ImageUtil.getRepository(S2iConfig.DEFAULT_BASE_NATIVE_IMAGE)
+        boolean usingDefaultBuilder = ImageUtil.getRepository(ContainerImageS2iConfig.DEFAULT_BASE_NATIVE_IMAGE)
                 .equals(ImageUtil.getRepository(s2iConfig.baseNativeImage));
         String outputNativeBinaryFileName = nativeImage.getPath().getFileName().toString();
 
@@ -146,7 +147,7 @@ public class S2iProcessor {
         //The default s2i builder for native builds, renames the native binary.
         //To make things easier for the user, we need to handle it.
         if (usingDefaultBuilder && !s2iConfig.nativeBinaryFileName.isPresent()) {
-            nativeBinaryFileName = S2iConfig.DEFAULT_NATIVE_TARGET_FILENAME;
+            nativeBinaryFileName = ContainerImageS2iConfig.DEFAULT_NATIVE_TARGET_FILENAME;
         } else {
             nativeBinaryFileName = s2iConfig.nativeBinaryFileName.orElse(outputNativeBinaryFileName);
         }
@@ -170,7 +171,7 @@ public class S2iProcessor {
     }
 
     @BuildStep(onlyIf = { IsNormalNotRemoteDev.class, S2iBuild.class }, onlyIfNot = NativeBuild.class)
-    public void s2iBuildFromJar(S2iConfig s2iConfig, ContainerImageConfig containerImageConfig,
+    public void s2iBuildFromJar(ContainerImageS2iConfig s2iConfig, ContainerImageConfig containerImageConfig,
             KubernetesClientBuildItem kubernetesClientBuilder,
             ContainerImageInfoBuildItem containerImage,
             ArchiveRootBuildItem archiveRoot, OutputTargetBuildItem out, PackageConfig packageConfig,
@@ -214,7 +215,7 @@ public class S2iProcessor {
     }
 
     @BuildStep(onlyIf = { IsNormalNotRemoteDev.class, S2iBuild.class, NativeBuild.class })
-    public void s2iBuildFromNative(S2iConfig s2iConfig, ContainerImageConfig containerImageConfig,
+    public void s2iBuildFromNative(ContainerImageS2iConfig s2iConfig, ContainerImageConfig containerImageConfig,
             KubernetesClientBuildItem kubernetesClientBuilder,
             ContainerImageInfoBuildItem containerImage,
             ArchiveRootBuildItem archiveRoot, OutputTargetBuildItem out, PackageConfig packageConfig,
@@ -259,7 +260,7 @@ public class S2iProcessor {
 
     public static void createContainerImage(KubernetesClient kubernetesClient,
             GeneratedFileSystemResourceBuildItem openshiftManifests,
-            S2iConfig s2iConfig,
+            ContainerImageS2iConfig s2iConfig,
             Path output,
             Path... additional) {
 
@@ -331,7 +332,7 @@ public class S2iProcessor {
     }
 
     private static void s2iBuild(OpenShiftClient client, List<HasMetadata> buildResources, File binaryFile,
-            S2iConfig s2iConfig) {
+            ContainerImageS2iConfig s2iConfig) {
         distinct(buildResources).stream().filter(i -> i instanceof BuildConfig).map(i -> (BuildConfig) i)
                 .forEach(bc -> s2iBuild(client, bc, binaryFile, s2iConfig));
     }
@@ -345,7 +346,8 @@ public class S2iProcessor {
      * @param binaryFile The binary file
      * @param s2iConfig The s2i configuration
      */
-    private static void s2iBuild(OpenShiftClient client, BuildConfig buildConfig, File binaryFile, S2iConfig s2iConfig) {
+    private static void s2iBuild(OpenShiftClient client, BuildConfig buildConfig, File binaryFile,
+            ContainerImageS2iConfig s2iConfig) {
         Build build;
         try {
             build = client.buildConfigs().withName(buildConfig.getMetadata().getName())
@@ -375,7 +377,8 @@ public class S2iProcessor {
         }
     }
 
-    private static void waitForBuildComplete(OpenShiftClient client, S2iConfig s2iConfig, String buildName, Closeable watch) {
+    private static void waitForBuildComplete(OpenShiftClient client, ContainerImageS2iConfig s2iConfig, String buildName,
+            Closeable watch) {
         CountDownLatch latch = new CountDownLatch(1);
         ExecutorService executor = Executors.newSingleThreadExecutor();
         executor.execute(() -> {


### PR DESCRIPTION
Otherwise, our users won't have a consistent experience when browsing the maintenance version documentation.

~~This is on hold for now as I reported an issue to @radcortez about the `deploying-to-openshift.adoc` configuration reference.~~ Fixed!