### PR TITLE
Prepare for ORM update

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/HibernateOrmDevInfoServiceTestResource.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/dev/HibernateOrmDevInfoServiceTestResource.java
@@ -83,9 +83,8 @@ public class HibernateOrmDevInfoServiceTestResource {
                         HibernateOrmDevInfo.Entity::getTableName);
 
         assertThat(pu.getCreateDDL())
-                .contains("Error creating SQL create commands for table : MyEntityTable")
-                .contains("org.hibernate.HibernateException: No type mapping for org.hibernate.type.SqlTypes code: "
-                        + TypeWithUnsupportedSqlCode.UNSUPPORTED_SQL_CODE + " (UNKNOWN("
+                .contains("MyEntityTable")
+                .contains(TypeWithUnsupportedSqlCode.UNSUPPORTED_SQL_CODE + " (UNKNOWN("
                         + TypeWithUnsupportedSqlCode.UNSUPPORTED_SQL_CODE + "))");
         // Drop script generation doesn't involve column types, so it didn't fail
         assertThat(pu.getDropDDL())


### PR DESCRIPTION
The next version of Hibernate ORM will produce a different error, so be more defensive in the assertion for the error.