### PR TITLE
Qute: type pollution fixes

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/CompletionStageSupport.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/CompletionStageSupport.java
@@ -1,0 +1,33 @@
+package io.quarkus.qute;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import io.smallrye.mutiny.operators.AbstractUni;
+
+class CompletionStageSupport {
+
+    static final String SYSTEM_PROPERTY = "quarkus.qute.unrestricted-completion-stage-support";
+
+    /**
+     * {@code true} if any {@link CompletionStage} implementation is supported. {@code false} if only {@link CompletableFuture}
+     * and {@link CompletedStage} are considered in the API.
+     */
+    static final boolean UNRESTRICTED = Boolean.getBoolean(SYSTEM_PROPERTY);
+
+    @SuppressWarnings("unchecked")
+    static CompletionStage<Object> toCompletionStage(Object result) {
+        // Note that we intentionally use "instanceof" to test interfaces as the last resort in order to mitigate the "type pollution"
+        // See https://github.com/RedHatPerf/type-pollution-agent for more information
+        if (result instanceof CompletableFuture) {
+            return (CompletableFuture<Object>) result;
+        } else if (result instanceof CompletedStage) {
+            return (CompletedStage<Object>) result;
+        } else if (result instanceof AbstractUni) {
+            return ((AbstractUni<Object>) result).subscribeAsCompletionStage();
+        } else if (UNRESTRICTED && result instanceof CompletionStage) {
+            return (CompletionStage<Object>) result;
+        }
+        return CompletedStage.of(result);
+    }
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
@@ -8,7 +8,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.jboss.logging.Logger;
@@ -16,7 +15,6 @@ import org.jboss.logging.Logger;
 import io.quarkus.qute.Expression.Part;
 import io.quarkus.qute.ExpressionImpl.PartImpl;
 import io.quarkus.qute.Results.NotFound;
-import io.smallrye.mutiny.operators.AbstractUni;
 
 class EvaluatorImpl implements Evaluator {
 
@@ -78,7 +76,7 @@ class EvaluatorImpl implements Evaluator {
                 // Very often a single matching resolver will be found
                 return matching[0].resolve(context).thenCompose(r -> (parts.size() > 1)
                         ? resolveReference(false, r, parts, resolutionContext, expression, 1)
-                        : toCompletionStage(r));
+                        : CompletionStageSupport.toCompletionStage(r));
             } else {
                 // Multiple namespace resolvers match
                 return resolveNamespace(context, resolutionContext, parts, matching, 0, expression);
@@ -113,7 +111,7 @@ class EvaluatorImpl implements Evaluator {
             } else if (parts.size() > 1) {
                 return resolveReference(false, r, parts, resolutionContext, expression, 1);
             } else {
-                return toCompletionStage(r);
+                return CompletionStageSupport.toCompletionStage(r);
             }
         });
     }
@@ -144,7 +142,7 @@ class EvaluatorImpl implements Evaluator {
                     if (Results.isNotFound(r)) {
                         return resolve(evalContext, null, false, expression, isLastPart, partIndex);
                     } else {
-                        return toCompletionStage(r);
+                        return CompletionStageSupport.toCompletionStage(r);
                     }
                 });
             }
@@ -212,25 +210,9 @@ class EvaluatorImpl implements Evaluator {
             } else {
                 // Cache the first resolver where a result is found
                 evalContext.setCachedResolver(foundResolver);
-                return toCompletionStage(r);
+                return CompletionStageSupport.toCompletionStage(r);
             }
         });
