### PR TITLE
Remove Deploy to OpenShift file from downstreamdoc.yaml file

### DIFF
--- a/docs/downstreamdoc.yaml
+++ b/docs/downstreamdoc.yaml
@@ -1,6 +1,5 @@
 guides:
   - src/main/asciidoc/datasource.adoc
-  - src/main/asciidoc/deploying-to-openshift.adoc
   - src/main/asciidoc/logging.adoc
   - src/main/asciidoc/security-architecture.adoc
   - src/main/asciidoc/security-authentication-mechanisms.adoc


### PR DESCRIPTION
Due to change in scope for 3.2, the upstream "Deploy to OpenShift" guides will not be published in Red Hat build of Quarkus for 3.2. Therefore, the OpenShift-specific files do not need to be imported downstream for 3.2.

This PR covers the update of the "downstreamdoc.yaml" file to remove the "deploying-to-openshift.adoc " file from the list of needed downstream files.