### PR TITLE
QuarkusComponentTest: refactorings and API changes

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1601,7 +1601,7 @@ import org.mockito.Mockito;
 public class FooTest {
 
     @RegisterExtension <1>
-    static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension().configProperty("bar","true");
+    static final QuarkusComponentTestExtension extension = QuarkusComponentTestExtension.builder().configProperty("bar","true").build();
 
     @Inject
     Foo foo;
@@ -1621,9 +1621,10 @@ public class FooTest {
 === Lifecycle
 
 So what exactly does the `QuarkusComponentTest` do?
-It starts the CDI container and registers a dedicated xref:config-reference.adoc[configuration object] during the `before all` test phase. 
-The container is stopped and the config is released during the `after all` test phase.
-The fields annotated with `@Inject` and `@InjectMock` are injected after a test instance is created and unset before a test instance is destroyed.
+It starts the CDI container and registers a dedicated xref:config-reference.adoc[configuration object].
+If the test instance lifecycle is `Lifecycle#PER_METHOD` (default) then the container is started during the `before each` test phase and stopped during the `after each` test phase. 
+However, if  the test instance lifecycle is `Lifecycle#PER_CLASS` then the container is started during the `before all` test phase and stopped during the `after all` test phase. 
+The fields annotated with `@Inject` and `@InjectMock` are injected after a test instance is created.
 Finally, the CDI request context is activated and terminated per each test method.
 
 === Auto Mocking Unsatisfied Dependencies
@@ -1637,13 +1638,15 @@ You can inject the mock in your test and leverage the Mockito API to configure t
 === Custom Mocks For Unsatisfied Dependencies
 
 Sometimes you need the full control over the bean attributes and maybe even configure the default mock behavior.
-You can use the mock configurator API via the `QuarkusComponentTestExtension#mock()` method.
+You can use the mock configurator API via the `QuarkusComponentTestExtensionBuilder#mock()` method.
 
 === Configuration
 
-A dedicated `SmallRyeConfig` is registered during the `before all` test phase.
-Moreover, it's possible to set the configuration properties via the `QuarkusComponentTestExtension#configProperty(String, String)` method or the `@TestConfigProperty` annotation.
-If you only need to use the default values for missing config properties, then the `QuarkusComponentTestExtension#useDefaultConfigProperties()` or `@QuarkusComponentTest#useDefaultConfigProperties()` might come in useful.
+You can set the configuration properties for a test with the `@io.quarkus.test.component.TestConfigProperty` annotation or with the `QuarkusComponentTestExtensionBuilder#configProperty(String, String)` method.
+If you only need to use the default values for missing config properties, then the `@QuarkusComponentTest#useDefaultConfigProperties()` or `QuarkusComponentTestExtensionBuilder#useDefaultConfigProperties()` might come in useful.
+
+It is also possible to set configuration properties for a test method with the `@io.quarkus.test.component.TestConfigProperty` annotation.
+However, if the test instance lifecycle is `Lifecycle#_PER_CLASS` this annotation can only be used on the test class and is ignored on test methods.
 
 === Mocking CDI Interceptors
 

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/MockBeanConfigurator.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/MockBeanConfigurator.java
@@ -36,20 +36,20 @@ public interface MockBeanConfigurator<T> {
      * @param create
      * @return the test extension
      */
-    QuarkusComponentTestExtension create(Function<SyntheticCreationalContext<T>, T> create);
+    QuarkusComponentTestExtensionBuilder create(Function<SyntheticCreationalContext<T>, T> create);
 
     /**
      * A Mockito mock object created from the bean class is used as a bean instance.
      *
      * @return the test extension
      */
-    QuarkusComponentTestExtension createMockitoMock();
+    QuarkusComponentTestExtensionBuilder createMockitoMock();
 
     /**
      * A Mockito mock object created from the bean class is used as a bean instance.
      *
      * @return the test extension
      */
-    QuarkusComponentTestExtension createMockitoMock(Consumer<T> mockInitializer);
+    QuarkusComponentTestExtensionBuilder createMockitoMock(Consumer<T> mockInitializer);
 
 }

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/MockBeanConfiguratorImpl.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/MockBeanConfiguratorImpl.java
@@ -29,7 +29,7 @@ import io.quarkus.arc.processor.Types;
 
 class MockBeanConfiguratorImpl<T> implements MockBeanConfigurator<T> {
 
-    final QuarkusComponentTestExtension test;
+    final QuarkusComponentTestExtensionBuilder builder;
     final Class<?> beanClass;
     Set<Type> types;
     Set<Annotation> qualifiers;
@@ -44,8 +44,8 @@ class MockBeanConfiguratorImpl<T> implements MockBeanConfigurator<T> {
     Set<org.jboss.jandex.Type> jandexTypes;
     Set<AnnotationInstance> jandexQualifiers;
 
-    public MockBeanConfiguratorImpl(QuarkusComponentTestExtension test, Class<?> beanClass) {
-        this.test = test;
+    public MockBeanConfiguratorImpl(QuarkusComponentTestExtensionBuilder builder, Class<?> beanClass) {
+        this.builder = builder;
         this.beanClass = beanClass;
         this.types = new HierarchyDiscovery(beanClass).getTypeClosure();
 
@@ -142,19 +142,19 @@ class MockBeanConfiguratorImpl<T> implements MockBeanConfigurator<T> {
     }
 
     @Override
-    public QuarkusComponentTestExtension create(Function<SyntheticCreationalContext<T>, T> create) {
+    public QuarkusComponentTestExtensionBuilder create(Function<SyntheticCreationalContext<T>, T> create) {
         this.create = create;
         return register();
     }
 
     @Override
-    public QuarkusComponentTestExtension createMockitoMock() {
+    public QuarkusComponentTestExtensionBuilder createMockitoMock() {
         this.create = c -> QuarkusComponentTestExtension.cast(Mockito.mock(beanClass));
         return register();
     }
 
     @Override
-    public QuarkusComponentTestExtension createMockitoMock(Consumer<T> mockInitializer) {
+    public QuarkusComponentTestExtensionBuilder createMockitoMock(Consumer<T> mockInitializer) {
         this.create = c -> {
             T mock = QuarkusComponentTestExtension.cast(Mockito.mock(beanClass));
             mockInitializer.accept(mock);
@@ -163,9 +163,9 @@ class MockBeanConfiguratorImpl<T> implements MockBeanConfigurator<T> {
         return register();
     }
 
-    public QuarkusComponentTestExtension register() {
-        test.registerMockBean(this);
-        return test;
+    public QuarkusComponentTestExtensionBuilder register() {
+        builder.registerMockBean(this);
+        return builder;
     }
 
     boolean matches(BeanResolver beanResolver, org.jboss.jandex.Type requiredType, Set<AnnotationInstance> qualifiers) {

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTest.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTest.java
@@ -41,7 +41,7 @@ public @interface QuarkusComponentTest {
      * <p>
      * For primitives the default values as defined in the JLS are used. For any other type {@code null} is injected.
      *
-     * @see QuarkusComponentTestExtension#useDefaultConfigProperties()
+     * @see QuarkusComponentTestExtensionBuilder#useDefaultConfigProperties()
      */
     boolean useDefaultConfigProperties() default false;
 
@@ -55,9 +55,9 @@ public @interface QuarkusComponentTest {
     /**
      * The ordinal of the config source used for all test config properties.
      *
-     * @see QuarkusComponentTestExtension#setConfigSourceOrdinal(int)
+     * @see QuarkusComponentTestExtensionBuilder#setConfigSourceOrdinal(int)
      */
-    int configSourceOrdinal() default QuarkusComponentTestExtension.DEFAULT_CONFIG_SOURCE_ORDINAL;
+    int configSourceOrdinal() default QuarkusComponentTestExtensionBuilder.DEFAULT_CONFIG_SOURCE_ORDINAL;
 
     /**
      * The additional annotation transformers.
@@ -65,7 +65,7 @@ public @interface QuarkusComponentTest {
      * The initial set includes the {@link JaxrsSingletonTransformer}.
      *
      * @see AnnotationsTransformer
-     * @see QuarkusComponentTestExtension#addAnnotationsTransformer(AnnotationsTransformer)
+     * @see QuarkusComponentTestExtensionBuilder#addAnnotationsTransformer(AnnotationsTransformer)
      */
     Class<? extends AnnotationsTransformer>[] annotationsTransformers() default {};
 

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestConfigSource.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestConfigSource.java
@@ -1,0 +1,38 @@
+package io.quarkus.test.component;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+class QuarkusComponentTestConfigSource implements ConfigSource {
+
+    private final Map<String, String> configProperties;
+    private final int ordinal;
+
+    QuarkusComponentTestConfigSource(Map<String, String> configProperties, int ordinal) {
+        this.configProperties = configProperties;
+        this.ordinal = ordinal;
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return configProperties.keySet();
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return configProperties.get(propertyName);
+    }
+
+    @Override
+    public String getName() {
+        return QuarkusComponentTestExtension.class.getName();
+    }
+
+    @Override
+    public int getOrdinal() {
+        return ordinal;
+    }
+
+}

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestConfiguration.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestConfiguration.java
@@ -1,0 +1,129 @@
+package io.quarkus.test.component;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.BeanContainer;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.arc.processor.AnnotationsTransformer;
+
+class QuarkusComponentTestConfiguration {
+
+    static final QuarkusComponentTestConfiguration DEFAULT = new QuarkusComponentTestConfiguration(Map.of(), List.of(),
+            List.of(), false, true, QuarkusComponentTestExtensionBuilder.DEFAULT_CONFIG_SOURCE_ORDINAL, List.of());
+
+    private static final Logger LOG = Logger.getLogger(QuarkusComponentTestConfiguration.class);
+
+    final Map<String, String> configProperties;
+    final List<Class<?>> componentClasses;
+    final List<MockBeanConfiguratorImpl<?>> mockConfigurators;
+    final boolean useDefaultConfigProperties;
+    final boolean addNestedClassesAsComponents;
+    final int configSourceOrdinal;
+    final List<AnnotationsTransformer> annotationsTransformers;
+
+    QuarkusComponentTestConfiguration(Map<String, String> configProperties, List<Class<?>> componentClasses,
+            List<MockBeanConfiguratorImpl<?>> mockConfigurators, boolean useDefaultConfigProperties,
+            boolean addNestedClassesAsComponents, int configSourceOrdinal,
+            List<AnnotationsTransformer> annotationsTransformers) {
+        this.configProperties = configProperties;
+        this.componentClasses = componentClasses;
+        this.mockConfigurators = mockConfigurators;
+        this.useDefaultConfigProperties = useDefaultConfigProperties;
+        this.addNestedClassesAsComponents = addNestedClassesAsComponents;
+        this.configSourceOrdinal = configSourceOrdinal;
+        this.annotationsTransformers = annotationsTransformers;
+    }
+
+    QuarkusComponentTestConfiguration update(Class<?> testClass) {
+        Map<String, String> configProperties = new HashMap<>(this.configProperties);
+        List<Class<?>> componentClasses = new ArrayList<>(this.componentClasses);
+        boolean useDefaultConfigProperties = this.useDefaultConfigProperties;
+        boolean addNestedClassesAsComponents = this.addNestedClassesAsComponents;
+        int configSourceOrdinal = this.configSourceOrdinal;
+        List<AnnotationsTransformer> annotationsTransformers = new ArrayList<>(this.annotationsTransformers);
+
+        QuarkusComponentTest testAnnotation = testClass.getAnnotation(QuarkusComponentTest.class);
+        if (testAnnotation != null) {
+            Collections.addAll(componentClasses, testAnnotation.value());
+            useDefaultConfigProperties = testAnnotation.useDefaultConfigProperties();
+            addNestedClassesAsComponents = testAnnotation.addNestedClassesAsComponents();
+            configSourceOrdinal = testAnnotation.configSourceOrdinal();
+            Class<? extends AnnotationsTransformer>[] transformers = testAnnotation.annotationsTransformers();
+            if (transformers.length > 0) {
+                for (Class<? extends AnnotationsTransformer> transformerClass : transformers) {
+                    try {
+                        annotationsTransformers.add(transformerClass.getDeclaredConstructor().newInstance());
+                    } catch (Exception e) {
+                        LOG.errorf("Unable to instantiate %s", transformerClass);
+                    }
+                }
+            }
+        }
+        // All fields annotated with @Inject represent component classes
+        Class<?> current = testClass;
+        while (current != null) {
+            for (Field field : current.getDeclaredFields()) {
+                if (field.isAnnotationPresent(Inject.class) && !resolvesToBuiltinBean(field.getType())) {
+                    componentClasses.add(field.getType());
+                }
+            }
+            current = current.getSuperclass();
+        }
+        // All static nested classes declared on the test class are components
+        if (addNestedClassesAsComponents) {
+            for (Class<?> declaredClass : testClass.getDeclaredClasses()) {
+                if (Modifier.isStatic(declaredClass.getModifiers())) {
+                    componentClasses.add(declaredClass);
+                }
+            }
+        }
+
+        List<TestConfigProperty> testConfigProperties = new ArrayList<>();
+        Collections.addAll(testConfigProperties, testClass.getAnnotationsByType(TestConfigProperty.class));
+        for (TestConfigProperty testConfigProperty : testConfigProperties) {
+            configProperties.put(testConfigProperty.key(), testConfigProperty.value());
+        }
+
+        return new QuarkusComponentTestConfiguration(Map.copyOf(configProperties), List.copyOf(componentClasses),
+                this.mockConfigurators,
+                useDefaultConfigProperties, addNestedClassesAsComponents, configSourceOrdinal,
+                List.copyOf(annotationsTransformers));
+    }
+
+    QuarkusComponentTestConfiguration update(Method testMethod) {
+        Map<String, String> configProperties = new HashMap<>(this.configProperties);
+        List<TestConfigProperty> testConfigProperties = new ArrayList<>();
+        Collections.addAll(testConfigProperties, testMethod.getAnnotationsByType(TestConfigProperty.class));
+        for (TestConfigProperty testConfigProperty : testConfigProperties) {
+            configProperties.put(testConfigProperty.key(), testConfigProperty.value());
+        }
+        return new QuarkusComponentTestConfiguration(configProperties, componentClasses,
+                mockConfigurators, useDefaultConfigProperties, addNestedClassesAsComponents, configSourceOrdinal,
+                annotationsTransformers);
+    }
+
+    private static boolean resolvesToBuiltinBean(Class<?> rawType) {
+        return Provider.class.equals(rawType)
+                || Instance.class.equals(rawType)
+                || InjectableInstance.class.equals(rawType)
+                || Event.class.equals(rawType)
+                || BeanContainer.class.equals(rawType)
+                || BeanManager.class.equals(rawType);
+    }
+
+}

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtensionBuilder.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtensionBuilder.java
@@ -1,0 +1,137 @@
+package io.quarkus.test.component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import io.quarkus.arc.processor.AnnotationsTransformer;
+
+/**
+ * Convenient builder for {@link QuarkusComponentTestExtension}.
+ */
+public class QuarkusComponentTestExtensionBuilder {
+
+    /**
+     * By default, test config properties take precedence over system properties (400), ENV variables (300) and
+     * application.properties (250)
+     *
+     * @see #setConfigSourceOrdinal(int)
+     */
+    public static final int DEFAULT_CONFIG_SOURCE_ORDINAL = 500;
+
+    private final Map<String, String> configProperties = new HashMap<>();
+    private final List<Class<?>> componentClasses = new ArrayList<>();
+    private final List<MockBeanConfiguratorImpl<?>> mockConfigurators = new ArrayList<>();
+    private final List<AnnotationsTransformer> annotationsTransformers = new ArrayList<>();
+    private boolean useDefaultConfigProperties = false;
+    private boolean addNestedClassesAsComponents = true;
+    private int configSourceOrdinal = QuarkusComponentTestExtensionBuilder.DEFAULT_CONFIG_SOURCE_ORDINAL;
+
+    /**
+     * The initial set of components under test is derived from the test class. The types of all fields annotated with
+     * {@link jakarta.inject.Inject} are considered the component types.
+     *
+     *
+     * @param componentClasses
+     * @return self
+     * @see #ignoreNestedClasses()
+     */
+    public QuarkusComponentTestExtensionBuilder addComponentClasses(Class<?>... componentClasses) {
+        Collections.addAll(this.componentClasses, componentClasses);
+        return this;
+    }
+
+    /**
+     * Set a configuration property for the test.
+     *
+     * @param key
+     * @param value
+     * @return self
+     */
+    public QuarkusComponentTestExtensionBuilder configProperty(String key, String value) {
+        configProperties.put(key, value);
+        return this;
+    }
+
+    /**
+     * Use the default values for missing config properties. By default, a missing config property results in a test
+     * failure.
+     * <p>
+     * For primitives the default values as defined in the JLS are used. For any other type {@code null} is injected.
+     *
+     * @return self
+     */
+    public QuarkusComponentTestExtensionBuilder useDefaultConfigProperties() {
+        useDefaultConfigProperties = true;
+        return this;
+    }
+
+    /**
+     * Ignore the static nested classes declared on the test class.
+     * <p>
+     * By default, all static nested classes declared on the test class are added to the set of additional components under
+     * test.
+     *
+     * @return self
+     */
+    public QuarkusComponentTestExtensionBuilder ignoreNestedClasses() {
+        addNestedClassesAsComponents = false;
+        return this;
+    }
+
+    /**
+     * Set the ordinal of the config source used for all test config properties. By default,
+     * {@value #DEFAULT_CONFIG_SOURCE_ORDINAL} is used.
+     *
+     * @param val
+     * @return self
+     */
+    public QuarkusComponentTestExtensionBuilder setConfigSourceOrdinal(int val) {
+        configSourceOrdinal = val;
+        return this;
+    }
+
+    /**
+     * Add an additional {@link AnnotationsTransformer}.
+     *
+     * @param transformer
+     * @return self
+     */
+    public QuarkusComponentTestExtensionBuilder addAnnotationsTransformer(AnnotationsTransformer transformer) {
+        annotationsTransformers.add(transformer);
+        return this;
+    }
+
+    /**
+     * Configure a new mock of a bean.
+     * <p>
+     * Note that a mock is created automatically for all unsatisfied dependencies in the test. This API provides full control
+     * over the bean attributes. The default values are derived from the bean class.
+     *
+     * @param beanClass
+     * @return a new mock bean configurator
+     * @see MockBeanConfigurator#create(Function)
+     */
+    public <T> MockBeanConfigurator<T> mock(Class<T> beanClass) {
+        return new MockBeanConfiguratorImpl<>(this, beanClass);
+    }
+
+    /**
+     *
+     * @return a new extension instance
+     */
+    public QuarkusComponentTestExtension build() {
+        return new QuarkusComponentTestExtension(new QuarkusComponentTestConfiguration(Map.copyOf(configProperties),
+                List.copyOf(componentClasses),
+                List.copyOf(mockConfigurators), useDefaultConfigProperties, addNestedClassesAsComponents, configSourceOrdinal,
+                List.copyOf(annotationsTransformers)));
+    }
+
+    void registerMockBean(MockBeanConfiguratorImpl<?> mock) {
+        this.mockConfigurators.add(mock);
+    }
+
+}

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/TestConfigProperty.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/TestConfigProperty.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.component;
 
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -7,16 +8,26 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
 import io.quarkus.test.component.TestConfigProperty.TestConfigProperties;
 
 /**
- * Set the value of a configuration property for a {@code io.quarkus.test.component.QuarkusComponentTest}.
+ * Set the value of a configuration property.
+ * <p>
+ * If declared on a class then the configuration property is used for all test methods declared on the test class.
+ * <p>
+ * If declared on a method then the configuration property is only used for that test method.
+ * If the test instance lifecycle is {@link Lifecycle#_PER_CLASS}, this annotation can only be used on the test class and is
+ * ignored on test methods.
+ * <p>
+ * Configuration properties declared on test methods take precedence over the configuration properties declared on test class.
  *
  * @see QuarkusComponentTest
- * @see QuarkusComponentTestExtension#configProperty(String, String)
+ * @see QuarkusComponentTestExtensionBuilder#configProperty(String, String)
  */
 @Retention(RUNTIME)
-@Target(TYPE)
+@Target({ TYPE, METHOD })
 @Repeatable(TestConfigProperties.class)
 public @interface TestConfigProperty {
 

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/AnnotationsTransformerTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/AnnotationsTransformerTest.java
@@ -17,11 +17,12 @@ import io.quarkus.test.component.beans.Charlie;
 public class AnnotationsTransformerTest {
 
     @RegisterExtension
-    static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension()
+    static final QuarkusComponentTestExtension extension = QuarkusComponentTestExtension.builder()
             .addAnnotationsTransformer(AnnotationsTransformer.appliedToClass()
                     .whenClass(c -> c.declaredAnnotations().isEmpty()
                             && c.annotationsMap().containsKey(DotName.createSimple(Inject.class)))
-                    .thenTransform(t -> t.add(Singleton.class)));
+                    .thenTransform(t -> t.add(Singleton.class)))
+            .build();
 
     @Inject
     NotABean bean;

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/ApplicationPropertiesConfigSourceTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/ApplicationPropertiesConfigSourceTest.java
@@ -12,8 +12,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class ApplicationPropertiesConfigSourceTest {
 
     @RegisterExtension
-    static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension()
-            .configProperty("org.acme.bar", "GRUT");
+    static final QuarkusComponentTestExtension extension = QuarkusComponentTestExtension.builder()
+            .configProperty("org.acme.bar", "GRUT")
+            .build();
 
     @Inject
     Component component;

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/DependencyMockingTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/DependencyMockingTest.java
@@ -15,9 +15,11 @@ import io.quarkus.test.component.beans.MyComponent;
 public class DependencyMockingTest {
 
     @RegisterExtension
-    static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension(MyComponent.class)
+    static final QuarkusComponentTestExtension extension = QuarkusComponentTestExtension.builder()
+            .addComponentClasses(MyComponent.class)
             // this config property is injected into MyComponent and the value is used in the ping() method
-            .configProperty("foo", "BAR");
+            .configProperty("foo", "BAR")
+            .build();
 
     @Inject
     MyComponent myComponent;

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/MockConfiguratorTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/MockConfiguratorTest.java
@@ -16,11 +16,12 @@ import io.quarkus.test.component.beans.MyComponent;
 public class MockConfiguratorTest {
 
     @RegisterExtension
-    static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension(MyComponent.class)
+    static final QuarkusComponentTestExtension extension = QuarkusComponentTestExtension.builder()
             .mock(Charlie.class).createMockitoMock(charlie -> {
                 Mockito.when(charlie.pong()).thenReturn("bar");
             })
-            .configProperty("foo", "BAR");
+            .configProperty("foo", "BAR")
+            .build();
 
     @Inject
     MyComponent myComponent;

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/MockNotSharedForClassHierarchyTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/MockNotSharedForClassHierarchyTest.java
@@ -15,8 +15,9 @@ import io.quarkus.test.InjectMock;
 public class MockNotSharedForClassHierarchyTest {
 
     @RegisterExtension
-    static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension(Component.class)
-            .ignoreNestedClasses();
+    static final QuarkusComponentTestExtension extension = QuarkusComponentTestExtension.builder()
+            .ignoreNestedClasses()
+            .build();
 
     @Inject
     Component component;

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/MockSharedForClassHierarchyTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/MockSharedForClassHierarchyTest.java
@@ -13,10 +13,13 @@ import org.mockito.Mockito;
 public class MockSharedForClassHierarchyTest {
 
     @RegisterExtension
-    static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension(Component.class).mock(Foo.class)
+    static final QuarkusComponentTestExtension extension = QuarkusComponentTestExtension.builder()
+            .mock(Foo.class)
             .createMockitoMock(foo -> {
                 Mockito.when(foo.ping()).thenReturn(11);
-            }).ignoreNestedClasses();
+            })
+            .ignoreNestedClasses()
+            .build();
 
     @Inject
     Component component;

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/ObserverInjectingMockTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/ObserverInjectingMockTest.java
@@ -16,8 +16,10 @@ import io.quarkus.test.component.beans.MyComponent;
 public class ObserverInjectingMockTest {
 
     @RegisterExtension
-    static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension(MyComponent.class)
-            .useDefaultConfigProperties();
+    static final QuarkusComponentTestExtension extension = QuarkusComponentTestExtension.builder()
+            .addComponentClasses(MyComponent.class)
+            .useDefaultConfigProperties()
+            .build();
 
     @Inject
     Event<Boolean> event;

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/UnsetConfigurationPropertiesTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/UnsetConfigurationPropertiesTest.java
@@ -14,8 +14,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class UnsetConfigurationPropertiesTest {
 
     @RegisterExtension
-    static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension(Component.class)
-            .useDefaultConfigProperties();
+    static final QuarkusComponentTestExtension extension = QuarkusComponentTestExtension.builder()
+            .useDefaultConfigProperties()
+            .build();
 
     @Inject
     Component component;

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/ConfigPropertyDeclaredOnMethodOverridesClassTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/ConfigPropertyDeclaredOnMethodOverridesClassTest.java
@@ -1,0 +1,33 @@
+package io.quarkus.test.component.declarative;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+import io.quarkus.test.component.TestConfigProperty;
+import io.quarkus.test.component.beans.Charlie;
+import io.quarkus.test.component.beans.MyComponent;
+
+@TestConfigProperty(key = "foo", value = "BAZ")
+@QuarkusComponentTest
+public class ConfigPropertyDeclaredOnMethodOverridesClassTest {
+
+    @Inject
+    MyComponent myComponent;
+
+    @InjectMock
+    Charlie charlie;
+
+    @TestConfigProperty(key = "foo", value = "BAR")
+    @Test
+    public void testPing() {
+        Mockito.when(charlie.ping()).thenReturn("1");
+        assertEquals("1 and BAR", myComponent.ping());
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/ConfigPropertyDeclaredOnMethodTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/ConfigPropertyDeclaredOnMethodTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.test.component.declarative;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTest;
+import io.quarkus.test.component.TestConfigProperty;
+import io.quarkus.test.component.beans.Charlie;
+import io.quarkus.test.component.beans.MyComponent;
+
+@QuarkusComponentTest
+public class ConfigPropertyDeclaredOnMethodTest {
+
+    @Inject
+    MyComponent myComponent;
+
+    @InjectMock
+    Charlie charlie;
+
+    @TestConfigProperty(key = "foo", value = "BAR")
+    @Test
+    public void testPing1() {
+        Mockito.when(charlie.ping()).thenReturn("1");
+        assertEquals("1 and BAR", myComponent.ping());
+    }
+
+    @TestConfigProperty(key = "foo", value = "BAZ")
+    @Test
+    public void testPing2() {
+        Mockito.when(charlie.ping()).thenReturn("2");
+        assertEquals("2 and BAZ", myComponent.ping());
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/lifecycle/PerClassLifecycleTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/lifecycle/PerClassLifecycleTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.test.component.lifecycle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTestExtension;
+import io.quarkus.test.component.beans.Charlie;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class PerClassLifecycleTest {
+
+    @RegisterExtension
+    static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension();
+
+    @Inject
+    MySingleton mySingleton;
+
+    @InjectMock
+    Charlie charlie;
+
+    @Order(1)
+    @Test
+    public void testPing1() {
+        Mockito.when(charlie.ping()).thenReturn("foo");
+        assertEquals("foo", mySingleton.ping());
+        assertEquals(1, MySingleton.COUNTER.get());
+    }
+
+    @Order(2)
+    @Test
+    public void testPing2() {
+        Mockito.when(charlie.ping()).thenReturn("baz");
+        assertEquals("baz", mySingleton.ping());
+        assertEquals(1, MySingleton.COUNTER.get());
+    }
+
+    @Singleton
+    public static class MySingleton {
+
+        static final AtomicInteger COUNTER = new AtomicInteger();
+
+        @Inject
+        Charlie charlie;
+
+        @PostConstruct
+        void init() {
+            COUNTER.incrementAndGet();
+        }
+
+        public String ping() {
+            return charlie.ping();
+        }
+
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/lifecycle/PerMethodLifecycleTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/lifecycle/PerMethodLifecycleTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.test.component.lifecycle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.component.QuarkusComponentTestExtension;
+import io.quarkus.test.component.beans.Charlie;
+
+@TestInstance(Lifecycle.PER_METHOD)
+public class PerMethodLifecycleTest {
+
+    @RegisterExtension
+    static final QuarkusComponentTestExtension extension = new QuarkusComponentTestExtension();
+
+    @Inject
+    MySingleton mySingleton;
+
+    @InjectMock
+    Charlie charlie;
+
+    @Order(1)
+    @Test
+    public void testPing1() {
+        Mockito.when(charlie.ping()).thenReturn("foo");
+        assertEquals("foo", mySingleton.ping());
+        assertEquals(1, MySingleton.COUNTER.get());
+    }
+
+    @Order(2)
+    @Test
+    public void testPing2() {
+        Mockito.when(charlie.ping()).thenReturn("baz");
+        assertEquals("baz", mySingleton.ping());
+        assertEquals(2, MySingleton.COUNTER.get());
+    }
+
+    @Singleton
+    public static class MySingleton {
+
+        static final AtomicInteger COUNTER = new AtomicInteger();
+
+        @Inject
+        Charlie charlie;
+
+        @PostConstruct
+        void init() {
+            COUNTER.incrementAndGet();
+        }
+
+        public String ping() {
+            return charlie.ping();
+        }
+
+    }
+
+}


### PR DESCRIPTION
- determine the test phase when the container is started from the TestInstance#value()
- introduce the QuarkusComponentTestExtensionBuilder to create immutable extension instance when programmatic API is used
- TestConfigProperty can be declared on test methods