### PR TITLE
Exclude test scoped dependency constraints from quarkus-bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1894,13 +1894,6 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-reactive-datasource-deployment</artifactId>
-                <version>${project.version}</version>
-                <scope>test</scope>
-                <type>test-jar</type>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-reactive-db2-client</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -2375,13 +2368,6 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
-                <version>${project.version}</version>
-                <scope>test</scope>
-                <type>test-jar</type>
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
@@ -6759,6 +6745,7 @@
                             <goal>flatten-platform-bom</goal>
                         </goals>
                         <configuration>
+                            <excludeScopes>test</excludeScopes>
                             <excludeArtifactKeys>
                                 <key>junit:junit</key> <!-- comes from the jackson-bom -->
                             </excludeArtifactKeys>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -234,6 +234,20 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-reactive-datasource-deployment</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+                <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+                <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-war-launcher-runner</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <gitflow-incremental-builder.version>4.5.0</gitflow-incremental-builder.version>
-        <quarkus-platform-bom-plugin.version>0.0.92</quarkus-platform-bom-plugin.version>
+        <quarkus-platform-bom-plugin.version>0.0.93</quarkus-platform-bom-plugin.version>
 
         <skipDocs>false</skipDocs>
         <skip.gradle.tests>false</skip.gradle.tests>


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/35428

With this change the following dependency constraints will be removed from the quarkus-bom:
```
[DEBUG] Excluded io.quarkus:quarkus-reactive-datasource-deployment:jar:tests:999-SNAPSHOT (test) by scope
[DEBUG] Excluded io.quarkus:quarkus-resteasy-reactive-deployment:jar:tests:999-SNAPSHOT (test) by scope
[DEBUG] Excluded org.slf4j:slf4j-simple:jar:1.7.21 (test) by scope
[DEBUG] Excluded org.slf4j:slf4j-log4j12:jar:1.7.21 (test) by scope
[DEBUG] Excluded org.slf4j:slf4j-jdk14:jar:1.7.21 (test) by scope
[DEBUG] Excluded org.slf4j:jcl-over-slf4j:jar:1.7.21 (test) by scope
[DEBUG] Excluded org.apache.logging.log4j:log4j-core:jar:2.17.1 (test) by scope
[DEBUG] Excluded org.apache.logging.log4j:log4j-slf4j-impl:jar:2.17.1 (test) by scope
```