### PR TITLE
Update Snappy to version 1.1.10.5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -149,7 +149,7 @@
         <mutiny.version>2.5.1</mutiny.version>
         <kafka3.version>3.5.1</kafka3.version>
         <lz4.version>1.8.0</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->
-        <snappy.version>1.1.10.1</snappy.version>
+        <snappy.version>1.1.10.5</snappy.version>
         <strimzi-test-container.version>0.100.0</strimzi-test-container.version>
         <!-- Scala is used by Kafka so we need to choose a compatible version -->
         <scala.version>2.13.12</scala.version>


### PR DESCRIPTION
Fix CVE-2023-43642 (https://access.redhat.com/security/cve/CVE-2023-43642)
