### PR TITLE
Restore missing parameters in OIDC Dev UI client cred and password SwaggerUI/GraphQL handlers

### DIFF
--- a/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
+++ b/extensions/oidc/deployment/src/main/resources/dev-ui/qwc-oidc-provider.js
@@ -493,6 +493,7 @@ export class QwcOidcProvider extends QwcHotReloadElement {
         this.jsonRpc
             .testServiceWithPassword({
                 tokenUrl: this._getTokenUrl(),
+                serviceUrl: null,
                 clientId: this._getClientId(),
                 clientSecret: this._getClientSecret(),
                 username: this._passwordGrantUsername,
@@ -510,6 +511,7 @@ export class QwcOidcProvider extends QwcHotReloadElement {
         this.jsonRpc
             .testServiceWithPassword({
                 tokenUrl: this._getTokenUrl(),
+                serviceUrl: null,
                 clientId: this._getClientId(),
                 clientSecret: this._getClientSecret(),
                 username: this._passwordGrantUsername,
@@ -542,6 +544,7 @@ export class QwcOidcProvider extends QwcHotReloadElement {
         this.jsonRpc
             .testServiceWithClientCred({
                 tokenUrl: this._getTokenUrl(),
+                serviceUrl: null,
                 clientId: this._getClientId(),
                 clientSecret: this._getClientSecret()
             })
@@ -557,6 +560,7 @@ export class QwcOidcProvider extends QwcHotReloadElement {
         this.jsonRpc
             .testServiceWithClientCred({
                 tokenUrl: this._getTokenUrl(),
+                serviceUrl: null,
                 clientId: this._getClientId(),
                 clientSecret: this._getClientSecret()
             })


### PR DESCRIPTION
Fixes #35599

There was another issue found by @tmulle in the way OIDC DevUI deals with the client credentials grant/password, a null parameter was accidentally dropped during the migration/refactoring. This PR restores and confirms it works with Swagger UI used from within OIDC DevUI.