### PR TITLE
Add support for Google Application Default Credentials

### DIFF
--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -383,6 +383,8 @@ public class JibProcessor {
                 }
                 registryImage.addCredentialRetriever(credentialRetrieverFactory.dockerConfig(dockerConfigPath));
             }
+
+            registryImage.addCredentialRetriever(credentialRetrieverFactory.googleApplicationDefaultCredentials());
         }
         return registryImage;
     }


### PR DESCRIPTION
This will try ADC as the last option if the container registry to push to is GCR or GAR. This should be equivalent to how the Maven and Gradle Jib plugins handle it.

Resolves quarkusio/quarkus#36306