### PR TITLE
Map deprecated `quarkus.http.cors` to ensure recording

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -18,6 +18,17 @@ import io.smallrye.config.WithName;
 public interface HttpConfiguration {
     /**
      * Enable the CORS filter.
+     *
+     * @deprecated Use {@link HttpConfiguration#corsEnabled()}. Deprecated because it requires additional syntax to
+     *             configure with the group {@link HttpConfiguration#cors()} in YAML config.
+     */
+    @WithName("cors")
+    @WithDefault("false")
+    @Deprecated
+    boolean oldCorsEnabled();
+
+    /**
+     * Enable the CORS filter.
      */
     @WithName("cors.enabled")
     @WithDefault("${quarkus.http.cors:false}")


### PR DESCRIPTION
- Fixes #35374

The issue is that because the property was not mapped, it was not being recorded in the native image.