### PR TITLE
Allow NodeJS 12 containers in GitHub Actions

### DIFF
--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'docs/src/main/asciidoc/**'
       - '.github/workflows/doc-build.yml'
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   preview-teardown:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -6,6 +6,8 @@ on:
     types:
       - completed
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 jobs:
   preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `actions-cool/maintain-one-comment@v3.1.0` needs to be upgraded to Node 16. Until this is done, we need to set this environment variable to allow Node 12 containers to run in GitHub Actions.

- See https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/ for details
- I've also created https://github.com/actions-cool/maintain-one-comment/pull/7 bumping it to Node 16
- As reported in https://github.com/quarkusio/quarkus/pull/35630#issuecomment-1700746999 and logged in https://github.com/quarkusio/quarkus/actions/runs/6035531292