### PR TITLE
Picocli: do not register all commands as beans automatically

### DIFF
--- a/extensions/picocli/deployment/src/main/java/io/quarkus/picocli/deployment/PicocliProcessor.java
+++ b/extensions/picocli/deployment/src/main/java/io/quarkus/picocli/deployment/PicocliProcessor.java
@@ -5,14 +5,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.jboss.jandex.AnnotationTarget;
-import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
-import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
+import io.quarkus.arc.deployment.AutoAddScopeBuildItem;
 import io.quarkus.arc.processor.AnnotationsTransformer;
+import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -21,6 +22,7 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.QuarkusApplicationClassBuildItem;
+import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.picocli.runtime.DefaultPicocliCommandLineFactory;
 import io.quarkus.picocli.runtime.PicocliRunner;
 import io.quarkus.picocli.runtime.annotations.TopCommand;
@@ -35,8 +37,34 @@ class PicocliProcessor {
     }
 
     @BuildStep
-    BeanDefiningAnnotationBuildItem commandBeanDefiningAnnotation() {
-        return new BeanDefiningAnnotationBuildItem(DotName.createSimple(CommandLine.Command.class.getName()));
+    void addScopeToCommands(BuildProducer<AutoAddScopeBuildItem> autoAddScope) {
+        // First add @Dependent to all classes annotated with @Command that:
+        // (a) require container services
+        autoAddScope.produce(AutoAddScopeBuildItem.builder()
+                .isAnnotatedWith(DotName.createSimple(CommandLine.Command.class.getName()))
+                .requiresContainerServices()
+                .defaultScope(BuiltinScope.DEPENDENT)
+                .priority(20)
+                .unremovable()
+                .build());
+        // (b) or declare a single constructor with at least one parameter
+        autoAddScope.produce(AutoAddScopeBuildItem.builder()
+                .match((clazz, annotations, index) -> {
+                    List<MethodInfo> constructors = clazz.methods().stream().filter(m -> m.name().equals(MethodDescriptor.INIT))
+                            .collect(Collectors.toList());
+                    return constructors.size() == 1 && constructors.get(0).parametersCount() > 0;
+                })
+                .isAnnotatedWith(DotName.createSimple(CommandLine.Command.class.getName()))
+                .defaultScope(BuiltinScope.DEPENDENT)
+                .priority(10)
+                .unremovable()
+                .build());
+        // Also add @Dependent to any class annotated with @TopCommand
+        autoAddScope.produce(AutoAddScopeBuildItem.builder()
+                .isAnnotatedWith(DotName.createSimple(TopCommand.class.getName()))
+                .defaultScope(BuiltinScope.DEPENDENT)
+                .unremovable()
+                .build());
     }
 
     @BuildStep
@@ -56,7 +84,14 @@ class PicocliProcessor {
             List<DotName> commands = classesAnnotatedWith(applicationIndex.getIndex(),
                     CommandLine.Command.class.getName());
             if (commands.size() == 1) {
-                annotationsTransformer.produce(createAnnotationTransformer(commands.get(0)));
+                // If there is exactly one @Command then make it @TopCommand
+                DotName singleCommandClassName = commands.get(0);
+                annotationsTransformer.produce(new AnnotationsTransformerBuildItem(
+                        AnnotationsTransformer.appliedToClass()
+                                .whenClass(c -> c.name().equals(singleCommandClassName))
+                                // Make sure the transformation is applied before AutoAddScopeBuildItem is processed
+                                .priority(2000)
+                                .thenTransform(t -> t.add(TopCommand.class))));
             }
         }
         if (index.getAnnotations(DotName.createSimple(QuarkusMain.class.getName())).isEmpty()) {
@@ -64,24 +99,6 @@ class PicocliProcessor {
             additionalBean.produce(AdditionalBeanBuildItem.unremovableOf(DefaultPicocliCommandLineFactory.class));
             quarkusApplicationClass.produce(new QuarkusApplicationClassBuildItem(PicocliRunner.class));
         }
-    }
-
-    private AnnotationsTransformerBuildItem createAnnotationTransformer(DotName className) {
-        return new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
-
-            @Override
-            public boolean appliesTo(org.jboss.jandex.AnnotationTarget.Kind kind) {
-                return kind == org.jboss.jandex.AnnotationTarget.Kind.CLASS;
-            }
-
-            @Override
-            public void transform(TransformationContext context) {
-                ClassInfo target = context.getTarget().asClass();
-                if (target.name().equals(className)) {
-                    context.transform().add(TopCommand.class).done();
-                }
-            }
-        });
     }
 
     private List<DotName> classesAnnotatedWith(IndexView indexView, String annotationClassName) {


### PR DESCRIPTION
Currently, we register all command classes as beans. This is unnecessary. This commit ensures that (1) commands that require a CDI service are registered as beans or (2) a single TopCommand is also registered as bean (if needed).