### PR TITLE
Rename field in GeneratedResourceBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedResourceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedResourceBuildItem.java
@@ -4,22 +4,22 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 public final class GeneratedResourceBuildItem extends MultiBuildItem {
     final String name;
-    final byte[] classData;
+    final byte[] data;
 
     // This option is only meant to be set by extensions that also generated the resource on the file system
     // and must rely on Quarkus not getting in the way of loading that resource.
     // It is currently used by Kogito to get serving of static resources in Dev Mode by Vert.x
     final boolean excludeFromDevCL;
 
-    public GeneratedResourceBuildItem(String name, byte[] classData) {
+    public GeneratedResourceBuildItem(String name, byte[] data) {
         this.name = name;
-        this.classData = classData;
+        this.data = data;
         this.excludeFromDevCL = false;
     }
 
-    public GeneratedResourceBuildItem(String name, byte[] classData, boolean excludeFromDevCL) {
+    public GeneratedResourceBuildItem(String name, byte[] data, boolean excludeFromDevCL) {
         this.name = name;
-        this.classData = classData;
+        this.data = data;
         this.excludeFromDevCL = excludeFromDevCL;
     }
 
@@ -27,8 +27,16 @@ public final class GeneratedResourceBuildItem extends MultiBuildItem {
         return name;
     }
 
+    public byte[] getData() {
+        return data;
+    }
+
+    /**
+     * @deprecated use {@link GeneratedResourceBuildItem#getData} instead
+     */
+    @Deprecated(forRemoval = true)
     public byte[] getClassData() {
-        return classData;
+        return getData();
     }
 
     public boolean isExcludeFromDevCL() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/jbang/JBangAugmentorImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jbang/JBangAugmentorImpl.java
@@ -111,7 +111,7 @@ public class JBangAugmentorImpl implements BiConsumer<CuratedApplication, Map<St
                 result.put(i.getName().replace(".", "/") + ".class", i.getClassData());
             }
             for (GeneratedResourceBuildItem i : buildResult.consumeMulti(GeneratedResourceBuildItem.class)) {
-                result.put(i.getName(), i.getClassData());
+                result.put(i.getName(), i.getData());
             }
             for (Map.Entry<Path, Set<TransformedClassesBuildItem.TransformedClass>> entry : buildResult
                     .consume(TransformedClassesBuildItem.class).getTransformedClassesByJar().entrySet()) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -661,7 +661,7 @@ public class JarResultBuildStep {
                 if (target.getParent() != null) {
                     Files.createDirectories(target.getParent());
                 }
-                Files.write(target, i.getClassData());
+                Files.write(target, i.getData());
             }
         }
         if (decompiler != null) {
@@ -1192,10 +1192,10 @@ public class JarResultBuildStep {
                 continue;
             }
             if (i.getName().startsWith("META-INF/services/")) {
-                concatenatedEntries.computeIfAbsent(i.getName(), (u) -> new ArrayList<>()).add(i.getClassData());
+                concatenatedEntries.computeIfAbsent(i.getName(), (u) -> new ArrayList<>()).add(i.getData());
             } else {
                 try (final OutputStream os = wrapForJDK8232879(Files.newOutputStream(target))) {
-                    os.write(i.getClassData());
+                    os.write(i.getData());
                 }
             }
         }

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -409,7 +409,7 @@ public class StartupActionImpl implements StartupAction {
                 if (i.isExcludeFromDevCL()) {
                     continue;
                 }
-                data.put(i.getName(), i.getClassData());
+                data.put(i.getName(), i.getData());
             }
         }
         return data;


### PR DESCRIPTION
The original name is legacy from when the
build item was used only for class data.
This is no longer the case