### PR TITLE
Improve Quarkus Bot labeling rules for cache

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -445,7 +445,7 @@ triage:
         - integration-tests/artemis-jms/
     - id: cache
       labels: [area/cache]
-      title: "cache"
+      title: "(?<!build )cache"
       notify: [gwenneg]
       directories:
         - extensions/cache/


### PR DESCRIPTION
no longer label build cache as a match

as suggested by @gsmet (https://github.com/quarkusio/quarkus/issues/35551#issuecomment-1693017558)