### PR TITLE
Qute: improve RESTEasy classic/reactive support

### DIFF
--- a/extensions/resteasy-classic/resteasy-qute/runtime/src/main/java/io/quarkus/resteasy/qute/runtime/TemplateResponseFilter.java
+++ b/extensions/resteasy-classic/resteasy-qute/runtime/src/main/java/io/quarkus/resteasy/qute/runtime/TemplateResponseFilter.java
@@ -17,6 +17,7 @@ import org.jboss.resteasy.core.interception.jaxrs.SuspendableContainerResponseCo
 
 import io.quarkus.arc.Arc;
 import io.quarkus.qute.Engine;
+import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.Variant;
 
@@ -34,10 +35,22 @@ public class TemplateResponseFilter implements ContainerResponseFilter {
 
             MediaType mediaType;
             TemplateInstance instance = (TemplateInstance) entity;
+
+            List<Variant> quteVariants = List.of();
             Object variantsAttr = instance.getAttribute(TemplateInstance.VARIANTS);
             if (variantsAttr != null) {
+                quteVariants = (List<Variant>) variantsAttr;
+            } else {
+                // If no variants are available then try to use the template variant
+                Template template = instance.getTemplate();
+                if (template.getVariant().isPresent()) {
+                    quteVariants = List.of(template.getVariant().get());
+                }
+            }
+
+            if (!quteVariants.isEmpty()) {
                 List<jakarta.ws.rs.core.Variant> variants = new ArrayList<>();
-                for (Variant variant : (List<Variant>) variantsAttr) {
+                for (Variant variant : quteVariants) {
                     variants.add(new jakarta.ws.rs.core.Variant(MediaType.valueOf(variant.getMediaType()), variant.getLocale(),
                             variant.getEncoding()));
                 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-qute/runtime/src/main/java/io/quarkus/resteasy/reactive/qute/runtime/Util.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-qute/runtime/src/main/java/io/quarkus/resteasy/reactive/qute/runtime/Util.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Request;
 
 import io.quarkus.qute.Engine;
+import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateException;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.Variant;
@@ -33,9 +34,18 @@ final class Util {
     @SuppressWarnings("unchecked")
     static MediaType setSelectedVariant(TemplateInstance result,
             Request request, List<Locale> acceptableLanguages) {
+        List<Variant> quteVariants = List.of();
         Object variantsAttr = result.getAttribute(TemplateInstance.VARIANTS);
         if (variantsAttr != null) {
-            List<Variant> quteVariants = (List<Variant>) variantsAttr;
+            quteVariants = (List<Variant>) variantsAttr;
+        } else {
+            // If no variants are available then try to use the template variant
+            Template template = result.getTemplate();
+            if (template.getVariant().isPresent()) {
+                quteVariants = List.of(template.getVariant().get());
+            }
+        }
+        if (!quteVariants.isEmpty()) {
             List<jakarta.ws.rs.core.Variant> jaxRsVariants = new ArrayList<>(quteVariants.size());
             for (Variant variant : quteVariants) {
                 jaxRsVariants.add(new jakarta.ws.rs.core.Variant(MediaType.valueOf(variant.getMediaType()), variant.getLocale(),


### PR DESCRIPTION
- set the content type for an unambiguous template
- fixes #27872