### PR TITLE
Include assembling the downstream doc in the default doc pipeline

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -3054,6 +3054,25 @@
                             </environmentVariables>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>assemble-downstream-doc</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <!-- using the exec goal here so that we can set the workingDirectory properly
+                                as this script has initially be developed to be a standalone JBang script
+                                running at the root of the docs module -->
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath />
+                                <argument>io.quarkus.docs.generation.AssembleDownstreamDocumentation</argument>
+                            </arguments>
+                            <workingDirectory>${project.basedir}</workingDirectory>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
This PR will include the downstream doc as part of the default pipeline.

So if you build the documentation as you used to (to get the transformed output), you will end up with the downstream doc in `docs/target/downstream-tree`.

Then you could automatically sync the result every day from the 3.2 branch given we only push doc fixes to the 3.2 branch. I'm not familiar with your GitLab setup but you should be able to set up a workflow doing that. I can help on the Quarkus specific side if you have someone familiar with GitLab around.