### PR TITLE
Separate Hibernate Reactive tests against MariaDB / MySQL

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -45,7 +45,7 @@
         {
             "category": "Data7",
             "timeout": 85,
-            "test-modules": "reactive-oracle-client, reactive-mysql-client, reactive-db2-client, hibernate-reactive-db2, hibernate-reactive-mysql, hibernate-reactive-mysql-agroal-flyway, hibernate-reactive-panache, hibernate-reactive-panache-kotlin",
+            "test-modules": "reactive-oracle-client, reactive-mysql-client, reactive-db2-client, hibernate-reactive-db2, hibernate-reactive-mariadb, hibernate-reactive-mysql, hibernate-reactive-mysql-agroal-flyway, hibernate-reactive-panache, hibernate-reactive-panache-kotlin",
             "os-name": "ubuntu-latest"
         },
         {

--- a/integration-tests/hibernate-reactive-mariadb/pom.xml
+++ b/integration-tests/hibernate-reactive-mariadb/pom.xml
@@ -9,12 +9,12 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-integration-test-hibernate-reactive-mysql</artifactId>
-    <name>Quarkus - Integration Tests - Hibernate Reactive - MySQL</name>
-    <description>Hibernate Reactive related tests running with the MySQL database</description>
+    <artifactId>quarkus-integration-test-hibernate-reactive-mariadb</artifactId>
+    <name>Quarkus - Integration Tests - Hibernate Reactive - MariaDB</name>
+    <description>Hibernate Reactive related tests running with the MariaDB database</description>
 
     <properties>
-        <reactive-mysql.url>vertx-reactive:mysql://localhost:3306/hibernate_orm_test</reactive-mysql.url>
+        <reactive-mariadb.url>vertx-reactive:mysql://localhost:3306/hibernate_orm_test</reactive-mariadb.url>
     </properties>
 
     <dependencies>
@@ -98,8 +98,7 @@
                 <configuration>
                     <skip>true</skip>
                     <systemPropertyVariables>
-                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true
-                        </org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -108,8 +107,7 @@
                 <configuration>
                     <skip>true</skip>
                     <systemPropertyVariables>
-                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true
-                        </org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
+                        <org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>true</org.hibernate.reactive.common.InternalStateAssertions.ENFORCE>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -154,14 +152,14 @@
         </profile>
 
         <profile>
-            <id>docker-mysql</id>
+            <id>docker-mariadb</id>
             <activation>
                 <property>
                     <name>start-containers</name>
                 </property>
             </activation>
             <properties>
-                <reactive-mysql.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test?allowPublicKeyRetrieval=true</reactive-mysql.url>
+                <reactive-mariadb.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test</reactive-mariadb.url>
             </properties>
             <build>
                 <plugins>
@@ -171,10 +169,10 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>healthcheck-${mysql.image}</name>
-                                    <alias>quarkus-test-mysql</alias>
+                                    <name>healthcheck-${mariadb.image}</name>
+                                    <alias>quarkus-test-mariadb</alias>
                                     <build>
-                                        <from>${mysql.image}</from>
+                                        <from>${mariadb.image}</from>
                                         <healthCheck>
                                             <!-- The exact values for these aren't very important, but it is important they are there -->
                                             <interval>5s</interval>
@@ -184,11 +182,14 @@
                                             <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
                                             Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
                                             <cmd>
-                                                <shell>mysqladmin ping -h localhost -u hibernate_orm_test -phibernate_orm_test || exit 1 </shell>
+                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
                                             </cmd>
                                         </healthCheck>
                                     </build>
                                     <run>
+                                        <network>
+                                            <mode>bridge</mode>
+                                        </network>
                                         <ports>
                                             <port>3308:3306</port>
                                         </ports>
@@ -199,21 +200,21 @@
                                             <MYSQL_RANDOM_ROOT_PASSWORD>true</MYSQL_RANDOM_ROOT_PASSWORD>
                                         </env>
                                         <log>
-                                            <prefix>MySQL:</prefix>
+                                            <prefix>MariaDB:</prefix>
                                             <date>default</date>
                                             <color>cyan</color>
                                         </log>
                                         <!-- Speed things up a bit by not actually flushing writes to disk -->
                                         <tmpfs>/var/lib/mysql</tmpfs>
-                                        <!-- good docs found at: https://dmp.fabric8.io/#start-wait -->
                                         <wait>
+                                            <!-- good docs found at: https://dmp.fabric8.io/#start-wait -->
                                             <time>20000</time>
                                             <healthy>true</healthy>
                                         </wait>
                                     </run>
                                 </image>
                             </images>
-                            <!--Stops all mysql images currently running, not just those we just started.
+                            <!--Stops all mariadb images currently running, not just those we just started.
                               Useful to stop processes still running from a previously failed integration test run -->
                             <allContainers>true</allContainers>
                         </configuration>

--- a/integration-tests/hibernate-reactive-mariadb/src/main/java/io/quarkus/it/hibernate/reactive/mariadb/GuineaPig.java
+++ b/integration-tests/hibernate-reactive-mariadb/src/main/java/io/quarkus/it/hibernate/reactive/mariadb/GuineaPig.java
@@ -1,0 +1,62 @@
+package io.quarkus.it.hibernate.reactive.mariadb;
+
+import java.util.Objects;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Pig")
+public class GuineaPig {
+
+    @Id
+    private Integer id;
+    private String name;
+
+    public GuineaPig() {
+    }
+
+    public GuineaPig(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return id + ": " + name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GuineaPig guineaPig = (GuineaPig) o;
+        return Objects.equals(name, guineaPig.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/integration-tests/hibernate-reactive-mariadb/src/main/java/io/quarkus/it/hibernate/reactive/mariadb/HibernateReactiveMariaDBTestEndpoint.java
+++ b/integration-tests/hibernate-reactive-mariadb/src/main/java/io/quarkus/it/hibernate/reactive/mariadb/HibernateReactiveMariaDBTestEndpoint.java
@@ -1,0 +1,101 @@
+package io.quarkus.it.hibernate.reactive.mariadb;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.mysqlclient.MySQLPool;
+import io.vertx.mutiny.sqlclient.Row;
+import io.vertx.mutiny.sqlclient.RowSet;
+import io.vertx.mutiny.sqlclient.Tuple;
+
+@Path("/tests")
+public class HibernateReactiveMariaDBTestEndpoint {
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    // Injecting a Vert.x Pool is not required, it us only used to
+    // independently validate the contents of the database for the test
+    @Inject
+    MySQLPool mysqlPool;
+
+    @GET
+    @Path("/reactiveFindMutiny")
+    public Uni<GuineaPig> reactiveFindMutiny() {
+        final GuineaPig expectedPig = new GuineaPig(5, "Aloi");
+        return populateDB()
+                .chain(() -> sessionFactory.withSession(s -> s.find(GuineaPig.class, expectedPig.getId())));
+    }
+
+    @GET
+    @Path("/reactivePersist")
+    public Uni<String> reactivePersist() {
+        return sessionFactory.withTransaction(s -> s.persist(new GuineaPig(10, "Tulip")))
+                .chain(() -> selectNameFromId(10));
+    }
+
+    @GET
+    @Path("/reactiveRemoveTransientEntity")
+    public Uni<String> reactiveRemoveTransientEntity() {
+        return populateDB()
+                .chain(() -> selectNameFromId(5))
+                .map(name -> {
+                    if (name == null) {
+                        throw new AssertionError("Database was not populated properly");
+                    }
+                    return name;
+                })
+                .chain(() -> sessionFactory
+                        .withTransaction(s -> s.merge(new GuineaPig(5, "Aloi")).chain(s::remove)))
+                .chain(() -> selectNameFromId(5))
+                .onItem().ifNotNull().transform(result -> result)
+                .onItem().ifNull().continueWith("OK");
+    }
+
+    @GET
+    @Path("/reactiveRemoveManagedEntity")
+    public Uni<String> reactiveRemoveManagedEntity() {
+        return populateDB()
+                .chain(() -> sessionFactory.withTransaction(s -> s.find(GuineaPig.class, 5).chain(s::remove)))
+                .chain(() -> selectNameFromId(5))
+                .onItem().ifNotNull().transform(result -> result)
+                .onItem().ifNull().continueWith("OK");
+    }
+
+    @GET
+    @Path("/reactiveUpdate")
+    public Uni<String> reactiveUpdate() {
+        final String NEW_NAME = "Tina";
+        return populateDB()
+                .chain(() -> sessionFactory.withTransaction(s -> s.find(GuineaPig.class, 5)
+                        .invoke(pig -> {
+                            if (NEW_NAME.equals(pig.getName())) {
+                                throw new AssertionError("Pig already had name " + NEW_NAME);
+                            }
+                            pig.setName(NEW_NAME);
+                        })))
+                .chain(() -> selectNameFromId(5));
+    }
+
+    private Uni<RowSet<Row>> populateDB() {
+        return mysqlPool.query("DELETE FROM Pig").execute()
+                .flatMap(junk -> mysqlPool.preparedQuery("INSERT INTO Pig (id, name) VALUES (5, 'Aloi')").execute());
+    }
+
+    private Uni<String> selectNameFromId(Integer id) {
+        return mysqlPool.preparedQuery("SELECT name FROM Pig WHERE id = ?").execute(Tuple.of(id)).map(rowSet -> {
+            if (rowSet.size() == 1) {
+                return rowSet.iterator().next().getString(0);
+            } else if (rowSet.size() > 1) {
+                throw new AssertionError("More than one result returned: " + rowSet.size());
+            } else {
+                return null; // Size 0
+            }
+        });
+    }
+
+}

--- a/integration-tests/hibernate-reactive-mariadb/src/main/resources/application.properties
+++ b/integration-tests/hibernate-reactive-mariadb/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+quarkus.datasource.db-kind=mariadb
+quarkus.datasource.username=hibernate_orm_test
+quarkus.datasource.password=hibernate_orm_test
+
+# Hibernate config
+#quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.database.generation=drop-and-create
+
+# Reactive config
+quarkus.datasource.reactive=true
+quarkus.datasource.reactive.url=${reactive-mariadb.url}

--- a/integration-tests/hibernate-reactive-mariadb/src/test/java/io/quarkus/it/hibernate/reactive/mariadb/HibernateReactiveMySQLInGraalIT.java
+++ b/integration-tests/hibernate-reactive-mariadb/src/test/java/io/quarkus/it/hibernate/reactive/mariadb/HibernateReactiveMySQLInGraalIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.hibernate.reactive.mariadb;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class HibernateReactiveMySQLInGraalIT extends HibernateReactiveMySQLTest {
+}

--- a/integration-tests/hibernate-reactive-mariadb/src/test/java/io/quarkus/it/hibernate/reactive/mariadb/HibernateReactiveMySQLTest.java
+++ b/integration-tests/hibernate-reactive-mariadb/src/test/java/io/quarkus/it/hibernate/reactive/mariadb/HibernateReactiveMySQLTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.it.hibernate.reactive.mariadb;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+/**
+ * Test various Reactive Hibernate operations running in Quarkus using MySQL
+ */
+@QuarkusTest
+public class HibernateReactiveMySQLTest {
+
+    @Test
+    public void reactiveFindMutiny() {
+        RestAssured.when()
+                .get("/tests/reactiveFindMutiny")
+                .then()
+                .body(is("{\"id\":5,\"name\":\"Aloi\"}"));
+    }
+
+    @Test
+    public void reactivePersist() {
+        RestAssured.when()
+                .get("/tests/reactivePersist")
+                .then()
+                .body(is("Tulip"));
+    }
+
+    @Test
+    public void reactiveRemoveTransientEntity() {
+        RestAssured.when()
+                .get("/tests/reactiveRemoveTransientEntity")
+                .then()
+                .body(is("OK"));
+    }
+
+    @Test
+    public void reactiveRemoveManagedEntity() {
+        RestAssured.when()
+                .get("/tests/reactiveRemoveManagedEntity")
+                .then()
+                .body(is("OK"));
+    }
+
+    @Test
+    public void reactiveUpdate() {
+        RestAssured.when()
+                .get("/tests/reactiveUpdate")
+                .then()
+                .body(is("Tina"));
+    }
+}

--- a/integration-tests/hibernate-reactive-mysql-agroal-flyway/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql-agroal-flyway/pom.xml
@@ -268,13 +268,6 @@
                                             <time>20000</time>
                                             <healthy>true</healthy>
                                         </wait>
-                                        <volumes>
-                                            <bind>
-                                                <volume>
-                                                    ${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d${volume.access.modifier}
-                                                </volume>
-                                            </bind>
-                                        </volumes>
                                     </run>
                                 </image>
                             </images>

--- a/integration-tests/hibernate-reactive-mysql-agroal-flyway/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql-agroal-flyway/pom.xml
@@ -208,14 +208,14 @@
         </profile>
 
         <profile>
-            <id>docker-mariadb</id>
+            <id>docker-mysql</id>
             <activation>
                 <property>
                     <name>start-containers</name>
                 </property>
             </activation>
             <properties>
-                <reactive-mysql.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test</reactive-mysql.url>
+                <reactive-mysql.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test?allowPublicKeyRetrieval=true</reactive-mysql.url>
                 <mysql.jdbc.url>jdbc:mysql://localhost:3308/hibernate_orm_test</mysql.jdbc.url>
             </properties>
             <build>
@@ -226,10 +226,10 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>healthcheck-${mariadb.image}</name>
-                                    <alias>quarkus-test-mariadb</alias>
+                                    <name>healthcheck-${mysql.image}</name>
+                                    <alias>quarkus-test-mysql</alias>
                                     <build>
-                                        <from>${mariadb.image}</from>
+                                        <from>${mysql.image}</from>
                                         <healthCheck>
                                             <!-- The exact values for these aren't very important, but it is important they are there -->
                                             <interval>5s</interval>
@@ -239,14 +239,11 @@
                                             <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
                                             Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
                                             <cmd>
-                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
+                                                <shell>mysqladmin ping -h localhost -u hibernate_orm_test -phibernate_orm_test || exit 1 </shell>
                                             </cmd>
                                         </healthCheck>
                                     </build>
                                     <run>
-                                        <network>
-                                            <mode>bridge</mode>
-                                        </network>
                                         <ports>
                                             <port>3308:3306</port>
                                         </ports>
@@ -257,21 +254,21 @@
                                             <MYSQL_RANDOM_ROOT_PASSWORD>true</MYSQL_RANDOM_ROOT_PASSWORD>
                                         </env>
                                         <log>
-                                            <prefix>MariaDB:</prefix>
+                                            <prefix>MySQL:</prefix>
                                             <date>default</date>
                                             <color>cyan</color>
                                         </log>
                                         <!-- Speed things up a bit by not actually flushing writes to disk -->
                                         <tmpfs>/var/lib/mysql</tmpfs>
+                                        <!-- good docs found at: https://dmp.fabric8.io/#start-wait -->
                                         <wait>
-                                            <!-- good docs found at: https://dmp.fabric8.io/#start-wait -->
                                             <time>20000</time>
                                             <healthy>true</healthy>
                                         </wait>
                                     </run>
                                 </image>
                             </images>
-                            <!--Stops all mariadb images currently running, not just those we just started.
+                            <!--Stops all mysql images currently running, not just those we just started.
                               Useful to stop processes still running from a previously failed integration test run -->
                             <allContainers>true</allContainers>
                         </configuration>

--- a/integration-tests/hibernate-reactive-mysql/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql/pom.xml
@@ -211,13 +211,6 @@
                                             <time>20000</time>
                                             <healthy>true</healthy>
                                         </wait>
-                                        <volumes>
-                                            <bind>
-                                                <volume>
-                                                    ${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d${volume.access.modifier}
-                                                </volume>
-                                            </bind>
-                                        </volumes>
                                     </run>
                                 </image>
                             </images>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -224,6 +224,7 @@
                 <module>hibernate-orm-graphql-panache</module>
                 <module>hibernate-orm-panache-kotlin</module>
                 <module>hibernate-reactive-db2</module>
+                <module>hibernate-reactive-mariadb</module>
                 <module>hibernate-reactive-mysql</module>
                 <module>hibernate-reactive-mysql-agroal-flyway</module>
                 <module>hibernate-reactive-postgresql</module>


### PR DESCRIPTION
~~Based on #33790 which should be merged first.~~ => Done

This creates a module `integration-tests/hibernate-reactive-mariadb` next to `integration-tests/hibernate-reactive-mysql`, and updates `integration-tests/hibernate-reactive-mysql*` to actually use a MySQL instance (and not MariaDB like it used to).

This is important because Hibernate Reactive has a different dialect for MariaDB and MySQL, so tests passing with one may not pass with the other.