### PR TITLE
Switch to io.mvnpm for importmaps

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -225,7 +225,7 @@
         <pulsar-client.version>3.0.0</pulsar-client.version>
         <async-http-client.version>2.12.3</async-http-client.version>
         <!-- Dev UI -->
-        <importmap.version>1.0.8</importmap.version>
+        <importmap.version>1.0.9</importmap.version>
         <vaadin.version>24.1.4</vaadin.version>
         <lit.version>2.8.0</lit.version>
         <lit-element.version>3.3.3</lit-element.version>
@@ -3284,7 +3284,7 @@
             <!-- Dev UI -->
             <!-- To create the import map -->
             <dependency>
-                <groupId>org.mvnpm</groupId>
+                <groupId>io.mvnpm</groupId>
                 <artifactId>importmap</artifactId>
                 <version>${importmap.version}</version>
             </dependency>
@@ -3302,6 +3302,12 @@
                 <scope>runtime</scope>
             </dependency>
             <!-- Vaadin Web components -->
+            <dependency>
+                <groupId>org.mvnpm.at.vaadin</groupId>
+                <artifactId>a11y-base</artifactId>
+                <version>${vaadin.version}</version>
+                <scope>runtime</scope>
+            </dependency>
             <dependency>
                 <groupId>org.mvnpm.at.vaadin</groupId>
                 <artifactId>app-layout</artifactId>

--- a/extensions/vertx-http/deployment/pom.xml
+++ b/extensions/vertx-http/deployment/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>quarkus-vertx-http-dev-ui-resources</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mvnpm</groupId>
+            <groupId>io.mvnpm</groupId>
             <artifactId>importmap</artifactId>
         </dependency>
         <!-- Used for the dev ui. Note that there is no corresponding runtime dependency -->

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/BuildTimeContentProcessor.java
@@ -40,11 +40,11 @@ import java.util.regex.Pattern;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
-import org.mvnpm.importmap.Aggregator;
-import org.mvnpm.importmap.Location;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import io.mvnpm.importmap.Aggregator;
+import io.mvnpm.importmap.Location;
 import io.quarkus.builder.Version;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;

--- a/extensions/vertx-http/dev-ui-resources/pom.xml
+++ b/extensions/vertx-http/dev-ui-resources/pom.xml
@@ -25,6 +25,11 @@
         <!-- Vaadin Web components -->
         <dependency>
             <groupId>org.mvnpm.at.vaadin</groupId>
+            <artifactId>a11y-base</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mvnpm.at.vaadin</groupId>
             <artifactId>app-layout</artifactId>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
This PR changes the importmaps groupId. It also add a new vaadin dependency that is already being pulled in transitively, this just locks the version