### PR TITLE
Register arrays of Hibernate ORM's JDBC basic types for reflection 

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/GraalVMFeatures.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/GraalVMFeatures.java
@@ -28,4 +28,13 @@ public class GraalVMFeatures {
                 .build();
     }
 
+    // Workaround for https://hibernate.atlassian.net/browse/HHH-16809
+    // See https://github.com/hibernate/hibernate-orm/pull/6815#issuecomment-1662197545
+    @BuildStep
+    ReflectiveClassBuildItem registerJdbcArrayTypesForReflection() {
+        return ReflectiveClassBuildItem
+                .builder(HibernateOrmTypes.JDBC_JAVA_TYPES.stream().map(d -> d.toString() + "[]").toArray(String[]::new))
+                .build();
+    }
+
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -461,10 +461,10 @@ public final class HibernateOrmProcessor {
             // but there are plans to make deep changes to XML mapping in ORM (to rely on Jandex directly),
             // so let's not waste our time on optimizations that won't be relevant in a few months.
             List<String> annotationClassNames = new ArrayList<>();
-            for (DotName name : HibernateOrmAnnotations.JPA_MAPPING_ANNOTATIONS) {
+            for (DotName name : HibernateOrmTypes.JPA_MAPPING_ANNOTATIONS) {
                 annotationClassNames.add(name.toString());
             }
-            for (DotName name : HibernateOrmAnnotations.HIBERNATE_MAPPING_ANNOTATIONS) {
+            for (DotName name : HibernateOrmTypes.HIBERNATE_MAPPING_ANNOTATIONS) {
                 annotationClassNames.add(name.toString());
             }
             reflective.produce(ReflectiveClassBuildItem.builder(annotationClassNames.toArray(new String[0]))
@@ -766,7 +766,7 @@ public final class HibernateOrmProcessor {
         Set<String> classes = new HashSet<>();
 
         // Built-in service classes; can't rely on Jandex as Hibernate ORM is not indexed by default.
-        HibernateOrmAnnotations.ANNOTATED_WITH_INJECT_SERVICE.stream()
+        HibernateOrmTypes.ANNOTATED_WITH_INJECT_SERVICE.stream()
                 .map(DotName::toString)
                 .forEach(classes::add);
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmTypes.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmTypes.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 import org.jboss.jandex.DotName;
 
-public final class HibernateOrmAnnotations {
+public final class HibernateOrmTypes {
 
-    private HibernateOrmAnnotations() {
+    private HibernateOrmTypes() {
     }
 
     public static final List<DotName> PACKAGE_ANNOTATIONS = List.of(
@@ -316,4 +316,41 @@ public final class HibernateOrmAnnotations {
             DotName.createSimple("jakarta.persistence.PreRemove"),
             DotName.createSimple("jakarta.persistence.PreUpdate"));
 
+    public static final List<DotName> JDBC_JAVA_TYPES = List.of(
+            DotName.createSimple("java.lang.Boolean"),
+            DotName.createSimple("java.lang.Byte"),
+            DotName.createSimple("java.lang.Character"),
+            DotName.createSimple("java.lang.Class"),
+            DotName.createSimple("java.lang.Double"),
+            DotName.createSimple("java.lang.Float"),
+            DotName.createSimple("java.lang.Integer"),
+            DotName.createSimple("java.lang.Long"),
+            DotName.createSimple("java.lang.Object"),
+            DotName.createSimple("java.lang.Short"),
+            DotName.createSimple("java.lang.String"),
+            DotName.createSimple("java.math.BigDecimal"),
+            DotName.createSimple("java.math.BigInteger"),
+            DotName.createSimple("java.net.InetAddress"),
+            DotName.createSimple("java.net.URL"),
+            DotName.createSimple("java.sql.Blob"),
+            DotName.createSimple("java.sql.Clob"),
+            DotName.createSimple("java.sql.NClob"),
+            DotName.createSimple("java.time.Duration"),
+            DotName.createSimple("java.time.Instant"),
+            DotName.createSimple("java.time.LocalDate"),
+            DotName.createSimple("java.time.LocalDateTime"),
+            DotName.createSimple("java.time.LocalTime"),
+            DotName.createSimple("java.time.OffsetDateTime"),
+            DotName.createSimple("java.time.OffsetTime"),
+            DotName.createSimple("java.time.Year"),
+            DotName.createSimple("java.time.ZoneId"),
+            DotName.createSimple("java.time.ZoneOffset"),
+            DotName.createSimple("java.time.ZonedDateTime"),
+            DotName.createSimple("java.util.Calendar"),
+            DotName.createSimple("java.util.Currency"),
+            DotName.createSimple("java.util.Date"),
+            DotName.createSimple("java.util.Locale"),
+            DotName.createSimple("java.util.Map$Entry"),
+            DotName.createSimple("java.util.TimeZone"),
+            DotName.createSimple("java.util.UUID"));
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/JpaJandexScavenger.java
@@ -85,7 +85,7 @@ public final class JpaJandexScavenger {
     public JpaModelBuildItem discoverModelAndRegisterForReflection() {
         Collector collector = new Collector();
 
-        for (DotName packageAnnotation : HibernateOrmAnnotations.PACKAGE_ANNOTATIONS) {
+        for (DotName packageAnnotation : HibernateOrmTypes.PACKAGE_ANNOTATIONS) {
             enlistJPAModelAnnotatedPackages(collector, packageAnnotation);
         }
         enlistJPAModelClasses(collector, ClassNames.JPA_ENTITY);
@@ -95,7 +95,7 @@ public final class JpaJandexScavenger {
         enlistEmbeddedsAndElementCollections(collector);
 
         enlistPotentialCdiBeanClasses(collector, ClassNames.CONVERTER);
-        for (DotName annotation : HibernateOrmAnnotations.JPA_LISTENER_ANNOTATIONS) {
+        for (DotName annotation : HibernateOrmTypes.JPA_LISTENER_ANNOTATIONS) {
             enlistPotentialCdiBeanClasses(collector, annotation);
         }
 

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityTestEndpoint.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/JPAFunctionalityTestEndpoint.java
@@ -57,6 +57,8 @@ public class JPAFunctionalityTestEndpoint extends HttpServlet {
 
         deleteAllPerson(entityManagerFactory);
 
+        // Try an entity using a UUID
+        verifyUUIDEntity(entityManagerFactory);
     }
 
     private static void verifyJPANamedQuery(final EntityManagerFactory emf) {
@@ -142,6 +144,27 @@ public class JPAFunctionalityTestEndpoint extends HttpServlet {
 
     private static String randomName() {
         return UUID.randomUUID().toString();
+    }
+
+    private static void verifyUUIDEntity(final EntityManagerFactory emf) {
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction transaction = em.getTransaction();
+        transaction.begin();
+        MyUUIDEntity myEntity = new MyUUIDEntity();
+        myEntity.setName("George");
+        em.persist(myEntity);
+        transaction.commit();
+        em.close();
+
+        em = emf.createEntityManager();
+        transaction = em.getTransaction();
+        transaction.begin();
+        myEntity = em.find(MyUUIDEntity.class, myEntity.getId());
+        if (myEntity == null || !"George".equals(myEntity.getName())) {
+            throw new RuntimeException("Incorrect loaded MyUUIDEntity " + myEntity);
+        }
+        transaction.commit();
+        em.close();
     }
 
     private void reportException(String errorMessage, final Exception e, final HttpServletResponse resp) throws IOException {

--- a/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/MyUUIDEntity.java
+++ b/integration-tests/jpa-postgresql/src/main/java/io/quarkus/it/jpa/postgresql/MyUUIDEntity.java
@@ -1,0 +1,41 @@
+package io.quarkus.it.jpa.postgresql;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity(name = "uuidentity")
+public class MyUUIDEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+    private String name;
+
+    public MyUUIDEntity() {
+    }
+
+    public MyUUIDEntity(UUID id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
Fixes #34071

Essentially this is a workaround for https://hibernate.atlassian.net/browse/HHH-16809, which from the looks of it is not considered a priority and won't be solved anytime soon.

See also https://github.com/hibernate/hibernate-orm/pull/6815#issuecomment-1662197545

And before anyone (i.e. @Sanne ;) ) tells me "you could have tried to detect which of those types are actually useful for a given application"... yes, I could have, but:

1. I'd need to process `@Id`, `@IdClass`/`@EmbeddedId` with a single column, XML mapping, ...
2. I couldn't do it with perfect accuracy, because it's the JDBC type that matters, and that's not the same as the property type. `AttributeConverter` being one example, but there are probably others.
3. GraalVM's "features" are not a viable option either as JDBC types are all reachable through a map (i.e. GraalVM cannot distinguish being one type being retrieved or another).
4. Frankly we're talking about just a few standard Java types (and not even those types, just *their array types*), so let's not bother.
