### PR TITLE
Upgrade vaadin and importmap and add caching

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -225,8 +225,8 @@
         <pulsar-client.version>3.0.0</pulsar-client.version>
         <async-http-client.version>2.12.3</async-http-client.version>
         <!-- Dev UI -->
-        <importmap.version>1.0.9</importmap.version>
-        <vaadin.version>24.1.4</vaadin.version>
+        <importmap.version>1.0.10</importmap.version>
+        <vaadin.version>24.1.6</vaadin.version>
         <lit.version>2.8.0</lit.version>
         <lit-element.version>3.3.3</lit-element.version>
         <lit-html.version>2.8.0</lit-html.version>


### PR DESCRIPTION
This PR upgrade to the latest vaadin, that is now build with a new version of mvnpm, that allows caching of these resources.