### PR TITLE
Scheduler: OTel Instrumentation feature improvements and refactoring

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2051,6 +2051,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-scheduler-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-scheduler-common</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/scheduler/OpenTelemetrySchedulerProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/scheduler/OpenTelemetrySchedulerProcessor.java
@@ -1,0 +1,20 @@
+package io.quarkus.opentelemetry.deployment.scheduler;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.opentelemetry.deployment.OpenTelemetryEnabled;
+import io.quarkus.opentelemetry.runtime.scheduler.OpenTelemetryJobInstrumenter;
+
+public class OpenTelemetrySchedulerProcessor {
+
+    @BuildStep(onlyIf = OpenTelemetryEnabled.class)
+    void registerJobInstrumenter(Capabilities capabilities, BuildProducer<AdditionalBeanBuildItem> beans) {
+        if (capabilities.isPresent(Capability.SCHEDULER)) {
+            beans.produce(new AdditionalBeanBuildItem(OpenTelemetryJobInstrumenter.class));
+        }
+    }
+
+}

--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/instrumentation/InstrumentationProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/instrumentation/InstrumentationProcessor.java
@@ -146,5 +146,4 @@ public class InstrumentationProcessor {
         preExceptionMapperHandlerBuildItemBuildProducer
                 .produce(new PreExceptionMapperHandlerBuildItem(new AttachExceptionHandler()));
     }
-
 }

--- a/extensions/opentelemetry/runtime/pom.xml
+++ b/extensions/opentelemetry/runtime/pom.xml
@@ -61,6 +61,11 @@
             <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-scheduler-spi</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- OpenTelemetry Dependencies -->
         <dependency>

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/scheduler/OpenTelemetryJobInstrumenter.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/scheduler/OpenTelemetryJobInstrumenter.java
@@ -1,0 +1,51 @@
+package io.quarkus.opentelemetry.runtime.scheduler;
+
+import java.util.concurrent.CompletionStage;
+
+import jakarta.inject.Singleton;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.instrumenter.ErrorCauseExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.quarkus.scheduler.spi.JobInstrumenter;
+
+@Singleton
+public class OpenTelemetryJobInstrumenter implements JobInstrumenter {
+
+    private final Instrumenter<JobInstrumentationContext, Void> instrumenter;
+
+    public OpenTelemetryJobInstrumenter(OpenTelemetry openTelemetry) {
+        InstrumenterBuilder<JobInstrumentationContext, Void> instrumenterBuilder = Instrumenter.builder(
+                openTelemetry, "io.quarkus.opentelemetry",
+                new SpanNameExtractor<JobInstrumentationContext>() {
+                    @Override
+                    public String extract(JobInstrumentationContext context) {
+                        return context.getSpanName();
+                    }
+                });
+        instrumenterBuilder.setErrorCauseExtractor(new ErrorCauseExtractor() {
+            @Override
+            public Throwable extract(Throwable throwable) {
+                return throwable;
+            }
+        });
+        this.instrumenter = instrumenterBuilder.buildInstrumenter();
+    }
+
+    @Override
+    public CompletionStage<Void> instrument(JobInstrumentationContext instrumentationContext) {
+        Context parentCtx = Context.current();
+        Context context = instrumenter.start(parentCtx, instrumentationContext);
+        try (Scope scope = context.makeCurrent()) {
+            return instrumentationContext
+                    .executeJob()
+                    .whenComplete(
+                            (result, throwable) -> instrumenter.end(context, instrumentationContext, null, throwable));
+        }
+    }
+
+}

--- a/extensions/quartz/runtime/pom.xml
+++ b/extensions/quartz/runtime/pom.xml
@@ -55,6 +55,17 @@
             -->
         </dependency>
 
