### PR TITLE
Bump Elasticsearch/OpenSearch server version for tests and dev services to 8.9/2.9

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -78,7 +78,7 @@
         <volume.access.modifier>:Z</volume.access.modifier>
 
         <!-- Defaults for integration tests -->
-        <elasticsearch-server.version>8.8.2</elasticsearch-server.version>
+        <elasticsearch-server.version>8.9.1</elasticsearch-server.version>
         <elasticsearch.image>docker.io/elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
         <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
         <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -83,7 +83,7 @@
         <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
         <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
-        <opensearch-server.version>1.2.3</opensearch-server.version>
+        <opensearch-server.version>2.9.0</opensearch-server.version>
         <opensearch.image>docker.io/opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>
         <opensearch.protocol>http</opensearch.protocol>
 

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -254,7 +254,7 @@ public class DevServicesElasticsearchProcessor {
         // Disable disk-based shard allocation thresholds:
         // in a single-node setup they just don't make sense,
         // and lead to problems on large disks with little space left.
-        // See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
+        // See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
         container.addEnv("cluster.routing.allocation.disk.threshold_enabled", "false");
         container.addEnv("ES_JAVA_OPTS", config.javaOpts);
         return container;

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
@@ -3,7 +3,7 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 
-quarkus.hibernate-search-orm.elasticsearch.version=8.8
+quarkus.hibernate-search-orm.elasticsearch.version=8.9
 # Simulate an offline Elasticsearch instance by pointing to a non-existing cluster
 quarkus.hibernate-search-orm.elasticsearch.hosts=localhost:14800
 quarkus.hibernate-search-orm.schema-management.strategy=none

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateSearchActiveFalseAndNamedPuActiveTrueTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateSearchActiveFalseAndNamedPuActiveTrueTest.java
@@ -19,11 +19,11 @@ public class DevUIHibernateSearchActiveFalseAndNamedPuActiveTrueTest extends Abs
                             + "quarkus.hibernate-orm.datasource=<default>\n"
                             + "quarkus.hibernate-orm.packages=io.quarkus.test.devui\n"
                             + "quarkus.hibernate-search-orm.active=false\n"
-                            + "quarkus.hibernate-search-orm.elasticsearch.version=8.8\n"
+                            + "quarkus.hibernate-search-orm.elasticsearch.version=8.9\n"
                             // ... but it's (implicitly) active for a named PU
                             + "quarkus.hibernate-orm.\"namedpu\".datasource=nameddatasource\n"
                             + "quarkus.hibernate-orm.\"namedpu\".packages=io.quarkus.test.devui.namedpu\n"
-                            + "quarkus.hibernate-search-orm.\"namedpu\".elasticsearch.version=8.8\n"
+                            + "quarkus.hibernate-search-orm.\"namedpu\".elasticsearch.version=8.9\n"
                             // Start Hibernate Search offline for the named PU,
                             // because we don't have dev services except for the default PU
                             + "quarkus.hibernate-search-orm.\"namedpu\".schema-management.strategy=none\n"

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateSearchActiveFalseTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateSearchActiveFalseTest.java
@@ -14,7 +14,7 @@ public class DevUIHibernateSearchActiveFalseTest extends AbstractDevUIHibernateS
                             + "quarkus.datasource.jdbc.url=jdbc:h2:mem:test\n"
                             // Hibernate Search is inactive: the dev console should be empty.
                             + "quarkus.hibernate-search-orm.active=false\n"
-                            + "quarkus.hibernate-search-orm.elasticsearch.version=8.8\n"),
+                            + "quarkus.hibernate-search-orm.elasticsearch.version=8.9\n"),
                     "application.properties")
                     .addClasses(MyIndexedEntity.class));
 

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateSearchSmokeTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateSearchSmokeTest.java
@@ -12,7 +12,7 @@ public class DevUIHibernateSearchSmokeTest extends AbstractDevUIHibernateSearchT
             .withApplicationRoot((jar) -> jar.addAsResource(
                     new StringAsset("quarkus.datasource.db-kind=h2\n"
                             + "quarkus.datasource.jdbc.url=jdbc:h2:mem:test\n"
-                            + "quarkus.hibernate-search-orm.elasticsearch.version=8.8\n"
+                            + "quarkus.hibernate-search-orm.elasticsearch.version=8.9\n"
                             // Start offline, we don't have an Elasticsearch cluster here
                             + "quarkus.hibernate-search-orm.schema-management.strategy=none\n"
                             + "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled=false\n"),

--- a/integration-tests/elasticsearch-java-client/pom.xml
+++ b/integration-tests/elasticsearch-java-client/pom.xml
@@ -170,7 +170,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/elasticsearch-rest-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-client/pom.xml
@@ -170,7 +170,7 @@
                       <!-- Disable disk-based shard allocation thresholds:
                            in a single-node setup they just don't make sense,
                            and lead to problems on large disks with little space left.
-                           See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
+                           See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
                        -->
                       <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                       <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch-coordination-outbox-polling/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-coordination-outbox-polling/pom.xml
@@ -211,7 +211,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
@@ -227,7 +227,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
@@ -189,7 +189,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
@@ -32,10 +32,13 @@ public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
             // we won't have an Elasticsearch instance to talk to.
             config.putAll(Map.of(
                     "quarkus.hibernate-search-orm.schema-management.strategy", "none",
-                    // This version does not matter as long as it's supported by Hibernate Search:
-                    // it won't be checked in this test anyway.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.9",
-                    "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false"));
+                    "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false",
+                    // When disabling the version check we need to set a more precise version
+                    // than what we have in application.properties.
+                    // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
+                    // so we're free to put anything.
+                    // Just make sure to set something consistent with what we have in application.properties.
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.9"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
@@ -34,7 +34,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
                     "quarkus.hibernate-search-orm.schema-management.strategy", "none",
                     // This version does not matter as long as it's supported by Hibernate Search:
                     // it won't be checked in this test anyway.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "7.5",
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.9",
                     "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false"));
             return config;
         }

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
@@ -31,10 +31,13 @@ public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
                     "quarkus.hibernate-search-orm.elasticsearch.hosts", EXPLICIT_HOSTS,
                     // Ensure we can work offline, because the host we set just above does not actually exist.
                     "quarkus.hibernate-search-orm.schema-management.strategy", "none",
