### PR TITLE
Update support information for extension descriptors

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/MetadataValue.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/MetadataValue.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 final class MetadataValue {
     private static final MetadataValue EMPTY_METADATA_VALUE = new MetadataValue(null);
@@ -59,6 +60,14 @@ final class MetadataValue {
         } else if (val instanceof List && !((List<?>) val).isEmpty()
                 && ((List<?>) val).get(0) instanceof String) {
             return (List<String>) val;
+        } else if (val instanceof List && !((List<?>) val).isEmpty()
+                && ((List<?>) val).get(0) instanceof Map) {
+            return ((List<Map>) val).stream()
+                    .map((entry) -> {
+                        // crude, but effective
+                        return entry.toString();
+                    })
+                    .collect(Collectors.toList());
         }
         return Collections.emptyList();
     }

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/platform/catalog/processor/ExtensionProcessorTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/platform/catalog/processor/ExtensionProcessorTest.java
@@ -2,10 +2,11 @@ package io.quarkus.platform.catalog.processor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -20,8 +21,7 @@ public class ExtensionProcessorTest {
                 .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/resteasy-extension.yaml").toURI()));
         Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
 
-        assertFalse(metadata.keySet().contains("supported-by"));
-        assertFalse(metadata.keySet().stream().anyMatch((k) -> k.endsWith("-support")));
+        assertFalse(metadata.keySet().contains("support"));
     }
 
     @Test
@@ -30,8 +30,10 @@ public class ExtensionProcessorTest {
                 .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/rest-client-mutiny-extension.yaml").toURI()));
         Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
 
-        assertEquals(Arrays.asList("xyz"), metadata.get("supported-by"));
-        assertEquals(Arrays.asList("techpreview", "deprecated"), metadata.get("xyz-support"));
+        assertTrue(metadata.keySet().contains("support"));
+        String supporter = metadata.get("support").iterator().next();
+        assertTrue(supporter.contains("id=xyz"));
+        assertTrue(supporter.contains("status=[techpreview, deprecated]"));
     }
 
     @Test
@@ -40,8 +42,10 @@ public class ExtensionProcessorTest {
                 .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/agroal-extension.yaml").toURI()));
         Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
 
-        assertEquals(Arrays.asList("redhat"), metadata.get("supported-by"));
-        assertEquals(Arrays.asList("stable"), metadata.get("redhat-support"));
+        assertTrue(metadata.keySet().contains("support"));
+        String supporter = metadata.get("support").iterator().next();
+        assertTrue(supporter.contains("id=redhat"));
+        assertTrue(supporter.contains("status=[stable]"));
     }
 
     @Test
@@ -50,9 +54,16 @@ public class ExtensionProcessorTest {
                 .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/datasource-extension.yaml").toURI()));
         Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
 
-        assertEquals(Arrays.asList("Red Hat", "xyz"), metadata.get("supported-by"));
-        assertEquals(Arrays.asList("stable", "awesome"), metadata.get("Red Hat-support"));
-        assertEquals(Arrays.asList("none"), metadata.get("xyz-support"));
+        assertTrue(metadata.keySet().contains("support"));
+        Collection<String> supporters = metadata.get("support");
+        assertEquals(2, supporters.size());
+        Iterator<String> it = supporters.iterator();
+        String supporter1 = it.next();
+        String supporter2 = it.next();
+        assertTrue(supporter1.contains("name=Red Hat"));
+        assertTrue(supporter1.contains("status=[stable, awesome]"));
+        assertTrue(supporter2.contains("id=xyz"));
+        assertTrue(supporter2.contains("status=[none]"));
     }
 
     @Test
