### PR TITLE
Re-enable BearerTokenAuthorizationInGraalITCase

### DIFF
--- a/integration-tests/oidc/src/main/resources/application.properties
+++ b/integration-tests/oidc/src/main/resources/application.properties
@@ -11,7 +11,7 @@ quarkus.oidc.tls.key-store-file=client-keystore.jks
 quarkus.oidc.tls.key-store-password=password
 quarkus.native.additional-build-args=-H:IncludeResources=.*\\.jks
 
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 
 quarkus.http.auth.basic=true

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationInGraalITCase.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationInGraalITCase.java
@@ -2,14 +2,12 @@ package io.quarkus.it.keycloak;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-@Disabled
 public class BearerTokenAuthorizationInGraalITCase extends BearerTokenAuthorizationTest {
 
     DevServicesContext context;


### PR DESCRIPTION
There is an issue with supporting `quarkus.http.cors=true` in native, it is expected to work right now according to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.4, so I'll open a separate issue