### PR TITLE
Fix version after which org.graalvm.nativeimage needs to be exported

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -131,6 +131,7 @@ public final class GraalVM {
         public static final Version VERSION_22_3_0 = new Version("GraalVM 22.3.0", "22.3.0", Distribution.ORACLE);
         public static final Version VERSION_22_2_0 = new Version("GraalVM 22.2.0", "22.2.0", Distribution.ORACLE);
         public static final Version VERSION_23_0_0 = new Version("GraalVM 23.0.0", "23.0.0", Distribution.ORACLE);
+        public static final Version VERSION_23_0_999 = new Version("GraalVM 23.0.999", "23.0.999", Distribution.ORACLE);
         public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", Distribution.ORACLE);
 
         public static final Version MINIMUM = VERSION_22_2_0;

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
@@ -53,7 +53,7 @@ public class NativeImageFeatureStep {
         features.produce(new JPMSExportBuildItem("org.graalvm.sdk", "org.graalvm.nativeimage.impl", null,
                 GraalVM.Version.VERSION_23_1_0));
         features.produce(new JPMSExportBuildItem("org.graalvm.nativeimage", "org.graalvm.nativeimage.impl",
-                GraalVM.Version.VERSION_23_0_0));
+                GraalVM.Version.VERSION_23_0_999));
     }
 
     @BuildStep


### PR DESCRIPTION
The goal is to export the module after 23.0.x not after `23.0.0`, i.e., when using `23.0.1` we should not export it.

Wrong version introduced in https://github.com/quarkusio/quarkus/pull/35377

Closes: https://github.com/quarkusio/quarkus/pull/36053