### PR TITLE
Upgrade MSSQL Docker image

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -91,7 +91,7 @@
         <postgres.image>docker.io/postgres:14</postgres.image>
         <mariadb.image>docker.io/mariadb:10.11</mariadb.image>
         <db2.image>docker.io/ibmcom/db2:11.5.7.0a</db2.image>
-        <mssql.image>mcr.microsoft.com/mssql/server:2019-latest</mssql.image>
+        <mssql.image>mcr.microsoft.com/mssql/server:2022-latest</mssql.image>
         <mysql.image>docker.io/mysql:8.0</mysql.image>
         <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
         <mongo.image>docker.io/mongo:4.4</mongo.image>
@@ -169,7 +169,7 @@
         <!-- Quarkus Analytics -->
         <properties-maven-plugin.version>1.1.0</properties-maven-plugin.version>
         <quarkus.analytics.disabled>true</quarkus.analytics.disabled>
-        
+
         <!-- Dev UI -->
         <vaadin.version>24.1.9</vaadin.version>
         <lit.version>2.8.0</lit.version>
@@ -382,7 +382,7 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            
+
             <!-- Dev UI -->
             <!-- Vaadin Router -->
             <dependency>
@@ -1332,9 +1332,8 @@
 
                 <!-- See
                 https://github.com/microsoft/mssql-docker/issues/668 and https://stackoverflow.com/questions/65398641/docker-connect-sql-server-container-non-zero-code-1/66919852#66919852.
-                The MS SQL image segfaults on ARM. Azure Edge is not fully compatible, but it is better than not running the tests at all.
-                The :latest tag segfaults with the same segfault as MSSQL Server but 1.0.6 seems to behave well -->
-                <mssql.image>mcr.microsoft.com/azure-sql-edge:1.0.6</mssql.image>
+                The MS SQL image segfaults on ARM. Azure Edge is not fully compatible, but it is better than not running the tests at all. -->
+                <mssql.image>mcr.microsoft.com/azure-sql-edge:latest</mssql.image>
             </properties>
         </profile>
     </profiles>

--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -56,7 +56,7 @@ An example file is shown below:
 .src/main/resources/container-license-acceptance.txt
 ----
 ibmcom/db2:11.5.0.0a
-mcr.microsoft.com/mssql/server:2017-CU12
+mcr.microsoft.com/mssql/server:2022-latest
 ----
 
 == Mapping volumes into Dev Services for Database
@@ -65,7 +65,7 @@ Mapping volumes from the Docker host's filesystem to the containers is handy to 
 
 [NOTE]
 ====
-Mapping volumes will only work in Dev Services with a container-based database like PostgreSQL. 
+Mapping volumes will only work in Dev Services with a container-based database like PostgreSQL.
 ====
 
 Dev Services volumes can be mapped to the filesystem or the classpath:
@@ -81,7 +81,7 @@ quarkus.datasource.devservices.volumes."classpath:./file"=/container/to <2>
 <1> The file or folder "/path/from" from the local machine will be accessible at "/container/to" in the container.
 <2> When using classpath volumes, the location has to start with "classpath:". The file or folder "./file" from the project's classpath will be accessible at "/container/to" in the container.
 
-IMPORTANT: when using a classpath volume, the container will only be granted read permission. On the other hand, when using a filesystem volume, the container will be granted read and write permission. 
+IMPORTANT: when using a classpath volume, the container will only be granted read permission. On the other hand, when using a filesystem volume, the container will be granted read and write permission.
 
 === Example of mapping volumes to persist the database data
 
@@ -101,7 +101,7 @@ quarkus.datasource.db-kind=mysql
 quarkus.datasource.devservices.volumes."/local/test/data"=/var/lib/mysql
 ----
 
-When starting Dev Services (for example, in tests or in DEV mode), you will see that the folder "/local/test/data" will be created at your file sytem and that will contain all the database data. When rerunning again the same dev services, this data will contain all the data you might have created beforehand. 
+When starting Dev Services (for example, in tests or in DEV mode), you will see that the folder "/local/test/data" will be created at your file sytem and that will contain all the database data. When rerunning again the same dev services, this data will contain all the data you might have created beforehand.
 
 [IMPORTANT]
 ====

