### PR TITLE
Properly initialize reactive Pool beans

### DIFF
--- a/extensions/reactive-datasource/deployment/src/main/java/io/quarkus/reactive/datasource/deployment/VertxPoolBuildItem.java
+++ b/extensions/reactive-datasource/deployment/src/main/java/io/quarkus/reactive/datasource/deployment/VertxPoolBuildItem.java
@@ -10,28 +10,26 @@ import io.vertx.sqlclient.Pool;
  * If you inject this build item when recording runtime init template calls, you are guaranteed the Pool configuration
  * has been injected and Pools can be created.
  */
+@Deprecated(forRemoval = true)
 public final class VertxPoolBuildItem extends MultiBuildItem {
 
-    private final RuntimeValue<? extends Pool> vertxPool;
-    private final String dbKind;
-    private final boolean isDefault;
+    public VertxPoolBuildItem() {
+    }
 
     public VertxPoolBuildItem(RuntimeValue<? extends Pool> vertxPool, String dbKind, boolean isDefault) {
-        this.vertxPool = vertxPool;
-        this.dbKind = dbKind;
-        this.isDefault = isDefault;
+
     }
 
     public RuntimeValue<? extends Pool> getPool() {
-        return vertxPool;
+        throw new IllegalStateException("should never be called");
     }
 
     public String getDbKind() {
-        return dbKind;
+        throw new IllegalStateException("should never be called");
     }
 
     public boolean isDefault() {
-        return isDefault;
+        throw new IllegalStateException("should never be called");
     }
 
 }

--- a/extensions/reactive-db2-client/deployment/src/main/java/io/quarkus/reactive/db2/client/deployment/DB2PoolBuildItem.java
+++ b/extensions/reactive-db2-client/deployment/src/main/java/io/quarkus/reactive/db2/client/deployment/DB2PoolBuildItem.java
@@ -1,17 +1,19 @@
 package io.quarkus.reactive.db2.client.deployment;
 
