### PR TITLE
Properly report Vertx worker pool size

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ThreadPoolConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ThreadPoolConfig.java
@@ -84,4 +84,12 @@ public class ThreadPoolConfig {
     @ConfigItem(defaultValue = "30")
     public Duration keepAliveTime;
 
+    public static ThreadPoolConfig empty() {
+        var config = new ThreadPoolConfig();
+        config.maxThreads = OptionalInt.empty();
+        config.queueSize = OptionalInt.empty();
+        config.shutdownCheckInterval = Optional.empty();
+        return config;
+    }
+
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -49,6 +49,7 @@ import io.quarkus.runtime.LiveReloadConfig;
 import io.quarkus.runtime.QuarkusBindException;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
+import io.quarkus.runtime.ThreadPoolConfig;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigInstantiator;
 import io.quarkus.runtime.configuration.ConfigUtils;
@@ -250,7 +251,11 @@ public class VertxHttpRecorder {
                     .addDiscoveredSources()
                     .withMapping(VertxConfiguration.class)
                     .build().getConfigMapping(VertxConfiguration.class);
-            vertx = VertxCoreRecorder.recoverFailedStart(vertxConfiguration).get();
+
+            ThreadPoolConfig threadPoolConfig = new ThreadPoolConfig();
+            ConfigInstantiator.handleObject(threadPoolConfig);
+
+            vertx = VertxCoreRecorder.recoverFailedStart(vertxConfiguration, threadPoolConfig).get();
         } else {
             vertx = supplier.get();
         }

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -52,6 +52,7 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.gizmo.Gizmo;
 import io.quarkus.netty.deployment.EventLoopSupplierBuildItem;
+import io.quarkus.runtime.ThreadPoolConfig;
 import io.quarkus.vertx.VertxOptionsCustomizer;
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
 import io.quarkus.vertx.core.runtime.VertxLocalsHelper;
@@ -215,6 +216,7 @@ class VertxCoreProcessor {
     CoreVertxBuildItem build(VertxCoreRecorder recorder,
             LaunchModeBuildItem launchMode, ShutdownContextBuildItem shutdown, VertxConfiguration config,
             List<VertxOptionsConsumerBuildItem> vertxOptionsConsumers,
+            ThreadPoolConfig threadPoolConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<EventLoopSupplierBuildItem> eventLoops,
             ExecutorBuildItem executorBuildItem) {
@@ -225,7 +227,7 @@ class VertxCoreProcessor {
             consumers.add(x.getConsumer());
         }
 
-        Supplier<Vertx> vertx = recorder.configureVertx(config,
+        Supplier<Vertx> vertx = recorder.configureVertx(config, threadPoolConfig,
                 launchMode.getLaunchMode(), shutdown, consumers, executorBuildItem.getExecutorProxy());
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(Vertx.class)
                 .types(Vertx.class)

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusExecutorFactory.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusExecutorFactory.java
@@ -7,8 +7,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.jboss.logging.Logger;
 import org.jboss.threads.EnhancedQueueExecutor;
 import org.jboss.threads.JBossExecutors;
-import org.wildfly.common.cpu.ProcessorInfo;
 
+import io.quarkus.runtime.ExecutorRecorder;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.vertx.core.runtime.config.VertxConfiguration;
 import io.vertx.core.spi.ExecutorServiceFactory;
@@ -47,10 +47,9 @@ public class QuarkusExecutorFactory implements ExecutorServiceFactory {
                 .setRegisterMBean(false)
                 .setHandoffExecutor(JBossExecutors.rejectingExecutor())
                 .setThreadFactory(JBossExecutors.resettingThreadFactory(threadFactory));
-        final int cpus = ProcessorInfo.availableProcessors();
         // run time config variables
         builder.setCorePoolSize(concurrency);
-        builder.setMaximumPoolSize(maxConcurrency != null ? maxConcurrency : Math.max(8 * cpus, 200));
+        builder.setMaximumPoolSize(maxConcurrency != null ? maxConcurrency : ExecutorRecorder.calculateMaxThreads());
 
         if (conf != null) {
             if (conf.queueSize().isPresent()) {

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
@@ -42,9 +42,10 @@ public interface VertxConfiguration {
     Duration warningExceptionTime();
 
     /**
-     * The size of the worker thread pool.
+     * @deprecated use {@code quarkus.thread-pool.max-threads} instead
      */
-    @WithDefault("20")
+    @WithDefault("${quarkus.thread-pool.max-threads:20}")
+    @Deprecated
     int workerPoolSize();
 
     /**

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.ThreadPoolConfig;
 import io.quarkus.vertx.core.runtime.VertxCoreRecorder.VertxOptionsCustomizer;
 import io.quarkus.vertx.core.runtime.config.AddressResolverConfiguration;
 import io.quarkus.vertx.core.runtime.config.ClusterConfiguration;
@@ -98,7 +99,8 @@ public class VertxCoreProducerTest {
         };
 
         try {
-            VertxCoreRecorder.initialize(configuration, null, null, LaunchMode.TEST);
+
+            VertxCoreRecorder.initialize(configuration, null, ThreadPoolConfig.empty(), null, LaunchMode.TEST);
             Assertions.fail("It should not have a cluster manager on the classpath, and so fail the creation");
         } catch (IllegalStateException e) {
             Assertions.assertTrue(e.getMessage().contains("No ClusterManagerFactory"),
@@ -155,7 +157,7 @@ public class VertxCoreProducerTest {
                     }
                 }));
 
-        VertxCoreRecorder.initialize(configuration, customizers, null, LaunchMode.TEST);
+        VertxCoreRecorder.initialize(configuration, customizers, ThreadPoolConfig.empty(), null, LaunchMode.TEST);
     }
 
     @Test
@@ -168,7 +170,9 @@ public class VertxCoreProducerTest {
                         called.set(true);
                     }
                 }));
-        Vertx v = VertxCoreRecorder.initialize(new DefaultVertxConfiguration(), customizers, null, LaunchMode.TEST);
+        Vertx v = VertxCoreRecorder.initialize(new DefaultVertxConfiguration(), customizers, ThreadPoolConfig.empty(),
+                null,
+                LaunchMode.TEST);
         Assertions.assertTrue(called.get(), "Customizer should get called during initialization");
     }
 

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/runtime/VertxProducerTest.java
@@ -29,7 +29,7 @@ public class VertxProducerTest {
 
     @Test
     public void shouldNotFailWithoutConfig() {
-        verifyProducer(VertxCoreRecorder.initialize(null, null, null, LaunchMode.TEST));
+        verifyProducer(VertxCoreRecorder.initialize(null, null, null, null, LaunchMode.TEST));
     }
 
     private void verifyProducer(Vertx v) {


### PR DESCRIPTION
This is done by setting the relevant property
in `VertxOptions` to the size of the Quarkus
ExecutorService that is actually by Vertx
(in prod mode).
The reason we update `VertxOptions` is that
`PoolMetrics` [uses](https://github.com/eclipse-vertx/vert.x/blob/4.4/src/main/java/io/vertx/core/impl/VertxImpl.java#L172) it to calculate the blocking
pool size.

Closes: #34998