### PR TITLE
Warn when wrong token proxy is accessed

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcJsonWebTokenProducer.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcJsonWebTokenProducer.java
@@ -79,7 +79,9 @@ public class OidcJsonWebTokenProducer {
             return new OidcJwtCallerPrincipal(jwtClaims, credential);
         }
         String tokenType = type == AccessTokenCredential.class ? "access" : "ID";
-        LOG.tracef("Current identity is not associated with an %s token", tokenType);
+        LOG.warnf(
+                "Identity is not associated with an %s token. Access 'JsonWebToken' with '@IdToken' qualifier if ID token is required and 'JsonWebToken' without this qualifier when JWT access token is required. Inject either 'io.quarkus.security.identity.SecurityIdentity' or 'io.quarkus.oidc.UserInfo' if you need to have the same endpoint code working for both authorization code and bearer token authentication flows.",
+                tokenType);
         return new NullJsonWebToken();
     }
 }


### PR DESCRIPTION
Closes #35964.

The user's code has both ID and access token injected - and tries to access the ID token when only the access token is sent. In such cases ID token's `NullJsonWebToken` would return `null` for most of its methods but for methods returning `long` it produces NPE earlier. 

This PR  warns users when such invalid access is attempted. It can't really fail the build - the endpoint tries to support both flows at the same time - to avoid such errors the code has to be refactored to manage the flows in separate sections or use a more generic approach, with `SecurityIdentity` or `UserInfo`