### PR TITLE
Upgrade maven to version 3.9.5

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
-distributionSha256Sum=7822eb593d29558d8edf87845a2c47e36e2a89d17a84cd2390824633214ed423
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.3/apache-maven-3.9.3-bin.zip
+distributionSha256Sum=80b3b63df0e40ca8cde902bb1a40e4488ede24b3f282bd7bd6fba8eb5a7e055c
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.3/apache-maven-3.9.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
+distributionSha256Sum=7822eb593d29558d8edf87845a2c47e36e2a89d17a84cd2390824633214ed423
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -62,7 +62,7 @@
         <supported-maven-versions>[3.8.2,)</supported-maven-versions>
 
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
-        <proposed-maven-version>3.9.3</proposed-maven-version>
+        <proposed-maven-version>3.9.5</proposed-maven-version>
         <maven-wrapper.version>3.2.0</maven-wrapper.version>
         <gradle-wrapper.version>8.3</gradle-wrapper.version>
         <quarkus-gradle-plugin.version>${project.version}</quarkus-gradle-plugin.version>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -47,7 +47,7 @@
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.5.3.Final</jboss-logging.version>
         <junit.jupiter.version>5.10.0</junit.jupiter.version>
-        <maven-core.version>3.9.3</maven-core.version><!-- Keep in sync with sisu.version -->
+        <maven-core.version>3.9.5</maven-core.version><!-- Keep in sync with sisu.version -->
         <sisu.version>0.3.5</sisu.version><!-- Keep in sync with maven-core.version -->
         <maven-plugin-annotations.version>3.7.1</maven-plugin-annotations.version>
         <maven-resolver.version>1.9.13</maven-resolver.version>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -40,7 +40,7 @@
         <!-- Keeping 3.0.0.M3 because 3.2.1 requires class changes -->
         <enforcer-api.version>3.0.0-M3</enforcer-api.version>
         <maven-invoker-plugin.version>3.6.0</maven-invoker-plugin.version>
-        <maven-core.version>3.8.8</maven-core.version>
+        <maven-core.version>3.9.5</maven-core.version>
 
         <!--
            Supported Maven versions, interpreted as a version range (Also defined in build-parent)

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -37,7 +37,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
-        <maven-core.version>3.9.3</maven-core.version>
+        <maven-core.version>3.9.5</maven-core.version>
         <version.compiler.plugin>3.11.0</version.compiler.plugin>
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.1.2</version.surefire.plugin>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -51,7 +51,7 @@
         <jandex.version>3.1.5</jandex.version>
         <bytebuddy.version>1.12.12</bytebuddy.version>
         <junit5.version>5.10.0</junit5.version>
-        <maven.version>3.9.3</maven.version>
+        <maven.version>3.9.5</maven.version>
         <assertj.version>3.24.2</assertj.version>
         <jboss-logging.version>3.5.3.Final</jboss-logging.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -386,7 +386,7 @@
         "gradle-plugin-id": "io.quarkus",
         "gradle-plugin-version": "999-FAKE",
         "supported-maven-versions": "[3.6.2,)",
-        "proposed-maven-version": "3.8.8",
+        "proposed-maven-version": "3.9.5",
         "maven-wrapper-version": "3.2.0",
         "gradle-wrapper-version": "8.3"
       }

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.release>11</maven.compiler.release>
 
         <!-- These properties are used by CreateProjectMojo to add the Maven Wrapper -->
-        <proposed-maven-version>3.9.3</proposed-maven-version>
+        <proposed-maven-version>3.9.5</proposed-maven-version>
         <maven-wrapper.version>3.2.0</maven-wrapper.version>
         <gradle-wrapper.version>8.3</gradle-wrapper.version>
 


### PR DESCRIPTION
Update version of maven building tool to the latest sable version 3.9.5 brings much improvements and bug fixing since the version 3.8.8

- update the maven version to version 3.9.5 
- update the desired maven version to 3.9.5 
- update the value of distributionSha256Sum 
- update the proposed maven version to 3.9.5 

For more information here is the release notes : https://maven.apache.org/docs/3.9.5/release-notes.html 