-    }
-
-    @SuppressWarnings("unchecked")
-    private static CompletionStage<Object> toCompletionStage(Object result) {
-        // Note that we intentionally avoid "result instanceof Uni"; see https://github.com/RedHatPerf/type-pollution-agent
-        // Unfortunatelly, we can't get rid of "result instanceof CompletionStage" so we at least try to test CompletableFuture and CompletedStage first
-        if (result instanceof CompletableFuture) {
-            return (CompletableFuture<Object>) result;
-        } else if (result instanceof CompletedStage) {
-            return (CompletedStage<Object>) result;
-        } else if (result instanceof AbstractUni) {
-            return ((AbstractUni<Object>) result).subscribeAsCompletionStage();
-        } else if (result instanceof CompletionStage) {
-            return (CompletionStage<Object>) result;
-        }
-        return CompletedStage.of(result);
     }
 
     private TemplateException propertyNotFound(Object result, Expression expression) {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/FieldAccessor.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/FieldAccessor.java
@@ -15,16 +15,10 @@ class FieldAccessor implements ValueAccessor, AccessorCandidate {
         this.field = field;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public CompletionStage<Object> getValue(Object instance) {
         try {
-            Object ret = field.get(instance);
-            if (ret instanceof CompletionStage) {
-                return (CompletionStage<Object>) ret;
-            } else {
-                return CompletedStage.of(ret);
-            }
+            return CompletionStageSupport.toCompletionStage(field.get(instance));
         } catch (Exception e) {
             throw new IllegalStateException("Reflection invocation error", e);
         }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/GetterAccessor.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/GetterAccessor.java
@@ -15,16 +15,10 @@ class GetterAccessor implements ValueAccessor, AccessorCandidate {
         this.method = method;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public CompletionStage<Object> getValue(Object instance) {
         try {
-            Object ret = method.invoke(instance);
-            if (ret instanceof CompletionStage) {
-                return (CompletionStage<Object>) ret;
-            } else {
-                return CompletedStage.of(ret);
-            }
+            return CompletionStageSupport.toCompletionStage(method.invoke(instance));
         } catch (Exception e) {
             throw new IllegalStateException("Reflection invocation error", e);
         }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
@@ -3,6 +3,8 @@ package io.quarkus.qute;
 import static io.quarkus.qute.Parameter.EMPTY;
 
 import java.lang.reflect.Array;
+import java.util.AbstractCollection;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -71,27 +73,31 @@ public class LoopSectionHelper implements SectionHelper {
     }
 
     private static int extractSize(Object it) {
-        if (it instanceof Collection) {
-            return ((Collection<?>) it).size();
-        } else if (it instanceof Map) {
-            return ((Map<?, ?>) it).size();
+        // Note that we intentionally use "instanceof" to test interfaces as the last resort in order to mitigate the "type pollution"
+        // See https://github.com/RedHatPerf/type-pollution-agent for more information
+        if (it instanceof AbstractCollection) {
+            return ((AbstractCollection<?>) it).size();
+        } else if (it instanceof AbstractMap) {
+            return ((AbstractMap<?, ?>) it).size();
         } else if (it.getClass().isArray()) {
             return Array.getLength(it);
         } else if (it instanceof Integer) {
             return ((Integer) it);
+        } else if (it instanceof Collection) {
+            return ((Collection<?>) it).size();
+        } else if (it instanceof Map) {
+            return ((Map<?, ?>) it).size();
         }
         return 10;
     }
 
     private Iterator<?> extractIterator(Object it) {
-        if (it instanceof Iterable) {
-            return ((Iterable<?>) it).iterator();
-        } else if (it instanceof Iterator) {
-            return (Iterator<?>) it;
-        } else if (it instanceof Map) {
-            return ((Map<?, ?>) it).entrySet().iterator();
-        } else if (it instanceof Stream) {
-            return ((Stream<?>) it).sequential().iterator();
+        // Note that we intentionally use "instanceof" to test interfaces as the last resort in order to mitigate the "type pollution"
+        // See https://github.com/RedHatPerf/type-pollution-agent for more information
+        if (it instanceof AbstractCollection) {
+            return ((AbstractCollection<?>) it).iterator();
+        } else if (it instanceof AbstractMap) {
+            return ((AbstractMap<?, ?>) it).entrySet().iterator();
         } else if (it instanceof Integer) {
             return IntStream.rangeClosed(1, (Integer) it).iterator();
         } else if (it.getClass().isArray()) {
@@ -102,6 +108,14 @@ public class LoopSectionHelper implements SectionHelper {
                 elements.add(Array.get(it, i));
             }
             return elements.iterator();
+        } else if (it instanceof Iterable) {
+            return ((Iterable<?>) it).iterator();
+        } else if (it instanceof Iterator) {
+            return (Iterator<?>) it;
+        } else if (it instanceof Map) {
+            return ((Map<?, ?>) it).entrySet().iterator();
+        } else if (it instanceof Stream) {
+            return ((Stream<?>) it).sequential().iterator();
         } else {
             TemplateException.Builder builder;
             if (Results.isNotFound(it)) {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/MultiResultNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/MultiResultNode.java
@@ -6,7 +6,7 @@ import java.util.function.Supplier;
 /**
  * A result node backed by an array of result nodes.
  */
-public final class MultiResultNode implements ResultNode {
+public final class MultiResultNode extends ResultNode {
 
     private final Supplier<ResultNode>[] results;
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResultNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResultNode.java
@@ -6,9 +6,9 @@ import java.util.function.Consumer;
 /**
  * Node of a result tree.
  */
-public interface ResultNode {
+public abstract class ResultNode {
 
-    static CompletionStage<ResultNode> NOOP = CompletedStage.of(new ResultNode() {
+    public static CompletionStage<ResultNode> NOOP = CompletedStage.of(new ResultNode() {
         @Override
         public void process(Consumer<String> resultConsumer) {
         }
@@ -18,6 +18,6 @@ public interface ResultNode {
      *
      * @param resultConsumer
      */
-    void process(Consumer<String> resultConsumer);
+    public abstract void process(Consumer<String> resultConsumer);
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SingleResultNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SingleResultNode.java
@@ -9,7 +9,7 @@ import java.util.function.Consumer;
 /**
  * A result node backed by a single object value.
  */
-public final class SingleResultNode implements ResultNode {
+public final class SingleResultNode extends ResultNode {
 
     private final Object value;
     private final ExpressionNode node;

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TextNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TextNode.java
@@ -6,7 +6,7 @@ import java.util.function.Consumer;
 /**
  * Static text.
  */
-public class TextNode implements TemplateNode, ResultNode {
+public class TextNode extends ResultNode implements TemplateNode {
 
     private final CompletedStage<ResultNode> result;
     private final String value;


### PR DESCRIPTION
I'm not exacly a fan of similar fixes, mainly because it usually leads to non-idiomatic code and the code is also more difficult to maintain. However, our [JMH benchmarks](https://github.com/mkouba/qute-benchmarks) show significant performance improvements, the throughput in some benchmarks  increases even by ~ 30%.

This is a breaking change.

1. `ResultNode` is now an abstract class (was an interface). `ResultNode` should not be implemented by users. Still, it's part of the public API.
2. The Qute API heavily uses the `CompletionStage` async type. Up to now, any implementation could be used in API. After this change only the `java.util.concurrent.CompletableFuture` and the internal `io.quarkus.qute.CompletedStage` are supported by default. The behavior can be changed with the system property `-Dquarkus.qute.unrestricted-completion-stage-support=true`.