### PR TITLE
QuarkusComponentTest: test config source ordinal improvements

### DIFF
--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTest.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTest.java
@@ -50,4 +50,11 @@ public @interface QuarkusComponentTest {
      * @see #value()
      */
     boolean addNestedClassesAsComponents() default true;
+
+    /**
+     * The ordinal of the config source used for all test config properties.
+     *
+     * @see QuarkusComponentTestExtension#setConfigSourceOrdinal(int)
+     */
+    int configSourceOrdinal() default QuarkusComponentTestExtension.DEFAULT_CONFIG_SOURCE_ORDINAL;
 }

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/config/ConfigSourceOrdinalTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/config/ConfigSourceOrdinalTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.test.component.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.component.QuarkusComponentTest;
+import io.quarkus.test.component.TestConfigProperty;
+
+@QuarkusComponentTest(configSourceOrdinal = 275)
+@TestConfigProperty(key = "foo", value = "baz")
+public class ConfigSourceOrdinalTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        System.setProperty("foo", "bar");
+    }
+
+    @AfterAll
+    static void afterAll() {
+        System.clearProperty("foo");
+    }
+
+    @Inject
+    FooConsumer consumer;
+
+    @Test
+    public void testOrdinal() {
+        assertEquals("bar", consumer.foo);
+    }
+
+    @Singleton
+    public static class FooConsumer {
+
+        @ConfigProperty(name = "foo")
+        String foo;
+
+    }
+}


### PR DESCRIPTION
- change the default value to 500 so that test config properties take predence over system properties, ENV variables and application.properties
- make the ordinal configurable
- fixes #35199