### PR TITLE
Fix version after which org.graalvm.nativeimage needs to be exported

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/JPMSExportBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/JPMSExportBuildItem.java
@@ -12,22 +12,30 @@ import io.quarkus.deployment.pkg.steps.GraalVM;
 public final class JPMSExportBuildItem extends MultiBuildItem {
     private final String moduleName;
     private final String packageName;
-    private final GraalVM.Version exportAfter;
+    private final GraalVM.Version exportSince;
     private final GraalVM.Version exportBefore;
 
     public JPMSExportBuildItem(String moduleName, String packageName) {
         this(moduleName, packageName, null, null);
     }
 
-    public JPMSExportBuildItem(String moduleName, String packageName, GraalVM.Version exportAfter) {
-        this(moduleName, packageName, exportAfter, null);
+    public JPMSExportBuildItem(String moduleName, String packageName, GraalVM.Version exportSince) {
+        this(moduleName, packageName, exportSince, null);
     }
 
-    public JPMSExportBuildItem(String moduleName, String packageName, GraalVM.Version exportAfter,
+    /**
+     * Creates a build item that indicates that a Java package should be exported for a specific GraalVM version range.
+     *
+     * @param moduleName the module name
+     * @param packageName the package name
+     * @param exportSince the version of GraalVM since which the package should be exported (inclusive)
+     * @param exportBefore the version of GraalVM before which the package should be exported (exclusive)
+     */
+    public JPMSExportBuildItem(String moduleName, String packageName, GraalVM.Version exportSince,
             GraalVM.Version exportBefore) {
         this.moduleName = moduleName;
         this.packageName = packageName;
-        this.exportAfter = exportAfter;
+        this.exportSince = exportSince;
         this.exportBefore = exportBefore;
     }
 
@@ -56,8 +64,8 @@ public final class JPMSExportBuildItem extends MultiBuildItem {
         return Objects.hash(moduleName, packageName);
     }
 
-    public GraalVM.Version getExportAfter() {
-        return exportAfter;
+    public GraalVM.Version getExportSince() {
+        return exportSince;
     }
 
     public GraalVM.Version getExportBefore() {
@@ -65,7 +73,7 @@ public final class JPMSExportBuildItem extends MultiBuildItem {
     }
 
     public boolean isRequired(GraalVM.Version current) {
-        return (exportAfter == null || current.compareTo(exportAfter) > 0) &&
+        return (exportSince == null || current.compareTo(exportSince) >= 0) &&
                 (exportBefore == null || current.compareTo(exportBefore) < 0);
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
@@ -53,7 +53,7 @@ public class NativeImageFeatureStep {
         features.produce(new JPMSExportBuildItem("org.graalvm.sdk", "org.graalvm.nativeimage.impl", null,
                 GraalVM.Version.VERSION_23_1_0));
         features.produce(new JPMSExportBuildItem("org.graalvm.nativeimage", "org.graalvm.nativeimage.impl",
-                GraalVM.Version.VERSION_23_0_0));
+                GraalVM.Version.VERSION_23_1_0));
     }
 
     @BuildStep


### PR DESCRIPTION
The goal is to export the module after 23.0.x not after 23.0.0, i.e., when using 23.0.1 we should not export it.

Wrong version introduced in #35377

Supersedes: https://github.com/quarkusio/quarkus/pull/36058

Closes: https://github.com/quarkusio/quarkus/issues/36053