+        <!-- OpenTelemetry tracing -->
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-instrumentation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-instrumentation-api-semconv</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/InstrumentedJob.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/InstrumentedJob.java
@@ -1,0 +1,51 @@
+package io.quarkus.quartz.runtime;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+
+import io.quarkus.scheduler.spi.JobInstrumenter;
+import io.quarkus.scheduler.spi.JobInstrumenter.JobInstrumentationContext;
+
+/**
+ *
+ * @see JobInstrumenter
+ */
+class InstrumentedJob implements Job {
+
+    private final Job delegate;
+    private final JobInstrumenter instrumenter;
+
+    InstrumentedJob(Job delegate, JobInstrumenter instrumenter) {
+        this.delegate = delegate;
+        this.instrumenter = instrumenter;
+    }
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        instrumenter.instrument(new JobInstrumentationContext() {
+
+            @Override
+            public CompletionStage<Void> executeJob() {
+                try {
+                    delegate.execute(context);
+                    return CompletableFuture.completedFuture(null);
+                } catch (Exception e) {
+                    return CompletableFuture.failedFuture(e);
+                }
+
+            }
+
+            @Override
+            public String getSpanName() {
+                JobKey key = context.getJobDetail().getKey();
+                return key.getGroup() + '.' + key.getName();
+            }
+        });
+    }
+
+}

--- a/extensions/scheduler/common/pom.xml
+++ b/extensions/scheduler/common/pom.xml
@@ -18,6 +18,14 @@
             <artifactId>quarkus-scheduler-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-scheduler-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-instrumentation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.cronutils</groupId>
             <artifactId>cron-utils</artifactId>
             <exclusions>

--- a/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/InstrumentedInvoker.java
+++ b/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/InstrumentedInvoker.java
@@ -1,0 +1,43 @@
+package io.quarkus.scheduler.common.runtime;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import io.quarkus.scheduler.ScheduledExecution;
+import io.quarkus.scheduler.spi.JobInstrumenter;
+import io.quarkus.scheduler.spi.JobInstrumenter.JobInstrumentationContext;
+
+/**
+ *
+ * @see JobInstrumenter
+ */
+public class InstrumentedInvoker extends DelegateInvoker {
+
+    private final JobInstrumenter instrumenter;
+
+    public InstrumentedInvoker(ScheduledInvoker delegate, JobInstrumenter instrumenter) {
+        super(delegate);
+        this.instrumenter = instrumenter;
+    }
+
+    @Override
+    public CompletionStage<Void> invoke(ScheduledExecution execution) throws Exception {
+        return instrumenter.instrument(new JobInstrumentationContext() {
+
+            @Override
+            public CompletionStage<Void> executeJob() {
+                try {
+                    return delegate.invoke(execution);
+                } catch (Exception e) {
+                    return CompletableFuture.failedFuture(e);
+                }
+            }
+
+            @Override
+            public String getSpanName() {
+                return execution.getTrigger().getId();
+            }
+        });
+    }
+
+}

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -367,30 +367,6 @@ public class SchedulerProcessor {
         }
     }
 
