### PR TITLE
Support Java 21 main launch protocol

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -26,6 +26,7 @@ import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.app.RunningQuarkusApplication;
 import io.quarkus.bootstrap.app.StartupAction;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.runner.MainMethodInvoker;
 import io.quarkus.builder.BuildResult;
 import io.quarkus.deployment.builditem.ApplicationClassNameBuildItem;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
@@ -104,13 +105,12 @@ public class StartupActionImpl implements StartupAction {
         try {
             // force init here
             Class<?> appClass = Class.forName(className, true, runtimeClassLoader);
-            Method start = appClass.getMethod("main", String[].class);
             Thread t = new Thread(new Runnable() {
                 @Override
                 public void run() {
                     Thread.currentThread().setContextClassLoader(runtimeClassLoader);
                     try {
-                        start.invoke(null, (Object) (args == null ? new String[0] : args));
+                        MainMethodInvoker.invoke(appClass, args);
                     } catch (Throwable e) {
                         log.error("Error running Quarkus", e);
                         //this can happen if we did not make it to application init

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/MainMethodInvoker.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/MainMethodInvoker.java
@@ -1,0 +1,73 @@
+package io.quarkus.bootstrap.runner;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+public final class MainMethodInvoker {
+
+    // follow the rules outlines in https://openjdk.org/jeps/445 section 'Selecting a main method'
+    public static void invoke(Class<?> mainClass, Object args)
+            throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, InstantiationException {
+
+        // public static void main(String[] args)
+        Method mainWithArgs = null;
+        try {
+            mainWithArgs = mainClass.getDeclaredMethod("main", String[].class);
+            int modifiers = mainWithArgs.getModifiers();
+            if (Modifier.isStatic(modifiers) && !Modifier.isPrivate(modifiers)) {
+                if (!Modifier.isPublic(modifiers)) {
+                    mainWithArgs.setAccessible(true);
+                }
+                mainWithArgs.invoke(null, args);
+                return;
+            }
+        } catch (NoSuchMethodException ignored) {
+
+        }
+
+        // public static void main()
+        Method mainWithoutArgs = null;
+        try {
+            mainWithoutArgs = mainClass.getDeclaredMethod("main");
+            int modifiers = mainWithoutArgs.getModifiers();
+            if (Modifier.isStatic(modifiers) && !Modifier.isPrivate(modifiers)) {
+                if (!Modifier.isPublic(modifiers)) {
+                    mainWithoutArgs.setAccessible(true);
+                }
+                mainWithoutArgs.invoke(null);
+                return;
+            }
+        } catch (NoSuchMethodException ignored) {
+
+        }
+
+        var instance = mainClass.getConstructor().newInstance();
+
+        // public void main(String[] args)
+        if (mainWithArgs != null) {
+            int modifiers = mainWithArgs.getModifiers();
+            if (!Modifier.isPrivate(modifiers)) {
+                if (!Modifier.isPublic(modifiers)) {
+                    mainWithArgs.setAccessible(true);
+                }
+                mainWithArgs.invoke(instance, args);
+                return;
+            }
+        }
+
+        // public void main()
+        if (mainWithoutArgs != null) {
+            int modifiers = mainWithoutArgs.getModifiers();
+            if (!Modifier.isPrivate(modifiers)) {
+                if (!Modifier.isPublic(modifiers)) {
+                    mainWithoutArgs.setAccessible(true);
+                }
+                mainWithoutArgs.invoke(instance);
+                return;
+            }
+        }
+
+        throw new NoSuchMethodException("Unable to find main method");
+    }
+}

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/QuarkusEntryPoint.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/QuarkusEntryPoint.java
@@ -1,5 +1,7 @@
 package io.quarkus.bootstrap.runner;
 
+import static io.quarkus.bootstrap.runner.MainMethodInvoker.invoke;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -36,7 +38,7 @@ public class QuarkusEntryPoint {
         }
     }
 
-    private static void doRun(Object args) throws IOException, ClassNotFoundException, IllegalAccessException,
+    private static void doRun(String[] args) throws IOException, ClassNotFoundException, IllegalAccessException,
             InvocationTargetException, NoSuchMethodException {
         String path = QuarkusEntryPoint.class.getProtectionDomain().getCodeSource().getLocation().getPath();
         String decodedPath = URLDecoder.decode(path, "UTF-8");
@@ -57,8 +59,12 @@ public class QuarkusEntryPoint {
             try {
                 Thread.currentThread().setContextClassLoader(appRunnerClassLoader);
                 QuarkusForkJoinWorkerThread.setQuarkusAppClassloader(appRunnerClassLoader);
+
                 Class<?> mainClass = appRunnerClassLoader.loadClass(app.getMainClass());
-                mainClass.getMethod("main", String[].class).invoke(null, args);
+
+                invoke(mainClass, args);
+            } catch (InstantiationException e) {
+                throw new RuntimeException(e);
             } finally {
                 QuarkusForkJoinWorkerThread.setQuarkusAppClassloader(null);
                 appRunnerClassLoader.close();


### PR DESCRIPTION
This is quick and dirty support for selecting the main method according to the new Java 21 protocol, 
but we might want to consider the alternative of doing bytecode transformation of the main method 
at build time (if necessary obviously)

Closes: #36154

