### PR TITLE
Added gzip compression feature for SmallRye-GraphQL, added tests

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/CompressionTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/CompressionTest.java
@@ -1,0 +1,80 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import java.util.Arrays;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class CompressionTest extends AbstractGraphQLTest {
+
+    private static final String PI = "3.141592653589793238462643383279502884197169399375105820";
+    private static final String TAU = "6.28";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"))
+            .overrideConfigKey("quarkus.http.enable-compression", "true");
+
+    @Test
+    public void singleValidQueryCompressedResponseTest() {
+        String body = getPayload("{ validPiQuery }");
+        assertCompressed(body, PI);
+    }
+
+    @Test
+    public void multipleValidQueriesCompressedResponseTest() {
+        String body = getPayload("{ validPiQuery validTauQuery }");
+        assertCompressed(body, PI, TAU);
+    }
+
+    @Test
+    public void singleInvalidQueryCompressedResponseTest() {
+        String body = getPayload("{ invalidQuery }");
+        assertCompressed(body, "errors");
+    }
+
+    private void assertCompressed(String body, String... expectedOutput) {
+        org.hamcrest.Matcher messageMatcher = Arrays.stream(expectedOutput)
+                .map(CoreMatchers::containsString)
+                .reduce(Matchers.allOf(), (a, b) -> Matchers.allOf(a, b));
+
+        RestAssured.given()
+                .body(body)
+                .contentType(MEDIATYPE_JSON)
+                .post("/graphql")
+                .prettyPeek()
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .header("Content-Encoding", "gzip")
+                .body(messageMatcher);
+    }
+
+    @GraphQLApi
+    public static class Schema {
+        @Query
+        public String validPiQuery() {
+            return PI;
+        }
+
+        @Query
+        public String validTauQuery() {
+            return TAU;
+        }
+
+        @Query
+        public String invalidQuery() {
+            throw new RuntimeException();
+        }
+    }
+
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLCompressionHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLCompressionHandler.java
@@ -1,0 +1,25 @@
+package io.quarkus.smallrye.graphql.runtime;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+
+public class SmallRyeGraphQLCompressionHandler implements Handler<RoutingContext> {
+
+    private final Handler<RoutingContext> routeHandler;
+
+    public SmallRyeGraphQLCompressionHandler(Handler<RoutingContext> routeHandler) {
+        this.routeHandler = routeHandler;
+    }
+
+    @Override
+    public void handle(RoutingContext context) {
+        context.addHeadersEndHandler(new Handler<Void>() {
+            @Override
+            public void handle(Void event) {
+                context.response().headers().remove(HttpHeaders.CONTENT_ENCODING);
+            }
+        });
+        routeHandler.handle(context);
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
@@ -32,11 +32,16 @@ public class SmallRyeGraphQLRecorder {
     }
 
     public Handler<RoutingContext> executionHandler(RuntimeValue<Boolean> initialized, boolean allowGet,
-            boolean allowPostWithQueryParameters, boolean runBlocking) {
+            boolean allowPostWithQueryParameters, boolean runBlocking, boolean allowCompression) {
         if (initialized.getValue()) {
-            return new SmallRyeGraphQLExecutionHandler(allowGet, allowPostWithQueryParameters, runBlocking,
+            Handler<RoutingContext> handler = new SmallRyeGraphQLExecutionHandler(allowGet,
+                    allowPostWithQueryParameters, runBlocking,
                     getCurrentIdentityAssociation(),
                     Arc.container().instance(CurrentVertxRequest.class).get());
+            if (allowCompression) {
+                return new SmallRyeGraphQLCompressionHandler(handler);
+            }
+            return handler;
         } else {
             return new SmallRyeGraphQLNoEndpointHandler();
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
@@ -90,7 +90,7 @@ public class HttpBuildTimeConfig {
      * List of media types for which the compression should be enabled automatically, unless declared explicitly via
      * {@link Compressed} or {@link Uncompressed}.
      */
-    @ConfigItem(defaultValue = "text/html,text/plain,text/xml,text/css,text/javascript,application/javascript")
+    @ConfigItem(defaultValue = "text/html,text/plain,text/xml,text/css,text/javascript,application/javascript,application/graphql+json")
     public Optional<List<String>> compressMediaTypes;
 
     /**


### PR DESCRIPTION
/cc @jmartisk @mkouba 
fixes: #21642

The one thing I am not sure about is this line of code: https://github.com/mskacelik/quarkus/blob/110e460ca5f5e468e9ce3811daa79620cc2576ee/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLCompressionHandler.java#L17

Here I use `addHeadersEndHandler` instend of `addEndHandler`.  The reason is because `SmallRyeGraphQLAbstractHandler` rewrites the `endHandler` for the `ExecutionHandler`.
