### PR TITLE
Remove update guide from docs yml

### DIFF
--- a/docs/downstreamdoc.yaml
+++ b/docs/downstreamdoc.yaml
@@ -17,4 +17,3 @@ guides:
   - src/main/asciidoc/security-openid-connect-client-reference.adoc
   - src/main/asciidoc/security-overview.adoc
   - src/main/asciidoc/security-proactive-authentication.adoc
-  - src/main/asciidoc/update-quarkus.adoc


### PR DESCRIPTION
Community and product update guides have slightly different steps and requirements.  For RHBQ 3.2, while the product equivalent is based on upstream raw content, it is tweaked and implemented in a Red Hat mod-doc assembly with some other product-specific information.
This PR removes `update.adoc` from the automated downstream import MR.