### PR TITLE
Address Elasticsearch-related integration test failures caused by timeouts

### DIFF
--- a/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/pom.xml
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/pom.xml
@@ -128,6 +128,16 @@
                                                  See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
+                                            <!-- Disable some features that are not needed in our tests and just slow down startup -->
+                                            <xpack.profiling.enabled>false</xpack.profiling.enabled>
+                                            <xpack.monitoring.templates.enabled>false</xpack.monitoring.templates.enabled>
+                                            <xpack.ml.enabled>false</xpack.ml.enabled>
+                                            <xpack.watcher.enabled>false</xpack.watcher.enabled>
+                                            <xpack.ent_search.enabled>false</xpack.ent_search.enabled>
+                                            <stack.templates.enabled>false</stack.templates.enabled>
+                                            <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
+                                            <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
+                                            <slm.history_index_enabled>false</slm.history_index_enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/pom.xml
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/pom.xml
@@ -133,6 +133,16 @@
                                                  See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
+                                            <!-- Disable some features that are not needed in our tests and just slow down startup -->
+                                            <xpack.profiling.enabled>false</xpack.profiling.enabled>
+                                            <xpack.monitoring.templates.enabled>false</xpack.monitoring.templates.enabled>
+                                            <xpack.ml.enabled>false</xpack.ml.enabled>
+                                            <xpack.watcher.enabled>false</xpack.watcher.enabled>
+                                            <xpack.ent_search.enabled>false</xpack.ent_search.enabled>
+                                            <stack.templates.enabled>false</stack.templates.enabled>
+                                            <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
+                                            <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
+                                            <slm.history_index_enabled>false</slm.history_index_enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/elasticsearch-java-client/pom.xml
+++ b/integration-tests/elasticsearch-java-client/pom.xml
@@ -198,7 +198,7 @@
                                                 <method>GET</method>
                                                 <status>200</status>
                                             </http>
-                                            <time>20000</time>
+                                            <time>30000</time>
                                         </wait>
                                     </run>
                                 </image>

--- a/integration-tests/elasticsearch-java-client/pom.xml
+++ b/integration-tests/elasticsearch-java-client/pom.xml
@@ -173,6 +173,16 @@
                                                  See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
+                                            <!-- Disable some features that are not needed in our tests and just slow down startup -->
+                                            <xpack.profiling.enabled>false</xpack.profiling.enabled>
+                                            <xpack.monitoring.templates.enabled>false</xpack.monitoring.templates.enabled>
+                                            <xpack.ml.enabled>false</xpack.ml.enabled>
+                                            <xpack.watcher.enabled>false</xpack.watcher.enabled>
+                                            <xpack.ent_search.enabled>false</xpack.ent_search.enabled>
+                                            <stack.templates.enabled>false</stack.templates.enabled>
+                                            <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
+                                            <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
+                                            <slm.history_index_enabled>false</slm.history_index_enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/elasticsearch-rest-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-client/pom.xml
@@ -173,6 +173,16 @@
                            See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
                        -->
                       <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
+                      <!-- Disable some features that are not needed in our tests and just slow down startup -->
+                      <xpack.profiling.enabled>false</xpack.profiling.enabled>
+                      <xpack.monitoring.templates.enabled>false</xpack.monitoring.templates.enabled>
+                      <xpack.ml.enabled>false</xpack.ml.enabled>
+                      <xpack.watcher.enabled>false</xpack.watcher.enabled>
+                      <xpack.ent_search.enabled>false</xpack.ent_search.enabled>
+                      <stack.templates.enabled>false</stack.templates.enabled>
+                      <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
+                      <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
+                      <slm.history_index_enabled>false</slm.history_index_enabled>
                     </env>
                     <ports>
                       <port>9200:9200</port>

--- a/integration-tests/hibernate-search-orm-elasticsearch-coordination-outbox-polling/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-coordination-outbox-polling/pom.xml
@@ -213,7 +213,18 @@
                                                  and lead to problems on large disks with little space left.
                                                  See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
                                              -->
-                                            <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>                                        </env>
+                                            <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
+                                            <!-- Disable some features that are not needed in our tests and just slow down startup -->
+                                            <xpack.profiling.enabled>false</xpack.profiling.enabled>
+                                            <xpack.monitoring.templates.enabled>false</xpack.monitoring.templates.enabled>
+                                            <xpack.ml.enabled>false</xpack.ml.enabled>
+                                            <xpack.watcher.enabled>false</xpack.watcher.enabled>
+                                            <xpack.ent_search.enabled>false</xpack.ent_search.enabled>
+                                            <stack.templates.enabled>false</stack.templates.enabled>
+                                            <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
+                                            <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
+                                            <slm.history_index_enabled>false</slm.history_index_enabled>
+                                        </env>
                                         <ports>
                                             <port>9200:9200</port>
                                         </ports>

