### PR TITLE
Allow Build time OpenAPI Filters

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -54,7 +54,7 @@
         <smallrye-config.version>3.3.4</smallrye-config.version>
         <smallrye-health.version>4.0.4</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>3.5.2</smallrye-open-api.version>
+        <smallrye-open-api.version>3.6.0</smallrye-open-api.version>
         <smallrye-graphql.version>2.4.0</smallrye-graphql.version>
         <smallrye-opentracing.version>3.0.3</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>6.2.6</smallrye-fault-tolerance.version>

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -84,6 +84,7 @@ import io.quarkus.resteasy.server.common.spi.AllowedJaxRsAnnotationPrefixBuildIt
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.util.ClassPathUtils;
 import io.quarkus.security.Authenticated;
+import io.quarkus.smallrye.openapi.OpenApiFilter;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.smallrye.openapi.deployment.filter.AutoRolesAllowedFilter;
 import io.quarkus.smallrye.openapi.deployment.filter.AutoServerFilter;
@@ -232,6 +233,23 @@ public class SmallRyeOpenApiProcessor {
 
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(OASFilter.class).setRuntimeInit()
                 .supplier(recorder.autoSecurityFilterSupplier(autoSecurityFilter)).done());
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void registerAnnotatedUserDefinedRuntimeFilters(BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
+            OpenApiFilteredIndexViewBuildItem apiFilteredIndexViewBuildItem,
+            OpenApiRecorder recorder) {
+        Config config = ConfigProvider.getConfig();
+        OpenApiConfig openApiConfig = new OpenApiConfigImpl(config);
+
+        List<String> userDefinedRuntimeFilters = getUserDefinedRuntimeFilters(openApiConfig,
+                apiFilteredIndexViewBuildItem.getIndex());
+
+        syntheticBeans.produce(SyntheticBeanBuildItem.configure(OpenApiRecorder.UserDefinedRuntimeFilters.class)
+                .supplier(recorder.createUserDefinedRuntimeFilters(userDefinedRuntimeFilters))
+                .done());
+
     }
 
     @BuildStep
@@ -430,6 +448,37 @@ public class SmallRyeOpenApiProcessor {
                 addToOpenAPIDefinitionProducer.produce(new AddToOpenAPIDefinitionBuildItem(serverFilter));
             }
         }
