### PR TITLE
Allow configuring MongoDB client UUID representation

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientConfig.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import org.bson.UuidRepresentation;
+
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -197,4 +199,10 @@ public class MongoClientConfig {
     @ConfigItem(name = "health.database", defaultValue = "admin")
     public String healthDatabase;
 
+    /**
+     * Configures the UUID representation to use when encoding instances of {@link java.util.UUID}
+     * and when decoding BSON binary values with subtype of 3.
+     */
+    @ConfigItem
+    public Optional<UuidRepresentation> uuidRepresentation;
 }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClients.java
@@ -322,6 +322,10 @@ public class MongoClients {
             settings.readConcern(new ReadConcern(ReadConcernLevel.fromString(config.readConcern.get())));
         }
 
+        if (config.uuidRepresentation.isPresent()) {
+            settings.uuidRepresentation(config.uuidRepresentation.get());
+        }
+
         return settings.build();
     }
 


### PR DESCRIPTION
Fixes #36210

Didn't add test as we didn't test all possible configuration item but I checked manually and the options is correctly passed to the client when setting `quarkus.mongodb.uuid-representation=JAVA_LEGACY`.