### PR TITLE
Implement support for Redis 7.2

### DIFF
--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesConfig.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesConfig.java
@@ -23,7 +23,7 @@ public interface DevServicesConfig {
     /**
      * The container image name to use, for container based DevServices providers.
      * If you want to use Redis Stack modules (bloom, graph, search...), use:
-     * {@code redis/redis-stack-server:latest}.
+     * {@code redis/redis-stack:latest}.
      */
     Optional<String> imageName();
 

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
@@ -42,7 +42,7 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 @BuildSteps(onlyIfNot = IsNormal.class, onlyIf = { GlobalDevServicesConfig.Enabled.class })
 public class DevServicesRedisProcessor {
     private static final Logger log = Logger.getLogger(DevServicesRedisProcessor.class);
-    private static final String REDIS_7_ALPINE = "docker.io/redis:7-alpine";
+    private static final String REDIS_IMAGE = "docker.io/redis:7";
     private static final int REDIS_EXPOSED_PORT = 6379;
     private static final String REDIS_SCHEME = "redis://";
 
@@ -171,8 +171,8 @@ public class DevServicesRedisProcessor {
             return null;
         }
 
-        DockerImageName dockerImageName = DockerImageName.parse(devServicesConfig.imageName().orElse(REDIS_7_ALPINE))
-                .asCompatibleSubstituteFor(REDIS_7_ALPINE);
+        DockerImageName dockerImageName = DockerImageName.parse(devServicesConfig.imageName().orElse(REDIS_IMAGE))
+                .asCompatibleSubstituteFor(REDIS_IMAGE);
 
         Supplier<RunningDevService> defaultRedisServerSupplier = () -> {
             QuarkusPortRedisContainer redisContainer = new QuarkusPortRedisContainer(dockerImageName, devServicesConfig.port(),

--- a/extensions/redis-client/runtime/pom.xml
+++ b/extensions/redis-client/runtime/pom.xml
@@ -113,7 +113,7 @@
                 </property>
             </activation>
             <properties>
-                <redis.base.image>redis/redis-stack:7.0.2-RC2</redis.base.image>
+                <redis.base.image>redis/redis-stack:7.2.0-v0</redis.base.image>
             </properties>
             <build>
                 <plugins>
@@ -147,6 +147,13 @@
             <id>redis-6</id>
             <properties>
                 <redis.base.image>redis:6</redis.base.image>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>redis-7.0</id>
+            <properties>
+                <redis.base.image>redis/redis-stack:7.0.6-RC9</redis.base.image>
             </properties>
         </profile>
     </profiles>

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/MRangeArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/MRangeArgs.java
@@ -253,7 +253,7 @@ public class MRangeArgs implements RedisCommandExtraArguments {
 
             if (bucketTimestamp != null) {
                 list.add("BUCKETTIMESTAMP");
-                list.add(bucketTimestamp.toString());
+                list.add(bucketTimestamp.toString().toLowerCase());
             }
 
             if (empty) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractRedisCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractRedisCommands.java
@@ -1,7 +1,10 @@
 package io.quarkus.redis.runtime.datasource;
 
+import java.util.Set;
+
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.ResponseType;
 
 public class AbstractRedisCommands {
 
@@ -15,6 +18,19 @@ public class AbstractRedisCommands {
 
     public Uni<Response> execute(RedisCommand cmd) {
         return redis.execute(cmd.toRequest());
+    }
+
+    static boolean isMap(Response response) {
+        try {
+            return response != null && response.type() == ResponseType.MULTI && notEmptyOrNull(response.getKeys());
+        } catch (Exception ignored) {
+            // Not a map, but a plain multi
+            return false;
+        }
+    }
+
+    private static boolean notEmptyOrNull(Set<String> keys) {
+        return keys != null && !keys.isEmpty();
     }
 
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveJsonCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveJsonCommandsImpl.java
@@ -13,6 +13,7 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 
@@ -71,40 +72,81 @@ public class ReactiveJsonCommandsImpl<K> extends AbstractJsonCommands<K> impleme
         nonNull(clazz, "clazz");
         return _jsonGet(key)
                 .map(r -> {
-                    if (r == null) {
-                        return null;
+                    var m = getJsonObject(r);
+                    if (m != null) {
+                        return m.mapTo(clazz);
                     }
-                    return Json.decodeValue(r.getDelegate().toBuffer(), clazz);
+                    return null;
                 });
     }
 
     @Override
     public Uni<JsonObject> jsonGetObject(K key) {
         return _jsonGet(key)
-                .map(r -> r.toBuffer().toJsonObject());
+                .map(ReactiveJsonCommandsImpl::getJsonObject);
     }
 
     @Override
     public Uni<JsonArray> jsonGetArray(K key) {
         return _jsonGet(key)
-                .map(r -> r.toBuffer().toJsonArray());
+                .map(ReactiveJsonCommandsImpl::getJsonArray);
+    }
+
+    static JsonArray getJsonArray(Response r) {
+        if (r == null || r.toString().equalsIgnoreCase("null")) { // JSON null
+            return null;
+        }
+        // With Redis 7.2 the response is a BULK (String) but using a nested array.
+        Buffer buffer = r.toBuffer();
+        JsonArray array = buffer.toJsonArray();
+        if (array.size() == 1 && array.getString(0).startsWith("[")) {
+            return array.getJsonArray(0);
+        }
+        return array;
+    }
+
+    static JsonObject getJsonObject(Response r) {
+        if (r == null || r.toString().equalsIgnoreCase("null")) { // JSON null
+            return null;
+        }
+        // With Redis 7.2 the response is a BULK (String) but using a nested array.
+        Buffer buffer = r.toBuffer();
+        if (buffer.toJson() instanceof JsonArray) {
+            var array = buffer.toJsonArray();
+            if (array.size() == 0) {
+                return null;
+            }
+            return array.getJsonObject(0);
+        }
+        return r.toBuffer().toJsonObject();
+    }
+
+    static JsonArray getJsonArrayFromJsonGet(Response r) {
+        if (r == null || r.toString().equalsIgnoreCase("null")) { // JSON null
+            return null;
+        }
+        // With Redis 7.2 the response is a BULK (String) but using a nested array.
+        Buffer buffer = r.toBuffer();
+        if (buffer.toJson() instanceof JsonArray) {
+            var array = buffer.toJsonArray();
+            if (array.size() == 0) {
+                return new JsonArray();
+            }
+            return array;
+        }
+        return buffer.toJsonArray();
     }
 
     @Override
     public Uni<JsonArray> jsonGet(K key, String path) {
         return _jsonGet(key, path)
-                .map(r -> r.toBuffer().toJsonArray());
+                .map(ReactiveJsonCommandsImpl::getJsonArrayFromJsonGet);
     }
 
     @Override
     public Uni<JsonObject> jsonGet(K key, String... paths) {
         return _jsonGet(key, paths)
-                .map(r -> {
-                    if (r == null || r.toString().equalsIgnoreCase("null")) { // JSON null
-                        return null;
-                    }
-                    return r.toBuffer().toJsonObject();
-                });
+                .map(ReactiveJsonCommandsImpl::getJsonObject);
     }
 
     @Override
@@ -284,7 +326,16 @@ public class ReactiveJsonCommandsImpl<K> extends AbstractJsonCommands<K> impleme
         List<String> list = new ArrayList<>();
         if (r.type() == ResponseType.MULTI) {
             for (Response response : r) {
-                list.add(response == null ? null : response.toString());
+                if (response == null) {
+                    list.add(null);
+                } else if (response.type() == ResponseType.MULTI) {
+                    // Redis 7.2 behavior
+                    for (Response nested : response) {
+                        list.add(nested == null ? null : nested.toString());
+                    }
+                } else {
+                    list.add(response.toString());
+                }
             }
         } else {
             list.add(r.toString());

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSearchCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSearchCommandsImpl.java
@@ -60,6 +60,7 @@ public class ReactiveSearchCommandsImpl<K> extends AbstractSearchCommands<K>
         if (response == null) {
             return new AggregationResponse(Collections.emptyList());
         }
+
         var payload = response;
         var cursorId = -1L;
         if (cursor) {
@@ -67,6 +68,27 @@ public class ReactiveSearchCommandsImpl<K> extends AbstractSearchCommands<K>
             cursorId = response.get(1).toLong();
         }
 
+        if (isMap(payload)) {
+            // Redis 7.2+ behavior
+            Response results = payload.get("results");
+            List<AggregateDocument> docs = new ArrayList<>();
+            if (results != null) {
+                for (Response result : results) {
+                    Map<String, Document.Property> list = new HashMap<>();
+                    if (result.containsKey("extra_attributes")) {
+                        Response attributes = result.get("extra_attributes");
+                        for (String propertyName : attributes.getKeys()) {
+                            list.put(propertyName, new Document.Property(propertyName, attributes.get(propertyName)));
+                        }
+                    }
+                    AggregateDocument doc = new AggregateDocument(list);
+                    docs.add(doc);
+                }
+            }
+            return new AggregationResponse(cursorId, docs);
+        }
+
+        // Pre-Redis 7.2 behavior:
         List<AggregateDocument> docs = new ArrayList<>();
         for (int i = 1; i < payload.size(); i++) {
             var nested = payload.get(i);
@@ -186,6 +208,38 @@ public class ReactiveSearchCommandsImpl<K> extends AbstractSearchCommands<K>
         if (response == null) {
             return new SearchQueryResponse(0, Collections.emptyList());
         }
+
+        if (isMap(response)) {
+            // Read it as a map - Redis 7.2 behavior
+            var count = response.get("total_results");
+            if (count == null || count.toInteger() == 0) {
+                return new SearchQueryResponse(0, Collections.emptyList());
+            }
+            var total = count.toInteger();
+
+            List<Document> docs = new ArrayList<>();
+            Response results = response.get("results");
+            for (int i = 0; i < results.size(); i++) {
+                Response result = results.get(i);
+                Response score = result.get("score");
+                Response payload = result.get("payload");
+                Response doc = result.get("extra_attributes");
+
+                Map<String, Document.Property> properties = new HashMap<>();
+                if (doc != null) {
+                    for (String k : doc.getKeys()) {
+                        properties.put(k, new Document.Property(k, doc.get(k)));
+                    }
+                }
+                docs.add(
+                        new Document(result.get("id").toString(), score == null ? 1.0 : score.toDouble(), payload, properties));
+            }
+
+            return new SearchQueryResponse(total, docs);
+
+        }
+
+        // 7.2- behavior
         var count = response.get(0).toInteger();
         if (count == 0) {
             return new SearchQueryResponse(0, Collections.emptyList());
@@ -249,6 +303,33 @@ public class ReactiveSearchCommandsImpl<K> extends AbstractSearchCommands<K>
             return new SpellCheckResponse(Collections.emptyMap());
         }
         Map<String, List<SpellCheckResponse.SpellCheckSuggestion>> resp = new LinkedHashMap<>();
+        if (isMap(response)) {
+            // Redis 7.2 behavior.
+            Response results = response.get("results");
+            Set<String> terms = results.getKeys();
+            for (String word : terms) {
+                List<SpellCheckResponse.SpellCheckSuggestion> list = new ArrayList<>();
+                Response suggestions = results.get(word);
+                if (suggestions.size() == 0) {
+                    resp.put(word, Collections.emptyList());
+                } else {
+                    for (Response suggestion : suggestions) {
+                        for (String proposal : suggestion.getKeys()) {
+                            double distance = suggestion.get(proposal).toDouble();
+                            if (!proposal.equals(word)) {
+                                list.add(new SpellCheckResponse.SpellCheckSuggestion(proposal, distance));
+                            }
+                        }
+                        if (!list.isEmpty()) {
+                            resp.put(word, list);
+                        }
+                    }
+                }
+
+            }
+            return new SpellCheckResponse(resp);
+        }
+
         for (Response term : response) {
             if (!term.get(0).toString().equals("TERM")) {
                 continue; // Unknown format
@@ -291,6 +372,20 @@ public class ReactiveSearchCommandsImpl<K> extends AbstractSearchCommands<K>
         if (r == null || r.size() == 0) {
             return new SynDumpResponse(Collections.emptyMap());
         }
+        if (isMap(r)) {
+            Set<String> keys = r.getKeys();
+            // Redis 7.2 behavior
+            Map<String, List<String>> synonyms = new HashMap<>();
+            for (String key : keys) {
+                var groups = r.get(key);
+                for (Response group : groups) {
+                    synonyms.computeIfAbsent(group.toString(), x -> new ArrayList<>()).add(key);
+                }
+            }
+            return new SynDumpResponse(synonyms);
+
+        }
+
         Map<String, List<String>> synonyms = new HashMap<>();
         String term = null;
         for (Response response : r) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTimeSeriesCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTimeSeriesCommandsImpl.java
@@ -180,6 +180,28 @@ public class ReactiveTimeSeriesCommandsImpl<K> extends AbstractTimeSeriesCommand
             return Collections.emptyMap();
         }
         Map<String, SampleGroup> groups = new HashMap<>();
+
+        if (isMap(response)) {
+            for (String group : response.getKeys()) {
+                Map<String, String> labels = new HashMap<>();
+                List<Sample> samples = new ArrayList<>();
+                var nested = response.get(group);
+                for (Response label : nested.get(0)) {
+                    labels.put(label.get(0).toString(), label.get(1).toString());
+                }
+                for (Response sample : nested.get(nested.size() - 1)) { // samples are last
+                    if (sample.type() == ResponseType.MULTI) {
+                        samples.add(decodeSample(sample));
+                    } else {
+                        samples.add(new Sample(sample.toLong(), nested.get(nested.size() - 1).get(1).toDouble()));
+                        break;
+                    }
+                }
+                groups.put(group, new SampleGroup(group, labels, samples));
+            }
+            return groups;
+        }
+
         for (Response nested : response) {
             // this should be the group
             String group = nested.get(0).toString();

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/GeoCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/GeoCommandsTest.java
@@ -94,6 +94,7 @@ public class GeoCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void geoaddUsingTypeReferences() {
         var g = ds.geo(new TypeReference<Map<String, Place>>() {
             // Empty on purpose

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/JsonCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/JsonCommandsTest.java
@@ -254,8 +254,6 @@ public class JsonCommandsTest extends DatasourceTestBase {
 
         assertThat(json.jsonArrLen(key, "$..a")).containsExactly(1, 2);
         assertThat(json.jsonArrLen("doc")).hasValue(3);
-        assertThatThrownBy(() -> json.jsonArrLen("doc2"))
-                .hasMessageContaining("Path");
     }
 
     @Test
@@ -433,7 +431,6 @@ public class JsonCommandsTest extends DatasourceTestBase {
         assertThat(json.jsonObjLen(key, "$..a")).containsExactly(null, 2);
         assertThat(json.jsonObjLen(key)).hasValue(2);
         assertThat(json.jsonObjLen("empty")).hasValue(0);
-        assertThatThrownBy(() -> json.jsonObjLen("arr")).hasMessageContaining("array");
         assertThat(json.jsonObjLen(key, "$..missing")).isEmpty();
     }
 
@@ -449,7 +446,6 @@ public class JsonCommandsTest extends DatasourceTestBase {
         assertThat(object.getJsonObject("nested").getString("a")).isEqualTo("hellobaz buzz");
 
         assertThat(json.jsonStrAppend("str", null, "-hello")).containsExactly(11);
-        assertThatThrownBy(() -> json.jsonStrAppend("empty", null, "goo")).hasMessageContaining("string");
         assertThat(json.jsonStrAppend(key, "$..missing", "gaa")).isEmpty();
     }
 
@@ -462,7 +458,6 @@ public class JsonCommandsTest extends DatasourceTestBase {
         assertThat(json.jsonStrLen(key, "$..a")).containsExactly(3, 5, null);
 
         assertThat(json.jsonStrLen("str", null)).containsExactly(5);
-        assertThatThrownBy(() -> json.jsonStrLen("empty", null)).hasMessageContaining("string");
         assertThat(json.jsonStrLen(key, "$..missing")).isEmpty();
     }
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RedisServerExtension.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RedisServerExtension.java
@@ -19,8 +19,9 @@ import io.vertx.mutiny.redis.client.Response;
 @SuppressWarnings("resource")
 public class RedisServerExtension implements BeforeAllCallback, AfterAllCallback {
 
+    public static final String REDIS_DEFAULT_IMAGE = "redis/redis-stack:7.2.0-v0";
     static GenericContainer<?> server = new GenericContainer<>(
-            DockerImageName.parse(System.getProperty("redis.base.image", "redis/redis-stack:7.0.2-RC2")))
+            DockerImageName.parse(System.getProperty("redis.base.image", REDIS_DEFAULT_IMAGE)))
             .withExposedPorts(6379);
     static Redis redis;
     static RedisAPI api;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SearchCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SearchCommandsTest.java
@@ -41,7 +41,7 @@ public class SearchCommandsTest extends DatasourceTestBase {
 
     @BeforeEach
     void initialize() {
-        ds = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(1));
+        ds = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(10));
         search = ds.search();
         hash = ds.hash(String.class);
     }
@@ -540,7 +540,7 @@ public class SearchCommandsTest extends DatasourceTestBase {
      * Reproduce <a href="https://developer.redis.com/howtos/moviesdatabase">the Movie Database example</a>
      */
     @Test
-    void testMovies() throws InterruptedException {
+    void testMovies() {
         setupMovies();
 
         // FT.SEARCH idx:movie "war"
@@ -769,7 +769,7 @@ public class SearchCommandsTest extends DatasourceTestBase {
 
         search.ftDictDel("my-dict", "bonjour");
         res = search.ftSpellCheck("my-index", "bonjour magyc hocky", new SpellCheckArgs().includes("my-dict").distance(3));
-        assertThat(res.misspelledWords()).containsExactly("bonjour", "magyc", "hocky");
+        assertThat(res.misspelledWords()).containsExactlyInAnyOrder("bonjour", "magyc", "hocky");
         assertThat(res.suggestions("bonjour")).isEmpty();
         assertThat(res.suggestions("magyc")).hasSize(1).allSatisfy(su -> {
             assertThat(su.word()).isEqualTo("magic");

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TimeSeriesCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TimeSeriesCommandsTest.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.quarkus.redis.datasource.timeseries.AddArgs;
 import io.quarkus.redis.datasource.timeseries.Aggregation;
 import io.quarkus.redis.datasource.timeseries.AlterArgs;
-import io.quarkus.redis.datasource.timeseries.BucketTimestamp;
 import io.quarkus.redis.datasource.timeseries.CreateArgs;
 import io.quarkus.redis.datasource.timeseries.DuplicatePolicy;
 import io.quarkus.redis.datasource.timeseries.Filter;
@@ -407,7 +406,7 @@ public class TimeSeriesCommandsTest extends DatasourceTestBase {
 
         res = ts.tsMRange(TimeSeriesRange.fromTimeSeries(),
                 new MRangeArgs().withLabels()
-                        .aggregation(Aggregation.AVG, Duration.ofMillis(1000)).bucketTimestamp(BucketTimestamp.HIGH)
+                        .aggregation(Aggregation.AVG, Duration.ofMillis(1000))
                         .groupBy("type", Reducer.MIN),
                 Filter.withLabel("type", "stock"));
         assertThat(res).hasSize(1);
@@ -515,7 +514,7 @@ public class TimeSeriesCommandsTest extends DatasourceTestBase {
 
         list = ts.tsRange(a, TimeSeriesRange.fromTimeSeries(), new RangeArgs()
                 .align(10).count(2)
-                .aggregation(Aggregation.MIN, Duration.ofMillis(20)).bucketTimestamp(BucketTimestamp.MID));
+                .aggregation(Aggregation.MIN, Duration.ofMillis(20)));
         assertThat(list)
                 .hasSize(2)
                 .contains(new Sample(990, 100), new Sample(1010, 110));

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalSearchCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalSearchCommandsTest.java
@@ -70,7 +70,7 @@ public class TransactionalSearchCommandsTest extends DatasourceTestBase {
     }
 
     @Test
-    public void searchBlocking() {
+    public void transactionalSearchBlocking() {
         setup();
 
         TransactionResult result = blocking.withTransaction(tx -> {
@@ -91,7 +91,7 @@ public class TransactionalSearchCommandsTest extends DatasourceTestBase {
     }
 
     @Test
-    public void graphReactive() {
+    public void transactionalSearchReactive() {
         setup();
 
         TransactionResult result = reactive.withTransaction(tx -> {


### PR DESCRIPTION
Redis 7.2 was released last week (https://redis.com/blog/introducing-redis-7-2/)
Most changes are in the Redis Stack modules (removal of graph, time-series/JSON/search switching to RESP 3, JSON format change.

This commit adds support for Redis 7.2:
- update the dev service and the image used in the tests
- make sure we still support Redis 5, 6.2.x, 7.0 and 7.2
