### PR TITLE
Type jar should be the default for GACT

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACT.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACT.java
@@ -60,7 +60,7 @@ public class GACT implements ArtifactKey, Serializable {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.classifier = classifier == null ? ArtifactCoords.DEFAULT_CLASSIFIER : classifier;
-        this.type = type;
+        this.type = type == null ? ArtifactCoords.TYPE_JAR : type;
     }
 
     public static String[] split(String str, String[] parts, int fromIndex) {


### PR DESCRIPTION
It is the default when coming from a string but not when you use: GACT(String groupId, String artifactId)
which is what ArtifactKey.ga() uses.

(Noticed while struggling with a `RemovedResourceBuildItem` as the `ArtifactKey` didn't match)

See https://github.com/quarkusio/quarkus/pull/35296/files#diff-13c694ed14a0cd90792fadbc7750d7caff15f4afaed3e39cd49a0d472494c743R72 where I tried to use `ArtifactKey.ga()` first.

Created as draft to see how CI goes.