### PR TITLE
Output build graph using `quarkus.builder.graph-output` property

### DIFF
--- a/core/builder/src/main/java/io/quarkus/builder/BuildChainBuilder.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildChainBuilder.java
@@ -30,7 +30,7 @@ import io.quarkus.builder.item.BuildItem;
  */
 public final class BuildChainBuilder {
 
-    private static final String GRAPH_OUTPUT = System.getProperty("jboss.builder.graph-output");
+    private static final String GRAPH_OUTPUT = System.getProperty("quarkus.builder.graph-output");
     static final boolean LOG_CONFLICT_CAUSING = Boolean.getBoolean("quarkus.builder.log-conflict-cause");
 
     private final BuildStepBuilder finalStep;

--- a/core/runtime/src/main/java/io/quarkus/runtime/BuilderConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/BuilderConfig.java
@@ -2,28 +2,27 @@ package io.quarkus.runtime;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
 
 /**
  * This configuration class is here to avoid warnings when using {@code -Dquarkus.builder.=...}.
  *
  * @see io.quarkus.builder.BuildChainBuilder
  */
-@ConfigRoot(name = "builder", phase = ConfigPhase.RUN_TIME)
-public class BuilderConfig {
+@ConfigMapping(prefix = "quarkus.builder")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface BuilderConfig {
 
     /**
      * Dump the graph output to a file. This is useful for debugging.
      */
-    @ConfigItem
-    public Optional<String> graphOutput;
+    Optional<String> graphOutput();
 
     /**
      * Whether to log the cause of a conflict.
      */
-    @ConfigItem
-    public Optional<Boolean> logConflictCause;
+    Optional<Boolean> logConflictCause();
 
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/BuilderConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/BuilderConfig.java
@@ -1,0 +1,29 @@
+package io.quarkus.runtime;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * This configuration class is here to avoid warnings when using {@code -Dquarkus.builder.=...}.
+ *
+ * @see io.quarkus.builder.BuildChainBuilder
+ */
+@ConfigRoot(name = "builder", phase = ConfigPhase.RUN_TIME)
+public class BuilderConfig {
+
+    /**
+     * Dump the graph output to a file. This is useful for debugging.
+     */
+    @ConfigItem
+    public Optional<String> graphOutput;
+
+    /**
+     * Whether to log the cause of a conflict.
+     */
+    @ConfigItem
+    public Optional<Boolean> logConflictCause;
+
+}


### PR DESCRIPTION
- This renames the property name from `jboss.builder.graph-output` to `quarkus.builder.graph-output`
- Useful for https://github.com/redhat-developer/intellij-quarkus/issues/1095