### PR TITLE
Upgrade Smallrye OpenAPI to 3.5.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,8 +60,6 @@ updates:
       - dependency-name: io.smallrye.common:*
       - dependency-name: io.smallrye.config:*
       - dependency-name: io.smallrye.reactive:*
-      # Swagger-UI
-      - dependency-name: org.webjars:swagger-ui
       # RX Java 2
       - dependency-name: io.reactivex.rxjava2:rxjava
       # Test dependencies

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -54,7 +54,7 @@
         <smallrye-config.version>3.3.4</smallrye-config.version>
         <smallrye-health.version>4.0.4</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>3.5.1</smallrye-open-api.version>
+        <smallrye-open-api.version>3.5.2</smallrye-open-api.version>
         <smallrye-graphql.version>2.4.0</smallrye-graphql.version>
         <smallrye-opentracing.version>3.0.3</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>6.2.6</smallrye-fault-tolerance.version>


### PR DESCRIPTION
This PR Upgrade to SmallRye OpenAPI 3.5.2, that changed from using webjars to mvnpm for the swagger-ui files