### PR TITLE
Do not start Keycloak devservice if tenant providers are configured

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -341,6 +341,16 @@ public class KeycloakDevServicesProcessor {
             LOG.debug("Not starting Dev Services for Keycloak as 'quarkus.oidc.provider' has been provided");
             return null;
         }
+        try {
+            for (String prop : ConfigProvider.getConfig().getPropertyNames()) {
+                if (prop.startsWith(CONFIG_PREFIX) && prop.endsWith(".provider")) {
+                    LOG.debugf("Not starting Dev Services for Keycloak as %s has been provided", prop);
+                    return null;
+                }
+            }
+        } catch (Throwable t) {
+            // continue
+        }
 
         if (!dockerStatusBuildItem.isDockerAvailable()) {
             LOG.warn("Please configure 'quarkus.oidc.auth-server-url' or get a working docker instance");


### PR DESCRIPTION
If `quarkus.oidc.auth-server-url` is configured then Keycloak devservice is not started, and the same is the case if for example `quarkus.oidc.provider=twitter` is configured.

But Keycloak is still started if multiple tenants/providers are enabled, example:

```
quarkus.oidc.1.provider=twitter
quarkus.oidc.2.provider=google
```

So this PR adds a check to `KeycloakDevServicesProcessor` to check if there are any properties starting from `quarkus.oidc.` and ending with `.provider`