### PR TITLE
Add validation of execution model annotations

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/execannotations/ExecutionModelAnnotationsAllowedBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/execannotations/ExecutionModelAnnotationsAllowedBuildItem.java
@@ -1,0 +1,28 @@
+package io.quarkus.deployment.execannotations;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Carries a predicate that identifies methods that can have annotations which affect
+ * the execution model ({@code @Blocking}, {@code @NonBlocking}, {@code @RunOnVirtualThread}).
+ * <p>
+ * Used to detect wrong usage of these annotations, as they are implemented directly
+ * by the various frameworks and may only be put on "entrypoint" methods. Placing these
+ * annotations on methods that can only be invoked by application code is always wrong.
+ */
+public final class ExecutionModelAnnotationsAllowedBuildItem extends MultiBuildItem {
+    private final Predicate<MethodInfo> predicate;
+
+    public ExecutionModelAnnotationsAllowedBuildItem(Predicate<MethodInfo> predicate) {
+        this.predicate = Objects.requireNonNull(predicate);
+    }
+
+    public boolean matches(MethodInfo method) {
+        return predicate.test(method);
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/execannotations/ExecutionModelAnnotationsConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/execannotations/ExecutionModelAnnotationsConfig.java
@@ -1,0 +1,35 @@
+package io.quarkus.deployment.execannotations;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+@ConfigMapping(prefix = "quarkus.execution-model-annotations")
+public interface ExecutionModelAnnotationsConfig {
+    /**
+     * Detection mode of invalid usage of execution model annotations.
+     * <p>
+     * An execution model annotation is {@code @Blocking}, {@code @NonBlocking} and {@code @RunOnVirtualThread}.
+     * These annotations may only be used on "entrypoint" methods (methods invoked by various frameworks in Quarkus);
+     * using them on methods that can only be invoked by application code is invalid.
+     */
+    @WithDefault("fail")
+    Mode detectionMode();
+
+    enum Mode {
+        /**
+         * Invalid usage of execution model annotations causes build failure.
+         */
+        FAIL,
+        /**
+         * Invalid usage of execution model annotations causes warning during build.
+         */
+        WARN,
+        /**
+         * No detection of invalid usage of execution model annotations.
+         */
+        DISABLED,
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/execannotations/ExecutionModelAnnotationsProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/execannotations/ExecutionModelAnnotationsProcessor.java
@@ -1,0 +1,115 @@
+package io.quarkus.deployment.execannotations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.StringJoiner;
+import java.util.function.Predicate;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.SuppressForbidden;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Produce;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+
+public class ExecutionModelAnnotationsProcessor {
+    private static final Logger log = Logger.getLogger(ExecutionModelAnnotationsProcessor.class);
+
+    private static final DotName BLOCKING = DotName.createSimple(Blocking.class);
+    private static final DotName NON_BLOCKING = DotName.createSimple(NonBlocking.class);
+    private static final DotName RUN_ON_VIRTUAL_THREAD = DotName.createSimple(RunOnVirtualThread.class);
+
+    @BuildStep
+    @Produce(GeneratedClassBuildItem.class) // only to make sure this build step is executed
+    void check(ExecutionModelAnnotationsConfig config, CombinedIndexBuildItem index,
+            List<ExecutionModelAnnotationsAllowedBuildItem> predicates) {
+
+        if (config.detectionMode() == ExecutionModelAnnotationsConfig.Mode.DISABLED) {
+            return;
+        }
+
+        StringBuilder message = new StringBuilder("\n");
+        doCheck(message, index.getIndex(), predicates, BLOCKING);
+        doCheck(message, index.getIndex(), predicates, NON_BLOCKING);
+        doCheck(message, index.getIndex(), predicates, RUN_ON_VIRTUAL_THREAD);
+
+        if (message.length() > 1) {
+            message.append("The @Blocking, @NonBlocking and @RunOnVirtualThread annotations may only be used "
+                    + "on \"entrypoint\" methods (methods invoked by various frameworks in Quarkus)\n");
+            message.append("Using the @Blocking, @NonBlocking and @RunOnVirtualThread annotations on methods "
+                    + "that can only be invoked by application code is invalid");
+            if (config.detectionMode() == ExecutionModelAnnotationsConfig.Mode.WARN) {
+                log.warn(message);
+            } else {
+                throw new IllegalStateException(message.toString());
+            }
+        }
+    }
+
+    private void doCheck(StringBuilder message, IndexView index,
+            List<ExecutionModelAnnotationsAllowedBuildItem> predicates, DotName annotationName) {
+
+        List<String> badMethods = new ArrayList<>();
+        for (AnnotationInstance annotation : index.getAnnotations(annotationName)) {
+            // these annotations may be put on classes too, but we'll ignore that for now
+            if (annotation.target() != null && annotation.target().kind() == AnnotationTarget.Kind.METHOD) {
+                MethodInfo method = annotation.target().asMethod();
+                boolean allowed = false;
+                for (ExecutionModelAnnotationsAllowedBuildItem predicate : predicates) {
+                    if (predicate.matches(method)) {
+                        allowed = true;
+                        break;
+                    }
+                }
+                if (!allowed) {
+                    badMethods.add(methodToString(method));
+                }
+            }
+        }
+
+        if (!badMethods.isEmpty()) {
+            message.append("Wrong usage(s) of @").append(annotationName.withoutPackagePrefix()).append(" found:\n");
+            for (String method : badMethods) {
+                message.append("\t- ").append(method).append("\n");
+            }
+        }
+    }
+
+    @BuildStep
+    ExecutionModelAnnotationsAllowedBuildItem devuiJsonRpcServices() {
+        return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {
+            @Override
+            public boolean test(MethodInfo method) {
+                // gross hack to allow methods declared in Dev UI JSON RPC service classes,
+                // as the proper way (consuming `JsonRPCProvidersBuildItem`) only works in dev mode
+                String clazz = method.declaringClass().name().toString().toLowerCase(Locale.ROOT);
+                return clazz.startsWith("io.quarkus.")
+                        || clazz.startsWith("io.quarkiverse.")
+                        || clazz.endsWith("jsonrpcservice");
+            }
+        });
+    }
+
+    @SuppressForbidden(reason = "Using Type.toString() to build an informative message")
+    private String methodToString(MethodInfo method) {
+        StringBuilder result = new StringBuilder();
+        result.append(method.declaringClass().name()).append('.').append(method.name());
+        StringJoiner joiner = new StringJoiner(", ", "(", ")");
+        for (Type parameter : method.parameterTypes()) {
+            joiner.add(parameter.toString());
+        }
+        result.append(joiner);
+        return result.toString();
+    }
+}

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcMethodsProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcMethodsProcessor.java
@@ -1,0 +1,20 @@
+package io.quarkus.grpc.deployment;
+
+import java.util.function.Predicate;
+
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
+
+public class GrpcMethodsProcessor {
+    @BuildStep
+    ExecutionModelAnnotationsAllowedBuildItem grpcMethods() {
+        return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {
+            @Override
+            public boolean test(MethodInfo method) {
+                return method.declaringClass().hasDeclaredAnnotation(GrpcDotNames.GRPC_SERVICE);
+            }
+        });
+    }
+}

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesMethodsProcessor.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesMethodsProcessor.java
@@ -1,0 +1,21 @@
+package io.quarkus.vertx.web.deployment;
+
+import java.util.function.Predicate;
+
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
+
+public class ReactiveRoutesMethodsProcessor {
+    @BuildStep
+    ExecutionModelAnnotationsAllowedBuildItem reactiveRoutesMethods() {
+        return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {
+            @Override
+            public boolean test(MethodInfo method) {
+                return method.hasDeclaredAnnotation(DotNames.ROUTE)
+                        || method.hasDeclaredAnnotation(DotNames.ROUTES);
+            }
+        });
+    }
+}

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkustest/execannotations/ExecAnnotationInvalidTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkustest/execannotations/ExecAnnotationInvalidTest.java
@@ -1,0 +1,34 @@
+package io.quarkustest.execannotations;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.annotation.Blocking;
+
+public class ExecAnnotationInvalidTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(MyService.class))
+            .assertException(e -> {
+                assertInstanceOf(IllegalStateException.class, e);
+                assertTrue(e.getMessage().contains("Wrong usage"));
+                assertTrue(e.getMessage().contains("MyService.hello()"));
+            });
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    static class MyService {
+        @Blocking
+        String hello() {
+            return "Hello world!";
+        }
+    }
+}

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkustest/execannotations/ExecAnnotationValidTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkustest/execannotations/ExecAnnotationValidTest.java
@@ -1,0 +1,30 @@
+package io.quarkustest.execannotations;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.Route;
+import io.smallrye.common.annotation.Blocking;
+
+public class ExecAnnotationValidTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(MyService.class));
+
+    @Test
+    public void test() {
+        when().get("/").then().statusCode(200).body(is("Hello world!"));
+    }
+
+    static class MyService {
+        @Route(path = "/")
+        @Blocking
+        String hello() {
+            return "Hello world!";
+        }
+    }
+}

