### PR TITLE
Fix `jandex-gradle-plugin-version` in CDI Reference

### DIFF
--- a/docs/src/main/asciidoc/_attributes.adoc
+++ b/docs/src/main/asciidoc/_attributes.adoc
@@ -19,7 +19,7 @@
 :kibana-image: ${kibana.image}
 :keycloak-docker-image: ${keycloak.docker.image}
 :jandex-version: ${jandex.version}
-:jandex-gradle-plugin.version: ${jandex-gradle-plugin.version}
+:jandex-gradle-plugin-version: ${jandex-gradle-plugin.version}
 :kotlin-version: ${kotlin.version}
 :grpc-version: ${grpc.version}
 :protoc-version: ${protoc.version}

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -82,7 +82,7 @@ plugins {
     id 'org.kordamp.gradle.jandex' version '{jandex-gradle-plugin-version}'
 }
 ----
-
+You can find the latest plugin version in the https://plugins.gradle.org/plugin/org.kordamp.gradle.jandex[Gradle Plugin Portal]
 ****
 
 [role="secondary asciidoc-tabs-sync-gradle-kotlin"]
@@ -95,6 +95,8 @@ plugins {
     id("org.kordamp.gradle.jandex") version '{jandex-gradle-plugin-version}'
 }
 ----
+You can find the latest plugin version in the https://plugins.gradle.org/plugin/org.kordamp.gradle.jandex[Gradle Plugin Portal]
+
 ****
 
 


### PR DESCRIPTION
- Adds a link to https://plugins.gradle.org/plugin/org.kordamp.gradle.jandex
- Fixes #35258


![image](https://github.com/quarkusio/quarkus/assets/54133/434318d1-f0e8-4c5e-8ce5-911ea43af637)
