### PR TITLE
Runtime initialize org.jboss.resteasy.spi.ResourceCleaner

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ResteasyReactiveCommonProcessor.java
@@ -54,6 +54,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.resteasy.reactive.common.runtime.JaxRsSecurityConfig;
 import io.quarkus.resteasy.reactive.common.runtime.ResteasyReactiveConfig;
@@ -76,6 +77,16 @@ public class ResteasyReactiveCommonProcessor {
     private static final int LEGACY_WRITER_PRIORITY = Priorities.USER / 2; // writers are compared by increased priority
 
     private static final String PROVIDERS_SERVICE_FILE = "META-INF/services/" + Providers.class.getName();
+
+    /**
+     * ResourceCleaner contains java.lang.ref.Cleaner references which need to get
+     * runtime initialized.
+     */
+    @BuildStep
+    public RuntimeInitializedClassBuildItem runtimeInitResourceCleaner() {
+        return new RuntimeInitializedClassBuildItem(
+                "org.jboss.resteasy.spi.ResourceCleaner");
+    }
 
     @BuildStep
     void searchForProviders(Capabilities capabilities,


### PR DESCRIPTION
org.jboss.resteasy.spi.ResourceCleaner needs to be runtime initialized both in resteasy-classic and resteasy-reactive.

Follow-up to https://github.com/quarkusio/quarkus/pull/31452

Resolves issue with quarkus test suite http-advanced-reactive test. To reproduce run:

```
git clone  -b 3.2 git@github.com:quarkus-qe/quarkus-test-suite.git
cd quarkus-test-suite/http/http-advanced-reactive
mvn clean verify -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.0-java17  -Dquarkus.platform.version=3.2.3.Final
```