### PR TITLE
Don't supply 0 as the initial value for AtomicInteger

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -1041,7 +1041,7 @@ public class VertxHttpRecorder {
 
         @Override
         public void start(Promise<Void> startFuture) {
-            final AtomicInteger remainingCount = new AtomicInteger(0);
+            final AtomicInteger remainingCount = new AtomicInteger();
             boolean httpServerEnabled = httpOptions != null && insecureRequests != HttpConfiguration.InsecureRequests.DISABLED;
             if (httpServerEnabled) {
                 remainingCount.incrementAndGet();
@@ -1201,7 +1201,7 @@ public class VertxHttpRecorder {
         @Override
         public void stop(Promise<Void> stopFuture) {
 
-            final AtomicInteger remainingCount = new AtomicInteger(0);
+            final AtomicInteger remainingCount = new AtomicInteger();
             if (httpServer != null) {
                 remainingCount.incrementAndGet();
             }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusExecutorFactory.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusExecutorFactory.java
@@ -15,7 +15,7 @@ import io.vertx.core.spi.ExecutorServiceFactory;
 
 public class QuarkusExecutorFactory implements ExecutorServiceFactory {
     static volatile ExecutorService sharedExecutor;
-    private static final AtomicInteger executorCount = new AtomicInteger(0);
+    private static final AtomicInteger executorCount = new AtomicInteger();
     private static final Logger log = Logger.getLogger(QuarkusExecutorFactory.class);
 
     private final VertxConfiguration conf;

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -527,7 +527,7 @@ public class VertxCoreRecorder {
 
     public ThreadFactory createThreadFactory(LaunchMode launchMode) {
         Optional<ClassLoader> nonDevModeTccl = setupThreadFactoryTccl(launchMode);
-        AtomicInteger threadCount = new AtomicInteger(0);
+        AtomicInteger threadCount = new AtomicInteger();
         return new ThreadFactory() {
             @Override
             public Thread newThread(Runnable runnable) {


### PR DESCRIPTION
@franz1981 IIRC, you had mentioned that this is slightly faster because it does not involve a volatile write, am I right?