-                    // This version does not matter as long as it's supported by Hibernate Search:
-                    // it won't be checked in this test anyway.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.9",
-                    "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false");
+                    "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false",
+                    // When disabling the version check we need to set a more precise version
+                    // than what we have in application.properties.
+                    // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
+                    // so we're free to put anything.
+                    // Just make sure to set something consistent with what we have in application.properties.
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.9");
         }
 
         @Override

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
@@ -33,7 +33,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
                     "quarkus.hibernate-search-orm.schema-management.strategy", "none",
                     // This version does not matter as long as it's supported by Hibernate Search:
                     // it won't be checked in this test anyway.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "7.6",
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.9",
                     "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false");
         }
 

--- a/integration-tests/hibernate-search-orm-opensearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-orm-opensearch/src/main/resources/application.properties
@@ -6,7 +6,7 @@ quarkus.datasource.jdbc.max-size=8
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 
-quarkus.hibernate-search-orm.elasticsearch.version=opensearch:2.9
+quarkus.hibernate-search-orm.elasticsearch.version=opensearch:2
 quarkus.hibernate-search-orm.elasticsearch.analysis.configurer=bean:backend-analysis
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
 quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=sync
@@ -14,7 +14,7 @@ quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=sync
 # Use drop-and-create instead of drop-and-create-and-drop
 # so we can differentiate between the value we set here
 # and the value set automatically by the extension when using dev services
-# See io.quarkus.it.hibernate.search.orm.opensearch.devservices.HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.testHibernateSearch
+# See io.quarkus.it.hibernate.search.orm.opensearch.devservices.HibernateSearchOpenSearchDevServicesEnabledImplicitlyTest.testHibernateSearch
 %test.quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create
 %test.quarkus.hibernate-search-orm.elasticsearch.hosts=${opensearch.hosts:localhost:9200}
 %test.quarkus.hibernate-search-orm.elasticsearch.protocol=${opensearch.protocol:http}

