### PR TITLE
JAVA_OPTS → JAVA_OPTS_APPEND, bump FROM version

### DIFF
--- a/extensions/container-image/container-image-docker/deployment/src/test/resources/openjdk-11-runtime
+++ b/extensions/container-image/container-image-docker/deployment/src/test/resources/openjdk-11-runtime
@@ -1,9 +1,9 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11-runtime:1.16
+FROM registry.access.redhat.com/ubi8/openjdk-11-runtime:1.17
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 
-# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+# Configure JAVA_OPTS_APPEND, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/

--- a/extensions/container-image/container-image-docker/deployment/src/test/resources/openjdk-17-runtime
+++ b/extensions/container-image/container-image-docker/deployment/src/test/resources/openjdk-17-runtime
@@ -1,10 +1,10 @@
 # Use Java 17 base image
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.16
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.17
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 
-# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+# Configure JAVA_OPTS_APPEND, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/


### PR DESCRIPTION
In the Red Hat OpenJDK container images, the Env JAVA_OPTS configuration parameter is supposed to override all JVM tuning options generated by the run script. The related parameter JAVA_OPTS_APPEND is used to add to the script-generated parameters.

In image versions including :1.14 to :1.16, a bug prevented it from behaving as intended: JAVA_OPTS did not override all tuning parameters, only some of them.

This was noticed in
<https://github.com/quarkusio/quarkus/issues/35863>

Version :1.17 and newer of the ubi8/openjdk-17 container image changes the behaviour of JAVA_OPTS to properly override all run script parameters.

Switch to using JAVA_OPTS_APPEND instead of JAVA_OPTS. Take the opportunity to update to the latest base image version (:1.17).

Note: The Fabric8 run-java script behaves differently: JAVA_OPTIONS appends, and neither JAVA_OPTS nor JAVA_OPTS_APPEND are supported. This commit does not touch Dockerfiles using the fabric8 run-java.