### PR TITLE
Update config-yaml.adoc

### DIFF
--- a/docs/src/main/asciidoc/config-yaml.adoc
+++ b/docs/src/main/asciidoc/config-yaml.adoc
@@ -218,7 +218,7 @@ YAML and JSON structures can be read in an application.yaml file.
 
 Certainly, here's a step-by-step guide on how to use complex configuration structures with Quarkus:
 
-<1> Define Your Configuration Interface.
+* Define Your Configuration Interface.
 
 [source,java]
 ----
@@ -234,7 +234,7 @@ public interface ServiceConfig {
 }
 ----
 
-<2> Create the appropriate JSON structure and store it in a YAML file.
+* Create the appropriate JSON structure and store it in a YAML file.
 
 [source,yaml]
 ----

--- a/docs/src/main/asciidoc/config-yaml.adoc
+++ b/docs/src/main/asciidoc/config-yaml.adoc
@@ -212,12 +212,9 @@ quarkus:
 
 YAML `null` keys are not included in the assembly of the configuration property name, allowing them to be used at any level for disambiguating configuration keys.
 
-== Current Limitation
-The smallrye-config library can only retrieve a single value at a time using a string representation of the path, and it does not provide a built-in way to retrieve complex nested structures in configuration files.  To work around this limitation, sources need to provide a single string representation of each value, effectively flattening the structure to a key-value pair of type `String -> String` . This means that nested structures in JSON or YAML files need to be represented in a flat format.
-
 Although Quarkus primarily uses `.properties` file extension for configuration, the snakeyaml library, which is used for parsing YAML in Quarkus, can also parse JSON structures. This means you can use YAML files with JSON content inside.
 
-To take advantage of this, you can use the application.yaml file (with the .yaml extension) and include JSON structures inside it. Snakeyaml will read both YAML and JSON formats within this file. This allows you to structure your configuration in a more hierarchical manner using JSON inside a YAML file.
+YAML and JSON structures can be read in an application.yaml file.
 
 Certainly, here's a step-by-step guide on how to use complex configuration structures with Quarkus:
 
@@ -237,17 +234,7 @@ public interface ServiceConfig {
 }
 ----
 
-2. Install the YAML Extension
-
-3. Configure Configuration Sources
-
-Add the following line to your application.properties or application.yml file:
-
-----
-quarkus.config.locations=path_to_yaml_file
-----
-
-4. Create the appropriate JSON structure and store it in a YAML file
+2. Create the appropriate JSON structure and store it in a YAML file
 
 [source,yaml]
 ----

--- a/docs/src/main/asciidoc/config-yaml.adoc
+++ b/docs/src/main/asciidoc/config-yaml.adoc
@@ -211,3 +211,58 @@ quarkus:
 ----
 
 YAML `null` keys are not included in the assembly of the configuration property name, allowing them to be used at any level for disambiguating configuration keys.
+
+== Current Limitation
+The smallrye-config library can only retrieve a single value at a time using a string representation of the path, and it does not provide a built-in way to retrieve complex nested structures in configuration files.  To work around this limitation, sources need to provide a single string representation of each value, effectively flattening the structure to a key-value pair of type `String -> String` . This means that nested structures in JSON or YAML files need to be represented in a flat format.
+
+Although Quarkus primarily uses `.properties` file extension for configuration, the snakeyaml library, which is used for parsing YAML in Quarkus, can also parse JSON structures. This means you can use YAML files with JSON content inside.
+
+To take advantage of this, you can use the application.yaml file (with the .yaml extension) and include JSON structures inside it. Snakeyaml will read both YAML and JSON formats within this file. This allows you to structure your configuration in a more hierarchical manner using JSON inside a YAML file.
+
+Certainly, here's a step-by-step guide on how to use complex configuration structures with Quarkus:
+
+1. Define Your Configuration Interface
+
+[source,java]
+----
+@ConfigMapping(prefix = "server")
+public interface ServiceConfig {
+
+  List<Environment> environments();
+
+  interface Environment {
+    String name();
+    String services();
+  }
+}
+----
+
+2. Install the YAML Extension
+
+3. Configure Configuration Sources
+
+Add the following line to your application.properties or application.yml file:
+
+----
+quarkus.config.locations=path_to_yaml_file
+----
+
+4. Create the appropriate JSON structure and store it in a YAML file
+
+[source,yaml]
+----
+{
+  "server": {
+    "environments": [
+      {
+        "name": "dev",
+        "services": "bookstore"
+      },
+      {
+        "name": "batch",
+        "services": "warehouse"
+      }
+    ]
+  }
+}
+----

--- a/docs/src/main/asciidoc/config-yaml.adoc
+++ b/docs/src/main/asciidoc/config-yaml.adoc
@@ -218,7 +218,7 @@ YAML and JSON structures can be read in an application.yaml file.
 
 Certainly, here's a step-by-step guide on how to use complex configuration structures with Quarkus:
 
-<1> Define Your Configuration Interface
+<1> Define Your Configuration Interface.
 
 [source,java]
 ----
@@ -234,7 +234,7 @@ public interface ServiceConfig {
 }
 ----
 
-<2> Create the appropriate JSON structure and store it in a YAML file
+<2> Create the appropriate JSON structure and store it in a YAML file.
 
 [source,yaml]
 ----

--- a/docs/src/main/asciidoc/config-yaml.adoc
+++ b/docs/src/main/asciidoc/config-yaml.adoc
@@ -218,7 +218,7 @@ YAML and JSON structures can be read in an application.yaml file.
 
 Certainly, here's a step-by-step guide on how to use complex configuration structures with Quarkus:
 
-1. Define Your Configuration Interface
+<1> Define Your Configuration Interface
 
 [source,java]
 ----
@@ -234,7 +234,7 @@ public interface ServiceConfig {
 }
 ----
 
-2. Create the appropriate JSON structure and store it in a YAML file
+<2> Create the appropriate JSON structure and store it in a YAML file
 
 [source,yaml]
 ----


### PR DESCRIPTION
This commit updates the Quarkus documentation to provide guidance on working with complex configuration structures in Quarkus applications. It addresses the current limitation where Quarkus can retrieve only single values using a string path and suggests strategies for flattening complex structures, such as using JSON within YAML files. Additionally, it recommends using the `quarkus.config.locations` property for including multiple configuration sources.