### PR TITLE
Fix Redis custom codec registration when there is more than one codec

### DIFF
--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/datasource/CustomCodecTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/deployment/client/datasource/CustomCodecTest.java
@@ -28,7 +28,8 @@ public class CustomCodecTest {
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(
-                    () -> ShrinkWrap.create(JavaArchive.class).addClass(Jedi.class).addClass(MyCustomCodec.class))
+                    () -> ShrinkWrap.create(JavaArchive.class).addClass(Jedi.class).addClass(Sith.class)
+                            .addClass(CustomJediCodec.class).addClass(CustomSithCodec.class))
             .overrideConfigKey("quarkus.redis.hosts", "${quarkus.redis.tr}");
 
     @Inject
@@ -37,28 +38,45 @@ public class CustomCodecTest {
     @Test
     void testCustomCodecs() {
         String key1 = UUID.randomUUID().toString();
-        // Check that the codec is registered
-        assertThat(Codecs.getDefaultCodecFor(Jedi.class)).isInstanceOf(MyCustomCodec.class);
+        // Check that all codec are registered
+        assertThat(Codecs.getDefaultCodecFor(Jedi.class)).isInstanceOf(CustomJediCodec.class);
+        assertThat(Codecs.getDefaultCodecFor(Sith.class)).isInstanceOf(CustomSithCodec.class);
 
-        HashCommands<String, String, Jedi> hash1 = ds.hash(Jedi.class);
-        hash1.hset(key1, "test", new Jedi("luke", "skywalker"));
-        var retrieved = hash1.hget(key1, "test");
-        assertThat(retrieved.firstName).isEqualTo("luke");
-        assertThat(retrieved.lastName).isEqualTo("SKYWALKER");
+        HashCommands<String, String, Jedi> jediHash1 = ds.hash(Jedi.class);
+        jediHash1.hset(key1, "test", new Jedi("luke", "skywalker"));
+        var jediRetrieved = jediHash1.hget(key1, "test");
+        assertThat(jediRetrieved.firstName).isEqualTo("luke");
+        assertThat(jediRetrieved.lastName).isEqualTo("SKYWALKER");
 
-        HashCommands<String, Jedi, String> hash2 = ds.hash(String.class, Jedi.class, String.class);
-        hash2.hset(key1, new Jedi("luke", "skywalker"), "test");
-        var retrieved2 = hash2.hget(key1, new Jedi("luke", "skywalker"));
-        assertThat(retrieved2).isEqualTo("test");
+        HashCommands<String, Jedi, String> jediHash2 = ds.hash(String.class, Jedi.class, String.class);
+        jediHash2.hset(key1, new Jedi("luke", "skywalker"), "test");
+        var jediRetrieved2 = jediHash2.hget(key1, new Jedi("luke", "skywalker"));
+        assertThat(jediRetrieved2).isEqualTo("test");
 
-        HashCommands<Jedi, String, String> hash3 = ds.hash(Jedi.class, String.class, String.class);
-        hash3.hset(new Jedi("luke", "skywalker"), "key", "value");
-        var retrieved3 = hash3.hget(new Jedi("luke", "skywalker"), "key");
-        assertThat(retrieved3).isEqualTo("value");
+        HashCommands<Jedi, String, String> jediHash3 = ds.hash(Jedi.class, String.class, String.class);
+        jediHash3.hset(new Jedi("luke", "skywalker"), "key", "value");
+        var jediRetrieved3 = jediHash3.hget(new Jedi("luke", "skywalker"), "key");
+        assertThat(jediRetrieved3).isEqualTo("value");
+
+        HashCommands<String, String, Sith> sithHash1 = ds.hash(Sith.class);
+        sithHash1.hset(key1, "test", new Sith("darth", "sidious"));
+        var sithRetrieved = sithHash1.hget(key1, "test");
+        assertThat(sithRetrieved.firstName).isEqualTo("darth");
+        assertThat(sithRetrieved.lastName).isEqualTo("SIDIOUS");
+
+        HashCommands<String, Sith, String> sithHash2 = ds.hash(String.class, Sith.class, String.class);
+        sithHash2.hset(key1, new Sith("darth", "sidious"), "test");
+        var sithRetrieved2 = sithHash2.hget(key1, new Sith("darth", "sidious"));
+        assertThat(sithRetrieved2).isEqualTo("test");
+
+        HashCommands<Sith, String, String> sithHash3 = ds.hash(Sith.class, String.class, String.class);
+        sithHash3.hset(new Sith("darth", "sidious"), "key", "value");
+        var sithRetrieved3 = sithHash3.hget(new Sith("darth", "sidious"), "key");
+        assertThat(sithRetrieved3).isEqualTo("value");
     }
 
     @ApplicationScoped
-    public static class MyCustomCodec implements Codec {
+    public static class CustomJediCodec implements Codec {
 
         @Override
         public boolean canHandle(Type clazz) {
@@ -79,11 +97,43 @@ public class CustomCodecTest {
         }
     }
 
+    @ApplicationScoped
+    public static class CustomSithCodec implements Codec {
+
+        @Override
+        public boolean canHandle(Type clazz) {
+            return clazz.equals(Sith.class);
+        }
+
+        @Override
+        public byte[] encode(Object item) {
+            var sith = (Sith) item;
+            return (sith.firstName + ";" + sith.lastName).getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public Object decode(byte[] item) {
+            String s = new String(item, StandardCharsets.UTF_8);
+            String[] strings = s.split(";");
+            return new Sith(strings[0], strings[1].toUpperCase());
+        }
+    }
+
     public static class Jedi {
         public final String firstName;
         public final String lastName;
 
         public Jedi(String firstName, String lastName) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+        }
+    }
+
+    public static class Sith {
+        public final String firstName;
+        public final String lastName;
+
+        public Sith(String firstName, String lastName) {
             this.firstName = firstName;
             this.lastName = lastName;
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisClientRecorder.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/RedisClientRecorder.java
@@ -65,9 +65,8 @@ public class RedisClientRecorder {
 
     private static void _registerCodecs() {
         Instance<Codec> codecs = CDI.current().select(Codec.class);
-        if (codecs.isResolvable()) {
-            Codecs.register(codecs.stream());
-        }
+
+        Codecs.register(codecs.stream());
     }
 
     public void _initialize(io.vertx.core.Vertx vertx, Set<String> names) {


### PR DESCRIPTION
Removes `isResolvable()` check and adds a second codec to the custom codec test.

Fixes #35661 