### PR TITLE
Allow built in `InstrumenterVertxTracer` classes to be disabled

### DIFF
--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/SpanConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/SpanConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.opentelemetry.runtime.config.runtime;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -43,4 +44,16 @@ public interface SpanConfig {
     @WithName("link.count.limit")
     @WithDefault("128")
     Integer linkCountLimit();
+
+    /**
+     * Controls which tracers Quarkus will use by default
+     */
+    @WithDefault("http,eventbus,sql")
+    List<Tracers> enabledTracers();
+
+    enum Tracers {
+        HTTP,
+        EVENTBUS,
+        SQL
+    }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/InstrumentationRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/InstrumentationRecorder.java
@@ -1,16 +1,22 @@
 package io.quarkus.opentelemetry.runtime.tracing.intrumentation;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.opentelemetry.runtime.config.runtime.OTelRuntimeConfig;
+import io.quarkus.opentelemetry.runtime.config.runtime.SpanConfig;
 import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.EventBusInstrumenterVertxTracer;
 import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.HttpInstrumenterVertxTracer;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.InstrumenterVertxTracer;
 import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.OpenTelemetryVertxMetricsFactory;
 import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.OpenTelemetryVertxTracer;
 import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.OpenTelemetryVertxTracingFactory;
 import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.SqlClientInstrumenterVertxTracer;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.metrics.MetricsOptions;
@@ -20,6 +26,12 @@ import io.vertx.core.tracing.TracingOptions;
 public class InstrumentationRecorder {
 
     public static final OpenTelemetryVertxTracingFactory FACTORY = new OpenTelemetryVertxTracingFactory();
+
+    private final RuntimeValue<OTelRuntimeConfig> config;
+
+    public InstrumentationRecorder(RuntimeValue<OTelRuntimeConfig> config) {
+        this.config = config;
+    }
 
     /* RUNTIME INIT */
     public Consumer<VertxOptions> getVertxTracingOptions() {
@@ -31,11 +43,20 @@ public class InstrumentationRecorder {
     /* RUNTIME INIT */
     public void setupVertxTracer(BeanContainer beanContainer) {
         OpenTelemetry openTelemetry = beanContainer.beanInstance(OpenTelemetry.class);
-        OpenTelemetryVertxTracer openTelemetryVertxTracer = new OpenTelemetryVertxTracer(List.of(
-                new HttpInstrumenterVertxTracer(openTelemetry),
-                new EventBusInstrumenterVertxTracer(openTelemetry),
-                // TODO - Selectively register this in the recorder if the SQL Client is available.
-                new SqlClientInstrumenterVertxTracer(openTelemetry)));
+        List<SpanConfig.Tracers> enabledTracers = config.getValue().span().enabledTracers();
+        List<InstrumenterVertxTracer<?, ?>> vertxTracers = enabledTracers.isEmpty() ? Collections.emptyList()
+                : new ArrayList<>(enabledTracers.size());
+        if (enabledTracers.contains(SpanConfig.Tracers.HTTP)) {
+            vertxTracers.add(new HttpInstrumenterVertxTracer(openTelemetry));
+        }
+        if (enabledTracers.contains(SpanConfig.Tracers.EVENTBUS)) {
+            vertxTracers.add(new EventBusInstrumenterVertxTracer(openTelemetry));
+        }
+        // TODO - Selectively register this in the recorder if the SQL Client is available.
+        if (enabledTracers.contains(SpanConfig.Tracers.SQL)) {
+            vertxTracers.add(new SqlClientInstrumenterVertxTracer(openTelemetry));
+        }
+        OpenTelemetryVertxTracer openTelemetryVertxTracer = new OpenTelemetryVertxTracer(vertxTracers);
         FACTORY.getVertxTracerDelegator().setDelegate(openTelemetryVertxTracer);
     }
 


### PR DESCRIPTION
If for example users do not want HTTP instrumentation, they can provide:
`quarkus.otel.span.enabled-tracers=eventbus,sql`

Resolves: #35376