### PR TITLE
Enable local build cache if GRADLE_LOCAL_BUILD_CACHE is defined

### DIFF
--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -23,7 +23,7 @@
     </buildScan>
     <buildCache>
         <local>
-            <enabled>false</enabled>
+            <enabled>#{env['GRADLE_LOCAL_BUILD_CACHE'] != null}</enabled>
         </local>
         <remote>
             <enabled>true</enabled>


### PR DESCRIPTION
Just use:
export GRADLE_LOCAL_BUILD_CACHE=true
to enable the local build cache.