### PR TITLE
Only publish latest docs for preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -70,7 +70,7 @@ jobs:
           ### In cases where you want to specify the cache key, enable the above 2 inputs
           ### Follows the format here https://github.com/actions/cache
           #
-          # custom_opts: '--future'
+          custom_opts: '--config _config.yml,_only_latest_guides_config.yml'
           ### If you need to specify any Jekyll build options, enable the above input
           ### Flags accepted can be found here https://jekyllrb.com/docs/configuration/options/#build-command-options
       - name: Publishing to surge for preview

--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -406,7 +406,7 @@ If this default mechanism is not sufficient and you need a custom locale resolut
 
 === Validation groups for REST endpoint or service method validation
 
-It's sometimes necessary to enable different validation constraints
+It is sometimes necessary to enable different validation constraints
 for the same class when it's passed to a different method.
 
 For example, a `Book` may need to have a `null` identifier when passed to the `post` method


### PR DESCRIPTION
Apparently, surge.sh has a size limit (at least for the free tier) so we need to reduce the number of versions for which we produce the guides.

(Not completely sure, this will work, let's have a try)

/cc @rolfedh 