### PR TITLE
Honor OIDC logout requests when ID token has expired

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/SecurityEvent.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/SecurityEvent.java
@@ -9,6 +9,8 @@ import io.quarkus.security.identity.SecurityIdentity;
  *
  */
 public class SecurityEvent {
+    public static final String SESSION_TOKENS_PROPERTY = "session-tokens";
+
     public enum Type {
         /**
          * OIDC Login event which is reported after the first user authentication but also when the user's session
@@ -29,6 +31,12 @@ public class SecurityEvent {
          * OIDC Logout event is reported when the current user has started an RP-initiated OIDC logout flow.
          */
         OIDC_LOGOUT_RP_INITIATED,
+
+        /**
+         * OIDC Logout event is reported when the current user has started an RP-initiated OIDC logout flow but the session has
+         * already expired.
+         */
+        OIDC_LOGOUT_RP_INITIATED_SESSION_EXPIRED,
 
         /**
          * OIDC BackChannel Logout initiated event is reported when the BackChannel logout request to logout the current user

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -80,6 +80,8 @@ quarkus.oidc.tenant-logout.application-type=web-app
 quarkus.oidc.tenant-logout.authentication.cookie-path=/tenant-logout
 quarkus.oidc.tenant-logout.logout.path=/tenant-logout/logout
 quarkus.oidc.tenant-logout.logout.post-logout-path=/tenant-logout/post-logout
+quarkus.oidc.tenant-logout.authentication.session-age-extension=2M
+quarkus.oidc.tenant-logout.token.refresh-expired=true
 
 quarkus.oidc.tenant-refresh.auth-server-url=${keycloak.url}/realms/logout-realm
 quarkus.oidc.tenant-refresh.client-id=quarkus-app

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -611,6 +611,22 @@ public class CodeFlowTest {
 
             page = webClient.getPage("http://localhost:8081/tenant-logout");
             assertEquals("Sign in to logout-realm", page.getTitleText());
+
+            // login again
+            loginForm = page.getForms().get(0);
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+            page = loginForm.getInputByName("login").click();
+            assertEquals("Tenant Logout, refreshed: false", page.asNormalizedText());
+
+            assertNotNull(getSessionCookie(webClient, "tenant-logout"));
+
+            await().atLeast(Duration.ofSeconds(11));
+
+            page = webClient.getPage("http://localhost:8081/tenant-logout/logout");
+            assertTrue(page.asNormalizedText().contains("You were logged out, please login again"));
+            assertNull(getSessionCookie(webClient, "tenant-logout"));
+
             webClient.getCookieManager().clearCookies();
         }
     }

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -35,7 +35,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
         // revoke refresh tokens so that they can only be used once
         logoutRealm.setRevokeRefreshToken(true);
         logoutRealm.setRefreshTokenMaxReuse(0);
-        logoutRealm.setSsoSessionMaxLifespan(15);
+        logoutRealm.setSsoSessionMaxLifespan(10);
         logoutRealm.setAccessTokenLifespan(5);
         client.createRealm(logoutRealm);
         realms.add(logoutRealm);


### PR DESCRIPTION
Fixes #35728.

Currently, if the user issued a logout request but the ID token has already expired, the user will requested to re-authenticate and the logout will be complete which is a bit strange at least.

For example, with `quickstarts/security-openid-connect-web-authentication-quickstart`, if I change it like this:
```
diff --git a/security-openid-connect-web-authentication-quickstart/src/main/java/org/acme/security/openid/connect/web/authentication/TokenResource.java b/security-openid-connect-web-authentication-quickstart/src/main/java/org/acme/security/openid/connect/web/authentication/TokenResource.java
index 80985795..25e3bdb0 100644
--- a/security-openid-connect-web-authentication-quickstart/src/main/java/org/acme/security/openid/connect/web/authentication/TokenResource.java
+++ b/security-openid-connect-web-authentication-quickstart/src/main/java/org/acme/security/openid/connect/web/authentication/TokenResource.java
@@ -61,4 +61,11 @@ public class TokenResource {
 
         return response.append("</ul>").append("</body>").append("</html>").toString();
     }
+    
+    @GET
+    @Produces("text/plain")
+    @Path("/postlogout")
+    public String postLogout() {
+        return "You were logged out";
+    }   
 }
diff --git a/security-openid-connect-web-authentication-quickstart/src/main/resources/application.properties b/security-openid-connect-web-authentication-quickstart/src/main/resources/application.properties
index a6544298..4f2b1b4c 100644
--- a/security-openid-connect-web-authentication-quickstart/src/main/resources/application.properties
+++ b/security-openid-connect-web-authentication-quickstart/src/main/resources/application.properties
@@ -2,9 +2,16 @@
 quarkus.keycloak.devservices.realm-path=quarkus-realm.json
 quarkus.oidc.client-id=frontend
 quarkus.oidc.credentials.secret=secret
+
+
 quarkus.oidc.application-type=web-app
-quarkus.http.auth.permission.authenticated.paths=/*
+quarkus.oidc.authentication.session-age-extension=1H
+quarkus.oidc.token.refresh-expired=true
+
+quarkus.oidc.logout.path=/logout
+quarkus.oidc.logout.post-logout-path=/tokens/postlogout
+
+# Only the authenticated users can initiate a logout:
+quarkus.http.auth.permission.authenticated.paths=/tokens,/logout
 quarkus.http.auth.permission.authenticated.policy=authenticated
```  

which says - after the user has successfully logged out by calling `/logout` - get the user to OIDC provider, where the user will be logged out and request this provider to redirect the user back to `/tokens/postlogout`. `/tokens` - the main endpoint path, and `/logout` - which initiates the logout are secured, `/tokens/postlogout` is public since the user is logged out, does not need to autenticate again to get to this landing page.

And then, `mvn quarkus:dev`, `http://localhost:8080/tokens`, which requires KC login, login as `alice:alice`, get the endpoint response. Now wait for just 10/20 secs as the session age is only a few secs long in the custom realm, and do `http://localhost:8080/logout`.

This emulates the general situation in #35728 - where the ID token has expired - and the logout request is in process. Now, Quarkus clears the session cookie, and since the session has expired, redirects the user to Keycloak to authenticate - so user, after requesting the logout, sees the authentication screen - now the user is redirected back to Quarkus and after another local redirect, the logout request is completed and the user sees ` You were logged out` from the new resource method added in the above diff.

Other providers may not challenge for the authentication again during this multiple redirects sequence, KC does because its own session cookie has also gone, in #35728, since the new login is in process while trying to meet the logout, user is redirected immediately back, and AFAIK, in that setup the callback is virtual, there might be something else going on and 404 is reported.

All of it can be avoided by a trivial fix. If the token has expired - instead of redirecting the user to reauthenticate - redirect the user to logout if it is a logout request - after which the user will have authenticate again if another access to secured resources will be needed.

So I added a simple code to check if it is RP initiated logout in case of the expired token, send an event with raw tokens since verified SecurityIdentiy is not available in this case - in case the event listener may need to revoke them, added simple test, and confirmed with the quickstart that now I'm not asked to authenticate when I access the logout endpoint with an active session cookie but redirected to Keycloak which brings me back to the postlogout URL