### PR TITLE
Make it very obvious where Getting Started with Security tutorial is

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -510,7 +510,7 @@ triage:
         - docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
         - docs/src/main/asciidoc/security-basic-authentication.adoc
         - docs/src/main/asciidoc/security-basic-authentication-howto.adoc
-        - docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
+        - docs/src/main/asciidoc/security-getting-started-tutorial.adoc
         - docs/src/main/asciidoc/security-identity-providers.adoc
         - docs/src/main/asciidoc/security-identity-providers-concept.adoc
         - docs/src/main/asciidoc/security-jpa.adoc

--- a/docs/downstreamdoc.yaml
+++ b/docs/downstreamdoc.yaml
@@ -6,7 +6,7 @@ guides:
   - src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
   - src/main/asciidoc/security-basic-authentication.adoc
   - src/main/asciidoc/security-basic-authentication-howto.adoc
-  - src/main/asciidoc/security-basic-authentication-tutorial.adoc
+  - src/main/asciidoc/security-getting-started-tutorial.adoc
   - src/main/asciidoc/security-identity-providers.adoc
   - src/main/asciidoc/security-jpa.adoc
   - src/main/asciidoc/security-oidc-bearer-token-authentication.adoc

--- a/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
@@ -65,7 +65,7 @@ For more information, see the following documentation:
 * xref:security-basic-authentication.adoc[Basic authentication]
 ** xref:security-basic-authentication-howto.adoc[Enable Basic authentication]
 * xref:security-jpa.adoc[Quarkus Security with Jakarta Persistence]
-** xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and Jakarta Persistence]
+** xref:security-getting-started-tutorial.adoc[Getting Started with Security using Basic authentication and Jakarta Persistence]
 * xref:security-identity-providers.adoc[Identity providers]
 
 [[form-auth]]

--- a/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
+++ b/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
@@ -730,5 +730,5 @@ CAUTION: Annotation permissions do not work with the custom xref:security-custom
 * xref:security-architecture.adoc[Quarkus Security architecture]
 * xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus]
 * xref:security-basic-authentication.adoc[Basic authentication]
-* xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and Jakarta Persistence]
+* xref:security-getting-started-tutorial.adoc[Getting Started with Security using Basic authentication and Jakarta Persistence]
 * xref:security-oidc-bearer-token-authentication.adoc#token-scopes-and-security-identity-permissions[OpenID Connect Bearer Token Scopes And SecurityIdentity Permissions]

--- a/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
@@ -51,7 +51,7 @@ If you are securing a production application, always use a database to store thi
 
 == Next steps
 
-For a more detailed walk-through that shows you how to configure Basic authentication together with Jakarta Persistence for storing user credentials in a database, see the xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and Jakarta Persistence] guide.
+For a more detailed walk-through that shows you how to configure Basic authentication together with Jakarta Persistence for storing user credentials in a database, see the xref:security-getting-started-tutorial.adoc[Getting Started with Security using Basic authentication and Jakarta Persistence] guide.
 
 == References
 

--- a/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-tutorial.adoc
@@ -4,15 +4,16 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="security-basic-authentication-tutorial"]
-= Secure a Quarkus application with Basic authentication and Jakarta Persistence
+= Getting Started with Security using Basic authentication and Jakarta Persistence
 include::_attributes.adoc[]
 :diataxis-type: tutorial
 :categories: security,getting-started
 :topics: security,authentication,basic-authentication,http
 :extensions: io.quarkus:quarkus-vertx-http,io.quarkus:quarkus-elytron-security-jdbc,io.quarkus:quarkus-elytron-security-ldap,io.quarkus:quarkus-security-jpa-reactive
 
-Secure your Quarkus application endpoints by combining the built-in Quarkus xref:security-basic-authentication.adoc[Basic authentication] with the Jakarta Persistence identity provider to enable role-based access control (RBAC).
-The Jakarta Persistence `IdentityProvider` creates a `SecurityIdentity` instance, which is used during user authentication to verify and authorize access requests making your Quarkus application secure.
+Get started with Quarkus Security by securing your Quarkus application endpoints with the built-in Quarkus xref:security-basic-authentication.adoc[Basic authentication] and the Jakarta Persistence identity provider and enabling role-based access control.
+
+The Jakarta Persistence `IdentityProvider` verifies and converts a xref:security-basic-authentication.adoc[Basic authentication] user name and password pair to a `SecurityIdentity` instance which is used to authorize access requests, making your Quarkus application secure.
 
 For more information about Jakarta Persistence, see the xref:security-jpa.adoc[Quarkus Security with Jakarta Persistence] guide.
 

--- a/docs/src/main/asciidoc/security-basic-authentication.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication.adoc
@@ -64,7 +64,7 @@ Depending on the use case, other authentication mechanisms that delegate usernam
 For more information about how you can secure your Quarkus applications by using Basic authentication, see the following resources:
 
 * xref:security-basic-authentication-howto.adoc[Enable Basic authentication]
-* xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and Jakarta Persistence]
+* xref:security-getting-started-tutorial.adoc[Getting Started with Security using Basic authentication and Jakarta Persistence]
 
 == Role-based access control
 

--- a/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
@@ -3,7 +3,7 @@ This document is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-[id="security-basic-authentication-tutorial"]
+[id="security-getting-started-tutorial"]
 = Getting Started with Security using Basic authentication and Jakarta Persistence
 include::_attributes.adoc[]
 :diataxis-type: tutorial

