### PR TITLE
Disable BearerTokenAuthorizationInGraalITCase as it is unstable

### DIFF
--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationInGraalITCase.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationInGraalITCase.java
@@ -2,12 +2,14 @@ package io.quarkus.it.keycloak;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
+@Disabled
 public class BearerTokenAuthorizationInGraalITCase extends BearerTokenAuthorizationTest {
 
     DevServicesContext context;


### PR DESCRIPTION
Not much information but here is the issue:

```
2023-08-15T23:51:05.1391158Z [ERROR] io.quarkus.it.keycloak.BearerTokenAuthorizationInGraalITCase.testSecureAccessSuccessWithCors -- Time elapsed: 1.302 s <<< FAILURE!
2023-08-15T23:51:05.1391707Z java.lang.AssertionError:
2023-08-15T23:51:05.1391945Z 1 expectation failed.
2023-08-15T23:51:05.1392184Z Expected status code <200> but was <404>.
2023-08-15T23:51:05.1392338Z
2023-08-15T23:51:05.1392611Z 	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
2023-08-15T23:51:05.1393208Z 	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
2023-08-15T23:51:05.1393899Z 	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
2023-08-15T23:51:05.1394484Z 	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
2023-08-15T23:51:05.1394937Z 	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:73)
2023-08-15T23:51:05.1395510Z 	at org.codehaus.groovy.reflection.CachedConstructor.doConstructorInvoke(CachedConstructor.java:60)
2023-08-15T23:51:05.1396169Z 	at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrap.callConstructor(ConstructorSite.java:86)
2023-08-15T23:51:05.1397115Z 	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:57)
2023-08-15T23:51:05.1397730Z 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:263)
2023-08-15T23:51:05.1398344Z 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:277)
2023-08-15T23:51:05.1398996Z 	at io.restassured.internal.ResponseSpecificationImpl$HamcrestAssertionClosure.validate(ResponseSpecificationImpl.groovy:512)
2023-08-15T23:51:05.1399610Z 	at io.restassured.internal.ResponseSpecificationImpl$HamcrestAssertionClosure$validate$1.call(Unknown Source)
2023-08-15T23:51:05.1400283Z 	at io.restassured.internal.ResponseSpecificationImpl.validateResponseIfRequired(ResponseSpecificationImpl.groovy:696)
2023-08-15T23:51:05.1400991Z 	at io.restassured.internal.ResponseSpecificationImpl.this$2$validateResponseIfRequired(ResponseSpecificationImpl.groovy)
2023-08-15T23:51:05.1401562Z 	at jdk.internal.reflect.GeneratedMethodAccessor147.invoke(Unknown Source)
2023-08-15T23:51:05.1402106Z 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2023-08-15T23:51:05.1402567Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
2023-08-15T23:51:05.1403093Z 	at org.codehaus.groovy.runtime.callsite.PlainObjectMetaMethodSite.doInvoke(PlainObjectMetaMethodSite.java:43)
2023-08-15T23:51:05.1403807Z 	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:198)
2023-08-15T23:51:05.1404509Z 	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:62)
2023-08-15T23:51:05.1405114Z 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:185)
2023-08-15T23:51:05.1405718Z 	at io.restassured.internal.ResponseSpecificationImpl.statusCode(ResponseSpecificationImpl.groovy:135)
2023-08-15T23:51:05.1406288Z 	at io.restassured.specification.ResponseSpecification$statusCode$0.callCurrent(Unknown Source)
2023-08-15T23:51:05.1406830Z 	at io.restassured.internal.ResponseSpecificationImpl.statusCode(ResponseSpecificationImpl.groovy:143)
2023-08-15T23:51:05.1407473Z 	at io.restassured.internal.ValidatableResponseOptionsImpl.statusCode(ValidatableResponseOptionsImpl.java:89)
2023-08-15T23:51:05.1408218Z 	at io.quarkus.it.keycloak.BearerTokenAuthorizationTest.testSecureAccessSuccessWithCors(BearerTokenAuthorizationTest.java:36)
```