### PR TITLE
Fix headers and preambles in all guides and reintroduce some keywords

### DIFF
--- a/docs/src/main/asciidoc/ansible.adoc
+++ b/docs/src/main/asciidoc/ansible.adoc
@@ -1,3 +1,8 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
 = Automate Quarkus deployment with Ansible
 include::_attributes.adoc[]
 :categories: command-line

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -6,6 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Contexts and Dependency Injection
 include::_attributes.adoc[]
 :categories: core
+:keywords: arc
 :summary: Go more in depth into the Quarkus implementation of CDI.
 :numbered:
 :sectnums:

--- a/docs/src/main/asciidoc/cdi.adoc
+++ b/docs/src/main/asciidoc/cdi.adoc
@@ -6,6 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Introduction to Contexts and Dependency Injection (CDI)
 include::_attributes.adoc[]
 :categories: core
+:keywords: qualifier event interceptor observer arc
 :summary: Quarkus DI solution is based on the [Jakarta Contexts and Dependency Injection 4.0](https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0.html) specification. This guide explains the basics of CDI.
 :numbered:
 :sectnums:
@@ -28,7 +29,7 @@ It creates and destroys the instances of beans, associates the instances with a 
 
 An application developer can focus on the business logic rather than finding out "where and how" to obtain a fully initialized component with all of its dependencies.
 
-NOTE: You've probably heard of the _inversion of control_ (IoC) programming principle. Dependency injection is one of the implementation techniques of IoC. 
+NOTE: You've probably heard of the _inversion of control_ (IoC) programming principle. Dependency injection is one of the implementation techniques of IoC.
 
 == What does a bean look like?
 