--- a/docs/src/main/asciidoc/security-identity-providers.adoc
+++ b/docs/src/main/asciidoc/security-identity-providers.adoc
@@ -27,7 +27,7 @@ To get started with security in Quarkus, consider combining the Quarkus built-in
 For more information about Basic authentication, its mechanisms, and related identity providers, see the following resources:
 
 * xref:security-jpa.adoc[Quarkus Security with Jakarta Persistence]
-** xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and Jakarta Persistence]
+** xref:security-getting-started-tutorial.adoc[Getting Started with Security using Basic authentication and Jakarta Persistence]
 * xref:security-authentication-mechanisms.adoc#form-auth[Form-based authentication]
 * xref:security-jdbc.adoc[Using security with JDBC]
 * xref:security-ldap.adoc[Using security with an LDAP realm]

--- a/docs/src/main/asciidoc/security-jpa.adoc
+++ b/docs/src/main/asciidoc/security-jpa.adoc
@@ -187,6 +187,6 @@ However, it is possible to store passwords as plain text with the `@Password(Pas
 
 == References
 
-* xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and Jakarta Persistence]
+* xref:security-getting-started-tutorial.adoc[Getting Started with Security using Basic authentication and Jakarta Persistence]
 * xref:security-identity-providers.adoc[Identity providers]
 * xref:security-overview.adoc[Quarkus Security overview]

--- a/docs/src/main/asciidoc/security-overview.adoc
+++ b/docs/src/main/asciidoc/security-overview.adoc
@@ -43,7 +43,7 @@ For more information, see the Quarkus xref:security-customization.adoc[Security 
 
 To get started with security in Quarkus, consider securing your Quarkus application endpoints with the built-in Quarkus xref:security-basic-authentication.adoc[Basic authentication] and the Jakarta Persistence identity provider and enabling role-based access control.
 
-Complete the steps in the xref:security-basic-authentication-tutorial.adoc[Getting Started with Security using Basic authentication and Jakarta Persistence] tutorial.
+Complete the steps in the xref:security-getting-started-tutorial.adoc[Getting Started with Security using Basic authentication and Jakarta Persistence] tutorial.
 
 After successfully securing your Quarkus application with Basic authentication, you can increase the security further by adding more advanced authentication mechanisms, for example, the xref:security-oidc-code-flow-authentication.adoc[OpenID Connect (OIDC) authorization code flow mechanism].
 
@@ -97,6 +97,6 @@ For information about security vulnerabilities, see the xref:security-vulnerabil
 
 == References
 
-* xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication and Jakarta Persistence]
+* xref:security-getting-started-tutorial.adoc[Getting Started with Security using Basic authentication and Jakarta Persistence]
 * xref:security-oidc-code-flow-authentication-tutorial.adoc[Protect a web application by using OIDC authorization code flow]
 * xref:security-oidc-bearer-token-authentication-tutorial.adoc[Protect a service application by using OIDC Bearer token authentication]

--- a/docs/src/main/asciidoc/security-overview.adoc
+++ b/docs/src/main/asciidoc/security-overview.adoc
@@ -41,8 +41,9 @@ For more information, see the Quarkus xref:security-customization.adoc[Security 
 
 == Getting started with Quarkus Security
 
-To get started with security in Quarkus, consider combining the Quarkus built-in xref:security-basic-authentication.adoc[Basic authentication] with the Jakarta Persistence identity provider to enable role-based access control (RBAC).
-Complete the steps in the xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication] tutorial.
+To get started with security in Quarkus, consider securing your Quarkus application endpoints with the built-in Quarkus xref:security-basic-authentication.adoc[Basic authentication] and the Jakarta Persistence identity provider and enabling role-based access control.
+
+Complete the steps in the xref:security-basic-authentication-tutorial.adoc[Getting Started with Security using Basic authentication and Jakarta Persistence] tutorial.
 
 After successfully securing your Quarkus application with Basic authentication, you can increase the security further by adding more advanced authentication mechanisms, for example, the xref:security-oidc-code-flow-authentication.adoc[OpenID Connect (OIDC) authorization code flow mechanism].
 


### PR DESCRIPTION
The latest independent review of Quarkus Security guides at https://quarkus.io/guides/ (Choose `Category:Security`) highlighted a problem: even the experienced reviewer could not see that `Secure a Quarkus Application with Basic Authentication and Jakarta Persistence` tutorial is in a `Getting Started` category, that it is meant to be seen as a `Getting Started with Security` guide, and therefore flagged it as a doc flaw.

The only visible indication that it is indeed the Getting Started with Security guide is in https://quarkus.io/guides/security-overview#getting-started-with-quarkus-security, but users looking at https://quarkus.io/guides/ (`Category:Security`) should get an immediate message where it really is.

This PR proposes 2 things:

* Highlight in the doc title and preamble that it is primarily about `Getting Started with Security` than about combining Basic Authentication and JPA - which are only basic tools in demonstrating how to get started and which have their own dedicated How-To/Concept docs. (Also added a minor clarification in the preamble text about the role of the identity provider)
* Renamed `security-basic-authentication-tutorial.adoc` to `security-getting-started-tutorial.adoc` - not critical but I think having an `https://quarkus.io/guides/security-getting-started-tutorial` link to represent a `Getting Started` tutorial should increase its visibility.

CC-ing to Michelle and Michal who helped with the initial text improvements related to this tutorial