### PR TITLE
Make it more obvious in CONTRIBUTING.md that native-tests.json needs to be updated

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,11 @@ Be sure to test your pull request in:
 1. Java mode
 2. Native mode
 
+Also, make sure that any native tests you add will actually get executed on CI.
+In the interest of speeding up CI, the native build job `native-tests` have been split into multiple categories which
+are run in parallel. This means that each new integration test module needs to be configured explicitly
+in [`native-tests.json`](.github/native-tests.json) to have its integration tests run in native mode.
+
 ## Setup
 
 If you have not done so on this machine, you need to:
@@ -752,7 +757,7 @@ This project is an open source project, please act responsibly, be nice, polite 
 * The native integration test for my extension didn't run in the CI
 
   In the interest of speeding up CI, the native build job `native-tests` have been split into multiple categories which
-  are run in parallel. This means that each new extension needs to be configured explicitly
+  are run in parallel. This means that each new integration test module needs to be configured explicitly
   in [`native-tests.json`](.github/native-tests.json) to have its integration tests run in native mode.
 
 * Build aborts complaining about missing (or superfluous) `minimal *-deployment dependencies`


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/pull/33790#issuecomment-1712843660

Ideally we'd have a job whose purpose is to execute any IT that are not found in native-tests.json, so that we're sure we execute everything even if someone forgets about this file. But I'm not sure how complex this would be.