### PR TITLE
Better support for OIDC JWK keys without kid

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -401,7 +401,7 @@ public class OidcProvider implements Closeable {
             }
 
             if (key == null && kid == null && thumbprint == null) {
-                key = jwks.getKeyWithoutKeyIdAndThumbprint();
+                key = jwks.getKeyWithoutKeyIdAndThumbprint(jws);
             }
 
             if (key == null) {

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcProviderTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcProviderTest.java
@@ -11,9 +11,13 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 
 import org.eclipse.microprofile.jwt.Claims;
+import org.jose4j.jwk.EcJwkGenerator;
+import org.jose4j.jwk.EllipticCurveJsonWebKey;
 import org.jose4j.jwk.RsaJsonWebKey;
 import org.jose4j.jwk.RsaJwkGenerator;
 import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.keys.EllipticCurves;
+import org.jose4j.lang.UnresolvableKeyException;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.oidc.OidcTenantConfig;
@@ -22,36 +26,72 @@ import io.smallrye.jwt.build.Jwt;
 
 public class OidcProviderTest {
 
-    @SuppressWarnings("resource")
     @Test
     public void testAlgorithmCustomizer() throws Exception {
 
         RsaJsonWebKey rsaJsonWebKey = RsaJwkGenerator.generateJwk(2048);
         rsaJsonWebKey.setKeyId("k1");
 
-        final String token = Jwt.issuer("http://keycloak/ream").jws().keyId("k1").sign(rsaJsonWebKey.getPrivateKey());
+        final String token = Jwt.issuer("http://keycloak/realm").jws().keyId("k1").sign(rsaJsonWebKey.getPrivateKey());
         final String newToken = replaceAlgorithm(token, "ES256");
         JsonWebKeySet jwkSet = new JsonWebKeySet("{\"keys\": [" + rsaJsonWebKey.toJson() + "]}");
         OidcTenantConfig oidcConfig = new OidcTenantConfig();
 
-        OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null, null);
-        try {
-            provider.verifyJwtToken(newToken, false, false, null);
-            fail("InvalidJwtException expected");
-        } catch (InvalidJwtException ex) {
-            // continue
+        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, null, null)) {
+            try {
+                provider.verifyJwtToken(newToken, false, false, null);
+                fail("InvalidJwtException expected");
+            } catch (InvalidJwtException ex) {
+                // continue
+            }
         }
 
-        provider = new OidcProvider(null, oidcConfig, jwkSet, new TokenCustomizer() {
+        try (OidcProvider provider = new OidcProvider(null, oidcConfig, jwkSet, new TokenCustomizer() {
 
             @Override
             public JsonObject customizeHeaders(JsonObject headers) {
                 return Json.createObjectBuilder(headers).add("alg", "RS256").build();
             }
 
-        }, null);
-        TokenVerificationResult result = provider.verifyJwtToken(newToken, false, false, null);
-        assertEquals("http://keycloak/ream", result.localVerificationResult.getString("iss"));
+        }, null)) {
+            TokenVerificationResult result = provider.verifyJwtToken(newToken, false, false, null);
+            assertEquals("http://keycloak/realm", result.localVerificationResult.getString("iss"));
+        }
+    }
+
+    @Test
+    public void testTokenWithoutKidSingleRsaJwkWithoutKid() throws Exception {
+        RsaJsonWebKey rsaJsonWebKey = RsaJwkGenerator.generateJwk(2048);
+        EllipticCurveJsonWebKey ecJsonWebKey = EcJwkGenerator.generateJwk(EllipticCurves.P256);
+
+        JsonWebKeySet jwkSet = new JsonWebKeySet("{\"keys\": [" + rsaJsonWebKey.toJson() + "," + ecJsonWebKey.toJson() + "]}");
+
+        final String token = Jwt.issuer("http://keycloak/realm").sign(rsaJsonWebKey.getPrivateKey());
+
+        try (OidcProvider provider = new OidcProvider(null, new OidcTenantConfig(), jwkSet, null, null)) {
+            TokenVerificationResult result = provider.verifyJwtToken(token, false, false, null);
+            assertEquals("http://keycloak/realm", result.localVerificationResult.getString("iss"));
+        }
+    }
+
+    @Test
+    public void testTokenWithoutKidMultipleRSAJwkWithoutKid() throws Exception {
+        RsaJsonWebKey rsaJsonWebKey1 = RsaJwkGenerator.generateJwk(2048);
+        RsaJsonWebKey rsaJsonWebKey2 = RsaJwkGenerator.generateJwk(2048);
+        JsonWebKeySet jwkSet = new JsonWebKeySet(
+                "{\"keys\": [" + rsaJsonWebKey1.toJson() + "," + rsaJsonWebKey2.toJson() + "]}");
+
+        final String token = Jwt.issuer("http://keycloak/realm").sign(rsaJsonWebKey1.getPrivateKey());
+
+        try (OidcProvider provider = new OidcProvider(null, new OidcTenantConfig(), jwkSet, null, null)) {
+            try {
+                provider.verifyJwtToken(token, false, false, null);
+                fail("InvalidJwtException expected");
+            } catch (InvalidJwtException ex) {
+                assertTrue(ex.getCause() instanceof UnresolvableKeyException);
+            }
+
+        }
     }
 
     private static String replaceAlgorithm(String token, String algorithm) {


### PR DESCRIPTION
This PR is the last one to get the OIDC Basic RP test plan passing:
https://www.certification.openid.net/plan-detail.html?plan=RPUGzpD20SQYS&public=true

This PR improves how verification keys without `kid` property are handled.
By default,  the token includes a key identifier, `kid` header and it is used to find a matching JWK, example, if the token `kid` is `1`, then, given `[{"kid":"1", "kty":"RSA", "alg":"RS256"}, {{"kid":"2", "kty":"RSA", "alg":"RS256"}]`, the key with the `"kid":"1"` will be selected.

There is a case (this was driven by a concrete user requirement), when the token does not include a key identifier (`kid`) property. Quarkus already supports verifying such tokens, but only (and this restriction was created without any specific justification) if the verification key set has a single JWK key only without `kid`, for example: `[{"kty":"RSA", "alg":"RS256"}]` - i.e, single key set only with this single key having no `kid`.

As it happens, the the OIDC Basic RP test plan tests this case too, but the verification key set contains more than one key without kid, with each key having its own key type, for example: `[{"kty":"RSA", "alg":"RS256"}, {{"kty":"EC", "alg":"ES256"}]` - i.e here 2 keys, one RSA, another EC, both without `kid` are included, and the test is expected to get the token without `kid`, signed with an RSA key, verified by the key with the matching key type, in this example, the first one, from the set.

So this PR just makes sure that all the keys without `kid` (or X509 thumbprint) are keyed by their type, so when the token without `kid` arrives, a single key with the matching key type is chosen.

The test plan has another test, where more than one key without `kid` but with the same key type is available, for example:

`[{"kty":"RSA", "alg":"RS256"}, {{""kty":"RSA", "alg":"RS256"}]` - with 2 results supported - the first one, if the token has no `kid` then Quarkus fails to verify it because more than one key without `kid` with the matching RSA type is available; and the 2nd result is that Quarkus iterates over all such matching keys until the verification succeeds. I don't see the 2nd result being an option for us at the moment - it can take a lot of time to iterate over all such keys, the whole such scenario seems very much test-specific (not practical) so I chose the 1st option - fail to verify in this case - which matches the current `main` expectations too.

So to summarize, the only real improvement which this PR brings is it allows correctly identify a matching JWK without `kid` in a set containing more than one JWK, with each JWK having its own key type, with only JWK per specific key type possible.

Tests added to `OidcProviderTest` to show it, `integration-tests/oidc-wiremock` already has tests for the current case where a JWK set has a single key only