### PR TITLE
Correct filtering syntax and hardcode variable that cannot be resolved

### DIFF
--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-callback-from-extension/pom.xml
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-callback-from-extension/pom.xml
@@ -12,8 +12,8 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>${surefire-plugin.version}</surefire-plugin.version>
-    <quarkus.version>@project.version</quarkus.version>
+    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <quarkus.version>@project.version@</quarkus.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-parameter-injection/pom.xml
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-parameter-injection/pom.xml
@@ -13,8 +13,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.bom.artifact-id>quarkus-bom</quarkus.bom.artifact-id>
-    <surefire-plugin.version>${surefire-plugin.version}</surefire-plugin.version>
-    <quarkus.version>@project.version</quarkus.version>
+    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <quarkus.version>@project.version@</quarkus.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension/pom.xml
+++ b/integration-tests/test-extension/tests/src/test/resources-filtered/projects/project-using-test-template-from-extension/pom.xml
@@ -12,8 +12,8 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>${surefire-plugin.version}</surefire-plugin.version>
-    <quarkus.version>@project.version</quarkus.version>
+    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <quarkus.version>@project.version@</quarkus.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
I discovered when I re-enabled the tests in https://github.com/quarkusio/quarkus/pull/35124 that some of the resource filtering adjustments didn't quite work. Because the tests were disabled for the merge, I didn't notice. I've now corrected a syntax error in the `@` variable declaration, and hardcoded the surefire plugin version, as other resource filtered tests do. With these changes, the tests now behave in the expected way. 

If we want to resolve the hardcoding we could set a global variable and then do a pass of all the filtered resources, but I'll leave that for another change. 