### PR TITLE
Optionally enforce the OIDC 'sub' claim

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -782,7 +782,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public Optional<List<String>> scopes = Optional.empty();
 
         /**
-         * Require that ID token includes `nonce` claim which must match `nonce` authentication request query parameter.
+         * Require that ID token includes a `nonce` claim which must match `nonce` authentication request query parameter.
          * Enabling this property can help mitigate replay attacks.
          * Do not enable this property if your OpenId Connect provider does not support setting `nonce` in ID token
          * or if you work with OAuth2 provider such as `GitHub` which does not issue ID tokens.
@@ -1302,6 +1302,15 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public Optional<List<String>> audience = Optional.empty();
 
         /**
+         * Require that the token includes a `sub` (subject) claim which is a unique
+         * and never reassigned identifier for the current user.
+         * Note that if you enable this property and if UserInfo is also required then
+         * both the token and UserInfo `sub` claims must be present and match each other.
+         */
+        @ConfigItem(defaultValue = "false")
+        public boolean subjectRequired = false;
+
+        /**
          * A map of required claims and their expected values.
          * For example, `quarkus.oidc.token.required-claims.org_id = org_xyz` would require tokens to have the `org_id` claim to
          * be present and set to `org_xyz`.
@@ -1605,6 +1614,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setCustomizerName(String customizerName) {
             this.customizerName = Optional.of(customizerName);
+        }
+
+        public boolean isSubjectRequired() {
+            return subjectRequired;
+        }
+
+        public void setSubjectRequired(boolean subjectRequired) {
+            this.subjectRequired = subjectRequired;
         }
     }
 

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -90,6 +90,7 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     config.setAuthServerUrl(authServerUri);
                     config.setDiscoveryEnabled(false);
                     config.authentication.setUserInfoRequired(true);
+                    config.token.setSubjectRequired(true);
                     config.setIntrospectionPath("introspect");
                     config.setUserInfoPath("userinfo");
                     config.setClientId("client-introspection-only");

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -494,10 +494,15 @@ public class BearerTokenAuthorizationTest {
                                     + "introspection_client_id:none,introspection_client_secret:none,active:true,userinfo:alice,cache-size:0"));
         }
 
+        RestAssured.given().auth().oauth2(getAccessTokenFromSimpleOidc("987654321", "2"))
+                .when().get("/tenant/tenant-oidc-introspection-only/api/user")
+                .then()
+                .statusCode(401);
+
         RestAssured.when().get("/oidc/jwk-endpoint-call-count").then().body(equalTo("0"));
-        RestAssured.when().get("/oidc/introspection-endpoint-call-count").then().body(equalTo("3"));
+        RestAssured.when().get("/oidc/introspection-endpoint-call-count").then().body(equalTo("4"));
         RestAssured.when().post("/oidc/disable-introspection").then().body(equalTo("false"));
-        RestAssured.when().get("/oidc/userinfo-endpoint-call-count").then().body(equalTo("3"));
+        RestAssured.when().get("/oidc/userinfo-endpoint-call-count").then().body(equalTo("4"));
         RestAssured.when().get("/cache/size").then().body(equalTo("0"));
     }
 
@@ -645,8 +650,13 @@ public class BearerTokenAuthorizationTest {
     }
 
     private String getAccessTokenFromSimpleOidc(String kid) {
+        return getAccessTokenFromSimpleOidc("123456789", kid);
+    }
+
+    private String getAccessTokenFromSimpleOidc(String subject, String kid) {
         String json = RestAssured
                 .given()
+                .queryParam("sub", subject)
                 .queryParam("kid", kid)
                 .formParam("grant_type", "authorization_code")
                 .when()


### PR DESCRIPTION
Fixes #35397.

This PR supports an optional enforcement of the tokens containing a `sub` claim, and adds tests to confirm that if the token and UserInfo `sub` claims do not match then 401 is returned.

Along the way, it optimizes the `nonce` verification added with one of the recent PRs, in #35039 (where an extra token parsing was done before the required token verification involving the same token parsed again). Now it is done in the same ``OidcProvider#verifyJwtTokenInternal` place.