### PR TITLE
Updated @RequestParam#required handling

### DIFF
--- a/extensions/spring-web/resteasy-reactive/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebResteasyReactiveProcessor.java
+++ b/extensions/spring-web/resteasy-reactive/deployment/src/main/java/io/quarkus/spring/web/deployment/SpringWebResteasyReactiveProcessor.java
@@ -289,19 +289,21 @@ public class SpringWebResteasyReactiveProcessor {
                             }
                             transform.add(create(jaxRsAnnotation, annotation.target(), annotationValues));
 
-                            boolean required = true; // the default value
-                            String defaultValueStr = DEFAULT_NONE; // default value of @RequestMapping#defaultValue
+                            String defaultValueStr = null;
                             AnnotationValue defaultValue = annotation.value("defaultValue");
                             if (defaultValue != null) {
                                 defaultValueStr = defaultValue.asString();
-                                required = false; // implicitly set according to the javadoc of @RequestMapping#defaultValue
                             } else {
                                 AnnotationValue requiredValue = annotation.value("required");
                                 if (requiredValue != null) {
-                                    required = requiredValue.asBoolean();
+                                    if (requiredValue.asBoolean()) {
+                                        throw new IllegalArgumentException(
+                                                "Using required @RequestMapping is not supported. Offending method is '"
+                                                        + methodInfo.declaringClass().name() + "#" + methodInfo.name() + "'");
+                                    }
                                 }
                             }
-                            if (!required) {
+                            if (defaultValueStr != null) {
                                 transform.add(create(DEFAULT_VALUE, annotation.target(),
                                         Collections
                                                 .singletonList(AnnotationValue.createStringValue("value", defaultValueStr))));

--- a/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/test/RequiredFalseTest.java
+++ b/extensions/spring-web/resteasy-reactive/tests/src/test/java/io/quarkus/spring/web/test/RequiredFalseTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.spring.web.test;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RequiredFalseTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Controller.class));
+
+    @Test
+    public void test() {
+        when().get("/endpoint/boxed")
+                .then()
+                .statusCode(200)
+                .body(is(""));
+
+        when().get("/endpoint/primitive")
+                .then()
+                .statusCode(200)
+                .body(is("0"));
+    }
+
+    @RestController
+    @RequestMapping("/endpoint")
+    public static class Controller {
+
+        @GetMapping("/boxed")
+        public ResponseEntity<Long> boxed(@RequestParam(value = "id", required = false) Long id) {
+            return ResponseEntity.ok(id);
+        }
+
+        @GetMapping("/primitive")
+        public ResponseEntity<Long> primitive(@RequestParam(value = "id", required = false) long id) {
+            return ResponseEntity.ok(id);
+        }
+    }
+}


### PR DESCRIPTION
The previous behavior was misleading and led to incorrect results when
non-String types were being used.

The reason we don't support `required=true` is that JAX-RS
does not have the concept of a required parameter so to fix
this would need to introduce something specific to RESTEasy Reactive

Closes: #35845