### PR TITLE
Clarify preconditions of using `quarkus.kubernetes.app-secret` and `quarkus.kubernetes.app-config-map`

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -612,6 +612,28 @@ quarkus.kubernetes.app-config-map=<name of the config map containing the configu
 When these properties are used, the generated manifests will contain everything required.
 The application config volumes will be created using path: `/mnt/app-secret` and `/mnt/app-config-map` for secrets and configmaps respectively.
 
+[NOTE]
+====
+
+For this to work, the secret or configmap must contain an entry with a configuration file name recognized by Quarkus (e.g. `config.properties`)
+as its key and the file content as its value.
+
+To create such a secret from the existing properties file `config.properties` in the active Kubernetes cluster via `kubectl`, use
+
+[source,bash]
+----
+kubectl create secret generic <name of the secret containing the configuration> --from-file config.properties
+----
+
+For a config map, the command would be
+
+[source,bash]
+----
+kubectl create configmap <name of the config map containing the configuration> --from-file config.properties
+----
+
+====
+
 Note: Users may use both properties at the same time.
 
 === Changing the number of replicas:


### PR DESCRIPTION
I followed the instructions in the [Kubernetes Extension guide](https://quarkus.io/guides/deploying-to-kubernetes#passing-application-configuration) to configure my Quarkus app via Kubernetes secrets and MP Config.

I found the instructions insufficient, though.
There are special requirements for the documented mechanism to work which should be clarified.

The documented usage of `quarkus.kubernetes.app-secret` and `quarkus.kubernetes.app-config-map` will mount the secret as files into the directories `/mnt/app-secret` or `/mnt/app-config-map`. But for Smallrye to pick them up there, they have to be named properly.

A configmap created like this will not work:

```shell
kubectl create configmap configmap1 --from-literal "property=value"
```
because it will be mounted as `/mnt/app-config-map/property` with the content "value".

In contrast, a configmap created by

```shell
kubectl create configmap configmap2 --from-literal "config.properties=property=value"
```
will be mounted as `/mnt/app-config-map/config.properties` with the content "property=value" and thus be picked up by Smallrye config.

I do not think it is appropriate to focus on this too much in the documentation and thus opted to describe the more intuitive `--form-file` syntax instead of `--from-literal`.
This syntax assumes the existence of a (probably) working Quarkus configuration file and ist therefore less error-prone.