### PR TITLE
Use constants for Vert.x web route order marks

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -591,21 +591,19 @@ link:https://undertow.io/undertow-docs/undertow-docs-2.0.0/index.html#predicates
 
 If you are using a `web.xml` file as your configuration file, you can place it in the `src/main/resources/META-INF` directory.
 
-== References
+=== Built-in route order values
 
-=== Well-known route order values
+Route order values are the values that are specified via Vert.x route `io.vertx.ext.web.Route.order(int)` function.
 
-Route order marks are the values that are specified via Vert.x route `io.vertx.ext.web.Route.order(int)` function.
-
-Quarkus uses a couple of route order marks itself. Your route order mark values should be at least a positive integer
-value above `20000` (see `RouteConstants.ROUTE_ORDER_AFTER_DEFAULT_MARK`) to not interfere with the functionality provided
-by Quarkus or its extensions.
+Quarkus registers a couple of routes with specific order values.
+The constants are defined in the `io.quarkus.vertx.http.runtime.RouteConstants` class and listed in the table below.
+A custom route should define the order of value 20000 or higher so that it does not interfere with the functionality provided by Quarkus and extensions.
 
 Route order constants defined in `io.quarkus.vertx.http.runtime.RouteConstants` and known extensions:
 
 [cols="1,1,3"]
 |===
-| Route order mark| Constant name| Origin
+| Route order value| Constant name| Origin
 | `Integer.MIN_VALUE` | `ROUTE_ORDER_ACCESS_LOG_HANDLER` | Access-log handler, if enabled in the configuration.
 | `Integer.MIN_VALUE` | `ROUTE_ORDER_RECORD_START_TIME` | Handler adding the start-time, if enabled in the configuration.
 | `Integer.MIN_VALUE` | `ROUTE_ORDER_HOT_REPLACEMENT` | -replacement body handler.
@@ -615,7 +613,7 @@ Route order constants defined in `io.quarkus.vertx.http.runtime.RouteConstants` 
 | `Integer.MIN_VALUE + 1` | `ROUTE_ORDER_BODY_HANDLER` | Body handler.
 | `-2` | `ROUTE_ORDER_UPLOAD_LIMIT` | Route that enforces the upload body size limit.
 | `0` | `ROUTE_ORDER_COMPRESSION` | Compression handler.
-| `1000` | `ROUTE_ORDER_BEFORE_DEFAULT_MARK` | Route with priority over the default route (add an offset from this mark).
+| `1000` | `ROUTE_ORDER_BEFORE_DEFAULT` | Route with priority over the default route (add an offset from this value).
 | `10000` | `ROUTE_ORDER_DEFAULT` | Default route order (i.e. Static Resources, Servlet).
-| `20000` | `ROUTE_ORDER_AFTER_DEFAULT_MARK` | Route without priority over the default route (add an offset from this mark)
+| `20000` | `ROUTE_ORDER_AFTER_DEFAULT` | Route without priority over the default route (add an offset from this value)
 |===

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -590,3 +590,32 @@ link:https://undertow.io/undertow-docs/undertow-docs-2.0.0/index.html#predicates
 === web.xml
 
 If you are using a `web.xml` file as your configuration file, you can place it in the `src/main/resources/META-INF` directory.
+
+== References
+
+=== Well-known route order values
+
+Route order marks are the values that are specified via Vert.x route `io.vertx.ext.web.Route.order(int)` function.
+
+Quarkus uses a couple of route order marks itself. Your route order mark values should be at least a positive integer
+value above `20000` (see `RouteConstants.ROUTE_ORDER_AFTER_DEFAULT_MARK`) to not interfere with the functionality provided
+by Quarkus or its extensions.
+
+Route order constants defined in `io.quarkus.vertx.http.runtime.RouteConstants` and known extensions:
+
+[cols="1,1,3"]
+|===
+| Route order mark| Constant name| Origin
+| `Integer.MIN_VALUE` | `ROUTE_ORDER_ACCESS_LOG_HANDLER` | Access-log handler, if enabled in the configuration.
+| `Integer.MIN_VALUE` | `ROUTE_ORDER_RECORD_START_TIME` | Handler adding the start-time, if enabled in the configuration.
+| `Integer.MIN_VALUE` | `ROUTE_ORDER_HOT_REPLACEMENT` | -replacement body handler.
+| `Integer.MIN_VALUE` | `ROUTE_ORDER_BODY_HANDLER_MANAGEMENT` | Body handler for the management router.
+| `Integer.MIN_VALUE` | `ROUTE_ORDER_HEADERS` | Handlers that add headers specified in the configuration.
+| `Integer.MIN_VALUE` | `ROUTE_ORDER_CORS_MANAGEMENT` | CORS-Origin handler of the management router.
+| `Integer.MIN_VALUE + 1` | `ROUTE_ORDER_BODY_HANDLER` | Body handler.
+| `-2` | `ROUTE_ORDER_UPLOAD_LIMIT` | Route that enforces the upload body size limit.
+| `0` | `ROUTE_ORDER_COMPRESSION` | Compression handler.
+| `1000` | `ROUTE_ORDER_BEFORE_DEFAULT_MARK` | Route with priority over the default route (add an offset from this mark).
+| `10000` | `ROUTE_ORDER_DEFAULT` | Default route order (i.e. Static Resources, Servlet).
+| `20000` | `ROUTE_ORDER_AFTER_DEFAULT_MARK` | Route without priority over the default route (add an offset from this mark)
+|===

