### PR TITLE
AssembleDownstreamDocumentation - print guide name

### DIFF
--- a/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java
@@ -124,6 +124,7 @@ public class AssembleDownstreamDocumentation {
             Files.createDirectories(TARGET_ROOT_DIRECTORY);
 
             for (Path guide : guides) {
+                System.out.println("[INFO] Processing guide " + guide.getFileName());
                 copyAsciidoc(guide, TARGET_ROOT_DIRECTORY.resolve(guide.getFileName()), downstreamGuides);
             }
             for (Path simpleInclude : simpleIncludes) {


### PR DESCRIPTION
AssembleDownstreamDocumentation - print guide name

Motivation: we had 2 issues with docs during 2 last days, this helps to identify which guide has issues.

CC @sberyozkin 