### PR TITLE
Fix duplicate circuit breaker name detection

### DIFF
--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceScanner.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceScanner.java
@@ -80,7 +80,7 @@ final class FaultToleranceScanner {
     void forEachMethod(ClassInfo clazz, Consumer<MethodInfo> action) {
         for (MethodInfo method : clazz.methods()) {
             if (method.name().startsWith("<")) {
-                // constructors (or static init blocks) can't be intercepted
+                // constructors and static inititalizers can't be intercepted
                 continue;
             }
             if (method.isSynthetic()) {

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/duplicate/CircuitBreakerService1.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/duplicate/CircuitBreakerService1.java
@@ -4,11 +4,13 @@ import jakarta.inject.Singleton;
 
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 
+import io.smallrye.faulttolerance.api.CircuitBreakerName;
+
 @Singleton
-@CircuitBreaker
-public class SubCircuitBreakerService extends SuperCircuitBreakerService {
-    @Override
+public class CircuitBreakerService1 {
+    @CircuitBreaker
+    @CircuitBreakerName("hello")
     public String hello() {
-        return "sub";
+        return "1";
     }
 }

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/duplicate/CircuitBreakerService2.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/duplicate/CircuitBreakerService2.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.faulttolerance.test.circuitbreaker.maintenance.inheritance;
+package io.quarkus.smallrye.faulttolerance.test.circuitbreaker.maintenance.duplicate;
 
 import jakarta.inject.Singleton;
 

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/duplicate/DuplicateCircuitBreakerNameTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/duplicate/DuplicateCircuitBreakerNameTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.faulttolerance.test.circuitbreaker.maintenance.inheritance;
+package io.quarkus.smallrye.faulttolerance.test.circuitbreaker.maintenance.duplicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/inheritance/CircuitBreakerNameInheritanceTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/inheritance/CircuitBreakerNameInheritanceTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.faulttolerance.test.circuitbreaker.maintenance.duplicate;
+package io.quarkus.smallrye.faulttolerance.test.circuitbreaker.maintenance.inheritance;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/inheritance/SubCircuitBreakerService.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/inheritance/SubCircuitBreakerService.java
@@ -4,13 +4,11 @@ import jakarta.inject.Singleton;
 
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 
-import io.smallrye.faulttolerance.api.CircuitBreakerName;
-
 @Singleton
-public class CircuitBreakerService1 {
-    @CircuitBreaker
-    @CircuitBreakerName("hello")
+@CircuitBreaker
+public class SubCircuitBreakerService extends SuperCircuitBreakerService {
+    @Override
     public String hello() {
-        return "1";
+        return "sub";
     }
 }

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/inheritance/SuperCircuitBreakerService.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/inheritance/SuperCircuitBreakerService.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.faulttolerance.test.circuitbreaker.maintenance.duplicate;
+package io.quarkus.smallrye.faulttolerance.test.circuitbreaker.maintenance.inheritance;
 
 import jakarta.inject.Singleton;
 

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/noduplicate/CircuitBreakerService1.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/noduplicate/CircuitBreakerService1.java
@@ -1,0 +1,16 @@
+package io.quarkus.smallrye.faulttolerance.test.circuitbreaker.maintenance.noduplicate;
+
+import jakarta.inject.Singleton;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+import io.smallrye.faulttolerance.api.CircuitBreakerName;
+
+@Singleton
+public class CircuitBreakerService1 {
+    @CircuitBreaker
+    @CircuitBreakerName("hello")
+    public String hello() {
+        return "1";
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/noduplicate/CircuitBreakerService2.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/noduplicate/CircuitBreakerService2.java
@@ -1,0 +1,14 @@
+package io.quarkus.smallrye.faulttolerance.test.circuitbreaker.maintenance.noduplicate;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+import io.smallrye.faulttolerance.api.CircuitBreakerName;
+
+public class CircuitBreakerService2 {
+    // this class is not a bean, so there's no circuit breaker and hence no duplicate circuit breaker name
+    @CircuitBreaker
+    @CircuitBreakerName("hello")
+    public String hello() {
+        return "2";
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/noduplicate/NoDuplicateCircuitBreakerNameTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/circuitbreaker/maintenance/noduplicate/NoDuplicateCircuitBreakerNameTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.smallrye.faulttolerance.test.circuitbreaker.maintenance.noduplicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.faulttolerance.api.CircuitBreakerMaintenance;
+import io.smallrye.faulttolerance.api.CircuitBreakerState;
+
+public class NoDuplicateCircuitBreakerNameTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(CircuitBreakerService1.class, CircuitBreakerService2.class));
+
+    @Inject
+    CircuitBreakerMaintenance cb;
+
+    @Test
+    public void deploysWithoutError() {
+        assertNotNull(cb);
+        assertEquals(CircuitBreakerState.CLOSED, cb.currentState("hello"));
+    }
+}


### PR DESCRIPTION
Previously, duplicate circuit breaker names were detected in a crude way: find all occurences of `@CircuitBreakerName` in the Jandex index, collect the values, and fail of some value is present more than once.

With this commit, circuit breaker names are collected in a more precise way: only from beans, and only from methods that are actually detected as methods with fault tolerance annotations. This even correctly includes transformed annotations.

Fixes #36075