### PR TITLE
Update SmallRye OpenAPI to 3.6.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -54,7 +54,7 @@
         <smallrye-config.version>3.3.4</smallrye-config.version>
         <smallrye-health.version>4.0.4</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>3.6.1</smallrye-open-api.version>
+        <smallrye-open-api.version>3.6.2</smallrye-open-api.version>
         <smallrye-graphql.version>2.4.0</smallrye-graphql.version>
         <smallrye-opentracing.version>3.0.3</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>6.2.6</smallrye-fault-tolerance.version>

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/OpenApiTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/OpenApiTestCase.java
@@ -90,7 +90,8 @@ public class OpenApiTestCase {
         Assertions.assertEquals(1, keys.size());
         Assertions.assertEquals("get", keys.iterator().next());
 
-        String uniSchemaType = schemaType("200", DEFAULT_MEDIA_TYPE, uniObj.getJsonObject("get").getJsonObject("responses"),
+        String uniSchemaType = schemaType("200", DEFAULT_MEDIA_TYPE_PRIMITAVE,
+                uniObj.getJsonObject("get").getJsonObject("responses"),
                 schemasObj);
         // make sure String, CompletionStage<String> and Uni<String> are detected the same
         Assertions.assertEquals(testSchemaType,


### PR DESCRIPTION
Update OpenAPI to 3.6.2

Fix #36253

This also implements the default content type for wrapped types as discussed here:
https://github.com/quarkusio/quarkus/issues/34700#issuecomment-1743697186