--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
@@ -41,7 +41,7 @@ import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
+import io.quarkus.vertx.http.runtime.RouteConstants;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
@@ -136,7 +136,7 @@ public class ResteasyStandaloneBuildStep {
         routes.produce(
                 RouteBuildItem.builder()
                         .orderedRoute(standalone.deploymentRootPath,
-                                VertxHttpRecorder.AFTER_DEFAULT_ROUTE_ORDER_MARK + REST_ROUTE_ORDER_OFFSET)
+                                RouteConstants.ROUTE_ORDER_AFTER_DEFAULT_MARK + REST_ROUTE_ORDER_OFFSET)
                         .handler(handler).build());
         String matchPath = standalone.deploymentRootPath;
         if (matchPath.endsWith("/")) {
@@ -146,7 +146,7 @@ public class ResteasyStandaloneBuildStep {
         }
         // Match paths that begin with the deployment path
         routes.produce(RouteBuildItem.builder()
-                .orderedRoute(matchPath, VertxHttpRecorder.AFTER_DEFAULT_ROUTE_ORDER_MARK + REST_ROUTE_ORDER_OFFSET)
+                .orderedRoute(matchPath, RouteConstants.ROUTE_ORDER_AFTER_DEFAULT_MARK + REST_ROUTE_ORDER_OFFSET)
                 .handler(handler).build());
 
         recorder.start(shutdown, requireVirtual.isPresent());

--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
@@ -136,7 +136,7 @@ public class ResteasyStandaloneBuildStep {
         routes.produce(
                 RouteBuildItem.builder()
                         .orderedRoute(standalone.deploymentRootPath,
-                                RouteConstants.ROUTE_ORDER_AFTER_DEFAULT_MARK + REST_ROUTE_ORDER_OFFSET)
+                                RouteConstants.ROUTE_ORDER_AFTER_DEFAULT + REST_ROUTE_ORDER_OFFSET)
                         .handler(handler).build());
         String matchPath = standalone.deploymentRootPath;
         if (matchPath.endsWith("/")) {
@@ -146,7 +146,7 @@ public class ResteasyStandaloneBuildStep {
         }
         // Match paths that begin with the deployment path
         routes.produce(RouteBuildItem.builder()
-                .orderedRoute(matchPath, RouteConstants.ROUTE_ORDER_AFTER_DEFAULT_MARK + REST_ROUTE_ORDER_OFFSET)
+                .orderedRoute(matchPath, RouteConstants.ROUTE_ORDER_AFTER_DEFAULT + REST_ROUTE_ORDER_OFFSET)
                 .handler(handler).build());
 
         recorder.start(shutdown, requireVirtual.isPresent());

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -203,7 +203,7 @@ import io.quarkus.vertx.http.deployment.EagerSecurityInterceptorBuildItem;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
+import io.quarkus.vertx.http.runtime.RouteConstants;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -1251,11 +1251,11 @@ public class ResteasyReactiveProcessor {
                 .produce(new ResteasyReactiveDeploymentInfoBuildItem(deploymentInfo));
 
         boolean servletPresent = false;
-        int order = VertxHttpRecorder.AFTER_DEFAULT_ROUTE_ORDER_MARK + REST_ROUTE_ORDER_OFFSET;
+        int order = RouteConstants.ROUTE_ORDER_AFTER_DEFAULT_MARK + REST_ROUTE_ORDER_OFFSET;
         if (capabilities.isPresent("io.quarkus.servlet")) {
             //if servlet is present we run RR before the default route
             //otherwise we run after it
-            order = VertxHttpRecorder.BEFORE_DEFAULT_ROUTE_ORDER_MARK + REST_ROUTE_ORDER_OFFSET;
+            order = RouteConstants.ROUTE_ORDER_BEFORE_DEFAULT_MARK + REST_ROUTE_ORDER_OFFSET;
             servletPresent = true;
         }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -1251,11 +1251,11 @@ public class ResteasyReactiveProcessor {
                 .produce(new ResteasyReactiveDeploymentInfoBuildItem(deploymentInfo));
 
         boolean servletPresent = false;
-        int order = RouteConstants.ROUTE_ORDER_AFTER_DEFAULT_MARK + REST_ROUTE_ORDER_OFFSET;
+        int order = RouteConstants.ROUTE_ORDER_AFTER_DEFAULT + REST_ROUTE_ORDER_OFFSET;
         if (capabilities.isPresent("io.quarkus.servlet")) {
             //if servlet is present we run RR before the default route
             //otherwise we run after it
-            order = RouteConstants.ROUTE_ORDER_BEFORE_DEFAULT_MARK + REST_ROUTE_ORDER_OFFSET;
+            order = RouteConstants.ROUTE_ORDER_BEFORE_DEFAULT + REST_ROUTE_ORDER_OFFSET;
             servletPresent = true;
         }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RouteConstants.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RouteConstants.java
@@ -1,0 +1,62 @@
+package io.quarkus.vertx.http.runtime;
+
+/**
+ * Route order mark constants used in Quarkus, update {@code reactive-routes.adoc} when changing this class.
+ */
+@SuppressWarnings("JavadocDeclaration")
+public final class RouteConstants {
+    private RouteConstants() {
+    }
+
+    /**
+     * Order mark ({@value #ROUTE_ORDER_ACCESS_LOG_HANDLER}) for the access-log handler, if enabled in the configuration.
+     */
+    public static final int ROUTE_ORDER_ACCESS_LOG_HANDLER = Integer.MIN_VALUE;
+    /**
+     * Order mark ({@value #ROUTE_ORDER_RECORD_START_TIME}) for the handler adding the start-time, if enabled in the
+     * configuration.
+     */
+    public static final int ROUTE_ORDER_RECORD_START_TIME = Integer.MIN_VALUE;
+    /**
+     * Order mark ({@value #ROUTE_ORDER_HOT_REPLACEMENT}) for the hot-replacement body handler.
+     */
+    public static final int ROUTE_ORDER_HOT_REPLACEMENT = Integer.MIN_VALUE;
+    /**
+     * Order mark ({@value #ROUTE_ORDER_BODY_HANDLER_MANAGEMENT}) for the body handler for the management router.
+     */
+    public static final int ROUTE_ORDER_BODY_HANDLER_MANAGEMENT = Integer.MIN_VALUE;
+    /**
+     * Order mark ({@value #ROUTE_ORDER_HEADERS}) for the handlers that add headers specified in the configuration.
+     */
+    public static final int ROUTE_ORDER_HEADERS = Integer.MIN_VALUE;
+    /**
+     * Order mark ({@value #ROUTE_ORDER_CORS_MANAGEMENT}) for the CORS-Origin handler of the management router.
+     */
+    public static final int ROUTE_ORDER_CORS_MANAGEMENT = Integer.MIN_VALUE;
+    /**
+     * Order mark ({@value #ROUTE_ORDER_BODY_HANDLER}) for the body handler.
+     */
+    public static final int ROUTE_ORDER_BODY_HANDLER = Integer.MIN_VALUE + 1;
+    /**
+     * Order mark ({@value #ROUTE_ORDER_UPLOAD_LIMIT}) for the route that enforces the upload body size limit.
+     */
+    public static final int ROUTE_ORDER_UPLOAD_LIMIT = -2;
+    /**
+     * Order mark ({@value #ROUTE_ORDER_COMPRESSION}) for the compression handler.
+     */
+    public static final int ROUTE_ORDER_COMPRESSION = 0;
+    /**
+     * Order mark ({@value #ROUTE_ORDER_BEFORE_DEFAULT_MARK}) for route with priority over the default route (add an offset from
+     * this mark)
+     */
+    public static final int ROUTE_ORDER_BEFORE_DEFAULT_MARK = 1_000;
+    /**
+     * Default route order (i.e. Static Resources, Servlet): ({@value #ROUTE_ORDER_DEFAULT})
+     */
+    public static final int ROUTE_ORDER_DEFAULT = 10_000;
+    /**
+     * Order mark ({@value #ROUTE_ORDER_AFTER_DEFAULT_MARK}) for route without priority over the default route (add an offset
+     * from this mark)
+     */
+    public static final int ROUTE_ORDER_AFTER_DEFAULT_MARK = 20_000;
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RouteConstants.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RouteConstants.java
@@ -1,7 +1,7 @@
 package io.quarkus.vertx.http.runtime;
 
 /**
- * Route order mark constants used in Quarkus, update {@code reactive-routes.adoc} when changing this class.
+ * Route order value constants used in Quarkus, update {@code reactive-routes.adoc} when changing this class.
  */
 @SuppressWarnings("JavadocDeclaration")
 public final class RouteConstants {
@@ -9,54 +9,54 @@ public final class RouteConstants {
     }
 
     /**
-     * Order mark ({@value #ROUTE_ORDER_ACCESS_LOG_HANDLER}) for the access-log handler, if enabled in the configuration.
+     * Order value ({@value #ROUTE_ORDER_ACCESS_LOG_HANDLER}) for the access-log handler, if enabled in the configuration.
      */
     public static final int ROUTE_ORDER_ACCESS_LOG_HANDLER = Integer.MIN_VALUE;
     /**
-     * Order mark ({@value #ROUTE_ORDER_RECORD_START_TIME}) for the handler adding the start-time, if enabled in the
+     * Order value ({@value #ROUTE_ORDER_RECORD_START_TIME}) for the handler adding the start-time, if enabled in the
      * configuration.
      */
     public static final int ROUTE_ORDER_RECORD_START_TIME = Integer.MIN_VALUE;
     /**
-     * Order mark ({@value #ROUTE_ORDER_HOT_REPLACEMENT}) for the hot-replacement body handler.
+     * Order value ({@value #ROUTE_ORDER_HOT_REPLACEMENT}) for the hot-replacement body handler.
      */
     public static final int ROUTE_ORDER_HOT_REPLACEMENT = Integer.MIN_VALUE;
     /**
-     * Order mark ({@value #ROUTE_ORDER_BODY_HANDLER_MANAGEMENT}) for the body handler for the management router.
+     * Order value ({@value #ROUTE_ORDER_BODY_HANDLER_MANAGEMENT}) for the body handler for the management router.
      */
     public static final int ROUTE_ORDER_BODY_HANDLER_MANAGEMENT = Integer.MIN_VALUE;
     /**
-     * Order mark ({@value #ROUTE_ORDER_HEADERS}) for the handlers that add headers specified in the configuration.
+     * Order value ({@value #ROUTE_ORDER_HEADERS}) for the handlers that add headers specified in the configuration.
      */
     public static final int ROUTE_ORDER_HEADERS = Integer.MIN_VALUE;
     /**
-     * Order mark ({@value #ROUTE_ORDER_CORS_MANAGEMENT}) for the CORS-Origin handler of the management router.
+     * Order value ({@value #ROUTE_ORDER_CORS_MANAGEMENT}) for the CORS-Origin handler of the management router.
      */
     public static final int ROUTE_ORDER_CORS_MANAGEMENT = Integer.MIN_VALUE;
     /**
-     * Order mark ({@value #ROUTE_ORDER_BODY_HANDLER}) for the body handler.
+     * Order value ({@value #ROUTE_ORDER_BODY_HANDLER}) for the body handler.
      */
     public static final int ROUTE_ORDER_BODY_HANDLER = Integer.MIN_VALUE + 1;
     /**
-     * Order mark ({@value #ROUTE_ORDER_UPLOAD_LIMIT}) for the route that enforces the upload body size limit.
+     * Order value ({@value #ROUTE_ORDER_UPLOAD_LIMIT}) for the route that enforces the upload body size limit.
      */
     public static final int ROUTE_ORDER_UPLOAD_LIMIT = -2;
     /**
-     * Order mark ({@value #ROUTE_ORDER_COMPRESSION}) for the compression handler.
+     * Order value ({@value #ROUTE_ORDER_COMPRESSION}) for the compression handler.
      */
     public static final int ROUTE_ORDER_COMPRESSION = 0;
     /**
-     * Order mark ({@value #ROUTE_ORDER_BEFORE_DEFAULT_MARK}) for route with priority over the default route (add an offset from
-     * this mark)
+     * Order value ({@value #ROUTE_ORDER_BEFORE_DEFAULT}) for route with priority over the default route (add an offset from
+     * this value)
      */
-    public static final int ROUTE_ORDER_BEFORE_DEFAULT_MARK = 1_000;
+    public static final int ROUTE_ORDER_BEFORE_DEFAULT = 1_000;
     /**
      * Default route order (i.e. Static Resources, Servlet): ({@value #ROUTE_ORDER_DEFAULT})
      */
     public static final int ROUTE_ORDER_DEFAULT = 10_000;
     /**
-     * Order mark ({@value #ROUTE_ORDER_AFTER_DEFAULT_MARK}) for route without priority over the default route (add an offset
-     * from this mark)
+     * Order value ({@value #ROUTE_ORDER_AFTER_DEFAULT}) for route without priority over the default route (add an offset
+     * from this value)
      */
-    public static final int ROUTE_ORDER_AFTER_DEFAULT_MARK = 20_000;
+    public static final int ROUTE_ORDER_AFTER_DEFAULT = 20_000;
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlers.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerCommonHandlers.java
@@ -16,6 +16,7 @@ import io.quarkus.vertx.http.runtime.ForwardingProxyOptions;
 import io.quarkus.vertx.http.runtime.HeaderConfig;
 import io.quarkus.vertx.http.runtime.ProxyConfig;
 import io.quarkus.vertx.http.runtime.ResumingRequestWrapper;
+import io.quarkus.vertx.http.runtime.RouteConstants;
 import io.quarkus.vertx.http.runtime.ServerLimitsConfig;
 import io.quarkus.vertx.http.runtime.TrustedProxyCheck;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
@@ -33,7 +34,7 @@ public class HttpServerCommonHandlers {
         if (limits.maxBodySize.isPresent()) {
             long limit = limits.maxBodySize.get().asLongValue();
             Long limitObj = limit;
-            httpRouteRouter.route().order(-2).handler(new Handler<RoutingContext>() {
+            httpRouteRouter.route().order(RouteConstants.ROUTE_ORDER_UPLOAD_LIMIT).handler(new Handler<RoutingContext>() {
                 @Override
                 public void handle(RoutingContext event) {
                     String lengthString = event.request().headers().get(HttpHeaderNames.CONTENT_LENGTH);
@@ -150,7 +151,7 @@ public class HttpServerCommonHandlers {
                 var config = entry.getValue();
                 if (config.methods.isEmpty()) {
                     httpRouteRouter.route(config.path)
-                            .order(Integer.MIN_VALUE)
+                            .order(RouteConstants.ROUTE_ORDER_HEADERS)
                             .handler(new Handler<RoutingContext>() {
                                 @Override
                                 public void handle(RoutingContext event) {
@@ -161,7 +162,7 @@ public class HttpServerCommonHandlers {
                 } else {
                     for (String method : config.methods.get()) {
                         httpRouteRouter.route(HttpMethod.valueOf(method.toUpperCase(Locale.ROOT)), config.path)
-                                .order(Integer.MIN_VALUE)
+                                .order(RouteConstants.ROUTE_ORDER_HEADERS)
                                 .handler(new Handler<RoutingContext>() {
                                     @Override
                                     public void handle(RoutingContext event) {

--- a/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/UploadRoute.java
+++ b/integration-tests/vertx-http/src/main/java/io/quarkus/it/vertx/UploadRoute.java
@@ -6,6 +6,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
 import io.quarkus.runtime.StartupEvent;
+import io.quarkus.vertx.http.runtime.RouteConstants;
 import io.quarkus.vertx.http.runtime.ServerLimitsConfig;
 import io.quarkus.vertx.http.runtime.options.HttpServerCommonHandlers;
 import io.vertx.core.buffer.Buffer;
@@ -21,11 +22,12 @@ public class UploadRoute {
 
     /**
      * Installs two POST-routes - one that bypasses the body-length limit using {@code order(-3)}
-     * ({@link HttpServerCommonHandlers#enforceMaxBodySize(ServerLimitsConfig, Router)} uses {@code order(-2)}) and one that
+     * ({@link HttpServerCommonHandlers#enforceMaxBodySize(ServerLimitsConfig, Router)} uses
+     * {@value RouteConstants#ROUTE_ORDER_UPLOAD_LIMIT} for {@link io.vertx.ext.web.Route#order(int)}) and one that
      * does not bypass body-size enforcement.
      */
     void installRoute(@Observes StartupEvent startupEvent, Router router) {
-        router.post("/unlimited-upload").order(-3).handler(UploadHandler::newRequest);
+        router.post("/unlimited-upload").order(RouteConstants.ROUTE_ORDER_UPLOAD_LIMIT - 1).handler(UploadHandler::newRequest);
         router.post("/limited-upload").handler(UploadHandler::newRequest);
     }
 


### PR DESCRIPTION
As discussed in #35513 it is beneficial to have the route order marks defined as constants.

This change introduces a class containing nearly all these constants, except the extension specific values.