### PR TITLE
Add support for Vert.x Web sessions

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1226,6 +1226,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-infinispan-client-runtime-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-infinispan-client-deployment-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-infinispan-client-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1241,6 +1241,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-infinispan-client-sessions</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-infinispan-client-sessions-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-jaeger</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -5979,6 +5989,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-redis-client-sessions</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-redis-cache</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -5991,6 +6006,11 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-redis-client-deployment-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-redis-client-sessions-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5974,6 +5974,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-redis-client-runtime-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-redis-cache</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -5981,6 +5986,11 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-redis-client-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-redis-client-deployment-spi</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -891,6 +891,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-infinispan-client-sessions</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-info</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
@@ -1828,6 +1841,19 @@
                 <dependency>
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-redis-client</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-redis-client-sessions</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>
                     <scope>test</scope>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -907,6 +907,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client-sessions-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-info-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
@@ -1844,6 +1857,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-redis-client-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-redis-client-sessions-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -546,7 +546,150 @@ link:https://undertow.io/undertow-docs/undertow-docs-2.0.0/index.html#predicates
 
 If you are using a `web.xml` file as your configuration file, you can place it in the `src/main/resources/META-INF` directory.
 
-=== Built-in route order values
+[[vertx-web-sessions]]
+== Sessions
+
+Quarkus includes support for sessions, based on https://vertx.io/docs/vertx-web/java/#_handling_sessions[Vert.x Web sessions].
+
+By default, sessions are disabled.
+To enable them, set the `quarkus.http.sessions.mode` configuration property to:
+
+`in-memory`:: for sessions stored in memory of the Quarkus application
+`redis`:: for sessions stored in an external Redis server; requires using the Quarkus Redis Client extension
+`infinispan`:: for sessions stored in an external Infinispan data grid; requires using the Quarkus Infinispan Client extension
+
+This configuration property is fixed at build time and cannot be changed at runtime.
+
+WARNING: Undertow includes its own support for sessions.
+If Undertow is present, Vert.x Web sessions cannot be enabled.
+
+Sessions require using a cookie, which holds the session identifier.
+By default, the cookie name is `JSESSIONID`.
+Cookieless sessions are not supported.
+Storing session data directly into the session cookie is not supported either.
+
+=== Accessing sessions
+
+When sessions are enabled, the Vert.x Web `Session` object may be obtained from the current `RoutingContext` using `RoutingContext.session()`.
+Alternatively, the `io.vertx.ext.web.Session` object may be injected.
+
+When using non-clustered in-memory sessions, arbitrary objects may be stored into a session.
+
+With Redis, Infinispan, or cluster-wide in-memory sessions, the following data types may be stored into a session:
+
+* primitive wrapper types
+** `java.lang.Boolean`
+** `java.lang.Byte`
+** `java.lang.Short`
+** `java.lang.Integer`
+** `java.lang.Long`
+** `java.lang.Float`
+** `java.lang.Double`
+** `java.lang.Character`
+* `java.lang.String`
+* `byte[]`
+* `io.vertx.core.buffer.Buffer`
+* `io.vertx.core.json.JsonObject`
+* `io.vertx.core.json.JsonArray`
+
+Session data are stored in a _session store_.
+At the beginning of request processing, session data are loaded from the session store and put into the `Session` object.
+The `Session` object contains an independent snapshot of session data and can be accessed freely during request processing.
+When the response is being written, session data are stored back to the session store.
+
+Session data are loaded and stored as an entire whole, which means that they are always internally consistent.
+In case of concurrent access to the session, the initial session state (at the beginning of a request) is identical to the final session state of some previous request.
+There is no guarantee that modifications will survive (another conflicting write may win the race).
+
+[WARNING]
+====
+In case of non-clustered in-memory sessions, requests share the `Session` object and the instances stored in it.
+It is your responsibility as an application programmer to properly synchronize access to these shared data.
+
+With Redis or Infinispan, the `Session` objects are truly independent snapshots.
+There are no objects shared between requests in this case.
+====
+
+Loading and storing session data in a fine-grained fashion (per individual attribute) is not supported, which makes reasoning about concurrent session access easier.
+It also means you need to pay attention to the session size.
+
+Persisting session data back to the session store is initiated when response headers are written, but the operation is otherwise asynchronous to response body writing.
+It is possible that persisting the session to the session store takes longer than writing the entire response, especially in case of tiny responses.
+
+=== General configuration
+
+include::{generated-dir}/config/quarkus-vertx-http-config-group-sessions-build-time-config.adoc[leveloffset=+1, opts=optional]
+
+include::{generated-dir}/config/quarkus-vertx-http-config-group-sessions-config.adoc[leveloffset=+1, opts=optional]
+
+=== In-memory sessions
+
+When `quarkus.http.sessions.mode` is set to `in-memory`, session data are stored in a Vert.x shared map.
+By default, that shared map is _local_, which means that the session data are stored only in the JVM heap of the Quarkus application.
+
+In this mode, if an application is deployed in multiple replicas fronted with a load balancer, it is necessary to enable sticky sessions (also known as session affinity) on the load balancer.
+Still, losing a replica means losing all sessions stored on that replica.
+In a multi-replica deployment, it is recommended to use an external session store (Redis or Infinispan).
+
+Alternatively, if Vert.x clustering is configured, in-memory sessions may also be configured to be _cluster-wide_.
+In this mode, a Vert.x _cluster-wide_ shared map is used to store session data, which means that sticky sessions are not necessary and losing one replica doesn't lead to session data loss.
+
+include::{generated-dir}/config/quarkus-http-sessions-in-memory-sessions-in-memory-config.adoc[leveloffset=+1, opts=optional]
+
+=== Redis sessions
+
+When `quarkus.http.sessions.mode` is set to `redis`, session data are stored in an external Redis server.
+The xref:./redis.adoc[Quarkus Redis Client] extension must be present and a connection to the Redis server used to store session data must be configured there.
+
+By default, the default (unnamed) Redis connection is used.
+To select a different (named) Redis connection, set the `quarkus.http.sessions.redis.client-name` configuration property.
+For example:
+
+[source,properties]
+----
+quarkus.http.sessions.mode=redis
+quarkus.http.sessions.redis.client-name=web-sessions <1>
+
+quarkus.redis.web-sessions.hosts=redis://localhost:6379/7 <2>
+----
+<1> Use the `web-sessions` Redis client for storing session data.
+<2> Use database `7` on the Redis server at `localhost:6379`.
+
+The Redis-based session store requires an entire Redis database for itself.
+When using a standalone Redis server, you can use a https://redis.io/commands/select/[logical database] that is not used for other purposes.
+If you want to store session data into a Redis cluster, you need to dedicate an entire cluster, because Redis cluster only supports database zero.
+
+include::{generated-dir}/config/quarkus-redis-sessions.adoc[leveloffset=+1, opts=optional]
+
+=== Infinispan sessions
+
+When `quarkus.http.sessions.mode` is set to `infinispan`, session data are stored in an external Infinispan data grid.
+The xref:./infinispan-client.adoc[Quarkus Infinispan Client] extension must be present and a connection to the Infinispan data grid used to store session data must be configured there.
+
+By default, the default (unnamed) Infinispan connection is used.
+To select a different (named) Infinispan connection, set the `quarkus.http.sessions.infinispan.client-name` configuration property.
+For example:
+
+[source,properties]
+----
+quarkus.http.sessions.mode=infinispan
+quarkus.http.sessions.infinispan.client-name=web-sessions <1>
+
+quarkus.infinispan-client.web-sessions.hosts=localhost:11222 <2>
+----
+<1> Use the `web-sessions` Infinispan client for storing session data.
+<2> Use the Infinispan data grid at `localhost:11222`.
+
+By default, the Infinispan cache used for storing session data is called `quarkus.sessions`.
+To use a different cache, set the `quarkus.http.sessions.infinispan.cache-name` configuration property.
+
+The Infinispan-based session store verifies if the configured cache exists.
+If it does not, it is created automatically from the `DIST_SYNC` default template.
+Therefore, the Infinispan client must be configured to connect as a user with permissions equivalent to at least the `deployer` Infinispan role.
+
+include::{generated-dir}/config/quarkus-infinispan-sessions.adoc[leveloffset=+1, opts=optional]
+
+== Built-in route order values
 
 Route order values are the values that are specified via Vert.x route `io.vertx.ext.web.Route.order(int)` function.
 
