### PR TITLE
Reduce allocations while loading classes

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/ClassLoadingResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/ClassLoadingResource.java
@@ -11,7 +11,7 @@ public interface ClassLoadingResource {
      */
     void init();
 
-    byte[] getResourceData(String resource);
+    PooledBufferAllocator.Buffer getResourceData(String resource, PooledBufferAllocator allocator);
 
     URL getResourceURL(String resource);
 

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/ClassLoadingResource.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/ClassLoadingResource.java
@@ -11,6 +11,11 @@ public interface ClassLoadingResource {
      */
     void init();
 
+    /**
+     * Returns the bytes for the given resource, or {@code null} if the resource does not exist.<br>
+     * This resource is not in charge to release the buffer, it is the caller's responsibility.
+     * Furthermore, it cannot retain a reference to the buffer, as it may be pooled and reused.
+     */
     PooledBufferAllocator.Buffer getResourceData(String resource, PooledBufferAllocator allocator);
 
     URL getResourceURL(String resource);

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/PooledBufferAllocator.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/PooledBufferAllocator.java
@@ -1,0 +1,107 @@
+package io.quarkus.bootstrap.runner;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A thread-safe buffer allocator that pools heap buffers.<br>
+ * It's currently implemented using a concurrent linked stack, but the users shouldn't rely on how it's implemented,
+ * as it's subject to change. Conversely, users can rely on the fact that it's thread-safe.
+ *
+ * Users which relies on its buffer API, but doesn't need anymore to pool buffers, can call {@link #disablePooling()}
+ * which will make it behave as if it was disabled from the start and release any buffer that was still pooled.
+ */
+public final class PooledBufferAllocator {
+
+    // This is a sentinel value used to forcibly disable pooling.
+    private static final Buffer EMPTY = new Buffer();
+
+    /**
+     * A buffer that contains the data of a resource.<br>
+     * It can be released back (once) to its allocator via {@link PooledBufferAllocator#release(Buffer)}.
+     */
+    public static final class Buffer {
+        private byte[] data;
+        private int length;
+        private Buffer next;
+
+        private Buffer(byte[] data, int length) {
+            assert data != null && length >= 0;
+            this.data = data;
+            this.length = length;
+        }
+
+        private Buffer() {
+        }
+
+        public byte[] array() {
+            return data;
+        }
+
+        public int length() {
+            return length;
+        }
+
+        /**
+         * It moves the data from this buffer to a new one, and returns the new one.
+         */
+        private Buffer moveDataToNewBufferOf(final int requiredCapacity) {
+            byte[] data = this.data;
+            // it's forbidden to modify EMPTY
+            if (this != EMPTY) {
+                this.data = null;
+            }
+            if (data == null || data.length < requiredCapacity) {
+                data = new byte[requiredCapacity];
+            }
+            return new Buffer(data, requiredCapacity);
+        }
+    }
+
+    // This is the top of the stack of buffers that are available for reuse.
+    private final AtomicReference<Buffer> topStack;
+
+    public PooledBufferAllocator() {
+        topStack = new AtomicReference<>(null);
+    }
+
+    public Buffer allocate(final int requiredCapacity) {
+        // to avoid ABA problems on release, we need to make sure that the buffer is not reused
+        return popBuffer().moveDataToNewBufferOf(requiredCapacity);
+    }
+
+    private Buffer popBuffer() {
+        AtomicReference<Buffer> top = topStack;
+        Buffer topBuffer;
+        do {
+            topBuffer = top.get();
+            if (topBuffer == EMPTY || topBuffer == null) {
+                return EMPTY;
+            }
+        } while (!top.compareAndSet(topBuffer, topBuffer.next));
+        topBuffer.next = null;
+        assert topBuffer != EMPTY;
+        return topBuffer;
+    }
+
+    /**
+     * This method is called when a buffer obtained by {@link #allocate(int)} is no longer needed.<br>
+     * It doesn't enforce belonging to this specific allocator, but the behaviour is undefined if it doesn't.
+     * The same applies in case {@code buffer} is released more than once.
+     */
+    public void release(Buffer buffer) {
+        final AtomicReference<Buffer> top = topStack;
+        Buffer topBuffer;
+        do {
+            topBuffer = top.get();
+            if (topBuffer == EMPTY) {
+                return;
+            }
+            // implicit throw NPE, no need to check upfront
+            buffer.next = topBuffer;
+        } while (!top.compareAndSet(topBuffer, buffer));
+    }
+
+    public void disablePooling() {
+        topStack.lazySet(EMPTY);
+    }
+}

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/RunnerClassLoader.java
@@ -1,7 +1,12 @@
 package io.quarkus.bootstrap.runner;
 
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.crac.Context;
 import org.crac.Resource;


### PR DESCRIPTION
Based on the allocation profiling data, there are several `byte[]` and malloc/free allocations happening on `RunnerClassLoader::loadClass`.

This PR is suggesting 2 ways to reduce both:
- recycling the heap one, necessary to read out of the zip file at `JarResource::getResourceData`, in order to reuse it when possible
- recycling the off-heap one, hidden on https://github.com/openjdk/jdk/blob/455c471ee36e26dd1ece61c615b8421d65359d5d/src/java.base/share/native/libjava/ClassLoader.c#L107 whichi is allocated by the JVM to read the heap one of the previous point

The second one is very beneficial to avoid off-heap fragmentation while using the default OS allocator, 
but I need to understand how to perform a prompty `free` of it: in Netty we use `Cleaner`s if available, but I have never worked with class loader so maybe there's some adverse effect by trying to access them (?).
In case, I would like to be able to dynamically perform at least the first optimization (reusing the heap data).

To understand the magnitude of the improvement in term of allocations, at startup, using config-quickstart, the heap buffer represent ~15% of the total allocations (which doesn't count yet with the malloc/free ones ie off-heap, which would have the same capacity).

At worse it should perform the same as what we got, in theory, but the reality is that allocating an heap NIO `ByteBuffer` add some footprint, if  compared to "raw" byte[] eg +`56` bytes according to Java Object Layout with COOPS, CCPS.

To fix this, I can create a bespoke wrapper eg `BytesSpan` which contains the `length` of the span and a reference to the underlying `byte[]` (not final), avoiding to allocate it over and over, hence reducing this cost to few bytes, just once.
But in the ocean of allocations probably won't matter....

ie quickstart-config startup allocate (in total) 45 MB and ~15% means saving at best 6.75 MB - (the biggest byte[] allocated) which still sounds like a good improvement.
The other thing we're going to save is the zeroing of both buffers, although the copy heap -> off-heap (which were still happening on the JDK JNI code, but not performed by the application code) will become dominant, likely, but with some better performance if the buffers keep on being reused, because hot in the CPU caches.