### PR TITLE
Re-enable kafka-virtual-threads alert-message test

### DIFF
--- a/integration-tests/virtual-threads/amqp-virtual-threads/src/main/java/io/quarkus/it/vthreads/amqp/PriceConsumer.java
+++ b/integration-tests/virtual-threads/amqp-virtual-threads/src/main/java/io/quarkus/it/vthreads/amqp/PriceConsumer.java
@@ -1,6 +1,5 @@
 package io.quarkus.it.vthreads.amqp;
 
-import static io.quarkus.it.vthreads.amqp.AssertHelper.assertThatItDoesNotRunOnVirtualThread;
 import static io.quarkus.it.vthreads.amqp.AssertHelper.assertThatItRunsOnADuplicatedContext;
 import static io.quarkus.it.vthreads.amqp.AssertHelper.assertThatItRunsOnVirtualThread;
 
@@ -34,7 +33,8 @@ public class PriceConsumer {
         }
         return msg.ack().thenAccept(x -> {
             assertThatItRunsOnADuplicatedContext();
-            assertThatItDoesNotRunOnVirtualThread();
+            // While the ack always runs on event loop thread
+            // the post-ack may run on the processing virtual-thread which executed the method.
         });
     }
 

--- a/integration-tests/virtual-threads/kafka-virtual-threads/src/main/java/io/quarkus/it/vthreads/kafka/PriceConsumer.java
+++ b/integration-tests/virtual-threads/kafka-virtual-threads/src/main/java/io/quarkus/it/vthreads/kafka/PriceConsumer.java
@@ -1,6 +1,5 @@
 package io.quarkus.it.vthreads.kafka;
 
-import static io.quarkus.it.vthreads.kafka.AssertHelper.assertThatItDoesNotRunOnVirtualThread;
 import static io.quarkus.it.vthreads.kafka.AssertHelper.assertThatItRunsOnADuplicatedContext;
 import static io.quarkus.it.vthreads.kafka.AssertHelper.assertThatItRunsOnVirtualThread;
 
@@ -34,7 +33,8 @@ public class PriceConsumer {
         }
         return msg.ack().thenAccept(x -> {
             assertThatItRunsOnADuplicatedContext();
-            assertThatItDoesNotRunOnVirtualThread();
+            // While the ack always runs on event loop thread
+            // the post-ack may run on the processing virtual-thread which executed the method.
         });
     }
 

--- a/integration-tests/virtual-threads/kafka-virtual-threads/src/test/java/io/quarkus/it/vthreads/kafka/VirtualThreadTest.java
+++ b/integration-tests/virtual-threads/kafka-virtual-threads/src/test/java/io/quarkus/it/vthreads/kafka/VirtualThreadTest.java
@@ -6,7 +6,6 @@ import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern;
 import static org.awaitility.Awaitility.await;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -29,7 +28,6 @@ public class VirtualThreadTest {
     }
 
     @Test
-    @Disabled("flaky")
     void testAlertMessage() {
         await().untilAsserted(() -> mockServer.verify(new CountMatchingStrategy(GREATER_THAN_OR_EQUAL, EXPECTED_CALLS),
                 newRequestPattern(POST, urlPathEqualTo("/price/alert-message"))));


### PR DESCRIPTION
Post-ack may run on the caller thread (which is the virtual-thread that executed the method)

It was disabled in https://github.com/quarkusio/quarkus/commit/94772f80d792a768f2db3ecc4b50fd8408d91fdc