### PR TITLE
Log invalid CORS origin and method

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSFilter.java
@@ -150,6 +150,7 @@ public class CORSFilter implements Handler<RoutingContext> {
                 }
             }
             if (!allowsOrigin) {
+                LOG.debugf("Invalid origin %s", origin);
                 response.setStatusCode(403);
                 response.setStatusMessage("CORS Rejected - Invalid origin");
             } else {
@@ -183,7 +184,7 @@ public class CORSFilter implements Handler<RoutingContext> {
 
             //we check that the actual request matches the allowed methods and headers
             if (!isMethodAllowed(request.method())) {
-                LOG.debug("Method is not allowed");
+                LOG.debugf("Method %s is not allowed", request.method());
                 response.setStatusCode(403);
                 response.setStatusMessage("CORS Rejected - Invalid method");
                 response.end();


### PR DESCRIPTION
The invalid origin failing the same origin test is already logged, but there could be cases where invalid origins can not be logged, so did a minor update to log it and also did the same for the invalid method. These are only 2 cases where 403 is returned. 
Preflight requests can also fail indirectly with 200, by not including some of the expected CORS headers for allowed/exposed headers but making a correct LOG message as to whether a given header is invalid is trickier and may be misleading, for this PR I'd like to avoid it