### PR TITLE
Reduce the number of ArchivePathTree instances for the same path and opening same JARs multiple times

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/BootstrapConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/BootstrapConfig.java
@@ -25,6 +25,16 @@ public class BootstrapConfig {
     Boolean workspaceDiscovery;
 
     /**
+     * By default, the bootstrap mechanism will create a shared cache of open JARs for
+     * Quarkus classloaders to reduce the total number of opened ZIP FileSystems in dev and test modes.
+     * Setting system property {@code quarkus.bootstrap.disable-jar-cache} to {@code true} will make
+     * Quarkus classloaders create a new ZIP FileSystem for each JAR classpath element every time it is added
+     * to a Quarkus classloader.
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean disableJarCache;
+
+    /**
      * Whether to throw an error, warn or silently ignore misaligned platform BOM imports
      */
     @ConfigItem(defaultValue = "error")

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
@@ -47,7 +47,8 @@ public interface PathTree {
     static PathTree ofDirectoryOrArchive(Path p, PathFilter filter) {
         try {
             final BasicFileAttributes fileAttributes = Files.readAttributes(p, BasicFileAttributes.class);
-            return fileAttributes.isDirectory() ? new DirectoryPathTree(p, filter) : new ArchivePathTree(p, filter);
+            return fileAttributes.isDirectory() ? new DirectoryPathTree(p, filter)
+                    : ofArchive(p, filter);
         } catch (IOException e) {
             throw new IllegalArgumentException(p + " does not exist", e);
         }
@@ -76,7 +77,8 @@ public interface PathTree {
         if (!Files.exists(archive)) {
             throw new IllegalArgumentException(archive + " does not exist");
         }
-        return new ArchivePathTree(archive, filter);
+
+        return ArchivePathTree.forPath(archive, filter);
     }
 
     /**

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeBuilder.java
@@ -71,7 +71,7 @@ public class PathTreeBuilder {
             throw new IllegalArgumentException(root + " does not exist");
         }
         if (archive) {
-            return new ArchivePathTree(root, getPathFilter(), manifestEnabled == null ? true : manifestEnabled);
+            return ArchivePathTree.forPath(root, getPathFilter(), manifestEnabled == null ? true : manifestEnabled);
         }
         if (Files.isDirectory(root)) {
             return new DirectoryPathTree(root, getPathFilter(), manifestEnabled == null ? false : manifestEnabled);

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeWithManifest.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTreeWithManifest.java
@@ -34,7 +34,7 @@ public abstract class PathTreeWithManifest implements PathTree {
         } catch (Exception e) {
             //version 8
             throw new IllegalStateException(
-                    "Failed to obtain the Java vesion from java.lang.Runtime, possibly it's Java 8 which is not supported anymore",
+                    "Failed to obtain the Java version from java.lang.Runtime, possibly it's Java 8 which is not supported anymore",
                     e);
         }
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/SharedArchivePathTree.java
@@ -1,0 +1,187 @@
+package io.quarkus.paths;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.jar.Manifest;
+
+/**
+ * While {@link ArchivePathTree} implementation is thread-safe, this implementation
+ * provides a way for multiple concurrent users to share the same instance of an open archive,
+ * instead of every user opening its own copy of it.
+ */
+class SharedArchivePathTree extends ArchivePathTree {
+
+    // It would probably be better to have a weak hash map based cache,
+    // however as the first iteration it'll already be more efficient than before
+    private static final Map<Path, SharedArchivePathTree> CACHE = new ConcurrentHashMap<>();
+
+    /**
+     * Returns an instance of {@link ArchivePathTree} for the {@code path} either from a cache
+     * or creates a new instance for it and puts it in the cache.
+     *
+     * @param path path to an archive
+     * @return instance of {@link ArchivePathTree}, never null
+     */
+    static ArchivePathTree forPath(Path path) {
+        return CACHE.computeIfAbsent(path, SharedArchivePathTree::new);
+    }
+
+    /**
+     * Removes an entry for {@code path} from the path tree cache. If the cache
+     * does not contain an entry for the {@code path}, the method will return silently.
+     *
+     * @param path path to remove from the cache
+     */
+    static void removeFromCache(Path path) {
+        CACHE.remove(path);
+    }
+
+    private final AtomicInteger openCount = new AtomicInteger();
+    private volatile SharedOpenArchivePathTree lastOpen;
+
+    SharedArchivePathTree(Path archive) {
+        super(archive);
+    }
+
+    @Override
+    public OpenPathTree open() {
+        var lastOpen = this.lastOpen;
+        if (lastOpen != null && lastOpen.acquire()) {
+            return new CallerOpenPathTree(lastOpen);
+        }
+        try {
+            this.lastOpen = new SharedOpenArchivePathTree(openFs());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return new CallerOpenPathTree(this.lastOpen);
+    }
+
+    private class SharedOpenArchivePathTree extends OpenArchivePathTree {
+
+        private final AtomicInteger users = new AtomicInteger(1);
+
+        protected SharedOpenArchivePathTree(FileSystem fs) {
+            super(fs);
+            openCount.incrementAndGet();
+        }
+
+        private boolean acquire() {
+            readLock().lock();
+            final boolean result = lastOpen == this && isOpen();
+            if (result) {
+                users.incrementAndGet();
+            }
+            readLock().unlock();
+            return result;
+        }
+
+        @Override
+        public void close() throws IOException {
+            writeLock().lock();
+            final boolean close = users.decrementAndGet() == 0;
+            try {
+                if (close) {
+                    if (lastOpen == this) {
+                        lastOpen = null;
+                    }
+                    if (openCount.decrementAndGet() == 0) {
+                        removeFromCache(archive);
+                    }
+                    super.close();
+                }
+            } finally {
+                writeLock().unlock();
+            }
+        }
+    }
+
+    /**
+     * This is a caller "view" of an underlying {@link OpenPathTree} instance that
+     * delegates only the first {@link #close()} call by the caller to the underlying {@link OpenPathTree} instance
+     * with subsequent {@link #close()} calls ignored.
+     */
+    private static class CallerOpenPathTree implements OpenPathTree {
+
+        private final SharedOpenArchivePathTree delegate;
+        private volatile boolean closed;
+
+        private CallerOpenPathTree(SharedOpenArchivePathTree delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public PathTree getOriginalTree() {
+            return delegate.getOriginalTree();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return !closed && delegate.isOpen();
+        }
+
+        @Override
+        public Path getPath(String relativePath) {
+            return delegate.getPath(relativePath);
+        }
+
+        @Override
+        public Collection<Path> getRoots() {
+            return delegate.getRoots();
+        }
+
+        @Override
+        public Manifest getManifest() {
+            return delegate.getManifest();
+        }
+
+        @Override
+        public void walk(PathVisitor visitor) {
+            delegate.walk(visitor);
+        }
+
+        @Override
+        public <T> T apply(String relativePath, Function<PathVisit, T> func) {
+            return delegate.apply(relativePath, func);
+        }
+
+        @Override
+        public void accept(String relativePath, Consumer<PathVisit> consumer) {
+            delegate.accept(relativePath, consumer);
+        }
+
+        @Override
+        public boolean contains(String relativePath) {
+            return delegate.contains(relativePath);
+        }
+
+        @Override
+        public OpenPathTree open() {
+            return delegate.open();
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed) {
+                return;
+            }
+            delegate.writeLock().lock();
+            try {
+                if (!closed) {
+                    closed = true;
+                    delegate.close();
+                }
+            } finally {
+                delegate.writeLock().unlock();
+            }
+        }
+    }
+}

--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/RunAndCheckMojoTestBase.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/RunAndCheckMojoTestBase.java
@@ -101,7 +101,7 @@ public class RunAndCheckMojoTestBase extends MojoTestBase {
         //running at once, if they add default to 75% of total mem we can easily run out
         //of physical memory as they will consume way more than what they need instead of
         //just running GC
-        args.add("-Djvm.args=-Xmx192m");
+        args.add("-Djvm.args=-Xmx128m");
         running.execute(args, Map.of());
     }
 


### PR DESCRIPTION
Related to #35280

This change reduces the number of `ArchivePathTree` instances (pretty much to 1 per JAR) and enables sharing of ZIP FS instances between Quarkus classloaders.

The new behavior is enabled by default but can be disabled by adding `-Dbootstrap.quarkus.disable-jar-cache` to the command line launching dev mode, for example.

With this change `DevMojoIT#testThatTheApplicationIsReloadedMultiModule` passes on my laptop with `-Xmx95m` instead of `-Xmx115` running with `-Dbootstrap.quarkus.disable-jar-cache`.
