### PR TITLE
Reduce to 0 the required StringBuilder/String allocations on PropertiesUtil::isPropertyInRoot

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/NameIterator.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/NameIterator.java
@@ -271,6 +271,9 @@ public final class NameIterator {
                 other.pos = other.getPosition(otherCookie);
                 return true;
             }
+            if (other.isSegmentDelimiter(otherCookie)) {
+                return false;
+            }
             if (charAt(cookie) != other.charAt(otherCookie)) {
                 return false;
             }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/NameIterator.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/NameIterator.java
@@ -249,6 +249,34 @@ public final class NameIterator {
         }
     }
 
+    public boolean moveBothToNextSegmentIfEquals(NameIterator other) {
+        if (other == this) {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            next();
+            return true;
+        }
+        int cookie = initIteration();
+        int otherCookie = other.initIteration();
+        for (;;) {
+            cookie = nextPos(cookie);
+            otherCookie = other.nextPos(otherCookie);
+            if (isSegmentDelimiter(cookie)) {
+                if (!other.isSegmentDelimiter(otherCookie)) {
+                    return false;
+                }
+                // move both to next
+                pos = getPosition(cookie);
+                other.pos = other.getPosition(otherCookie);
+                return true;
+            }
+            if (charAt(cookie) != other.charAt(otherCookie)) {
+                return false;
+            }
+        }
+    }
+
     public String getNextSegment() {
         final StringBuilder b = new StringBuilder();
         int cookie = initIteration();

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/PropertiesUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/PropertiesUtil.java
@@ -24,20 +24,14 @@ public class PropertiesUtil {
             final NameIterator rootNi = new NameIterator(root);
             // compare segments
             while (rootNi.hasNext()) {
-                String segment = rootNi.getNextSegment();
                 if (!propertyName.hasNext()) {
                     propertyName.goToStart();
                     break;
                 }
-
-                final String nextSegment = propertyName.getNextSegment();
-                if (!segment.equals(nextSegment)) {
+                if (!propertyName.moveBothToNextSegmentIfEquals(rootNi)) {
                     propertyName.goToStart();
                     break;
                 }
-
-                rootNi.next();
-                propertyName.next();
 
                 // root has no more segments, and we reached this far so everything matched.
                 // on top, property still has more segments to do the mapping.


### PR DESCRIPTION
@radcortez 

Running pretty much every startup profiling test using https://github.com/quarkusio/quarkus/issues/35406#issuecomment-1692824446 method, we can spot this is an hot spot.

I would like to add a (unit) test for the new method, but cannot see any in the quarkus repo.
