### PR TITLE
REST Data with Panache should not produce links when hal is disabled

### DIFF
--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/PanacheEntityResourceHalDisabledTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/PanacheEntityResourceHalDisabledTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.entity;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.response.Response;
+
+class PanacheEntityResourceHalDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Project.class, ProjectResource.class)
+                    .addAsResource("application.properties"));
+
+    @Test
+    void shouldHalNotBeSupported() {
+        given().accept("application/hal+json")
+                .when().get("/group/projects/1")
+                .then().statusCode(406);
+    }
+
+    @Test
+    void shouldNotContainLocationAndLinks() {
+        Response response = given().accept("application/json")
+                .and().contentType("application/json")
+                .and().body("{\"name\": \"projectname\"}")
+                .when().post("/group/projects")
+                .thenReturn();
+        assertThat(response.statusCode()).isEqualTo(201);
+        assertThat(response.header("Location")).isBlank();
+        assertThat(response.getHeaders().getList("Link")).isEmpty();
+
+        response = given().accept("application/json")
+                .when().get("/group/projects/projectname")
+                .thenReturn();
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.header("Location")).isBlank();
+        assertThat(response.getHeaders().getList("Link")).isEmpty();
+    }
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/Project.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/Project.java
@@ -1,0 +1,13 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+
+@Entity
+public class Project extends PanacheEntityBase {
+
+    @Id
+    public String name;
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/ProjectResource.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/ProjectResource.java
@@ -1,0 +1,11 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.entity;
+
+import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
+import io.quarkus.rest.data.panache.ResourceProperties;
+
+/**
+ * Having a path param in the path reproduces the issue of having HAL enabled spites it should be disabled by default.
+ */
+@ResourceProperties(path = "/{group}/projects")
+public interface ProjectResource extends PanacheEntityResource<Project, String> {
+}

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/entity/PanacheEntityResourceHalDisabledTest.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/entity/PanacheEntityResourceHalDisabledTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.hibernate.reactive.rest.data.panache.deployment.entity;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.response.Response;
+
+class PanacheEntityResourceHalDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Project.class, ProjectResource.class)
+                    .addAsResource("application.properties"));
+
+    @Test
+    void shouldHalNotBeSupported() {
+        given().accept("application/hal+json")
+                .when().get("/group/projects/1")
+                .then().statusCode(406);
+    }
+
+    @Test
+    void shouldNotContainLocationAndLinks() {
+        Response response = given().accept("application/json")
+                .and().contentType("application/json")
+                .and().body("{\"name\": \"projectname\"}")
+                .when().post("/group/projects")
+                .thenReturn();
+        assertThat(response.statusCode()).isEqualTo(201);
+        assertThat(response.header("Location")).isBlank();
+        assertThat(response.getHeaders().getList("Link")).isEmpty();
+
+        response = given().accept("application/json")
+                .when().get("/group/projects/projectname")
+                .thenReturn();
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.header("Location")).isBlank();
+        assertThat(response.getHeaders().getList("Link")).isEmpty();
+    }
+}

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/entity/Project.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/entity/Project.java
@@ -1,0 +1,13 @@
+package io.quarkus.hibernate.reactive.rest.data.panache.deployment.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import io.quarkus.hibernate.reactive.panache.PanacheEntityBase;
+
+@Entity
+public class Project extends PanacheEntityBase {
+
+    @Id
+    public String name;
+}

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/entity/ProjectResource.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/entity/ProjectResource.java
@@ -1,0 +1,11 @@
+package io.quarkus.hibernate.reactive.rest.data.panache.deployment.entity;
+
+import io.quarkus.hibernate.reactive.rest.data.panache.PanacheEntityResource;
+import io.quarkus.rest.data.panache.ResourceProperties;
+
+/**
+ * Having a path param in the path reproduces the issue of having HAL enabled spites it should be disabled by default.
+ */
+@ResourceProperties(path = "/{group}/projects")
+public interface ProjectResource extends PanacheEntityResource<Project, String> {
+}

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
@@ -114,7 +114,7 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
         addContextAnnotation(methodCreator.getParameterAnnotations(1));
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
-        addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
         addOpenApiResponseAnnotation(methodCreator, Response.Status.CREATED, resourceMetadata.getEntityType());
         addSecurityAnnotations(methodCreator, resourceProperties);
         // Add parameter annotations