+import java.util.function.Function;
+
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
-import io.quarkus.runtime.RuntimeValue;
 import io.vertx.db2client.DB2Pool;
 
 public final class DB2PoolBuildItem extends MultiBuildItem {
 
     private final String dataSourceName;
 
-    private final RuntimeValue<DB2Pool> db2Pool;
+    private final Function<SyntheticCreationalContext<DB2Pool>, DB2Pool> db2Pool;
 
-    public DB2PoolBuildItem(String dataSourceName, RuntimeValue<DB2Pool> db2Pool) {
+    public DB2PoolBuildItem(String dataSourceName, Function<SyntheticCreationalContext<DB2Pool>, DB2Pool> db2Pool) {
         this.dataSourceName = dataSourceName;
         this.db2Pool = db2Pool;
     }
@@ -20,7 +22,7 @@ public final class DB2PoolBuildItem extends MultiBuildItem {
         return dataSourceName;
     }
 
-    public RuntimeValue<DB2Pool> getDB2Pool() {
+    public Function<SyntheticCreationalContext<DB2Pool>, DB2Pool> getDB2Pool() {
         return db2Pool;
     }
 

--- a/extensions/reactive-db2-client/deployment/src/main/java/io/quarkus/reactive/db2/client/deployment/ReactiveDB2ClientProcessor.java
+++ b/extensions/reactive-db2-client/deployment/src/main/java/io/quarkus/reactive/db2/client/deployment/ReactiveDB2ClientProcessor.java
@@ -6,15 +6,20 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem.ExtendedBeanConfigurator;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
@@ -51,7 +56,6 @@ import io.quarkus.reactive.db2.client.DB2PoolCreator;
 import io.quarkus.reactive.db2.client.runtime.DB2PoolRecorder;
 import io.quarkus.reactive.db2.client.runtime.DB2ServiceBindingConverter;
 import io.quarkus.reactive.db2.client.runtime.DataSourcesReactiveDB2Config;
-import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.vertx.core.deployment.EventLoopCountBuildItem;
 import io.quarkus.vertx.deployment.VertxBuildItem;
@@ -59,6 +63,12 @@ import io.vertx.db2client.DB2Pool;
 import io.vertx.sqlclient.Pool;
 
 class ReactiveDB2ClientProcessor {
+
+    private static final ParameterizedType POOL_INJECTION_TYPE = ParameterizedType.create(DotName.createSimple(Instance.class),
+            new Type[] { ClassType.create(DotName.createSimple(DB2PoolCreator.class.getName())) }, null);
+    private static final AnnotationInstance[] EMPTY_ANNOTATIONS = new AnnotationInstance[0];
+
+    private static final DotName REACTIVE_DATASOURCE = DotName.createSimple(ReactiveDataSource.class);
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
@@ -81,7 +91,7 @@ class ReactiveDB2ClientProcessor {
         feature.produce(new FeatureBuildItem(Feature.REACTIVE_DB2_CLIENT));
 
         for (String dataSourceName : dataSourcesBuildTimeConfig.dataSources().keySet()) {
-            createPoolIfDefined(recorder, vertx, eventLoopCount, shutdown, db2Pool, vertxPool, syntheticBeans, dataSourceName,
+            createPoolIfDefined(recorder, vertx, eventLoopCount, shutdown, db2Pool, syntheticBeans, dataSourceName,
                     dataSourcesBuildTimeConfig, dataSourcesRuntimeConfig, dataSourcesReactiveBuildTimeConfig,
                     dataSourcesReactiveRuntimeConfig, dataSourcesReactiveDB2Config, defaultDataSourceDbKindBuildItems,
                     curateOutcomeBuildItem);
@@ -90,6 +100,7 @@ class ReactiveDB2ClientProcessor {
         // Enable SSL support by default
         sslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(Feature.REACTIVE_DB2_CLIENT));
 
+        vertxPool.produce(new VertxPoolBuildItem());
         return new ServiceStartBuildItem("reactive-db2-client");
     }
 
@@ -168,7 +179,6 @@ class ReactiveDB2ClientProcessor {
             EventLoopCountBuildItem eventLoopCount,
             ShutdownContextBuildItem shutdown,
             BuildProducer<DB2PoolBuildItem> db2Pool,
-            BuildProducer<VertxPoolBuildItem> vertxPool,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             String dataSourceName,
             DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
@@ -184,20 +194,21 @@ class ReactiveDB2ClientProcessor {
             return;
         }
 
-        RuntimeValue<DB2Pool> pool = recorder.configureDB2Pool(vertx.getVertx(),
+        Function<SyntheticCreationalContext<DB2Pool>, DB2Pool> poolFunction = recorder.configureDB2Pool(vertx.getVertx(),
                 eventLoopCount.getEventLoopCount(),
                 dataSourceName,
                 dataSourcesRuntimeConfig,
                 dataSourcesReactiveRuntimeConfig,
                 dataSourcesReactiveDB2Config,
                 shutdown);
-        db2Pool.produce(new DB2PoolBuildItem(dataSourceName, pool));
+        db2Pool.produce(new DB2PoolBuildItem(dataSourceName, poolFunction));
 
         ExtendedBeanConfigurator db2PoolBeanConfigurator = SyntheticBeanBuildItem.configure(DB2Pool.class)
                 .defaultBean()
                 .addType(Pool.class)
                 .scope(ApplicationScoped.class)
-                .runtimeValue(pool)
+                .addInjectionPoint(POOL_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
+                .createWith(poolFunction)
                 .unremovable()
                 .setRuntimeInit();
 
@@ -209,14 +220,21 @@ class ReactiveDB2ClientProcessor {
                 .configure(io.vertx.mutiny.db2client.DB2Pool.class)
                 .defaultBean()
                 .scope(ApplicationScoped.class)
-                .runtimeValue(recorder.mutinyDB2Pool(pool))
+                .addInjectionPoint(POOL_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
+                .createWith(recorder.mutinyDB2Pool(poolFunction))
                 .setRuntimeInit();
 
         addQualifiers(mutinyDB2PoolConfigurator, dataSourceName);
 
         syntheticBeans.produce(mutinyDB2PoolConfigurator.done());
+    }
 
-        vertxPool.produce(new VertxPoolBuildItem(pool, DatabaseKind.DB2, DataSourceUtil.isDefault(dataSourceName)));
+    private AnnotationInstance[] injectionPointAnnotations(String dataSourceName) {
+        if (DataSourceUtil.isDefault(dataSourceName)) {
+            return EMPTY_ANNOTATIONS;
+        }
+        return new AnnotationInstance[] {
+                AnnotationInstance.builder(REACTIVE_DATASOURCE).add("value", dataSourceName).build() };
     }
 
     private static boolean isReactiveDB2PoolDefined(DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,

--- a/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/MSSQLPoolBuildItem.java
+++ b/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/MSSQLPoolBuildItem.java
@@ -1,17 +1,19 @@
 package io.quarkus.reactive.mssql.client.deployment;
 
+import java.util.function.Function;
+
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
-import io.quarkus.runtime.RuntimeValue;
 import io.vertx.mssqlclient.MSSQLPool;
 
 public final class MSSQLPoolBuildItem extends MultiBuildItem {
 
     private final String dataSourceName;
 
-    private final RuntimeValue<MSSQLPool> mssqlPool;
+    private final Function<SyntheticCreationalContext<MSSQLPool>, MSSQLPool> mssqlPool;
 
-    public MSSQLPoolBuildItem(String dataSourceName, RuntimeValue<MSSQLPool> mssqlPool) {
+    public MSSQLPoolBuildItem(String dataSourceName, Function<SyntheticCreationalContext<MSSQLPool>, MSSQLPool> mssqlPool) {
         this.dataSourceName = dataSourceName;
         this.mssqlPool = mssqlPool;
     }
@@ -20,7 +22,7 @@ public final class MSSQLPoolBuildItem extends MultiBuildItem {
         return dataSourceName;
     }
 
-    public RuntimeValue<MSSQLPool> getMSSQLPool() {
+    public Function<SyntheticCreationalContext<MSSQLPool>, MSSQLPool> getMSSQLPool() {
         return mssqlPool;
     }
 

--- a/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/MySQLPoolBuildItem.java
+++ b/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/MySQLPoolBuildItem.java
@@ -1,17 +1,19 @@
 package io.quarkus.reactive.mysql.client.deployment;
 
+import java.util.function.Function;
+
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
-import io.quarkus.runtime.RuntimeValue;
 import io.vertx.mysqlclient.MySQLPool;
 
 public final class MySQLPoolBuildItem extends MultiBuildItem {
 
     private final String dataSourceName;
 
-    private final RuntimeValue<MySQLPool> mysqlPool;
+    private final Function<SyntheticCreationalContext<MySQLPool>, MySQLPool> mysqlPool;
 
-    public MySQLPoolBuildItem(String dataSourceName, RuntimeValue<MySQLPool> mysqlPool) {
+    public MySQLPoolBuildItem(String dataSourceName, Function<SyntheticCreationalContext<MySQLPool>, MySQLPool> mysqlPool) {
         this.dataSourceName = dataSourceName;
         this.mysqlPool = mysqlPool;
     }
@@ -20,7 +22,7 @@ public final class MySQLPoolBuildItem extends MultiBuildItem {
         return dataSourceName;
     }
 
-    public RuntimeValue<MySQLPool> getMySQLPool() {
+    public Function<SyntheticCreationalContext<MySQLPool>, MySQLPool> getMySQLPool() {
         return mysqlPool;
     }
 

--- a/extensions/reactive-oracle-client/deployment/src/main/java/io/quarkus/reactive/oracle/client/deployment/OraclePoolBuildItem.java
+++ b/extensions/reactive-oracle-client/deployment/src/main/java/io/quarkus/reactive/oracle/client/deployment/OraclePoolBuildItem.java
@@ -1,17 +1,19 @@
 package io.quarkus.reactive.oracle.client.deployment;
 
+import java.util.function.Function;
+
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
-import io.quarkus.runtime.RuntimeValue;
 import io.vertx.oracleclient.OraclePool;
 
 public final class OraclePoolBuildItem extends MultiBuildItem {
 
     private final String dataSourceName;
 
-    private final RuntimeValue<OraclePool> oraclePool;
+    private final Function<SyntheticCreationalContext<OraclePool>, OraclePool> oraclePool;
 
-    public OraclePoolBuildItem(String dataSourceName, RuntimeValue<OraclePool> oraclePool) {
+    public OraclePoolBuildItem(String dataSourceName, Function<SyntheticCreationalContext<OraclePool>, OraclePool> oraclePool) {
         this.dataSourceName = dataSourceName;
         this.oraclePool = oraclePool;
     }
@@ -20,7 +22,7 @@ public final class OraclePoolBuildItem extends MultiBuildItem {
         return dataSourceName;
     }
 
-    public RuntimeValue<OraclePool> getOraclePool() {
+    public Function<SyntheticCreationalContext<OraclePool>, OraclePool> getOraclePool() {
         return oraclePool;
     }
 

--- a/extensions/reactive-oracle-client/deployment/src/main/java/io/quarkus/reactive/oracle/client/deployment/ReactiveOracleClientProcessor.java
+++ b/extensions/reactive-oracle-client/deployment/src/main/java/io/quarkus/reactive/oracle/client/deployment/ReactiveOracleClientProcessor.java
@@ -6,15 +6,20 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem.ExtendedBeanConfigurator;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
@@ -51,7 +56,6 @@ import io.quarkus.reactive.oracle.client.OraclePoolCreator;
 import io.quarkus.reactive.oracle.client.runtime.DataSourcesReactiveOracleConfig;
 import io.quarkus.reactive.oracle.client.runtime.OraclePoolRecorder;
 import io.quarkus.reactive.oracle.client.runtime.OracleServiceBindingConverter;
-import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.vertx.core.deployment.EventLoopCountBuildItem;
 import io.quarkus.vertx.deployment.VertxBuildItem;
@@ -59,6 +63,11 @@ import io.vertx.oracleclient.OraclePool;
 import io.vertx.sqlclient.Pool;
 
 class ReactiveOracleClientProcessor {
+
+    private static final ParameterizedType POOL_INJECTION_TYPE = ParameterizedType.create(DotName.createSimple(Instance.class),
+            new Type[] { ClassType.create(DotName.createSimple(OraclePoolCreator.class.getName())) }, null);
+    private static final AnnotationInstance[] EMPTY_ANNOTATIONS = new AnnotationInstance[0];
+    private static final DotName REACTIVE_DATASOURCE = DotName.createSimple(ReactiveDataSource.class);
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
@@ -81,7 +90,7 @@ class ReactiveOracleClientProcessor {
         feature.produce(new FeatureBuildItem(Feature.REACTIVE_ORACLE_CLIENT));
 
         for (String dataSourceName : dataSourcesBuildTimeConfig.dataSources().keySet()) {
-            createPoolIfDefined(recorder, vertx, eventLoopCount, shutdown, oraclePool, vertxPool, syntheticBeans,
+            createPoolIfDefined(recorder, vertx, eventLoopCount, shutdown, oraclePool, syntheticBeans,
                     dataSourceName,
                     dataSourcesBuildTimeConfig, dataSourcesRuntimeConfig, dataSourcesReactiveBuildTimeConfig,
                     dataSourcesReactiveRuntimeConfig, dataSourcesReactiveOracleConfig, defaultDataSourceDbKindBuildItems,
@@ -91,6 +100,7 @@ class ReactiveOracleClientProcessor {
         // Enable SSL support by default
         sslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(Feature.REACTIVE_ORACLE_CLIENT));
 
+        vertxPool.produce(new VertxPoolBuildItem());
         return new ServiceStartBuildItem("reactive-oracle-client");
     }
 
@@ -169,7 +179,6 @@ class ReactiveOracleClientProcessor {
             EventLoopCountBuildItem eventLoopCount,
             ShutdownContextBuildItem shutdown,
             BuildProducer<OraclePoolBuildItem> oraclePool,
-            BuildProducer<VertxPoolBuildItem> vertxPool,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             String dataSourceName,
             DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
@@ -185,20 +194,22 @@ class ReactiveOracleClientProcessor {
             return;
         }
 
-        RuntimeValue<OraclePool> pool = recorder.configureOraclePool(vertx.getVertx(),
+        Function<SyntheticCreationalContext<OraclePool>, OraclePool> poolFunction = recorder.configureOraclePool(
+                vertx.getVertx(),
                 eventLoopCount.getEventLoopCount(),
                 dataSourceName,
                 dataSourcesRuntimeConfig,
                 dataSourcesReactiveRuntimeConfig,
                 dataSourcesReactiveOracleConfig,
                 shutdown);
-        oraclePool.produce(new OraclePoolBuildItem(dataSourceName, pool));
+        oraclePool.produce(new OraclePoolBuildItem(dataSourceName, poolFunction));
 
         ExtendedBeanConfigurator oraclePoolBeanConfigurator = SyntheticBeanBuildItem.configure(OraclePool.class)
                 .defaultBean()
                 .addType(Pool.class)
                 .scope(ApplicationScoped.class)
-                .runtimeValue(pool)
+                .addInjectionPoint(POOL_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
+                .createWith(poolFunction)
                 .unremovable()
                 .setRuntimeInit();
 
@@ -210,14 +221,21 @@ class ReactiveOracleClientProcessor {
                 .configure(io.vertx.mutiny.oracleclient.OraclePool.class)
                 .defaultBean()
                 .scope(ApplicationScoped.class)
-                .runtimeValue(recorder.mutinyOraclePool(pool))
+                .addInjectionPoint(POOL_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
+                .createWith(recorder.mutinyOraclePool(poolFunction))
                 .setRuntimeInit();
 
         addQualifiers(mutinyOraclePoolConfigurator, dataSourceName);
 
         syntheticBeans.produce(mutinyOraclePoolConfigurator.done());
+    }
 
-        vertxPool.produce(new VertxPoolBuildItem(pool, DatabaseKind.ORACLE, DataSourceUtil.isDefault(dataSourceName)));
+    private AnnotationInstance[] injectionPointAnnotations(String dataSourceName) {
+        if (DataSourceUtil.isDefault(dataSourceName)) {
+            return EMPTY_ANNOTATIONS;
+        }
+        return new AnnotationInstance[] {
+                AnnotationInstance.builder(REACTIVE_DATASOURCE).add("value", dataSourceName).build() };
     }
 
     private static boolean isReactiveOraclePoolDefined(DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,

--- a/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/PgPoolBuildItem.java
+++ b/extensions/reactive-pg-client/deployment/src/main/java/io/quarkus/reactive/pg/client/deployment/PgPoolBuildItem.java
@@ -1,17 +1,19 @@
 package io.quarkus.reactive.pg.client.deployment;
 
+import java.util.function.Function;
+
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
-import io.quarkus.runtime.RuntimeValue;
 import io.vertx.pgclient.PgPool;
 
 public final class PgPoolBuildItem extends MultiBuildItem {
 
     private final String dataSourceName;
 
-    private final RuntimeValue<PgPool> pgPool;
+    private final Function<SyntheticCreationalContext<PgPool>, PgPool> pgPool;
 
-    public PgPoolBuildItem(String dataSourceName, RuntimeValue<PgPool> pgPool) {
+    public PgPoolBuildItem(String dataSourceName, Function<SyntheticCreationalContext<PgPool>, PgPool> pgPool) {
         this.dataSourceName = dataSourceName;
         this.pgPool = pgPool;
     }
@@ -20,7 +22,7 @@ public final class PgPoolBuildItem extends MultiBuildItem {
         return dataSourceName;
     }
 
-    public RuntimeValue<PgPool> getPgPool() {
+    public Function<SyntheticCreationalContext<PgPool>, PgPool> getPgPool() {
         return pgPool;
     }
 


### PR DESCRIPTION
We introduce an injection point to the
synthetic bean creation process thus
giving Arc all the declarative context
it needs in order to ensure proper bean
creation order

Relates to https://github.com/quarkiverse/quarkus-vault/pull/167