### PR TITLE
MockServer KubernetesClient shouldn't be used

### DIFF
--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -163,6 +163,8 @@ public class KubernetesClientTest {
 
     @KubernetesTestServer
     KubernetesServer mockServer;
+    @Inject
+    KubernetesClient client;
 
     @BeforeEach
     public void before() {
@@ -170,8 +172,8 @@ public class KubernetesClientTest {
         final Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").withNamespace("test").and().build();
 
         // Set up Kubernetes so that our "pretend" pods are created
-        mockServer.getClient().pods().create(pod1);
-        mockServer.getClient().pods().create(pod2);
+        client.pods().resource(pod1).create();
+        client.pods().resource(pod2).create();
     }
 
     @Test

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesNewClientTest.java
@@ -45,8 +45,8 @@ class KubernetesNewClientTest {
         Pod pod1 = new PodBuilder().withNewMetadata().withName("pod1").withNamespace("test").and().build();
         Pod pod2 = new PodBuilder().withNewMetadata().withName("pod2").withNamespace("test").and().build();
 
-        mockServer.getClient().inNamespace("test").pods().create(pod1);
-        mockServer.getClient().inNamespace("test").pods().create(pod2);
+        mockServer.getClient().inNamespace("test").resource(pod1).create();
+        mockServer.getClient().inNamespace("test").resource(pod2).create();
     }
 
 }

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/OpenShiftTestServerTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/OpenShiftTestServerTest.java
@@ -30,12 +30,10 @@ class OpenShiftTestServerTest {
 
     @Test
     void testInjectionDefaultsToCrud() {
-        mockServer.getOpenshiftClient().projects().createOrReplace(new ProjectBuilder()
+        client.projects().createOrReplace(new ProjectBuilder()
                 .withNewMetadata().withName("example-project").addToLabels("project", "crud-is-true").endMetadata()
                 .build());
         assertThat(client)
-                .isNotSameAs(mockServer.getOpenshiftClient())
-                .isNotSameAs(mockServer.getOpenshiftClient())
                 .returns("crud-is-true",
                         c -> c.projects().withName("example-project").get().getMetadata().getLabels().get("project"));
     }


### PR DESCRIPTION
Related to #35338

Users should inject the Quarkus-customized `KubernetesClient` instead of relying on the one provided by the Mock Server.

Not doing so might cause issue with the `KubernetesSerialization` and `ObjectMapper` customizations handled by Quarkus.

e.g. For Kotlin to work users need to add the `KotlinModule`

```
mapper.registerModule(KotlinModule.Builder().enable(KotlinFeature.NullToEmptyCollection).enable(KotlinFeature.NullToEmptyMap).build())
```

This PR addresses the issue by modifying the documentation so that it becomes clear.
It also removes some invalid use-cases within the Quarkus code-base.