### PR TITLE
ArcProcessor: split the generateResources() method

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcContainerBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcContainerBuildItem.java
@@ -1,0 +1,18 @@
+package io.quarkus.arc.deployment;
+
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.builder.item.SimpleBuildItem;
+
+final class ArcContainerBuildItem extends SimpleBuildItem {
+
+    private final ArcContainer container;
+
+    ArcContainerBuildItem(ArcContainer container) {
+        this.container = container;
+    }
+
+    public ArcContainer getContainer() {
+        return container;
+    }
+
+}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ResourcesGeneratedPhaseBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ResourcesGeneratedPhaseBuildItem.java
@@ -1,0 +1,7 @@
+package io.quarkus.arc.deployment;
+
+import io.quarkus.builder.item.EmptyBuildItem;
+
+final class ResourcesGeneratedPhaseBuildItem extends EmptyBuildItem {
+
+}


### PR DESCRIPTION
- into the generateResources(), initializeContainer() and notifyBeanContainerListeners() methods
- in order to simplify maintenance and clarify the output when quarkus.debug.print-startup-times system property is used