### PR TITLE
Fix some typos on code and javadoc on maven devtool project

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/AbstractDeploymentMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/AbstractDeploymentMojo.java
@@ -15,8 +15,6 @@ import io.quarkus.runtime.LaunchMode;
 
 public class AbstractDeploymentMojo extends BuildMojo {
 
-    Optional<String> deployer = Optional.empty();
-
     @Parameter(property = "quarkus.deployment.dry-run")
     boolean dryRun;
 
@@ -34,9 +32,7 @@ public class AbstractDeploymentMojo extends BuildMojo {
             getLog().info("Deployment configuration:");
             systemProperties.entrySet().stream()
                     .filter(e -> e.getKey().contains("quarkus.deployment"))
-                    .forEach(e -> {
-                        getLog().info(" - " + e.getKey() + ": " + e.getValue());
-                    });
+                    .forEach(e -> getLog().info(" - " + e.getKey() + ": " + e.getValue()));
         } else {
             super.doExecute();
         }
@@ -58,13 +54,13 @@ public class AbstractDeploymentMojo extends BuildMojo {
         List<Dependency> dependencies = new ArrayList<>();
         MavenProject project = mavenProject();
         Deployer deployer = getDeployer();
-        deployer.getExtensionArtifact(project).ifPresent(d -> dependencies.add(d));
+        deployer.getExtensionArtifact(project).ifPresent(dependencies::add);
         if (this.imageBuild || this.imageBuilder != null) {
             Set<ImageBuilder> projectBuilders = ImageBuilder.getProjectBuilder(project).stream().map(ImageBuilder::valueOf)
                     .collect(Collectors.toSet());
             Optional<ImageBuilder> imageBuilder = ImageBuilder.getBuilder(this.imageBuilder, projectBuilders);
             imageBuilder.filter(b -> !projectBuilders.contains(b)).flatMap(b -> b.getExtensionArtifact(project))
-                    .ifPresent(d -> dependencies.add(d));
+                    .ifPresent(dependencies::add);
         }
         return dependencies;
     }

--- a/devtools/maven/src/main/java/io/quarkus/maven/AbstractImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/AbstractImageMojo.java
@@ -36,9 +36,7 @@ public class AbstractImageMojo extends BuildMojo {
             getLog().info("Container image configuration:");
             systemProperties.entrySet().stream()
                     .filter(e -> e.getKey().contains("quarkus.container-image"))
-                    .forEach(e -> {
-                        getLog().info(" - " + e.getKey() + ": " + e.getValue());
-                    });
+                    .forEach(e -> getLog().info(" - " + e.getKey() + ": " + e.getValue()));
         } else {
             super.doExecute();
         }
@@ -47,7 +45,7 @@ public class AbstractImageMojo extends BuildMojo {
     @Override
     protected List<Dependency> forcedDependencies(LaunchMode mode) {
         List<Dependency> dependencies = new ArrayList<>();
-        getBuilder().getExtensionArtifact(mavenProject()).ifPresent(d -> dependencies.add(d));
+        getBuilder().getExtensionArtifact(mavenProject()).ifPresent(dependencies::add);
         return dependencies;
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/Deployer.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/Deployer.java
@@ -1,7 +1,6 @@
 package io.quarkus.maven;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -64,22 +63,22 @@ public enum Deployer {
     /**
      * Get the deployer by name or the first one found in the project.
      *
-     * @project the project to search for deployer extensions
+     * @param project the project to search for deployer extensions
      * @return the {@link Optional} builder matching the name, project.
      */
     public static Optional<Deployer> getDeployer(MavenProject project) {
         return DeploymentUtil.getEnabledDeployer()
-                .or(() -> getProjecDeployer(project).stream().findFirst()).map(Deployer::valueOf);
+                .or(() -> getProjectDeployer(project).stream().findFirst()).map(Deployer::valueOf);
     }
 
     /**
-     * Get teh deployer extensions found in the project.
+     * Get the deployer extensions found in the project.
      *
-     * @param the project to search for extensions
-     * @return A set with the discovered extenions.
+     * @param project The project to search for extensions
+     * @return A set with the discovered extensions.
      */
-    public static Set<String> getProjecDeployer(MavenProject project) {
-        return getProjecDeployers(project.getDependencies());
+    public static Set<String> getProjectDeployer(MavenProject project) {
+        return getProjectDeployers(project.getDependencies());
     }
 
     /**
@@ -88,9 +87,9 @@ public enum Deployer {
      * @param dependencies the dependencies for extensions
      * @return A set with the discovered extenions.
      */
-    public static Set<String> getProjecDeployers(List<Dependency> dependencies) {
+    public static Set<String> getProjectDeployers(List<Dependency> dependencies) {
         if (dependencies == null) {
-            return Collections.emptySet();
+            return Set.of();
         }
         return dependencies.stream()
                 .filter(d -> QUARKUS_GROUP_ID.equals(d.getGroupId()))
@@ -99,7 +98,7 @@ public enum Deployer {
                 .collect(Collectors.toSet());
     }
 
-    private static final String strip(String s) {
+    private static String strip(String s) {
         return s.replaceAll("^" + Pattern.quote(QUARKUS_PREFIX), "");
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -1,7 +1,5 @@
 package io.quarkus.maven;
 
-import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
-
 import java.util.List;
 
 import org.apache.maven.execution.MavenSession;
@@ -34,11 +32,6 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
      */
     @Parameter(property = "perModule")
     boolean perModule;
-
-    /**
-     * If true, instead of checking and recommending the latest available Quarkus platform version,
-     * recommendations to properly align the current project configuration will be logged (if any)
-     */
 
     /**
      * Version of the target platform (e.g: 2.0.0.Final)

--- a/devtools/maven/src/test/java/io/quarkus/maven/DeployerTest.java
+++ b/devtools/maven/src/test/java/io/quarkus/maven/DeployerTest.java
@@ -15,35 +15,35 @@ public class DeployerTest {
 
     @Test
     void shouldNotFindDeployer() {
-        Set<String> deployers = Deployer.getProjecDeployers(List.of());
+        Set<String> deployers = Deployer.getProjectDeployers(List.of());
         assertTrue(deployers.isEmpty());
 
-        deployers = Deployer.getProjecDeployers(List.of(newDependency("quarkus-arc"), newDependency("quarkus-resteasy")));
+        deployers = Deployer.getProjectDeployers(List.of(newDependency("quarkus-arc"), newDependency("quarkus-resteasy")));
         assertTrue(deployers.isEmpty());
     }
 
     @Test
     void shouldFindDeployer() {
-        Set<String> deployers = Deployer.getProjecDeployers(
+        Set<String> deployers = Deployer.getProjectDeployers(
                 List.of(newDependency("quarkus-arc"), newDependency("quarkus-resteasy"), newDependency("quarkus-kubernetes")));
         assertEquals(Set.of("kubernetes"), deployers);
 
-        deployers = Deployer.getProjecDeployers(
+        deployers = Deployer.getProjectDeployers(
                 List.of(newDependency("quarkus-arc"), newDependency("quarkus-resteasy"), newDependency("quarkus-openshift")));
         assertEquals(Set.of("openshift"), deployers);
 
-        deployers = Deployer.getProjecDeployers(
+        deployers = Deployer.getProjectDeployers(
                 List.of(newDependency("quarkus-arc"), newDependency("quarkus-resteasy"), newDependency("quarkus-kind")));
         assertEquals(Set.of("kind"), deployers);
 
-        deployers = Deployer.getProjecDeployers(
+        deployers = Deployer.getProjectDeployers(
                 List.of(newDependency("quarkus-arc"), newDependency("quarkus-resteasy"), newDependency("quarkus-minikube")));
         assertEquals(Set.of("minikube"), deployers);
     }
 
     @Test
     void shouldFindMultipleDeployer() {
-        Set<String> deployers = Deployer.getProjecDeployers(
+        Set<String> deployers = Deployer.getProjectDeployers(
                 List.of(newDependency("quarkus-arc"), newDependency("quarkus-resteasy"), newDependency("quarkus-kubernetes"),
                         newDependency("quarkus-openshift")));
         assertEquals(Set.of("kubernetes", "openshift"), deployers);


### PR DESCRIPTION
This pull request is to fix some typos on java doc and java method name and some minor cleanup

- fix typo on java doc 
- fix typo in java method getProjectDeployer
- remove unnecessary final keyword on static method
- favorite the usage of method reference over lambda expression 
