### PR TITLE
Allow using a servicePath with capital letters when testing with the OIDC provider test Service

### DIFF
--- a/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
+++ b/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
@@ -780,7 +780,7 @@ export class QwcOidcProvider extends QwcHotReloadElement {
                     <vaadin-text-field class="frm-field"
                                        value="/"
                                        @value-changed="${e => {
-            this._servicePath = (e.detail?.value || '').trim().toLowerCase();
+            this._servicePath = (e.detail?.value || '').trim();
             if (!this._servicePath.startsWith('/')) {
                 this._servicePath = '/' + this._servicePath;
             }


### PR DESCRIPTION
In an URL the path is Case sensitive and can be writen with capital letters. This PR remove the usage of the `toLowerCase()` method when retriving the path to test the application Endpoint.

Fixes #35636