### PR TITLE
Arc - LockInterceptor should only use secondary locking if there are existing reads

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/LockInterceptor.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/LockInterceptor.java
@@ -45,7 +45,9 @@ public class LockInterceptor {
         boolean locked = false;
 
         try {
-            rl.lock();
+            if (readHoldCount > 0) {
+                rl.lock();
+            }
             try {
                 if (readHoldCount > 0) {
                     // Release all read locks hold by the current thread before acquiring the write lock
@@ -63,7 +65,9 @@ public class LockInterceptor {
                     locked = true;
                 }
             } finally {
-                rl.unlock();
+                if (readHoldCount > 0) {
+                    rl.unlock();
+                }
             }
             return ctx.proceed();
         } finally {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/lock/LockInterceptorDoubleWriteDeadlockTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/lock/LockInterceptorDoubleWriteDeadlockTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.arc.test.lock;
+
+import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.Lock;
+import io.quarkus.arc.impl.LockInterceptor;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class LockInterceptorDoubleWriteDeadlockTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(LockBean.class, LockInterceptor.class,
+            LockInterceptor.class);
+
+    private final ExecutorService threadPool = Executors.newCachedThreadPool();
+
+    @Test
+    void testLocks() throws ExecutionException, InterruptedException {
+        LockBean lockBean = Arc.container().instance(LockBean.class).get();
+        final var futures = new ArrayList<Future<String>>();
+        for (int i = 0; i < 10; i++) {
+            final Future<String> submit = threadPool.submit(() -> {
+                lockBean.method1();
+                return "value";
+            });
+            futures.add(submit);
+        }
+
+        for (final var future : futures) {
+            future.get();
+        }
+
+    }
+
+    @ApplicationScoped
+    @Lock
+    public static class LockBean {
+
+        public void method1() {
+            // invokes another intercepted write-locked method
+            method2();
+        }
+
+        public void method2() {
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #35345

This is a simple fix (and a test) preventing the scenario described in the issue.