### PR TITLE
Invoke Quarkus JUnit `invokeBeforeClassCallbacks` only once per test class

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestCallbacksTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestCallbacksTestCase.java
@@ -86,7 +86,7 @@ public class QuarkusTestCallbacksTestCase {
     @Test
     @Order(2)
     public void testBeforeClass() {
-        assertEquals(2, SimpleAnnotationCheckerBeforeClassCallback.count.get());
+        assertEquals(1, SimpleAnnotationCheckerBeforeClassCallback.count.get());
     }
 
     @Test


### PR DESCRIPTION
Fixes: #35692