+    }
+
+    private List<String> getUserDefinedBuildtimeFilters(OpenApiConfig openApiConfig, IndexView index) {
+        return getUserDefinedFilters(openApiConfig, index, OpenApiFilter.RunStage.BUILD);
+    }
+
+    private List<String> getUserDefinedRuntimeFilters(OpenApiConfig openApiConfig, IndexView index) {
+        List<String> userDefinedFilters = getUserDefinedFilters(openApiConfig, index, OpenApiFilter.RunStage.RUN);
+        // Also add the MP way
+        String filter = openApiConfig.filter();
+        if (filter != null) {
+            userDefinedFilters.add(filter);
+        }
+        return userDefinedFilters;
+    }
+
+    private List<String> getUserDefinedFilters(OpenApiConfig openApiConfig, IndexView index, OpenApiFilter.RunStage stage) {
+        List<String> userDefinedFilters = new ArrayList<>();
+        Collection<AnnotationInstance> annotations = index.getAnnotations(DotName.createSimple(OpenApiFilter.class.getName()));
+        for (AnnotationInstance ai : annotations) {
+            AnnotationTarget annotationTarget = ai.target();
+            ClassInfo classInfo = annotationTarget.asClass();
+            if (classInfo.interfaceNames().contains(DotName.createSimple(OASFilter.class.getName()))) {
+
+                OpenApiFilter.RunStage runStage = OpenApiFilter.RunStage.valueOf(ai.value().asEnum());
+                if (runStage.equals(OpenApiFilter.RunStage.BOTH) || runStage.equals(stage)) {
+                    userDefinedFilters.add(classInfo.name().toString());
+                }
+            }
+        }
+        return userDefinedFilters;
     }
 
     private boolean isManagement(ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
@@ -1100,7 +1149,10 @@ public class SmallRyeOpenApiProcessor {
         OpenApiDocument document = prepareOpenApiDocument(loadedModel, null, Collections.emptyList(), index);
 
         if (includeRuntimeFilters) {
-            document.filter(filter(openApiConfig, index)); // This usually happens at runtime, so when storing we want to filter here too.
+            List<String> userDefinedRuntimeFilters = getUserDefinedRuntimeFilters(openApiConfig, index);
+            for (String s : userDefinedRuntimeFilters) {
+                document.filter(filter(s, index)); // This usually happens at runtime, so when storing we want to filter here too.
+            }
         }
 
         // By default, also add the auto generated server
@@ -1151,6 +1203,11 @@ public class SmallRyeOpenApiProcessor {
             OASFilter otherExtensionFilter = openAPIBuildItem.getOASFilter();
             document.filter(otherExtensionFilter);
         }
+        // Add user defined Build time filters
+        List<String> userDefinedFilters = getUserDefinedBuildtimeFilters(openApiConfig, index);
+        for (String filter : userDefinedFilters) {
+            document.filter(filter(filter, index));
+        }
         return document;
     }
 
@@ -1161,8 +1218,7 @@ public class SmallRyeOpenApiProcessor {
         return document;
     }
 
-    private OASFilter filter(OpenApiConfig openApiConfig, IndexView index) {
-        return OpenApiProcessor.getFilter(openApiConfig,
-                Thread.currentThread().getContextClassLoader(), index);
+    private OASFilter filter(String className, IndexView index) {
+        return OpenApiProcessor.getFilter(className, Thread.currentThread().getContextClassLoader(), index);
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyBuildTimeFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyBuildTimeFilter.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import java.util.Collection;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.info.Info;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.IndexView;
+
+import io.quarkus.smallrye.openapi.OpenApiFilter;
+
+/**
+ * Filter to add custom elements
+ */
+@OpenApiFilter(OpenApiFilter.RunStage.BUILD)
+public class MyBuildTimeFilter implements OASFilter {
+
+    private IndexView view;
+
+    public MyBuildTimeFilter(IndexView view) {
+        this.view = view;
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI openAPI) {
+        Collection<ClassInfo> knownClasses = this.view.getKnownClasses();
+        Info info = OASFactory.createInfo();
+        info.setDescription("Created from Annotated Buildtime filter with " + knownClasses.size() + " known indexed classes");
+        openAPI.setInfo(info);
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyRunTimeFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyRunTimeFilter.java
@@ -1,0 +1,23 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.info.Info;
+
+import io.quarkus.smallrye.openapi.OpenApiFilter;
+
+/**
+ * Filter to add custom elements
+ */
+@OpenApiFilter(OpenApiFilter.RunStage.RUN)
+public class MyRunTimeFilter implements OASFilter {
+
+    @Override
+    public void filterOpenAPI(OpenAPI openAPI) {
+        Info info = OASFactory.createInfo();
+        info.setDescription("Created from Annotated Runtime filter");
+        openAPI.setInfo(info);
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiBuiltTimeFilterTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiBuiltTimeFilterTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiBuiltTimeFilterTestCase {
+    private static final String OPEN_API_PATH = "/q/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(OpenApiResource.class, ResourceBean.class, MyBuildTimeFilter.class));
+
+    @Test
+    public void testOpenApiFilterResource() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("info.description", Matchers.startsWith("Created from Annotated Buildtime filter with"));
+
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiRunTimeFilterTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiRunTimeFilterTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiRunTimeFilterTestCase {
+    private static final String OPEN_API_PATH = "/q/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(OpenApiResource.class, ResourceBean.class, MyRunTimeFilter.class));
+
+    @Test
+    public void testOpenApiFilterResource() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("info.description", Matchers.startsWith("Created from Annotated Runtime filter"));
+
+    }
+
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/OpenApiFilter.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/OpenApiFilter.java
@@ -1,0 +1,27 @@
+package io.quarkus.smallrye.openapi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This extends the MP way to define an `org.eclipse.microprofile.openapi.OASFilter`.
+ * Currently in MP, this needs to be added to a config `mp.openapi.filter` and only allows one filter (class) per application.
+ *
+ * This Annotation, that is Quarkus specific, will allow users to annotate one or more classes and that will be
+ * all that is needed to include the filter. (No config needed). Filters still need to extend.
+ *
+ * @see https://download.eclipse.org/microprofile/microprofile-open-api-3.1.1/microprofile-openapi-spec-3.1.1.html#_oasfilter
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface OpenApiFilter {
+    RunStage value() default RunStage.RUN; // When this filter should run, default Runtime
+
+    static enum RunStage {
+        BUILD,
+        RUN,
+        BOTH
+    }
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -108,5 +109,23 @@ public class OpenApiRecorder {
                 return autoSecurityFilter;
             }
         };
+    }
+
+    public Supplier<?> createUserDefinedRuntimeFilters(List<String> filters) {
+        return new Supplier<Object>() {
+            @Override
+            public UserDefinedRuntimeFilters get() {
+                return new UserDefinedRuntimeFilters() {
+                    @Override
+                    public List<String> filters() {
+                        return filters;
+                    }
+                };
+            }
+        };
+    }
+
+    public interface UserDefinedRuntimeFilters {
+        List<String> filters();
     }
 }


### PR DESCRIPTION
This PR allows users to define Multiple Filters, and allow users to define the filters to run in build time. Users can use an annotation to do this:

```
/**
 * Filter to add custom elements
 */
@OpenApiFilter(OpenApiFilter.RunStage.BUILD)
public class MyBuildTimeFilter implements OASFilter {

    private IndexView view;

    public MyBuildTimeFilter(IndexView view) {
        this.view = view;
    }

    @Override
    public void filterOpenAPI(OpenAPI openAPI) {
        Collection<ClassInfo> knownClasses = this.view.getKnownClasses();
        Info info = OASFactory.createInfo();
        info.setDescription("Created from Annotated Buildtime filter with " + knownClasses.size() + " known indexed classes");
        openAPI.setInfo(info);
    }

}
```
Draft for now, waiting for SmallRye release. 

/cc @MikeEdgar 
/cc @ChMThiel

see this discussion: https://github.com/smallrye/smallrye-open-api/pull/1475