### PR TITLE
Fix jakarta.el.ELException: Function 'match' not found

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -695,8 +695,8 @@ triage:
     - id: mailer
       labels: [area/mailer]
       expression: |
-        match("\\bmail\\b", title)
-        || match("mailer", title)
+        matches("\\bmail\\b", title)
+        || matches("mailer", title)
       notify: [cescoffier]
       directories:
         - extensions/mailer/


### PR DESCRIPTION
This error is happening frequently in the Quarkus Bot logs