--- a/integration-tests/hibernate-search-orm-opensearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-orm-opensearch/src/main/resources/application.properties
@@ -6,7 +6,7 @@ quarkus.datasource.jdbc.max-size=8
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 
-quarkus.hibernate-search-orm.elasticsearch.version=opensearch:1.2
+quarkus.hibernate-search-orm.elasticsearch.version=opensearch:2.9
 quarkus.hibernate-search-orm.elasticsearch.analysis.configurer=bean:backend-analysis
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
 quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=sync

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchElasticsearchDevServicesConfiguredExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchElasticsearchDevServicesConfiguredExplicitlyTest.java
@@ -25,8 +25,11 @@ public class HibernateSearchElasticsearchDevServicesConfiguredExplicitlyTest {
         public Map<String, String> getConfigOverrides() {
             return Map.of(
                     "quarkus.elasticsearch.devservices.enabled", "true",
+                    // This needs to be different from the default image, or the test makes no sense.
                     "quarkus.elasticsearch.devservices.image-name", "docker.io/opensearchproject/opensearch:2.6.0",
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2");
+                    // This needs to match the version used just above,
+                    // so that Hibernate Search itself will assert that we're using a custom version.
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.6");
         }
 
         @Override

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -17,9 +18,19 @@ import io.restassured.RestAssured;
 
 @QuarkusTest
 @DisabledOnOs(OS.WINDOWS)
-@TestProfile(HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.Profile.class)
-public class HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest {
+@TestProfile(HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest.Profile.class)
+public class HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest {
     public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.elasticsearch.devservices.enabled", "true",
+                    // This needs to be different from the default image, or the test makes no sense.
+                    "quarkus.elasticsearch.devservices.image-name", "docker.io/opensearchproject/opensearch:2.6.0",
+                    // This needs to match the version used just above,
+                    // so that Hibernate Search itself will assert that we're using a custom version.
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.6");
+        }
 
         @Override
         public String getConfigProfile() {

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
@@ -19,8 +19,8 @@ import io.restassured.RestAssured;
 
 @QuarkusTest
 @DisabledOnOs(OS.WINDOWS)
-@TestProfile(HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.Profile.class)
-public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
+@TestProfile(HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.Profile.class)
+public class HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest {
     public static class Profile implements QuarkusTestProfile {
         @Override
         public Map<String, String> getConfigOverrides() {
@@ -32,10 +32,13 @@ public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
             // we won't have an Elasticsearch instance to talk to.
             config.putAll(Map.of(
                     "quarkus.hibernate-search-orm.schema-management.strategy", "none",
-                    // This version does not matter as long as it's supported by Hibernate Search:
-                    // it won't be checked in this test anyway.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.9.0",
-                    "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false"));
+                    "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false",
+                    // When disabling the version check we need to set a more precise version
+                    // than what we have in application.properties.
+                    // But here it doesn't matter as we won't send a request to OpenSearch anyway,
+                    // so we're free to put anything.
+                    // Just make sure to set something consistent with what we have in application.properties.
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.9"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
@@ -18,8 +18,8 @@ import io.restassured.RestAssured;
 
 @QuarkusTest
 @DisabledOnOs(OS.WINDOWS)
-@TestProfile(HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.Profile.class)
-public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
+@TestProfile(HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.Profile.class)
+public class HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest {
     private static final String EXPLICIT_HOSTS = "mycompany.com:4242";
 
     public static class Profile implements QuarkusTestProfile {
@@ -31,10 +31,13 @@ public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
                     "quarkus.hibernate-search-orm.elasticsearch.hosts", EXPLICIT_HOSTS,
                     // Ensure we can work offline, because the host we set just above does not actually exist.
                     "quarkus.hibernate-search-orm.schema-management.strategy", "none",
-                    // This version does not matter as long as it's supported by Hibernate Search:
-                    // it won't be checked in this test anyway.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.9.0",
-                    "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false");
+                    "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false",
+                    // When disabling the version check we need to set a more precise version
+                    // than what we have in application.properties.
+                    // But here it doesn't matter as we won't send a request to OpenSearch anyway,
+                    // so we're free to put anything.
+                    // Just make sure to set something consistent with what we have in application.properties.
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.9");
         }
 
         @Override

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesEnabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesEnabledImplicitlyTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -18,19 +17,9 @@ import io.restassured.RestAssured;
 
 @QuarkusTest
 @DisabledOnOs(OS.WINDOWS)
-@TestProfile(HibernateSearchElasticsearchDevServicesConfiguredExplicitlyTest.Profile.class)
-public class HibernateSearchElasticsearchDevServicesConfiguredExplicitlyTest {
+@TestProfile(HibernateSearchOpenSearchDevServicesEnabledImplicitlyTest.Profile.class)
+public class HibernateSearchOpenSearchDevServicesEnabledImplicitlyTest {
     public static class Profile implements QuarkusTestProfile {
-        @Override
-        public Map<String, String> getConfigOverrides() {
-            return Map.of(
-                    "quarkus.elasticsearch.devservices.enabled", "true",
-                    // This needs to be different from the default image, or the test makes no sense.
-                    "quarkus.elasticsearch.devservices.image-name", "docker.io/opensearchproject/opensearch:2.6.0",
-                    // This needs to match the version used just above,
-                    // so that Hibernate Search itself will assert that we're using a custom version.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.6");
-        }
 
         @Override
         public String getConfigProfile() {

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -162,7 +162,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.8/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->


### PR DESCRIPTION
~~Creating as draft since we need to upgrade Hibernate Search first: #35445~~ => Done

Should not be backported as this affects the version of Elasticsearch/OpenSearch started by default in dev services, which I think is technically a breaking change.