### PR TITLE
Packs libraries alongside executable in function.zip

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -1004,7 +1004,7 @@ public class NativeImageBuildStep {
                                             + CONTAINER_BUILD_VOLUME_PATH + "/" + MOVED_TRUST_STORE_NAME);
                                 } catch (IOException e) {
                                     throw new UncheckedIOException("Unable to copy trustStore file '" + configuredTrustStorePath
-                                            + "' to volume root directory '" + outputDir.toAbsolutePath().toString() + "'", e);
+                                            + "' to volume root directory '" + outputDir.toAbsolutePath() + "'", e);
                                 }
                             }
                         } else {

--- a/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/FunctionZipProcessor.java
+++ b/extensions/amazon-lambda/common-deployment/src/main/java/io/quarkus/amazon/lambda/deployment/FunctionZipProcessor.java
@@ -2,7 +2,9 @@ package io.quarkus.amazon.lambda.deployment;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -21,8 +23,10 @@ import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.JarBuildItem;
 import io.quarkus.deployment.pkg.builditem.LegacyJarRequiredBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageBuildItem;
+import io.quarkus.deployment.pkg.builditem.NativeImageRunnerBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.UpxCompressedBuildItem;
+import io.quarkus.deployment.pkg.steps.GraalVM;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
 
 /**
@@ -106,7 +110,8 @@ public class FunctionZipProcessor {
     public void nativeZip(OutputTargetBuildItem target,
             Optional<UpxCompressedBuildItem> upxCompressed, // used to ensure that we work with the compressed native binary if compression was enabled
             BuildProducer<ArtifactResultBuildItem> artifactResultProducer,
-            NativeImageBuildItem nativeImage) throws Exception {
+            NativeImageBuildItem nativeImage,
+            NativeImageRunnerBuildItem nativeImageRunner) throws Exception {
         Path zipDir = findNativeZipDir(target.getOutputDirectory());
 
         Path zipPath = target.getOutputDirectory().resolve("function.zip");
@@ -137,8 +142,26 @@ public class FunctionZipProcessor {
                 }
             }
             addZipEntry(zip, nativeImage.getPath(), executableName, 0755);
+
+            final GraalVM.Version graalVMVersion = nativeImageRunner.getBuildRunner().getGraalVMVersion();
+            if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_0_0) >= 0) {
+                // See https://github.com/oracle/graal/issues/4921
+                try (DirectoryStream<Path> sharedLibs = Files.newDirectoryStream(nativeImage.getPath().getParent(),
+                        "*.{so,dll}")) {
+                    sharedLibs.forEach(src -> {
+                        try {
+                            // In this use case, we can force all libs to be non-executable.
+                            addZipEntry(zip, src, src.getFileName().toString(), 0644);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                } catch (IOException e) {
+                    log.errorf("Could not list files in directory %s. Continuing. Error: %s", nativeImage.getPath().getParent(),
+                            e);
+                }
+            }
         }
-        ;
     }
 
     private void copyZipEntry(ZipArchiveOutputStream zip, InputStream zinput, ZipArchiveEntry from) throws Exception {


### PR DESCRIPTION
Fixes #35713

Using the reproducer from https://github.com/quarkusio/quarkus/issues/35256#issuecomment-1705087637

I tested that it indeed packs the libraries now:

```
$ unzip -l  target/function.zip
Archive:  target/function.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
 76905784  09-04-2023 15:00   bootstrap
   871000  09-04-2023 15:00   libawt.so
    46504  09-04-2023 15:00   libawt_headless.so
   486832  09-04-2023 15:00   libawt_xawt.so
  2495760  09-04-2023 15:00   libfontmanager.so
   239768  09-04-2023 15:00   libjavajpeg.so
   606272  09-04-2023 15:00   liblcms.so
   606952  09-04-2023 15:00   libmlib_image.so
     7888  09-04-2023 15:00   libjava.so
     7888  09-04-2023 15:00   libjvm.so
---------                     -------
 82274648                     10 files
```

And that it also works on AWS:

![setup-1](https://github.com/quarkusio/quarkus/assets/691097/b1d1a266-d250-471c-93fb-bb43d40e387b)

Upload function.zip and run it:

![setup-2](https://github.com/quarkusio/quarkus/assets/691097/b4f6cbb5-9b61-4c14-8cce-45cd421935a8)

The output is sane:
```
$ echo 'JVBERi0xLjQKJfbk/N8KMSAwIG9iago8PAovVHlwZSAvQ2F0YWxvZwovVmVyc2lvbiAvMS43Ci9QYWdlcyAyIDAgUgo+PgplbmRvYmoKMyAwIG9iago8PAovQ3JlYXRpb25EYXRlIChEOjIwMjMwOTA0MTMwNTEyKzAwJzAwJykKL1Byb2R1Y2VyIChvcGVuaHRtbHRvcGRmLmNvbSkKPj4KZW5kb2JqCjIgMCBvYmoKPDwKL1R5cGUgL1BhZ2VzCi9LaWRzIFs0IDAgUl0KL0NvdW50IDEKPj4KZW5kb2JqCjQgMCBvYmoKPDwKL1R5cGUgL1BhZ2UKL01lZGlhQm94IFswLjAgMC4wIDU5NS4yNzUgODQxLjg3NV0KL1BhcmVudCAyIDAgUgovQ29udGVudHMgNSAwIFIKL1Jlc291cmNlcyA2IDAgUgo+PgplbmRvYmoKNSAwIG9iago8PAovTGVuZ3RoIDEyOAovRmlsdGVyIC9GbGF0ZURlY29kZQo+PgpzdHJlYW0NCnicVcw7CwJBDATgfn7FlNqsSW6X22sFLQQLIWAhdr44PMEH+PfdtfBBIIRvhkiQpk18wriAsIcKl9hsKdzhWiRHDbk0BqQuBWuT2MfOPyb1UczF5O/+dk9Y41LTMrcjpo7JXKlGP0DfWnduNKha7OgDRr6/P8b0HjPHCi+awCLiDQplbmRzdHJlYW0KZW5kb2JqCjYgMCBvYmoKPDwKL0ZvbnQgNyAwIFIKPj4KZW5kb2JqCjcgMCBvYmoKPDwKL0YxIDggMCBSCj4+CmVuZG9iago4IDAgb2JqCjw8Ci9UeXBlIC9Gb250Ci9TdWJ0eXBlIC9UeXBlMQovQmFzZUZvbnQgL1RpbWVzLVJvbWFuCi9FbmNvZGluZyAvV2luQW5zaUVuY29kaW5nCj4+CmVuZG9iagp4cmVmCjAgOQowMDAwMDAwMDAwIDY1NTM1IGYNCjAwMDAwMDAwMTUgMDAwMDAgbg0KMDAwMDAwMDE2OSAwMDAwMCBuDQowMDAwMDAwMDc4IDAwMDAwIG4NCjAwMDAwMDAyMjYgMDAwMDAgbg0KMDAwMDAwMDM0MiAwMDAwMCBuDQowMDAwMDAwNTQ0IDAwMDAwIG4NCjAwMDAwMDA1NzcgMDAwMDAgbg0KMDAwMDAwMDYwOCAwMDAwMCBuDQp0cmFpbGVyCjw8Ci9Sb290IDEgMCBSCi9JbmZvIDMgMCBSCi9JRCBbPEJENkI3NzQ2MEY1QTBEREFCREIyMjE2MEM2MUQ2RUQ3PiA8QkQ2Qjc3NDYwRjVBMEREQUJEQjIyMTYwQzYxRDZFRDc+XQovU2l6ZSA5Cj4+CnN0YXJ0eHJlZgo3MDcKJSVFT0YK' 
| base64 -di > test.pdf; evince ./test.pdf
```
![setup-3](https://github.com/quarkusio/quarkus/assets/691097/a903c05d-8d91-473c-bf31-7998fb530c46)