--- a/extensions/reactive-mssql-client/deployment/pom.xml
+++ b/extensions/reactive-mssql-client/deployment/pom.xml
@@ -151,7 +151,7 @@
                                         </ports>
                                         <env>
                                             <ACCEPT_EULA>Y</ACCEPT_EULA>
-                                            <SA_PASSWORD>A_Str0ng_Required_Password</SA_PASSWORD>
+                                            <SA_PASSWORD>yourStrong(!)Password</SA_PASSWORD>
                                         </env>
                                         <log>
                                             <prefix>MSSQL:</prefix>

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsProvider.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsProvider.java
@@ -8,6 +8,6 @@ import io.quarkus.reactive.datasource.ChangingCredentialsProviderBase;
 public class ChangingCredentialsProvider extends ChangingCredentialsProviderBase {
 
     public ChangingCredentialsProvider() {
-        super("sa", "yourStrong(!)Password", "user2", "user2_yourStrong(!)Password");
+        super("sa", "yourStrong(!)Password", "user2", "yourStrong(!)Password2");
     }
 }

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsProvider.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsProvider.java
@@ -8,6 +8,6 @@ import io.quarkus.reactive.datasource.ChangingCredentialsProviderBase;
 public class ChangingCredentialsProvider extends ChangingCredentialsProviderBase {
 
     public ChangingCredentialsProvider() {
-        super("sa", "A_Str0ng_Required_Password", "user2", "user2_Has_A_Str0ng_Required_Password");
+        super("sa", "yourStrong(!)Password", "user2", "user2_yourStrong(!)Password");
     }
 }

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsTestResource.java
@@ -24,7 +24,7 @@ public class ChangingCredentialsTestResource {
     ChangingCredentialsProvider credentialsProvider;
 
     void addUser(@Observes StartupEvent ignored) {
-        client.query("CREATE LOGIN user2 WITH PASSWORD = 'user2_yourStrong(!)Password'").executeAndAwait();
+        client.query("CREATE LOGIN user2 WITH PASSWORD = 'yourStrong(!)Password2'").executeAndAwait();
         client.query("CREATE USER user2 FOR LOGIN user2").executeAndAwait();
     }
 

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsTestResource.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/ChangingCredentialsTestResource.java
@@ -24,7 +24,7 @@ public class ChangingCredentialsTestResource {
     ChangingCredentialsProvider credentialsProvider;
 
     void addUser(@Observes StartupEvent ignored) {
-        client.query("CREATE LOGIN user2 WITH PASSWORD = 'user2_Has_A_Str0ng_Required_Password'").executeAndAwait();
+        client.query("CREATE LOGIN user2 WITH PASSWORD = 'user2_yourStrong(!)Password'").executeAndAwait();
         client.query("CREATE USER user2 FOR LOGIN user2").executeAndAwait();
     }
 

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/CustomCredentialsProvider.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/CustomCredentialsProvider.java
@@ -18,7 +18,7 @@ public class CustomCredentialsProvider implements CredentialsProvider {
     public Map<String, String> getCredentials(String credentialsProviderName) {
         Map<String, String> properties = new HashMap<>();
         properties.put(USER_PROPERTY_NAME, "sa");
-        properties.put(PASSWORD_PROPERTY_NAME, "A_Str0ng_Required_Password");
+        properties.put(PASSWORD_PROPERTY_NAME, "yourStrong(!)Password");
         log.info("credentials provider returning " + properties);
         return properties;
     }

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-datasources-with-health.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-datasources-with-health.properties
@@ -1,11 +1,11 @@
 quarkus.datasource.db-kind=mssql
 quarkus.datasource.username=sa
-quarkus.datasource.password=A_Str0ng_Required_Password
+quarkus.datasource.password=yourStrong(!)Password
 quarkus.datasource.reactive.url=${reactive-mssql.url}
 # this data source is broken, but will be excluded from the health check, so the overall check should pass
 quarkus.datasource."broken".db-kind=mssql
 quarkus.datasource."broken".username=BROKEN
-quarkus.datasource."broken".password=A_Str0ng_Required_Password
+quarkus.datasource."broken".password=yourStrong(!)Password
 quarkus.datasource."broken".reactive.url=${reactive-mssql.url}
 quarkus.datasource."broken".health-exclude=true
 quarkus.datasource.health.enabled=true

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-multiple-datasources-with-erroneous-url.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-multiple-datasources-with-erroneous-url.properties
@@ -1,9 +1,9 @@
 quarkus.datasource.db-kind=mssql
 quarkus.datasource.username=sa
-quarkus.datasource.password=A_Str0ng_Required_Password
+quarkus.datasource.password=yourStrong(!)Password
 quarkus.datasource.reactive.url=vertx-reactive:sqlserver://test:12345
 
 quarkus.datasource."hibernate".db-kind=mssql
 quarkus.datasource."hibernate".username=sa
-quarkus.datasource."hibernate".password=A_Str0ng_Required_Password
+quarkus.datasource."hibernate".password=yourStrong(!)Password
 quarkus.datasource."hibernate".reactive.url=vertx-reactive:sqlserver://test:55555

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-multiple-datasources.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-multiple-datasources.properties
@@ -1,9 +1,9 @@
 quarkus.datasource.db-kind=mssql
 quarkus.datasource.username=sa
-quarkus.datasource.password=A_Str0ng_Required_Password
+quarkus.datasource.password=yourStrong(!)Password
 quarkus.datasource.reactive.url=${reactive-mssql.url}
 
 quarkus.datasource."hibernate".db-kind=mssql
 quarkus.datasource."hibernate".username=sa
-quarkus.datasource."hibernate".password=A_Str0ng_Required_Password
+quarkus.datasource."hibernate".password=yourStrong(!)Password
 quarkus.datasource."hibernate".reactive.url=${reactive-mssql.url}

--- a/integration-tests/hibernate-reactive-mssql/pom.xml
+++ b/integration-tests/hibernate-reactive-mssql/pom.xml
@@ -187,7 +187,7 @@
             </activation>
             <properties>
                 <!-- Careful: SQL Server refuses to work with trivial passwords. -->
-                <mssqldb.sa-password>ActuallyRequired11Complexity</mssqldb.sa-password>
+                <mssqldb.sa-password>yourStrong(!)Password</mssqldb.sa-password>
             </properties>
             <build>
                 <plugins>
@@ -205,7 +205,7 @@
                                         </ports>
                                         <env>
                                             <ACCEPT_EULA>Y</ACCEPT_EULA>
-                                            <SA_PASSWORD>ActuallyRequired11Complexity</SA_PASSWORD>
+                                            <SA_PASSWORD>yourStrong(!)Password</SA_PASSWORD>
                                         </env>
                                         <log>
                                             <prefix>MS SQL Server:</prefix>

--- a/integration-tests/jpa-mssql/README.md
+++ b/integration-tests/jpa-mssql/README.md
@@ -18,14 +18,14 @@ mvn clean install -Dstart-containers -Dtest-containers -Dnative
 
 Alternatively you can connect to your own SQL Server.
 Reconfigure the connection URL with `-Dmssqldb.url=jdbc:sqlserver://...`;
-you'll probably want to change the authentication password too: `-Dmssqldb.sa-password=NotS0Secret`.
+you'll probably want to change the authentication password too: `-Dmssqldb.sa-password=yourStrong(!)Password`.
 
 ### With Podman
 
 If you prefer to run the MSSQL Server container via podman, use:
 
 ```
-podman run --rm=true --net=host --memory-swappiness=0 --name mssql_testing -e SA_PASSWORD=ActuallyRequired11Complexity -e ACCEPT_EULA=Y -p 1433:1433 mcr.microsoft.com/mssql/2019-CU8-ubuntu-16.04
+podman run --rm=true --net=host --memory-swappiness=0 --name mssql_testing -e SA_PASSWORD=yourStrong(!)Password -e ACCEPT_EULA=Y -p 1433:1433 mcr.microsoft.com/mssql/2022-latest
 ```
 
 ## Limitations

--- a/integration-tests/jpa-mssql/pom.xml
+++ b/integration-tests/jpa-mssql/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <mssqldb.url>jdbc:sqlserver://localhost:1433;databaseName=tempdb</mssqldb.url>
-        <mssqldb.sa-password>ActuallyRequired11Complexity</mssqldb.sa-password>
+        <mssqldb.sa-password>yourStrong(!)Password</mssqldb.sa-password>
     </properties>
 
     <dependencies>
@@ -187,7 +187,7 @@
             <properties>
                 <mssqldb.url>jdbc:sqlserver://localhost:1433;databaseName=tempdb</mssqldb.url>
                 <!-- Careful: SQL Server refuses to work with trivial passwords. -->
-                <mssqldb.sa-password>ActuallyRequired11Complexity</mssqldb.sa-password>
+                <mssqldb.sa-password>yourStrong(!)Password</mssqldb.sa-password>
             </properties>
             <build>
                 <plugins>
@@ -205,7 +205,7 @@
                                         </ports>
                                         <env>
                                             <ACCEPT_EULA>Y</ACCEPT_EULA>
-                                            <SA_PASSWORD>ActuallyRequired11Complexity</SA_PASSWORD>
+                                            <SA_PASSWORD>yourStrong(!)Password</SA_PASSWORD>
                                         </env>
                                         <log>
                                             <prefix>MS SQL Server:</prefix>

--- a/integration-tests/reactive-mssql-client/README.md
+++ b/integration-tests/reactive-mssql-client/README.md
@@ -17,7 +17,7 @@ mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
 If you don't want to run MS SQL as a Docker container, you can start your own.
-It needs to listen on the default port and be accessible to the user `sa` with the password `A_Str0ng_Required_Password`.
+It needs to listen on the default port and be accessible to the user `sa` with the password `yourStrong(!)Password`.
 
 You can then run the tests as follows (either with `-Dnative` or not):
 

--- a/integration-tests/reactive-mssql-client/pom.xml
+++ b/integration-tests/reactive-mssql-client/pom.xml
@@ -170,7 +170,7 @@
                                         </ports>
                                         <env>
                                             <ACCEPT_EULA>Y</ACCEPT_EULA>
-                                            <SA_PASSWORD>A_Str0ng_Required_Password</SA_PASSWORD>
+                                            <SA_PASSWORD>yourStrong(!)Password</SA_PASSWORD>
                                         </env>
                                         <log>
                                             <prefix>MSSQL:</prefix>

--- a/integration-tests/reactive-mssql-client/src/main/resources/application.properties
+++ b/integration-tests/reactive-mssql-client/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.datasource.db-kind=mssql
 quarkus.datasource.username=sa
-quarkus.datasource.password=A_Str0ng_Required_Password
+quarkus.datasource.password=yourStrong(!)Password
 quarkus.datasource.reactive.url=${reactive-mssql.url}
 #Uncomment to connect over SSL/TLS
 #quarkus.datasource.reactive.trust-all=true

--- a/integration-tests/reactive-mssql-client/src/test/resources/application-tl.properties
+++ b/integration-tests/reactive-mssql-client/src/test/resources/application-tl.properties
@@ -1,6 +1,6 @@
 quarkus.datasource.db-kind=mssql
 quarkus.datasource.username=sa
-quarkus.datasource.password=A_Str0ng_Required_Password
+quarkus.datasource.password=yourStrong(!)Password
 quarkus.datasource.reactive.url=${reactive-mssql.url}
 quarkus.log.category."io.quarkus.reactive.datasource".level=DEBUG
 #Uncomment to connect over SSL/TLS


### PR DESCRIPTION
Updates the Docker image for MSSQL to `2022-latest` and sets the default suggested password with the required complexity (one of the tests failed on this), see https://hub.docker.com/_/microsoft-mssql-server

> MSSQL_SA_PASSWORD is the database system administrator (userid = 'sa') password used to connect to SQL Server once the container is running. Important note: This password needs to include at least 8 characters of at least three of these four categories: uppercase letters, lowercase letters, numbers and non-alphanumeric symbols.

For M1 Macs we update the image to `azure-sql-edge:latest` as this now seems to work (verified locally), see https://hub.docker.com/_/microsoft-azure-sql-edge