--- a/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
@@ -230,6 +230,16 @@
                                                  See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
+                                            <!-- Disable some features that are not needed in our tests and just slow down startup -->
+                                            <xpack.profiling.enabled>false</xpack.profiling.enabled>
+                                            <xpack.monitoring.templates.enabled>false</xpack.monitoring.templates.enabled>
+                                            <xpack.ml.enabled>false</xpack.ml.enabled>
+                                            <xpack.watcher.enabled>false</xpack.watcher.enabled>
+                                            <xpack.ent_search.enabled>false</xpack.ent_search.enabled>
+                                            <stack.templates.enabled>false</stack.templates.enabled>
+                                            <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
+                                            <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
+                                            <slm.history_index_enabled>false</slm.history_index_enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
@@ -192,6 +192,16 @@
                                                  See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
+                                            <!-- Disable some features that are not needed in our tests and just slow down startup -->
+                                            <xpack.profiling.enabled>false</xpack.profiling.enabled>
+                                            <xpack.monitoring.templates.enabled>false</xpack.monitoring.templates.enabled>
+                                            <xpack.ml.enabled>false</xpack.ml.enabled>
+                                            <xpack.watcher.enabled>false</xpack.watcher.enabled>
+                                            <xpack.ent_search.enabled>false</xpack.ent_search.enabled>
+                                            <stack.templates.enabled>false</stack.templates.enabled>
+                                            <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
+                                            <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
+                                            <slm.history_index_enabled>false</slm.history_index_enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -165,6 +165,16 @@
                                                  See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
+                                            <!-- Disable some features that are not needed in our tests and just slow down startup -->
+                                            <xpack.profiling.enabled>false</xpack.profiling.enabled>
+                                            <xpack.monitoring.templates.enabled>false</xpack.monitoring.templates.enabled>
+                                            <xpack.ml.enabled>false</xpack.ml.enabled>
+                                            <xpack.watcher.enabled>false</xpack.watcher.enabled>
+                                            <xpack.ent_search.enabled>false</xpack.ent_search.enabled>
+                                            <stack.templates.enabled>false</stack.templates.enabled>
+                                            <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
+                                            <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
+                                            <slm.history_index_enabled>false</slm.history_index_enabled>
                                         </env>
                                         <log>
                                             <prefix>Elasticsearch:</prefix>

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-efk.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-efk.yml
@@ -7,7 +7,17 @@ services:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       discovery.type: "single-node"
       xpack.security.enabled: "false"
-      cluster.routing.allocation.disk.threshold_enabled: false
+      cluster.routing.allocation.disk.threshold_enabled: "false"
+      # Disable some features that are not needed in our tests and just slow down startup -->
+      xpack.profiling.enabled: "false"
+      xpack.monitoring.templates.enabled: "false"
+      xpack.ml.enabled: "false"
+      xpack.watcher.enabled: "false"
+      xpack.ent_search.enabled: "false"
+      stack.templates.enabled: "false"
+      cluster.deprecation_indexing.enabled: "false"
+      indices.lifecycle.history_index_enabled: "false"
+      slm.history_index_enabled: "false"
     networks:
       - efk
 

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-elk.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-elk.yml
@@ -8,6 +8,16 @@ services:
       discovery.type: "single-node"
       xpack.security.enabled: "false"
       cluster.routing.allocation.disk.threshold_enabled: false
+      # Disable some features that are not needed in our tests and just slow down startup -->
+      xpack.profiling.enabled: "false"
+      xpack.monitoring.templates.enabled: "false"
+      xpack.ml.enabled: "false"
+      xpack.watcher.enabled: "false"
+      xpack.ent_search.enabled: "false"
+      stack.templates.enabled: "false"
+      cluster.deprecation_indexing.enabled: "false"
+      indices.lifecycle.history_index_enabled: "false"
+      slm.history_index_enabled: "false"
     networks:
       - elk
 

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
@@ -8,6 +8,16 @@ services:
       discovery.type: "single-node"
       xpack.security.enabled: "false"
       cluster.routing.allocation.disk.threshold_enabled: false
+      # Disable some features that are not needed in our tests and just slow down startup -->
+      xpack.profiling.enabled: "false"
+      xpack.monitoring.templates.enabled: "false"
+      xpack.ml.enabled: "false"
+      xpack.watcher.enabled: "false"
+      xpack.ent_search.enabled: "false"
+      stack.templates.enabled: "false"
+      cluster.deprecation_indexing.enabled: "false"
+      indices.lifecycle.history_index_enabled: "false"
+      slm.history_index_enabled: "false"
     networks:
       - graylog
 


### PR DESCRIPTION
I'm not 100% sure about the Gelf tests (they may rely on some of the disabled features), so let's see what CI has to say about it.

cc @gsmet 