### PR TITLE
Remove deleted `bootstrap-config/application` from Misc2 native test job

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -105,7 +105,7 @@
         {
             "category": "Misc2",
             "timeout": 70,
-            "test-modules": "hibernate-validator, test-extension/tests, logging-gelf, bootstrap-config/application, mailer, native-config-profile, locales",
+            "test-modules": "hibernate-validator, test-extension/tests, logging-gelf, mailer, native-config-profile, locales",
             "os-name": "ubuntu-latest"
         },
         {


### PR DESCRIPTION
Spotted here: https://github.com/quarkusio/quarkus/pull/35251#issuecomment-1668902760

Module was deleted via #35150.

/cc @radcortez 