@@ -61,9 +72,16 @@ public class ExtensionProcessorTest {
                 .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/flyway-extension.yaml").toURI()));
         Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
 
-        assertEquals(Arrays.asList("xyz", "abc"), metadata.get("supported-by"));
-        assertEquals(Arrays.asList("stable"), metadata.get("xyz-support"));
-        assertEquals(Arrays.asList("stable"), metadata.get("abc-support"));
+        assertTrue(metadata.keySet().contains("support"));
+        Collection<String> supporters = metadata.get("support");
+        assertEquals(2, supporters.size());
+        Iterator<String> it = supporters.iterator();
+        String supporter1 = it.next();
+        String supporter2 = it.next();
+        assertTrue(supporter1.contains("id=xyz"));
+        assertTrue(supporter1.contains("status=[stable]"));
+        assertTrue(supporter2.contains("id=abc"));
+        assertTrue(supporter2.contains("status=[stable]"));
     }
 
 }

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/platform/catalog/processor/ExtensionProcessorTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/platform/catalog/processor/ExtensionProcessorTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.platform.catalog.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.registry.catalog.Extension;
+
+public class ExtensionProcessorTest {
+
+    @Test
+    public void testNoSupportData() throws Exception {
+        Extension extension = Extension
+                .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/resteasy-extension.yaml").toURI()));
+        Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
+
+        assertFalse(metadata.keySet().contains("supported-by"));
+        assertFalse(metadata.keySet().stream().anyMatch((k) -> k.endsWith("-support")));
+    }
+
+    @Test
+    public void testFullSupportData() throws Exception {
+        Extension extension = Extension
+                .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/rest-client-mutiny-extension.yaml").toURI()));
+        Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
+
+        assertEquals(Arrays.asList("xyz"), metadata.get("supported-by"));
+        assertEquals(Arrays.asList("techpreview", "deprecated"), metadata.get("xyz-support"));
+    }
+
+    @Test
+    public void testLegacySupportData() throws Exception {
+        Extension extension = Extension
+                .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/agroal-extension.yaml").toURI()));
+        Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
+
+        assertEquals(Arrays.asList("redhat"), metadata.get("supported-by"));
+        assertEquals(Arrays.asList("stable"), metadata.get("redhat-support"));
+    }
+
+    @Test
+    public void testComplexSupportData() throws Exception {
+        Extension extension = Extension
+                .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/datasource-extension.yaml").toURI()));
+        Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
+
+        assertEquals(Arrays.asList("Red Hat", "xyz"), metadata.get("supported-by"));
+        assertEquals(Arrays.asList("stable", "awesome"), metadata.get("Red Hat-support"));
+        assertEquals(Arrays.asList("none"), metadata.get("xyz-support"));
+    }
+
+    @Test
+    public void testSupporterWithoutStatus() throws Exception {
+        Extension extension = Extension
+                .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/flyway-extension.yaml").toURI()));
+        Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
+
+        assertEquals(Arrays.asList("xyz", "abc"), metadata.get("supported-by"));
+        assertEquals(Arrays.asList("stable"), metadata.get("xyz-support"));
+        assertEquals(Arrays.asList("stable"), metadata.get("abc-support"));
+    }
+
+}

--- a/independent-projects/tools/devtools-common/src/test/resources/agroal-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/agroal-extension.yaml
@@ -11,7 +11,10 @@ metadata:
   categories:
   - "data"
   status: "stable"
-  redhat-support: "stable"
+  support: 
+  - id: redhat
+    status: 
+    - stable
   config:
   - "quarkus.datasource."
   built-with-quarkus-core: "999-SNAPSHOT"

--- a/independent-projects/tools/devtools-common/src/test/resources/agroal-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/agroal-extension.yaml
@@ -1,0 +1,28 @@
+---
+name: "Agroal - Database connection pool"
+artifact: "io.quarkus:quarkus-agroal:999-SNAPSHOT"
+metadata:
+  keywords:
+  - "agroal"
+  - "database-connection-pool"
+  - "datasource"
+  - "jdbc"
+  guide: "https://quarkus.io/guides/datasource"
+  categories:
+  - "data"
+  status: "stable"
+  redhat-support: "stable"
+  config:
+  - "quarkus.datasource."
+  built-with-quarkus-core: "999-SNAPSHOT"
+  capabilities:
+    provides:
+    - "io.quarkus.agroal"
+  extension-dependencies:
+  - "io.quarkus:quarkus-core"
+  - "io.quarkus:quarkus-arc"
+  - "io.quarkus:quarkus-datasource"
+  - "io.quarkus:quarkus-narayana-jta"
+  - "io.quarkus:quarkus-mutiny"
+  - "io.quarkus:quarkus-smallrye-context-propagation"
+description: "Pool JDBC database connections (included in Hibernate ORM)"

--- a/independent-projects/tools/devtools-common/src/test/resources/datasource-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/datasource-extension.yaml
@@ -10,9 +10,12 @@ metadata:
   status: "stable"
   supported-by: 
       - "Red Hat"
-  Red Hat-support:
-      - "stable"
-      - "awesome"
+  support: 
+  - id: redhat
+    name: Red Hat
+    status: 
+    - stable
+    - awesome
   xyz-support:
       - "none"
   unlisted: true

--- a/independent-projects/tools/devtools-common/src/test/resources/datasource-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/datasource-extension.yaml
@@ -1,0 +1,23 @@
+---
+artifact: "io.quarkus:quarkus-datasource:999-SNAPSHOT"
+name: "Datasources"
+metadata:
+  keywords:
+  - "datasource"
+  guide: "https://quarkus.io/guides/datasource"
+  categories:
+  - "data"
+  status: "stable"
+  supported-by: 
+      - "Red Hat"
+  Red Hat-support:
+      - "stable"
+      - "awesome"
+  xyz-support:
+      - "none"
+  unlisted: true
+  built-with-quarkus-core: "999-SNAPSHOT"
+  extension-dependencies:
+  - "io.quarkus:quarkus-core"
+  - "io.quarkus:quarkus-arc"
+description: "Configure your datasources"

--- a/independent-projects/tools/devtools-common/src/test/resources/flyway-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/flyway-extension.yaml
@@ -10,9 +10,11 @@ metadata:
   categories:
   - "data"
   status: "stable"
-  supported-by: 
-  - "xyz"
-  - "abc"
+  support: 
+  - id: xyz
+    name: Xyz Co.
+  - id: abc
+    name: Abc, LLC
   config:
   - "quarkus.flyway."
   built-with-quarkus-core: "999-SNAPSHOT"

