### PR TITLE
Avoid keeping references to BytecodeRecorderImpl

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/RecordingProxyFactories.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/RecordingProxyFactories.java
@@ -1,0 +1,30 @@
+package io.quarkus.deployment.recording;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.deployment.proxy.ProxyFactory;
+
+class RecordingProxyFactories {
+
+    private static final Map<Class<?>, ProxyFactory<?>> RECORDING_PROXY_FACTORIES = new ConcurrentHashMap<>();
+
+    static <T> void put(Class<T> clazz, ProxyFactory<T> proxyFactory) {
+        RECORDING_PROXY_FACTORIES.put(clazz, proxyFactory);
+
+        if (clazz.getClassLoader() instanceof QuarkusClassLoader) {
+            ((QuarkusClassLoader) clazz.getClassLoader()).addCloseTask(new Runnable() {
+                @Override
+                public void run() {
+                    RecordingProxyFactories.RECORDING_PROXY_FACTORIES.remove(clazz);
+                }
+            });
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> ProxyFactory<T> get(Class<T> clazz) {
+        return (ProxyFactory<T>) RECORDING_PROXY_FACTORIES.get(clazz);
+    }
+}


### PR DESCRIPTION
`BytecodeRecorderImpl` references are kept around for the whole life of the classloader. And these classes can be huge (for a lot of reasons, local data structures, references to generated classes in build items).

Moving the static map to another class so that it is properly isolated and avoid keeping a reference to the bytecode recorder.
Note that I know we could have changed that differently and use a static runnable accessing the map statically but I think isolation the things that are supposed to be long lived is better.

This is related to https://github.com/quarkusio/quarkus/issues/32209 . With this patch alone, I'm able to get back to `128M` of Xmx (but not a lot lower, I tried 92 and didn't work well).

![Screenshot from 2023-08-09 13-13-44](https://github.com/quarkusio/quarkus/assets/1279749/d2984a1c-808b-440c-9027-634c068ca388)
