### PR TITLE
Fix DevUI fix serialization error on Throwable

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/jsonrpc/ByteArrayInputStreamDeserializer.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/jsonrpc/ByteArrayInputStreamDeserializer.java
@@ -1,0 +1,27 @@
+package io.quarkus.devui.deployment.jsonrpc;
+
+import static io.quarkus.vertx.runtime.jackson.JsonUtil.BASE64_DECODER;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+public class ByteArrayInputStreamDeserializer extends JsonDeserializer<ByteArrayInputStream> {
+
+    @Override
+    public ByteArrayInputStream deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        String text = p.getText();
+        try {
+            byte[] decode = BASE64_DECODER.decode(text);
+            return new ByteArrayInputStream(decode);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidFormatException(p, "Expected a base64 encoded byte array", text, ByteArrayInputStream.class);
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/jsonrpc/ByteArrayInputStreamSerializer.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/jsonrpc/ByteArrayInputStreamSerializer.java
@@ -1,0 +1,21 @@
+package io.quarkus.devui.deployment.jsonrpc;
+
+import static io.quarkus.vertx.runtime.jackson.JsonUtil.BASE64_ENCODER;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import io.quarkus.deployment.util.IoUtil;
+
+public class ByteArrayInputStreamSerializer extends JsonSerializer<ByteArrayInputStream> {
+
+    @Override
+    public void serialize(ByteArrayInputStream value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        byte[] readBytes = IoUtil.readBytes(value);
+        jgen.writeString(BASE64_ENCODER.encodeToString(readBytes));
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/jsonrpc/DevUIDatabindCodec.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/jsonrpc/DevUIDatabindCodec.java
@@ -1,5 +1,6 @@
 package io.quarkus.devui.deployment.jsonrpc;
 
+import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Instant;
@@ -137,6 +138,8 @@ public class DevUIDatabindCodec implements JsonMapper {
             module.addDeserializer(Instant.class, new InstantDeserializer());
             module.addSerializer(byte[].class, new ByteArraySerializer());
             module.addDeserializer(byte[].class, new ByteArrayDeserializer());
+            module.addSerializer(ByteArrayInputStream.class, new ByteArrayInputStreamSerializer());
+            module.addDeserializer(ByteArrayInputStream.class, new ByteArrayInputStreamDeserializer());
             mapper.registerModule(module);
 
             SimpleModule runtimeModule = new SimpleModule("vertx-module-runtime");

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/menu/ContinuousTestingProcessor.java
@@ -1,12 +1,9 @@
 package io.quarkus.devui.deployment.menu;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.deployment.IsDevelopment;
@@ -233,7 +230,6 @@ public class ContinuousTestingProcessor {
 
     private void registerGetResultsMethod(LaunchModeBuildItem launchModeBuildItem) {
         DevConsoleManager.register(NAMESPACE + DASH + "getResults", ignored -> {
-            ObjectMapper objectMapper = new ObjectMapper(); // Remove in favior of build in.
             try {
                 Optional<TestSupport> ts = TestSupport.instance();
                 if (testsDisabled(launchModeBuildItem, ts)) {
@@ -246,10 +242,7 @@ public class ContinuousTestingProcessor {
                     return null;
                 }
 
-                try (StringWriter sw = new StringWriter()) {
-                    objectMapper.writeValue(sw, testRunResults);
-                    return sw.toString();
-                }
+                return testRunResults;
 
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/continuoustesting/ContinuousTestingJsonRPCService.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/devui/runtime/continuoustesting/ContinuousTestingJsonRPCService.java
@@ -16,10 +16,10 @@ import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 public class ContinuousTestingJsonRPCService implements Consumer<ContinuousTestingSharedStateManager.State> {
 
     private final BroadcastProcessor<String> stateBroadcaster = BroadcastProcessor.create();
-    private final BroadcastProcessor<String> resultBroadcaster = BroadcastProcessor.create();
+    private final BroadcastProcessor<Object> resultBroadcaster = BroadcastProcessor.create();
 
     private String lastKnownState = "";
-    private String lastKnownResults = "";
+    private Object lastKnownResults = "";
 
     @Override
     public void accept(ContinuousTestingSharedStateManager.State state) {
@@ -46,7 +46,7 @@ public class ContinuousTestingJsonRPCService implements Consumer<ContinuousTesti
         return stateBroadcaster;
     }
 
-    public Multi<String> streamTestResults() {
+    public Multi<Object> streamTestResults() {
         return resultBroadcaster;
     }
 
@@ -56,7 +56,7 @@ public class ContinuousTestingJsonRPCService implements Consumer<ContinuousTesti
     }
 
     @NonBlocking
-    public String lastKnownResults() {
+    public Object lastKnownResults() {
         return this.lastKnownResults;
     }
 
@@ -89,7 +89,7 @@ public class ContinuousTestingJsonRPCService implements Consumer<ContinuousTesti
         return invokeAction("toggleInstrumentation");
     }
 
-    public String getResults() {
+    public Object getResults() {
         return invokeAction("getResults");
     }
 


### PR DESCRIPTION
Fix #35653

At the beginning of the new Dev UI we did not have a way to send object between deployment cp and runtime cp, but support for that has been added recently. Some of the older extensions that we converted first still use their own object mapper that send Strings between the two. This was one of those. This PR change to use the Dedicated mapper, and also adds support for the missing serialization. 

![Peek 2023-09-01 13-22](https://github.com/quarkusio/quarkus/assets/6836179/385ed67d-bf55-44ed-95aa-27f2753aa897)

/cc @alexkolson