### PR TITLE
OIDC Dev UI Auth0 improvements

### DIFF
--- a/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
+++ b/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
@@ -208,13 +208,16 @@ export class QwcOidcProvider extends QwcHotReloadElement {
         .decoded-token pre {
           white-space: break-spaces;
         }
-        .token-success {
+        .token-payload {
           color: var(--lumo-success-color);
         }
-        .token-danger {
+        .token-headers {
           color: var(--lumo-error-color);
         }
-        .token-primary {
+        .token-signature {
+          color: var(--quarkus-blue);
+        }
+        .token-encryption {
           color: var(--quarkus-blue);
         }
         .margin-top-space-m {
@@ -1150,8 +1153,21 @@ export class QwcOidcProvider extends QwcHotReloadElement {
                 const signature = parts[2]?.trim();
 
                 return html`
-                <span class='token-danger' title='Header'>${headers}</span>.<span class='token-success' title='Payload'
-                >${payload}</span>.<span class='token-primary' title='Signature'>${signature}</span>
+                <span class='token-headers' title='Header'>${headers}</span>.<span class='token-payload' title='Claims'
+                >${payload}</span>.<span class='token-signature' title='Signature'>${signature}</span>
+            `;
+            } else if (parts.length === 5) {
+                const headers = parts[0]?.trim();
+                const encryptedKey = parts[1]?.trim();
+                const initVector = parts[2]?.trim();
+                const ciphertext = parts[3]?.trim();
+                const authTag = parts[4]?.trim();
+
+                return html`
+                <span class='token-headers' title='Header'>${headers}</span>.<span class='token-encryption' title='Encrypted Key'
+                >${encryptedKey}.<span class='token-encryption' title='Init Vector'
+                >${initVector}</span>.<span class='token-payload' title='Ciphertext'
+                >${ciphertext}</span>.<span class='token-encryption' title='Authentication Tag'>${authTag}</span>
             `;
             } else {
                 return html`${token}`;
@@ -1169,10 +1185,24 @@ export class QwcOidcProvider extends QwcHotReloadElement {
                 const signature = parts[2];
                 const jsonPayload = JSON.parse(payload);
                 return html`
-                <pre class='token-danger' title='Header'>${JSON.stringify(JSON.parse(headers), null, 4)?.trim()}</pre>
-                <pre class='token-success' title='Payload'>${JSON.stringify(jsonPayload,null,4)?.trim()}</pre>
-                <span class='token-primary' title='Signature'>${signature?.trim()}</span>
+                <pre class='token-headers' title='Header'>${JSON.stringify(JSON.parse(headers), null, 4)?.trim()}</pre>
+                <pre class='token-payload' title='Claims'>${JSON.stringify(jsonPayload,null,4)?.trim()}</pre>
+-                <span class='token-signature' title='Signature'>${signature?.trim()}</span>
                 `;
+            } else if (parts.length === 5) {
+                const headers = window.atob(parts[0]?.trim());
+                const encryptedKey = parts[1]?.trim();
+                const initVector = parts[2]?.trim();
+                const ciphertext = parts[3]?.trim();
+                const authTag = parts[4]?.trim();
+
+                return html`
+                <pre class='token-headers' title='Header'>${JSON.stringify(JSON.parse(headers), null, 4)?.trim()}</pre>
+                <pre class='token-encryption' title='Encrypted Key'>${encryptedKey}</pre>
+                <pre class='token-encryption' title='Init Vector'>${initVector}</pre>
+                <pre class='token-payload' title='Ciphertext'>${ciphertext}</pre>
+                <span class='token-encryption' title='Authentication Tag'>${authTag}</span>
+            `;
             } else {
                 return html`${token}`;
             }

--- a/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
+++ b/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
@@ -1131,6 +1131,7 @@ export class QwcOidcProvider extends QwcHotReloadElement {
 
     _logout() {
         localStorage.removeItem('authorized');
+        const clientId = this._getClientId();
 
         let address;
         if (propertiesState.keycloakAdminUrl && this._selectedRealm) {
@@ -1141,7 +1142,8 @@ export class QwcOidcProvider extends QwcHotReloadElement {
 
         window.location.assign(address
             + '?' + (propertiesState.postLogoutUriParam ?? '') + '=' + this._getEncodedPath()
-            + '&id_token_hint=' + propertiesState.idToken);
+            + '&id_token_hint=' + propertiesState.idToken
+            + "&client_id=" + clientId);
     }
 
     static _prettyToken(token){


### PR DESCRIPTION
This is another PR improving the Auth0 user experience in Dev UI

1. Auth0 access tokens are encrypted JWE tokens, currently they are shown like this:

![OpaqueAccessToken](https://github.com/quarkusio/quarkus/assets/467639/fab0d14e-5ec0-4bfd-82af-901e049018c3)

but after this PR it will be shown like this:

![JweAccessToken](https://github.com/quarkusio/quarkus/assets/467639/60990170-b925-4943-8abc-2def432a2458)

which will make it easier to explain, by pointing to the decoded token headers, that this is an encrypted token.

Along the way I've just renamed some style classes, ex, instead of `token-danger` which was used exclusively for showing the token headers in red, it is now `token-headers`, etc

2. Auth0 logout request should include `client_id`, without it it can still work but requires more advanced Auth0 configuration to support a global logout URL, with the `client_id` can get the allowed logout callback from the registered application properties instead. I've confirmed it does not affect the Keycloak logout, it should not really as query parameters are optional
 