### PR TITLE
Config: injection verification during the native image build

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -70,6 +70,7 @@ import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.configuration.definition.RootDefinition;
+import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -83,7 +84,7 @@ public class ConfigBuildStep {
     private static final Logger LOGGER = Logger.getLogger(ConfigBuildStep.class.getName());
 
     private static final DotName MP_CONFIG = DotName.createSimple(Config.class.getName());
-    private static final DotName MP_CONFIG_PROPERTY_NAME = DotName.createSimple(ConfigProperty.class.getName());
+    static final DotName MP_CONFIG_PROPERTY_NAME = DotName.createSimple(ConfigProperty.class.getName());
     private static final DotName MP_CONFIG_PROPERTIES_NAME = DotName.createSimple(ConfigProperties.class.getName());
     private static final DotName MP_CONFIG_VALUE_NAME = DotName.createSimple(ConfigValue.class.getName());
 
@@ -290,6 +291,7 @@ public class ConfigBuildStep {
             BeanRegistrationPhaseBuildItem beanRegistration,
             List<ConfigClassBuildItem> configClasses,
             CombinedIndexBuildItem combinedIndex,
+            PackageConfig packageConfig,
             BuildProducer<BeanConfiguratorBuildItem> beanConfigurator) {
 
         if (configClasses.isEmpty()) {
@@ -323,7 +325,8 @@ public class ConfigBuildStep {
                     .creator(ConfigMappingCreator.class)
                     .addInjectionPoint(ClassType.create(DotNames.INJECTION_POINT))
                     .param("type", configClass.getConfigClass())
-                    .param("prefix", configClass.getPrefix());
+                    .param("prefix", configClass.getPrefix())
+                    .param("nativeBuild", packageConfig.type.equalsIgnoreCase(PackageConfig.BuiltInType.NATIVE.getValue()));
 
             if (configClass.getConfigClass().isAnnotationPresent(Unremovable.class)) {
                 bean.unremovable();
@@ -338,6 +341,7 @@ public class ConfigBuildStep {
             BeanRegistrationPhaseBuildItem beanRegistration,
             List<ConfigClassBuildItem> configClasses,
             CombinedIndexBuildItem combinedIndex,
+            PackageConfig packageConfig,
             BuildProducer<BeanConfiguratorBuildItem> beanConfigurator) {
 
         if (configClasses.isEmpty()) {
@@ -371,7 +375,9 @@ public class ConfigBuildStep {
                             .creator(ConfigMappingCreator.class)
                             .addInjectionPoint(ClassType.create(DotNames.INJECTION_POINT))
                             .param("type", configClass.getConfigClass())
-                            .param("prefix", configClass.getPrefix())));
+                            .param("prefix", configClass.getPrefix())
+                            .param("nativeBuild",
+                                    packageConfig.type.equalsIgnoreCase(PackageConfig.BuiltInType.NATIVE.getValue()))));
         }
     }
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigBuildStep.java
@@ -30,7 +30,6 @@ import java.util.stream.Stream;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.CreationException;
 
-import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigValue;
 import org.eclipse.microprofile.config.inject.ConfigProperties;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -42,10 +41,8 @@ import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.MethodInfo;
-import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
-import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Unremovable;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem.BeanConfiguratorBuildItem;
@@ -67,7 +64,6 @@ import io.quarkus.deployment.builditem.ConfigMappingBuildItem;
 import io.quarkus.deployment.builditem.ConfigPropertiesBuildItem;
 import io.quarkus.deployment.builditem.ConfigurationBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
-import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.configuration.definition.RootDefinition;
 import io.quarkus.deployment.pkg.PackageConfig;
@@ -81,14 +77,11 @@ import io.smallrye.config.inject.ConfigProducer;
  * MicroProfile Config related build steps.
  */
 public class ConfigBuildStep {
-    private static final Logger LOGGER = Logger.getLogger(ConfigBuildStep.class.getName());
 
-    private static final DotName MP_CONFIG = DotName.createSimple(Config.class.getName());
     static final DotName MP_CONFIG_PROPERTY_NAME = DotName.createSimple(ConfigProperty.class.getName());
     private static final DotName MP_CONFIG_PROPERTIES_NAME = DotName.createSimple(ConfigProperties.class.getName());
     private static final DotName MP_CONFIG_VALUE_NAME = DotName.createSimple(ConfigValue.class.getName());
 
-    private static final DotName SR_CONFIG = DotName.createSimple(io.smallrye.config.SmallRyeConfig.class.getName());
     private static final DotName SR_CONFIG_VALUE_NAME = DotName.createSimple(io.smallrye.config.ConfigValue.class.getName());
 
     private static final DotName MAP_NAME = DotName.createSimple(Map.class.getName());
@@ -478,67 +471,6 @@ public class ConfigBuildStep {
         }
 
         toRegister.forEach(configProperties::produce);
-    }
-
-    @BuildStep
-    void warnStaticInitInjectionPoints(
-            CombinedIndexBuildItem indexBuildItem,
-            ValidationPhaseBuildItem validationPhase,
-            List<ConfigClassBuildItem> configClasses,
-            List<ConfigInjectionStaticInitBuildItem> configInjectionStaticInit,
-            BuildProducer<RunTimeConfigurationDefaultBuildItem> runTimeConfigurationDefault) {
-
-        // Add here annotated classes that are initialized during static init
-        Set<DotName> declaringClassCandidates = configInjectionStaticInit.stream()
-                .map(ConfigInjectionStaticInitBuildItem::getDeclaringCandidate).collect(toSet());
-
-        Set<Type> configClassesTypes = configClasses.stream().map(ConfigClassBuildItem::getTypes).flatMap(Collection::stream)
-                .collect(toSet());
-
-        for (InjectionPointInfo injectionPoint : validationPhase.getContext().getInjectionPoints()) {
-            if (injectionPoint.getType().name().equals(DotNames.INSTANCE)) {
-                continue;
-            }
-
-            Type type = Type.create(injectionPoint.getRequiredType().name(), Type.Kind.CLASS);
-            DotName injectionTypeName = null;
-            if (type.name().equals(MP_CONFIG) || type.name().equals(SR_CONFIG)) {
-                injectionTypeName = type.name();
-            } else if (injectionPoint.getRequiredQualifier(MP_CONFIG_PROPERTY_NAME) != null) {
-                injectionTypeName = MP_CONFIG_PROPERTY_NAME;
-            } else if (configClassesTypes.contains(type)) {
-                injectionTypeName = type.name();
-            }
-
-            if (injectionTypeName != null) {
-                AnnotationTarget target = injectionPoint.getTarget();
-                if (FIELD.equals(target.kind())) {
-                    FieldInfo field = target.asField();
-                    ClassInfo declaringClass = field.declaringClass();
-                    Map<DotName, List<AnnotationInstance>> annotationsMap = declaringClass.annotationsMap();
-                    for (DotName declaringClassCandidate : declaringClassCandidates) {
-                        List<AnnotationInstance> annotationInstances = annotationsMap.get(declaringClassCandidate);
-                        if (annotationInstances != null && annotationInstances.size() == 1) {
-                            AnnotationInstance annotationInstance = annotationInstances.get(0);
-                            if (annotationInstance.target().equals(declaringClass)) {
-                                LOGGER.warn("Directly injecting a " +
-                                        injectionTypeName +
-                                        " into a " +
-                                        declaringClassCandidate +
-                                        " may lead to unexpected results. To ensure proper results, please " +
-                                        "change the type of the field to " +
-                                        ParameterizedType.create(DotNames.INSTANCE, new Type[] { type }, null) +
-                                        ". Offending field is '" +
-                                        field.name() +
-                                        "' of class '" +
-                                        field.declaringClass() +
-                                        "'");
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 
     @BuildStep

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigInjectionStaticInitBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigInjectionStaticInitBuildItem.java
@@ -4,7 +4,13 @@ import org.jboss.jandex.DotName;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
+/**
+ *
+ * @deprecated TODO
+ */
+@Deprecated(forRemoval = true)
 public final class ConfigInjectionStaticInitBuildItem extends MultiBuildItem {
+
     private final DotName declaringCandidate;
 
     public ConfigInjectionStaticInitBuildItem(final DotName declaringCandidate) {

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigInjectionStaticInitBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ConfigInjectionStaticInitBuildItem.java
@@ -6,7 +6,7 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  *
- * @deprecated TODO
+ * @deprecated This build item is not used anymore
  */
 @Deprecated(forRemoval = true)
 public final class ConfigInjectionStaticInitBuildItem extends MultiBuildItem {

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/NativeBuildConfigSteps.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/NativeBuildConfigSteps.java
@@ -1,0 +1,73 @@
+package io.quarkus.arc.deployment;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.inject.Singleton;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
+
+import io.quarkus.arc.processor.AnnotationsTransformer;
+import io.quarkus.arc.processor.DotNames;
+import io.quarkus.arc.processor.InjectionPointInfo;
+import io.quarkus.arc.runtime.NativeBuildConfigCheck;
+import io.quarkus.arc.runtime.NativeBuildConfigCheckInterceptor;
+import io.quarkus.arc.runtime.NativeBuildConfigContext;
+import io.quarkus.arc.runtime.NativeBuildConfigContextCreator;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ConfigurationBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeBuild;
+
+public class NativeBuildConfigSteps {
+
+    @BuildStep(onlyIf = NativeBuild.class)
+    SyntheticBeanBuildItem registerNativeBuildConfigContext(ConfigurationBuildItem config,
+            BeanDiscoveryFinishedBuildItem beanDiscoveryFinished) {
+
+        // Collect all @ConfigProperty injection points
+        Set<String> injectedProperties = new HashSet<>();
+        for (InjectionPointInfo injectionPoint : beanDiscoveryFinished.getInjectionPoints()) {
+            if (injectionPoint.hasDefaultedQualifier()) {
+                continue;
+            }
+            AnnotationInstance configProperty = injectionPoint.getRequiredQualifier(ConfigBuildStep.MP_CONFIG_PROPERTY_NAME);
+            if (configProperty != null) {
+                injectedProperties.add(configProperty.value("name").asString());
+            }
+        }
+
+        // Retain only BUILD_AND_RUN_TIME_FIXED properties
+        injectedProperties.retainAll(config.getReadResult().getBuildTimeRunTimeValues().keySet());
+
+        return SyntheticBeanBuildItem.configure(NativeBuildConfigContext.class)
+                .param(
+                        "buildAndRunTimeFixed",
+                        injectedProperties.toArray(String[]::new))
+                .creator(NativeBuildConfigContextCreator.class)
+                .scope(Singleton.class)
+                .done();
+
+    }
+
+    @BuildStep(onlyIf = NativeBuild.class)
+    AdditionalBeanBuildItem registerBeans() {
+        return AdditionalBeanBuildItem.builder().addBeanClasses(NativeBuildConfigCheckInterceptor.class,
+                NativeBuildConfigCheck.class).build();
+    }
+
+    @BuildStep(onlyIf = NativeBuild.class)
+    AnnotationsTransformerBuildItem transformConfigProducer() {
+        DotName configProducerName = DotName.createSimple("io.smallrye.config.inject.ConfigProducer");
+
+        return new AnnotationsTransformerBuildItem(AnnotationsTransformer.appliedToMethod().whenMethod(m -> {
+            // Apply to all producer methods declared on io.smallrye.config.inject.ConfigProducer
+            return m.declaringClass().name().equals(configProducerName)
+                    && m.hasAnnotation(DotNames.PRODUCES)
+                    && m.hasAnnotation(ConfigBuildStep.MP_CONFIG_PROPERTY_NAME);
+        }).thenTransform(t -> {
+            t.add(NativeBuildConfigCheck.class);
+        }));
+    }
+
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/nativebuild/Fail.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/nativebuild/Fail.java
@@ -1,0 +1,19 @@
+package io.quarkus.arc.test.config.nativebuild;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Singleton
+public class Fail {
+
+    @ConfigProperty(name = "foo", defaultValue = "bar")
+    String value;
+
+    // triggers init during static init of native build
+    void init(@Observes @Initialized(ApplicationScoped.class) Object event) {
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/nativebuild/NativeBuildConfigInjectionFailTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/nativebuild/NativeBuildConfigInjectionFailTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.arc.test.config.nativebuild;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class NativeBuildConfigInjectionFailTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
+            .setBuildNative(true)
+            .withApplicationRoot(
+                    root -> root.addClass(Fail.class))
+            // ImageGenerationFailureException is private
+            .setExpectedException(RuntimeException.class);
+
+    @Test
+    void test() {
+        fail();
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/nativebuild/NativeBuildConfigInjectionOkTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/nativebuild/NativeBuildConfigInjectionOkTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.arc.test.config.nativebuild;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class NativeBuildConfigInjectionOkTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
+            .setBuildNative(true)
+            .withApplicationRoot(
+                    root -> root.addClass(Ok.class));
+
+    @Test
+    void test() {
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/nativebuild/Ok.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/nativebuild/Ok.java
@@ -1,0 +1,22 @@
+package io.quarkus.arc.test.config.nativebuild;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.arc.config.NativeBuildTime;
+
+@Singleton
+public class Ok {
+
+    @NativeBuildTime
+    @ConfigProperty(name = "foo", defaultValue = "bar")
+    String value;
+
+    // triggers init during static init of native build
+    void init(@Observes @Initialized(ApplicationScoped.class) Object event) {
+    }
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/config/NativeBuildTime.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/config/NativeBuildTime.java
@@ -1,0 +1,20 @@
+package io.quarkus.arc.config;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * A config property injected during the static initialization phase of a native image build may result in unexpected errors
+ * because the injected value was obtained at build time and cannot be updated at runtime.
+ * <p>
+ * If it's intentional and expected then use this annotation to eliminate the false positive.
+ */
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER })
+public @interface NativeBuildTime {
+
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigMappingCreator.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigMappingCreator.java
@@ -2,6 +2,7 @@ package io.quarkus.arc.runtime;
 
 import java.lang.annotation.Annotation;
 import java.util.Optional;
+import java.util.Set;
 
 import jakarta.enterprise.inject.spi.Annotated;
 import jakarta.enterprise.inject.spi.InjectionPoint;
@@ -21,6 +22,10 @@ public class ConfigMappingCreator implements BeanCreator<Object> {
         InjectionPoint injectionPoint = context.getInjectedReference(InjectionPoint.class);
         if (injectionPoint == null) {
             throw new IllegalStateException("No current injection point found");
+        }
+
+        if ((boolean) context.getParams().get("nativeBuild")) {
+            NativeBuildConfigCheckInterceptor.verifyCurrentImageMode(Set.of());
         }
 
         Class<?> interfaceType = (Class<?>) context.getParams().get("type");

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/NativeBuildConfigCheck.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/NativeBuildConfigCheck.java
@@ -1,0 +1,20 @@
+package io.quarkus.arc.runtime;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.interceptor.InterceptorBinding;
+
+/**
+ * Interceptor binding for {@link NativeBuildConfigCheckInterceptor}.
+ */
+@InterceptorBinding
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD })
+public @interface NativeBuildConfigCheck {
+
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/NativeBuildConfigCheckInterceptor.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/NativeBuildConfigCheckInterceptor.java
@@ -1,0 +1,114 @@
+package io.quarkus.arc.runtime;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.spi.Annotated;
+import jakarta.enterprise.inject.spi.AnnotatedConstructor;
+import jakarta.enterprise.inject.spi.AnnotatedField;
+import jakarta.enterprise.inject.spi.AnnotatedParameter;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.config.NativeBuildTime;
+import io.quarkus.arc.impl.InjectionPointProvider;
+import io.quarkus.runtime.ImageMode;
+
+/**
+ * The goal of this interceptor is to verify the current ImageMode when a dependent config property is being injected.
+ */
+@Priority(jakarta.interceptor.Interceptor.Priority.PLATFORM_BEFORE)
+@Interceptor
+@NativeBuildConfigCheck
+public class NativeBuildConfigCheckInterceptor {
+
+    private static final Logger LOG = Logger.getLogger(NativeBuildConfigCheckInterceptor.class);
+
+    @Inject
+    NativeBuildConfigContext nativeBuildConfigContext;
+
+    @AroundInvoke
+    Object aroundInvoke(InvocationContext context) throws Exception {
+        verifyCurrentImageMode(nativeBuildConfigContext.getBuildAndRunTimeFixed());
+        return context.proceed();
+    }
+
+    static void verifyCurrentImageMode(Set<String> buildAndRunTimeFixed) {
+        if (ImageMode.current() != ImageMode.NATIVE_BUILD) {
+            return;
+        }
+        InjectionPoint injectionPoint = InjectionPointProvider.get();
+        if (injectionPoint != null) {
+            // Skip injection points annotated with NativeBuildTime
+            Annotated annotated = injectionPoint.getAnnotated();
+            if (annotated != null && annotated.isAnnotationPresent(NativeBuildTime.class)) {
+                return;
+            }
+            // Skip BUILD_AND_RUN_TIME_FIXED properties
+            if (!buildAndRunTimeFixed.isEmpty()) {
+                String propertyName = null;
+                for (Annotation qualifier : injectionPoint.getQualifiers()) {
+                    if (qualifier instanceof ConfigProperty) {
+                        propertyName = ((ConfigProperty) qualifier).name();
+                    }
+                }
+                if (propertyName != null && buildAndRunTimeFixed.contains(propertyName)) {
+                    return;
+                }
+            }
+        }
+        StringBuilder b = new StringBuilder();
+        b.append("\n\n");
+        b.append("=".repeat(120));
+        b.append("\nPOSSIBLE CONFIG INJECTION PROBLEM DETECTED\n");
+        b.append("-".repeat(120));
+        b.append("\nA config object was injected during the static initialization phase of a native image build.\n");
+        b.append(
+                "This may result in unexpected errors.\n");
+        b.append("The injected value was obtained at native image build time and cannot be updated at runtime.\n\n");
+        if (injectionPoint != null) {
+            b.append("Injection point: ");
+            b.append(injectionPointToString(injectionPoint));
+            b.append("\n");
+        }
+        b.append("Solutions:\n");
+        b.append("\t- If that's intentional then annotate the injected field/parameter with @");
+        b.append(NativeBuildTime.class.getName());
+        b.append(" to eliminate the false positive\n");
+        b.append(
+                "\t- You can leverage the programmatic lookup to delay the retrieval of a config property; for example '@ConfigProperty(name = \"foo\") Instance<String> foo'\n");
+        b.append(
+                "\t- You can try to use a normal CDI scope (e.g. @ApplicationScoped) to initialize the bean lazily; this may help if the is only injected but not directly used during the static initialization phase");
+        b.append("\n");
+        b.append("=".repeat(120));
+        b.append("\n\n");
+
+        LOG.error(b.toString());
+        throw new IllegalStateException(
+                "POSSIBLE CONFIG INJECTION PROBLEM DETECTED: a config object was injected during the static initialization phase of a native image build. See the error message above for more details.");
+    }
+
+    private static String injectionPointToString(InjectionPoint injectionPoint) {
+        Annotated annotated = injectionPoint.getAnnotated();
+        if (annotated instanceof AnnotatedField) {
+            AnnotatedField<?> field = (AnnotatedField<?>) annotated;
+            return field.getDeclaringType().getJavaClass().getName() + "#" + field.getJavaMember().getName();
+        } else if (annotated instanceof AnnotatedParameter) {
+            AnnotatedParameter<?> param = (AnnotatedParameter<?>) annotated;
+            if (param.getDeclaringCallable() instanceof AnnotatedConstructor) {
+                return param.getDeclaringCallable().getDeclaringType().getJavaClass().getName() + "()";
+            } else {
+                return param.getDeclaringCallable().getDeclaringType().getJavaClass().getName() + "#"
+                        + param.getDeclaringCallable().getJavaMember().getName() + "()";
+            }
+        }
+        return injectionPoint.toString();
+    }
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/NativeBuildConfigContext.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/NativeBuildConfigContext.java
@@ -1,0 +1,18 @@
+package io.quarkus.arc.runtime;
+
+import java.util.Set;
+
+import io.quarkus.arc.config.NativeBuildTime;
+
+/**
+ * @see NativeBuildTime
+ * @see NativeBuildConfigCheckInterceptor
+ */
+public interface NativeBuildConfigContext {
+
+    /**
+     *
+     * @return the injected BUILD_AND_RUN_TIME_FIXED properties
+     */
+    Set<String> getBuildAndRunTimeFixed();
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/NativeBuildConfigContextCreator.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/NativeBuildConfigContextCreator.java
@@ -1,0 +1,22 @@
+package io.quarkus.arc.runtime;
+
+import java.util.Set;
+
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+
+public class NativeBuildConfigContextCreator implements BeanCreator<NativeBuildConfigContext> {
+
+    @Override
+    public NativeBuildConfigContext create(SyntheticCreationalContext<NativeBuildConfigContext> context) {
+        Set<String> buildAndRunTimeFixed = Set.of((String[]) context.getParams().get("buildAndRunTimeFixed"));
+        return new NativeBuildConfigContext() {
+
+            @Override
+            public Set<String> getBuildAndRunTimeFixed() {
+                return buildAndRunTimeFixed;
+            }
+        };
+    }
+
+}

--- a/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -43,7 +43,6 @@ import org.jboss.resteasy.spi.InjectorFactory;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanArchiveIndexBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
-import io.quarkus.arc.deployment.ConfigInjectionStaticInitBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.Capabilities;
@@ -179,11 +178,6 @@ public class ResteasyCommonProcessor {
             ResteasyInjectorFactoryRecorder recorder) {
         RuntimeValue<InjectorFactory> injectorFactory = recorder.setup();
         return new ResteasyInjectionReadyBuildItem(injectorFactory);
-    }
-
-    @BuildStep
-    ConfigInjectionStaticInitBuildItem configInjectionStaticInitProvider() {
-        return new ConfigInjectionStaticInitBuildItem(ResteasyDotNames.PROVIDER);
     }
 
     @BuildStep

--- a/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
+++ b/extensions/undertow/deployment/src/main/java/io/quarkus/undertow/deployment/UndertowBuildStep.java
@@ -81,7 +81,6 @@ import org.jboss.metadata.web.spec.WebResourceCollectionMetaData;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
-import io.quarkus.arc.deployment.ConfigInjectionStaticInitBuildItem;
 import io.quarkus.arc.deployment.ContextRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.ContextRegistrationPhaseBuildItem.ContextConfiguratorBuildItem;
 import io.quarkus.arc.deployment.CustomScopeBuildItem;
@@ -683,11 +682,6 @@ public class UndertowBuildStep {
             UndertowDeploymentRecorder recorder) {
         return SyntheticBeanBuildItem.configure(ServletContext.class).scope(ApplicationScoped.class)
                 .supplier(recorder.servletContextSupplier()).done();
-    }
-
-    @BuildStep
-    ConfigInjectionStaticInitBuildItem configInjectionStaticInitAnnotations() {
-        return new ConfigInjectionStaticInitBuildItem(WEB_FILTER);
     }
 
     /**


### PR DESCRIPTION
- verify the current ImageMode when a config object is injected
- fail if injected  during the static initialization phase of a native image build

See also discussion in https://github.com/quarkusio/quarkus/discussions/36125

The error message looks like:
```
========================================================================================================================
POSSIBLE CONFIG INJECTION PROBLEM DETECTED
------------------------------------------------------------------------------------------------------------------------
A config object was injected during the static initialization phase of a native image build.
This may result in unexpected errors.
The injected value was obtained at native image build time and cannot be updated at runtime.

Injection point: org.acme.config.Failure#init()
Solutions:
	- If that's intentional then annotate the injected field/parameter with @io.quarkus.arc.config.NativeBuildTime to eliminate the false positive
	- You can leverage the programmatic lookup to delay the injection of a config property; for example '@ConfigProperty(name = "foo") Instance<String> foo'
	- You can try to use a normal CDI scope to initialize the bean lazily; this may help if the is only injected but not directly used during the static initialization phase
========================================================================================================================

```