### PR TITLE
Let OIDC Twitter users use X if they prefer

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -3,9 +3,14 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
+[id="security-openid-connect-providers"]
 = Configuring Well-Known OpenID Connect Providers
-
 include::_attributes.adoc[]
+:diataxis-type: concept
+:categories: security,web
+:toclevels: 3
+
+This document explains how to configure well-known social OIDC and OAuth2 providers.
 
 == Introduction
 
@@ -389,6 +394,18 @@ generate a secure random secret key for encrypting it.
 You can provide your own secret key for encrypting the PKCE code verifier if you prefer with the `quarkus.oidc.authentication.state-secret` property but
 note that this secret should be 32 characters long, and an error will be reported if it is less than 16 characters long.
 ====
+
+[NOTE]
+====
+`X` is a new name for `Twitter`, see <<x>>. You can continue using `quarkus.oidc.provider=twitter` but it might need to be changed to `quarkus.oidc.provider=x` in the future.
+====
+
+[[x]]
+=== X
+
+`X` is a new name for `Twitter`. You can currently use either `quarkus.oidc.provider=x` or `quarkus.oidc.provider=twitter` but only `quarkus.oidc.provider=x` may end up supported in the future.
+
+Please see <<twitter>> for more information about registering your Quarkus application in `X` (`Twitter`).
 
 [[spotify]]
 === Spotify

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1661,7 +1661,9 @@ public class OidcTenantConfig extends OidcCommonConfig {
         MICROSOFT,
         SPOTIFY,
         TWITCH,
-        TWITTER
+        TWITTER,
+        // New name for Twitter
+        X
     }
 
     public Optional<Provider> getProvider() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
@@ -10,24 +10,27 @@ import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 public class KnownOidcProviders {
 
     public static OidcTenantConfig provider(OidcTenantConfig.Provider provider) {
-        if (OidcTenantConfig.Provider.GITHUB == provider) {
-            return github();
-        } else if (OidcTenantConfig.Provider.GOOGLE == provider) {
-            return google();
-        } else if (OidcTenantConfig.Provider.APPLE == provider) {
-            return apple();
-        } else if (OidcTenantConfig.Provider.MICROSOFT == provider) {
-            return microsoft();
-        } else if (OidcTenantConfig.Provider.FACEBOOK == provider) {
-            return facebook();
-        } else if (OidcTenantConfig.Provider.SPOTIFY == provider) {
-            return spotify();
-        } else if (OidcTenantConfig.Provider.TWITTER == provider) {
-            return twitter();
-        } else if (OidcTenantConfig.Provider.TWITCH == provider) {
-            return twitch();
+        switch (provider) {
+            case APPLE:
+                return apple();
+            case FACEBOOK:
+                return facebook();
+            case GITHUB:
+                return github();
+            case GOOGLE:
+                return google();
+            case MICROSOFT:
+                return microsoft();
+            case SPOTIFY:
+                return spotify();
+            case TWITCH:
+                return twitch();
+            case TWITTER:
+            case X:
+                return twitter();
+            default:
+                return null;
         }
-        return null;
     }
 
     private static OidcTenantConfig github() {

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -146,6 +146,62 @@ public class OidcUtilsTest {
     }
 
     @Test
+    public void testAcceptXProperties() throws Exception {
+        OidcTenantConfig tenant = new OidcTenantConfig();
+        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.X));
+
+        assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
+        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertFalse(config.isDiscoveryEnabled().get());
+        assertEquals("https://api.twitter.com/2/oauth2", config.getAuthServerUrl().get());
+        assertEquals("https://twitter.com/i/oauth2/authorize", config.getAuthorizationPath().get());
+        assertEquals("token", config.getTokenPath().get());
+        assertEquals("https://api.twitter.com/2/users/me", config.getUserInfoPath().get());
+
+        assertFalse(config.authentication.idTokenRequired.get());
+        assertTrue(config.authentication.userInfoRequired.get());
+        assertFalse(config.authentication.addOpenidScope.get());
+        assertEquals(List.of("offline.access", "tweet.read", "users.read"), config.authentication.scopes.get());
+        assertTrue(config.authentication.pkceRequired.get());
+    }
+
+    @Test
+    public void testOverrideXProperties() throws Exception {
+        OidcTenantConfig tenant = new OidcTenantConfig();
+        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+
+        tenant.setApplicationType(ApplicationType.HYBRID);
+        tenant.setDiscoveryEnabled(true);
+        tenant.setAuthServerUrl("http://localhost/wiremock");
+        tenant.setAuthorizationPath("authorization");
+        tenant.setTokenPath("tokens");
+        tenant.setUserInfoPath("userinfo");
+
+        tenant.authentication.setIdTokenRequired(true);
+        tenant.authentication.setUserInfoRequired(false);
+        tenant.authentication.setAddOpenidScope(true);
+        tenant.authentication.setPkceRequired(false);
+        tenant.authentication.setScopes(List.of("write"));
+
+        OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.X));
+
+        assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
+        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertTrue(config.isDiscoveryEnabled().get());
+        assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
+        assertEquals("authorization", config.getAuthorizationPath().get());
+        assertEquals("tokens", config.getTokenPath().get());
+        assertEquals("userinfo", config.getUserInfoPath().get());
+
+        assertTrue(config.authentication.idTokenRequired.get());
+        assertFalse(config.authentication.userInfoRequired.get());
+        assertEquals(List.of("write"), config.authentication.scopes.get());
+        assertTrue(config.authentication.addOpenidScope.get());
+        assertFalse(config.authentication.pkceRequired.get());
+    }
+
+    @Test
     public void testAcceptFacebookProperties() throws Exception {
         OidcTenantConfig tenant = new OidcTenantConfig();
         tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);


### PR DESCRIPTION
For the moment `quarkus.oidc.provider=twitter` works, I have just confirmed, but the endpoints containing `twitter` may stop working so it makes sense to start preparing a possible switch to `X`.  Some users might want to switch to using `X` too, who knows.
For now `Twitter` and `X` offer the same provider support in Quarkus but it may diverge. I'm not deprecating the `Twitter` provider enum yet.

CC @FroMage 