@@ -130,7 +130,7 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
             ResultHandle entity = tryBlock.invokeVirtualMethod(
                     ofMethod(resourceMetadata.getResourceClass(), RESOURCE_METHOD_NAME, Object.class, Object.class),
                     resource, entityToSave);
-            tryBlock.returnValue(responseImplementor.created(tryBlock, entity));
+            tryBlock.returnValue(responseImplementor.created(tryBlock, entity, resourceProperties));
             tryBlock.close();
         } else {
             ResultHandle uniEntity = methodCreator.invokeVirtualMethod(
@@ -138,7 +138,7 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
                     resource, entityToSave);
 
             methodCreator.returnValue(UniImplementor.map(methodCreator, uniEntity, EXCEPTION_MESSAGE,
-                    (body, item) -> body.returnValue(responseImplementor.created(body, item))));
+                    (body, item) -> body.returnValue(responseImplementor.created(body, item, resourceProperties))));
         }
 
         methodCreator.close();

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
@@ -87,7 +87,7 @@ public final class CountMethodImplementor extends StandardMethodImplementor {
         if (!isResteasyClassic()) {
             // We only add the Links annotation in Resteasy Reactive because Resteasy Classic ignores the REL parameter:
             // it always uses "list" for GET methods, so it interferes with the list implementation.
-            addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+            addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
         }
 
         ResultHandle resource = methodCreator.readInstanceField(resourceField, methodCreator.getThis());

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
@@ -91,7 +91,7 @@ public final class DeleteMethodImplementor extends StandardMethodImplementor {
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_METHOD_NAME), "{id}"));
         addDeleteAnnotation(methodCreator);
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
-        addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
         addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
         addOpenApiResponseAnnotation(methodCreator, Response.Status.NO_CONTENT);
         addSecurityAnnotations(methodCreator, resourceProperties);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
@@ -98,7 +98,7 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
         addSecurityAnnotations(methodCreator, resourceProperties);
 
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
-        addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
 
         ResultHandle resource = methodCreator.readInstanceField(resourceField, methodCreator.getThis());
         ResultHandle id = methodCreator.getMethodParam(0);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
@@ -193,7 +193,7 @@ public class ListMethodImplementor extends StandardMethodImplementor {
         addGetAnnotation(methodCreator);
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addProducesJsonAnnotation(methodCreator, resourceProperties);
-        addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
         addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
         addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, resourceMetadata.getEntityType(), true);
         addSecurityAnnotations(methodCreator, resourceProperties);
@@ -280,7 +280,7 @@ public class ListMethodImplementor extends StandardMethodImplementor {
         addGetAnnotation(methodCreator);
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addProducesJsonAnnotation(methodCreator, resourceProperties);
-        addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
         addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
         addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, resourceMetadata.getEntityType(), true);
         addSecurityAnnotations(methodCreator, resourceProperties);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
@@ -100,20 +100,23 @@ public abstract class StandardMethodImplementor implements MethodImplementor {
         element.addAnnotation(DELETE.class);
     }
 
