### PR TITLE
Mark CLI tooling as stable

### DIFF
--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -4,15 +4,12 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Building Quarkus apps with Quarkus Command Line Interface (CLI)
-:extension-status: stable
 include::_attributes.adoc[]
 :categories: tooling
 :summary: Use the Quarkus CLI to create, build, run, and manage extensions for Quarkus projects.
 
 The `quarkus` command lets you create projects, manage extensions and
 do essential build and development tasks using the underlying project build tool.
-
-include::{includes}/extension-status.adoc[]
 
 == Installing the CLI
 

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Building Quarkus apps with Quarkus Command Line Interface (CLI)
-:extension-status: preview
+:extension-status: stable
 include::_attributes.adoc[]
 :categories: tooling
 :summary: Use the Quarkus CLI to create, build, run, and manage extensions for Quarkus projects.


### PR DESCRIPTION
cli is stable (actually since 3.0/3.2)

see https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/CLI.20preview.20warning/near/376596814