### PR TITLE
Replace "Java Persistence API" (obsolete)  with "Jakarta Persistence API"

### DIFF
--- a/independent-projects/tools/registry-client/src/test/resources/catalog-config/quarkus-universe-bom-quarkus-platform-descriptor-2.0.3.Final-2.0.3.Final.json
+++ b/independent-projects/tools/registry-client/src/test/resources/catalog-config/quarkus-universe-bom-quarkus-platform-descriptor-2.0.3.Final-2.0.3.Final.json
@@ -4930,7 +4930,7 @@
     "origins" : [ "io.quarkus:quarkus-universe-bom-quarkus-platform-descriptor:2.0.3.Final:json:2.0.3.Final" ]
   }, {
     "name" : "Camel JPA",
-    "description" : "Store and retrieve Java objects from databases using Java Persistence API (JPA)",
+    "description" : "Store and retrieve Java objects from databases using Jakarta Persistence API (JPA)",
     "metadata" : {
       "guide" : "https://camel.apache.org/camel-quarkus/latest/reference/extensions/jpa.html",
       "categories" : [ "integration" ],


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/35857 - Replace "Java Persistence API" (obsolete)  with "Jakarta Persistence API"

Our community docs consistently use "Jakarta Persistence" and "Jakarta Persistence API" instead of the obsolete term,  "Java Persistence API."

Here, I am replacing the single instance of the obsolete term that slipped by.