### PR TITLE
Fix typo which affects OIDC Dev UI when either client credentials or password grant is used

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevServicesUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/devui/OidcDevServicesUtils.java
@@ -185,9 +185,9 @@ public final class OidcDevServicesUtils {
         return token.eventually(client::close);
     }
 
-    private static Uni<String> testServiceInternal(WebClient client, String serviceUrl, Uni<String> token) {
-        return token
-                .flatMap(t -> {
+    private static Uni<String> testServiceInternal(WebClient client, String serviceUrl, Uni<String> tokenUni) {
+        return tokenUni
+                .flatMap(token -> {
                     LOG.infof("Sending token to '%s'", serviceUrl);
                     return client
                             .getAbs(serviceUrl)


### PR DESCRIPTION
Related to #35599.

This typo appeared at some point during the OIDC Dev UI migration, as the old code was passing the token directly, but with the amount of code changes and refactoring it went unnoticed, it is not a blocker as it will only not work if Dev UI is used to test service using one of these 2 grants, which is quite rare as well, typical Dev UI SPA flow is a user login to Keycloak.