### PR TITLE
HTTP fix response compression support

### DIFF
--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/HttpCompressionHandler.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/HttpCompressionHandler.java
@@ -3,7 +3,6 @@ package io.quarkus.vertx.web.runtime;
 import java.util.Set;
 
 import io.quarkus.vertx.http.runtime.HttpCompression;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
@@ -24,33 +23,31 @@ public class HttpCompressionHandler implements Handler<RoutingContext> {
 
     @Override
     public void handle(RoutingContext context) {
-        context.addEndHandler(new Handler<AsyncResult<Void>>() {
+        context.addHeadersEndHandler(new Handler<Void>() {
             @Override
-            public void handle(AsyncResult<Void> result) {
-                if (result.succeeded()) {
-                    MultiMap headers = context.response().headers();
-                    String contentEncoding = headers.get(HttpHeaders.CONTENT_ENCODING);
-                    if (contentEncoding != null && HttpHeaders.IDENTITY.toString().equals(contentEncoding)) {
-                        switch (compression) {
-                            case ON:
-                                headers.remove(HttpHeaders.CONTENT_ENCODING);
-                                break;
-                            case UNDEFINED:
-                                String contentType = headers.get(HttpHeaders.CONTENT_TYPE);
-                                if (contentType != null) {
-                                    int paramIndex = contentType.indexOf(';');
-                                    if (paramIndex > -1) {
-                                        contentType = contentType.substring(0, paramIndex);
-                                    }
-                                    if (compressedMediaTypes.contains(contentType)) {
-                                        headers.remove(HttpHeaders.CONTENT_ENCODING);
-                                    }
+            public void handle(Void result) {
+                MultiMap headers = context.response().headers();
+                String contentEncoding = headers.get(HttpHeaders.CONTENT_ENCODING);
+                if (contentEncoding != null && HttpHeaders.IDENTITY.toString().equals(contentEncoding)) {
+                    switch (compression) {
+                        case ON:
+                            headers.remove(HttpHeaders.CONTENT_ENCODING);
+                            break;
+                        case UNDEFINED:
+                            String contentType = headers.get(HttpHeaders.CONTENT_TYPE);
+                            if (contentType != null) {
+                                int paramIndex = contentType.indexOf(';');
+                                if (paramIndex > -1) {
+                                    contentType = contentType.substring(0, paramIndex);
                                 }
-                                break;
-                            default:
-                                // OFF - no action is needed because the "Content-Encoding: identity" header is set
-                                break;
-                        }
+                                if (compressedMediaTypes.contains(contentType)) {
+                                    headers.remove(HttpHeaders.CONTENT_ENCODING);
+                                }
+                            }
+                            break;
+                        default:
+                            // OFF - no action is needed because the "Content-Encoding: identity" header is set
+                            break;
                     }
                 }
             }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCompressionHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCompressionHandler.java
@@ -2,7 +2,6 @@ package io.quarkus.vertx.http.runtime;
 
 import java.util.Set;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
@@ -25,12 +24,10 @@ public class HttpCompressionHandler implements Handler<RoutingContext> {
 
     @Override
     public void handle(RoutingContext context) {
-        context.addEndHandler(new Handler<AsyncResult<Void>>() {
+        context.addHeadersEndHandler(new Handler<Void>() {
             @Override
-            public void handle(AsyncResult<Void> result) {
-                if (result.succeeded()) {
-                    compressIfNeeded(context, compressedMediaTypes);
-                }
+            public void handle(Void result) {
+                compressIfNeeded(context, compressedMediaTypes);
             }
         });
         routeHandler.handle(context);


### PR DESCRIPTION
- affected extensions include Reactive Routes, Undertow and RESTEasy Classsic (standalone mode)
- the "end handler" cannot not be used as it may be called too late
- the tests passed by coincidence