### PR TITLE
Update Netty to 4.1.100

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -142,7 +142,7 @@
         <infinispan.version>14.0.17.Final</infinispan.version>
         <infinispan.protostream.version>4.6.5.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>
-        <netty.version>4.1.97.Final</netty.version>
+        <netty.version>4.1.100.Final</netty.version>
         <brotli4j.version>1.12.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.5.3.Final</jboss-logging.version>


### PR DESCRIPTION
Contains the fix for CVE-2023-44487.
