### PR TITLE
Check semicolon during the OIDC scope to permission conversion

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -302,11 +302,17 @@ public final class OidcUtils {
         }
     }
 
-    private static Permission[] transformScopesToPermissions(Collection<String> scopes) {
+    static Permission[] transformScopesToPermissions(Collection<String> scopes) {
         final Permission[] permissions = new Permission[scopes.size()];
         int i = 0;
         for (String scope : scopes) {
-            permissions[i++] = new StringPermission(scope);
+            int semicolonIndex = scope.indexOf(':');
+            if (semicolonIndex > 0 && semicolonIndex < scope.length() - 1) {
+                permissions[i++] = new StringPermission(scope.substring(0, semicolonIndex),
+                        scope.substring(semicolonIndex + 1));
+            } else {
+                permissions[i++] = new StringPermission(scope);
+            }
         }
         return permissions;
     }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.security.Permission;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -662,6 +663,22 @@ public class OidcUtilsTest {
         assertTrue(json.containsKey("iat"));
         assertTrue(json.containsKey("exp"));
         assertTrue(json.containsKey("jti"));
+    }
+
+    @Test
+    public void testTransformScopeToPermission() throws Exception {
+        Permission[] perms = OidcUtils.transformScopesToPermissions(
+                List.of("read", "read:d", "read:", ":read"));
+        assertEquals(4, perms.length);
+
+        assertEquals("read", perms[0].getName());
+        assertNull(perms[0].getActions());
+        assertEquals("read", perms[1].getName());
+        assertEquals("d", perms[1].getActions());
+        assertEquals("read:", perms[2].getName());
+        assertNull(perms[2].getActions());
+        assertEquals(":read", perms[3].getName());
+        assertNull(perms[3].getActions());
     }
 
     public static JsonObject read(InputStream input) throws IOException {

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/ServiceProtectedResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/ServiceProtectedResource.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.Path;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import io.quarkus.security.Authenticated;
+import io.quarkus.security.PermissionsAllowed;
 
 @Path("/service/tenant-public-key")
 @Authenticated
@@ -16,6 +17,7 @@ public class ServiceProtectedResource {
     JsonWebToken accessToken;
 
     @GET
+    @PermissionsAllowed("read:data")
     public String getName() {
         return "tenant-public-key" + ":" + accessToken.getName();
     }

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/ServicePublicKeyTestCase.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/ServicePublicKeyTestCase.java
@@ -1,9 +1,10 @@
 package io.quarkus.it.keycloak;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 import java.time.Instant;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -15,21 +16,28 @@ import io.smallrye.jwt.build.Jwt;
 public class ServicePublicKeyTestCase {
 
     @Test
-    public void testAccessTokenInjection() throws IOException, InterruptedException {
-        String jwt = Jwt.claims().preferredUserName("alice").sign();
-        Assertions.assertEquals("tenant-public-key:alice", RestAssured.given().auth()
+    public void testAccessTokenInjection() {
+        String jwt = Jwt.claim("scope", "read:data").preferredUserName("alice").sign();
+        assertEquals("tenant-public-key:alice", RestAssured.given().auth()
                 .oauth2(jwt)
                 .get("/service/tenant-public-key").getBody().asString());
     }
 
     @Test
-    public void testModifiedSignature() throws IOException, InterruptedException {
+    public void testAccessTokenInjection403() {
+        String jwt = Jwt.claim("scope", "read:doc").preferredUserName("alice").sign();
+        RestAssured.given().auth().oauth2(jwt)
+                .get("/service/tenant-public-key").then().statusCode(403);
+    }
+
+    @Test
+    public void testModifiedSignature() {
         String jwt = Jwt.claims().preferredUserName("alice").sign();
         // the last section of the jwt token is a signature
         Response r = RestAssured.given().auth()
                 .oauth2(jwt + "1")
                 .get("/service/tenant-public-key");
-        Assertions.assertEquals(401, r.getStatusCode());
+        assertEquals(401, r.getStatusCode());
     }
 
     @Test
@@ -39,6 +47,6 @@ public class ServicePublicKeyTestCase {
         Response r = RestAssured.given().auth()
                 .oauth2(jwt)
                 .get("/service/tenant-public-key");
-        Assertions.assertEquals(401, r.getStatusCode());
+        assertEquals(401, r.getStatusCode());
     }
 }


### PR DESCRIPTION
Fixes #36313.

Supports #35931.

OIDC `scope` claim is automatically converted to one or more `StringPermission`s.
Currently, if the scope is named `read:data` then the permission name will become `read:data`, but `StringPermission` which will be created from `@PermissionAllowed("read:data")` will have its name set to `read`,  and its actions set to `data` which makes the comparison produce a false result.

This simple PR checks the semicolon during the OIDC scope to Permission conversion, if it is there, assumes that the first part is the name, the second part is the actions. 
It does nothing for cases like `:a` or `b:` as it is not a conversion's concern if such a value makes sense or what it may mean - it should never happen in any case
