### PR TITLE
More hierarchical classes are not picked up as global interceptors

### DIFF
--- a/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/PriorityImplInterceptor.java
+++ b/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/PriorityImplInterceptor.java
@@ -1,0 +1,24 @@
+package io.quarkus.grpc.examples.interceptors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.quarkus.grpc.GlobalInterceptor;
+
+@ApplicationScoped
+@GlobalInterceptor
+public class PriorityImplInterceptor implements PriorityInterceptor {
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+        HelloWorldEndpoint.invoked.add(getClass().getName());
+        return next.startCall(call, headers);
+    }
+
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+}

--- a/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/PriorityInterceptor.java
+++ b/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/PriorityInterceptor.java
@@ -1,0 +1,8 @@
+package io.quarkus.grpc.examples.interceptors;
+
+import jakarta.enterprise.inject.spi.Prioritized;
+
+import io.grpc.ServerInterceptor;
+
+public interface PriorityInterceptor extends ServerInterceptor, Prioritized {
+}

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldEndpointTestBase.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldEndpointTestBase.java
@@ -21,6 +21,7 @@ class HelloWorldEndpointTestBase {
         assertThat(invoked).containsExactlyInAnyOrder(
                 "io.quarkus.grpc.examples.interceptors.ClientInterceptors$TypeTarget",
                 "io.quarkus.grpc.examples.interceptors.ClientInterceptors$MethodTarget",
+                "io.quarkus.grpc.examples.interceptors.PriorityImplInterceptor",
                 "io.quarkus.grpc.examples.interceptors.ServerInterceptors$TypeTarget",
                 "io.quarkus.grpc.examples.interceptors.ServerInterceptors$MethodTarget");
 


### PR DESCRIPTION
Missing interfaces check when looking for global server interceptors.

Fixes #35634 