### PR TITLE
Rename tooling codestarts

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/filtered/codestarts/quarkus/tooling/gradle-wrapper/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/filtered/codestarts/quarkus/tooling/gradle-wrapper/codestart.yml
@@ -1,4 +1,4 @@
-name: gradle-wrapper
+name: tooling-gradle-wrapper
 type: tooling
 output-strategy:
   "gradlew": "executable"

--- a/independent-projects/tools/base-codestarts/src/main/filtered/codestarts/quarkus/tooling/maven-wrapper/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/filtered/codestarts/quarkus/tooling/maven-wrapper/codestart.yml
@@ -1,4 +1,4 @@
-name: maven-wrapper
+name: tooling-maven-wrapper
 type: tooling
 output-strategy:
   "mvnw": "executable"

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/codestart.yml
@@ -1,4 +1,4 @@
-name: dockerfiles
+name: tooling-dockerfiles
 type: tooling
 language:
   base:

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/github-action/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/github-action/codestart.yml
@@ -1,2 +1,2 @@
-name: github-action
+name: tooling-github-action
 type: tooling

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
@@ -69,9 +69,10 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
     }
 
     public enum Tooling implements DataKey {
-        GRADLE_WRAPPER,
-        MAVEN_WRAPPER,
-        DOCKERFILES
+        TOOLING_GRADLE_WRAPPER,
+        TOOLING_MAVEN_WRAPPER,
+        TOOLING_DOCKERFILES,
+        TOOLING_GITHUB_ACTION
     }
 
     public enum ExtensionCodestart implements DataKey {
@@ -244,17 +245,17 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
             switch (projectInput.getBuildTool()) {
                 case GRADLE:
                 case GRADLE_KOTLIN_DSL:
-                    codestarts.add(QuarkusCodestartCatalog.Tooling.GRADLE_WRAPPER.key());
+                    codestarts.add(Tooling.TOOLING_GRADLE_WRAPPER.key());
                     break;
                 case MAVEN:
-                    codestarts.add(QuarkusCodestartCatalog.Tooling.MAVEN_WRAPPER.key());
+                    codestarts.add(Tooling.TOOLING_MAVEN_WRAPPER.key());
                     break;
                 default:
                     throw new IllegalArgumentException("Unsupported build tool wrapper: " + projectInput.getBuildTool());
             }
         }
         if (projectInput.getAppContent().contains(AppContent.DOCKERFILES)) {
-            codestarts.add(QuarkusCodestartCatalog.Tooling.DOCKERFILES.key());
+            codestarts.add(QuarkusCodestartCatalog.Tooling.TOOLING_DOCKERFILES.key());
         }
         return codestarts;
     }

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalogTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalogTest.java
@@ -82,8 +82,8 @@ class QuarkusCodestartCatalogTest {
                 .isEqualTo("java");
         assertThat(projectDefinition.getBaseCodestarts()).hasSize(4);
         assertThat(projectDefinition.getExtraCodestarts()).extracting(Codestart::getName)
-                .containsExactlyInAnyOrder("dockerfiles",
-                        "maven-wrapper");
+                .containsExactlyInAnyOrder("tooling-dockerfiles",
+                        "tooling-maven-wrapper");
     }
 
     @Test
@@ -136,8 +136,8 @@ class QuarkusCodestartCatalogTest {
                 .contains("config-properties");
         assertThat(projectDefinition.getExtraCodestarts()).extracting(Codestart::getName)
                 .containsExactlyInAnyOrder(
-                        "dockerfiles",
-                        "maven-wrapper",
+                        "tooling-dockerfiles",
+                        "tooling-maven-wrapper",
                         "resteasy-codestart");
     }
 

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
@@ -267,7 +267,7 @@ class QuarkusCodestartGenerationTest {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                 .buildTool(BuildTool.GRADLE)
                 .addData(getGenerationTestInputData())
-                .addCodestarts(Collections.singletonList("github-action"))
+                .addCodestarts(Collections.singletonList("tooling-github-action"))
                 .build();
         Path projectDir = testDirPath.resolve("gradle-github");
         getCatalog().createProject(input).generate(projectDir);
@@ -284,7 +284,7 @@ class QuarkusCodestartGenerationTest {
                 .buildTool(BuildTool.GRADLE)
                 .noBuildToolWrapper()
                 .addData(getGenerationTestInputData())
-                .addCodestarts(Collections.singletonList("github-action"))
+                .addCodestarts(Collections.singletonList("tooling-github-action"))
                 .build();
         Path projectDir = testDirPath.resolve("gradle-nowrapper-github");
         getCatalog().createProject(input).generate(projectDir);


### PR DESCRIPTION
The goal is to avoid future conflicts between codestarts