### PR TITLE
OpenShiftClientProducer tests

### DIFF
--- a/extensions/openshift-client/deployment/src/test/java/io/quarkus/openshift/client/deployment/BeanDefaultsTest.java
+++ b/extensions/openshift-client/deployment/src/test/java/io/quarkus/openshift/client/deployment/BeanDefaultsTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.openshift.client.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BeanDefaultsTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.kubernetes-client.devservices.enabled", "false");
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @Inject
+    OpenShiftClient openShiftClient;
+
+    @Test
+    public void openShiftClientIsInstantiated() {
+        assertNotNull(openShiftClient);
+    }
+
+    @Test
+    public void kubernetesClientIsInstantiatedAsOpenShiftClient() {
+        assertNotNull(kubernetesClient);
+        assertTrue(kubernetesClient instanceof OpenShiftClient);
+    }
+}

--- a/extensions/openshift-client/deployment/src/test/java/io/quarkus/openshift/client/deployment/BeanOverridesTest.java
+++ b/extensions/openshift-client/deployment/src/test/java/io/quarkus/openshift/client/deployment/BeanOverridesTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.openshift.client.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BeanOverridesTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.kubernetes-client.devservices.enabled", "false");
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @Inject
+    OpenShiftClient openShiftClient;
+
+    @Test
+    public void openShiftClientCanBeOverridden() {
+        assertEquals("https://example.com/overridden/", openShiftClient.getConfiguration().getMasterUrl());
+    }
+
+    @Test
+    public void kubernetesClientCanIsOpenShiftInstance() {
+        assertEquals("https://example.com/overridden/", kubernetesClient.getConfiguration().getMasterUrl());
+    }
+
+    @Singleton
+    public static class BeanOverridesConfig {
+        @Produces
+        public OpenShiftClient openShiftClient() {
+            return new KubernetesClientBuilder()
+                    .withConfig(new ConfigBuilder(Config.empty())
+                            .withMasterUrl("https://example.com/overridden/")
+                            .build())
+                    .build().adapt(OpenShiftClient.class);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Closes #35525 

As [discussed](https://github.com/quarkusio/quarkus/pull/35525#issuecomment-1699225968), #35525 can't be merged since there is no support for the [`@Specializes`](https://docs.jboss.org/weld/reference/latest/en-US/html/specialization.html#_using_specialization) annotation.

This PR contains the tests that were introduced in #35525 to ensure the behavior of the beans provided by OpenShiftClientProducer.

From https://github.com/quarkusio/quarkus/pull/35525#issuecomment-1692765728:

> - **BeanDefaultsTest:** A user is able to inject `KubernetesClient` and `OpenShiftClient` fields.
  The injected KubernetesClient instance should be the one produced by OpenShiftClientProducer (OpenShiftClient)
> - **BeanOverridesTest:** A user is able to override the **default** `OpenShiftClient` with their own instance and producer method **without** providing further configurations or annotations.
>  _(requires that all of our producer methods are annotated with `@DefaultBean`. Requires our processor methods to remove one of the producers in case both extensions coexist.)_