### PR TITLE
Remove devconsole-spi from core

### DIFF
--- a/extensions/container-image/container-image-openshift/deployment/pom.xml
+++ b/extensions/container-image/container-image-openshift/deployment/pom.xml
@@ -20,10 +20,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http-dev-console-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-client-spi</artifactId>
         </dependency>
         <dependency>

--- a/extensions/datasource/runtime/pom.xml
+++ b/extensions/datasource/runtime/pom.xml
@@ -24,11 +24,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http-dev-console-runtime-spi</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>

--- a/extensions/grpc/runtime/pom.xml
+++ b/extensions/grpc/runtime/pom.xml
@@ -52,11 +52,6 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http-dev-console-runtime-spi</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc-stubs</artifactId>
             <exclusions>
                 <exclusion>

--- a/extensions/liquibase/runtime/pom.xml
+++ b/extensions/liquibase/runtime/pom.xml
@@ -60,12 +60,7 @@
             <artifactId>quarkus-vertx-http</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http-dev-console-runtime-spi</artifactId>
-            <optional>true</optional>
-        </dependency>
-
+        
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/vertx-http/deployment/pom.xml
+++ b/extensions/vertx-http/deployment/pom.xml
@@ -27,10 +27,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http-dev-console-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-mutiny-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ArcDevProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ArcDevProcessor.java
@@ -20,7 +20,6 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.devmode.ArcDevRecorder;
@@ -98,21 +97,4 @@ public class ArcDevProcessor {
         props.put("quarkus.arc.exclude-types", "" + arcConfig.excludeTypes.map(Object::toString).orElse(""));
         return props;
     }
-
-    // NOTE: we can't add this build step to the ArC extension as it would cause a cyclic dependency
-    @BuildStep
-    @Record(value = ExecutionTime.STATIC_INIT, optional = true)
-    DevConsoleRouteBuildItem eventsEndpoint(ArcDevRecorder recorder) {
-        return DevConsoleRouteBuildItem.builder().ga("io.quarkus", "quarkus-arc").path("events").method("POST")
-                .handler(recorder.events()).build();
-    }
-
-    // NOTE: we can't add this build step to the ArC extension as it would cause a cyclic dependency
-    @BuildStep
-    @Record(value = ExecutionTime.STATIC_INIT, optional = true)
-    DevConsoleRouteBuildItem invocationsEndpoint(ArcDevRecorder recorder) {
-        return DevConsoleRouteBuildItem.builder().ga("io.quarkus", "quarkus-arc").path("invocations").method("POST")
-                .handler(recorder.invocations()).build();
-    }
-
 }

--- a/extensions/vertx-http/dev-console-spi/pom.xml
+++ b/extensions/vertx-http/dev-console-spi/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>quarkus-vertx-http-dev-console-spi</artifactId>
     <name>Quarkus - Vert.x - HTTP - Dev Console SPI</name>
-
+    
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -34,10 +34,6 @@
             <artifactId>smallrye-common-vertx-context</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http-dev-console-runtime-spi</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus.security</groupId>
             <artifactId>quarkus-security</artifactId>
             <exclusions>

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ArcDevRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ArcDevRecorder.java
@@ -12,20 +12,15 @@ import java.util.Map.Entry;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Default;
 
-import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableObserverMethod;
 import io.quarkus.arc.RemovedBean;
 import io.quarkus.arc.impl.ArcContainerImpl;
-import io.quarkus.arc.runtime.devconsole.InvocationsMonitor;
-import io.quarkus.arc.runtime.devmode.EventsMonitor;
 import io.quarkus.dev.console.DevConsoleManager;
-import io.quarkus.devconsole.runtime.spi.DevConsolePostHandler;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.devmode.Json.JsonArrayBuilder;
 import io.quarkus.vertx.http.runtime.devmode.Json.JsonObjectBuilder;
 import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
 import io.vertx.ext.web.RoutingContext;
 
 @Recorder
@@ -230,37 +225,4 @@ public class ArcDevRecorder {
             }
         };
     }
-
-    // NOTE: we can't add this recorder to the ArC extension as it would cause a cyclic dependency
-    public Handler<RoutingContext> events() {
-        return new DevConsolePostHandler() {
-            @Override
-            protected void handlePost(RoutingContext event, MultiMap form)
-                    throws Exception {
-                String action = form.get("action");
-                if ("skipContext".equals(action)) {
-                    Arc.container().instance(EventsMonitor.class).get().toggleSkipContextEvents();
-                } else {
-                    Arc.container().instance(EventsMonitor.class).get().clear();
-                }
-            }
-        };
-    }
-
-    // NOTE: we can't add this recorder to the ArC extension as it would cause a cyclic dependency
-    public Handler<RoutingContext> invocations() {
-        return new DevConsolePostHandler() {
-            @Override
-            protected void handlePost(RoutingContext event, MultiMap form)
-                    throws Exception {
-                String action = form.get("action");
-                if ("filterOutQuarkusBeans".equals(action)) {
-                    Arc.container().instance(InvocationsMonitor.class).get().toggleFilterOutQuarkusBeans();
-                } else {
-                    Arc.container().instance(InvocationsMonitor.class).get().clear();
-                }
-            }
-        };
-    }
-
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigDescriptionsManager.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigDescriptionsManager.java
@@ -15,15 +15,12 @@ import java.util.function.Supplier;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
-import io.quarkus.devconsole.runtime.spi.DevConsolePostHandler;
 import io.quarkus.devui.runtime.config.ConfigDescription;
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.SmallRyeConfig;
-import io.vertx.core.MultiMap;
 import io.vertx.core.impl.ConcurrentHashSet;
-import io.vertx.ext.web.RoutingContext;
 
-public class ConfigDescriptionsManager extends DevConsolePostHandler implements Supplier<ConfigDescriptionsManager> {
+public class ConfigDescriptionsManager implements Supplier<ConfigDescriptionsManager> {
 
     private final List<ConfigDescription> configDescriptions;
     private final Set<String> devServicesProperties;
@@ -305,16 +302,6 @@ public class ConfigDescriptionsManager extends DevConsolePostHandler implements 
     public ConfigDescriptionsManager get() {
         currentCl = Thread.currentThread().getContextClassLoader();
         return this;
-    }
-
-    @Override
-    protected void handlePost(RoutingContext event, MultiMap form) throws Exception {
-        String name = event.request().getFormAttribute("name");
-        String value = event.request().getFormAttribute("value");
-        addNamedConfigGroup(name + value);
-        event.redirect(event.request().path().replace("add-named-group", "config") + "?"
-                + event.request().query());
-
     }
 
     static class Holder {


### PR DESCRIPTION
@gsmet the classes in the spi module is already deprecated. This PR remove all usage from core.