### PR TITLE
Significantly improve the output of the update command

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -16,6 +16,7 @@ import io.quarkus.devtools.commands.data.QuarkusCommandException;
 import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
 import io.quarkus.devtools.project.QuarkusProject;
 import io.quarkus.devtools.project.QuarkusProjectHelper;
+import io.quarkus.devtools.project.update.rewrite.QuarkusUpdateExitErrorException;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.registry.RegistryResolutionException;
 import io.quarkus.registry.catalog.ExtensionCatalog;
@@ -129,10 +130,12 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
             final QuarkusCommandOutcome result = invoker.execute();
             if (!result.isSuccess()) {
                 throw new MojoExecutionException(
-                        "The command did not succeed.");
+                        "Failed to apply the updates.");
             }
+        } catch (QuarkusUpdateExitErrorException e) {
+            throw new MojoExecutionException(e.getMessage());
         } catch (QuarkusCommandException e) {
-            throw new MojoExecutionException("Failed to resolve the available updates", e);
+            throw new MojoExecutionException("Failed to apply the updates", e);
         }
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -30,7 +30,6 @@ import io.quarkus.devtools.project.update.ProjectExtensionsUpdateInfo;
 import io.quarkus.devtools.project.update.ProjectPlatformUpdateInfo;
 import io.quarkus.devtools.project.update.ProjectUpdateInfos;
 import io.quarkus.devtools.project.update.rewrite.QuarkusUpdateCommand;
-import io.quarkus.devtools.project.update.rewrite.QuarkusUpdateException;
 import io.quarkus.devtools.project.update.rewrite.QuarkusUpdates;
 import io.quarkus.devtools.project.update.rewrite.QuarkusUpdatesRepository;
 import io.quarkus.maven.dependency.ArtifactCoords;
@@ -116,8 +115,6 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
                             rewriteDryRun);
                 } catch (IOException e) {
                     throw new QuarkusCommandException("Error while generating the project update script", e);
-                } catch (QuarkusUpdateException e) {
-                    throw new QuarkusCommandException("Error while running the project update script", e);
                 }
             }
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateException.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateException.java
@@ -1,6 +1,6 @@
 package io.quarkus.devtools.project.update.rewrite;
 
-public class QuarkusUpdateException extends Exception {
+public class QuarkusUpdateException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateExitErrorException.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdateExitErrorException.java
@@ -1,0 +1,14 @@
+package io.quarkus.devtools.project.update.rewrite;
+
+public class QuarkusUpdateExitErrorException extends QuarkusUpdateException {
+
+    private static final long serialVersionUID = 1L;
+
+    public QuarkusUpdateExitErrorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public QuarkusUpdateExitErrorException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
When having an error, it was extremely confusing, you had confusing error messages, a lot of nested exceptions...

This will improve the output, make sure we have proper colors for the log levels and avoid having two levels logged.
Also avoid a couple of nested exceptions and make the error messages more actionable.

This is slightly related to me fixing #35511 as I noticed a few times that in case of errors, it was relatively hard to find the culprit.