@@ -565,6 +708,7 @@ Route order constants defined in `io.quarkus.vertx.http.runtime.RouteConstants` 
 | `Integer.MIN_VALUE` | `ROUTE_ORDER_BODY_HANDLER_MANAGEMENT` | Body handler for the management router.
 | `Integer.MIN_VALUE` | `ROUTE_ORDER_HEADERS` | Handlers that add headers specified in the configuration.
 | `Integer.MIN_VALUE` | `ROUTE_ORDER_CORS_MANAGEMENT` | CORS-Origin handler of the management router.
+| `Integer.MIN_VALUE` | `ROUTE_ORDER_SESSION_HANDLER` | Session handler, if enabled in the configuration.
 | `Integer.MIN_VALUE + 1` | `ROUTE_ORDER_BODY_HANDLER` | Body handler.
 | `-2` | `ROUTE_ORDER_UPLOAD_LIMIT` | Route that enforces the upload body size limit.
 | `0` | `ROUTE_ORDER_COMPRESSION` | Compression handler.

--- a/extensions/infinispan-client/deployment-spi/pom.xml
+++ b/extensions/infinispan-client/deployment-spi/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-infinispan-client-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-infinispan-client-deployment-spi</artifactId>
+    <name>Quarkus - Infinispan - Client - Deployment SPI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client-runtime-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-hotrod-jakarta</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.infinispan</groupId>
+                    <artifactId>infinispan-jboss-marshalling</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                    <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/extensions/infinispan-client/deployment-spi/src/main/java/io/quarkus/infinispan/client/deployment/spi/InfinispanClientBuildItem.java
+++ b/extensions/infinispan-client/deployment-spi/src/main/java/io/quarkus/infinispan/client/deployment/spi/InfinispanClientBuildItem.java
@@ -1,4 +1,4 @@
-package io.quarkus.infinispan.client.deployment;
+package io.quarkus.infinispan.client.deployment.spi;
 
 import org.infinispan.client.hotrod.RemoteCacheManager;
 
