### PR TITLE
Fix doc link asciidoc change link to xref where applicable

### DIFF
--- a/docs/src/main/asciidoc/security-architecture.adoc
+++ b/docs/src/main/asciidoc/security-architecture.adoc
@@ -73,7 +73,7 @@ You can customize the following core security components of Quarkus:
 * `IdentityProvider`
 * `SecurityidentityAugmentor`
 
-For more information about customizing Quarkus Security, including reactive security and how to register a security provider, see the Quarkus link:{url-quarkusio-guides}security-customization[Security tips and tricks] guide.
+For more information about customizing Quarkus Security, including reactive security and how to register a security provider, see the Quarkus xref:security-customization.adoc[Security tips and tricks] guide.
 
 == References
 

--- a/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
@@ -150,7 +150,7 @@ X509Certificate certificate = credential.getCertificate();
 
 The information from the client certificate can be used to enhance Quarkus `SecurityIdentity`.
 For example, you can add new roles after checking a client certificate subject name, and so on.
-For more information about customizing `SecurityIdentity`, see the link:{url-quarkusio-guides}security-customization#security-identity-customization[Security identity customization] section in the Quarkus "Security tips and tricks" guide.
+For more information about customizing `SecurityIdentity`, see the xref:security-customization.adoc#security-identity-customization[Security identity customization] section in the Quarkus "Security tips and tricks" guide.
 
 [[other-supported-authentication-mechanisms]]
 == Other supported authentication mechanisms
@@ -209,7 +209,7 @@ For more information about OIDC authentication and authorization methods that yo
 To enable the Quarkus OIDC extension at runtime, set `quarkus.oidc.tenant-enabled=false` at build time.
 Then re-enable it at runtime by using a system property.
 
-For more information about managing the individual tenant configurations in multitenant OIDC deployments, see the link:{url-quarkusio-guides}security-openid-connect-multitenancy#disable-tenant[Disabling tenant configurations] section in the "Using OpenID Connect (OIDC) multi-tenancy" guide.
+For more information about managing the individual tenant configurations in multitenant OIDC deployments, see the xref:security-openid-connect-multitenancy.adoc#disable-tenant[Disabling tenant configurations] section in the "Using OpenID Connect (OIDC) multi-tenancy" guide.
 ====
 
 ==== OpenID Connect client and filters

--- a/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
@@ -8,7 +8,7 @@ Enable xref:security-basic-authentication.adoc[Basic authentication] for your Qu
 
 == Prerequisites
 
-* You have installed at least one extension that provides an `IdentityProvider` based on username and password, such as link:{url-quarkusio-guides}security-jdbc[Elytron JDBC].
+* You have installed at least one extension that provides an `IdentityProvider` based on username and password, such as xref:security-jdbc.adoc[Elytron JDBC].
 
 == Procedure
 


### PR DESCRIPTION
This PR fixes some broken 404s identified during downstream testing.

Changed instances of bad `link:` markup (missing / char & attribute) to `xref:` because in these instances the guides are local Quarkus guides and using an `xref` ensures that the linked guide version maps to the correct Quarkus version of the docs.

