### PR TITLE
Remove 'Security vulnerability detection' topic from downstream doc list

### DIFF
--- a/docs/downstreamdoc.yaml
+++ b/docs/downstreamdoc.yaml
@@ -17,5 +17,4 @@ guides:
   - src/main/asciidoc/security-openid-connect-client-reference.adoc
   - src/main/asciidoc/security-overview.adoc
   - src/main/asciidoc/security-proactive-authentication.adoc
-  - src/main/asciidoc/security-vulnerability-detection.adoc
   - src/main/asciidoc/update-quarkus.adoc


### PR DESCRIPTION
The product process for reporting security vulnerabilities differs, therefore we will not be needing this topic downstream.
Removing from the YAML file so that our automated downstream import build no longer includes it.