### PR TITLE
Adopt --strict-image-heap that will land in GraalVM for JDK 21

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -796,6 +796,11 @@ public class NativeImageBuildStep {
                             "-H:BuildOutputJSONFile=" + nativeImageName + "-build-output-stats.json");
                 }
 
+                // only available in GraalVM 23.1.0+. Expected to become the default in GraalVM 24.0.0.
+                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_1_0) >= 0) {
+                    nativeImageArgs.add("--strict-image-heap");
+                }
+
                 /*
                  * Any parameters following this call are forced over the user provided parameters in
                  * quarkus.native.additional-build-args. So if you need a parameter to be overridable through

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
@@ -49,7 +49,7 @@ public class NativeImageFeatureStep {
     @BuildStep
     void addExportsToNativeImage(BuildProducer<JPMSExportBuildItem> features) {
         // required in order to access org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport
-        // prior to 23.1 the class was provided by org.graalvm.sdk module and with 23.1 onwards, it's provided by org.graalvm.nativimage instead
+        // prior to 23.1 the class was provided by org.graalvm.sdk module and with 23.1 onwards, it's provided by org.graalvm.nativeimage instead
         features.produce(new JPMSExportBuildItem("org.graalvm.sdk", "org.graalvm.nativeimage.impl", null,
                 GraalVM.Version.VERSION_23_1_0));
         features.produce(new JPMSExportBuildItem("org.graalvm.nativeimage", "org.graalvm.nativeimage.impl",


### PR DESCRIPTION
oracle/graal#7393 adds a new --strict-image-heap option, that will eventually become the new default. Quarkus should start using the option with GraalVM for JDK 21 (23.1.0) to be able to test it before it becomes the new default.

Closes #35901

Draft till CI run https://github.com/graalvm/mandrel/actions/runs/6168707496 completes