### PR TITLE
Ignore the module-info from the application in dev mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/CompilationProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/CompilationProvider.java
@@ -50,6 +50,7 @@ public interface CompilationProvider extends Closeable {
         private final String targetJvmVersion;
         private final List<String> compilePluginArtifacts;
         private final List<String> compilerPluginOptions;
+        private final boolean ignoreModuleInfo;
 
         public Context(
                 String name,
@@ -64,7 +65,7 @@ public interface CompilationProvider extends Closeable {
                 String sourceJavaVersion,
                 String targetJvmVersion,
                 List<String> compilePluginArtifacts,
-                List<String> compilerPluginOptions) {
+                List<String> compilerPluginOptions, String ignoreModuleInfo) {
             this.name = name;
             this.classpath = classpath;
             this.reloadableClasspath = reloadableClasspath;
@@ -78,6 +79,7 @@ public interface CompilationProvider extends Closeable {
             this.targetJvmVersion = targetJvmVersion;
             this.compilePluginArtifacts = compilePluginArtifacts;
             this.compilerPluginOptions = compilerPluginOptions;
+            this.ignoreModuleInfo = Boolean.parseBoolean(ignoreModuleInfo);
         }
 
         public String getName() {
@@ -130,6 +132,10 @@ public interface CompilationProvider extends Closeable {
 
         public List<String> getCompilerPluginOptions() {
             return compilerPluginOptions;
+        }
+
+        public boolean ignoreModuleInfo() {
+            return ignoreModuleInfo;
         }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
@@ -74,7 +74,8 @@ public class JavaCompilationProvider implements CompilationProvider {
 
         final QuarkusFileManager.Context sourcesContext = new QuarkusFileManager.Context(
                 context.getClasspath(), context.getReloadableClasspath(),
-                context.getOutputDirectory(), context.getSourceEncoding());
+                context.getOutputDirectory(), context.getSourceEncoding(),
+                context.ignoreModuleInfo());
 
         if (this.fileManager == null) {
             final Supplier<StandardJavaFileManager> supplier = () -> {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusCompiler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusCompiler.java
@@ -209,7 +209,9 @@ public class QuarkusCompiler implements Closeable {
                                 context.getSourceJavaVersion(),
                                 context.getTargetJvmVersion(),
                                 context.getCompilerPluginArtifacts(),
-                                context.getCompilerPluginsOptions()));
+                                context.getCompilerPluginsOptions(),
+                                context.getBuildSystemProperties().getOrDefault("quarkus.live-reload.ignore-module-info",
+                                        "true")));
             }
         }
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
@@ -407,6 +407,8 @@ public abstract class QuarkusDevModeLauncher {
         devModeContext.getBuildSystemProperties().putIfAbsent("quarkus.application.name", applicationName);
         devModeContext.getBuildSystemProperties().putIfAbsent("quarkus.application.version", applicationVersion);
 
+        devModeContext.getBuildSystemProperties().putIfAbsent("quarkus.live-reload.ignore-module-info", "true");
+
         devModeContext.setSourceEncoding(sourceEncoding);
         devModeContext.setCompilerOptions(compilerOptions);
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/filesystem/QuarkusFileManager.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/filesystem/QuarkusFileManager.java
@@ -44,13 +44,15 @@ public abstract class QuarkusFileManager extends ForwardingJavaFileManager<Stand
         private final Set<File> reloadableClassPath;
         private final File outputDirectory;
         private final Charset sourceEncoding;
+        private final boolean ignoreModuleInfo;
 
         public Context(Set<File> classPath, Set<File> reloadableClassPath,
-                File outputDirectory, Charset sourceEncoding) {
+                File outputDirectory, Charset sourceEncoding, boolean ignoreModuleInfo) {
             this.classPath = classPath;
             this.reloadableClassPath = reloadableClassPath;
             this.outputDirectory = outputDirectory;
             this.sourceEncoding = sourceEncoding;
+            this.ignoreModuleInfo = ignoreModuleInfo;
         }
 
         public Set<File> getClassPath() {
@@ -67,6 +69,10 @@ public abstract class QuarkusFileManager extends ForwardingJavaFileManager<Stand
 
         public Charset getSourceEncoding() {
             return sourceEncoding;
+        }
+
+        public boolean ignoreModuleInfo() {
+            return ignoreModuleInfo;
         }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/filesystem/StaticFileManager.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/filesystem/StaticFileManager.java
@@ -1,22 +1,46 @@
 package io.quarkus.deployment.dev.filesystem;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
+
+import org.jboss.logging.Logger;
 
 /**
  * This static file manager handle the class-paths and file locations of a single manager instance.
  */
 public class StaticFileManager extends QuarkusFileManager {
 
+    private final Context context;
+    private final AtomicBoolean once = new AtomicBoolean();
+
     public StaticFileManager(Supplier<StandardJavaFileManager> supplier, Context context) {
         super(supplier.get(), context);
+        this.context = context;
     }
 
     @Override
     public Iterable<? extends JavaFileObject> getJavaSources(Iterable<? extends File> files) {
         return this.fileManager.getJavaFileObjectsFromFiles(files);
     }
+
+    @Override
+    public JavaFileObject getJavaFileForInput(Location location, String className, JavaFileObject.Kind kind)
+            throws IOException {
+        // Ignore the module info of the application in dev mode.
+        if (context.ignoreModuleInfo() && "CLASS_OUTPUT".equalsIgnoreCase(location.getName())
+                && "module-info".equalsIgnoreCase(className)) {
+            if (once.compareAndSet(false, true)) {
+                Logger.getLogger(StaticFileManager.class).info("Ignoring module-info.java in dev mode, " +
+                        "set the `quarkus.live-reload.ignore-module-info` property to `false` in your project descriptor (`pom.xml` or `build.gradle`) to disable this behavior.");
+            }
+            return null;
+        }
+        return this.fileManager.getJavaFileForInput(location, className, kind);
+    }
+
 }


### PR DESCRIPTION
As described in https://github.com/quarkusio/quarkus/issues/17747, the modules are not found in dev mode, breaking the hot reload.

Fix https://github.com/quarkusio/quarkus/issues/17747 - as described in the issue