--- a/independent-projects/tools/devtools-common/src/test/resources/flyway-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/flyway-extension.yaml
@@ -1,0 +1,30 @@
+---
+artifact: "io.quarkus:quarkus-flyway:999-SNAPSHOT"
+name: "Flyway"
+metadata:
+  keywords:
+  - "flyway"
+  - "database"
+  - "data"
+  guide: "https://quarkus.io/guides/flyway"
+  categories:
+  - "data"
+  status: "stable"
+  supported-by: 
+  - "xyz"
+  - "abc"
+  config:
+  - "quarkus.flyway."
+  built-with-quarkus-core: "999-SNAPSHOT"
+  capabilities:
+    provides:
+    - "io.quarkus.flyway"
+  extension-dependencies:
+  - "io.quarkus:quarkus-core"
+  - "io.quarkus:quarkus-agroal"
+  - "io.quarkus:quarkus-arc"
+  - "io.quarkus:quarkus-datasource"
+  - "io.quarkus:quarkus-narayana-jta"
+  - "io.quarkus:quarkus-mutiny"
+  - "io.quarkus:quarkus-smallrye-context-propagation"
+description: "Handle your database schema migrations"

--- a/independent-projects/tools/devtools-common/src/test/resources/rest-client-mutiny-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/rest-client-mutiny-extension.yaml
@@ -1,0 +1,31 @@
+---
+artifact: "io.quarkus:quarkus-rest-client-mutiny:999-SNAPSHOT"
+name: "REST Client Classic Mutiny support"
+metadata:
+  keywords:
+  - "rest-client-mutiny"
+  - "rest-client"
+  - "web-client"
+  - "microprofile-rest-client"
+  - "mutiny"
+  categories:
+  - "web"
+  - "reactive"
+  status: "deprecated"
+  supported-by: 
+      - "xyz"
+  xyz-support:
+      - "techpreview"
+      - "deprecated"
+  built-with-quarkus-core: "999-SNAPSHOT"
+  extension-dependencies:
+  - "io.quarkus:quarkus-rest-client"
+  - "io.quarkus:quarkus-core"
+  - "io.quarkus:quarkus-arc"
+  - "io.quarkus:quarkus-resteasy-common"
+  - "io.quarkus:quarkus-apache-httpclient"
+  - "io.quarkus:quarkus-rest-client-config"
+  - "io.quarkus:quarkus-resteasy-mutiny-common"
+  - "io.quarkus:quarkus-mutiny"
+  - "io.quarkus:quarkus-smallrye-context-propagation"
+description: "Enable Mutiny for the REST client"

--- a/independent-projects/tools/devtools-common/src/test/resources/rest-client-mutiny-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/rest-client-mutiny-extension.yaml
@@ -12,11 +12,10 @@ metadata:
   - "web"
   - "reactive"
   status: "deprecated"
-  supported-by: 
-      - "xyz"
-  xyz-support:
-      - "techpreview"
-      - "deprecated"
+  support: 
+  - id: xyz
+    name: Xyz
+    status: [techpreview, deprecated]
   built-with-quarkus-core: "999-SNAPSHOT"
   extension-dependencies:
   - "io.quarkus:quarkus-rest-client"

--- a/independent-projects/tools/devtools-common/src/test/resources/resteasy-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/resteasy-extension.yaml
@@ -1,0 +1,39 @@
+---
+name: "RESTEasy Classic"
+artifact: "io.quarkus:quarkus-resteasy:999-SNAPSHOT"
+metadata:
+  short-name: "jax-rs"
+  keywords:
+  - "resteasy"
+  - "jaxrs"
+  - "web"
+  - "rest"
+  guide: "https://quarkus.io/guides/resteasy"
+  categories:
+  - "web"
+  status: "stable"
+  codestart:
+    name: "resteasy"
+    languages:
+    - "java"
+    - "kotlin"
+    - "scala"
+    artifact: "io.quarkus:quarkus-project-core-extension-codestarts::jar:999-SNAPSHOT"
+  config:
+  - "quarkus.resteasy."
+  built-with-quarkus-core: "999-SNAPSHOT"
+  capabilities:
+    provides:
+    - "io.quarkus.rest"
+    - "io.quarkus.resteasy"
+  extension-dependencies:
+  - "io.quarkus:quarkus-vertx-http"
+  - "io.quarkus:quarkus-core"
+  - "io.quarkus:quarkus-mutiny"
+  - "io.quarkus:quarkus-smallrye-context-propagation"
+  - "io.quarkus:quarkus-vertx"
+  - "io.quarkus:quarkus-netty"
+  - "io.quarkus:quarkus-resteasy-server-common"
+  - "io.quarkus:quarkus-arc"
+  - "io.quarkus:quarkus-resteasy-common"
+description: "REST endpoint framework implementing JAX-RS and more"


### PR DESCRIPTION
In support of quarkusio#8021, process the supported-by attribute to find a supporter name, then create or update an attribute with the supporter id, name with the status(es) for the extension supporter.  If there are existing tags ending with `-support`, a support entry will be created / updated for the supporter(s).  If any
of the support entries are missing a status, the default value of `stable` will be used.

Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>
