### PR TITLE
Update to Vert.x 4.4.5 and Netty 4.1.97

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -34,7 +34,7 @@
         <opentelemetry.version>1.28.0</opentelemetry.version>
         <opentelemetry-alpha.version>1.28.0-alpha</opentelemetry-alpha.version>
         <jaeger.version>1.8.1</jaeger.version>
-        <quarkus-http.version>5.0.2.Final</quarkus-http.version>
+        <quarkus-http.version>5.0.3.Final</quarkus-http.version>
         <micrometer.version>1.11.1</micrometer.version><!-- keep in sync with hdrhistogram -->
         <hdrhistogram.version>2.1.12</hdrhistogram.version><!-- keep in sync with micrometer -->
         <google-auth.version>0.22.0</google-auth.version>
@@ -120,7 +120,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.2.2.Final</wildfly-elytron.version>
         <jboss-threads.version>3.5.0.Final</jboss-threads.version>
-        <vertx.version>4.4.4</vertx.version>
+        <vertx.version>4.4.5</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -142,7 +142,7 @@
         <infinispan.version>14.0.14.Final</infinispan.version>
         <infinispan.protostream.version>4.6.2.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>
-        <netty.version>4.1.94.Final</netty.version>
+        <netty.version>4.1.97.Final</netty.version>
         <brotli4j.version>1.12.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.5.3.Final</jboss-logging.version>

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxUtil.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxUtil.java
@@ -37,11 +37,12 @@ public class VertxUtil {
         if (uri.startsWith(protocol + "://")) {
             uriString = uri;
         } else {
-            String host = req.host();
-            if (host == null) {
-                host = "unknown";
+            var authority = req.authority();
+            if (authority == null) {
+                uriString = protocol + "//unknown" + uri;
+            } else {
+                uriString = protocol + "://" + authority + uri;
             }
-            uriString = protocol + "://" + host + uri;
         }
 
         // ResteasyUriInfo expects a context path to start with a "/" character

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
@@ -26,6 +26,7 @@ import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.StreamPriority;
 import io.vertx.core.http.impl.HttpServerRequestInternal;
 import io.vertx.core.http.impl.HttpServerRequestWrapper;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 
@@ -189,6 +190,11 @@ public class ForwardedServerRequestWrapper extends HttpServerRequestWrapper impl
     @Override
     public SocketAddress remoteAddress() {
         return forwardedParser.remoteAddress();
+    }
+
+    @Override
+    public HostAndPort authority() {
+        return forwardedParser.authority();
     }
 
     @Override

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/AbstractResponseWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/AbstractResponseWrapper.java
@@ -12,6 +12,7 @@ import io.vertx.core.http.HttpFrame;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.StreamPriority;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.streams.ReadStream;
 
 class AbstractResponseWrapper implements HttpServerResponse {
@@ -323,6 +324,7 @@ class AbstractResponseWrapper implements HttpServerResponse {
     }
 
     @Override
+    @Deprecated
     public void close() {
         delegate.close();
     }
@@ -376,7 +378,7 @@ class AbstractResponseWrapper implements HttpServerResponse {
 
     @Override
     public Future<HttpServerResponse> push(HttpMethod method, String host, String path) {
-        return null;
+        return delegate.push(method, host, path);
     }
 
     @Override
@@ -389,7 +391,7 @@ class AbstractResponseWrapper implements HttpServerResponse {
 
     @Override
     public Future<HttpServerResponse> push(HttpMethod method, String path, MultiMap headers) {
-        return null;
+        return delegate.push(method, path, headers);
     }
 
     @Override
@@ -401,7 +403,7 @@ class AbstractResponseWrapper implements HttpServerResponse {
 
     @Override
     public Future<HttpServerResponse> push(HttpMethod method, String path) {
-        return null;
+        return delegate.push(method, path);
     }
 
     @Override
@@ -413,8 +415,14 @@ class AbstractResponseWrapper implements HttpServerResponse {
     }
 
     @Override
+    @Deprecated
     public Future<HttpServerResponse> push(HttpMethod method, String host, String path, MultiMap headers) {
-        return null;
+        return delegate.push(method, host, path, headers);
+    }
+
+    @Override
+    public Future<HttpServerResponse> push(HttpMethod method, HostAndPort authority, String path, MultiMap headers) {
+        return delegate.push(method, authority, path, headers);
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -64,7 +64,7 @@
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <mutiny.version>2.3.1</mutiny.version>
         <smallrye-common.version>2.1.0</smallrye-common.version>
-        <vertx.version>4.4.4</vertx.version>
+        <vertx.version>4.4.5</vertx.version>
         <rest-assured.version>5.3.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.15.2</jackson-bom.version>


### PR DESCRIPTION
Also bump Quarkus HTTP to 5.0.3.Final to handle a breaking change in the Vert.x API.

Fix #35180
Fix #34719
Fix #35278 
