### PR TITLE
Allow parallel execution of blocking health checks

### DIFF
--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/QuarkusAsyncHealthCheckFactory.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/QuarkusAsyncHealthCheckFactory.java
@@ -29,7 +29,7 @@ public class QuarkusAsyncHealthCheckFactory extends AsyncHealthCheckFactory {
     public Uni<HealthCheckResponse> callSync(HealthCheck healthCheck) {
         Uni<HealthCheckResponse> healthCheckResponseUni = super.callSync(healthCheck);
         return BlockingOperationControl.isBlockingAllowed() ? healthCheckResponseUni
-                : healthCheckResponseUni.runSubscriptionOn(MutinyHelper.blockingExecutor(vertx));
+                : healthCheckResponseUni.runSubscriptionOn(MutinyHelper.blockingExecutor(vertx, false));
     }
 
     @Override


### PR DESCRIPTION
Closes #36419

I would hope this could be backported to Quarkus 3.2 so we can used in in Keycloak before the next LTS of Quarkus is available.
