### PR TITLE
Add gradle deps example to unblock downstream docs build

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -693,6 +693,13 @@ Now, if you decided to use OIDC Database Token State Manager, you need to add fo
 </dependency>
 ----
 
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.quarkus:quarkus-oidc-db-token-state-manager")
+implementation("io.quarkus:quarkus-reactive-pg-client")
+----
+
 [source, properties]
 ----
 quarkus.datasource.reactive.url=postgresql://localhost:5432/quarkus_test


### PR DESCRIPTION
Add gradle deps example to unblock downstream docs build

Fixes https://github.com/quarkusio/quarkus/issues/36349

Details:
Docs build gets stuck on `security-oidc-code-flow-authentication.adoc` file when working with `TABS_REPLACEMENTS` in https://github.com/quarkusio/quarkus/blob/main/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java#L322

`tabReplacement.getKey().matcher(rewrittenGuideWithoutTabs)` call gets stuck on pattern looking for xml and gradle example https://github.com/quarkusio/quarkus/blob/main/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java#L50 (first pattern defined in `TABS_REPLACEMENTS`)

`security-oidc-code-flow-authentication.adoc` had one case where `[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]` was defined but `[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]` wasn't defined. And execution got stuck on this.

I couldn't figure out how to detect this stuck situation in java code, thus I changed the problematic file.
`tabReplacement.getKey().matcher(rewrittenGuideWithoutTabs).results().count();` is also stuck.
Not sure what can be done to prevent this in the future, not super strong in matchers area, cc @gsmet 
We could probably start listing files that are processed so we know where the build got stuck

Problematic change was introduced in https://github.com/quarkusio/quarkus/pull/36175 and Documentation build failed after 6 hours on that PR.