### PR TITLE
Make Maven ITs less fragile

### DIFF
--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -451,7 +451,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
     @Test
     public void testThatSourceChangesAreDetectedOnPomChange() throws Exception {
         testDir = initProject("projects/classic", "projects/project-classic-run-src-and-pom-change");
-        runAndCheck();
+        runAndCheck(false);
 
         // Edit a Java file too
         final File javaSource = new File(testDir, "src/main/java/org/acme/HelloResource.java");

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -474,7 +474,10 @@ public class DevMojoIT extends LaunchMojoTestBase {
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
                 .atMost(1, TimeUnit.MINUTES)
-                .until(() -> devModeClient.getHttpResponse("/app/hello").contains("hello " + uuid));
+                .until(() -> {
+                    System.out.println(devModeClient.getHttpResponse("/app/hello"));
+                    return devModeClient.getHttpResponse("/app/hello").contains("hello " + uuid);
+                });
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -37,6 +37,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.bootstrap.model.CapabilityErrors;
 import io.quarkus.devui.tests.DevUIJsonRPCTest;
@@ -1410,6 +1412,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Installing the library again is failing on Windows, probably because the jar is accessed by the dev mode process")
     public void testExternalReloadableArtifacts() throws Exception {
         final String rootProjectPath = "projects/external-reloadable-artifacts";
 

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -310,7 +310,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains(uuid));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains(uuid));
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
@@ -322,7 +323,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "carambar"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains("carambar"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains("carambar"));
     }
 
     @Test
@@ -359,7 +361,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "hello"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains("hello"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains("hello"));
     }
 
     @Test
@@ -381,7 +384,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains(uuid));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains(uuid));
 
         //verify that this was an instrumentation based reload
         Assertions.assertEquals(firstUuid, devModeClient.getHttpResponse("/app/uuid"));
@@ -392,7 +396,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "Stuart Douglas"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/name").contains("Stuart Douglas"));
 
         //this bean observes startup event, so it should be different UUID
@@ -408,7 +412,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "hello"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains("hello"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains("hello"));
 
         //verify that this was not instrumentation based reload
         Assertions.assertNotEquals(secondUUid, devModeClient.getHttpResponse("/app/uuid"));
@@ -423,7 +428,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get uuid
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains(uuid));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains(uuid));
 
         //verify that this was an instrumentation based reload
         Assertions.assertEquals(secondUUid, devModeClient.getHttpResponse("/app/uuid"));
@@ -440,7 +446,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "hello"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains("hello"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains("hello"));
 
         //verify that this was not instrumentation based reload
         Assertions.assertNotEquals(secondUUid, devModeClient.getHttpResponse("/app/uuid"));
@@ -473,7 +480,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get the updated responses
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> {
                     System.out.println(devModeClient.getHttpResponse("/app/hello"));
                     return devModeClient.getHttpResponse("/app/hello").contains("hello " + uuid);
@@ -481,7 +488,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/hello/greeting").contains(uuid));
 
     }
@@ -531,7 +538,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/q/openapi").contains("hello"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/q/openapi").contains("hello"));
     }
 
     @Test
@@ -606,7 +614,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains(uuid));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains(uuid));
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
@@ -633,7 +642,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "carambar"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains("carambar"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains("carambar"));
 
         // Create a new resource
         source = new File(testDir, "html/src/main/resources/META-INF/resources/lorem.txt");
@@ -642,21 +652,21 @@ public class DevMojoIT extends LaunchMojoTestBase {
                 "UTF-8");
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/lorem.txt").contains("Lorem ipsum"));
 
         // Update the resource
         FileUtils.write(source, uuid, "UTF-8");
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/lorem.txt").contains(uuid));
 
         // Delete the resource
         source.delete();
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/lorem.txt", 404));
     }
 
@@ -680,7 +690,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/hello/greeting").contains(uuid));
 
         greeting = devModeClient.getHttpResponse("/app/hello");
@@ -702,7 +712,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains(uuid));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains(uuid));
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
@@ -747,7 +758,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "bar"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/foo").contains("bar"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/foo").contains("bar"));
     }
 
     @Test
@@ -782,7 +794,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until source file is compiled
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/deletion").contains("to be deleted"));
 
         // Remove InnerClass
@@ -795,7 +807,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Make sure that other class files have not been deleted.
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/hello/package", 200));
 
         // Verify that only ClassDeletionResource$InnerClass.class to be deleted
@@ -809,7 +821,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "404 Not Found" because ClassDeletionResource.class have been deleted.
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/deletion", 404));
 
         // Make sure that class files for the deleted source file have also been deleted
@@ -862,7 +874,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/hello/greeting").contains(uuid));
     }
 
@@ -941,7 +953,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
                 "UTF-8");
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/lorem.txt"), containsString("Lorem ipsum"));
 
         // Update the resource
@@ -949,14 +961,14 @@ public class DevMojoIT extends LaunchMojoTestBase {
         FileUtils.write(source, uuid, "UTF-8");
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/lorem.txt"), equalTo(uuid));
 
         // Delete the resource
         source.delete();
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/lorem.txt", 404));
     }
 
@@ -967,7 +979,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/hello/greetings").contains("Bonjour"));
 
         File source = new File(testDir, "src/main/resources/application.properties");
@@ -975,7 +987,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/hello/greetings").contains("Guten Morgen"));
     }
 
@@ -995,7 +1007,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         runAndCheck();
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/hello/greetings").contains("Bonjour/Other"));
 
         // Update the application.properties
@@ -1003,7 +1015,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         FileUtils.write(source, "greeting=Salut", "UTF-8");
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/hello/greetings").contains("Salut/Other"));
 
         // Add the application.yaml
@@ -1012,7 +1024,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
                 "  greeting: Buenos dias", "UTF-8");
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/hello/greetings").contains("Salut/Buenos dias"));
 
         // Update the application.yaml