@@ -47,9 +48,9 @@ public class Translator {
 
     @Inject
     Dictionary dictionary; <2>
-    
+
     @Counted  <3>
-    String translate(String sentence) { 
+    String translate(String sentence) {
       // ...
     }
 }
@@ -86,8 +87,8 @@ public class Translator {
 
     @Inject
     Instance<Dictionary> dictionaries; <1>
-    
-    String translate(String sentence) { 
+
+    String translate(String sentence) {
       for (Dictionary dict : dictionaries) { <2>
          // ...
       }
@@ -122,11 +123,11 @@ public class Translator {
     }
 }
 ----
-<1> This is a constructor injection. 
-In fact, this code would not work in regular CDI implementations where a bean with a normal scope must always declare a no-args constructor and the bean constructor must be annotated with `@Inject`. 
+<1> This is a constructor injection.
+In fact, this code would not work in regular CDI implementations where a bean with a normal scope must always declare a no-args constructor and the bean constructor must be annotated with `@Inject`.
 However, in Quarkus we detect the absence of no-args constructor and "add" it directly in the bytecode.
 It's also not necessary to add `@Inject` if there is only one constructor present.
-<2> An initializer method must be annotated with `@Inject`. 
+<2> An initializer method must be annotated with `@Inject`.
 <3> An initializer may accept multiple parameters - each one is an injection point.
 
 == You talked about some qualifiers?
@@ -155,7 +156,7 @@ The qualifiers of a bean are declared by annotating the bean class or producer m
 @ApplicationScoped
 public class SuperiorTranslator extends Translator {
 
-    String translate(String sentence) { 
+    String translate(String sentence) {
       // ...
     }
 }
@@ -180,11 +181,11 @@ You can use all the built-in scopes mentioned by the specification except for `j
 
 [options="header",cols="1,1"]
 |===
-|Annotation   |Description   
+|Annotation   |Description
 //----------------------
-|`@jakarta.enterprise.context.ApplicationScoped`   | A single bean instance is used for the application and shared among all injection points. The instance is created lazily, i.e. once a method is invoked upon the <<client_proxies, client proxy>>. 
+|`@jakarta.enterprise.context.ApplicationScoped`   | A single bean instance is used for the application and shared among all injection points. The instance is created lazily, i.e. once a method is invoked upon the <<client_proxies, client proxy>>.
 |`@jakarta.inject.Singleton`   | Just like `@ApplicationScoped` except that no client proxy is used. The instance is created when an injection point that resolves to a @Singleton bean is being injected.
-|`@jakarta.enterprise.context.RequestScoped`   | The bean instance is associated with the current _request_ (usually an HTTP request). 
+|`@jakarta.enterprise.context.RequestScoped`   | The bean instance is associated with the current _request_ (usually an HTTP request).
 |`@jakarta.enterprise.context.Dependent`   | This is a pseudo-scope. The instances are not shared and every injection point spawns a new instance of the dependent bean. The lifecycle of dependent bean is bound to the bean injecting it - it will be created and destroyed along with the bean injecting it.
 |`@jakarta.enterprise.context.SessionScoped`   | This scope is backed by a `jakarta.servlet.http.HttpSession` object. It's only available if the `quarkus-undertow` extension is used.
 |===
@@ -217,7 +218,7 @@ Indeed, the https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0.html#
 A client proxy is basically an object that delegates all method invocations to a target bean instance.
 It's a container construct that implements `io.quarkus.arc.ClientProxy` and extends the bean class.
 
-IMPORTANT: Client proxies only delegate method invocations. So never read or write a field of a normal scoped bean, otherwise you will work with non-contextual or stale data. 
+IMPORTANT: Client proxies only delegate method invocations. So never read or write a field of a normal scoped bean, otherwise you will work with non-contextual or stale data.
 
 .Generated Client Proxy Example
 [source,java]
@@ -225,7 +226,7 @@ IMPORTANT: Client proxies only delegate method invocations. So never read or wri
 @ApplicationScoped
 class Translator {
 
-    String translate(String sentence) { 
+    String translate(String sentence) {
       // ...
     }
 }
@@ -233,7 +234,7 @@ class Translator {
 // The client proxy class is generated and looks like...
 class Translator_ClientProxy extends Translator { <1>
 
-    String translate(String sentence) { 
+    String translate(String sentence) {
       // Find the correct translator instance...
       Translator translator = getTranslatorInstanceFromTheApplicationContext();
       // And delegate the method invocation...
@@ -247,10 +248,10 @@ Client proxies allow for:
 
 * Lazy instantiation - the instance is created once a method is invoked upon the proxy.
 * Ability to inject a bean with "narrower" scope to a bean with "wider" scope; i.e. you can inject a `@RequestScoped` bean into an `@ApplicationScoped` bean.
-* Circular dependencies in the dependency graph. Having circular dependencies is often an indication that a redesign should be considered, but sometimes it's inevitable. 
+* Circular dependencies in the dependency graph. Having circular dependencies is often an indication that a redesign should be considered, but sometimes it's inevitable.
 * In rare cases it's practical to destroy the beans manually. A direct injected reference would lead to a stale bean instance.
- 
- 
+
+
 == OK. You said that there are several kinds of beans?
 
 Yes. In general, we distinguish:
@@ -273,7 +274,7 @@ public class Producers {
 
     @Produces <1>
     double pi = Math.PI; <2>
-    
+
     @Produces <3>
     List<String> names() {
        List<String> names = new ArrayList<>();
@@ -289,26 +290,26 @@ public class Consumer {
 
    @Inject
    double pi;
-   
+
    @Inject
    List<String> names;
-   
-   // ...   
-} 
+
+   // ...
+}
 ----
 <1> The container analyses the field annotations to build a bean metadata.
-The _type_ is used to build the set of bean types. 
+The _type_ is used to build the set of bean types.
 In this case, it will be `double` and `java.lang.Object`.
 No scope annotation is declared and so it's defaulted to `@Dependent`.
 <2> The container will read this field when creating the bean instance.
 <3> The container analyses the method annotations to build a bean metadata.
-The _return type_ is used to build the set of bean types. 
+The _return type_ is used to build the set of bean types.
 In this case, it will be `List<String>`, `Collection<String>`, `Iterable<String>` and `java.lang.Object`.
 No scope annotation is declared and so it's defaulted to `@Dependent`.
 <4> The container will call this method when creating the bean instance.
 
-There's more about producers. 
-You can declare qualifiers, inject dependencies into the producer methods parameters, etc. 
+There's more about producers.
+You can declare qualifiers, inject dependencies into the producer methods parameters, etc.
 You can read more about producers for example in the https://docs.jboss.org/weld/reference/latest/en-US/html/producermethods.html[Weld docs, window="_blank"].
 
 == OK, injection looks cool. What other services are provided?
@@ -330,7 +331,7 @@ public class Translator {
     void init() {
        // ...
     }
-    
+
     @PreDestroy <2>
     void destroy() {
       // ...
@@ -345,7 +346,7 @@ TIP: It's a good practice to keep the logic in the callbacks "without side effec
 [[interceptors]]
 === Interceptors
 
-Interceptors are used to separate cross-cutting concerns from business logic. 
+Interceptors are used to separate cross-cutting concerns from business logic.
 There is a separate specification - Java Interceptors - that defines the basic programming model and semantics.
 
 .Simple Interceptor Binding Example
@@ -392,11 +393,11 @@ public class LoggingInterceptor {
       // ...log after
       return ret;
    }
-    
+
 }
 ----
 <1> The interceptor binding annotation is used to bind our interceptor to a bean. Simply annotate a bean class with `@Logged`, as in the following example.
-<2> `Priority` enables the interceptor and affects the interceptor ordering. Interceptors with smaller priority values are called first. 
+<2> `Priority` enables the interceptor and affects the interceptor ordering. Interceptors with smaller priority values are called first.
 <3> Marks an interceptor component.
 <4> An interceptor may inject dependencies.
 <5> `AroundInvoke` denotes a method that interposes on business methods.
@@ -448,7 +449,7 @@ public class LargeTxAccount implements Account { <3>
    @Any
    @Delegate
    Account delegate; <4>
-   
+
    @Inject
    LogService logService; <5>
 
@@ -458,10 +459,10 @@ public class LargeTxAccount implements Account { <3>
          logService.logWithdrawal(delegate, amount);
       }
    }
-    
+
 }
 ----
-<1> `@Priority` enables the decorator. Decorators with smaller priority values are called first. 
+<1> `@Priority` enables the decorator. Decorators with smaller priority values are called first.
 <2> `@Decorator` marks a decorator component.
 <3> The set of decorated types includes all bean types which are Java interfaces, except for `java.io.Serializable`.
 <4> Each decorator must declare exactly one _delegate injection point_. The decorator applies to beans that are assignable to this delegate injection point.
@@ -471,7 +472,7 @@ public class LargeTxAccount implements Account { <3>
 NOTE: Instances of decorators are dependent objects of the bean instance they intercept, i.e. a new decorator instance is created for each intercepted bean.
 
 === Events and Observers
-	
+
 Beans may also produce and consume events to interact in a completely decoupled fashion.
 Any Java object can serve as an event payload.
 The optional qualifiers act as topic selectors.

--- a/docs/src/main/asciidoc/extension-metadata.adoc
+++ b/docs/src/main/asciidoc/extension-metadata.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Extension Metadata
-
 include::_attributes.adoc[]
 
 Quarkus extensions are distributed as Maven JAR artifacts that application and other libraries may depend on. When a Quarkus application project is built, tested or edited using the Quarkus dev tools, Quarkus extension JAR artifacts will be identified on the application classpath by the presence of the Quarkus extension metadata files in them.
@@ -127,11 +126,11 @@ The following properties may appear in this file:
 
 | `parent-first-artifacts`
 | Optional
-| Comma-separated list of artifact keys (`groupId:artifactId:classifier:type`) that are to be loaded in a parent first manner. This can be used to work around issues where a given class needs to be loaded by the system ClassLoader. 
+| Comma-separated list of artifact keys (`groupId:artifactId:classifier:type`) that are to be loaded in a parent first manner. This can be used to work around issues where a given class needs to be loaded by the system ClassLoader.
 
 | `runner-parent-first-artifacts`
 | Optional
-| Comma-separated list of artifact keys that are to be loaded in a parent first manner in addition to those configured with `parent-first-artifacts` when an application is launched from a production binary package. This can be used to work around issues where a given class needs to be loaded by the system ClassLoader. 
+| Comma-separated list of artifact keys that are to be loaded in a parent first manner in addition to those configured with `parent-first-artifacts` when an application is launched from a production binary package. This can be used to work around issues where a given class needs to be loaded by the system ClassLoader.
 
 | `excluded-artifacts`
 | Optional
@@ -143,7 +142,7 @@ The following properties may appear in this file:
 
 | `removed-resources.*`
 | Optional
-| Resources that should be removed/hidden from dependencies. This allows for classes and other resources to be removed from dependencies, so they are not accessible to the application. This is a map of artifact key to a comma-separated list of resources to be removed. When running in dev and test mode these resources are hidden from the ClassLoader, when running in production mode these files are removed from the jars that contain them. Note that if you want to remove a class you need to specify the class file name. e.g. to remove com.acme.Foo you would specify com/acme/Foo.class. 
+| Resources that should be removed/hidden from dependencies. This allows for classes and other resources to be removed from dependencies, so they are not accessible to the application. This is a map of artifact key to a comma-separated list of resources to be removed. When running in dev and test mode these resources are hidden from the ClassLoader, when running in production mode these files are removed from the jars that contain them. Note that if you want to remove a class you need to specify the class file name. e.g. to remove com.acme.Foo you would specify com/acme/Foo.class.
 
 | `provides-capabilities`
 | Optional

--- a/docs/src/main/asciidoc/grpc-virtual-threads.adoc
+++ b/docs/src/main/asciidoc/grpc-virtual-threads.adoc
@@ -1,5 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
 = Quarkus Virtual Thread support for gRPC services
-
 include::_attributes.adoc[]
 :runonvthread: https://javadoc.io/doc/io.smallrye.common/smallrye-common-annotation/latest/io/smallrye/common/annotation/RunOnVirtualThread.html
 :blocking_annotation: https://javadoc.io/doc/io.smallrye.reactive/smallrye-reactive-messaging-api/latest/io/smallrye/reactive/messaging/annotations/Blocking.html

--- a/docs/src/main/asciidoc/lifecycle.adoc
+++ b/docs/src/main/asciidoc/lifecycle.adoc
@@ -6,6 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Application Initialization and Termination
 include::_attributes.adoc[]
 :categories: core
+:keywords: lifecycle event
 :summary: You often need to execute custom actions when the application starts and clean up everything when the application stops. This guide explains how to be notified when an application stops or starts.
 
 You often need to execute custom actions when the application starts and clean up everything when the application stops.
@@ -175,7 +176,7 @@ NOTE: The methods can access injected beans. Check the link:{quickstarts-blob-ur
 
 === What is the difference from `@Initialized(ApplicationScoped.class)` and `@Destroyed(ApplicationScoped.class)`
 
-In the JVM mode, there is no real difference, except that `StartupEvent` is always fired *after* `@Initialized(ApplicationScoped.class)` and `ShutdownEvent` is fired *before* `@Destroyed(ApplicationScoped.class)`. 
+In the JVM mode, there is no real difference, except that `StartupEvent` is always fired *after* `@Initialized(ApplicationScoped.class)` and `ShutdownEvent` is fired *before* `@Destroyed(ApplicationScoped.class)`.
 For a native executable build, however, `@Initialized(ApplicationScoped.class)` is fired as *part of the native build process*, whereas `StartupEvent` is fired when the native image is executed.
 See xref:writing-extensions.adoc#bootstrap-three-phases[Three Phases of Bootstrap and Quarkus Philosophy] for more details.
 
@@ -193,10 +194,10 @@ package org.acme.lifecycle;
 import io.quarkus.runtime.Startup;
 import jakarta.enterprise.context.ApplicationScoped;
 
-@Startup // <1> 
+@Startup // <1>
 @ApplicationScoped
 public class EagerAppBean {
-  
+
    private final String name;
 
    EagerAppBean(NameGenerator generator) { // <2>
@@ -222,10 +223,10 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class EagerAppBean {
-  
+
    @Startup
    void init() { <1>
-     doSomeCoolInit(); 
+     doSomeCoolInit();
    }
 }
 ----
@@ -234,7 +235,7 @@ public class EagerAppBean {
 [[shutdown_annotation]]
 === Using `@Shutdown` to execute a business method of a CDI bean during application shutdown
 
-The `@io.quarkus.runtime.Shutdown` annotation is used to mark a business method of a CDI bean that should be executed during application shutdown. 
+The `@io.quarkus.runtime.Shutdown` annotation is used to mark a business method of a CDI bean that should be executed during application shutdown.
 The annotated method must be non-private and non-static and declare no arguments.
 The behavior is similar to a declaration of a `ShutdownEvent` observer.
 The following examples are functionally equivalent.

--- a/docs/src/main/asciidoc/liquibase-mongodb.adoc
+++ b/docs/src/main/asciidoc/liquibase-mongodb.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Liquibase MongoDB
-
 include::_attributes.adoc[]
 :change-log: src/main/resources/db/changeLog.xml
 :config-file: application.properties

--- a/docs/src/main/asciidoc/messaging-virtual-threads.adoc
+++ b/docs/src/main/asciidoc/messaging-virtual-threads.adoc
@@ -1,5 +1,9 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
 = Quarkus Virtual Thread support with Reactive Messaging
-
 include::_attributes.adoc[]
 :runonvthread: https://javadoc.io/doc/io.smallrye.common/smallrye-common-annotation/latest/io/smallrye/common/annotation/RunOnVirtualThread.html
 :rm_blocking_annotation: https://javadoc.io/doc/io.smallrye.reactive/smallrye-reactive-messaging-api/latest/io/smallrye/reactive/messaging/annotations/Blocking.html

--- a/docs/src/main/asciidoc/mutiny-primer.adoc
+++ b/docs/src/main/asciidoc/mutiny-primer.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Mutiny - Async for bare mortal
-
 include::_attributes.adoc[]
 
 https://smallrye.io/smallrye-mutiny[Mutiny] is an intuitive, reactive programming library.

--- a/docs/src/main/asciidoc/pulsar-dev-services.adoc
+++ b/docs/src/main/asciidoc/pulsar-dev-services.adoc
@@ -62,6 +62,6 @@ The following example enables transaction support:
 
 [source, properties]
 ----
-quarkus.pulsar.devservices.broker-config.transactionCoordinatorEnabled=true
-quarkus.pulsar.devservices.broker-config.systemTopicEnabled=true
+quarkus.pulsar.devservices.broker-config.transaction-coordinator-enabled=true
+quarkus.pulsar.devservices.broker-config.system-topic-enabled=true
 ----

--- a/docs/src/main/asciidoc/quarkus-maven-plugin.adoc
+++ b/docs/src/main/asciidoc/quarkus-maven-plugin.adoc
@@ -4,11 +4,10 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Maven Plugin
+include::_attributes.adoc[]
 
 The Quarkus Maven Plugin builds the Quarkus applications, and provides helpers to launch dev mode or build native executables.
 For more information about how to use the Quarkus Maven Plugin, please refer to the xref:maven-tooling.adoc[Maven Tooling guide].
-
-include::_attributes.adoc[]
 
 == Discover Maven goals
 

--- a/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
+++ b/docs/src/main/asciidoc/quarkus-runtime-base-image.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Quarkus Base Runtime Image
-
 include::_attributes.adoc[]
 
 To ease the containerization of native executables, Quarkus provides a base image providing the requirements to run these executables.

--- a/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Dev Services for RabbitMQ
-
 include::_attributes.adoc[]
 
 Dev Services for RabbitMQ automatically starts a RabbitMQ broker in dev mode and when running tests.

--- a/docs/src/main/asciidoc/rabbitmq-reference.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-reference.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Reactive Messaging RabbitMQ Connector Reference Documentation
-
 include::_attributes.adoc[]
 
 This guide is the companion from the xref:rabbitmq.adoc[Getting Started with RabbitMQ].

--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Redis Extension Reference Guide
-
 :extension-status: preview
 include::_attributes.adoc[]
 :numbered:

--- a/docs/src/main/asciidoc/resteasy.adoc
+++ b/docs/src/main/asciidoc/resteasy.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = RESTEasy Classic
-
 include::_attributes.adoc[]
 
 [WARNING]
@@ -210,7 +209,7 @@ public class RegisterCustomModuleCustomizer implements ObjectMapperCustomizer {
 
 Users can even provide their own `ObjectMapper` bean if they so choose.
 If this is done, it is very important to manually inject and apply all `io.quarkus.jackson.ObjectMapperCustomizer` beans in the CDI producer that produces `ObjectMapper`.
-Failure to do so will prevent Jackson specific customizations provided by various extensions from being applied. 
+Failure to do so will prevent Jackson specific customizations provided by various extensions from being applied.
 
 [source,java]
 ----
@@ -293,7 +292,7 @@ public class CustomJsonbConfig {
 [[links]]
 === JSON Hypertext Application Language (HAL) support
 
-The https://tools.ietf.org/id/draft-kelly-json-hal-01.html[HAL] standard is a simple format to represent web links. 
+The https://tools.ietf.org/id/draft-kelly-json-hal-01.html[HAL] standard is a simple format to represent web links.
 
 To enable the HAL support, add the `quarkus-hal` extension to your project. Also, as HAL needs JSON support, you need to add either the `quarkus-resteasy-jsonb` or the `quarkus-resteasy-jackson` extension.
 
@@ -330,7 +329,7 @@ public class RecordsResource {
 }
 ----
 
-Now, the endpoints `/records` and `/records/first` will accept the media type both `json` and `hal+json` to print the records in Hal format. 
+Now, the endpoints `/records` and `/records/first` will accept the media type both `json` and `hal+json` to print the records in Hal format.
 
 For example, if we invoke the `/records` endpoint using curl to return a list of records, the HAL format will look like as follows:
 

--- a/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
@@ -1,3 +1,8 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
 [id="security-authentication-mechanisms"]
 = Authentication mechanisms in Quarkus
 include::_attributes.adoc[]

--- a/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
@@ -1,3 +1,8 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
 [id="security-basic-authentication-howto"]
 = Enable Basic authentication
 include::_attributes.adoc[]

--- a/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
@@ -1,3 +1,8 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
 [id="security-basic-authentication-tutorial"]
 = Secure a Quarkus application with Basic authentication and Jakarta Persistence
 include::_attributes.adoc[]

--- a/docs/src/main/asciidoc/security-basic-authentication.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication.adoc
@@ -1,3 +1,8 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
 [id="security-basic-authentication"]
 = Basic authentication
 include::_attributes.adoc[]

--- a/docs/src/main/asciidoc/security-csrf-prevention.adoc
+++ b/docs/src/main/asciidoc/security-csrf-prevention.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Cross-Site Request Forgery Prevention
-
 include::_attributes.adoc[]
 
 https://owasp.org/www-community/attacks/csrf[Cross-Site Request Forgery (CSRF)] is an attack that forces an end user to execute unwanted actions on a web application in which they are currently authenticated.
@@ -58,14 +57,14 @@ Next, let's add a `csrfToken.html` Qute template producing an HTML form in the `
 <html>
 <head>
 <meta charset="UTF-8">
-<title>User Name Input</title> 
+<title>User Name Input</title>
 </head>
 <body>
     <h1>User Name Input</h1>
 
     <form action="/service/csrfTokenForm" method="post">
     	<input type="hidden" name="{inject:csrf.parameterName}" value="{inject:csrf.token}" />  <1>
-    	
+
     	<p>Your Name: <input type="text" name="name" /></p>
     	<p><input type="submit" name="submit"/></p>
     </form>

--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Security Tips and Tricks
-
 include::_attributes.adoc[]
 
 == Quarkus Security Dependency
@@ -621,6 +620,6 @@ xref:context-propagation.adoc[Context Propagation Guide].
 == References
 
 * xref:security-overview.adoc[Quarkus Security overview]
-* xref:security-architecture.adoc[Quarkus Security architecture] 
+* xref:security-architecture.adoc[Quarkus Security architecture]
 * xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
 * xref:security-identity-providers.adoc[Identity providers]

--- a/docs/src/main/asciidoc/security-jpa.adoc
+++ b/docs/src/main/asciidoc/security-jpa.adoc
@@ -1,3 +1,8 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
 [id="security-jpa"]
 = Quarkus Security with Jakarta Persistence
 include::_attributes.adoc[]

--- a/docs/src/main/asciidoc/security-jwt-build.adoc
+++ b/docs/src/main/asciidoc/security-jwt-build.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Build, Sign and Encrypt JSON Web Tokens
-
 include::_attributes.adoc[]
 
 According to link:https://datatracker.ietf.org/doc/html/rfc7519[RFC7519], JSON Web Token (JWT) is a compact, URL-safe means of representing claims which are encoded as a JSON object that is used as the payload of a JSON Web Signature (JWS) structure or as the plaintext of a JSON Web Encryption (JWE) structure, enabling the claims to be digitally signed or integrity protected with a Message Authentication Code(MAC) and/or encrypted.

--- a/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
@@ -4,8 +4,9 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Keycloak Admin Client
-
 include::_attributes.adoc[]
+:categories: security
+:keywords: sso oidc security keycloak
 
 The Quarkus Keycloak Admin Client and its reactive twin support Keycloak Admin Client which can be used to configure a running Keycloak server.
 

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -6,6 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using OpenID Connect (OIDC) and Keycloak to Centralize Authorization
 include::_attributes.adoc[]
 :categories: security
+:keywords: sso oidc security keycloak
 :summary: This guide demonstrates how your Quarkus application can authorize access to protected resources using Keycloak Authorization Services.
 
 This guide demonstrates how your Quarkus application can authorize a bearer token access to protected resources using https://www.keycloak.org/docs/latest/authorization_services/index.html[Keycloak Authorization Services].

--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -6,6 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using OAuth2 RBAC
 include::_attributes.adoc[]
 :categories: security
+:keywords: oauth
 :summary: This guide explains how your Quarkus application can utilize OAuth2 tokens to provide secured access to the Jakarta REST endpoints.
 :extension-name: Elytron Security OAuth2
 

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -1,3 +1,8 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
 [id="security-oidc-code-flow-authentication-tutorial"]
 = Protect a web application by using OpenID Connect (OIDC) authorization code flow
 include::_attributes.adoc[]

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = OpenID Connect (OIDC) and OAuth2 Client and Filters Reference Guide
-
 include::_attributes.adoc[]
 
 This reference guide explains how to use:

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -6,6 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Dev Services and UI for OpenID Connect (OIDC)
 include::_attributes.adoc[]
 :categories: security
+:keywords: sso oidc security keycloak
 :summary: Start Keycloak or other providers automatically in dev and test modes.
 
 This guide covers the Dev Services and UI for OpenID Connect (OIDC) Keycloak provider and explains how to support Dev Services and UI for other OpenID Connect providers.

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -6,6 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using OpenID Connect (OIDC) Multi-Tenancy
 include::_attributes.adoc[]
 :categories: security
+:keywords: sso oidc oauth2 security
 :summary: This guide demonstrates how your OpenID Connect application can support multi-tenancy so that you can serve multiple tenants from a single application.
 
 This guide demonstrates how your OpenID Connect (OIDC) application can support multi-tenancy so that you can serve multiple tenants from a single application. Tenants can be distinct realms or security domains within the same OpenID Provider or even distinct OpenID Providers.
@@ -590,9 +591,9 @@ To configure the resolution of the tenant identifier, use one of the following o
 [[default-tenant-resolver]]
 === Default resolution
 
-The default resolution for a tenant identifier is convention based, whereby the authentication request must include the tenant identifier in the last segment of the request path. 
+The default resolution for a tenant identifier is convention based, whereby the authentication request must include the tenant identifier in the last segment of the request path.
 
-The following `application.properties` example shows how you can configure two tenants named `google` and `github`:  
+The following `application.properties` example shows how you can configure two tenants named `google` and `github`:
 
 [source,properties]
 ----
@@ -609,7 +610,7 @@ quarkus.oidc.github.credentials.secret=${github-client-secret}
 quarkus.oidc.github.authentication.redirect-path=/signed-in
 ----
 
-In this example, both tenants configure OIDC `web-app` applications to use an authorization code flow to authenticate users and also require session cookies to get generated after the authentication has taken place. 
+In this example, both tenants configure OIDC `web-app` applications to use an authorization code flow to authenticate users and also require session cookies to get generated after the authentication has taken place.
 After either Google or GitHub authenticates the current user, the user gets returned to the `/signed-in` area for authenticated users, for example, a secured resource path on the JAX-RS endpoint.
 
 Finally, to complete the default tenant resolution, set the following configuration property:
@@ -620,8 +621,8 @@ quarkus.http.auth.permission.login.paths=/google,/github
 quarkus.http.auth.permission.login.policy=authenticated
 ----
 
-If the endpoint is running on `http://localhost:8080`, you can also provide UI options for users to log in to either `http://localhost:8080/google` or `http://localhost:8080/github`, without having to add specific`/google` or `/github` JAX-RS resource paths. 
-Tenant identifiers are also recorded in the session cookie names after the authentication is completed. 
+If the endpoint is running on `http://localhost:8080`, you can also provide UI options for users to log in to either `http://localhost:8080/google` or `http://localhost:8080/github`, without having to add specific`/google` or `/github` JAX-RS resource paths.
+Tenant identifiers are also recorded in the session cookie names after the authentication is completed.
 Therefore, authenticated users can access the secured application area without requiring either the `google` or `github` path values to be included in the secured URL.
 
 Default resolution can also work for Bearer token authentication but it might be less practical in this case because a tenant identifier will always need to be set as the last path segment value.
@@ -629,7 +630,7 @@ Default resolution can also work for Bearer token authentication but it might be
 [[tenant-resolver]]
 === Resolve with `TenantResolver`
 
-The following `application.properties` example shows how you can resolve the tenant identifier of two tenants named `a` and `b` by using the `TenantResolver` method: 
+The following `application.properties` example shows how you can resolve the tenant identifier of two tenants named `a` and `b` by using the `TenantResolver` method:
 
 [source,properties]
 ----

--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -8,6 +8,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::_attributes.adoc[]
 :diataxis-type: concept
 :categories: security,web
+:keywords: oidc github twitter google facebook mastodon microsoft apple spotify twitch
 :toclevels: 3
 
 This document explains how to configure well-known social OIDC and OAuth2 providers.
@@ -211,7 +212,7 @@ quarkus.oidc.token.customizer-name=azure-access-token-customizer
 [[apple]]
 === Apple
 
-In order to set up OIDC for Apple you need to create a developer account, and sign up for the 99€/year program, but you cannot test your application on `localhost` like most other OIDC providers: 
+In order to set up OIDC for Apple you need to create a developer account, and sign up for the 99€/year program, but you cannot test your application on `localhost` like most other OIDC providers:
 you will need to run it over `https` and make it publicly accessible, so for development purposes
 you may want to use a service such as https://ngrok.com.
 
@@ -320,7 +321,7 @@ quarkus.oidc.credentials.jwt.subject=<Bundle ID}
 [[facebook]]
 === Facebook
 
-Facebook you will not be let you test your application on `localhost` like most other OIDC providers: 
+Facebook you will not be let you test your application on `localhost` like most other OIDC providers:
 you will need to run it over `https` and make it publicly accessible, so for development purposes
 you may want to use a service such as https://ngrok.com.
 
@@ -444,7 +445,7 @@ Please see <<twitter>> for more information about registering your Quarkus appli
 === Spotify
 
 Create a https://developer.spotify.com/documentation/general/guides/authorization/app-settings/[Spotify application]:
- 
+
 image::oidc-spotify-1.png[role="thumb"]
 
 Don't forget to add `http://localhost:8080` as a redirect URI for testing during development purposes. You should get a client id and secret generated once a Spotify application setup has been complete, for example:
@@ -466,7 +467,7 @@ quarkus.oidc.credentials.secret=<Client Secret>
 === Twitch
 
 Create a https://dev.twitch.tv/console/apps[Twitch application]:
- 
+
 image::oidc-twitch-1.png[role="thumb"]
 
 You can now configure your `application.properties`:
@@ -519,7 +520,7 @@ For more information, see the Quarkus xref:security-openid-connect-multitenancy.
 Sometimes, only authenticating users with a social provider is not enough.
 A provider-specific service also needs to be accessed for the Quarkus OIDC `web-app` application to fetch or update data from the provider service on behalf of the currently authenticated user.
 
-As mentioned in the xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications] guide, ID and access tokens are returned after the authorization code flow has been completed, with some providers like `GitHub` returning an access token only. 
+As mentioned in the xref:security-oidc-code-flow-authentication.adoc[OIDC code flow mechanism for protecting web applications] guide, ID and access tokens are returned after the authorization code flow has been completed, with some providers like `GitHub` returning an access token only.
 It is this access token that has to be propagated to services such as `Google Calendar`, or `Spotify Playlists` for the currently authenticated user to be able to use such services.
 
 You do not have to bring provider-specific libraries in order to achieve this, but instead you can use a reactive `Token Propagation` filter, which can be bound to a given REST client with a simple annotation.

--- a/docs/src/main/asciidoc/security-overview.adoc
+++ b/docs/src/main/asciidoc/security-overview.adoc
@@ -1,3 +1,8 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
 [id="security-overview"]
 = Quarkus Security overview
 include::_attributes.adoc[]

--- a/docs/src/main/asciidoc/security-testing.adoc
+++ b/docs/src/main/asciidoc/security-testing.adoc
@@ -4,7 +4,6 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Security Testing
-
 include::_attributes.adoc[]
 
 This document describes how to test Quarkus Security.

--- a/docs/src/main/asciidoc/smallrye-metrics.adoc
+++ b/docs/src/main/asciidoc/smallrye-metrics.adoc
@@ -3,7 +3,6 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-
 = SmallRye Metrics
 :extension-status: deprecated
 include::_attributes.adoc[]
@@ -177,7 +176,7 @@ The application will respond that 350 is not a prime number because it can be di
 curl localhost:8080/629521085409773
 ----
 +
-The application will respond that 629521085409773 is a prime number. 
+The application will respond that 629521085409773 is a prime number.
 
 .. Perform additional calls with numbers of your choice.
 

--- a/docs/src/main/asciidoc/stork-kubernetes.adoc
+++ b/docs/src/main/asciidoc/stork-kubernetes.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Stork with Kubernetes
 :extension-status: preview
-
 include::_attributes.adoc[]
 
 This guide explains how to use Stork with Kubernetes for service discovery and load balancing.

--- a/docs/src/main/asciidoc/stork-reference.adoc
+++ b/docs/src/main/asciidoc/stork-reference.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Stork Reference Guide
 :extension-status: preview
-
 include::_attributes.adoc[]
 
 This guide is the companion from the xref:stork.adoc[Stork Getting Started Guide].

--- a/docs/src/main/asciidoc/stork.adoc
+++ b/docs/src/main/asciidoc/stork.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Getting Started with SmallRye Stork
 :extension-status: preview
-
 include::_attributes.adoc[]
 
 The essence of distributed systems resides in the interaction between services.


### PR DESCRIPTION
There were some remaining issues in the preambles of some guides with some additional new lines that are causing issues. Also some guides were missing the header redirecting the contributors here.

As for keywords, guide owners will have to reintroduce them back if needed as I wasn't able to do a 1-1 mapping.

Sorry, there is some noise with VS Code cleaning up the new lines.

@sberyozkin this should help with what you reported about `twitter` not being found. The infra to push them to the index was already there but the keywords went missing. Note that I haven't been able to add all the keywords that were in the original index as I had troubles finding a 1-1 mapping between the old guides and the new structure. In any case, no need to add the `security` keywords everywhere as done before as it's in the title already.

Fixes https://github.com/quarkusio/quarkusio.github.io/issues/1800