### PR TITLE
Report 401 and remove OIDC session cookie if it is malformed

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -301,9 +301,9 @@ public class OidcProvider implements Closeable {
                             throw new AuthenticationFailedException(t);
                         }
                         if (!introspectionResult.isActive()) {
-                            LOG.debugf("Token issued to client %s is not active", oidcConfig.clientId.get());
                             verifyTokenExpiry(introspectionResult.getLong(OidcConstants.INTROSPECTION_TOKEN_EXP));
-                            throw new AuthenticationFailedException();
+                            throw new AuthenticationFailedException(
+                                    String.format("Token issued to client %s is not active", oidcConfig.clientId.get()));
                         }
                         verifyTokenExpiry(introspectionResult.getLong(OidcConstants.INTROSPECTION_TOKEN_EXP));
                         try {

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -733,11 +733,28 @@ public class CodeFlowTest {
 
             Cookie sessionCookie = getSessionCookie(webClient, null);
             assertNotNull(sessionCookie);
+            // Replace the session cookie with the correctly formatted cookie but with invalid token values
             webClient.getCookieManager().clearCookies();
             webClient.getCookieManager().addCookie(new Cookie(sessionCookie.getDomain(), sessionCookie.getName(),
                     "1|2|3"));
             sessionCookie = getSessionCookie(webClient, null);
             assertEquals("1|2|3", sessionCookie.getValue());
+
+            try {
+                webClient.getPage("http://localhost:8081/web-app");
+                fail("401 status error is expected");
+            } catch (FailingHttpStatusCodeException ex) {
+                assertEquals(401, ex.getStatusCode());
+                assertNull(getSessionCookie(webClient, null));
+            }
+            webClient.getCookieManager().clearCookies();
+
+            // Replace the session cookie with malformed cookie
+            webClient.getCookieManager().clearCookies();
+            webClient.getCookieManager().addCookie(new Cookie(sessionCookie.getDomain(), sessionCookie.getName(),
+                    "1"));
+            sessionCookie = getSessionCookie(webClient, null);
+            assertEquals("1", sessionCookie.getValue());
 
             try {
                 webClient.getPage("http://localhost:8081/web-app");


### PR DESCRIPTION
Fixes #35482

Test already exists when the session cookie is well-formed but contains invalid tokens (401 is returned, the cookie is removed), but if the token is malformed then `500` escapes.

I've just added an `ArrayIndexOutOfBoundsException` catch block - as it may originate from several parts of the code parsing the token, and make sure the cookie is removed. 
Minor updates to `OidcProvider` to make sure the error is correctly reported at the `CodeAuthenticationMechanism` level when the session cookie is well-formed but can not be verified.