-    protected void addLinksAnnotation(AnnotatedElement element, String entityClassName, String rel) {
-        if (isResteasyClassic()) {
-            AnnotationCreator linkResource = element.addAnnotation("org.jboss.resteasy.links.LinkResource");
-            linkResource.addValue("entityClassName", entityClassName);
-            linkResource.addValue("rel", rel);
-        } else {
-            AnnotationCreator linkResource = element.addAnnotation("io.quarkus.resteasy.reactive.links.RestLink");
-            Class<?> entityClass;
-            try {
-                entityClass = Thread.currentThread().getContextClassLoader().loadClass(entityClassName);
-                linkResource.addValue("entityType", entityClass);
+    protected void addLinksAnnotation(AnnotatedElement element, ResourceProperties resourceProperties, String entityClassName,
+            String rel) {
+        if (resourceProperties.isHal()) {
+            if (isResteasyClassic()) {
+                AnnotationCreator linkResource = element.addAnnotation("org.jboss.resteasy.links.LinkResource");
+                linkResource.addValue("entityClassName", entityClassName);
                 linkResource.addValue("rel", rel);
-            } catch (ClassNotFoundException e) {
-                LOGGER.error("Unable to create links for entity: '" + entityClassName + "'", e);
+            } else {
+                AnnotationCreator linkResource = element.addAnnotation("io.quarkus.resteasy.reactive.links.RestLink");
+                Class<?> entityClass;
+                try {
+                    entityClass = Thread.currentThread().getContextClassLoader().loadClass(entityClassName);
+                    linkResource.addValue("entityType", entityClass);
+                    linkResource.addValue("rel", rel);
+                } catch (ClassNotFoundException e) {
+                    LOGGER.error("Unable to create links for entity: '" + entityClassName + "'", e);
+                }
             }
         }
     }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
@@ -148,7 +148,7 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
         addContextAnnotation(methodCreator.getParameterAnnotations(2));
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
-        addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addLinksAnnotation(methodCreator, resourceProperties, resourceMetadata.getEntityType(), REL);
         addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_UPDATE_METHOD_NAME));
         addOpenApiResponseAnnotation(methodCreator, Response.Status.CREATED, resourceMetadata.getEntityType());
         addSecurityAnnotations(methodCreator, resourceProperties);
@@ -162,9 +162,9 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
         ResultHandle entityToSave = methodCreator.getMethodParam(1);
 
         if (isNotReactivePanache()) {
-            implementClassicVersion(methodCreator, resourceMetadata, resource, id, entityToSave);
+            implementClassicVersion(methodCreator, resourceMetadata, resourceProperties, resource, id, entityToSave);
         } else {
-            implementReactiveVersion(methodCreator, resourceMetadata, resource, id, entityToSave);
+            implementReactiveVersion(methodCreator, resourceMetadata, resourceProperties, resource, id, entityToSave);
         }
 
         methodCreator.close();
@@ -175,8 +175,8 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
         return RESOURCE_UPDATE_METHOD_NAME;
     }
 
-    private void implementReactiveVersion(MethodCreator methodCreator, ResourceMetadata resourceMetadata, ResultHandle resource,
-            ResultHandle id, ResultHandle entityToSave) {
+    private void implementReactiveVersion(MethodCreator methodCreator, ResourceMetadata resourceMetadata,
+            ResourceProperties resourceProperties, ResultHandle resource, ResultHandle id, ResultHandle entityToSave) {
         ResultHandle uniResponse = methodCreator.invokeVirtualMethod(
                 ofMethod(resourceMetadata.getResourceClass(), RESOURCE_GET_METHOD_NAME, Uni.class, Object.class),
                 resource, id);
@@ -193,15 +193,16 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
                             (updateBody, itemUpdated) -> {
                                 BranchResult ifEntityIsNew = updateBody.ifNull(itemWasFound);
                                 ifEntityIsNew.trueBranch()
-                                        .returnValue(responseImplementor.created(ifEntityIsNew.trueBranch(), itemUpdated));
+                                        .returnValue(responseImplementor.created(ifEntityIsNew.trueBranch(), itemUpdated,
+                                                resourceProperties));
                                 ifEntityIsNew.falseBranch()
                                         .returnValue(responseImplementor.noContent(ifEntityIsNew.falseBranch()));
                             }));
                 }));
     }
 
