### PR TITLE
Exclude new GraalVM dependencies that are part of GraalVM/Mandrel

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -1003,11 +1003,15 @@ public class JarResultBuildStep {
 
             // Remove svm and graal-sdk artifacts as they are provided by GraalVM itself
             if (classLoadingConfig.removedArtifacts.isEmpty()) {
-                classLoadingConfig.removedArtifacts = Optional.of(new ArrayList<>(2));
+                classLoadingConfig.removedArtifacts = Optional.of(new ArrayList<>(6));
             }
             List<String> removedArtifacts = classLoadingConfig.removedArtifacts.get();
             removedArtifacts.add("org.graalvm.nativeimage:svm");
             removedArtifacts.add("org.graalvm.sdk:graal-sdk");
+            removedArtifacts.add("org.graalvm.sdk:nativeimage");
+            removedArtifacts.add("org.graalvm.sdk:word");
+            removedArtifacts.add("org.graalvm.sdk:collections");
+            removedArtifacts.add("org.graalvm.polyglot:polyglot");
 
             doLegacyThinJarGeneration(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses,
                     applicationArchivesBuildItem, applicationInfo, packageConfig, generatedResources, libDir, allClasses,


### PR DESCRIPTION
https://github.com/oracle/graal/pull/7171 splits graal-sdk in 4 new
modules/artifacts. As a result starting with GraalVM for JDK 21 (23.1)
we need to remove those as well. Note that it's OK to have them marked
for removal even when using GraalVM < 23.1 despite them not actually
being present.

Closes https://github.com/quarkusio/quarkus/issues/35872

Marked as draft till CI run https://github.com/graalvm/mandrel/actions/runs/6158348245 completes

Update: CI run looks good