### PR TITLE
Minor OIDC devui updates

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -133,7 +133,7 @@ You may need to register a redirect URI for the authorization code flow initiate
 
 If Keycloak does enforce it then you will see an authentication error informing you that the `redirect_uri` value is wrong.
 
-In this case select the `Keycloak Admin` option in the right top corner, login as `admin:admin`, select the test realm and the client which Dev UI for Keycloak is configured with and add `http://localhost:8080/q/dev/io.quarkus.quarkus-oidc/provider` to `Valid Redirect URIs`. If you used `-Dquarkus.http.port` when starting Quarkus then change `8080` to the value of `quarkus.http.port`
+In this case select the `Keycloak Admin` option in the right top corner, login as `admin:admin`, select the test realm and the client which Dev UI for Keycloak is configured with and add `http://localhost:8080/q/dev-ui/io.quarkus.quarkus-oidc/keycloak-provider` to `Valid Redirect URIs`. If you used `-Dquarkus.http.port` when starting Quarkus then change `8080` to the value of `quarkus.http.port`
 
 If the container is shared between multiple applications running on different ports then you will need to register `redirect_uri` values for each of these applications.
 
@@ -318,7 +318,7 @@ image::dev-ui-oidc-devconsole-card.png[alt=Generic Dev UI OpenID Connect Card,ro
 
 Follow the link, and you will be able to log in to your provider, get the tokens and test the application. The experience will be the same as described in the <<keycloak-authorization-code-grant,Authorization Code Grant for Keycloak>> section, where `Dev Services for Keycloak` container has been started, especially if you work with Keycloak.
 
-You will most likely need to configure your OpenId Connect provider to support redirecting back to the `Dev Console`. Add `http://localhost:8080/q/dev-v1/io.quarkus.quarkus-oidc/provider` as one of the supported redirect and logout URLs. one of the supported redirect and logout URLs.
+You will most likely need to configure your OpenId Connect provider to support redirecting back to the `Dev Console`. Add `http://localhost:8080/q/dev-ui/io.quarkus.quarkus-oidc/`providerName`-provider` as one of the supported redirect and logout URLs, where `providerName` will need to be replaced by the name of the provider shown in DevUI, for example, `auth0`.
 
 If you work with other providers then a Dev UI experience described in the <<keycloak-authorization-code-grant,Authorization Code Grant for Keycloak>> section might differ slightly. For example, an access token may not be in a JWT format, so it won't be possible to show its internal content, though all providers should return an ID Token as JWT.
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfigPropertySupplier.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfigPropertySupplier.java
@@ -111,7 +111,11 @@ public class OidcConfigPropertySupplier implements Supplier<String> {
                 scopes = providerConfig.authentication.scopes;
             }
             if (scopes.isPresent()) {
-                return OidcCommonUtils.urlEncode(String.join(" ", scopes.get()));
+                String scopesString = String.join(" ", scopes.get());
+                if (!scopes.get().contains(OidcConstants.OPENID_SCOPE)) {
+                    scopesString += (" " + OidcConstants.OPENID_SCOPE);
+                }
+                return OidcCommonUtils.urlEncode(scopesString);
             } else {
                 return OidcConstants.OPENID_SCOPE;
             }


### PR DESCRIPTION
Minor updates to the DevUI after testing it with Auth0:

* DevUI script should include `openid` scope if it is not explicitly configured, example, with `quarkus.oidc.authentication.scopes=profile`.  It has always been the case with the Quarkus OIDC itself, but in DevUI it is not currently done. I've found out about it after successfully testing a Quarkus OIDC endpoint with `quarkus.oidc.authentication.scopes=profile` and then spending a couple of hours trying to figure why in DevUI SPA, IdToken is not returned from Auth0 - turned out the `openid` scope was missing - it can be easily fixed with `quarkus.oidc.authentication.scopes=openid,profile` but users should not spend time chasing it if they omit `openid`
* For redirect from OIDC providers back to DevUI SPA to work, in many case users would have to register a DevUI page address in the provider's console. The currently documented address has changed so I fixed it in the docs. (it works with the default Keycloak devservice launch because a wildcard redirect is enabled)

