### PR TITLE
Improve the way HTTP authorizer logs exceptions

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractHttpAuthorizer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/AbstractHttpAuthorizer.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 import org.jboss.logging.Logger;
 
 import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.AuthenticationRedirectException;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -120,10 +121,15 @@ abstract class AbstractHttpAuthorizer {
                         // the exception twice;at this point, the exception could be failed by the default auth failure handler
                         if (!routingContext.response().ended() && !throwable.equals(routingContext.failure())) {
                             routingContext.fail(throwable);
-                        } else if (!(throwable instanceof AuthenticationFailedException)) {
-                            //don't log auth failure
+                        } else if (throwable instanceof AuthenticationFailedException) {
+                            log.debug("Authentication challenge is required");
+                        } else if (throwable instanceof AuthenticationRedirectException) {
+                            log.debugf("Completing authentication with a redirect to %s",
+                                    ((AuthenticationRedirectException) throwable).getRedirectUri());
+                        } else {
                             log.error("Exception occurred during authorization", throwable);
                         }
+
                     }
                 });
     }


### PR DESCRIPTION
Fixes #35975.

The current verbose error reporting for the successful (OIDC) flows is not reported in all cases - I don't see it in my demos, but in any case, it makes sense to improve the way HTTP authorizer logs them. If it is an `AuthenticationFailedException` - report it means the challenge is required, and if it is `AuthenticationRedirectException` then report that it means the authentication is about to be completed (at that level we can't say `successful authentication` - while it is the case for OIDC, it might not be for some other cases)