### PR TITLE
Improve latency of CLI plugin commands

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/JBangCatalogService.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/JBangCatalogService.java
@@ -40,6 +40,10 @@ public class JBangCatalogService extends CatalogService<JBangCatalog> {
         this.jbang = new JBangSupport(interactiveMode, output);
     }
 
+    public boolean ensureJBangIsInstalled() {
+        return jbang.ensureJBangIsInstalled();
+    }
+
     @Override
     public JBangCatalog readCatalog(Path path) {
         if (!jbang.isAvailable() && !jbang.isInstallable()) {
@@ -93,8 +97,9 @@ public class JBangCatalogService extends CatalogService<JBangCatalog> {
             });
         });
 
-        //If not catalog have been specified use all available.
-        if (remoteCatalogs.length == 0) {
+        if (!jbang.isAvailable()) {
+            //If jbang is not available, ignore aliases
+        } else if (remoteCatalogs.length == 0) { //If not catalog have been specified use all available.
             aliases.putAll(listAliasesOrFallback(jbang, fallbackCatalog).entrySet()
                     .stream()
                     .filter(e -> !aliases.containsKey(e.getKey()))

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/JBangSupport.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/JBangSupport.java
@@ -38,6 +38,7 @@ public class JBangSupport {
     private Path workingDirectory;
 
     private Optional<Boolean> installed = Optional.empty();
+    private Optional<String> version = Optional.empty();
 
     public JBangSupport(boolean interactiveMode, MessageWriter output) {
         this(interactiveMode, output, Paths.get(System.getProperty("user.dir")));
@@ -138,8 +139,12 @@ public class JBangSupport {
     }
 
     public Optional<String> version() {
-        return execute("version").stream().findFirst();
-
+        if (version.isPresent()) {
+            return version;
+        } else {
+            version = execute("version").stream().findFirst();
+        }
+        return version;
     }
 
     public boolean isAvailable() {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManager.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManager.java
@@ -238,7 +238,9 @@ public class PluginManager {
                 .orElseThrow(() -> new IllegalArgumentException("Unknwon plugin catalog location."));
         List<PluginType> installedTypes = catalog.getPlugins().entrySet().stream().map(Map.Entry::getValue).map(Plugin::getType)
                 .collect(Collectors.toList());
-        Map<String, Plugin> installablePlugins = state.getInstallablePlugins().entrySet().stream()
+        //Let's only fetch installable plugins of the corresponding types.
+        //This will help us avoid uneeded calls to things like jbang if no jbang plugins are installed
+        Map<String, Plugin> installablePlugins = state.installablePlugins(installedTypes).entrySet().stream()
                 .filter(e -> installedTypes.contains(e.getValue().getType()))
                 .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginMangerState.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginMangerState.java
@@ -141,6 +141,7 @@ class PluginMangerState {
     public Map<String, Plugin> jbangPlugins() {
         boolean isUserScoped = !projectRoot.isPresent();
         Map<String, Plugin> jbangPlugins = new HashMap<>();
+        jbangCatalogService.ensureJBangIsInstalled();
         JBangCatalog jbangCatalog = jbangCatalogService.readCombinedCatalog(projectRoot, userHome);
         jbangCatalog.getAliases().forEach((location, alias) -> {
             String name = util.getName(location);


### PR DESCRIPTION
The pull request adds the following improvements:

- cache jbang version to avoid multiple jbang calls
- reconcile focuses on installed plugin types (avoid uneeded calls to jbang).
- limit the cases where we check for jbang installation.