### PR TITLE
Don't use RuntimeDelegate in ResponseHandler

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResponseHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResponseHandler.java
@@ -146,13 +146,13 @@ public class ResponseHandler implements ServerRestHandler {
                         if (result instanceof GenericEntity) {
                             GenericEntity<?> genericEntity = (GenericEntity<?>) result;
                             requestContext.setGenericReturnType(genericEntity.getType());
-                            responseBuilder = (ResponseBuilderImpl) ResponseImpl.ok(genericEntity.getEntity());
+                            responseBuilder = ResponseBuilderImpl.ok(genericEntity.getEntity());
                         } else if (result == null) {
                             // FIXME: custom status codes depending on method?
-                            responseBuilder = (ResponseBuilderImpl) ResponseImpl.noContent();
+                            responseBuilder = ResponseBuilderImpl.noContent();
                         } else {
                             // FIXME: custom status codes depending on method?
-                            responseBuilder = (ResponseBuilderImpl) ResponseImpl.ok(result);
+                            responseBuilder = ResponseBuilderImpl.ok(result);
                         }
                         if (responseBuilder.getEntity() != null) {
                             EncodedMediaType produces = requestContext.getResponseContentType();

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/ResponseBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/ResponseBuilderImpl.java
@@ -96,19 +96,19 @@ public class ResponseBuilderImpl extends AbstractResponseBuilder {
 
     //TODO: add the rest of static methods of Response if we need them
 
-    public static Response.ResponseBuilder withStatus(Response.Status status) {
-        return new ResponseBuilderImpl().status(status);
+    public static ResponseBuilderImpl withStatus(Response.Status status) {
+        return (ResponseBuilderImpl) new ResponseBuilderImpl().status(status);
     }
 
-    public static Response.ResponseBuilder ok() {
+    public static ResponseBuilderImpl ok() {
         return withStatus(Response.Status.OK);
     }
 
-    public static Response.ResponseBuilder ok(Object entity) {
-        return ok().entity(entity);
+    public static ResponseBuilderImpl ok(Object entity) {
+        return (ResponseBuilderImpl) ok().entity(entity);
     }
 
-    public static Response.ResponseBuilder noContent() {
+    public static ResponseBuilderImpl noContent() {
         return withStatus(Response.Status.NO_CONTENT);
     }
 }


### PR DESCRIPTION
This is needed in order to avoid getting CCE
when other implementations of Jakarta REST are
on the classpath

Closes: #36024