### PR TITLE
Unification of the devtools includes - 3.2

### DIFF
--- a/docs/src/main/asciidoc/_includes/devtools/build-native-container-parameters.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/build-native-container-parameters.adoc
@@ -1,11 +1,11 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[source,bash,subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
 .CLI
 ----
 quarkus build --native -Dquarkus.native.container-build=true {build-additional-parameters}
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
 .Maven
 ----
 ./mvnw install -Dnative -Dquarkus.native.container-build=true {build-additional-parameters}
@@ -13,7 +13,7 @@ ifdef::devtools-wrapped[+]
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
 .Gradle
 ----
 ./gradlew build -Dquarkus.package.type=native -Dquarkus.native.container-build=true {build-additional-parameters}

--- a/docs/src/main/asciidoc/_includes/devtools/build-native-container.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/build-native-container.adoc
@@ -1,4 +1,4 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[source,bash,subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
 .CLI
 ----
 ifdef::build-additional-parameters[]
@@ -11,7 +11,7 @@ endif::[]
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
 .Maven
 ----
 ifdef::build-additional-parameters[]
@@ -24,7 +24,7 @@ endif::[]
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
 .Gradle
 ----
 ifdef::build-additional-parameters[]

--- a/docs/src/main/asciidoc/_includes/devtools/build-native.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/build-native.adoc
@@ -1,4 +1,4 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[source,bash,subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
 .CLI
 ----
 ifdef::build-additional-parameters[]
@@ -10,7 +10,7 @@ endif::[]
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
 .Maven
 ----
 ifdef::build-additional-parameters[]
@@ -23,7 +23,7 @@ endif::[]
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
 .Gradle
 ----
 ifdef::build-additional-parameters[]

--- a/docs/src/main/asciidoc/_includes/devtools/build.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/build.adoc
@@ -1,4 +1,4 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[source,bash,subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
 .CLI
 ----
 ifdef::build-additional-parameters[]
@@ -10,7 +10,7 @@ endif::[]
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
 .Maven
 ----
 ifdef::build-additional-parameters[]
@@ -23,7 +23,7 @@ endif::[]
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
 .Gradle
 ----
 ifdef::build-additional-parameters[]

--- a/docs/src/main/asciidoc/_includes/devtools/create-app.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/create-app.adoc
@@ -52,7 +52,7 @@ ifndef::devtools-no-gradle[]
 To create a Gradle project, add the `--gradle` or `--gradle-kotlin-dsl` option.
 endif::[]
 
-_For more information about how to install the Quarkus CLI and use it, please refer to xref:cli-tooling.adoc[the Quarkus CLI guide]._
+For more information about how to install and use the Quarkus CLI, see the xref:cli-tooling.adoc[Quarkus CLI] guide.
 ****
 
 [role="secondary asciidoc-tabs-sync-maven"]

--- a/docs/src/main/asciidoc/_includes/devtools/create-cli.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/create-cli.adoc
@@ -50,7 +50,7 @@ endif::[]
 
 To create a Gradle project, add the `--gradle` or `--gradle-kotlin-dsl` option.
 
-_For more information about how to install the Quarkus CLI and use it, please refer to xref:cli-tooling.adoc[the Quarkus CLI guide]._
+For more information about how to install and use the Quarkus CLI, see the xref:cli-tooling.adoc[Quarkus CLI] guide.
 ****
 
 [role="secondary asciidoc-tabs-sync-maven"]

--- a/docs/src/main/asciidoc/_includes/devtools/dev-parameters.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/dev-parameters.adoc
@@ -1,11 +1,11 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[source,bash,subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
 .CLI
 ----
 quarkus dev {dev-additional-parameters}
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
 .Maven
 ----
 ./mvnw quarkus:dev {dev-additional-parameters}
@@ -13,7 +13,7 @@ ifdef::devtools-wrapped[+]
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
 .Gradle
 ----
 ./gradlew --console=plain quarkusDev {dev-additional-parameters}

--- a/docs/src/main/asciidoc/_includes/devtools/dev.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/dev.adoc
@@ -1,4 +1,4 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[source,bash,subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
 .CLI
 ----
 ifdef::dev-additional-parameters[]
@@ -10,7 +10,7 @@ endif::[]
 ----
 ifdef::devtools-wrapped[+]
 ifndef::devtools-no-maven[]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
 .Maven
 ----
 ifdef::dev-additional-parameters[]
@@ -23,7 +23,7 @@ endif::[]
 endif::[]
 ifdef::devtools-wrapped[+]
 ifndef::devtools-no-gradle[]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
 .Gradle
 ----
 ifdef::dev-additional-parameters[]

--- a/docs/src/main/asciidoc/_includes/devtools/extension-add.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/extension-add.adoc
@@ -1,11 +1,11 @@
-[source,bash,subs=attributes+,role="primary asciidoc-tabs-sync-cli"]
+[source,bash,subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
 .CLI
 ----
 quarkus extension add '{add-extension-extensions}'
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source,bash,subs=attributes+,role="secondary asciidoc-tabs-sync-maven"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
 .Maven
 ----
 ./mvnw quarkus:add-extension -Dextensions='{add-extension-extensions}'

--- a/docs/src/main/asciidoc/_includes/devtools/extension-list.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/extension-list.adoc
@@ -1,11 +1,11 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[source,bash,subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
 .CLI
 ----
 quarkus extension
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
 .Maven
 ----
 ./mvnw quarkus:list-extensions
@@ -13,7 +13,7 @@ ifdef::devtools-wrapped[+]
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
 .Gradle
 ----
 ./gradlew listExtensions

--- a/docs/src/main/asciidoc/_includes/devtools/maven-opts.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/maven-opts.adoc
@@ -1,11 +1,11 @@
-[source, bash, subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
+[source,bash,subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
 .CLI
 ----
 MAVEN_OPTS='--enable-preview' quarkus build
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
 .Maven
 ----
 MAVEN_OPTS='--enable-preview' ./mvnw install

--- a/docs/src/main/asciidoc/_includes/devtools/test.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/test.adoc
@@ -1,5 +1,5 @@
 ifndef::devtools-no-maven[]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
 .Maven
 ----
 ./mvnw test
@@ -7,7 +7,7 @@ ifndef::devtools-no-maven[]
 endif::[]
 ifdef::devtools-wrapped[+]
 ifndef::devtools-no-gradle[]
-[source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
+[source,bash,subs=attributes+, role="secondary asciidoc-tabs-sync-gradle"]
 .Gradle
 ----
 ./gradlew test


### PR DESCRIPTION
Aligning some snippets cosmetics for better maintenance and followup use in RHBQ 3.2.
Unifying header spaces for easier regex search.
Removing empty lines at the end of the files for better use with additional asciidoc elements such as `+`.
Fixing the style in the sentences with the xref link.

This PR is only for 3.2. No further backport needed.