### PR TITLE
OIDC Db Token State Manager - disable MSSQL test due to limited Github CI resources and cancel timer on shutdown

### DIFF
--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/MsSqlDbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/MsSqlDbTokenStateManagerTest.java
@@ -1,10 +1,13 @@
 package io.quarkus.oidc.db.token.state.manager;
 
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 
+// Becomes flaky in Github CI due to limited resources
+@EnabledIfSystemProperty(named = "run-mssql-db-token-state-manager-test", disabledReason = "Insufficient GH CI resources", matches = "true")
 public class MsSqlDbTokenStateManagerTest extends AbstractDbTokenStateManagerTest {
 
     @RegisterExtension


### PR DESCRIPTION
- https://github.com/quarkusio/quarkus/pull/36175#pullrequestreview-1660233982 suggested to cancel timer on shutdown, the bean is dependent (which feels right as there is no good reason to keep it after events are resolved), so I saved it in static property
- https://github.com/quarkusio/quarkus/pull/36361#issuecomment-1753312049 showed tests are flaky in Github CI; I played with these tests quite a while and can't see anything wrong. The test failed with `Keycloak server is not available: Retries exhausted : 5 attempts against 1696866807307/1696866807257 expiration [Error Occurred After Shutdown]`. It seems like in Github CI runners don't have sufficient resources. I'm still convinced we should run as much tests as possible (that's why I'm only disabling the one that failed), but can't simply add more space. I think we need to go back to it.