### PR TITLE
Initialize datasources at startup again

### DIFF
--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -24,6 +24,7 @@ import org.jboss.logging.Logger;
 import io.agroal.api.AgroalDataSource;
 import io.agroal.api.AgroalPoolInterceptor;
 import io.quarkus.agroal.DataSource;
+import io.quarkus.agroal.runtime.AgroalDataSourcesInitializer;
 import io.quarkus.agroal.runtime.AgroalRecorder;
 import io.quarkus.agroal.runtime.DataSourceJdbcBuildTimeConfig;
 import io.quarkus.agroal.runtime.DataSourceSupport;
@@ -233,11 +234,13 @@ class AgroalProcessor {
             return;
         }
 
-        // make a DataSourceProducer bean
+        // make a DataSources bean
         additionalBeans.produce(AdditionalBeanBuildItem.builder().addBeanClasses(DataSources.class).setUnremovable()
                 .setDefaultScope(DotNames.SINGLETON).build());
         // add the @DataSource class otherwise it won't be registered as a qualifier
         additionalBeans.produce(AdditionalBeanBuildItem.builder().addBeanClass(DataSource.class).build());
+        // make source datasources are initialized at startup
+        additionalBeans.produce(new AdditionalBeanBuildItem(AgroalDataSourcesInitializer.class));
 
         // make AgroalPoolInterceptor beans unremovable, users still have to make them beans
         unremovableBeans.produce(UnremovableBeanBuildItem.beanTypes(AgroalPoolInterceptor.class));

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalDataSourcesInitializer.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalDataSourcesInitializer.java
@@ -1,0 +1,19 @@
+package io.quarkus.agroal.runtime;
+
+import java.util.List;
+
+import jakarta.enterprise.event.Observes;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.arc.All;
+import io.quarkus.runtime.StartupEvent;
+
+/**
+ * Make sure datasources are initialized at startup.
+ */
+public class AgroalDataSourcesInitializer {
+
+    void init(@Observes StartupEvent event, @All List<AgroalDataSource> dataSources) {
+        // nothing to do here, eager injection will initialize the beans
+    }
+}


### PR DESCRIPTION
Prior to
https://github.com/quarkusio/quarkus/pull/34545/commits/3f9de0c8af37a6bf9a869af117f95b5ae206dd28, datasources were initialized at startup and this is a property we want to keep.
ArC will now take care of the initialization.

Fixes #35238
