### PR TITLE
CLI: test command updates

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Test.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Test.java
@@ -9,8 +9,11 @@ import java.util.function.Supplier;
 
 import io.quarkus.cli.build.BaseBuildCommand;
 import io.quarkus.cli.build.BuildSystemRunner;
+import io.quarkus.cli.build.BuildSystemRunner.BuildCommandArgs;
+import io.quarkus.cli.common.BuildOptions;
 import io.quarkus.cli.common.DebugOptions;
 import io.quarkus.cli.common.DevOptions;
+import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 import picocli.CommandLine.Parameters;
@@ -24,6 +27,9 @@ public class Test extends BaseBuildCommand implements Callable<Integer> {
     @CommandLine.ArgGroup(order = 3, exclusive = false, validate = true, heading = "%nDebug options:%n")
     DebugOptions debugOptions = new DebugOptions();
 
+    @CommandLine.Option(names = "--once", description = "Run the test suite with continuous mode disabled.")
+    boolean runOnce = false;
+
     @Parameters(description = "Parameters passed to the application.")
     List<String> params = new ArrayList<>();
 
@@ -34,11 +40,25 @@ public class Test extends BaseBuildCommand implements Callable<Integer> {
             output.throwIfUnmatchedArguments(spec.commandLine());
 
             BuildSystemRunner runner = getRunner();
+
+            if (runOnce) {
+                BuildOptions buildOptions = new BuildOptions();
+                buildOptions.clean = testOptions.clean;
+                buildOptions.offline = testOptions.offline;
+                buildOptions.skipTests = !testOptions.runTests;
+                BuildCommandArgs commandArgs = runner.prepareTest(buildOptions, new RunModeOption(), params);
+                if (testOptions.isDryRun()) {
+                    dryRunTest(spec.commandLine().getHelp(), runner.getBuildTool(), commandArgs, false);
+                    return CommandLine.ExitCode.OK;
+                }
+                return runner.run(commandArgs);
+            }
+
             List<Supplier<BuildSystemRunner.BuildCommandArgs>> commandArgs = runner.prepareDevTestMode(
                     false, testOptions, debugOptions, params);
 
             if (testOptions.isDryRun()) {
-                dryRunTest(spec.commandLine().getHelp(), runner.getBuildTool(), commandArgs.iterator().next().get());
+                dryRunTest(spec.commandLine().getHelp(), runner.getBuildTool(), commandArgs.iterator().next().get(), true);
                 return CommandLine.ExitCode.OK;
             }
             int ret = 1;
@@ -55,8 +75,8 @@ public class Test extends BaseBuildCommand implements Callable<Integer> {
         }
     }
 
-    void dryRunTest(CommandLine.Help help, BuildTool buildTool, BuildSystemRunner.BuildCommandArgs args) {
-        output.printText("\nRun current project in test mode\n",
+    void dryRunTest(CommandLine.Help help, BuildTool buildTool, BuildSystemRunner.BuildCommandArgs args, boolean isContinuous) {
+        output.printText("\nRun current project in" + (isContinuous ? " continuous" : "") + " test mode\n",
                 "\t" + projectRoot().toString());
         Map<String, String> dryRunOutput = new TreeMap<>();
         dryRunOutput.put("Build tool", buildTool.name());

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
@@ -111,7 +111,7 @@ public interface BuildSystemRunner {
 
     BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params);
 
-    BuildCommandArgs prepareTest(BuildOptions buildOptions, RunModeOption runMode, List<String> params);
+    BuildCommandArgs prepareTest(BuildOptions buildOptions, RunModeOption runMode, List<String> params, String filter);
 
     List<Supplier<BuildCommandArgs>> prepareDevTestMode(boolean devMode, DevOptions commonOptions,
             DebugOptions debugOptions, List<String> params);

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
@@ -111,6 +111,8 @@ public interface BuildSystemRunner {
 
     BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params);
 
+    BuildCommandArgs prepareTest(BuildOptions buildOptions, RunModeOption runMode, List<String> params);
+
     List<Supplier<BuildCommandArgs>> prepareDevTestMode(boolean devMode, DevOptions commonOptions,
             DebugOptions debugOptions, List<String> params);
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -218,7 +218,10 @@ public class GradleRunner implements BuildSystemRunner {
     }
 
     @Override
-    public BuildCommandArgs prepareTest(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
+    public BuildCommandArgs prepareTest(BuildOptions buildOptions, RunModeOption runMode, List<String> params, String filter) {
+        if (filter != null) {
+            params.add("--tests " + filter);
+        }
         return prepareAction("test", buildOptions, runMode, params);
     }
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -218,6 +218,11 @@ public class GradleRunner implements BuildSystemRunner {
     }
 
     @Override
+    public BuildCommandArgs prepareTest(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
+        return prepareAction("test", buildOptions, runMode, params);
+    }
+
+    @Override
     public List<Supplier<BuildCommandArgs>> prepareDevTestMode(boolean devMode, DevOptions commonOptions,
             DebugOptions debugOptions, List<String> params) {
         ArrayDeque<String> args = new ArrayDeque<>();

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
@@ -114,7 +114,7 @@ public class JBangRunner implements BuildSystemRunner {
     }
 
     @Override
-    public BuildCommandArgs prepareTest(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
+    public BuildCommandArgs prepareTest(BuildOptions buildOptions, RunModeOption runMode, List<String> params, String filter) {
         throw new UnsupportedOperationException("Not there yet. ;)");
     }
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
@@ -114,6 +114,11 @@ public class JBangRunner implements BuildSystemRunner {
     }
 
     @Override
+    public BuildCommandArgs prepareTest(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
+        throw new UnsupportedOperationException("Not there yet. ;)");
+    }
+
+    @Override
     public List<Supplier<BuildCommandArgs>> prepareDevTestMode(boolean devMode, DevOptions commonOptions,
             DebugOptions debugOptions,
             List<String> params) {

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
@@ -224,7 +224,10 @@ public class MavenRunner implements BuildSystemRunner {
     }
 
     @Override
-    public BuildCommandArgs prepareTest(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
+    public BuildCommandArgs prepareTest(BuildOptions buildOptions, RunModeOption runMode, List<String> params, String filter) {
+        if (filter != null) {
+            params.add("-Dtest=" + filter);
+        }
         return prepareAction("test", buildOptions, runMode, params);
     }
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
@@ -224,6 +224,11 @@ public class MavenRunner implements BuildSystemRunner {
     }
 
     @Override
+    public BuildCommandArgs prepareTest(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
+        return prepareAction("test", buildOptions, runMode, params);
+    }
+
+    @Override
     public List<Supplier<BuildCommandArgs>> prepareDevTestMode(boolean devMode, DevOptions commonOptions,
             DebugOptions debugOptions, List<String> params) {
         ArrayDeque<String> args = new ArrayDeque<>();

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
@@ -353,17 +353,19 @@ public class CliProjectGradleTest {
 
         // 4 TEST MODE: test --clean --debug --suspend --offline
         result = CliDriver.execute(project, "test", "-e", "--dry-run",
-                "--clean", "--debug", "--suspend", "--debug-mode=listen", "--offline");
+                "--clean", "--debug", "--suspend", "--debug-mode=listen", "--offline", "--filter=FooTest");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("Run current project in continuous test mode"), result.toString());
+        Assertions.assertTrue(result.stdout.contains("-Dquarkus.test.include-pattern=FooTest"), result.toString());
 
         // 5 TEST MODE - run once: test --once --offline
         result = CliDriver.execute(project, "test", "-e", "--dry-run",
-                "--once", "--offline");
+                "--once", "--offline", "--filter=FooTest");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("Run current project in test mode"), result.toString());
+        Assertions.assertTrue(result.stdout.contains("--tests FooTest"), result.toString());
     }
 
     @Test

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
@@ -350,6 +350,20 @@ public class CliProjectGradleTest {
 
         Assertions.assertTrue(result.stdout.contains("-Dquarkus.args='arg1 arg2'"),
                 "gradle command should not specify -Dquarkus.args='arg1 arg2'\n" + result);
+
+        // 4 TEST MODE: test --clean --debug --suspend --offline
+        result = CliDriver.execute(project, "test", "-e", "--dry-run",
+                "--clean", "--debug", "--suspend", "--debug-mode=listen", "--offline");
+        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+                "Expected OK return code. Result:\n" + result);
+        Assertions.assertTrue(result.stdout.contains("Run current project in continuous test mode"), result.toString());
+
+        // 5 TEST MODE - run once: test --once --offline
+        result = CliDriver.execute(project, "test", "-e", "--dry-run",
+                "--once", "--offline");
+        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+                "Expected OK return code. Result:\n" + result);
+        Assertions.assertTrue(result.stdout.contains("Run current project in test mode"), result.toString());
     }
 
     @Test

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -279,6 +279,14 @@ public class CliProjectMavenTest {
                 "--clean", "--debug", "--suspend", "--debug-mode=listen", "--offline");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
+        Assertions.assertTrue(result.stdout.contains("Run current project in continuous test mode"), result.toString());
+
+        // 5 TEST MODE - run once: test --once --offline
+        result = CliDriver.execute(project, "test", "-e", "--dry-run",
+                "--once", "--offline");
+        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+                "Expected OK return code. Result:\n" + result);
+        Assertions.assertTrue(result.stdout.contains("Run current project in test mode"), result.toString());
     }
 
     @Test

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -276,17 +276,19 @@ public class CliProjectMavenTest {
 
         // 4 TEST MODE: test --clean --debug --suspend --offline
         result = CliDriver.execute(project, "test", "-e", "--dry-run",
-                "--clean", "--debug", "--suspend", "--debug-mode=listen", "--offline");
+                "--clean", "--debug", "--suspend", "--debug-mode=listen", "--offline", "--filter=FooTest");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("Run current project in continuous test mode"), result.toString());
+        Assertions.assertTrue(result.stdout.contains("-Dquarkus.test.include-pattern=FooTest"), result.toString());
 
         // 5 TEST MODE - run once: test --once --offline
         result = CliDriver.execute(project, "test", "-e", "--dry-run",
-                "--once", "--offline");
+                "--once", "--offline", "--filter=FooTest");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("Run current project in test mode"), result.toString());
+        Assertions.assertTrue(result.stdout.contains("-Dtest=FooTest"), result.toString());
     }
 
     @Test


### PR DESCRIPTION
- add an option to run the test suite and exit (fixes #35290)
- add an option to filter the tests  (fixes #35292)

As for the names - the option to disable the continuous mode is currently `--once`, but I can imagine that we use `--no-continuous` instead (or maybe even the single-character variant `-n`), i.e. `quarkus test --no-continuous` instead of `quarkus test --once`, which would be consistent with other negatable = true options such as `--no-tests` and `--tests`. OTOH `--once` is easier to type :shrug:.