@@ -1020,7 +1032,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
                 "  greeting: Hola", "UTF-8");
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/hello/greetings").contains("Salut/Hola"));
     }
 
@@ -1038,7 +1050,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         AtomicReference<String> last = new AtomicReference<>();
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> {
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                     String content = devModeClient.getHttpResponse("/app/hello", true);
                     last.set(content);
                     return content.contains(uuid);
@@ -1057,7 +1069,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains("carambar"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains("carambar"));
     }
 
     @Test
@@ -1073,7 +1086,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         AtomicReference<String> last = new AtomicReference<>();
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> {
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                     String content = devModeClient.getHttpResponse("/app/hello", true);
                     last.set(content);
                     return content.contains("Error restarting Quarkus");
@@ -1085,7 +1098,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> {
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                     String content = devModeClient.getHttpResponse("/app/hello", true);
                     last.set(content);
                     return content.equals("hello");
@@ -1122,7 +1135,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains("message"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains("message"));
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
@@ -1133,7 +1147,8 @@ public class DevMojoIT extends LaunchMojoTestBase {
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains("foobarbaz"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains("foobarbaz"));
     }
 
     @Test
@@ -1184,7 +1199,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/hello/otherGreeting").contains(uuid));
     }
 
@@ -1235,7 +1250,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         // make sure the application starts
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/cp/hello").equals("hello"));
 
         // test that we don't get multiple instances of a resource when loading from the ClassLoader
@@ -1278,7 +1293,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
 
         await()
                 .pollDelay(300, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/hello").contains("hello world"));
     }
 
@@ -1315,7 +1330,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         filter(resource, Collections.singletonMap("return \"mock-service\";", "return \"mock-service!\";"));
         await()
                 .pollDelay(300, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/hello").contains("acme other mock-service!"));
 
         // Update AcmeBean
@@ -1323,7 +1338,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         filter(resource, Collections.singletonMap("return \"acme\";", "return \"acme!\";"));
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/hello").contains("acme! other mock-service!"));
 
         // Update Other bean
@@ -1331,7 +1346,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         filter(resource, Collections.singletonMap("return \"other\";", "return \"other!\";"));
         await()
                 .pollDelay(300, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/hello").contains("acme! other! mock-service!"));
     }
 
@@ -1348,7 +1363,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         filter(resource, Collections.singletonMap("return \"acme-service\";", "return \"acme-service!\";"));
         await()
                 .pollDelay(300, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/hello").contains("acme other acme-service!"));
 
         // Update AcmeBean
@@ -1356,7 +1371,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         filter(resource, Collections.singletonMap("return \"acme\";", "return \"acme!\";"));
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/hello").contains("acme! other acme-service!"));
 
         // Update Other bean
@@ -1364,7 +1379,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
         filter(resource, Collections.singletonMap("return \"other\";", "return \"other!\";"));
         await()
                 .pollDelay(300, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/hello").contains("acme! other! acme-service!"));
     }
 
@@ -1377,7 +1392,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/hello").contains("Servus"));
 
         // Update the .env
@@ -1388,7 +1403,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/hello").contains("Hallo"));
 
         assertTrue(source.exists());
@@ -1412,7 +1427,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/hello").contains("Hello"));
 
         final File greetingJava = externalJarDir.toPath().resolve("src").resolve("main")
@@ -1435,7 +1450,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/hello").contains("Bonjour"));
 
         // Change bonjour() method content in Greeting.java
@@ -1447,7 +1462,7 @@ public class DevMojoIT extends LaunchMojoTestBase {
 
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/hello").contains("BONJOUR!"));
     }
 }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/JarRunnerIT.java
@@ -37,8 +37,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.deployment.pkg.steps.JarResultBuildStep;
 import io.quarkus.deployment.util.IoUtil;
@@ -60,13 +62,15 @@ public class JarRunnerIT extends MojoTestBase {
      * @see <a href="https://github.com/quarkusio/quarkus/issues/11511"/>
      */
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "With maven-compiler-plugin 2.11.0, this test is not working anymore on Windows: Error while storing the mojo status: Input length = 1")
     public void testNonAsciiDir() throws Exception {
         final File testDir = initProject("projects/classic", "projects/ěščřžýáíéůú");
         final RunningInvoker running = new RunningInvoker(testDir, false);
 
         final MavenProcessInvocationResult result = running.execute(Arrays.asList("install", "-DskipTests"),
                 Collections.emptyMap());
-        await().atMost(1, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+        await().atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> result.getProcess() != null && !result.getProcess().isAlive());
         assertThat(running.log()).containsIgnoringCase("BUILD SUCCESS");
         running.stop();
 
@@ -79,7 +83,8 @@ public class JarRunnerIT extends MojoTestBase {
             // Wait until server up
             dumpFileContentOnFailure(() -> {
                 await().pollDelay(1, TimeUnit.SECONDS)
-                        .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello/package", 200));
+                        .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                        .until(() -> devModeClient.getHttpResponse("/app/hello/package", 200));
                 return null;
             }, output, ConditionTimeoutException.class);
         } finally {
@@ -94,7 +99,8 @@ public class JarRunnerIT extends MojoTestBase {
         RunningInvoker running = new RunningInvoker(testDir, false);
 
         MavenProcessInvocationResult result = running.execute(Arrays.asList("package", "-DskipTests"), Collections.emptyMap());
-        await().atMost(1, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+        await().atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> result.getProcess() != null && !result.getProcess().isAlive());
         assertThat(running.log()).containsIgnoringCase("BUILD SUCCESS");
         running.stop();
 
@@ -108,7 +114,8 @@ public class JarRunnerIT extends MojoTestBase {
             // Wait until server up
             await()
                     .pollDelay(1, TimeUnit.SECONDS)
-                    .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello/package", 200));
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                    .until(() -> devModeClient.getHttpResponse("/app/hello/package", 200));
 
             String logs = FileUtils.readFileToString(output, "UTF-8");
 
@@ -132,7 +139,8 @@ public class JarRunnerIT extends MojoTestBase {
 
         final MavenProcessInvocationResult result = running.execute(Arrays.asList("install"),
                 Collections.emptyMap());
-        await().atMost(1, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+        await().atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> result.getProcess() != null && !result.getProcess().isAlive());
         assertThat(running.log()).containsIgnoringCase("BUILD SUCCESS");
         running.stop();
 
@@ -157,7 +165,8 @@ public class JarRunnerIT extends MojoTestBase {
         final MavenProcessInvocationResult result = running.execute(
                 Arrays.asList("install -Dquarkus.native.builder-image=commandline -DskipTests"),
                 Collections.emptyMap());
-        await().atMost(1, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+        await().atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> result.getProcess() != null && !result.getProcess().isAlive());
         assertThat(running.log()).containsIgnoringCase("BUILD SUCCESS");
         running.stop();
 
@@ -203,7 +212,8 @@ public class JarRunnerIT extends MojoTestBase {
                         "-DskipTests",
                         "-Dquarkus.package.type=legacy-jar"), Collections.emptyMap());
 
-        await().atMost(1, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+        await().atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> result.getProcess() != null && !result.getProcess().isAlive());
         assertThat(running.log()).containsIgnoringCase("BUILD SUCCESS");
         running.stop();
 
@@ -238,7 +248,8 @@ public class JarRunnerIT extends MojoTestBase {
             dumpFileContentOnFailure(() -> {
                 await()
                         .pollDelay(1, TimeUnit.SECONDS)
-                        .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello/package", 200));
+                        .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                        .until(() -> devModeClient.getHttpResponse("/app/hello/package", 200));
                 return null;
             }, output, ConditionTimeoutException.class);
 
@@ -264,7 +275,8 @@ public class JarRunnerIT extends MojoTestBase {
         MavenProcessInvocationResult result = running
                 .execute(List.of("package", "-DskipTests", "-Dquarkus.package.type=mutable-jar",
                         "-Dquarkus.analytics.disabled=true"), Map.of());
-        await().atMost(1, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+        await().atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> result.getProcess() != null && !result.getProcess().isAlive());
         assertThat(running.log()).containsIgnoringCase("BUILD SUCCESS");
         running.stop();
 
@@ -281,7 +293,7 @@ public class JarRunnerIT extends MojoTestBase {
             AtomicReference<String> response = new AtomicReference<>();
             await()
                     .pollDelay(1, TimeUnit.SECONDS)
-                    .atMost(1, TimeUnit.MINUTES).until(() -> {
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                         String ret = devModeClient.getHttpResponse("/cp/resourceCount/entry", false);
                         response.set(ret);
                         return true;
@@ -309,7 +321,7 @@ public class JarRunnerIT extends MojoTestBase {
             AtomicReference<String> response = new AtomicReference<>();
             await()
                     .pollDelay(1, TimeUnit.SECONDS)
-                    .atMost(1, TimeUnit.MINUTES).until(() -> {
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                         String ret = devModeClient.getHttpResponse("/cp/resourceCount/entry", false);
                         response.set(ret);
                         return true;
@@ -334,7 +346,7 @@ public class JarRunnerIT extends MojoTestBase {
             AtomicReference<String> response = new AtomicReference<>();
             await()
                     .pollDelay(1, TimeUnit.SECONDS)
-                    .atMost(1, TimeUnit.MINUTES).until(() -> {
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                         String ret = devModeClient.getHttpResponse("/cp/resourceCount/entry", false);
                         response.set(ret);
                         return true;
@@ -357,7 +369,8 @@ public class JarRunnerIT extends MojoTestBase {
         // The default build
         MavenProcessInvocationResult result = running
                 .execute(List.of("package", "-DskipTests", "-Dquarkus.package.type=mutable-jar"), Map.of());
-        await().atMost(1, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+        await().atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> result.getProcess() != null && !result.getProcess().isAlive());
         assertThat(running.log()).containsIgnoringCase("BUILD SUCCESS");
         running.stop();
 
@@ -374,7 +387,7 @@ public class JarRunnerIT extends MojoTestBase {
             AtomicReference<String> response = new AtomicReference<>();
             await()
                     .pollDelay(1, TimeUnit.SECONDS)
-                    .atMost(1, TimeUnit.MINUTES).until(() -> {
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                         String ret = devModeClient.getHttpResponse("/words/runtime", false);
                         response.set(ret);
                         return true;
@@ -383,7 +396,7 @@ public class JarRunnerIT extends MojoTestBase {
 
             await()
                     .pollDelay(1, TimeUnit.SECONDS)
-                    .atMost(1, TimeUnit.MINUTES).until(() -> {
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                         String ret = devModeClient.getHttpResponse("/words/buildtime", false);
                         response.set(ret);
                         return true;
@@ -409,7 +422,7 @@ public class JarRunnerIT extends MojoTestBase {
             AtomicReference<String> response = new AtomicReference<>();
             await()
                     .pollDelay(1, TimeUnit.SECONDS)
-                    .atMost(1, TimeUnit.MINUTES).until(() -> {
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                         String ret = devModeClient.getHttpResponse("/words/runtime", false);
                         response.set(ret);
                         return true;
@@ -418,7 +431,7 @@ public class JarRunnerIT extends MojoTestBase {
 
             await()
                     .pollDelay(1, TimeUnit.SECONDS)
-                    .atMost(1, TimeUnit.MINUTES).until(() -> {
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                         String ret = devModeClient.getHttpResponse("/words/buildtime", false);
                         response.set(ret);
                         return true;
@@ -441,7 +454,7 @@ public class JarRunnerIT extends MojoTestBase {
             AtomicReference<String> response = new AtomicReference<>();
             await()
                     .pollDelay(1, TimeUnit.SECONDS)
-                    .atMost(1, TimeUnit.MINUTES).until(() -> {
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                         String ret = devModeClient.getHttpResponse("/words/runtime", false);
                         response.set(ret);
                         return true;
@@ -450,7 +463,7 @@ public class JarRunnerIT extends MojoTestBase {
 
             await()
                     .pollDelay(1, TimeUnit.SECONDS)
-                    .atMost(1, TimeUnit.MINUTES).until(() -> {
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                         String ret = devModeClient.getHttpResponse("/words/buildtime", false);
                         response.set(ret);
                         return true;
@@ -470,7 +483,8 @@ public class JarRunnerIT extends MojoTestBase {
                 .execute(Arrays.asList("package", "-DskipTests", "-Dquarkus.package.type=mutable-jar",
                         "-Dquarkus.package.user-providers-directory=" + providersDir), Collections.emptyMap());
 
-        await().atMost(1, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+        await().atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> result.getProcess() != null && !result.getProcess().isAlive());
         assertThat(running.log()).containsIgnoringCase("BUILD SUCCESS");
         running.stop();
 
@@ -495,7 +509,8 @@ public class JarRunnerIT extends MojoTestBase {
             dumpFileContentOnFailure(() -> {
                 await()
                         .pollDelay(1, TimeUnit.SECONDS)
-                        .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello/package", 200));
+                        .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                        .until(() -> devModeClient.getHttpResponse("/app/hello/package", 200));
                 return null;
             }, output, ConditionTimeoutException.class);
             performRequest("/app/added", 404);
@@ -532,7 +547,8 @@ public class JarRunnerIT extends MojoTestBase {
             // Wait until server up
             await()
                     .pollDelay(1, TimeUnit.SECONDS)
-                    .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/moved/app/hello/package", 200));
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                    .until(() -> devModeClient.getHttpResponse("/moved/app/hello/package", 200));
 
             String logs = FileUtils.readFileToString(output, "UTF-8");
 
@@ -570,7 +586,7 @@ public class JarRunnerIT extends MojoTestBase {
             // Wait until server up
             await()
                     .pollDelay(1, TimeUnit.SECONDS)
-                    .atMost(1, TimeUnit.MINUTES)
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                     .until(() -> devModeClient.getHttpResponse("/anothermove/app/hello/package", 200));
 
             String logs = FileUtils.readFileToString(output, "UTF-8");
@@ -599,7 +615,8 @@ public class JarRunnerIT extends MojoTestBase {
                 .execute(Arrays.asList("package", "-DskipTests", "-Dquarkus.package.create-appcds=true"),
                         Collections.emptyMap());
 
-        await().atMost(1, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+        await().atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> result.getProcess() != null && !result.getProcess().isAlive());
         assertThat(running.log()).containsIgnoringCase("BUILD SUCCESS");
         running.stop();
 
@@ -617,8 +634,9 @@ public class JarRunnerIT extends MojoTestBase {
             // Wait until server up
             dumpFileContentOnFailure(() -> {
                 await()
-                        .pollDelay(1, TimeUnit.SECONDS)
-                        .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello/package", 200));
+                        .pollDelay(10, TimeUnit.SECONDS)
+                        .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                        .until(() -> devModeClient.getHttpResponse("/app/hello/package", 200));
                 return null;
             }, output, ConditionTimeoutException.class);
 
@@ -640,7 +658,8 @@ public class JarRunnerIT extends MojoTestBase {
         RunningInvoker running = new RunningInvoker(testDir, false);
 
         MavenProcessInvocationResult result = running.execute(Arrays.asList("package", "-DskipTests"), Collections.emptyMap());
-        await().atMost(1, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+        await().atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> result.getProcess() != null && !result.getProcess().isAlive());
         assertThat(running.log()).containsIgnoringCase("BUILD SUCCESS");
         running.stop();
 
@@ -656,7 +675,7 @@ public class JarRunnerIT extends MojoTestBase {
             AtomicReference<String> response = new AtomicReference<>();
             await()
                     .pollDelay(1, TimeUnit.SECONDS)
-                    .atMost(1, TimeUnit.MINUTES).until(() -> {
+                    .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                         String ret = devModeClient.getHttpResponse("/hello", true);
                         response.set(ret);
                         return ret.contains("hello:");
@@ -798,7 +817,8 @@ public class JarRunnerIT extends MojoTestBase {
                         "-Dquarkus.package.type=fast-jar",
                         outputDir == null ? "" : "-Dquarkus.package.output-directory=" + outputDir), Collections.emptyMap());
 
-        await().atMost(1, TimeUnit.MINUTES).until(() -> result.getProcess() != null && !result.getProcess().isAlive());
+        await().atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> result.getProcess() != null && !result.getProcess().isAlive());
         assertThat(running.log()).containsIgnoringCase("BUILD SUCCESS");
         running.stop();
 
@@ -827,7 +847,8 @@ public class JarRunnerIT extends MojoTestBase {
             dumpFileContentOnFailure(() -> {
                 await()
                         .pollDelay(1, TimeUnit.SECONDS)
-                        .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello/package", 200));
+                        .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                        .until(() -> devModeClient.getHttpResponse("/app/hello/package", 200));
                 return null;
             }, output, ConditionTimeoutException.class);
 

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusITBase.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/QuarkusITBase.java
@@ -25,7 +25,7 @@ abstract class QuarkusITBase extends MojoTestBase {
                 .execute(Arrays.asList("package", "-B",
                         "-D" + profile), Collections.emptyMap());
 
-        await().atMost(1, TimeUnit.MINUTES)
+        await().atMost(3, TimeUnit.MINUTES)
                 .until(() -> packageInvocationResult.getProcess() != null && !packageInvocationResult.getProcess().isAlive());
         assertThat(packageInvocation.log()).containsIgnoringCase("BUILD SUCCESS");
 
@@ -35,7 +35,7 @@ abstract class QuarkusITBase extends MojoTestBase {
                 .execute(Arrays.asList("failsafe:integration-test", "-B",
                         "-D" + profile), Collections.emptyMap());
 
-        await().atMost(1, TimeUnit.MINUTES)
+        await().atMost(3, TimeUnit.MINUTES)
                 .until(() -> integrationTestsInvocationResult.getProcess() != null
                         && !integrationTestsInvocationResult.getProcess().isAlive());
         assertThat(integrationTestsInvocation.log()).containsIgnoringCase("BUILD SUCCESS");

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
@@ -40,7 +40,8 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains(uuid));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains(uuid));
 
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
@@ -52,7 +53,8 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
         // Wait until we get "carambar"
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains("carambar"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains("carambar"));
 
         //also verify that the dev ui console is disabled
         devModeClient.getHttpResponse("/q/dev-v1", 404, 10, TimeUnit.SECONDS);
@@ -87,7 +89,8 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
         // Wait until we get "bar"
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/foo").contains("bar"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/foo").contains("bar"));
     }
 
     @Test
@@ -119,7 +122,7 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/app/hello/greeting").contains(uuid));
     }
 
@@ -137,7 +140,7 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
                 "UTF-8");
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/lorem.txt").contains("Lorem ipsum"));
 
         // Update the resource
@@ -145,7 +148,7 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
         FileUtils.write(source, uuid, "UTF-8");
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
-                .atMost(1, TimeUnit.MINUTES)
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
                 .until(() -> devModeClient.getHttpResponse("/lorem.txt").contains(uuid));
 
         // Delete the resource
@@ -153,7 +156,7 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
         //        source.delete();
         //        await()
         //                .pollDelay(1, TimeUnit.SECONDS)
-        //                .atMost(1, TimeUnit.MINUTES)
+        //                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
         //                .until(() -> getHttpResponse("/lorem.txt", 404));
     }
 
@@ -172,7 +175,7 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
         AtomicReference<String> last = new AtomicReference<>();
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> {
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES).until(() -> {
                     String content = devModeClient.getHttpResponse("/app/hello", true);
                     last.set(content);
                     return content.contains(uuid);
@@ -191,7 +194,8 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains("carambar"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains("carambar"));
     }
 
     @Test
@@ -224,7 +228,8 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
         // Wait until we get "uuid"
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains("message"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains("message"));
 
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
@@ -235,7 +240,8 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
 
         await()
                 .pollDelay(1, TimeUnit.SECONDS)
-                .atMost(1, TimeUnit.MINUTES).until(() -> devModeClient.getHttpResponse("/app/hello").contains("foobarbaz"));
+                .atMost(TestUtils.getDefaultTimeout(), TimeUnit.MINUTES)
+                .until(() -> devModeClient.getHttpResponse("/app/hello").contains("foobarbaz"));
     }
 
 }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/TestUtils.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/TestUtils.java
@@ -1,0 +1,15 @@
+package io.quarkus.maven.it;
+
+import io.smallrye.common.os.OS;
+
+final class TestUtils {
+
+    private static final long DEFAULT_TIMEOUT = OS.current() == OS.WINDOWS ? 3L : 1L;
+
+    private TestUtils() {
+    }
+
+    static long getDefaultTimeout() {
+        return DEFAULT_TIMEOUT;
+    }
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/arc-exclude-dependencies/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/arc-exclude-dependencies/pom.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project>
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.acme</groupId>
@@ -12,10 +13,11 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     </properties>
     <modules>
         <module>library</module>
@@ -23,13 +25,19 @@
     </modules>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>\${quarkus-plugin.version}</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>\${quarkus-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/basic-command-mode/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/basic-command-mode/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -38,6 +39,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/build-mode-quarkus-profile-override/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/build-mode-quarkus-profile-override/pom.xml
@@ -11,9 +11,10 @@
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus.profile>bar</quarkus.profile>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -36,6 +37,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/build-mode-quarkus-profile-property/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/build-mode-quarkus-profile-property/pom.xml
@@ -11,9 +11,10 @@
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus.profile>foo</quarkus.profile>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -36,6 +37,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-conflict/acme-ext/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-conflict/acme-ext/pom.xml
@@ -18,11 +18,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <quarkus.version>@project.version@</quarkus.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     </properties>
 
     <modules>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-conflict/alt-ext/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-conflict/alt-ext/pom.xml
@@ -18,11 +18,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <quarkus.version>@project.version@</quarkus.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     </properties>
 
     <modules>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-conflict/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-conflict/pom.xml
@@ -12,10 +12,11 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <modules>
         <module>acme-ext</module>
@@ -24,13 +25,19 @@
     </modules>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>\${quarkus-plugin.version}</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                  </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>\${quarkus-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/acme-ext/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/acme-ext/pom.xml
@@ -18,11 +18,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <quarkus.version>@project.version@</quarkus.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     </properties>
 
     <modules>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/alt-ext/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/alt-ext/pom.xml
@@ -18,11 +18,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <quarkus.version>@project.version@</quarkus.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     </properties>
 
     <modules>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/pom.xml
@@ -12,10 +12,11 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <modules>
         <module>acme-ext</module>
@@ -24,13 +25,19 @@
     </modules>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>\${quarkus-plugin.version}</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                  </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>\${quarkus-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-2.x/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-2.x/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>2.14.3.Final</quarkus.platform.version>
     <quarkus-plugin.version>2.14.3.Final</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
 
     <!-- do not update this dependency, it needs to be stable for testing -->
     <webjar.jquery-ui.version>1.13.0</webjar.jquery-ui.version>
@@ -65,6 +66,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-inst/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-inst/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -58,6 +59,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-no-build/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-no-build/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -49,6 +50,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-no-generate/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-no-generate/pom.xml
@@ -10,9 +10,11 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <resources-plugin.version>${maven-resources-plugin.version}</resources-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -50,8 +52,12 @@
     </resources>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>\${resources-plugin.version}</version>
         <configuration>
             <nonFilteredFileExtensions>
                 <nonFilteredFileExtension>zip</nonFilteredFileExtension>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-no-undertow/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-no-undertow/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -43,6 +44,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-noconfig/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-noconfig/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -53,6 +54,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-remote-dev/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-remote-dev/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -54,6 +55,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-resource-filtering/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-resource-filtering/pom.xml
@@ -10,9 +10,11 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <resources-plugin.version>${maven-resources-plugin.version}</resources-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
     <my.greeting>bonjour</my.greeting>
   </properties>
   <dependencyManagement>
@@ -52,12 +54,16 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>\${resources-plugin.version}</version>
         <configuration>
             <nonFilteredFileExtensions>
                 <nonFilteredFileExtension>zip</nonFilteredFileExtension>
             </nonFilteredFileExtensions>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
 
     <!-- do not update this dependency, it needs to be stable for testing -->
     <webjar.jquery-ui.version>1.13.0</webjar.jquery-ui.version>
@@ -70,6 +71,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classloader-linkage-error/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classloader-linkage-error/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
     <stax-api.version>1.0.1</stax-api.version>
   </properties>
   <dependencyManagement>
@@ -45,6 +46,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/codegen-config-factory/pom.xml
@@ -8,14 +8,14 @@
   <packaging>pom</packaging>
   <name>Acme - Parent</name>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.release>${maven.compiler.release}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/maven/src/test/resources-filtered/projects/command-mode-app-args-plugin-config/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/command-mode-app-args-plugin-config/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
     <quarkus.package.type>uber-jar</quarkus.package.type>
   </properties>
   <dependencyManagement>
@@ -39,6 +40,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/conditional-dependencies/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/conditional-dependencies/pom.xml
@@ -13,13 +13,13 @@
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
         <quarkus.version>@project.version@</quarkus.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
     </properties>
     <modules>
         <module>quarkus-ext-a</module>

--- a/integration-tests/maven/src/test/resources-filtered/projects/create-extension-pom/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/create-extension-pom/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.version>1.6.0.Final</quarkus.version>
         <rest-assured.version>3.3.0</rest-assured.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     </properties>
 
     <modules>

--- a/integration-tests/maven/src/test/resources-filtered/projects/create-extension-quarkus-core/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/create-extension-quarkus-core/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
     <properties>
         <rest-assured.version>3.3.0</rest-assured.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     </properties>
 
     <modules>

--- a/integration-tests/maven/src/test/resources-filtered/projects/custom-manifest-attributes/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/custom-manifest-attributes/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -45,6 +46,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/custom-packaging-app/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/custom-packaging-app/pom.xml
@@ -14,8 +14,9 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
   </properties>
 
   <dependencyManagement>
@@ -32,6 +33,10 @@
 
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/custom-packaging-plugin/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/custom-packaging-plugin/pom.xml
@@ -15,8 +15,9 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
   </properties>
 
   <dependencyManagement>
@@ -33,6 +34,10 @@
 
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
         <version>3.7.1</version>

--- a/integration-tests/maven/src/test/resources-filtered/projects/dependency-on-pom/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/dependency-on-pom/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -51,6 +52,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-env-vars-config/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-env-vars-config/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -35,6 +36,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-file-deletion/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-file-deletion/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -50,6 +51,10 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-multiple-resource-dirs-with-profile/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-multiple-resource-dirs-with-profile/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -54,6 +55,10 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-multiple-resource-dirs/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-multiple-resource-dirs/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -57,6 +58,10 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-sys-props-config/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-sys-props-config/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -35,6 +36,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-codestart/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-codestart/pom.xml
@@ -12,8 +12,8 @@
     <module>runtime</module>
   </modules>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.release>${maven.compiler.release}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>@project.version@</quarkus.version>

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/pom.xml
@@ -7,14 +7,15 @@
   <artifactId>code-with-quarkus</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.release>${maven.compiler.release}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -51,12 +52,18 @@
     <module>runner</module>
   </modules>
   <build>
-    <plugins>
-      <plugin>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-maven-plugin</artifactId>
-        <version>\${quarkus.platform.version}</version>
-      </plugin>
-    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>\${compiler-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-maven-plugin</artifactId>
+          <version>\${quarkus.platform.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 </project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-test-with-no-main/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-test-with-no-main/pom.xml
@@ -13,13 +13,13 @@
     <module>integration-tests</module>
   </modules>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     <failsafe-plugin.version>\${surefire-plugin.version}</failsafe-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>${maven.compiler.release}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>@project.version@</quarkus.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/maven/src/test/resources-filtered/projects/external-reloadable-artifacts/app/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/external-reloadable-artifacts/app/pom.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.acme</groupId>
@@ -12,9 +14,10 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <maven.compiler.source>11</maven.compiler.source>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencyManagement>
@@ -44,6 +47,15 @@
 
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>\${compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/external-reloadable-artifacts/external-lib/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/external-reloadable-artifacts/external-lib/pom.xml
@@ -8,14 +8,24 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.jar.plugin.version>3.2.2</maven.jar.plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <maven.jar.plugin.version>${version.jar.plugin}</maven.jar.plugin.version>
     </properties>
 
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>\${compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/ignore-entries-uber-jar/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/ignore-entries-uber-jar/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
     <quarkus.package.type>uber-jar</quarkus.package.type>
   </properties>
   <dependencyManagement>
@@ -40,6 +41,15 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/modules-in-profiles/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/modules-in-profiles/pom.xml
@@ -12,10 +12,11 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <modules>
         <module>runner</module>
@@ -24,6 +25,15 @@
 
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>\${compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode-parallel/module-1/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode-parallel/module-1/pom.xml
@@ -9,12 +9,21 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>module-1</artifactId>
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode-parallel/module-2/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode-parallel/module-2/pom.xml
@@ -9,12 +9,21 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>module-2</artifactId>
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
   </properties>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode-parallel/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode-parallel/pom.xml
@@ -11,10 +11,11 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
+    <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode/pom.xml
@@ -10,10 +10,11 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
     <commons.collections.version>4.4</commons.collections.version>
     <commons.io.version>1.3.2</commons.io.version>
   </properties>
@@ -60,6 +61,15 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multijar-module/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multijar-module/pom.xml
@@ -14,10 +14,12 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <jar-plugin.version>${version.jar.plugin}</jar-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <modules>
         <module>beans</module>
@@ -30,9 +32,18 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>${jar-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-classpath/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-classpath/pom.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project>
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>cp.acme</groupId>
@@ -8,14 +9,15 @@
     <packaging>pom</packaging>
 
     <properties>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>@project.version@</quarkus.platform.version>
-    <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.version>@project.version@</quarkus.platform.version>
+        <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <modules>
         <module>rest</module>
@@ -25,13 +27,24 @@
     </modules>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>\${quarkus-plugin.version}</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>\${quarkus-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-parent-dep/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-parent-dep/pom.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project>
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.acme</groupId>
@@ -12,10 +13,11 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <modules>
         <module>level0</module>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-revision-prop/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-revision-prop/pom.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project>
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.acme</groupId>
@@ -13,10 +14,11 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>\${project.version}</quarkus.platform.version>
         <quarkus-plugin.version>\${project.version}</quarkus-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <modules>
         <module>rest</module>
@@ -25,13 +27,24 @@
     </modules>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>\${quarkus-plugin.version}</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>\${quarkus-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-root-no-src/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-root-no-src/pom.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project>
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.acme</groupId>
@@ -8,14 +9,15 @@
     <packaging>pom</packaging>
 
     <properties>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>@project.version@</quarkus.platform.version>
-    <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>2.22.1</surefire-plugin.version>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.version>@project.version@</quarkus.platform.version>
+        <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <modules>
         <module>rest</module>
@@ -24,13 +26,24 @@
     </modules>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>\${quarkus-plugin.version}</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>\${quarkus-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule/pom.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project>
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.acme</groupId>
@@ -8,14 +9,15 @@
     <packaging>pom</packaging>
 
     <properties>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>@project.version@</quarkus.platform.version>
-    <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.version>@project.version@</quarkus.platform.version>
+        <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <modules>
         <module>rest</module>
@@ -24,13 +26,24 @@
     </modules>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>\${quarkus-plugin.version}</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>\${quarkus-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/native-image-app/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/native-image-app/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -34,6 +35,15 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/no-resource-root/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/no-resource-root/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -35,6 +36,15 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/platform-properties-overrides/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/platform-properties-overrides/pom.xml
@@ -7,17 +7,17 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <surefire-plugin.version>2.22.1</surefire-plugin.version>
+    <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/maven/src/test/resources-filtered/projects/pom-in-target-dir/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/pom-in-target-dir/pom.xml
@@ -7,7 +7,7 @@
   <version>1.0.0-SNAPSHOT</version>
   <properties>
     <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>${maven.compiler.release}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/integration-tests/maven/src/test/resources-filtered/projects/project-with-extension/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/project-with-extension/pom.xml
@@ -12,10 +12,11 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <modules>
         <module>common</module>
@@ -26,13 +27,24 @@
     </modules>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>\${quarkus-plugin.version}</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>\${quarkus-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/project-with-extension/quarkus-ext/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/project-with-extension/quarkus-ext/pom.xml
@@ -18,11 +18,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <quarkus.version>@project.version@</quarkus.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     </properties>
 
     <modules>

--- a/integration-tests/maven/src/test/resources-filtered/projects/property-expansion/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/property-expansion/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
 
     <expansion.application.name>myapp</expansion.application.name>
     <quarkus.application.name>\${expansion.application.name}</quarkus.application.name>
@@ -56,25 +57,34 @@
   <build>
     <plugins>
       <plugin>
-      <groupId>org.codehaus.mojo</groupId>
-      <artifactId>build-helper-maven-plugin</artifactId>
-      <version>3.2.0</version>
-      <executions>
-        <execution>
-          <id>regex-property</id>
-          <phase>validate</phase>
-          <goals>
-            <goal>regex-property</goal>
-          </goals>
-          <configuration>
-            <name>expansion.image.tag</name>
-            <value>tag</value>
-            <regex>tag</regex>
-            <replacement>tag</replacement>
-            <failIfNoMatch>false</failIfNoMatch>
-          </configuration>
-        </execution>
-      </executions>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>regex-property</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>expansion.image.tag</name>
+              <value>tag</value>
+              <regex>tag</regex>
+              <replacement>tag</replacement>
+              <failIfNoMatch>false</failIfNoMatch>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/property-overrides/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/property-overrides/pom.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project>
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.acme</groupId>
@@ -12,10 +13,11 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <local-dep.version>2.0-SNAPSHOT</local-dep.version>
     </properties>
     <modules>
@@ -25,13 +27,24 @@
     </modules>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>\${quarkus-plugin.version}</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>\${quarkus-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/proto-gen/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/proto-gen/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -49,6 +50,15 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/quarkus-index-dependencies/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/quarkus-index-dependencies/pom.xml
@@ -12,10 +12,11 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     </properties>
     <modules>
         <module>library</module>
@@ -23,13 +24,24 @@
     </modules>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>\${quarkus-plugin.version}</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>\${quarkus-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/quarkus.package.output-directory/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/quarkus.package.output-directory/pom.xml
@@ -10,10 +10,11 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -46,6 +47,15 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/reactive-routes/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/reactive-routes/pom.xml
@@ -9,15 +9,15 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
-        <maven.compiler.source>11</maven.compiler.source>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>11</maven.compiler.target>
-        <awaitility.version>3.0.0</awaitility.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -56,12 +56,20 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>\${awaitility.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>\${compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/rest-client-custom-headers-extension/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rest-client-custom-headers-extension/pom.xml
@@ -12,10 +12,11 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <modules>
         <module>rest-client-custom-headers</module>
@@ -23,13 +24,24 @@
     </modules>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>\${quarkus-plugin.version}</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>\${quarkus-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/rest-client-custom-headers-extension/rest-client-custom-headers/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rest-client-custom-headers-extension/rest-client-custom-headers/pom.xml
@@ -18,11 +18,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <quarkus.version>@project.version@</quarkus.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
     </properties>
 
     <modules>

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -63,6 +64,15 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/setup-on-existing-pom/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/setup-on-existing-pom/pom.xml
@@ -10,10 +10,10 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>${compiler-plugin.version}</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/setup-with-custom-quarkus-version/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/setup-with-custom-quarkus-version/pom.xml
@@ -9,10 +9,10 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>${compiler-plugin.version}</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-module-dependency/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-module-dependency/pom.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project>
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.acme</groupId>
@@ -12,10 +13,11 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+        <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
+        <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <modules>
         <module>app</module>
@@ -25,13 +27,24 @@
     </modules>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>\${quarkus-plugin.version}</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>\${quarkus-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-plugin-classpath-config/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-plugin-classpath-config/pom.xml
@@ -7,14 +7,14 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.release>${maven.compiler.release}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-source-sets/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-source-sets/pom.xml
@@ -8,9 +8,9 @@
   <properties>
     <!-- Maven plugin -->
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <dependency-plugin.version>3.2.0</dependency-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <dependency-plugin.version>${maven-dependency-plugin.version}</dependency-plugin.version>
+    <maven.compiler.release>${maven.compiler.release}</maven.compiler.release>
 
     <!-- General project setup -->
     <failsafe.it-phase>verify</failsafe.it-phase>
@@ -39,7 +39,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>${version.surefire.plugin}</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/maven/src/test/resources-filtered/projects/uberjar-check/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/uberjar-check/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -53,6 +54,15 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/uberjar-maven-plugin-config/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/uberjar-maven-plugin-config/pom.xml
@@ -10,9 +10,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-    <maven.compiler.source>11</maven.compiler.source>
+    <compiler-plugin.version>${compiler-plugin.version}</compiler-plugin.version>
+    <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>11</maven.compiler.target>
     <quarkus.package.type>uber-jar</quarkus.package.type>
   </properties>
   <dependencyManagement>
@@ -48,6 +49,15 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>\${compiler-plugin.version}</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>

--- a/test-framework/devmode-test-utils/pom.xml
+++ b/test-framework/devmode-test-utils/pom.xml
@@ -39,6 +39,10 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-os</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/test-framework/devmode-test-utils/src/main/java/io/quarkus/test/devmode/util/DevModeClient.java
+++ b/test-framework/devmode-test-utils/src/main/java/io/quarkus/test/devmode/util/DevModeClient.java
@@ -20,7 +20,15 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
+import io.smallrye.common.os.OS;
+
 public class DevModeClient {
+
+    private static final long DEFAULT_TIMEOUT = OS.current() == OS.WINDOWS ? 3L : 1L;
+
+    static long getDefaultTimeout() {
+        return DEFAULT_TIMEOUT;
+    }
 
     private final int port;
 
@@ -62,7 +70,7 @@ public class DevModeClient {
     }
 
     public void awaitUntilServerDown() {
-        await().atMost(1, TimeUnit.MINUTES).until(() -> {
+        await().atMost(DEFAULT_TIMEOUT, TimeUnit.MINUTES).until(() -> {
             try {
                 get(); // Ignore result on purpose
                 return false;
@@ -82,7 +90,7 @@ public class DevModeClient {
                 .pollDelay(1, TimeUnit.SECONDS)
                 //Allow for a long maximum time as the first hit to a build might require to download dependencies from Maven repositories;
                 //some, such as org.jetbrains.kotlin:kotlin-compiler, are huge and will take more than a minute.
-                .atMost(3, TimeUnit.MINUTES).until(() -> {
+                .atMost(2L + DEFAULT_TIMEOUT, TimeUnit.MINUTES).until(() -> {
                     try {
                         String broken = brokenReason.get();
                         if (broken != null) {

--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/verifier/RunningInvoker.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/verifier/RunningInvoker.java
@@ -112,6 +112,7 @@ public class RunningInvoker extends MavenProcessInvoker {
 
         DefaultInvocationRequest request = new DefaultInvocationRequest();
         request.setGoals(goals);
+        request.setShowErrors(true);
         request.setDebug(debug);
         if (parallel) {
             request.setThreads("1C");


### PR DESCRIPTION
Enforcing versions of the plugins make sure we don't start downloading
them when running the tests which can lead to timeouts.
Also it makes the build more stable and actually tests the version we
are using when creating new projects.

Created as draft as I'd like Alexey's feedback.

To reproduce:
- get this PR
- drop this commit as it fixes the issue: https://github.com/quarkusio/quarkus/commit/d7922d9dbc2109d0b164c5dc2842108f7d783bba
- `mvn clean install`
- `mvn clean install -f integration-tests/maven -Dtest=DevMojoIT#testThatSourceChangesAreDetectedOnPomChange`

My understanding is that if `compile` is in the command line, we don't execute it ourselves but... when we are restarting dev mode due to a POM change, we should run `compile` again.