### PR TITLE
Remove or replace Pinning cases?

### DIFF
--- a/docs/src/main/asciidoc/virtual-threads.adoc
+++ b/docs/src/main/asciidoc/virtual-threads.adoc
@@ -139,6 +139,8 @@ results in frequent pinning.
 Most JDBC drivers still pin the carrier thread.
 Even worse, lots of widespread libraries are pinning and would require code changes.
 
+For more information, see link:https://quarkus.io/blog/virtual-thread-1/[When Quarkus meets Virtual Threads]
+
 [[pooling]]
 ==== The pooling case
 Some libraries are using `ThreadLocal` as an object pooling mechanism.


### PR DESCRIPTION
It's unclear from this issue, Thread pinning with PostgreSQL JDBC driver #33337 , whether to simply remove the section or replace it with new information.