### PR TITLE
Disable io.quarkus.it.vthreads.kafka.VirtualThreadTest.testAlertMessage

### DIFF
--- a/integration-tests/virtual-threads/kafka-virtual-threads/src/test/java/io/quarkus/it/vthreads/kafka/VirtualThreadTest.java
+++ b/integration-tests/virtual-threads/kafka-virtual-threads/src/test/java/io/quarkus/it/vthreads/kafka/VirtualThreadTest.java
@@ -6,6 +6,7 @@ import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern;
 import static org.awaitility.Awaitility.await;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -28,6 +29,7 @@ public class VirtualThreadTest {
     }
 
     @Test
+    @Disabled("flaky")
     void testAlertMessage() {
         await().untilAsserted(() -> mockServer.verify(new CountMatchingStrategy(GREATER_THAN_OR_EQUAL, EXPECTED_CALLS),
                 newRequestPattern(POST, urlPathEqualTo("/price/alert-message"))));


### PR DESCRIPTION
It is flaky.