### PR TITLE
Add optional deployment dependencies to reactive-messaging-kafka-deployment

### DIFF
--- a/extensions/smallrye-reactive-messaging-kafka/deployment/pom.xml
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/pom.xml
@@ -46,6 +46,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-deployment-spi</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-reactive-deployment</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-redis-client-deployment</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
The #31446 described an issue with the build order of HR extension in regard to the RM Kafka which holds an optional dependency to it.

With this change, we are able to get the following maven build order:
 Quarkus - Hibernate Reactive - Runtime
 Quarkus - SmallRye Reactive Messaging - Kafka - Runtime
 Quarkus - Hibernate Reactive - Deployment
 Quarkus - SmallRye Reactive Messaging - Kafka - Deployment

Fixes #31446