### PR TITLE
Elasticsearch guide - Fix FruitResource example and docker run command

### DIFF
--- a/docs/src/main/asciidoc/elasticsearch.adoc
+++ b/docs/src/main/asciidoc/elasticsearch.adoc
@@ -204,9 +204,11 @@ Now, create the `org.acme.elasticsearch.FruitResource` class as follows:
 package org.acme.elasticsearch;
 
 import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -350,7 +352,7 @@ If you want to use Docker to run an Elasticsearch instance, you can use the foll
 [source,bash,subs=attributes+]
 ----
 docker run --name elasticsearch  -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m"\
-       -e "cluster.routing.allocation.disk.threshold_enabled=false"
+       -e "cluster.routing.allocation.disk.threshold_enabled=false" -e "xpack.security.enabled=false"\
        --rm -p 9200:9200 {elasticsearch-image}
 ----
 


### PR DESCRIPTION
Elasticsearch guide - Fix FruitResource example and docker run command

FruitResource example
 - imports

Docker run command
 - add `\` to the second line
 - configure http traffic (which is default for `quarkus.elasticsearch.protocol`)

Otherwise one can see something like `{"@timestamp":"2023-09-01T09:14:45.905Z", "log.level": "WARN", "message":"received plaintext http traffic on an https channel, closing connection Netty4HttpChannel{localAddress=/172.17.0.2:9200,  ...` in the log of Elasticsearch instance
