### PR TITLE
Upgrade to Hibernate Search 6.2.2.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -105,7 +105,7 @@
         <hibernate-reactive.version>2.0.5.Final</hibernate-reactive.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <!-- When updating, align hibernate-search.version-for-documentation in docs/pom.xml -->
-        <hibernate-search.version>6.2.1.Final</hibernate-search.version>
+        <hibernate-search.version>6.2.2.Final</hibernate-search.version>
         <narayana.version>7.0.0.Final</narayana.version>
         <agroal.version>2.1</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>


### PR DESCRIPTION
https://in.relation.to/2023/10/03/hibernate-search-6-2-2-Final/

> This release mainly adds compatibility with Elasticsearch 8.10 and OpenSearch 2.10, upgrades to Hibernate ORM 6.2.9.Final for `-orm6` artifacts, upgrades to Elasticsearch client 8.10.2, Jackson 2.15.2 and Avro 1.11.3, deprecates the `~` operator in regexp predicates, and fixes several bugs.

None of the bugfixes are relevant to Quarkus.