--- a/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/JaxrsMethodsProcessor.java
+++ b/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/JaxrsMethodsProcessor.java
@@ -1,0 +1,35 @@
+package io.quarkus.resteasy.common.deployment;
+
+import java.util.function.Predicate;
+
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
+import io.quarkus.resteasy.common.spi.ResteasyDotNames;
+
+public class JaxrsMethodsProcessor {
+    @BuildStep
+    ExecutionModelAnnotationsAllowedBuildItem jaxrsMethods() {
+        return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {
+            @Override
+            public boolean test(MethodInfo method) {
+                // looking for `@Path` on the declaring class is enough
+                // to avoid having to process inherited JAX-RS annotations
+                if (method.declaringClass().hasDeclaredAnnotation(ResteasyDotNames.PATH)) {
+                    return true;
+                }
+
+                // we currently don't handle custom @HttpMethod annotations, should be fine most of the time
+                return method.hasDeclaredAnnotation(ResteasyDotNames.PATH)
+                        || method.hasDeclaredAnnotation(ResteasyDotNames.GET)
+                        || method.hasDeclaredAnnotation(ResteasyDotNames.POST)
+                        || method.hasDeclaredAnnotation(ResteasyDotNames.PUT)
+                        || method.hasDeclaredAnnotation(ResteasyDotNames.DELETE)
+                        || method.hasDeclaredAnnotation(ResteasyDotNames.PATCH)
+                        || method.hasDeclaredAnnotation(ResteasyDotNames.HEAD)
+                        || method.hasDeclaredAnnotation(ResteasyDotNames.OPTIONS);
+            }
+        });
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/JaxrsMethodsProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/JaxrsMethodsProcessor.java
@@ -1,0 +1,35 @@
+package io.quarkus.resteasy.reactive.common.deployment;
+
+import java.util.function.Predicate;
+
+import org.jboss.jandex.MethodInfo;
+import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
+
+public class JaxrsMethodsProcessor {
+    @BuildStep
+    ExecutionModelAnnotationsAllowedBuildItem jaxrsMethods() {
+        return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {
+            @Override
+            public boolean test(MethodInfo method) {
+                // looking for `@Path` on the declaring class is enough
+                // to avoid having to process inherited JAX-RS annotations
+                if (method.declaringClass().hasDeclaredAnnotation(ResteasyReactiveDotNames.PATH)) {
+                    return true;
+                }
+
+                // we currently don't handle custom @HttpMethod annotations, should be fine most of the time
+                return method.hasDeclaredAnnotation(ResteasyReactiveDotNames.PATH)
+                        || method.hasDeclaredAnnotation(ResteasyReactiveDotNames.GET)
+                        || method.hasDeclaredAnnotation(ResteasyReactiveDotNames.POST)
+                        || method.hasDeclaredAnnotation(ResteasyReactiveDotNames.PUT)
+                        || method.hasDeclaredAnnotation(ResteasyReactiveDotNames.DELETE)
+                        || method.hasDeclaredAnnotation(ResteasyReactiveDotNames.PATCH)
+                        || method.hasDeclaredAnnotation(ResteasyReactiveDotNames.HEAD)
+                        || method.hasDeclaredAnnotation(ResteasyReactiveDotNames.OPTIONS);
+            }
+        });
+    }
+}

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerMethodsProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerMethodsProcessor.java
@@ -1,0 +1,21 @@
+package io.quarkus.scheduler.deployment;
+
+import java.util.function.Predicate;
+
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
+
+public class SchedulerMethodsProcessor {
+    @BuildStep
+    ExecutionModelAnnotationsAllowedBuildItem schedulerMethods() {
+        return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {
+            @Override
+            public boolean test(MethodInfo method) {
+                return method.hasDeclaredAnnotation(SchedulerDotNames.SCHEDULED_NAME)
+                        || method.hasDeclaredAnnotation(SchedulerDotNames.SCHEDULES_NAME);
+            }
+        });
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceMethodsProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceMethodsProcessor.java
@@ -1,0 +1,32 @@
+package io.quarkus.smallrye.faulttolerance.deployment;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
+
+// SmallRye Fault Tolerance has made a mistake and allowed `@Blocking` and `@NonBlocking`
+// on regular, non-entrypoint methods; this is now deprecated and will be disallowed
+// in the future, but for now, we need to allow this too
+public class FaultToleranceMethodsProcessor {
+    @BuildStep
+    ExecutionModelAnnotationsAllowedBuildItem eventConsumerMethods() {
+        return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {
+            @Override
+            public boolean test(MethodInfo method) {
+                Set<DotName> classAnnotations = method.declaringClass().annotationsMap().keySet();
+                return classAnnotations.contains(DotNames.ASYNCHRONOUS)
+                        || classAnnotations.contains(DotNames.BULKHEAD)
+                        || classAnnotations.contains(DotNames.CIRCUIT_BREAKER)
+                        || classAnnotations.contains(DotNames.FALLBACK)
+                        || classAnnotations.contains(DotNames.RATE_LIMIT)
+                        || classAnnotations.contains(DotNames.RETRY)
+                        || classAnnotations.contains(DotNames.TIMEOUT);
+            }
+        });
+    }
+}

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/GraphqlMethodsProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/GraphqlMethodsProcessor.java
@@ -1,0 +1,31 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import java.util.function.Predicate;
+
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Query;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
+import io.smallrye.graphql.api.Subscription;
+
+public class GraphqlMethodsProcessor {
+    private static final DotName QUERY = DotName.createSimple(Query.class);
+    private static final DotName MUTATION = DotName.createSimple(Mutation.class);
+    private static final DotName SUBSCRIPTION = DotName.createSimple(Subscription.class);
+
+    @BuildStep
+    ExecutionModelAnnotationsAllowedBuildItem graphqlMethods() {
+        return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {
+            @Override
+            public boolean test(MethodInfo method) {
+                // maybe just look for `@GraphQLApi` on the declaring class?
+                return method.hasDeclaredAnnotation(QUERY)
+                        || method.hasDeclaredAnnotation(MUTATION)
+                        || method.hasDeclaredAnnotation(SUBSCRIPTION);
+            }
+        });
+    }
+}

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingMethodsProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/ReactiveMessagingMethodsProcessor.java
@@ -1,0 +1,23 @@
+package io.quarkus.smallrye.reactivemessaging.deployment;
+
+import java.util.function.Predicate;
+
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
+
+public class ReactiveMessagingMethodsProcessor {
+    @BuildStep
+    ExecutionModelAnnotationsAllowedBuildItem reactiveMessagingMethods() {
+        return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {
+            @Override
+            public boolean test(MethodInfo method) {
+                return method.hasDeclaredAnnotation(ReactiveMessagingDotNames.INCOMING)
+                        || method.hasDeclaredAnnotation(ReactiveMessagingDotNames.INCOMINGS)
+                        || method.hasDeclaredAnnotation(ReactiveMessagingDotNames.OUTGOING)
+                        || method.hasDeclaredAnnotation(ReactiveMessagingDotNames.OUTGOINGS);
+            }
+        });
+    }
+}

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventConsumerMethodsProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventConsumerMethodsProcessor.java
@@ -1,0 +1,20 @@
+package io.quarkus.vertx.deployment;
+
+import java.util.function.Predicate;
+
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
+
+public class EventConsumerMethodsProcessor {
+    @BuildStep
+    ExecutionModelAnnotationsAllowedBuildItem eventConsumerMethods() {
+        return new ExecutionModelAnnotationsAllowedBuildItem(new Predicate<MethodInfo>() {
+            @Override
+            public boolean test(MethodInfo method) {
+                return method.hasDeclaredAnnotation(VertxConstants.CONSUME_EVENT);
+            }
+        });
+    }
+}


### PR DESCRIPTION
The `@Blocking`, `@NonBlocking` and `@RunOnVirtualThread` annotations
may only be used on "entrypoint" methods (methods invoked by various
frameworks in Quarkus). Using these annotations on methods that can
only be invoked by application code is invalid.

This is based on the discussion in https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/.40Blocking.20ignored.3F