### PR TITLE
Fix "my second guide" title, and cross-link

### DIFF
--- a/docs/src/main/asciidoc/getting-started-dev-services.adoc
+++ b/docs/src/main/asciidoc/getting-started-dev-services.adoc
@@ -3,18 +3,21 @@ This document is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-
 [id="getting-started-dev-services-tutorial"]
 = Your second Quarkus application
 include::_attributes.adoc[]
 :diataxis-type: tutorial
 :categories: getting-started, data, core
-
+:summary: Discover some of the features that make developing with Quarkus a joyful experience.
 
 This tutorial shows you how to create an application which writes to and reads from a database.
 You will use Dev Services, so you will not actually download, configure, or even start the database yourself.
 You will also use Panache, a layer on top of Hibernate ORM, to make reading and writing data easier.
 
+This guide helps you:
+
+ *  Read and write objects to a database
+ *  Develop and test against services with zero configuration
 
 == Prerequisites
 

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -488,8 +488,9 @@ include::{generated-dir}/config/quarkus-info.adoc[opts=optional, leveloffset=+2]
 
 This guide covered the creation of an application using Quarkus.
 However, there is much more.
-We recommend continuing the journey with the xref:building-native-image.adoc[building a native executable guide], where you learn about creating a native executable and packaging it in a container.
-If you are interested in reactive, we recommend the xref:getting-started-reactive.adoc[Getting Started with Reactive guide], where you can see how to implement reactive applications with Quarkus.
+We recommend continuing the journey by creating xref:getting-started-dev-services.adoc[your second Quarkus application], with dev services and persistence.
+You can learn about creating a native executable and packaging it in a container with the xref:building-native-image.adoc[building a native executable guide].
+If you are interested in reactive, we recommend the xref:getting-started-reactive.adoc[getting started with reactive guide], where you can see how to implement reactive applications with Quarkus.
 
 In addition, the xref:tooling.adoc[tooling guide] document explains how to:
 


### PR DESCRIPTION
I don't know how we didn't notice this in preview, but despite having a title, the title for ["my second application"](https://quarkus.io/guides/getting-started-dev-services) is generated nonsense: 

<img width="675" alt="image" src="https://github.com/quarkusio/quarkus/assets/11509290/db117275-77ad-4f57-8976-02543aa394a2">

The adoc looks fine in an adoc editor, so I'm not sure what's wrong. I've tried removing the id to see if that helps. 

I've also cross-linked from the first application guide to the second application guide.