### PR TITLE
Disable docker-prune.sh for now

### DIFF
--- a/.github/docker-prune.sh
+++ b/.github/docker-prune.sh
@@ -5,9 +5,11 @@ set -e
 # pruning is only run when inside CI to avoid accidentally removing stuff
 # GITHUB_ACTIONS is always set to true inside Github Actions
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables
-if [ "${GITHUB_ACTIONS}" == true ] ; then
-  docker container prune -f
-  docker image prune -f
-  docker network prune -f
-  docker volume prune -f
-fi
+#if [ "${GITHUB_ACTIONS}" == true ] ; then
+#  docker container prune -f
+#  docker image prune -f
+#  docker network prune -f
+#  docker volume prune -f
+#fi
+
+echo "docker-prune.sh is disabled for now"

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -120,7 +120,7 @@
         <jacoco.agent.argLine></jacoco.agent.argLine>
 
         <asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>
-        <docker-maven-plugin.version>0.43.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
         <maven-invoker-plugin.version>3.6.0</maven-invoker-plugin.version>


### PR DESCRIPTION
It is causing a lot of problems on CI:
Error response from daemon: a prune operation is already running

Let's try to disable it as it might not be useful anymore.

Also upgrade the docker-maven-plugin to the latest.