### PR TITLE
Update doc regarding quarkus.builder.graph-output

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1045,7 +1045,7 @@ and add them to the reflective hierarchy for `BUILD_TIME` analysis.
 
 ==== Visualizing build step dependencies
 
-It can occasionally be useful to see a visual representation of the interactions between the various build steps. For such cases, adding `-Djboss.builder.graph-output=build.dot` when building an application
+It can occasionally be useful to see a visual representation of the interactions between the various build steps. For such cases, adding `-Dquarkus.builder.graph-output=build.dot` when building an application
 will result in the creation of the `build.dot` file in the project's root directory. See link:https://graphviz.org/resources/[this] for a list of software that can open the file and show the actual visual representation.
 
 [[configuration]]


### PR DESCRIPTION
It was renamed in https://github.com/quarkusio/quarkus/pull/35299 but we forgot to update the documentation.