### PR TITLE
Arc - Revisit BeanContainer API

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/UnusedExclusionTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/UnusedExclusionTest.java
@@ -74,7 +74,7 @@ public class UnusedExclusionTest {
 
         public void test(BeanContainer beanContainer) {
             // This should trigger the warning - Gama was removed
-            Gama gama = beanContainer.beanInstance(Gama.class);
+            Gama gama = beanContainer.beanInstanceFactory(Gama.class).create().get();
             // Test that fallback was used - no injection was performed
             Assertions.assertNull(gama.beanManager);
         }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
@@ -88,33 +88,12 @@ public interface ArcContainer {
     /**
      * Returns a supplier that can be used to create new instances, or null if no matching bean can be found.
      *
-     * Note that if there are multiple sub classes of the given type this will return the exact match. This means
-     * that this can be used to directly instantiate superclasses of other beans without causing problems. This behavior differs
-     * to standard CDI rules where an ambiguous dependency would exist.
-     *
-     * see https://github.com/quarkusio/quarkus/issues/3369
-     *
      * @param type
      * @param qualifiers
      * @param <T>
      * @return
      */
     <T> Supplier<InstanceHandle<T>> beanInstanceSupplier(Class<T> type, Annotation... qualifiers);
-
-    /**
-     * This method is deprecated and will be removed in future versions.
-     * Use {@link #beanInstanceSupplier(Class, Annotation...)} instead.
-     * </p>
-     * As opposed to {@link #beanInstanceSupplier(Class, Annotation...)}, this method does <b>NOT</b> follow CDI
-     * resolution rules and in case of ambiguous resolution performs a choice based on the class type parameter.
-     *
-     * @param type
-     * @param qualifiers
-     * @return
-     * @param <T>
-     */
-    @Deprecated
-    <T> Supplier<InstanceHandle<T>> instanceSupplier(Class<T> type, Annotation... qualifiers);
 
     /**
      *

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -291,16 +291,6 @@ public class ArcContainerImpl implements ArcContainer {
 
     @Override
     public <T> Supplier<InstanceHandle<T>> beanInstanceSupplier(Class<T> type, Annotation... qualifiers) {
-        return createInstanceSupplier(false, type, qualifiers);
-    }
-
-    @Override
-    public <T> Supplier<InstanceHandle<T>> instanceSupplier(Class<T> type, Annotation... qualifiers) {
-        return createInstanceSupplier(true, type, qualifiers);
-    }
-
-    private <T> Supplier<InstanceHandle<T>> createInstanceSupplier(boolean resolveAmbiguities, Class<T> type,
-            Annotation... qualifiers) {
         if (qualifiers == null || qualifiers.length == 0) {
             qualifiers = new Annotation[] { Default.Literal.INSTANCE };
         }
@@ -311,20 +301,8 @@ public class ArcContainerImpl implements ArcContainer {
         }
         Set<InjectableBean<?>> filteredBean = resolvedBeans;
         if (resolvedBeans.size() > 1) {
-            if (resolveAmbiguities) {
-                // this is non-standard CDI behavior that we momentarily keep to retain compatibility
-                // if there are multiple beans we look for an exact match
-                // this method is only called with the exact type required
-                // so ignoring subclasses is the correct behaviour
-                filteredBean = new HashSet<>();
-                for (InjectableBean<?> i : resolvedBeans) {
-                    if (i.getBeanClass().equals(type)) {
-                        filteredBean.add(i);
-                    }
-                }
-            } else {
-                throw new AmbiguousResolutionException("Beans: " + resolvedBeans);
-            }
+            throw new AmbiguousResolutionException("Beans: " + resolvedBeans);
+
         }
         @SuppressWarnings("unchecked")
         InjectableBean<T> bean = filteredBean.size() != 1 ? null


### PR DESCRIPTION
Fixes #35744

A draft of changes for `BeanContainer` API - some of these are breaking in behavior although they were already dubious in how they worked because we had conflicting javadoc and implementation.

The `BeanContainer#beanInstanceFactory` method stays in terms of what it does and it now has a javadoc documenting this behavior (i.e. no longer says it can return `null`). There is also a new variant allowing users to specify a custom fallback `Factory` implementation that can be used to perform arbitrary fallack in case the bean isn't present.

The `BeanContainer#beanInstance` method which is used in our own extensions remains in place but also changes in that it can no longer return `null` - instead it is a proper CDI lookup dealing with ambiguous and unsatisfied dependencies. Extensions looking to implement fallbacks in case the beans are missing can leverage the `beanInstanceFactory` method, or just access `ArcContainer` and query for a bean via dynamic resolution.

Last but not least, formerly deprecated methods (deprecated since version 2.14) are now deleted.
