### PR TITLE
Don't ignore empty SSE events in client

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/sse/SseParserTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/sse/SseParserTest.java
@@ -140,23 +140,12 @@ public class SseParserTest {
     }
 
     private void testParser(String event, String data, String comment, String lastId, String name, long reconnectDelay) {
-        if (data != null) {
-            testParser(Collections.singletonList(event), Collections.singletonList(new InboundSseEventImpl(null, null)
-                    .setData(data)
-                    .setComment(comment)
-                    .setId(lastId)
-                    .setName(name)
-                    .setReconnectDelay(reconnectDelay)));
-        } else if (comment != null) {
-            testParser(Collections.singletonList(event), Collections.singletonList(new InboundSseEventImpl(null, null)
-                    .setData(null)
-                    .setComment(comment)
-                    .setId(lastId)
-                    .setName(name)
-                    .setReconnectDelay(reconnectDelay)));
-        } else {
-            testParser(Collections.singletonList(event), Collections.emptyList());
-        }
+        testParser(Collections.singletonList(event), Collections.singletonList(new InboundSseEventImpl(null, null)
+                .setData(data)
+                .setComment(comment)
+                .setId(lastId)
+                .setName(name)
+                .setReconnectDelay(reconnectDelay)));
     }
 
     private void testParser(List<String> events, List<InboundSseEvent> expectedEvents) {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/SseParser.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/SseParser.java
@@ -144,9 +144,6 @@ public class SseParser implements Handler<Buffer> {
     }
 
     private void dispatchEvent() {
-        // ignore empty events
-        if (dataBuffer.length() == 0 && commentBuffer.length() == 0)
-            return;
         WebTargetImpl webTarget = sseEventSource.getWebTarget();
         InboundSseEventImpl event;
         // tests don't set a web target, and we don't want them to end up starting vertx just to test parsing


### PR DESCRIPTION
RESTEasy Classic does not ignore them,
so let's keep the same behavior

Closes: #35966