### PR TITLE
Vertx: add priority to the SafeVertxContextInterceptor

### DIFF
--- a/docs/src/main/asciidoc/duplicated-context.adoc
+++ b/docs/src/main/asciidoc/duplicated-context.adoc
@@ -183,7 +183,7 @@ context can have spans in which it's safe, followed by spans in which it's not s
 
 To mark a context as safe, you can:
 
-1. Use the `io.quarkus.vertx.core.runtime.context.SafeVertxContext` annotation
+1. Use the `io.quarkus.vertx.SafeVertxContext` annotation
 2. Use the `io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle` class
 
 By using the `io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle` class, the current context can be explicitly marked as `safe`, or it can be explicitly marked as `unsafe`; there's a third state which is the default of any new context: `unmarked`.

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/locals/SafeVertxContextTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/locals/SafeVertxContextTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.quarkus.vertx.core.runtime.context.SafeVertxContext;
+import io.quarkus.vertx.SafeVertxContext;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
 import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Context;

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/SafeVertxContext.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/SafeVertxContext.java
@@ -1,4 +1,4 @@
-package io.quarkus.vertx.core.runtime.context;
+package io.quarkus.vertx;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/context/SafeVertxContextInterceptor.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/context/SafeVertxContextInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkus.vertx.core.runtime.context;
 
+import static jakarta.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
+
+import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
@@ -7,9 +10,11 @@ import jakarta.interceptor.Interceptor;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.ArcInvocationContext;
+import io.quarkus.vertx.SafeVertxContext;
 import io.vertx.core.Vertx;
 
 @SafeVertxContext
+@Priority(PLATFORM_BEFORE)
 @Interceptor
 public class SafeVertxContextInterceptor {
 


### PR DESCRIPTION
- also move the SafeVertxContext binding to the io.quarkus.vertx package because io.quarkus.vertx.core.runtime.context should not be considered part of the public API
- fixes #35173