### PR TITLE
Add a metric for rejected submissions to the pool

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxPoolMetrics.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/vertx/VertxPoolMetrics.java
@@ -25,6 +25,7 @@ public class VertxPoolMetrics implements PoolMetrics<EventTiming> {
     private final LongAdder current = new LongAdder();
     private final LongAdder queue = new LongAdder();
     private final Counter completed;
+    private final Counter rejected;
     private final Timer queueDelay;
 
     VertxPoolMetrics(MeterRegistry registry, String poolType, String poolName, int maxPoolSize) {
@@ -89,6 +90,11 @@ public class VertxPoolMetrics implements PoolMetrics<EventTiming> {
                 .tags(tags)
                 .register(registry);
 
+        rejected = Counter.builder(name("rejected"))
+                .description("Number of times submissions to the pool have been rejected")
+                .tags(tags)
+                .register(registry);
+
     }
 
     private String name(String suffix) {
@@ -104,6 +110,7 @@ public class VertxPoolMetrics implements PoolMetrics<EventTiming> {
     @Override
     public void rejected(EventTiming submitted) {
         queue.decrement();
+        rejected.increment();
         submitted.end();
     }
 


### PR DESCRIPTION
In addition to the existing metric: 

```
# HELP worker_pool_completed_total Number of times resources from the pool have been acquired
# TYPE worker_pool_completed_total counter
worker_pool_completed_total{pool_name="vert.x-internal-blocking",pool_type="worker",} 0.0
worker_pool_completed_total{pool_name="vert.x-worker-thread",pool_type="worker",} 2.0
```

this adds a new metric which counts only the rejected one, which is a subset of the `completed`

```
# HELP worker_pool_rejected_total Number of times submissions to the pool have been rejected
# TYPE worker_pool_rejected_total counter
worker_pool_rejected_total{pool_name="vert.x-internal-blocking",pool_type="worker",} 0.0
worker_pool_rejected_total{pool_name="vert.x-worker-thread",pool_type="worker",} 0.0
```

Please let me know if the description of this metric is ok, or if it should be changed. I didn't find a test for this class - if one exists, I'd be happy to add another test.

Thanks!

Closes #35540