### PR TITLE
Release the virtual thread executor

### DIFF
--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsRecorder.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/VirtualThreadsRecorder.java
@@ -47,6 +47,7 @@ public class VirtualThreadsRecorder {
                 @Override
                 public void run() {
                     Executor executor = current;
+                    current = null;
                     if (executor instanceof ExecutorService) {
                         ExecutorService service = (ExecutorService) executor;
                         service.shutdown();


### PR DESCRIPTION
Thus, the next test/dev execution would recreate a new executor.

Fix #35575
