### PR TITLE
Request reauthentication by default if OIDC state state query param is missing

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -889,8 +889,8 @@ public class OidcTenantConfig extends OidcCommonConfig {
          * It will cause a new authentication redirect to OpenId Connect provider. Please be aware doing so may increase the
          * risk of browser redirect loops.
          */
-        @ConfigItem(defaultValue = "true")
-        public boolean failOnMissingStateParam = true;
+        @ConfigItem(defaultValue = "false")
+        public boolean failOnMissingStateParam = false;
 
         /**
          * If this property is set to 'true' then an OIDC UserInfo endpoint will be called.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -270,8 +270,10 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
         if (!oidcTenantConfig.authentication.allowMultipleCodeFlows
                 || context.request().path().equals(getRedirectPath(oidcTenantConfig, context))) {
             if (oidcTenantConfig.authentication.failOnMissingStateParam) {
+                removeStateCookies(oidcTenantConfig, context, cookies);
                 return Uni.createFrom().failure(new AuthenticationCompletionException());
-            } else {
+            }
+            if (!oidcTenantConfig.authentication.allowMultipleCodeFlows) {
                 removeStateCookies(oidcTenantConfig, context, cookies);
             }
         }

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -112,7 +112,7 @@ quarkus.oidc.tenant-https.authentication.pkce-required=true
 quarkus.oidc.tenant-https.authentication.nonce-required=true
 quarkus.oidc.tenant-https.authentication.pkce-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 quarkus.oidc.tenant-https.authentication.cookie-same-site=strict
-quarkus.oidc.tenant-https.authentication.fail-on-missing-state-param=false
+quarkus.oidc.tenant-https.authentication.fail-on-missing-state-param=true
 
 quarkus.oidc.tenant-nonce.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.tenant-nonce.client-id=quarkus-app


### PR DESCRIPTION
Fixes #35754 

Instead of getting the users puzzled with 401, let them re-authenticate again if the previous authentication attempt did not complete with the redirect to Quarkusand thus leaving some state cookie in the browser cache - failing with 401 when the user retries to access Quarkus is only causing confusion with the users likely finding `fail-on-missing-state-param` and disabling it.

Tests have been added/fixed to check that when this parameter is disabled, default now, then `302`  is returned, with the re-authentication redirect. `401` is enabled only if this property is enforced