### PR TITLE
Improve handling of broken accept headers in MediaTypeHeaderDelegate

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/headers/MediaTypeHeaderDelegate.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/headers/MediaTypeHeaderDelegate.java
@@ -80,6 +80,9 @@ public class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<M
         } else {
             major = type.substring(0, typeIndex);
             if (paramIndex > -1) {
+                if (typeIndex + 1 > paramIndex) {
+                    throw new IllegalArgumentException("Failed to parse media type " + type);
+                }
                 subtype = type.substring(typeIndex + 1, paramIndex);
             } else {
                 subtype = type.substring(typeIndex + 1);

--- a/independent-projects/resteasy-reactive/common/runtime/src/test/java/org/jboss/resteasy/reactive/common/headers/MediaTypeHeaderDelegateTest.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/test/java/org/jboss/resteasy/reactive/common/headers/MediaTypeHeaderDelegateTest.java
@@ -1,0 +1,21 @@
+package org.jboss.resteasy.reactive.common.headers;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MediaTypeHeaderDelegateTest {
+
+    public void parsingBrokenMediaTypeShouldThrowIllegalArgumentException_minimized() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            MediaTypeHeaderDelegate.parse("x; /x");
+        });
+    }
+
+    @Test
+    public void parsingBrokenMediaTypeShouldThrowIllegalArgumentException_actual() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            MediaTypeHeaderDelegate.parse("() { ::}; echo \"NS:\" $(/bin/sh -c \"expr 123456 - 123456\")");
+        });
+    }
+
+}


### PR DESCRIPTION
Previously, a "broken" MIME-type in an access header could trigger an StringIndexOutOfBoundsException during MediaTypeHeaderDelegate.parse(..) instead of the more suitable IllegalArgumentException.

Example: "Accept: x; /x"

This PR now throws an IllegalArgumentException in case of a broken MIME-type like in the example.

Fixes #36159