### PR TITLE
CLI: remove unused PluginCatalogService in CliPluginsSync

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsSync.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsSync.java
@@ -15,8 +15,6 @@ public class CliPluginsSync extends CliPluginsBase implements Callable<Integer> 
     @CommandLine.Mixin
     RunModeOption runMode;
 
-    PluginCatalogService pluginCatalogService = new PluginCatalogService();
-
     @Override
     public Integer call() {
         output.throwIfUnmatchedArguments(spec.commandLine());


### PR DESCRIPTION
- PluginCatalogService initializes a new com.fasterxml.jackson.databind.ObjectMapper eagerly