### PR TITLE
ArC: log warning about removed beans for BeanContainer operations

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/ArcContainerLookupProblemDetectedTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/ArcContainerLookupProblemDetectedTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.arc.test.unused;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.impl.ArcContainerImpl;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ArcContainerLookupProblemDetectedTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(Alpha.class))
+            .setLogRecordPredicate(log -> ArcContainerImpl.class.getPackage().getName().equals(log.getLoggerName()))
+            .assertLogRecords(records -> {
+                LogRecord warning = records.stream()
+                        .filter(l -> l.getMessage().contains("programmatic lookup problem detected")).findAny().orElse(null);
+                assertNotNull(warning);
+                Formatter fmt = new PatternFormatter("%m");
+                String message = fmt.format(warning);
+                assertTrue(message.contains(
+                        "Stack frame: io.quarkus.arc.test.unused.ArcContainerLookupProblemDetectedTest.testWarning"),
+                        message);
+                assertTrue(message.contains(
+                        "Required type: class io.quarkus.arc.test.unused.ArcContainerLookupProblemDetectedTest$Alpha"),
+                        message);
+            });
+
+    @Test
+    public void testWarning() {
+        // Note that the warning is only displayed once, subsequent calls use a cached result
+        assertFalse(Arc.container().instance(Alpha.class).isAvailable());
+    }
+
+    // unused bean, will be removed
+    @ApplicationScoped
+    static class Alpha {
+
+        public String ping() {
+            return "ok";
+        }
+
+    }
+
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/ArcContainerSupplierLookupProblemDetectedTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/ArcContainerSupplierLookupProblemDetectedTest.java
@@ -1,7 +1,7 @@
 package io.quarkus.arc.test.unused;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.logging.Formatter;
@@ -17,7 +17,7 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.impl.ArcContainerImpl;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class ApiLookupProblemDetectedTest {
+public class ArcContainerSupplierLookupProblemDetectedTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
@@ -31,17 +31,17 @@ public class ApiLookupProblemDetectedTest {
                 Formatter fmt = new PatternFormatter("%m");
                 String message = fmt.format(warning);
                 assertTrue(message.contains(
-                        "Stack frame: io.quarkus.arc.test.unused.ApiLookupProblemDetectedTest.testWarning"),
+                        "Stack frame: io.quarkus.arc.test.unused.ArcContainerSupplierLookupProblemDetectedTest.testWarning"),
                         message);
                 assertTrue(message.contains(
-                        "Required type: class io.quarkus.arc.test.unused.ApiLookupProblemDetectedTest$Alpha"),
+                        "Required type: class io.quarkus.arc.test.unused.ArcContainerSupplierLookupProblemDetectedTest$Alpha"),
                         message);
             });
 
     @Test
     public void testWarning() {
         // Note that the warning is only displayed once, subsequent calls use a cached result
-        assertFalse(Arc.container().instance(Alpha.class).isAvailable());
+        assertNull(Arc.container().beanInstanceSupplier(Alpha.class));
     }
 
     // unused bean, will be removed

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/CDIProviderLookupProblemDetectedTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/CDIProviderLookupProblemDetectedTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.arc.impl.ArcContainerImpl;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class ArcLookupProblemDetectedTest {
+public class CDIProviderLookupProblemDetectedTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
@@ -32,10 +32,10 @@ public class ArcLookupProblemDetectedTest {
                 Formatter fmt = new PatternFormatter("%m");
                 String message = fmt.format(warning);
                 assertTrue(message.contains(
-                        "Stack frame: io.quarkus.arc.test.unused.ArcLookupProblemDetectedTest"),
+                        "Stack frame: io.quarkus.arc.test.unused.CDIProviderLookupProblemDetectedTest"),
                         message);
                 assertTrue(message.contains(
-                        "Required type: class io.quarkus.arc.test.unused.ArcLookupProblemDetectedTest$Alpha"),
+                        "Required type: class io.quarkus.arc.test.unused.CDIProviderLookupProblemDetectedTest$Alpha"),
                         message);
             });
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -304,7 +304,11 @@ public class ArcContainerImpl implements ArcContainer {
         if (qualifiers == null || qualifiers.length == 0) {
             qualifiers = new Annotation[] { Default.Literal.INSTANCE };
         }
-        Set<InjectableBean<?>> resolvedBeans = resolved.getValue(new Resolvable(type, qualifiers));
+        Resolvable resolvable = new Resolvable(type, qualifiers);
+        Set<InjectableBean<?>> resolvedBeans = resolved.getValue(resolvable);
+        if (resolvedBeans.isEmpty()) {
+            scanRemovedBeans(resolvable);
+        }
         Set<InjectableBean<?>> filteredBean = resolvedBeans;
         if (resolvedBeans.size() > 1) {
             if (resolveAmbiguities) {


### PR DESCRIPTION
- this warning got accidentally removed in https://github.com/quarkusio/quarkus/pull/28112 (quarkus 2.14)