### PR TITLE
Default response content type using GraphQL spec

### DIFF
--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
@@ -295,8 +295,9 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
     }
 
     private boolean isValidAcceptRequest(String mimeType) {
-        // At this point we only accept two
         return mimeType.startsWith("application/json")
+                || mimeType.startsWith("application/graphql-response+json")
+                // application/graphql+json is incorrect, but we keep it for backwards compatibility
                 || mimeType.startsWith("application/graphql+json");
     }
 

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
@@ -46,7 +46,7 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
     private static final String EXTENSIONS = "extensions";
     private static final String APPLICATION_GRAPHQL = "application/graphql";
     private static final String OK = "OK";
-    private static final String DEFAULT_RESPONSE_CONTENT_TYPE = "application/graphql+json; charset="
+    private static final String DEFAULT_RESPONSE_CONTENT_TYPE = "application/graphql-response+json; charset="
             + StandardCharsets.UTF_8.name();
     private static final String DEFAULT_REQUEST_CONTENT_TYPE = "application/json; charset="
             + StandardCharsets.UTF_8.name();


### PR DESCRIPTION
So the default content type header was not recognized properly by [GraphQL gateway](https://github.com/apollographql/federation/blob/%40apollo/gateway%402.5.4/gateway-js/src/datasources/RemoteGraphQLDataSource.ts#L299). I tried to [submit PR](https://github.com/apollographql/federation/pull/2769) but they said it doesn't conform to the [GraphQL spec](https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#serialization-format).