### PR TITLE
Unwrap `AssertionError` from `InvocationTargetException` during Quarkus JUnit5 callbacks

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractTestWithCallbacksExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractTestWithCallbacksExtension.java
@@ -158,7 +158,12 @@ public abstract class AbstractTestWithCallbacksExtension {
                         .invoke(callback, classInstance);
             }
         } catch (InvocationTargetException e) {
-            throw e.getCause() instanceof Exception ? (Exception) e.getCause() : e;
+            if (e.getCause() instanceof Exception) {
+                throw (Exception) e.getCause();
+            } else if (e.getCause() instanceof AssertionError) {
+                throw (AssertionError) e.getCause();
+            }
+            throw e;
         }
     }
 }

--- a/test-framework/junit5/src/test/java/io/quarkus/test/junit/ErrorThrowingCallback.java
+++ b/test-framework/junit5/src/test/java/io/quarkus/test/junit/ErrorThrowingCallback.java
@@ -1,0 +1,34 @@
+package io.quarkus.test.junit;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.junit.jupiter.api.AssertionFailureBuilder;
+
+import io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback;
+import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
+
+/**
+ * Test handling of {@link AssertionError}s and {@link RuntimeException} in callbacks.
+ *
+ * @see QuarkusTestCallbacksErrorHandlingTest
+ */
+public class ErrorThrowingCallback implements QuarkusTestAfterEachCallback {
+    @Override
+    public void afterEach(QuarkusTestMethodContext context) {
+        String throwableType = System.getProperty("quarkus.test.callback.throwableType");
+
+        if ("AssertionError".equalsIgnoreCase(throwableType)) {
+            AssertionFailureBuilder
+                    .assertionFailure()
+                    .expected("a")
+                    .actual("b")
+                    .reason("Oh no, it broke! Here's an assertion error")
+                    .buildAndThrow();
+        }
+
+        if ("RuntimeException".equalsIgnoreCase(throwableType)) {
+            throw new UncheckedIOException(new IOException("Oh dear, it broke again"));
+        }
+    }
+}

--- a/test-framework/junit5/src/test/java/io/quarkus/test/junit/QuarkusTestCallbacksErrorHandlingTest.java
+++ b/test-framework/junit5/src/test/java/io/quarkus/test/junit/QuarkusTestCallbacksErrorHandlingTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.test.junit;
+
+import java.io.UncheckedIOException;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
+
+/**
+ * Generally, {@link AssertionError} is thrown by testing frameworks such as JUnit. However,
+ * it does not derive from {@link RuntimeException} hierarchy, and hence separate unwrapping of each type
+ * must be handled in {@link io.quarkus.test.junit.AbstractTestWithCallbacksExtension}.
+ * <p>
+ * Ensuring that <code>AssertionError</code> is at the top of any stack track allows tooling to properly
+ * parse and display expected vs actual diffs, etc.
+ *
+ * @see ErrorThrowingCallback
+ */
+public class QuarkusTestCallbacksErrorHandlingTest {
+
+    @Test
+    public void testAssertionErrorsAreUnwrappedFromCallback() {
+        Assertions.assertThrows(AssertionError.class, () -> {
+            System.setProperty("quarkus.test.callback.throwableType", "AssertionError");
+            MockCallbackExtension extension = new MockCallbackExtension();
+            QuarkusTestMethodContext mockContext = new QuarkusTestMethodContext(new Object(), List.of(), null, null);
+            extension.invokeAfterEachCallbacks(mockContext);
+        });
+    }
+
+    @Test
+    public void testRuntimeExceptionsAreUnwrappedFromCallback() {
+        Assertions.assertThrows(UncheckedIOException.class, () -> {
+            System.setProperty("quarkus.test.callback.throwableType", "RuntimeException");
+            MockCallbackExtension extension = new MockCallbackExtension();
+            QuarkusTestMethodContext mockContext = new QuarkusTestMethodContext(new Object(), List.of(), null, null);
+            extension.invokeAfterEachCallbacks(mockContext);
+        });
+    }
+
+    public static class MockCallbackExtension extends AbstractTestWithCallbacksExtension {
+
+        public MockCallbackExtension() throws ClassNotFoundException {
+            populateCallbacks(Thread.currentThread().getContextClassLoader());
+        }
+
+    }
+}

--- a/test-framework/junit5/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
+++ b/test-framework/junit5/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
@@ -1,0 +1,1 @@
+io.quarkus.test.junit.ErrorThrowingCallback


### PR DESCRIPTION
I have been writing some custom Quarkus JUnit 5 callbacks; these are specially provided by Quarkus to allow callbacks within the context of the Quarkus classloader to do things like CDI, etc.

I've generally managed to get most things working after experimentation, plus digging through code and documentation, but there was one nit:

Currently, only `RuntimeException`-derived throwables are being unwrapped, but many test frameworks use throwables deriving from `AssertionError`. Hence, if an `AssertionError` is thrown in the callback, it currently ends up being wrapped by an `InvocationTargetException`, which means that tooling doesn't parse the stack trace properly for "expected" vs "actual" comparisons, etcetera.

This small pull request ensures that `AssertionError` is unwrapped properly (but not `Error` more generically, as this could mask categories of error that emanate from other sources such as OOM, where leaving it unwrapped may be helpful).

I added a test that exercises the existing codepaths as well as the new one.

p.s: I initially tried to add the tests to existing `@QuarkusTest`s that cover callbacks, but despite sinking many hours into it, I couldn't find a sensible way to capture the exceptions thrown from the Quarkus callbacks inside of the JUnit test, so this semi-mocked approach seems the most practical way without significant code changes, which I doubt are worth it.