### PR TITLE
Include `jakarta.resource-api` 2.1.0 to BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -20,11 +20,6 @@
         <bouncycastle.tls.fips.version>1.0.16</bouncycastle.tls.fips.version>
         <expressly.version>5.0.0</expressly.version>
         <findbugs.version>3.0.2</findbugs.version>
-        <jakarta.authentication-api>3.0.0</jakarta.authentication-api>
-        <jakarta.authorization-api.version>2.1.0</jakarta.authorization-api.version>
-        <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
-        <jakarta.json-api.version>2.1.2</jakarta.json-api.version>
-        <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
         <jandex.version>3.1.2</jandex.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.inject.version>1</javax.inject.version>
@@ -72,16 +67,22 @@
         <smallrye-stork.version>2.3.1</smallrye-stork.version>
         <jakarta.activation.version>2.1.2</jakarta.activation.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
+        <jakarta.authentication-api>3.0.0</jakarta.authentication-api>
+        <jakarta.authorization-api.version>2.1.0</jakarta.authorization-api.version>
+        <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
         <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <jakarta.interceptor-api.version>2.1.0</jakarta.interceptor-api.version>
+        <jakarta.json-api.version>2.1.2</jakarta.json-api.version>
         <jakarta.json.bind-api.version>3.0.0</jakarta.json.bind-api.version>
         <jakarta.mail.version>2.0.1</jakarta.mail.version>
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
+        <jakarta.resource-api.version>2.1.0</jakarta.resource-api.version>
         <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
         <jakarta.websocket-api.version>2.1.1</jakarta.websocket-api.version>
+        <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
         <jakarta.xml.bind-api.version>4.0.0</jakarta.xml.bind-api.version>
         <jaxb-runtime.version>4.0.3</jaxb-runtime.version>
         <asm.version>9.5</asm.version>
@@ -4573,6 +4574,11 @@
                 <groupId>jakarta.persistence</groupId>
                 <artifactId>jakarta.persistence-api</artifactId>
                 <version>${jakarta.persistence-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.resource</groupId>
+                <artifactId>jakarta.resource-api</artifactId>
+                <version>${jakarta.resource-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.servlet</groupId>


### PR DESCRIPTION
This dependency is resolved transitively and it is part of Jakarta 10 umbrella