-    private void implementClassicVersion(MethodCreator methodCreator, ResourceMetadata resourceMetadata, ResultHandle resource,
-            ResultHandle id, ResultHandle entityToSave) {
+    private void implementClassicVersion(MethodCreator methodCreator, ResourceMetadata resourceMetadata,
+            ResourceProperties resourceProperties, ResultHandle resource, ResultHandle id, ResultHandle entityToSave) {
         // Invoke resource methods inside a supplier function which will be given to an update executor.
         // For ORM, this update executor will have the @Transactional annotation to make
         // sure that all database operations are executed in a single transaction.
@@ -214,7 +215,8 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
                 updateExecutor, updateFunction);
 
         BranchResult createdNewEntity = tryBlock.ifNotNull(newEntity);
-        createdNewEntity.trueBranch().returnValue(responseImplementor.created(createdNewEntity.trueBranch(), newEntity));
+        createdNewEntity.trueBranch()
+                .returnValue(responseImplementor.created(createdNewEntity.trueBranch(), newEntity, resourceProperties));
         createdNewEntity.falseBranch().returnValue(responseImplementor.noContent(createdNewEntity.falseBranch()));
     }
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResponseImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResponseImplementor.java
@@ -19,6 +19,7 @@ import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.hal.HalService;
+import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
 import io.quarkus.resteasy.links.runtime.hal.ResteasyHalService;
 import io.quarkus.resteasy.reactive.links.runtime.hal.ResteasyReactiveHalService;
 
@@ -44,17 +45,12 @@ public final class ResponseImplementor {
         return creator.invokeVirtualMethod(ofMethod(ResponseBuilder.class, "build", Response.class), builder);
     }
 
-    public ResultHandle created(BytecodeCreator creator, ResultHandle entity) {
-        return created(creator, entity, getEntityUrl(creator, entity));
-    }
+    public ResultHandle created(BytecodeCreator creator, ResultHandle entity, ResourceProperties resourceProperties) {
+        if (resourceProperties.isHal()) {
+            return doCreated(creator, entity, getEntityUrl(creator, entity));
+        }
 
-    public ResultHandle created(BytecodeCreator creator, ResultHandle entity, ResultHandle location) {
-        ResultHandle builder = getResponseBuilder(creator, Response.Status.CREATED.getStatusCode());
-        creator.invokeVirtualMethod(
-                ofMethod(ResponseBuilder.class, "entity", ResponseBuilder.class, Object.class), builder, entity);
-        creator.invokeVirtualMethod(
-                ofMethod(ResponseBuilder.class, "location", ResponseBuilder.class, URI.class), builder, location);
-        return creator.invokeVirtualMethod(ofMethod(ResponseBuilder.class, "build", Response.class), builder);
+        return doCreated(creator, entity, null);
     }
 
     public ResultHandle getEntityUrl(BytecodeCreator creator, ResultHandle entity) {
@@ -87,6 +83,18 @@ public final class ResponseImplementor {
     public ResultHandle notFoundException(BytecodeCreator creator) {
         return creator.newInstance(MethodDescriptor.ofConstructor(WebApplicationException.class, int.class),
                 creator.load(Response.Status.NOT_FOUND.getStatusCode()));
+    }
+
+    private ResultHandle doCreated(BytecodeCreator creator, ResultHandle entity, ResultHandle location) {
+        ResultHandle builder = getResponseBuilder(creator, Response.Status.CREATED.getStatusCode());
+        creator.invokeVirtualMethod(
+                ofMethod(ResponseBuilder.class, "entity", ResponseBuilder.class, Object.class), builder, entity);
+        if (location != null) {
+            creator.invokeVirtualMethod(
+                    ofMethod(ResponseBuilder.class, "location", ResponseBuilder.class, URI.class), builder, location);
+        }
+
+        return creator.invokeVirtualMethod(ofMethod(ResponseBuilder.class, "build", Response.class), builder);
     }
 
     private ResultHandle status(BytecodeCreator creator, int status) {


### PR DESCRIPTION
This is related to https://github.com/quarkusio/quarkus/issues/35167. 
Even though HAL is disabled by default, it still generates unexpected links and sets the location using the HAL service (which dependency might be excluded on purpose).