### PR TITLE
Unblock SmallRye Health exposed routes

### DIFF
--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -217,7 +216,6 @@ class SmallRyeHealthProcessor {
                 .routeConfigKey("quarkus.smallrye-health.root-path")
                 .handler(new SmallRyeHealthHandler())
                 .displayOnNotFoundPage()
-                .blockingRoute()
                 .build());
 
         // Register the liveness handler
@@ -226,7 +224,6 @@ class SmallRyeHealthProcessor {
                 .nestedRoute(healthConfig.rootPath, healthConfig.livenessPath)
                 .handler(new SmallRyeLivenessHandler())
                 .displayOnNotFoundPage()
-                .blockingRoute()
                 .build());
 
         // Register the readiness handler
@@ -235,21 +232,7 @@ class SmallRyeHealthProcessor {
                 .nestedRoute(healthConfig.rootPath, healthConfig.readinessPath)
                 .handler(new SmallRyeReadinessHandler())
                 .displayOnNotFoundPage()
-                .blockingRoute()
                 .build());
-
-        // Find all health groups
-        Set<String> healthGroups = new HashSet<>();
-        // with simple @HealthGroup annotations
-        for (AnnotationInstance healthGroupAnnotation : index.getAnnotations(HEALTH_GROUP)) {
-            healthGroups.add(healthGroupAnnotation.value().asString());
-        }
-        // with @HealthGroups repeatable annotations
-        for (AnnotationInstance healthGroupsAnnotation : index.getAnnotations(HEALTH_GROUPS)) {
-            for (AnnotationInstance healthGroupAnnotation : healthGroupsAnnotation.value().asNestedArray()) {
-                healthGroups.add(healthGroupAnnotation.value().asString());
-            }
-        }
 
         // Register the health group handlers
         routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
@@ -257,7 +240,6 @@ class SmallRyeHealthProcessor {
                 .nestedRoute(healthConfig.rootPath, healthConfig.groupPath)
                 .handler(new SmallRyeHealthGroupHandler())
                 .displayOnNotFoundPage()
-                .blockingRoute()
                 .build());
 
         SmallRyeIndividualHealthGroupHandler handler = new SmallRyeIndividualHealthGroupHandler();
@@ -266,7 +248,6 @@ class SmallRyeHealthProcessor {
                 .nestedRoute(healthConfig.rootPath, healthConfig.groupPath + "/*")
                 .handler(handler)
                 .displayOnNotFoundPage()
-                .blockingRoute()
                 .build());
 
         // Register the wellness handler
@@ -275,7 +256,6 @@ class SmallRyeHealthProcessor {
                 .nestedRoute(healthConfig.rootPath, healthConfig.wellnessPath)
                 .handler(new SmallRyeWellnessHandler())
                 .displayOnNotFoundPage()
-                .blockingRoute()
                 .build());
 
         // Register the startup handler
@@ -284,7 +264,6 @@ class SmallRyeHealthProcessor {
                 .nestedRoute(healthConfig.rootPath, healthConfig.startupPath)
                 .handler(new SmallRyeStartupHandler())
                 .displayOnNotFoundPage()
-                .blockingRoute()
                 .build());
 
     }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthGroupHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthGroupHandler.java
@@ -2,12 +2,13 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
+import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeHealthGroupHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
-        return reporter.getHealthGroups();
+    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
+        return reporter.getHealthGroupsAsync();
     }
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandler.java
@@ -2,12 +2,13 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
+import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeHealthHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
-        return reporter.getHealth();
+    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
+        return reporter.getHealthAsync();
     }
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandlerBase.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandlerBase.java
@@ -10,7 +10,11 @@ import io.quarkus.vertx.core.runtime.BufferOutputStream;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.vertx.MutinyHelper;
+import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
@@ -18,7 +22,7 @@ import io.vertx.ext.web.RoutingContext;
 
 abstract class SmallRyeHealthHandlerBase implements Handler<RoutingContext> {
 
-    protected abstract SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext routingContext);
+    protected abstract Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext routingContext);
 
     @Override
     public void handle(RoutingContext ctx) {
@@ -41,19 +45,21 @@ abstract class SmallRyeHealthHandlerBase implements Handler<RoutingContext> {
             Arc.container().instance(CurrentIdentityAssociation.class).get().setIdentity(user.getSecurityIdentity());
         }
         SmallRyeHealthReporter reporter = Arc.container().instance(SmallRyeHealthReporter.class).get();
-        SmallRyeHealth health = getHealth(reporter, ctx);
-        HttpServerResponse resp = ctx.response();
-        if (health.isDown()) {
-            resp.setStatusCode(503);
-        }
-        resp.headers().set(HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8");
-        Buffer buffer = Buffer.buffer(256); // this size seems to cover the basic health checks
-        try (BufferOutputStream outputStream = new BufferOutputStream(buffer);) {
-            reporter.reportHealth(outputStream, health);
-            resp.end(buffer);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        Context context = Vertx.currentContext();
+        getHealth(reporter, ctx).emitOn(MutinyHelper.executor(context))
+                .subscribe().with(health -> {
+                    HttpServerResponse resp = ctx.response();
+                    if (health.isDown()) {
+                        resp.setStatusCode(503);
+                    }
+                    resp.headers().set(HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8");
+                    Buffer buffer = Buffer.buffer(256); // this size seems to cover the basic health checks
+                    try (BufferOutputStream outputStream = new BufferOutputStream(buffer);) {
+                        reporter.reportHealth(outputStream, health);
+                        resp.end(buffer);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
     }
-
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeIndividualHealthGroupHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeIndividualHealthGroupHandler.java
@@ -2,13 +2,14 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
+import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeIndividualHealthGroupHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
+    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
         String group = ctx.normalizedPath().substring(ctx.normalizedPath().lastIndexOf("/") + 1);
-        return reporter.getHealthGroup(group);
+        return reporter.getHealthGroupAsync(group);
     }
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeLivenessHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeLivenessHandler.java
@@ -2,12 +2,13 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
+import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeLivenessHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
-        return reporter.getLiveness();
+    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
+        return reporter.getLivenessAsync();
     }
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeReadinessHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeReadinessHandler.java
@@ -2,12 +2,13 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
+import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeReadinessHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext routingContext) {
-        return reporter.getReadiness();
+    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
+        return reporter.getReadinessAsync();
     }
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeStartupHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeStartupHandler.java
@@ -2,12 +2,13 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
+import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeStartupHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext routingContext) {
-        return reporter.getStartup();
+    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
+        return reporter.getStartupAsync();
     }
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeWellnessHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeWellnessHandler.java
@@ -2,12 +2,13 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
+import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeWellnessHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext routingContext) {
-        return reporter.getWellness();
+    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
+        return reporter.getWellnessAsync();
     }
 }


### PR DESCRIPTION
Fixes #35099 

Purposely leaving out OutputStream blocking processing. I want to measure it. - https://github.com/quarkusio/quarkus/issues/36433

There is PoC that also consumes the Vertx context in the SR Health - https://github.com/smallrye/smallrye-health/commit/f08198c1b3b156e5753c7fd309db71a5eb256377. Again, I want to measure whether the `Uni.combine()` running on the same eventloop thread as the health request makes a difference. In that case, I'll release SR health with the hook for Quarkus to plug in. 

`Uni.combine()` in SR Health in this PR still runs on the thread of the last emitted HealthCheckResponse from the collected health checks. But with the above commit, it will run on the same thread.