### PR TITLE
Use OpenSearch 2.8 instead of 2.6 in HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest

### DIFF
--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest.java
@@ -26,10 +26,10 @@ public class HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest {
             return Map.of(
                     "quarkus.elasticsearch.devservices.enabled", "true",
                     // This needs to be different from the default image, or the test makes no sense.
-                    "quarkus.elasticsearch.devservices.image-name", "docker.io/opensearchproject/opensearch:2.6.0",
+                    "quarkus.elasticsearch.devservices.image-name", "docker.io/opensearchproject/opensearch:2.8.0",
                     // This needs to match the version used just above,
                     // so that Hibernate Search itself will assert that we're using a custom version.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.6");
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.8");
         }
 
         @Override


### PR DESCRIPTION
We use OpenSearch 2.9 by default, but `HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest` is about checking that we can override that version, so we need to use an older version there.

However, we've had some problems on CI with this test, with OpenSearch hanging on startup. We don't know what's the cause exactly, but let's try upgrading OpenSearch to 2.8 at least, in the hope that this fixes the problem.

See also #35583 (not marking as fixed though, since I have no way to reproduce the problem so I don't know if this fixes things).