### PR TITLE
Optionally run Gradle build + ITs using different JDK

### DIFF
--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -50,6 +50,28 @@
             </properties>
         </profile>
         <profile>
+            <id>gradleJavaHomeSet</id>
+            <activation>
+                <property>
+                    <name>env.GRADLE_JAVA_HOME</name>
+                </property>
+            </activation>
+            <properties>
+                <gradleJavaHome>${env.GRADLE_JAVA_HOME}</gradleJavaHome>
+            </properties>
+        </profile>
+        <profile>
+            <id>gradleJavaHomeNotSet</id>
+            <activation>
+                <property>
+                    <name>!env.GRADLE_JAVA_HOME</name>
+                </property>
+            </activation>
+            <properties>
+                <gradleJavaHome>${env.JAVA_HOME}</gradleJavaHome>
+            </properties>
+        </profile>
+        <profile>
             <id>run-gradle</id>
             <activation>
                 <file>
@@ -79,6 +101,7 @@
                                     <environmentVariables>
                                         <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
                                         <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
+                                        <JAVA_HOME>${gradleJavaHome}</JAVA_HOME>
                                     </environmentVariables>
                                     <skip>${skip.gradle.build}</skip>
                                 </configuration>

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
@@ -84,7 +84,10 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
                 .redirectOutput(logOutput)
                 // Should prevent "fragmented" output (parts of stdout and stderr interleaved)
                 .redirectErrorStream(true);
-        if (System.getenv("JAVA_HOME") == null) {
+        if (System.getenv("GRADLE_JAVA_HOME") != null) {
+            // JAVA_HOME for Gradle explicitly configured.
+            pb.environment().put("JAVA_HOME", System.getenv("GRADLE_JAVA_HOME"));
+        } else if (System.getenv("JAVA_HOME") == null || System.getenv("JAVA_HOME").isEmpty()) {
             // This helps running the tests in IntelliJ w/o configuring an explicit JAVA_HOME env var.
             pb.environment().put("JAVA_HOME", System.getProperty("java.home"));
         }


### PR DESCRIPTION
When the environment variable `GRADLE_JAVA_HOME` is present, it will be used as the `JAVA_HOME` when building `devtools/gradle/` using Gradle via Maven, Gradle devtools integration tests respect the environment variable as well.