### PR TITLE
Use quarkus-parent in independent-projects/enforcer-rules IT

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -19,7 +19,6 @@
         <!-- Maven plugin versions -->
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
-        <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <kotlin.version>1.9.0</kotlin.version>
         <dokka.version>1.8.20</dokka.version>
@@ -28,7 +27,6 @@
         <!-- not pretty but this is used in the codestarts and we don't want to break compatibility -->
         <scala-plugin.version>${scala-maven-plugin.version}</scala-plugin.version>
 
-        <!-- version.* properties are defined in jboss-parent and are overridden/updated here: -->
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.1.2</version.surefire.plugin>
         <version.exec.plugin>3.0.0</version.exec.plugin>

--- a/independent-projects/enforcer-rules/src/it/smoketest/pom.xml
+++ b/independent-projects/enforcer-rules/src/it/smoketest/pom.xml
@@ -3,9 +3,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jboss</groupId>
-        <artifactId>jboss-parent</artifactId>
-        <version>39</version>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>io.quarkus</groupId>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -45,7 +45,6 @@
         <gradle-wrapper.version>8.1.1</gradle-wrapper.version>
 
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
-        <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <kotlin.version>1.6.0</kotlin.version>
         <scala.version>2.12.13</scala.version>

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/pom.xml
@@ -48,12 +48,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.6</version>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-engine</artifactId>
-      <version>7.51.0.Final</version>
+      <version>2.13.0</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/src/main/java/org/acme/ClasspathResources.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/src/main/java/org/acme/ClasspathResources.java
@@ -165,11 +165,13 @@ public class ClasspathResources {
     private String assertUniqueDirectories() {
         final String testType = "unique-directories";
         try {
-            Enumeration<URL> resources = this.getClass().getClassLoader().getResources("META-INF/kie.conf");
+            Enumeration<URL> resources = this.getClass().getClassLoader().getResources("META-INF/quarkus-extension.yaml");
             List<URL> resourcesList = Collections.list(resources);
-            // 'META-INF/kie.conf' should be present in 'kie-internal', 'drools-core', 'drools-compiler' and 'drools-model-compiler'
-            if (resourcesList.size() != 4) {
-                return errorResult(testType, "wrong number of directory urls");
+            // 'META-INF/quarkus-extension.yaml' should be present in all extensions
+            int expected = 12;
+            if (resourcesList.size() != expected) {
+                return errorResult(testType,
+                        "wrong number of directory urls, expected " + expected + " but got " + resourcesList.size());
             }
             return SUCCESS;
         } catch (Exception e) {


### PR DESCRIPTION
JBoss Nexus is currently extremely slow and this is blocking the release.
I disabled the tests anyway for the release in
https://github.com/quarkusio/quarkus/pull/35368 but let's not rely on
jboss-parent anymore.