### PR TITLE
Upgrade: Hibernate ORM 6.2.11.Final and Reactive 2.0.6.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -99,10 +99,10 @@
         <classmate.version>1.5.1</classmate.version>
         <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below),
              as well as hibernate-orm.version-for-documentation in docs/pom.xml -->
-        <hibernate-orm.version>6.2.9.Final</hibernate-orm.version>
+        <hibernate-orm.version>6.2.11.Final</hibernate-orm.version>
         <bytebuddy.version>1.14.7</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
-        <hibernate-reactive.version>2.0.5.Final</hibernate-reactive.version>
+        <hibernate-reactive.version>2.0.6.Final</hibernate-reactive.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <!-- When updating, align hibernate-search.version-for-documentation in docs/pom.xml -->
         <hibernate-search.version>6.2.2.Final</hibernate-search.version>

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateLogFilterBuildStep.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateLogFilterBuildStep.java
@@ -32,5 +32,13 @@ public final class HibernateLogFilterBuildStep {
                 "HHH90006001"));
         // https://hibernate.atlassian.net/browse/HHH-16546
         filters.produce(new LogCleanupFilterBuildItem("org.hibernate.tuple.entity.EntityMetamodel", "HHH000157"));
+
+        //This "deprecation" warning isn't practical for the specific Quarkus needs, as it reminds users they don't need
+        //to set the 'hibernate.dialect' property, however it's being set by Quarkus buildsteps so they can't avoid it.
+        //Ignore for now, perhaps remove it upstream however this may make sense for other Hibernate users.
+        //Wondering if we should have the Quarkus build differentiate between an explicitly set vs an inferred Dialect
+        //property (we have a custom DialectFactory already so this could be trivial), however even in this case ORM
+        //can't guess things since there is no connection, so even if we did so, this message wouldn't be applicable.
+        filters.produce(new LogCleanupFilterBuildItem("org.hibernate.orm.deprecation", "HHH90000025"));
     }
 }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/HibernateOrmTypesTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/HibernateOrmTypesTest.java
@@ -90,6 +90,7 @@ public class HibernateOrmTypesTest {
         annotationSet.removeIf(name -> name.toString().equals("org.hibernate.Incubating"));
         annotationSet.removeIf(name -> name.toString().equals("org.hibernate.Internal"));
         annotationSet.removeIf(name -> name.toString().equals("org.hibernate.Remove"));
+        annotationSet.removeIf(name -> name.toString().equals("org.hibernate.service.JavaServiceLoadable"));
     }
 
     @Test


### PR DESCRIPTION

I was only able to run the core integration tests of the ORM classic and HR extensions.
For all other extensions I need to cross fingers and let CI run them.