### PR TITLE
Simplify wiremock config in oidc

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -110,7 +110,7 @@
 
         <assertj.version>3.24.2</assertj.version>
 
-        <wiremock.version>3.0.0</wiremock.version>
+        <wiremock.version>3.0.3</wiremock.version>
         <wiremock-maven-plugin.version>7.3.0</wiremock-maven-plugin.version>
 
         <!-- Artemis test dependencies -->

--- a/independent-projects/tools/analytics-common/pom.xml
+++ b/independent-projects/tools/analytics-common/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <segment.analytics.version>3.3.1</segment.analytics.version>
         <httpclient.version>4.5.14</httpclient.version>
-        <wiremock.version>3.0.0</wiremock.version>
+        <wiremock.version>3.0.3</wiremock.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
     </properties>
 


### PR DESCRIPTION
In wiremock 3, `ResponseTemplateTransformer` should not be created manually; see https://github.com/wiremock/wiremock/pull/2350#issuecomment-1706610158

Wiremock now creates one internally, by default local. Also made few simplifications within the same class by using static imports + bump to 3.0.3  while at it.

follows up on https://github.com/quarkusio/quarkus/pull/35649

supersedes https://github.com/quarkusio/quarkus/pull/35820
supersedes https://github.com/quarkusio/quarkus/pull/35821