-    @BuildStep
-    public void tracing(SchedulerConfig config,
-            Capabilities capabilities, BuildProducer<AnnotationsTransformerBuildItem> annotationsTransformer) {
-
-        if (config.tracingEnabled && capabilities.isPresent(Capability.OPENTELEMETRY_TRACER)) {
-            DotName withSpan = DotName.createSimple("io.opentelemetry.instrumentation.annotations.WithSpan");
-            DotName legacyWithSpan = DotName.createSimple("io.opentelemetry.extension.annotations.WithSpan");
-
-            annotationsTransformer.produce(new AnnotationsTransformerBuildItem(AnnotationsTransformer.builder()
-                    .appliesTo(METHOD)
-                    .whenContainsAny(List.of(SchedulerDotNames.SCHEDULED_NAME, SchedulerDotNames.SCHEDULES_NAME))
-                    .whenContainsNone(List.of(withSpan, legacyWithSpan))
-                    .transform(context -> {
-                        MethodInfo scheduledMethod = context.getTarget().asMethod();
-                        context.transform()
-                                .add(withSpan)
-                                .done();
-                        LOGGER.debugf("Added OpenTelemetry @WithSpan to a @Scheduled method %s#%s()",
-                                scheduledMethod.declaringClass().name(),
-                                scheduledMethod.name());
-                    })));
-        }
-    }
-
     private String generateInvoker(ScheduledBusinessMethodItem scheduledMethod, ClassOutput classOutput) {
 
         BeanInfo bean = scheduledMethod.getBean();

--- a/extensions/scheduler/pom.xml
+++ b/extensions/scheduler/pom.xml
@@ -17,6 +17,7 @@
   <modules>
     <module>deployment</module>
     <module>api</module>
+    <module>spi</module>
     <module>common</module>
     <module>kotlin</module>
     <module>runtime</module>

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerConfig.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerConfig.java
@@ -25,9 +25,9 @@ public class SchedulerConfig {
     public boolean metricsEnabled;
 
     /**
-     * Tracing will be enabled if the OpenTelemetry extension is present and this value is true.
+     * Controls whether tracing is enabled. If set to true and the OpenTelemetry extension is present,
+     * tracing will be enabled, creating automatic Spans for each scheduled task.
      */
     @ConfigItem(name = "tracing.enabled")
     public boolean tracingEnabled;
-
 }

--- a/extensions/scheduler/spi/pom.xml
+++ b/extensions/scheduler/spi/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-scheduler-parent</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>quarkus-scheduler-spi</artifactId>
+  <name>Quarkus - Scheduler - SPI</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-scheduler-api</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/extensions/scheduler/spi/src/main/java/io/quarkus/scheduler/spi/JobInstrumenter.java
+++ b/extensions/scheduler/spi/src/main/java/io/quarkus/scheduler/spi/JobInstrumenter.java
@@ -1,0 +1,23 @@
+package io.quarkus.scheduler.spi;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Instruments a scheduled job.
+ * <p>
+ * Telemetry extensions can provide exactly one CDI bean of this type. The scope must be either {@link jakarta.inject.Singleton}
+ * or {@link jakarta.enterprise.context.ApplicationScoped}.
+ */
+public interface JobInstrumenter {
+
+    CompletionStage<Void> instrument(JobInstrumentationContext context);
+
+    interface JobInstrumentationContext {
+
+        String getSpanName();
+
+        CompletionStage<Void> executeJob();
+
+    }
+
+}

--- a/integration-tests/opentelemetry-quartz/pom.xml
+++ b/integration-tests/opentelemetry-quartz/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-opentelemetry-quartz</artifactId>
+    <name>Quarkus - Integration Tests - OpenTelemetry Quartz</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-quartz</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+
+        <!-- Needed for InMemorySpanExporter to verify captured traces -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-quartz-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/CountResource.java
+++ b/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/CountResource.java
@@ -1,0 +1,40 @@
+package io.quarkus.it.opentelemetry.quartz;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/scheduler/count")
+public class CountResource {
+
+    @Inject
+    Counter counter;
+
+    @Inject
+    ManualScheduledCounter manualScheduledCounter;
+
+    @Inject
+    JobDefinitionCounter jobDefinitionCounter;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Integer getCount() {
+        return counter.get();
+    }
+
+    @GET
+    @Path("manual")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Integer getManualCount() {
+        return manualScheduledCounter.get();
+    }
+
+    @GET
+    @Path("job-definition")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Integer getJobDefinitionCount() {
+        return jobDefinitionCounter.get();
+    }
+}

--- a/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/Counter.java
+++ b/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/Counter.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.opentelemetry.quartz;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.scheduler.Scheduled;
+
+@ApplicationScoped
+public class Counter {
+
+    AtomicInteger counter;
+
+    @PostConstruct
+    void init() {
+        counter = new AtomicInteger();
+    }
+
+    public int get() {
+        return counter.get();
+    }
+
+    @Scheduled(cron = "*/1 * * * * ?", identity = "myCounter")
+    void increment() throws InterruptedException {
+        Thread.sleep(100l);
+        counter.incrementAndGet();
+    }
+
+}

--- a/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/ExporterResource.java
+++ b/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/ExporterResource.java
@@ -1,0 +1,38 @@
+package io.quarkus.it.opentelemetry.quartz;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+
+@Path("")
+public class ExporterResource {
+    @Inject
+    InMemorySpanExporter inMemorySpanExporter;
+
+    @GET
+    @Path("/export")
+    public List<SpanData> export() { // only export scheduled spans
+        return inMemorySpanExporter.getFinishedSpanItems()
+                .stream()
+                .filter(sd -> !sd.getName().contains("export") && !sd.getName().contains("GET"))
+                .collect(Collectors.toList());
+    }
+
+    @ApplicationScoped
+    static class InMemorySpanExporterProducer {
+        @Produces
+        @Singleton
+        InMemorySpanExporter inMemorySpanExporter() {
+            return InMemorySpanExporter.create();
+        }
+    }
+}

--- a/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/FailedBasicScheduler.java
+++ b/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/FailedBasicScheduler.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.opentelemetry.quartz;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.scheduler.Scheduled;
+
+@ApplicationScoped
+public class FailedBasicScheduler {
+
+    @Scheduled(cron = "*/1 * * * * ?", identity = "myFailedBasicScheduler")
+    void init() throws InterruptedException {
+        Thread.sleep(100l);
+        throw new RuntimeException("error occurred in myFailedBasicScheduler.");
+
+    }
+
+}

--- a/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/FailedJobDefinitionScheduler.java
+++ b/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/FailedJobDefinitionScheduler.java
@@ -1,0 +1,29 @@
+package io.quarkus.it.opentelemetry.quartz;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.quartz.QuartzScheduler;
+import io.quarkus.runtime.Startup;
+
+@ApplicationScoped
+@Startup
+public class FailedJobDefinitionScheduler {
+
+    @Inject
+    QuartzScheduler scheduler;
+
+    @PostConstruct
+    void init() {
+        scheduler.newJob("myFailedJobDefinition").setCron("*/1 * * * * ?").setTask(ex -> {
+            try {
+                Thread.sleep(100l);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            throw new RuntimeException("error occurred in myFailedJobDefinition.");
+        }).schedule();
+    }
+
+}

--- a/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/FailedManualScheduler.java
+++ b/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/FailedManualScheduler.java
@@ -1,0 +1,52 @@
+package io.quarkus.it.opentelemetry.quartz;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+
+import io.quarkus.runtime.Startup;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@Startup
+@ApplicationScoped
+public class FailedManualScheduler {
+    @Inject
+    org.quartz.Scheduler quartz;
+
+    @PostConstruct
+    void init() throws SchedulerException {
+        JobDetail job = JobBuilder.newJob(CountingJob.class).withIdentity("myFailedManualJob", "myFailedGroup").build();
+        Trigger trigger = TriggerBuilder
+                .newTrigger()
+                .withIdentity("myFailedTrigger", "myFailedGroup")
+                .startNow()
+                .withSchedule(SimpleScheduleBuilder
+                        .simpleSchedule()
+                        .repeatForever()
+                        .withIntervalInSeconds(1))
+                .build();
+        quartz.scheduleJob(job, trigger);
+    }
+
+    @RegisterForReflection
+    public static class CountingJob implements Job {
+        @Override
+        public void execute(JobExecutionContext jobExecutionContext) {
+            try {
+                Thread.sleep(100l);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            throw new RuntimeException("error occurred in myFailedManualJob.");
+        }
+    }
+}

--- a/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/JobDefinitionCounter.java
+++ b/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/JobDefinitionCounter.java
@@ -1,0 +1,37 @@
+package io.quarkus.it.opentelemetry.quartz;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.quartz.QuartzScheduler;
+import io.quarkus.runtime.Startup;
+
+@ApplicationScoped
+@Startup
+public class JobDefinitionCounter {
+
+    @Inject
+    QuartzScheduler scheduler;
+
+    AtomicInteger counter;
+
+    @PostConstruct
+    void init() {
+        counter = new AtomicInteger();
+        scheduler.newJob("myJobDefinition").setCron("*/1 * * * * ?").setTask(ex -> {
+            try {
+                Thread.sleep(100l);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            counter.incrementAndGet();
+        }).schedule();
+    }
+
+    public int get() {
+        return counter.get();
+    }
+}

--- a/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/ManualScheduledCounter.java
+++ b/integration-tests/opentelemetry-quartz/src/main/java/io/quarkus/it/opentelemetry/quartz/ManualScheduledCounter.java
@@ -1,0 +1,59 @@
+package io.quarkus.it.opentelemetry.quartz;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+
+import io.quarkus.runtime.Startup;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@Startup
+@ApplicationScoped
+public class ManualScheduledCounter {
+    @Inject
+    org.quartz.Scheduler quartz;
+    private static AtomicInteger counter = new AtomicInteger();
+
+    public int get() {
+        return counter.get();
+    }
+
+    @PostConstruct
+    void init() throws SchedulerException {
+        JobDetail job = JobBuilder.newJob(CountingJob.class).withIdentity("myManualJob", "myGroup").build();
+        Trigger trigger = TriggerBuilder
+                .newTrigger()
+                .withIdentity("myTrigger", "myGroup")
+                .startNow()
+                .withSchedule(SimpleScheduleBuilder
+                        .simpleSchedule()
+                        .repeatForever()
+                        .withIntervalInSeconds(1))
+                .build();
+        quartz.scheduleJob(job, trigger);
+    }
+
+    @RegisterForReflection
+    public static class CountingJob implements Job {
+        @Override
+        public void execute(JobExecutionContext jobExecutionContext) {
+            try {
+                Thread.sleep(100l);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            counter.incrementAndGet();
+        }
+    }
+}

--- a/integration-tests/opentelemetry-quartz/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-quartz/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# speed up build
+quarkus.otel.bsp.schedule.delay=100
+quarkus.otel.bsp.export.timeout=5s
+
+quarkus.scheduler.tracing.enabled=true

--- a/integration-tests/opentelemetry-quartz/src/test/java/io/quarkus/it/opentelemetry/quartz/OpenTelemetryQuartzIT.java
+++ b/integration-tests/opentelemetry-quartz/src/test/java/io/quarkus/it/opentelemetry/quartz/OpenTelemetryQuartzIT.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.opentelemetry.quartz;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class OpenTelemetryQuartzIT extends OpenTelemetryQuartzTest {
+    @Test
+    @DisabledOnIntegrationTest("native mode testing span does not have a field 'exception' (only in integration-test, not in quarkus app)")
+    @Override
+    public void quartzSpanTest() {
+        super.quartzSpanTest();
+    }
+}

--- a/integration-tests/opentelemetry-quartz/src/test/java/io/quarkus/it/opentelemetry/quartz/OpenTelemetryQuartzTest.java
+++ b/integration-tests/opentelemetry-quartz/src/test/java/io/quarkus/it/opentelemetry/quartz/OpenTelemetryQuartzTest.java
@@ -1,0 +1,104 @@
+package io.quarkus.it.opentelemetry.quartz;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.Response;
+
+@QuarkusTest
+public class OpenTelemetryQuartzTest {
+
+    private static long DURATION_IN_NANOSECONDS = 100_000_000; // Thread.sleep(100l) for each job
+
+    @Test
+    public void quartzSpanTest() {
+        // ensure that scheduled job is called
+        assertCounter("/scheduler/count", 1, Duration.ofSeconds(1));
+        // assert programmatically scheduled job is called
+        assertCounter("/scheduler/count/manual", 1, Duration.ofSeconds(1));
+        // assert JobDefinition type scheduler
+        assertCounter("/scheduler/count/job-definition", 1, Duration.ofSeconds(1));
+
+        // ------- SPAN ASSERTS -------
+        List<Map<String, Object>> spans = getSpans();
+
+        assertJobSpan(spans, "myCounter", DURATION_IN_NANOSECONDS); // identity
+        assertJobSpan(spans, "myGroup.myManualJob", DURATION_IN_NANOSECONDS); // group + identity
+        assertJobSpan(spans, "myJobDefinition", DURATION_IN_NANOSECONDS); // identity
+
+        // errors
+        assertErrorJobSpan(spans, "myFailedBasicScheduler", DURATION_IN_NANOSECONDS,
+                "error occurred in myFailedBasicScheduler.");
+        assertErrorJobSpan(spans, "myFailedGroup.myFailedManualJob", DURATION_IN_NANOSECONDS,
+                "error occurred in myFailedManualJob.");
+        assertErrorJobSpan(spans, "myFailedJobDefinition", DURATION_IN_NANOSECONDS,
+                "error occurred in myFailedJobDefinition.");
+
+    }
+
+    private void assertCounter(String counterPath, int expectedCount, Duration timeout) {
+        await().atMost(timeout)
+                .until(() -> {
+                    Response response = given().when().get(counterPath);
+                    int code = response.statusCode();
+                    if (code != 200) {
+                        return false;
+                    }
+                    String body = response.asString();
+                    int count = Integer.valueOf(body);
+                    return count >= expectedCount;
+                });
+
+    }
+
+    private List<Map<String, Object>> getSpans() {
+        return get("/export").body().as(new TypeRef<>() {
+        });
+    }
+
+    private void assertJobSpan(List<Map<String, Object>> spans, String expectedName, long expectedDuration) {
+        assertNotNull(spans);
+        assertFalse(spans.isEmpty());
+        Map<String, Object> span = spans.stream().filter(map -> map.get("name").equals(expectedName)).findFirst().orElse(null);
+        assertNotNull(span, "Span with name '" + expectedName + "' not found.");
+        assertEquals(SpanKind.INTERNAL.toString(), span.get("kind"), "Span with name '" + expectedName + "' is not internal.");
+
+        long start = (long) span.get("startEpochNanos");
+        long end = (long) span.get("endEpochNanos");
+        long delta = (end - start);
+        assertTrue(delta >= expectedDuration,
+                "Duration of span with name '" + expectedName +
+                        "' is not longer than 100ms, actual duration: " + delta + " (ns)");
+    }
+
+    private void assertErrorJobSpan(List<Map<String, Object>> spans, String expectedName, long expectedDuration,
+            String expectedErrorMessage) {
+        assertJobSpan(spans, expectedName, expectedDuration);
+        Map<String, Object> span = spans.stream().filter(map -> map.get("name").equals(expectedName)).findFirst()
+                .orElseThrow(AssertionError::new); // this assert should never be thrown, since we already checked it in `assertJobSpan`
+
+        Map<String, Object> statusAttributes = (Map<String, Object>) span.get("status");
+        assertNotNull(statusAttributes, "Span with name '" + expectedName + "' is not an ERROR");
+        assertEquals(StatusCode.ERROR.toString(), statusAttributes.get("statusCode"),
+                "Span with name '" + expectedName + "' is not an ERROR");
+        Map<String, Object> exception = (Map<String, Object>) ((List<Map<String, Object>>) span.get("events")).stream()
+                .map(map -> map.get("exception")).findFirst().orElseThrow(AssertionError::new);
+        assertTrue(((String) exception.get("message")).contains(expectedErrorMessage),
+                "Span with name '" + expectedName + "' has wrong error message");
+    }
+}

--- a/integration-tests/opentelemetry-scheduler/pom.xml
+++ b/integration-tests/opentelemetry-scheduler/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-opentelemetry-scheduler</artifactId>
+    <name>Quarkus - Integration Tests - OpenTelemetry Scheduler</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-scheduler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+
+        <!-- Needed for InMemorySpanExporter to verify captured traces -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-scheduler-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/CountResource.java
+++ b/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/CountResource.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.opentelemetry.scheduler;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/scheduler/count")
+public class CountResource {
+
+    @Inject
+    Counter counter;
+
+    @Inject
+    JobDefinitionCounter jobDefinitionCounter;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Integer getCount() {
+        return counter.get();
+    }
+
+    @GET
+    @Path("job-definition")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Integer getJobDefinitionCount() {
+        return jobDefinitionCounter.get();
+    }
+}

--- a/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/Counter.java
+++ b/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/Counter.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.opentelemetry.scheduler;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.scheduler.Scheduled;
+
+@ApplicationScoped
+public class Counter {
+
+    AtomicInteger counter;
+
+    @PostConstruct
+    void init() {
+        counter = new AtomicInteger();
+    }
+
+    public int get() {
+        return counter.get();
+    }
+
+    @Scheduled(cron = "*/1 * * * * ?", identity = "myCounter")
+    void increment() throws InterruptedException {
+        Thread.sleep(100l);
+        counter.incrementAndGet();
+    }
+
+}

--- a/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/ExporterResource.java
+++ b/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/ExporterResource.java
@@ -1,0 +1,38 @@
+package io.quarkus.it.opentelemetry.scheduler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+
+@Path("")
+public class ExporterResource {
+    @Inject
+    InMemorySpanExporter inMemorySpanExporter;
+
+    @GET
+    @Path("/export")
+    public List<SpanData> export() { // only export scheduled spans
+        return inMemorySpanExporter.getFinishedSpanItems()
+                .stream()
+                .filter(sd -> !sd.getName().contains("export") && !sd.getName().contains("GET"))
+                .collect(Collectors.toList());
+    }
+
+    @ApplicationScoped
+    static class InMemorySpanExporterProducer {
+        @Produces
+        @Singleton
+        InMemorySpanExporter inMemorySpanExporter() {
+            return InMemorySpanExporter.create();
+        }
+    }
+}

--- a/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/FailedBasicScheduler.java
+++ b/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/FailedBasicScheduler.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.opentelemetry.scheduler;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.scheduler.Scheduled;
+
+@ApplicationScoped
+public class FailedBasicScheduler {
+
+    @Scheduled(cron = "*/1 * * * * ?", identity = "myFailedBasicScheduler")
+    void init() throws InterruptedException {
+        Thread.sleep(100l);
+        throw new RuntimeException("error occurred in myFailedBasicScheduler.");
+
+    }
+
+}

--- a/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/FailedJobDefinitionScheduler.java
+++ b/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/FailedJobDefinitionScheduler.java
@@ -1,0 +1,29 @@
+package io.quarkus.it.opentelemetry.scheduler;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.runtime.Startup;
+import io.quarkus.scheduler.Scheduler;
+
+@ApplicationScoped
+@Startup
+public class FailedJobDefinitionScheduler {
+
+    @Inject
+    Scheduler scheduler;
+
+    @PostConstruct
+    void init() {
+        scheduler.newJob("myFailedJobDefinition").setCron("*/1 * * * * ?").setTask(ex -> {
+            try {
+                Thread.sleep(100l);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            throw new RuntimeException("error occurred in myFailedJobDefinition.");
+        }).schedule();
+    }
+
+}

--- a/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/JobDefinitionCounter.java
+++ b/integration-tests/opentelemetry-scheduler/src/main/java/io/quarkus/it/opentelemetry/scheduler/JobDefinitionCounter.java
@@ -1,0 +1,37 @@
+package io.quarkus.it.opentelemetry.scheduler;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.runtime.Startup;
+import io.quarkus.scheduler.Scheduler;
+
+@ApplicationScoped
+@Startup
+public class JobDefinitionCounter {
+
+    @Inject
+    Scheduler scheduler;
+
+    AtomicInteger counter;
+
+    @PostConstruct
+    void init() {
+        counter = new AtomicInteger();
+        scheduler.newJob("myJobDefinition").setCron("*/1 * * * * ?").setTask(ex -> {
+            try {
+                Thread.sleep(100l);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            counter.incrementAndGet();
+        }).schedule();
+    }
+
+    public int get() {
+        return counter.get();
+    }
+}

--- a/integration-tests/opentelemetry-scheduler/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-scheduler/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# speed up build
+quarkus.otel.bsp.schedule.delay=100
+quarkus.otel.bsp.export.timeout=5s
+
+quarkus.scheduler.tracing.enabled=true

--- a/integration-tests/opentelemetry-scheduler/src/test/java/io/quarkus/it/opentelemetry/scheduler/OpenTelemetrySchedulerIT.java
+++ b/integration-tests/opentelemetry-scheduler/src/test/java/io/quarkus/it/opentelemetry/scheduler/OpenTelemetrySchedulerIT.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.opentelemetry.scheduler;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class OpenTelemetrySchedulerIT extends OpenTelemetrySchedulerTest {
+    @Test
+    @DisabledOnIntegrationTest("native mode testing span does not have a field 'exception' (only in integration-test, not in quarkus app)")
+    @Override
+    public void schedulerSpanTest() {
+        super.schedulerSpanTest();
+    }
+}

--- a/integration-tests/opentelemetry-scheduler/src/test/java/io/quarkus/it/opentelemetry/scheduler/OpenTelemetrySchedulerTest.java
+++ b/integration-tests/opentelemetry-scheduler/src/test/java/io/quarkus/it/opentelemetry/scheduler/OpenTelemetrySchedulerTest.java
@@ -1,0 +1,99 @@
+package io.quarkus.it.opentelemetry.scheduler;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.Response;
+
+@QuarkusTest
+public class OpenTelemetrySchedulerTest {
+
+    private static long DURATION_IN_NANOSECONDS = 100_000_000; // Thread.sleep(100l) for each job
+
+    @Test
+    public void schedulerSpanTest() {
+        // ensure that scheduled job is called
+        assertCounter("/scheduler/count", 1, Duration.ofSeconds(1));
+        // assert JobDefinition type scheduler
+        assertCounter("/scheduler/count/job-definition", 1, Duration.ofSeconds(1));
+
+        // ------- SPAN ASSERTS -------
+        List<Map<String, Object>> spans = getSpans();
+
+        assertJobSpan(spans, "myCounter", DURATION_IN_NANOSECONDS); // identity
+        assertJobSpan(spans, "myJobDefinition", DURATION_IN_NANOSECONDS); // identity
+
+        // errors
+        assertErrorJobSpan(spans, "myFailedBasicScheduler", DURATION_IN_NANOSECONDS,
+                "error occurred in myFailedBasicScheduler.");
+        assertErrorJobSpan(spans, "myFailedJobDefinition", DURATION_IN_NANOSECONDS,
+                "error occurred in myFailedJobDefinition.");
+
+    }
+
+    private void assertCounter(String counterPath, int expectedCount, Duration timeout) {
+        await().atMost(timeout)
+                .until(() -> {
+                    Response response = given().when().get(counterPath);
+                    int code = response.statusCode();
+                    if (code != 200) {
+                        return false;
+                    }
+                    String body = response.asString();
+                    int count = Integer.valueOf(body);
+                    return count >= expectedCount;
+                });
+
+    }
+
+    private List<Map<String, Object>> getSpans() {
+        return get("/export").body().as(new TypeRef<>() {
+        });
+    }
+
+    private void assertJobSpan(List<Map<String, Object>> spans, String expectedName, long expectedDuration) {
+        assertNotNull(spans);
+        assertFalse(spans.isEmpty());
+        Map<String, Object> span = spans.stream().filter(map -> map.get("name").equals(expectedName)).findFirst().orElse(null);
+        assertNotNull(span, "Span with name '" + expectedName + "' not found.");
+        assertEquals(SpanKind.INTERNAL.toString(), span.get("kind"), "Span with name '" + expectedName + "' is not internal.");
+
+        long start = (long) span.get("startEpochNanos");
+        long end = (long) span.get("endEpochNanos");
+        long delta = (end - start);
+        assertTrue(delta >= expectedDuration,
+                "Duration of span with name '" + expectedName +
+                        "' is not longer than 100ms, actual duration: " + delta + " (ns)");
+    }
+
+    private void assertErrorJobSpan(List<Map<String, Object>> spans, String expectedName, long expectedDuration,
+            String expectedErrorMessage) {
+        assertJobSpan(spans, expectedName, expectedDuration);
+        Map<String, Object> span = spans.stream().filter(map -> map.get("name").equals(expectedName)).findFirst()
+                .orElseThrow(AssertionError::new); // this assert should never be thrown, since we already checked it in `assertJobSpan`
+
+        Map<String, Object> statusAttributes = (Map<String, Object>) span.get("status");
+        assertNotNull(statusAttributes, "Span with name '" + expectedName + "' is not an ERROR");
+        assertEquals(StatusCode.ERROR.toString(), statusAttributes.get("statusCode"),
+                "Span with name '" + expectedName + "' is not an ERROR");
+        Map<String, Object> exception = (Map<String, Object>) ((List<Map<String, Object>>) span.get("events")).stream()
+                .map(map -> map.get("exception")).findFirst().orElseThrow(AssertionError::new);
+        assertTrue(((String) exception.get("message")).contains(expectedErrorMessage),
+                "Span with name '" + expectedName + "' has wrong error message");
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -356,6 +356,8 @@
                 <module>opentelemetry</module>
                 <module>opentelemetry-spi</module>
                 <module>opentelemetry-jdbc-instrumentation</module>
+                <module>opentelemetry-quartz</module>
+                <module>opentelemetry-scheduler</module>
                 <module>opentelemetry-vertx</module>
                 <module>opentelemetry-reactive</module>
                 <module>opentelemetry-grpc</module>


### PR DESCRIPTION
/cc @brunobat 
fixes: #28552
draft PR

I have Added OTel Instrumentation for quartz scheduling.
Currently there are two types of scheduling in quartz:
### Using the annotation `@Schedule`
For this type of scheduling there seems to be already existing feature for creating spans. Yet I feel that my implementation might be better because the spans contains information about the name of the executed method + duration of the method.
     
![image](https://github.com/quarkusio/quarkus/assets/124160830/4cdb11dc-9b9e-4cba-9a55-14a81ac49580)
> [NOTE] the first span (the top one) is my implementation which contains name of the method which was executed + duration `Thread.sleep(1000l);`
The second span (the bottom one) is the current implementation which will be activated when using property `quarkus.scheduler.tracing.enabled=true`

For some reason with my implemetation I cannot log `traceId` and `spanId` inside the executed method even tho span has been created (gonna have a look at it in a meantime).

### Using Quartz API (Programmatic) 
I have created feature which enables OTel instrumentation for each Job.
Currently the span creating is enabled by default if it finds the OTel extension in the project, but maybe we could use the property `quarkus.scheduler.tracing.enabled=true` for explicit enabling (like the current `@Schedule` approach).
Logging `traceId` + `spanId` works.

Basis for the code: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0

>[NOTE]: In the issue's reproducer there were few errors for the use of programmatic style scheduling like: 
>* not using injected scheduler (using the factory)
> * not having property for forced start

### Tests
Currently missing.