### PR TITLE
Pass -H:+UnlockExperimentalVMOptions as necessary with Graalvm 23.1

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -792,7 +792,8 @@ public class NativeImageBuildStep {
                         nativeImageArgs.add("-H:ImageBuildStatisticsFile=" + nativeImageName + "-timing-stats.json");
                     }
                     // For getting the build output stats as a JSON file
-                    nativeImageArgs.add("-H:BuildOutputJSONFile=" + nativeImageName + "-build-output-stats.json");
+                    addExperimentalVMOption(nativeImageArgs,
+                            "-H:BuildOutputJSONFile=" + nativeImageName + "-build-output-stats.json");
                 }
 
                 /*
@@ -802,7 +803,7 @@ public class NativeImageBuildStep {
                  */
                 handleAdditionalProperties(nativeImageArgs);
 
-                nativeImageArgs.add("-H:+AllowFoldMethods");
+                addExperimentalVMOption(nativeImageArgs, "-H:+AllowFoldMethods");
 
                 if (nativeConfig.headless()) {
                     nativeImageArgs.add("-J-Djava.awt.headless=true");
@@ -824,7 +825,7 @@ public class NativeImageBuildStep {
                     nativeImageArgs.add("--report-unsupported-elements-at-runtime");
                 }
                 if (nativeConfig.reportExceptionStackTraces()) {
-                    nativeImageArgs.add("-H:+ReportExceptionStackTraces");
+                    addExperimentalVMOption(nativeImageArgs, "-H:+ReportExceptionStackTraces");
                 }
                 if (nativeConfig.debug().enabled()) {
                     nativeImageArgs.add("-g");
@@ -897,11 +898,11 @@ public class NativeImageBuildStep {
                     }
                 }
                 if (nativeConfig.autoServiceLoaderRegistration()) {
-                    nativeImageArgs.add("-H:+UseServiceLoaderFeature");
+                    addExperimentalVMOption(nativeImageArgs, "-H:+UseServiceLoaderFeature");
                     //When enabling, at least print what exactly is being added:
                     nativeImageArgs.add("-H:+TraceServiceLoaderFeature");
                 } else {
-                    nativeImageArgs.add("-H:-UseServiceLoaderFeature");
+                    addExperimentalVMOption(nativeImageArgs, "-H:-UseServiceLoaderFeature");
                 }
                 // This option has no effect on GraalVM 23.1+
                 if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_1_0) < 0) {
@@ -1010,6 +1011,16 @@ public class NativeImageBuildStep {
                             command.add(trimmedBuildArg);
                         }
                     }
+                }
+            }
+
+            private void addExperimentalVMOption(List<String> nativeImageArgs, String option) {
+                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_1_0) >= 0) {
+                    nativeImageArgs.add("-H:+UnlockExperimentalVMOptions");
+                }
+                nativeImageArgs.add(option);
+                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_1_0) >= 0) {
+                    nativeImageArgs.add("-H:-UnlockExperimentalVMOptions");
                 }
             }
         }


### PR DESCRIPTION
Needed since https://github.com/oracle/graal/pull/7190 to avoid warnings

Edit:

The implementation is surrounding the experimental option with enabling/disabling unlock to limit the scope as suggested in https://github.com/oracle/graal/issues/7105#issue-1833493484. Alternatively we could just pass -H:+UnlockExperimentalVMOptions as the first option and allow any experimental option to be passed afterwards. It would make things simpler but would also allow people (both Quarkus users and devs) to use experimental options possibly without noticing.