### PR TITLE
List specific guides about virtual threads

### DIFF
--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -417,6 +417,7 @@ If the xref:smallrye-metrics.adoc[SmallRye Metrics extension] is present, then a
 
 If `quarkus.scheduler.tracing.enabled` is set to `true` and the xref:opentelemetry.adoc[OpenTelemetry extension] is present then the `@io.opentelemetry.instrumentation.annotations.WithSpan` annotation is added automatically to every `@Scheduled` method. As a result, each execution of this method has a new `io.opentelemetry.api.trace.Span` associated.
 
+[[virtual_threads]]
 == Run @Scheduled methods on virtual threads
 
 Methods annotated with `@Scheduled` can also be annotated with `@RunOnVirtualThread`.

--- a/docs/src/main/asciidoc/virtual-threads.adoc
+++ b/docs/src/main/asciidoc/virtual-threads.adoc
@@ -80,7 +80,12 @@ It will either reduce the chance for the other virtual thread to run or will sta
 
 In Quarkus, the support of virtual thread is implemented using the link:{runonvthread}[@RunOnVirtualThread] annotation.
 This section briefly overviews the rationale and how to use it.
-There are dedicated guides for extensions supporting that annotation, such as // TODO.
+There are dedicated guides for extensions supporting that annotation, such as:
+
+- xref:./resteasy-reactive-virtual-threads.adoc[Virtual threads in REST applications]
+- xref:./messaging-virtual-threads.adoc[Virtual threads in reactive messaging applications]
+- xref:./grpc-virtual-threads.adoc[Virtual threads in gRPC services]
+- xref:./scheduler-reference.adoc#virtual_threads[Execute periodic tasks on virtual threads]
 
 [[why-not]]
 === Why not run everything on virtual threads?


### PR DESCRIPTION
The list was not written yet (there was a TODO). This commit adds the list of dedicated guides about virtual threads.
