### PR TITLE
Kafka Streams: restore the feature name at Quarkus startup

### DIFF
--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/KafkaStreamsProcessor.java
@@ -44,17 +44,18 @@ class KafkaStreamsProcessor {
 
     public static final String DEFAULT_PARTITION_GROUPER = "org.apache.kafka.streams.processor.DefaultPartitionGrouper";
 
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(Feature.KAFKA_STREAMS);
+    }
+
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
-    void build(BuildProducer<FeatureBuildItem> feature,
-            BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
+    void build(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<JniRuntimeAccessBuildItem> jniRuntimeAccessibleClasses,
             BuildProducer<RuntimeReinitializedClassBuildItem> reinitialized,
             BuildProducer<NativeImageResourceBuildItem> nativeLibs,
             LaunchModeBuildItem launchMode,
             NativeImageRunnerBuildItem nativeImageRunner) throws IOException {
-
-        feature.produce(new FeatureBuildItem(Feature.KAFKA_STREAMS));
-
         registerClassesThatAreLoadedThroughReflection(reflectiveClasses, launchMode);
         registerClassesThatAreAccessedViaJni(jniRuntimeAccessibleClasses);
         addSupportForRocksDbLib(nativeLibs, nativeImageRunner);


### PR DESCRIPTION
Fixes #35171

The FeatureBuildItem was returned in a BuildStep now annotated to only run when native compilation is used.
The consequence is that in JVM mode, the FeatureBuildItem is not created, and the feature name not appearing in the start logs of Quarkus.

Solution: extract the FeatureBuildItem creation in a dedicated BuildStep.
