### PR TITLE
Enhancements to Configuration section of the Logging guide

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -241,13 +241,34 @@ All potential properties are listed in the <<loggingConfigurationReference,loggi
 
 === Logging categories
 
-Logging is done on a per-category basis, with each category being configured independently.
-A category configuration recursively applies to all subcategories of that category unless there is a more specific matching sub-category configuration.
+Logging is configured on a per-category basis, with each category being configured independently.
+Configuration for a category applies recursively to all subcategories unless there is a more specific subcategory configuration.
 
-The parent of all logging categories is called the "root category".
-This category, being the ultimate parent, may contain configuration which applies globally to all other categories. This includes the globally configured handlers and formatters.
+The parent of all logging categories is called the "root category."
+As the ultimate parent, this category might contain a configuration that applies globally to all other categories.
+This includes the globally configured handlers and formatters.
 
-Thus, configurations made under `quarkus.log.console.+*+`, `quarkus.log.file.+*+`, and `quarkus.log.syslog.+*+` are global and apply for all categories.
+.An example of a global configuration that applies to all categories:
+====
+[source, properties]
+----
+quarkus.log.handlers=console,mylog
+----
+
+In this example, the root category is configured to use two handlers: `console` and `mylog`.
+====
+
+.An example of a per-category configuration:
+====
+[source, properties]
+----
+quarkus.log.category."org.apache.kafka.clients".level=INFO
+quarkus.log.category."org.apache.kafka.common.utils".level=INFO
+----
+
+This example shows how you can configure the minimal log level on the categories `org.apache.kafka.clients` and `org.apache.kafka.common.utils`.
+====
+
 For more information, see <<loggingConfigurationReference>>.
 
 If you want to configure something extra for a specific category, create a named handler like `quarkus.log.handler.[console|file|syslog].<your-handler-name>.*` and set it up for that category by using `quarkus.log.category.<my-category>.handlers`.


### PR DESCRIPTION
Fixing the badly rendered asciidoc markup that should provide an escape on used asterixes. In my local build, this worked perfectly fine, but for some reasons, it is not rendere as expected on Quarkus portal (main snapshot)

Bad asciidoc translation
![image](https://github.com/quarkusio/quarkus/assets/48474054/d72499e7-ed9c-4ca2-a9b0-61a135b3ee65)

Expected asciidoc translation
![image](https://github.com/quarkusio/quarkus/assets/48474054/d5070304-3262-4319-be8c-c802a0eedd38)

To fix this, I wanted to use `pass:[]` asciidoc macro that would allow me to use `*` in the backtick and render properly (no bold in the text, not escape macro leftovers). The `\` and `++` escape approaches weren't rendered properly, so I used the `pass[]` macro as my last resort.
I also wanted to reword the sentence slightly and put it in a bullet list:

```
An example of a global configuration that applies for all categories:

* `quarkus.log.console.pass:c,a[*]`
* `quarkus.log.file.pass:c,a[*]`
* `quarkus.log.syslog.pass:c,a[*]`
```

However, after consulting this with SME, we agreed on removing these handlers examples completely and replace then with the contextually correct examples (root and per-category) that better fits the overall context of this chapter.