### PR TITLE
Add note for logging request times in HTTP reference guide

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -437,6 +437,11 @@ include::{generated-dir}/config/quarkus-vertx-http-config-group-access-log-confi
 |Vert.x MDC data (e.g. 'traceId' for OpenTelemetry)                           |          | `%{X,mdc-key}`
 |===
 
+[NOTE]
+====
+Set `quarkus.http.record-request-start-time=true` to enable recording request start times when using any of the attributes related to logging request processing times.
+====
+
 [TIP]
 ====
 Use `quarkus.http.access-log.exclude-pattern=/some/path/.*` to exclude all entries concerning the path `/some/path/...` (_including subsequent paths_) from the log.


### PR DESCRIPTION
Add a note to enable recording request start times when using any of the attributes related to logging request processing times in the HTTP access log.

Related issues: #35472, #13129