### PR TITLE
VertxContextSupport: add utility methods for Multi

### DIFF
--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -445,6 +445,18 @@ NOTE: If necessary, the CDI request context is activated during execution of the
 
 CAUTION: `VertxContextSupport#subscribeAndAwait()` must not be called on an event loop!
 
+It is also possible to subscribe to a supplied `io.smallrye.mutiny.Multi` on a Vert.x duplicated context.
+In this case, the current thread is not blocked and the supplied subscription logic is used to consume the events.
+
+[source, java]
+----
+void onStart(@Observes StartupEvent event, ExternalService service) {
+   VertxContextSupport.subscribeWith(() -> service.getFoos(), foo -> {
+     // do something useful with foo
+   });
+}
+----
+
 
 == Going further
 


### PR DESCRIPTION
- subscribe() and subscribeWith() do not block the current thread