### PR TITLE
Use BeanContainer.beanInstance instead in docs

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -2532,7 +2532,7 @@ You can use the `io.quarkus.arc.runtime.BeanContainer` interface to interact wit
             TestBuildAndRunTimeConfig buildTimeConfig,
             TestRunTimeConfig runTimeConfig) {
         log.info("Begin BeanContainerListener callback\n");
-        IConfigConsumer instance = beanContainer.instance(beanClass); <4>
+        IConfigConsumer instance = beanContainer.beanInstance(beanClass); <4>
         instance.loadConfig(buildTimeConfig, runTimeConfig); <5>
         log.infof("configureBeans, instance=%s\n", instance);
     }


### PR DESCRIPTION
- BeanContainer.instance is deprecated since c5b87cf365729d0ecfc60da5e415174978ae87a4
