### PR TITLE
Introduce a `-Dclean-cache` flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,6 +352,10 @@ in `quarkus-parent` (root `pom.xml`).
 
 When contributing to Quarkus, it is recommended to respect the following rules.
 
+> **Note:** The `impsort-maven-plugin` uses the `.cache` directory on each module to speed up the build.
+> Because we have configured the plugin to store in a versioned directory, you may notice over time that the `.cache` directory grows in size. You can safely delete the `.cache` directory in each module to reclaim the space. 
+> Running `./mvnw clean -Dclean-cache` automatically deletes that directory for you.
+
 **Contributing to an extension**
 
 When you contribute to an extension, after having applied your changes, run:

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -692,6 +692,40 @@
     </build>
     <profiles>
         <profile>
+            <id>clean-cache</id>
+            <activation>
+                <property>
+                    <name>clean-cache</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>clean-cache-dirs</id>
+                                <phase>pre-clean</phase>
+                                <inherited>true</inherited>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                                <configuration>
+                                    <filesets>
+                                        <fileset>
+                                            <directory>.cache</directory>
+                                        </fileset>
+                                    </filesets>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>release</id>
             <build>
                 <plugins>


### PR DESCRIPTION
When the build is executed with this flag, it removes the `.cache` which contains storage from the import and sort plugins per version (which may grow over time)