### PR TITLE
Update quarkus-plugin.version as part of quarkus update

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
@@ -33,7 +33,8 @@ public final class QuarkusUpdates {
         switch (request.buildTool) {
             case MAVEN:
                 recipe.addOperation(new UpdatePropertyOperation("quarkus.platform.version", request.targetVersion))
-                        .addOperation(new UpdatePropertyOperation("quarkus.version", request.targetVersion));
+                        .addOperation(new UpdatePropertyOperation("quarkus.version", request.targetVersion))
+                        .addOperation(new UpdatePropertyOperation("quarkus-plugin.version", request.targetVersion));
                 if (request.kotlinVersion != null) {
                     recipe.addOperation(new UpdatePropertyOperation("kotlin.version", request.kotlinVersion));
                 }


### PR DESCRIPTION
This is only useful for projects created a looooong time ago but it is an easy fix.

Fixes #35511