### PR TITLE
Fix RESTEasy CDI dependency issue

### DIFF
--- a/extensions/resteasy-classic/rest-client/runtime/pom.xml
+++ b/extensions/resteasy-classic/rest-client/runtime/pom.xml
@@ -25,12 +25,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-common</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.resteasy</groupId>
-                    <artifactId>resteasy-cdi</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/resteasy-classic/resteasy-common/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-common/runtime/pom.xml
@@ -83,10 +83,6 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-cdi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
             <optional>true</optional>
             <exclusions>

--- a/extensions/resteasy-classic/resteasy-server-common/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-server-common/runtime/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>quarkus-resteasy-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-cdi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>


### PR DESCRIPTION
The problem is caused by 2aef5323b99f07fa4152179aa94f6207a9577ed4 which contained a Maven exclusion
which results in the dependency not being
added when the client and server part
are mixed.

Fixes: #35889