### PR TITLE
Reduce allocation cost reporting spans

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/VertxGrpcExporter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/exporter/otlp/VertxGrpcExporter.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.internal.ThrottlingLogger;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.quarkus.vertx.core.runtime.BufferOutputStream;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -194,10 +195,9 @@ final class VertxGrpcExporter implements SpanExporter {
 
             try {
                 int messageSize = marshaler.getBinarySerializedSize();
-                var baos = new NonCopyingByteArrayOutputStream(messageSize); // TODO: we can probably use Vert.x / Netty buffering here
-                marshaler.writeBinaryTo(baos);
                 Buffer buffer = Buffer.buffer(messageSize);
-                buffer.appendBytes(baos.toByteArray());
+                var os = new BufferOutputStream(buffer);
+                marshaler.writeBinaryTo(os);
                 request.send(buffer).onSuccess(new Handler<>() {
                     @Override
                     public void handle(GrpcClientResponse<Buffer, Buffer> response) {

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandlerBase.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandlerBase.java
@@ -1,12 +1,12 @@
 package io.quarkus.smallrye.health.runtime;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.UncheckedIOException;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.vertx.core.runtime.BufferOutputStream;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
@@ -56,22 +56,4 @@ abstract class SmallRyeHealthHandlerBase implements Handler<RoutingContext> {
         }
     }
 
-    private static class BufferOutputStream extends OutputStream {
-
-        private final Buffer buffer;
-
-        private BufferOutputStream(Buffer buffer) {
-            this.buffer = buffer;
-        }
-
-        @Override
-        public void write(byte[] b, int off, int len) throws IOException {
-            buffer.appendBytes(b, off, len);
-        }
-
-        @Override
-        public void write(int b) throws IOException {
-            buffer.appendInt(b);
-        }
-    }
 }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/BufferOutputStream.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/BufferOutputStream.java
@@ -1,0 +1,29 @@
+package io.quarkus.vertx.core.runtime;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * Simple {@link OutputStream} implementation that appends content
+ * written in given {@link Buffer} instance.
+ */
+public class BufferOutputStream extends OutputStream {
+
+    private final Buffer buffer;
+
+    public BufferOutputStream(Buffer buffer) {
+        this.buffer = buffer;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        buffer.appendBytes(b, off, len);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        buffer.appendInt(b);
+    }
+}


### PR DESCRIPTION
This is done by leveraging Vert.x's `Buffer`
directly instead of relying on a
`ByteArrayOutputStream`