@@ -12,8 +12,7 @@ public final class InfinispanClientBuildItem extends MultiBuildItem {
     private final RuntimeValue<RemoteCacheManager> client;
     private final String name;
 
-    public InfinispanClientBuildItem(RuntimeValue<RemoteCacheManager> client,
-            String name) {
+    public InfinispanClientBuildItem(RuntimeValue<RemoteCacheManager> client, String name) {
         this.client = client;
         this.name = name;
     }

--- a/extensions/infinispan-client/deployment-spi/src/main/java/io/quarkus/infinispan/client/deployment/spi/InfinispanClientNameBuildItem.java
+++ b/extensions/infinispan-client/deployment-spi/src/main/java/io/quarkus/infinispan/client/deployment/spi/InfinispanClientNameBuildItem.java
@@ -1,4 +1,4 @@
-package io.quarkus.infinispan.client.deployment;
+package io.quarkus.infinispan.client.deployment.spi;
 
 import io.quarkus.builder.item.MultiBuildItem;
 

--- a/extensions/infinispan-client/deployment/pom.xml
+++ b/extensions/infinispan-client/deployment/pom.xml
@@ -31,6 +31,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-caffeine-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanBindingProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanBindingProcessor.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.infinispan.client.deployment.spi.InfinispanClientBuildItem;
 import io.quarkus.infinispan.client.runtime.InfinispanClientUtil;
 import io.quarkus.kubernetes.service.binding.spi.ServiceBindingQualifierBuildItem;
 

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/InfinispanClientProcessor.java
@@ -92,6 +92,8 @@ import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.infinispan.client.InfinispanClientName;
 import io.quarkus.infinispan.client.Remote;
+import io.quarkus.infinispan.client.deployment.spi.InfinispanClientBuildItem;
+import io.quarkus.infinispan.client.deployment.spi.InfinispanClientNameBuildItem;
 import io.quarkus.infinispan.client.runtime.InfinispanClientBuildTimeConfig;
 import io.quarkus.infinispan.client.runtime.InfinispanClientProducer;
 import io.quarkus.infinispan.client.runtime.InfinispanClientUtil;
@@ -623,9 +625,9 @@ class InfinispanClientProcessor {
             List<InfinispanClientNameBuildItem> infinispanClientNames,
             // make sure all beans have been initialized
             @SuppressWarnings("unused") BeanContainerBuildItem beanContainer) {
-        List<InfinispanClientBuildItem> result = new ArrayList<>(infinispanClientNames.size());
-        for (InfinispanClientNameBuildItem ic : infinispanClientNames) {
-            String name = ic.getName();
+        Set<String> names = infinispanClientNames.stream().map(icn -> icn.getName()).collect(Collectors.toSet());
+        List<InfinispanClientBuildItem> result = new ArrayList<>(names.size());
+        for (String name : names) {
             result.add(new InfinispanClientBuildItem(recorder.getClient(name), name));
         }
         return result;

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
@@ -159,9 +159,7 @@ public class InfinispanDevServiceProcessor {
             Map<String, RunningDevService> newDevServices,
             Map<String, String> properties) {
         try {
-            log.infof("Starting Dev Service for connection %s", clientName);
             InfinispanDevServicesConfig namedDevServiceConfig = config.devService.devservices;
-            log.infof("Apply Dev Services config %s", namedDevServiceConfig);
             RunningDevService devService = startContainer(clientName, dockerStatusBuildItem, namedDevServiceConfig,
                     launchMode.getLaunchMode(),
                     !devServicesSharedNetworkBuildItem.isEmpty(), globalDevServicesConfig.timeout, properties);
@@ -189,7 +187,7 @@ public class InfinispanDevServiceProcessor {
         }
 
         String configPrefix = getConfigPrefix(clientName);
-        log.info("Config prefix " + configPrefix);
+        log.debugf("Config prefix %s", configPrefix);
 
         boolean needToStart = !ConfigUtils.isPropertyPresent(configPrefix + "hosts")
                 && !ConfigUtils.isPropertyPresent(configPrefix + "server-list");
@@ -204,6 +202,9 @@ public class InfinispanDevServiceProcessor {
                     "Please configure 'quarkus.infinispan-client.hosts' or 'quarkus.infinispan-client.uri' or get a working docker instance");
             return null;
         }
+
+        log.infof("Starting Dev Service for connection %s", clientName);
+        log.debugf("Apply Dev Services config %s", devServicesConfig);
 
         Supplier<RunningDevService> infinispanServerSupplier = () -> {
             QuarkusInfinispanContainer infinispanContainer = new QuarkusInfinispanContainer(clientName, devServicesConfig,

--- a/extensions/infinispan-client/pom.xml
+++ b/extensions/infinispan-client/pom.xml
@@ -15,6 +15,8 @@
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>
+        <module>deployment-spi</module>
         <module>runtime</module>
+        <module>runtime-spi</module>
     </modules>
 </project>

--- a/extensions/infinispan-client/pom.xml
+++ b/extensions/infinispan-client/pom.xml
@@ -18,5 +18,8 @@
         <module>deployment-spi</module>
         <module>runtime</module>
         <module>runtime-spi</module>
+
+        <module>sessions/deployment</module>
+        <module>sessions/runtime</module>
     </modules>
 </project>

--- a/extensions/infinispan-client/runtime-spi/pom.xml
+++ b/extensions/infinispan-client/runtime-spi/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-infinispan-client-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-infinispan-client-runtime-spi</artifactId>
+    <name>Quarkus - Infinispan - Client - Runtime SPI</name>
+
+</project>

--- a/extensions/infinispan-client/runtime-spi/src/main/java/io/quarkus/infinispan/client/runtime/spi/InfinispanConstants.java
+++ b/extensions/infinispan-client/runtime-spi/src/main/java/io/quarkus/infinispan/client/runtime/spi/InfinispanConstants.java
@@ -1,0 +1,6 @@
+package io.quarkus.infinispan.client.runtime.spi;
+
+public class InfinispanConstants {
+    public static final String DEFAULT_INFINISPAN_CLIENT_NAME = "<default>";
+    public static final String INFINISPAN_CLIENT_CONFIG_ROOT_NAME = "infinispan-client";
+}

--- a/extensions/infinispan-client/runtime/pom.xml
+++ b/extensions/infinispan-client/runtime/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>quarkus-elytron-security-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client-runtime-spi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-sasl-plain</artifactId>
         </dependency>
@@ -75,9 +79,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.jboss.spec.javax.transaction</groupId>
-                    <artifactId>
-                        jboss-transaction-api_1.2_spec
-                    </artifactId>
+                    <artifactId>jboss-transaction-api_1.2_spec</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>io.netty</groupId>

--- a/extensions/infinispan-client/runtime/pom.xml
+++ b/extensions/infinispan-client/runtime/pom.xml
@@ -149,6 +149,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client-sessions</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientUtil.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanClientUtil.java
@@ -3,11 +3,13 @@ package io.quarkus.infinispan.client.runtime;
 import java.util.Collection;
 import java.util.List;
 
+import io.quarkus.infinispan.client.runtime.spi.InfinispanConstants;
+
 public final class InfinispanClientUtil {
 
     public static final String DEFAULT_INFINISPAN_DEV_SERVICE_NAME = "infinispan";
-    public static final String DEFAULT_INFINISPAN_CLIENT_NAME = "<default>";
-    public static final String INFINISPAN_CLIENT_CONFIG_ROOT_NAME = "infinispan-client";
+    public static final String DEFAULT_INFINISPAN_CLIENT_NAME = InfinispanConstants.DEFAULT_INFINISPAN_CLIENT_NAME;
+    public static final String INFINISPAN_CLIENT_CONFIG_ROOT_NAME = InfinispanConstants.INFINISPAN_CLIENT_CONFIG_ROOT_NAME;
 
     public static boolean isDefault(String infinispanClientName) {
         return DEFAULT_INFINISPAN_CLIENT_NAME.equals(infinispanClientName);

--- a/extensions/infinispan-client/sessions/deployment/pom.xml
+++ b/extensions/infinispan-client/sessions/deployment/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-infinispan-client-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-infinispan-client-sessions-deployment</artifactId>
+
+    <name>Quarkus - Infinispan Client - Vert.x Web Sessions - Deployment</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client-sessions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-infinispan-client-deployment-spi</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/infinispan-client/sessions/deployment/src/main/java/io/quarkus/infinispan/sessions/deployment/InfinispanSessionsBuildTimeConfig.java
+++ b/extensions/infinispan-client/sessions/deployment/src/main/java/io/quarkus/infinispan/sessions/deployment/InfinispanSessionsBuildTimeConfig.java
@@ -1,0 +1,23 @@
+package io.quarkus.infinispan.sessions.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Configuration of Vert.x Web sessions stored in remote Infinispan cache.
+ */
+@ConfigRoot(name = "http.sessions.infinispan", phase = ConfigPhase.BUILD_TIME)
+public class InfinispanSessionsBuildTimeConfig {
+    /**
+     * Name of the Infinispan client configured in the Quarkus Infinispan Client extension configuration.
+     * If not set, uses the default (unnamed) Infinispan client.
+     * <p>
+     * Note that the Infinispan client must be configured to connect as a user with the necessary permissions
+     * on the Infinispan server. The required minimum is equivalent to the Infinispan {@code deployer} role.
+     */
+    @ConfigItem
+    public Optional<String> clientName;
+}

--- a/extensions/infinispan-client/sessions/deployment/src/main/java/io/quarkus/infinispan/sessions/deployment/InfinispanSessionsProcessor.java
+++ b/extensions/infinispan-client/sessions/deployment/src/main/java/io/quarkus/infinispan/sessions/deployment/InfinispanSessionsProcessor.java
@@ -1,0 +1,46 @@
+package io.quarkus.infinispan.sessions.deployment;
+
+import java.util.List;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.infinispan.client.deployment.spi.InfinispanClientBuildItem;
+import io.quarkus.infinispan.client.deployment.spi.InfinispanClientNameBuildItem;
+import io.quarkus.infinispan.client.runtime.spi.InfinispanConstants;
+import io.quarkus.infinispan.sessions.runtime.InfinispanSessionsRecorder;
+import io.quarkus.vertx.http.deployment.SessionStoreProviderBuildItem;
+import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.SessionsBuildTimeConfig;
+
+public class InfinispanSessionsProcessor {
+    @BuildStep
+    public void infinispanClients(HttpBuildTimeConfig httpConfig,
+            InfinispanSessionsBuildTimeConfig config,
+            BuildProducer<InfinispanClientNameBuildItem> infinispanRequest) {
+        if (httpConfig.sessions.mode == SessionsBuildTimeConfig.SessionsMode.INFINISPAN) {
+            String clientName = config.clientName.orElse(InfinispanConstants.DEFAULT_INFINISPAN_CLIENT_NAME);
+            infinispanRequest.produce(new InfinispanClientNameBuildItem(clientName));
+        }
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void infinispanSessions(HttpBuildTimeConfig httpConfig,
+            InfinispanSessionsBuildTimeConfig config,
+            List<InfinispanClientBuildItem> clients,
+            BuildProducer<SessionStoreProviderBuildItem> provider,
+            InfinispanSessionsRecorder recorder) {
+        if (httpConfig.sessions.mode == SessionsBuildTimeConfig.SessionsMode.INFINISPAN) {
+            String clientName = config.clientName.orElse(InfinispanConstants.DEFAULT_INFINISPAN_CLIENT_NAME);
+            for (InfinispanClientBuildItem infinispanClient : clients) {
+                if (clientName.equals(infinispanClient.getName())) {
+                    provider.produce(new SessionStoreProviderBuildItem(recorder.create(infinispanClient.getClient())));
+                    return;
+                }
+            }
+            throw new IllegalStateException("Unknown Infinispan client: " + clientName);
+        }
+    }
+}

--- a/extensions/infinispan-client/sessions/runtime/pom.xml
+++ b/extensions/infinispan-client/sessions/runtime/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-infinispan-client-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-infinispan-client-sessions</artifactId>
+
+    <name>Quarkus - Infinispan Client - Vert.x Web Sessions - Runtime</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-sstore-infinispan</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.infinispan</groupId>
+                    <artifactId>infinispan-client-hotrod</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.reactivex.rxjava3</groupId>
+                    <artifactId>rxjava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-hotrod-jakarta</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.infinispan</groupId>
+                    <artifactId>infinispan-jboss-marshalling</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                    <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <configuration>
+                    <dependencyCondition>
+                        <artifact>io.quarkus:quarkus-vertx-http</artifact>
+                    </dependencyCondition>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/infinispan-client/sessions/runtime/src/main/java/io/quarkus/infinispan/sessions/runtime/InfinispanSessionsConfig.java
+++ b/extensions/infinispan-client/sessions/runtime/src/main/java/io/quarkus/infinispan/sessions/runtime/InfinispanSessionsConfig.java
@@ -1,0 +1,28 @@
+package io.quarkus.infinispan.sessions.runtime;
+
+import java.time.Duration;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Configuration of Vert.x Web sessions stored in remote Infinispan cache.
+ */
+@ConfigRoot(name = "http.sessions.infinispan", phase = ConfigPhase.RUN_TIME)
+public class InfinispanSessionsConfig {
+    /**
+     * Name of the Infinispan cache used to store session data. If it does not exist, it is created
+     * automatically from Infinispan's default template {@code DIST_SYNC}.
+     */
+    @ConfigItem(defaultValue = "quarkus.sessions")
+    public String cacheName;
+
+    /**
+     * Maximum time to retry when retrieving session data from the Infinispan cache.
+     * The Vert.x session handler retries when the session data are not found, because
+     * distributing data across an Infinispan cluster may take time.
+     */
+    @ConfigItem(defaultValue = "5s")
+    public Duration retryTimeout;
+}

--- a/extensions/infinispan-client/sessions/runtime/src/main/java/io/quarkus/infinispan/sessions/runtime/InfinispanSessionsRecorder.java
+++ b/extensions/infinispan-client/sessions/runtime/src/main/java/io/quarkus/infinispan/sessions/runtime/InfinispanSessionsRecorder.java
@@ -1,0 +1,38 @@
+package io.quarkus.infinispan.sessions.runtime;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.sstore.SessionStore;
+import io.vertx.ext.web.sstore.infinispan.InfinispanSessionStore;
+
+@Recorder
+public class InfinispanSessionsRecorder {
+    private final RuntimeValue<InfinispanSessionsConfig> config;
+
+    public InfinispanSessionsRecorder(RuntimeValue<InfinispanSessionsConfig> config) {
+        this.config = config;
+    }
+
+    public Supplier<SessionStore> create(RuntimeValue<RemoteCacheManager> client) {
+        return new Supplier<SessionStore>() {
+            @Override
+            public SessionStore get() {
+                Vertx vertx = VertxCoreRecorder.getVertx().get();
+                String cacheName = config.getValue().cacheName;
+                Duration retryTimeout = config.getValue().retryTimeout;
+                JsonObject options = new JsonObject()
+                        .put("cacheName", cacheName)
+                        .put("retryTimeout", retryTimeout.toMillis());
+                return InfinispanSessionStore.create(vertx, options, client.getValue());
+            }
+        };
+    }
+}

--- a/extensions/infinispan-client/sessions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/infinispan-client/sessions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,13 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "Infinispan Client - Vert.x Web Sessions"
+metadata:
+  keywords:
+  - "infinispan"
+  - "vertx"
+  - "sessions"
+  guide: "https://quarkus.io/guides/http-reference#vertx-web-sessions"
+  categories:
+  - "web"
+  status: "preview"
+  unlisted: true

--- a/extensions/redis-cache/deployment/src/main/java/io/quarkus/cache/redis/deployment/RedisCacheProcessor.java
+++ b/extensions/redis-cache/deployment/src/main/java/io/quarkus/cache/redis/deployment/RedisCacheProcessor.java
@@ -34,7 +34,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.redis.deployment.client.RequestedRedisClientBuildItem;
+import io.quarkus.redis.deployment.client.spi.RequestedRedisClientBuildItem;
 import io.quarkus.redis.runtime.client.config.RedisConfig;
 import io.smallrye.mutiny.Uni;
 

--- a/extensions/redis-client/deployment-spi/pom.xml
+++ b/extensions/redis-client/deployment-spi/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-redis-client-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-redis-client-deployment-spi</artifactId>
+    <name>Quarkus - Redis Client - Deployment SPI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-redis-client-runtime-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-mutiny-vertx-redis-client</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/extensions/redis-client/deployment-spi/src/main/java/io/quarkus/redis/deployment/client/spi/RedisClientBuildItem.java
+++ b/extensions/redis-client/deployment-spi/src/main/java/io/quarkus/redis/deployment/client/spi/RedisClientBuildItem.java
@@ -1,0 +1,27 @@
+package io.quarkus.redis.deployment.client.spi;
+
+import java.util.function.Supplier;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.vertx.mutiny.redis.client.Redis;
+
+/**
+ * Provides runtime access to the Redis clients, in the Mutiny variant.
+ */
+public final class RedisClientBuildItem extends MultiBuildItem {
+    private final Supplier<Redis> client;
+    private final String name;
+
+    public RedisClientBuildItem(Supplier<Redis> client, String name) {
+        this.client = client;
+        this.name = name;
+    }
+
+    public Supplier<Redis> getClient() {
+        return client;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/extensions/redis-client/deployment-spi/src/main/java/io/quarkus/redis/deployment/client/spi/RequestedRedisClientBuildItem.java
+++ b/extensions/redis-client/deployment-spi/src/main/java/io/quarkus/redis/deployment/client/spi/RequestedRedisClientBuildItem.java
@@ -1,4 +1,4 @@
-package io.quarkus.redis.deployment.client;
+package io.quarkus.redis.deployment.client.spi;
 
 import io.quarkus.builder.item.MultiBuildItem;
 

--- a/extensions/redis-client/deployment/pom.xml
+++ b/extensions/redis-client/deployment/pom.xml
@@ -33,6 +33,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-redis-client-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health-spi</artifactId>
         </dependency>
         <dependency>

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisClientProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisClientProcessor.java
@@ -48,6 +48,8 @@ import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.redis.client.RedisHostsProvider;
 import io.quarkus.redis.client.RedisOptionsCustomizer;
 import io.quarkus.redis.client.reactive.ReactiveRedisClient;
+import io.quarkus.redis.deployment.client.spi.RedisClientBuildItem;
+import io.quarkus.redis.deployment.client.spi.RequestedRedisClientBuildItem;
 import io.quarkus.redis.runtime.client.RedisClientRecorder;
 import io.quarkus.redis.runtime.client.config.RedisConfig;
 import io.quarkus.runtime.LaunchMode;
@@ -127,7 +129,8 @@ public class RedisClientProcessor {
             VertxBuildItem vertxBuildItem,
             ApplicationArchivesBuildItem applicationArchivesBuildItem, LaunchModeBuildItem launchMode,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResources,
-            BuildProducer<HotDeploymentWatchedFileBuildItem> hotDeploymentWatchedFiles) {
+            BuildProducer<HotDeploymentWatchedFileBuildItem> hotDeploymentWatchedFiles,
+            BuildProducer<RedisClientBuildItem> clientSuppliers) {
 
         // Collect the used redis clients, the unused clients will not be instantiated.
         Set<String> names = new HashSet<>();
@@ -177,6 +180,9 @@ public class RedisClientProcessor {
                     .produce(configureAndCreateSyntheticBean(name, RedisClient.class, recorder.getLegacyRedisClient(name)));
             syntheticBeans.produce(configureAndCreateSyntheticBean(name, ReactiveRedisClient.class,
                     recorder.getLegacyReactiveRedisClient(name)));
+
+            // build items
+            clientSuppliers.produce(new RedisClientBuildItem(recorder.getRedisClient(name), name));
         }
 
         recorder.cleanup(shutdown);

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisDatasourceProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/RedisDatasourceProcessor.java
@@ -30,6 +30,7 @@ import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.codecs.Codec;
+import io.quarkus.redis.deployment.client.spi.RequestedRedisClientBuildItem;
 import io.quarkus.redis.runtime.client.RedisClientRecorder;
 import io.quarkus.vertx.deployment.VertxBuildItem;
 

--- a/extensions/redis-client/pom.xml
+++ b/extensions/redis-client/pom.xml
@@ -18,7 +18,9 @@
 
     <modules>
         <module>deployment</module>
+        <module>deployment-spi</module>
         <module>runtime</module>
+        <module>runtime-spi</module>
     </modules>
 
 

--- a/extensions/redis-client/pom.xml
+++ b/extensions/redis-client/pom.xml
@@ -21,6 +21,9 @@
         <module>deployment-spi</module>
         <module>runtime</module>
         <module>runtime-spi</module>
+
+        <module>sessions/deployment</module>
+        <module>sessions/runtime</module>
     </modules>
 
 

--- a/extensions/redis-client/runtime-spi/pom.xml
+++ b/extensions/redis-client/runtime-spi/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-redis-client-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-redis-client-runtime-spi</artifactId>
+    <name>Quarkus - Redis Client - Runtime SPI</name>
+
+</project>

--- a/extensions/redis-client/runtime-spi/src/main/java/io/quarkus/redis/runtime/spi/RedisConstants.java
+++ b/extensions/redis-client/runtime-spi/src/main/java/io/quarkus/redis/runtime/spi/RedisConstants.java
@@ -1,0 +1,7 @@
+package io.quarkus.redis.runtime.spi;
+
+public class RedisConstants {
+    public static final String REDIS_CONFIG_ROOT_NAME = "redis";
+    public static final String HOSTS_CONFIG_NAME = "hosts";
+    public static final String DEFAULT_CLIENT_NAME = "<default>";
+}

--- a/extensions/redis-client/runtime/pom.xml
+++ b/extensions/redis-client/runtime/pom.xml
@@ -27,6 +27,10 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-redis-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-redis-client-runtime-spi</artifactId>
+        </dependency>
         <!-- Add the health extension as optional as we will produce the health check only if it's included -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/redis-client/runtime/pom.xml
+++ b/extensions/redis-client/runtime/pom.xml
@@ -38,6 +38,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-redis-client-sessions</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.runtime.client.config;
 
 import java.util.Map;
 
+import io.quarkus.redis.runtime.spi.RedisConstants;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -12,9 +13,9 @@ import io.smallrye.config.WithParentName;
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public interface RedisConfig {
 
-    public final static String REDIS_CONFIG_ROOT_NAME = "redis";
-    public final static String HOSTS_CONFIG_NAME = "hosts";
-    public static final String DEFAULT_CLIENT_NAME = "<default>";
+    public final static String REDIS_CONFIG_ROOT_NAME = RedisConstants.REDIS_CONFIG_ROOT_NAME;
+    public final static String HOSTS_CONFIG_NAME = RedisConstants.HOSTS_CONFIG_NAME;
+    public static final String DEFAULT_CLIENT_NAME = RedisConstants.DEFAULT_CLIENT_NAME;
 
     /**
      * The default redis client

--- a/extensions/redis-client/sessions/deployment/pom.xml
+++ b/extensions/redis-client/sessions/deployment/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-redis-client-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-redis-client-sessions-deployment</artifactId>
+
+    <name>Quarkus - Redis Client - Vert.x Web Sessions - Deployment</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-redis-client-sessions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-redis-client-deployment-spi</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/redis-client/sessions/deployment/src/main/java/io/quarkus/redis/sessions/deployment/RedisSessionsBuildTimeConfig.java
+++ b/extensions/redis-client/sessions/deployment/src/main/java/io/quarkus/redis/sessions/deployment/RedisSessionsBuildTimeConfig.java
@@ -1,0 +1,20 @@
+package io.quarkus.redis.sessions.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Configuration of Vert.x Web sessions stored in Redis.
+ */
+@ConfigRoot(name = "http.sessions.redis", phase = ConfigPhase.BUILD_TIME)
+public class RedisSessionsBuildTimeConfig {
+    /**
+     * Name of the Redis client configured in the Quarkus Redis extension configuration.
+     * If not set, uses the default (unnamed) Redis client.
+     */
+    @ConfigItem
+    public Optional<String> clientName;
+}

--- a/extensions/redis-client/sessions/deployment/src/main/java/io/quarkus/redis/sessions/deployment/RedisSessionsProcessor.java
+++ b/extensions/redis-client/sessions/deployment/src/main/java/io/quarkus/redis/sessions/deployment/RedisSessionsProcessor.java
@@ -1,0 +1,46 @@
+package io.quarkus.redis.sessions.deployment;
+
+import java.util.List;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.redis.deployment.client.spi.RedisClientBuildItem;
+import io.quarkus.redis.deployment.client.spi.RequestedRedisClientBuildItem;
+import io.quarkus.redis.runtime.spi.RedisConstants;
+import io.quarkus.redis.sessions.runtime.RedisSessionsRecorder;
+import io.quarkus.vertx.http.deployment.SessionStoreProviderBuildItem;
+import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.SessionsBuildTimeConfig;
+
+public class RedisSessionsProcessor {
+    @BuildStep
+    public void redisClients(HttpBuildTimeConfig httpConfig,
+            RedisSessionsBuildTimeConfig config,
+            BuildProducer<RequestedRedisClientBuildItem> redisRequest) {
+        if (httpConfig.sessions.mode == SessionsBuildTimeConfig.SessionsMode.REDIS) {
+            String clientName = config.clientName.orElse(RedisConstants.DEFAULT_CLIENT_NAME);
+            redisRequest.produce(new RequestedRedisClientBuildItem(clientName));
+        }
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void redisSessions(HttpBuildTimeConfig httpConfig,
+            RedisSessionsBuildTimeConfig config,
+            List<RedisClientBuildItem> clients,
+            BuildProducer<SessionStoreProviderBuildItem> provider,
+            RedisSessionsRecorder recorder) {
+        if (httpConfig.sessions.mode == SessionsBuildTimeConfig.SessionsMode.REDIS) {
+            String clientName = config.clientName.orElse(RedisConstants.DEFAULT_CLIENT_NAME);
+            for (RedisClientBuildItem redisClient : clients) {
+                if (clientName.equals(redisClient.getName())) {
+                    provider.produce(new SessionStoreProviderBuildItem(recorder.create(redisClient.getClient())));
+                    return;
+                }
+            }
+            throw new IllegalStateException("Unknown Redis client: " + clientName);
+        }
+    }
+}

--- a/extensions/redis-client/sessions/runtime/pom.xml
+++ b/extensions/redis-client/sessions/runtime/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-redis-client-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-redis-client-sessions</artifactId>
+
+    <name>Quarkus - Redis Client - Vert.x Web Sessions - Runtime</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-sstore-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-mutiny-vertx-redis-client</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <configuration>
+                    <dependencyCondition>
+                        <artifact>io.quarkus:quarkus-vertx-http</artifact>
+                    </dependencyCondition>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/redis-client/sessions/runtime/src/main/java/io/quarkus/redis/sessions/runtime/RedisSessionsConfig.java
+++ b/extensions/redis-client/sessions/runtime/src/main/java/io/quarkus/redis/sessions/runtime/RedisSessionsConfig.java
@@ -1,0 +1,21 @@
+package io.quarkus.redis.sessions.runtime;
+
+import java.time.Duration;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Configuration of Vert.x Web sessions stored in Redis.
+ */
+@ConfigRoot(name = "http.sessions.redis", phase = ConfigPhase.RUN_TIME)
+public class RedisSessionsConfig {
+    /**
+     * Maximum time to retry when retrieving session data from the Redis server.
+     * The Vert.x session handler retries when the session data are not found, because
+     * distributing data across a potential Redis cluster may take some time.
+     */
+    @ConfigItem(defaultValue = "2s")
+    public Duration retryTimeout;
+}

--- a/extensions/redis-client/sessions/runtime/src/main/java/io/quarkus/redis/sessions/runtime/RedisSessionsRecorder.java
+++ b/extensions/redis-client/sessions/runtime/src/main/java/io/quarkus/redis/sessions/runtime/RedisSessionsRecorder.java
@@ -1,0 +1,32 @@
+package io.quarkus.redis.sessions.runtime;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.sstore.SessionStore;
+import io.vertx.ext.web.sstore.redis.RedisSessionStore;
+import io.vertx.mutiny.redis.client.Redis;
+
+@Recorder
+public class RedisSessionsRecorder {
+    private final RuntimeValue<RedisSessionsConfig> config;
+
+    public RedisSessionsRecorder(RuntimeValue<RedisSessionsConfig> config) {
+        this.config = config;
+    }
+
+    public Supplier<SessionStore> create(Supplier<Redis> client) {
+        return new Supplier<SessionStore>() {
+            @Override
+            public SessionStore get() {
+                Vertx vertx = VertxCoreRecorder.getVertx().get();
+                Duration retryTimeout = config.getValue().retryTimeout;
+                return RedisSessionStore.create(vertx, retryTimeout.toMillis(), client.get().getDelegate());
+            }
+        };
+    }
+}

--- a/extensions/redis-client/sessions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/redis-client/sessions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,13 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "Redis Client - Vert.x Web Sessions"
+metadata:
+  keywords:
+  - "redis"
+  - "vertx"
+  - "sessions"
+  guide: "https://quarkus.io/guides/http-reference#vertx-web-sessions"
+  categories:
+  - "web"
+  status: "preview"
+  unlisted: true

--- a/extensions/vertx-http/deployment/pom.xml
+++ b/extensions/vertx-http/deployment/pom.xml
@@ -33,7 +33,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-spi</artifactId>
         </dependency>
-        
+
         <!-- Dev UI -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/SessionStoreProviderBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/SessionStoreProviderBuildItem.java
@@ -1,0 +1,24 @@
+package io.quarkus.vertx.http.deployment;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.vertx.ext.web.sstore.SessionStore;
+
+/**
+ * This is a {@code MultiBuildItem} so that multiple producers may exist
+ * among the set of currently present extensions. However, at most one item
+ * of this type may be produced.
+ */
+public final class SessionStoreProviderBuildItem extends MultiBuildItem {
+    private final Supplier<SessionStore> provider;
+
+    public SessionStoreProviderBuildItem(Supplier<SessionStore> provider) {
+        this.provider = Objects.requireNonNull(provider);
+    }
+
+    public Supplier<SessionStore> getProvider() {
+        return provider;
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CurrentVertxRequest.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CurrentVertxRequest.java
@@ -4,6 +4,7 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.Session;
 
 @RequestScoped
 public class CurrentVertxRequest {
@@ -15,6 +16,16 @@ public class CurrentVertxRequest {
     @RequestScoped
     public RoutingContext getCurrent() {
         return current;
+    }
+
+    @Produces
+    @RequestScoped
+    public Session getCurrentSession() {
+        Session result = current.session();
+        if (result == null) {
+            throw new UnsupportedOperationException("No active session or support for sessions disabled");
+        }
+        return result;
     }
 
     public CurrentVertxRequest setCurrent(RoutingContext current) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
@@ -98,4 +98,10 @@ public class HttpBuildTimeConfig {
      */
     @ConfigItem
     public OptionalInt compressionLevel;
+
+    /**
+     * Configuration of Vert.x Web sessions.
+     */
+    @ConfigItem
+    public SessionsBuildTimeConfig sessions;
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -265,6 +265,11 @@ public class HttpConfiguration {
     @ConfigItem
     public Map<String, FilterConfig> filter;
 
+    /**
+     * Configuration of Vert.x Web sessions.
+     */
+    public SessionsConfig sessions;
+
     public ProxyConfig proxy;
 
     public int determinePort(LaunchMode launchMode) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RouteConstants.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/RouteConstants.java
@@ -1,7 +1,7 @@
 package io.quarkus.vertx.http.runtime;
 
 /**
- * Route order value constants used in Quarkus, update {@code reactive-routes.adoc} when changing this class.
+ * Route order value constants used in Quarkus, update {@code http-reference.adoc} when changing this class.
  */
 @SuppressWarnings("JavadocDeclaration")
 public final class RouteConstants {
@@ -33,6 +33,10 @@ public final class RouteConstants {
      * Order value ({@value #ROUTE_ORDER_CORS_MANAGEMENT}) for the CORS-Origin handler of the management router.
      */
     public static final int ROUTE_ORDER_CORS_MANAGEMENT = Integer.MIN_VALUE;
+    /**
+     * Order value ({@value #ROUTE_ORDER_SESSION_HANDLER}) for the session handler, if enabled in the configuration.
+     */
+    public static final int ROUTE_ORDER_SESSION_HANDLER = Integer.MIN_VALUE;
     /**
      * Order value ({@value #ROUTE_ORDER_BODY_HANDLER}) for the body handler.
      */

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/SessionsBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/SessionsBuildTimeConfig.java
@@ -1,0 +1,46 @@
+package io.quarkus.vertx.http.runtime;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * Configuration of Vert.x Web sessions.
+ */
+@ConfigGroup
+public class SessionsBuildTimeConfig {
+    /**
+     * Whether Vert.x Web support for sessions is enabled (the {@code SessionHandler} is added to the router)
+     * and if so, which session store is used. For the {@code redis} and {@code infinispan} modes, the corresponding
+     * Quarkus extension must be present and a connection to the data store must be configured there.
+     */
+    @ConfigItem(defaultValue = "disabled")
+    public SessionsMode mode;
+
+    public enum SessionsMode {
+        /**
+         * Support for Vert.x Web sessions is disabled.
+         */
+        DISABLED,
+        /**
+         * Support for Vert.x Web sessions is enabled and sessions are stored in memory.
+         * In this mode, if an application is deployed in multiple replicas fronted with a load balancer,
+         * it is necessary to enable sticky sessions (also known as session affinity) on the load balancer.
+         * Still, losing a replica means losing all sessions stored on that replica.
+         * In a multi-replica deployment, it is recommended to use an external session store (Redis or Infinispan).
+         * Alternatively, if Vert.x clustering is enabled, in-memory sessions may be configured to be stored
+         * cluster-wide, which also makes sticky sessions not necessary and prevents session data loss
+         * (depending on the Vert.x cluster manager configuration).
+         */
+        IN_MEMORY,
+        /**
+         * Support for Vert.x Web sessions is enabled and sessions are stored in a remote Redis server.
+         * The Quarkus Redis Client extension must be present and a Redis connection must be configured.
+         */
+        REDIS,
+        /**
+         * Support for Vert.x Web sessions is enabled and sessions are stored in a remote Infinispan cache.
+         * The Quarkus Infinispan Client extension must be present and an Infinispan connection must be configured.
+         */
+        INFINISPAN,
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/SessionsConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/SessionsConfig.java
@@ -1,0 +1,98 @@
+package io.quarkus.vertx.http.runtime;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.vertx.core.http.CookieSameSite;
+
+/**
+ * Configuration of Vert.x Web sessions.
+ */
+@ConfigGroup
+public class SessionsConfig {
+    /**
+     * The session timeout.
+     */
+    @ConfigItem(defaultValue = "30M")
+    public Duration timeout;
+
+    /**
+     * The requested length of the session identifier.
+     */
+    @ConfigItem(defaultValue = "16")
+    public int idLength;
+
+    /**
+     * The session cookie path. The value is relative to {@code quarkus.http.root-path}.
+     */
+    @ConfigItem(defaultValue = "/")
+    public String path;
+
+    /**
+     * The name of the session cookie.
+     */
+    @ConfigItem(defaultValue = "JSESSIONID")
+    public String cookieName;
+
+    /**
+     * Whether the session cookie has the {@code HttpOnly} attribute.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean cookieHttpOnly;
+
+    /**
+     * Whether the session cookie has the {@code Secure} attribute.
+     * <ul>
+     * <li>{@code always}: the session cookie always has the {@code Secure} attribute</li>
+     * <li>{@code never}: the session cookie never has the {@code Secure} attribute</li>
+     * <li>{@code auto}: the session cookie only has the {@code Secure} attribute when {@code quarkus.http.insecure-requests}
+     * is {@code redirect} or {@code disabled}; if {@code insecure-requests} is {@code enabled}, the session cookie
+     * does not have the {@code Secure} attribute
+     * </ul>
+     */
+    @ConfigItem(defaultValue = "auto")
+    public SessionCookieSecure cookieSecure;
+
+    /**
+     * The value of the {@code SameSite} attribute of the session cookie.
+     * By default, the {@code SameSite} attribute is not present.
+     */
+    @ConfigItem
+    public Optional<CookieSameSite> cookieSameSite;
+
+    /**
+     * The {@code Max-Age} attribute of the session cookie. Note that setting this option turns the session cookie
+     * into a <em>persistent</em> cookie.
+     */
+    @ConfigItem
+    public Optional<Duration> cookieMaxAge;
+
+    public enum SessionCookieSecure {
+        /**
+         * The session cookie only has the {@code Secure} attribute when {@code quarkus.http.insecure-requests}
+         * is {@code redirect} or {@code disabled}. If {@code insecure-requests} is {@code enabled}, the session cookie
+         * does not have the {@code Secure} attribute.
+         */
+        AUTO,
+        /**
+         * The session cookie always has the {@code Secure} attribute.
+         */
+        ALWAYS,
+        /**
+         * The session cookie never has the {@code Secure} attribute.
+         */
+        NEVER;
+
+        boolean isEnabled(HttpConfiguration.InsecureRequests insecureRequests) {
+            if (this == ALWAYS) {
+                return true;
+            } else if (this == NEVER) {
+                return false;
+            } else {
+                return insecureRequests != HttpConfiguration.InsecureRequests.ENABLED;
+            }
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/SessionsInMemoryConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/SessionsInMemoryConfig.java
@@ -1,0 +1,37 @@
+package io.quarkus.vertx.http.runtime;
+
+import java.time.Duration;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Configuration of Vert.x Web sessions stored in memory.
+ */
+@ConfigRoot(name = "http.sessions.in-memory", phase = ConfigPhase.RUN_TIME)
+public class SessionsInMemoryConfig {
+    /**
+     * Name of the Vert.x local map or cluster-wide map to store the session data.
+     */
+    @ConfigItem(defaultValue = "quarkus.sessions")
+    public String mapName;
+
+    /**
+     * Whether in-memory sessions are stored cluster-wide.
+     * <p>
+     * Ignored when Vert.x clustering is not enabled.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean clusterWide;
+
+    /**
+     * Maximum time to retry when retrieving session data from the cluster-wide map.
+     * The Vert.x session handler retries when the session data are not found, because
+     * distributing data across the cluster may take time.
+     * <p>
+     * Ignored when in-memory sessions are not cluster-wide.
+     */
+    @ConfigItem(defaultValue = "5s")
+    public Duration retryTimeout;
+}

--- a/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/websessions/CounterResource.java
+++ b/integration-tests/infinispan-client/src/main/java/io/quarkus/it/infinispan/client/websessions/CounterResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.infinispan.client.websessions;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.vertx.ext.web.Session;
+
+@Path("/counter")
+public class CounterResource {
+    @Inject
+    Session session;
+
+    @GET
+    public String counter() {
+        Integer counter = session.get("counter");
+        counter = counter == null ? 1 : counter + 1;
+        session.put("counter", counter);
+        return session.id() + "|" + counter;
+    }
+}

--- a/integration-tests/infinispan-client/src/main/resources/application.properties
+++ b/integration-tests/infinispan-client/src/main/resources/application.properties
@@ -21,3 +21,4 @@ quarkus.infinispan-client.another.devservices.mcast-port=46667
 quarkus.infinispan-client.another.devservices.port=31223
 quarkus.infinispan-client.another.devservices.service-name=infinispanAnother
 
+quarkus.http.sessions.mode=infinispan

--- a/integration-tests/infinispan-client/src/test/java/io/quarkus/it/infinispan/client/websessions/CounterTest.java
+++ b/integration-tests/infinispan-client/src/test/java/io/quarkus/it/infinispan/client/websessions/CounterTest.java
@@ -1,0 +1,93 @@
+package io.quarkus.it.infinispan.client.websessions;
+
+import static io.restassured.RestAssured.with;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.filter.session.SessionFilter;
+import io.restassured.response.Response;
+
+@QuarkusTest
+public class CounterTest {
+    @Test
+    public void test() throws InterruptedException {
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            users.add(new User(20));
+        }
+
+        for (User user : users) {
+            user.start();
+        }
+        for (User user : users) {
+            user.join();
+        }
+        for (User user : users) {
+            user.verify();
+        }
+    }
+
+    static class User extends Thread {
+        private static final AtomicInteger counter = new AtomicInteger();
+
+        private final Set<String> sessionIds = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        private final Queue<String> responses = new ConcurrentLinkedQueue<>();
+
+        private final int requests;
+
+        User(int requests) {
+            super("User" + counter.incrementAndGet());
+            this.requests = requests;
+        }
+
+        @Override
+        public void run() {
+            SessionFilter sessions = new SessionFilter();
+            for (int i = 0; i < requests; i++) {
+                Response response = with().filter(sessions).get("/counter");
+                if (response.sessionId() != null) {
+                    sessionIds.add(response.sessionId());
+                }
+                responses.add(response.body().asString());
+
+                try {
+                    // need to sleep longer to give the session store some time to finish
+                    //
+                    // the operation to store session data into Infinispan is fired off when response headers are written,
+                    // but there's nothing waiting for that operation to complete when the response is being sent
+                    //
+                    // therefore, if we send a 2nd request too quickly after receiving the 1st response,
+                    // the session data may still be in the process of being stored and the 2nd request
+                    // would get stale session data
+                    Thread.sleep(500 + ThreadLocalRandom.current().nextInt(500));
+                } catch (InterruptedException e) {
+                    return;
+                }
+            }
+        }
+
+        public void verify() {
+            assertEquals(1, sessionIds.size());
+            String id = sessionIds.iterator().next();
+
+            assertEquals(requests, responses.size());
+            int i = 1;
+            for (String response : responses) {
+                assertEquals(id + "|" + i, response);
+                i++;
+            }
+        }
+    }
+}

--- a/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/websessions/CounterResource.java
+++ b/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/websessions/CounterResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.redis.it.websessions;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.vertx.ext.web.Session;
+
+@Path("/counter")
+public class CounterResource {
+    @Inject
+    Session session;
+
+    @GET
+    public String counter() {
+        Integer counter = session.get("counter");
+        counter = counter == null ? 1 : counter + 1;
+        session.put("counter", counter);
+        return session.id() + "|" + counter;
+    }
+}

--- a/integration-tests/redis-client/src/main/resources/application.properties
+++ b/integration-tests/redis-client/src/main/resources/application.properties
@@ -9,3 +9,9 @@ quarkus.redis.instance-client.hosts=redis://localhost:6379/5
 quarkus.redis.provided-hosts.hosts-provider-name=test-hosts-provider
 
 quarkus.redis.load-script=starwars.redis
+
+quarkus.redis.web-sessions.hosts=redis://localhost:6379/7
+quarkus.redis.web-sessions.max-pool-waiting=100
+
+quarkus.http.sessions.mode=redis
+quarkus.http.sessions.redis.client-name=web-sessions

--- a/integration-tests/redis-client/src/test/java/io/quarkus/redis/it/websessions/CounterTest.java
+++ b/integration-tests/redis-client/src/test/java/io/quarkus/redis/it/websessions/CounterTest.java
@@ -1,0 +1,93 @@
+package io.quarkus.redis.it.websessions;
+
+import static io.restassured.RestAssured.with;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.filter.session.SessionFilter;
+import io.restassured.response.Response;
+
+@QuarkusTest
+public class CounterTest {
+    @Test
+    public void test() throws InterruptedException {
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            users.add(new User(20));
+        }
+
+        for (User user : users) {
+            user.start();
+        }
+        for (User user : users) {
+            user.join();
+        }
+        for (User user : users) {
+            user.verify();
+        }
+    }
+
+    static class User extends Thread {
+        private static final AtomicInteger counter = new AtomicInteger();
+
+        private final Set<String> sessionIds = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        private final Queue<String> responses = new ConcurrentLinkedQueue<>();
+
+        private final int requests;
+
+        User(int requests) {
+            super("User" + counter.incrementAndGet());
+            this.requests = requests;
+        }
+
+        @Override
+        public void run() {
+            SessionFilter sessions = new SessionFilter();
+            for (int i = 0; i < requests; i++) {
+                Response response = with().filter(sessions).get("/counter");
+                if (response.sessionId() != null) {
+                    sessionIds.add(response.sessionId());
+                }
+                responses.add(response.body().asString());
+
+                try {
+                    // need to sleep longer to give the session store some time to finish
+                    //
+                    // the operation to store session data into Redis is fired off when response headers are written,
+                    // but there's nothing waiting for that operation to complete when the response is being sent
+                    //
+                    // therefore, if we send a 2nd request too quickly after receiving the 1st response,
+                    // the session data may still be in the process of being stored and the 2nd request
+                    // would get stale session data
+                    Thread.sleep(500 + ThreadLocalRandom.current().nextInt(500));
+                } catch (InterruptedException e) {
+                    return;
+                }
+            }
+        }
+
+        public void verify() {
+            assertEquals(1, sessionIds.size());
+            String id = sessionIds.iterator().next();
+
+            assertEquals(requests, responses.size());
+            int i = 1;
+            for (String response : responses) {
+                assertEquals(id + "|" + i, response);
+                i++;
+            }
+        }
+    }
+}

--- a/integration-tests/vertx-web/src/main/java/io/quarkus/it/vertx/websessions/CounterEndpoint.java
+++ b/integration-tests/vertx-web/src/main/java/io/quarkus/it/vertx/websessions/CounterEndpoint.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.vertx.websessions;
+
+import io.quarkus.vertx.web.Route;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.Session;
+
+public class CounterEndpoint {
+    @Route(path = "/counter", methods = Route.HttpMethod.GET)
+    String counter(RoutingContext ctx) {
+        Session session = ctx.session();
+        Integer counter = session.get("counter");
+        counter = counter == null ? 1 : counter + 1;
+        session.put("counter", counter);
+        return session.id() + "|" + counter;
+    }
+
+    @Route(path = "/check-sessions", methods = Route.HttpMethod.GET)
+    void checkSessions(RoutingContext ctx) {
+        Session session = ctx.session();
+        ctx.end(session != null ? "OK" : "KO");
+    }
+}

--- a/integration-tests/vertx-web/src/main/resources/application.properties
+++ b/integration-tests/vertx-web/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.http.sessions.mode=in-memory

--- a/integration-tests/vertx-web/src/test/java/io/quarkus/it/vertx/websessions/CounterTest.java
+++ b/integration-tests/vertx-web/src/test/java/io/quarkus/it/vertx/websessions/CounterTest.java
@@ -1,0 +1,89 @@
+package io.quarkus.it.vertx.websessions;
+
+import static io.restassured.RestAssured.when;
+import static io.restassured.RestAssured.with;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.filter.session.SessionFilter;
+import io.restassured.response.Response;
+
+@QuarkusTest
+public class CounterTest {
+    @Test
+    public void test() throws InterruptedException {
+        when().get("/check-sessions").then().statusCode(200).body(Matchers.is("OK"));
+
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            users.add(new User(100));
+        }
+
+        for (User user : users) {
+            user.start();
+        }
+        for (User user : users) {
+            user.join();
+        }
+        for (User user : users) {
+            user.verify();
+        }
+    }
+
+    static class User extends Thread {
+        private static final AtomicInteger counter = new AtomicInteger();
+
+        private final Set<String> sessionIds = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        private final Queue<String> responses = new ConcurrentLinkedQueue<>();
+
+        private final int requests;
+
+        User(int requests) {
+            super("User" + counter.incrementAndGet());
+            this.requests = requests;
+        }
+
+        @Override
+        public void run() {
+            SessionFilter sessions = new SessionFilter();
+            for (int i = 0; i < requests; i++) {
+                Response response = with().filter(sessions).get("/counter");
+                if (response.sessionId() != null) {
+                    sessionIds.add(response.sessionId());
+                }
+                responses.add(response.body().asString());
+
+                try {
+                    Thread.sleep(ThreadLocalRandom.current().nextInt(50));
+                } catch (InterruptedException e) {
+                    return;
+                }
+            }
+        }
+
+        public void verify() {
+            assertEquals(1, sessionIds.size());
+            String id = sessionIds.iterator().next();
+
+            assertEquals(requests, responses.size());
+            int i = 1;
+            for (String response : responses) {
+                assertEquals(id + "|" + i, response);
+                i++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The individual commits are:

- Infinispan Client: improve dev services logging
- Infinispan Client: add runtime SPI and deployment SPI modules
- Redis Client: add runtime SPI and deployment SPI modules
- Add support for Vert.x Web sessions

The last commit being the biggest obviously. Tagging @karesti for review of the 1st and 2nd commit, and @cescoffier for review of the 3rd commit.