### PR TITLE
Clarify REST Clients extension names

### DIFF
--- a/extensions/resteasy-classic/pom.xml
+++ b/extensions/resteasy-classic/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-parent-aggregator</artifactId>
-    <name>Quarkus - RESTEasy - Parent - Aggregator</name>
+    <name>Quarkus - RESTEasy Classic - Parent - Aggregator</name>
     <packaging>pom</packaging>
     <modules>
         <module>resteasy-common</module>

--- a/extensions/resteasy-classic/rest-client-config/deployment/pom.xml
+++ b/extensions/resteasy-classic/rest-client-config/deployment/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-config-deployment</artifactId>
-    <name>Quarkus - REST Client Config - Deployment</name>
+    <name>Quarkus - REST Clients Config - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/rest-client-config/pom.xml
+++ b/extensions/resteasy-classic/rest-client-config/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-config-parent</artifactId>
-    <name>Quarkus - REST Client Config</name>
+    <name>Quarkus - REST Clients Config</name>
     <packaging>pom</packaging>
     <modules>
         <module>runtime</module>

--- a/extensions/resteasy-classic/rest-client-config/runtime/pom.xml
+++ b/extensions/resteasy-classic/rest-client-config/runtime/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-config</artifactId>
-    <name>Quarkus - REST Client Config - Runtime</name>
+    <name>Quarkus - REST Clients Config - Runtime</name>
     <description>Shared configuration for REST client extensions</description>
 
     <dependencies>

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client Config"
+name: "REST Clients Config"
 metadata:
   keywords:
   - "rest-client"

--- a/extensions/resteasy-classic/rest-client-jackson/deployment/pom.xml
+++ b/extensions/resteasy-classic/rest-client-jackson/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
-    <name>Quarkus - REST Client - Jackson - Deployment</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - Jackson - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/rest-client-jackson/pom.xml
+++ b/extensions/resteasy-classic/rest-client-jackson/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-jackson-parent</artifactId>
-    <name>Quarkus - REST Client - Jackson</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - Jackson</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-classic/rest-client-jackson/runtime/pom.xml
+++ b/extensions/resteasy-classic/rest-client-jackson/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-jackson</artifactId>
-    <name>Quarkus - REST Client - Jackson - Runtime</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - Jackson - Runtime</name>
     <description>Jackson serialization support for the REST Client</description>
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/rest-client-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/rest-client-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client Classic Jackson"
+name: "RESTEasy Classic's REST Client Jackson"
 metadata:
   keywords:
   - "rest-client-jackson"

--- a/extensions/resteasy-classic/rest-client-jaxb/deployment/pom.xml
+++ b/extensions/resteasy-classic/rest-client-jaxb/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-jaxb-deployment</artifactId>
-    <name>Quarkus - REST Client - JAXB - Deployment</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - JAXB - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/rest-client-jaxb/pom.xml
+++ b/extensions/resteasy-classic/rest-client-jaxb/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-jaxb-parent</artifactId>
-    <name>Quarkus - REST Client - JAXB</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - JAXB</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-classic/rest-client-jaxb/runtime/pom.xml
+++ b/extensions/resteasy-classic/rest-client-jaxb/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-jaxb</artifactId>
-    <name>Quarkus - REST Client - JAXB - Runtime</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - JAXB - Runtime</name>
     <description>XML serialization support for the REST Client</description>
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/rest-client-jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/rest-client-jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client Classic JAXB"
+name: "RESTEasy Classic's REST Client JAXB"
 metadata:
   keywords:
   - "rest-client-jaxb"

--- a/extensions/resteasy-classic/rest-client-jsonb/deployment/pom.xml
+++ b/extensions/resteasy-classic/rest-client-jsonb/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-jsonb-deployment</artifactId>
-    <name>Quarkus - REST Client - JSON-B - Deployment</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - JSON-B - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/rest-client-jsonb/pom.xml
+++ b/extensions/resteasy-classic/rest-client-jsonb/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-jsonb-parent</artifactId>
-    <name>Quarkus - REST Client - JSON-B</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - JSON-B</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-classic/rest-client-jsonb/runtime/pom.xml
+++ b/extensions/resteasy-classic/rest-client-jsonb/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-jsonb</artifactId>
-    <name>Quarkus - REST Client - JSON-B - Runtime</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - JSON-B - Runtime</name>
     <description>JSON-B serialization support for the REST client</description>
 
     <dependencies>

--- a/extensions/resteasy-classic/rest-client-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/rest-client-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client Classic JSON-B"
+name: "RESTEasy Classic's REST Client JSON-B"
 metadata:
   keywords:
   - "rest-client-jsonb"

--- a/extensions/resteasy-classic/rest-client-mutiny/deployment/pom.xml
+++ b/extensions/resteasy-classic/rest-client-mutiny/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-mutiny-deployment</artifactId>
-    <name>Quarkus - REST Client - Mutiny - Deployment</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - Mutiny - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/rest-client-mutiny/pom.xml
+++ b/extensions/resteasy-classic/rest-client-mutiny/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-mutiny-parent</artifactId>
-    <name>Quarkus - REST Client - Mutiny</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - Mutiny</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-classic/rest-client-mutiny/runtime/pom.xml
+++ b/extensions/resteasy-classic/rest-client-mutiny/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-mutiny</artifactId>
-    <name>Quarkus - REST Client - Mutiny - Runtime</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - Mutiny - Runtime</name>
     <description>Enable Mutiny for the REST client</description>
 
     <dependencies>

--- a/extensions/resteasy-classic/rest-client-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/rest-client-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client Classic Mutiny support"
+name: "RESTEasy Classic's REST Client Mutiny support"
 metadata:
   keywords:
   - "rest-client-mutiny"

--- a/extensions/resteasy-classic/rest-client/deployment/pom.xml
+++ b/extensions/resteasy-classic/rest-client/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-deployment</artifactId>
-    <name>Quarkus - REST Client - Deployment</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/rest-client/pom.xml
+++ b/extensions/resteasy-classic/rest-client/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-parent</artifactId>
-    <name>Quarkus - REST Client</name>
+    <name>Quarkus - RESTEasy Classic's REST Client</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-classic/rest-client/runtime/pom.xml
+++ b/extensions/resteasy-classic/rest-client/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client</artifactId>
-    <name>Quarkus - REST Client - Runtime</name>
+    <name>Quarkus - RESTEasy Classic's REST Client - Runtime</name>
     <description>Call REST services</description>
 
     <dependencies>

--- a/extensions/resteasy-classic/rest-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/rest-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client Classic"
+name: "RESTEasy Classic's REST Client"
 metadata:
   keywords:
   - "rest-client"

--- a/extensions/resteasy-classic/resteasy-common/deployment/pom.xml
+++ b/extensions/resteasy-classic/resteasy-common/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-common-deployment</artifactId>
-    <name>Quarkus - RESTEasy - Common - Deployment</name>
+    <name>Quarkus - RESTEasy Classic - Common - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-common/pom.xml
+++ b/extensions/resteasy-classic/resteasy-common/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-common-parent</artifactId>
-    <name>Quarkus - RESTEasy - Common</name>
+    <name>Quarkus - RESTEasy Classic - Common</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-classic/resteasy-common/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-common/runtime/pom.xml
@@ -10,8 +10,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-common</artifactId>
-    <name>Quarkus - RESTEasy - Common - Runtime</name>
-    <description>Components common to the RESTEasy server and the REST Client</description>
+    <name>Quarkus - RESTEasy Classic - Common - Runtime</name>
+    <description>Components common to the RESTEasy Classic server and REST Client</description>
     <dependencies>
         <dependency>
             <groupId>org.graalvm.sdk</groupId>

--- a/extensions/resteasy-classic/resteasy-common/spi/pom.xml
+++ b/extensions/resteasy-classic/resteasy-common/spi/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-common-spi</artifactId>
-    <name>Quarkus - RESTEasy - Common - SPI</name>
+    <name>Quarkus - RESTEasy Classic - Common - SPI</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-jackson/deployment/pom.xml
+++ b/extensions/resteasy-classic/resteasy-jackson/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
-    <name>Quarkus - RESTEasy - Jackson - Deployment</name>
+    <name>Quarkus - RESTEasy Classic - Jackson - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-jackson/pom.xml
+++ b/extensions/resteasy-classic/resteasy-jackson/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-jackson-parent</artifactId>
-    <name>Quarkus - RESTEasy - Jackson</name>
+    <name>Quarkus - RESTEasy Classic - Jackson</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-classic/resteasy-jackson/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-jackson/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-jackson</artifactId>
-    <name>Quarkus - RESTEasy - Jackson - Runtime</name>
+    <name>Quarkus - RESTEasy Classic - Jackson - Runtime</name>
     <description>Jackson serialization support for RESTEasy Classic</description>
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-jaxb/deployment/pom.xml
+++ b/extensions/resteasy-classic/resteasy-jaxb/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-jaxb-deployment</artifactId>
-    <name>Quarkus - RESTEasy - JAXB - Deployment</name>
+    <name>Quarkus - RESTEasy Classic - JAXB - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-jaxb/pom.xml
+++ b/extensions/resteasy-classic/resteasy-jaxb/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-jaxb-parent</artifactId>
-    <name>Quarkus - RESTEasy - JAXB</name>
+    <name>Quarkus - RESTEasy Classic - JAXB</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-classic/resteasy-jaxb/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-jaxb/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-jaxb</artifactId>
-    <name>Quarkus - RESTEasy - JAXB - Runtime</name>
+    <name>Quarkus - RESTEasy Classic - JAXB - Runtime</name>
     <description>XML serialization support for RESTEasy Classic</description>
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-jsonb/deployment/pom.xml
+++ b/extensions/resteasy-classic/resteasy-jsonb/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
-    <name>Quarkus - RESTEasy - JSON-B - Deployment</name>
+    <name>Quarkus - RESTEasy Classic - JSON-B - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-jsonb/pom.xml
+++ b/extensions/resteasy-classic/resteasy-jsonb/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-jsonb-parent</artifactId>
-    <name>Quarkus - RESTEasy - JSON-B</name>
+    <name>Quarkus - RESTEasy Classic - JSON-B</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-classic/resteasy-jsonb/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-jsonb/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-jsonb</artifactId>
-    <name>Quarkus - RESTEasy - JSON-B - Runtime</name>
+    <name>Quarkus - RESTEasy Classic - JSON-B - Runtime</name>
     <description>JSON-B serialization support for RESTEasy Classic</description>
 
     <dependencies>

--- a/extensions/resteasy-classic/resteasy-links/deployment/pom.xml
+++ b/extensions/resteasy-classic/resteasy-links/deployment/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>quarkus-resteasy-links-deployment</artifactId>
-    <name>Quarkus - RESTEasy - Links - Deployment</name>
+    <name>Quarkus - RESTEasy Classic - Links - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-links/pom.xml
+++ b/extensions/resteasy-classic/resteasy-links/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>quarkus-resteasy-links-parent</artifactId>
-    <name>Quarkus - RESTEasy - Links</name>
+    <name>Quarkus - RESTEasy Classic - Links</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-classic/resteasy-links/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-links/runtime/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>quarkus-resteasy-links</artifactId>
-    <name>Quarkus - RESTEasy - Links - Runtime</name>
+    <name>Quarkus - RESTEasy Classic - Links - Runtime</name>
     <description>Web Links support for RESTEasy Classic. Inject web links into response HTTP headers by annotating your endpoint resources.</description>
 
     <dependencies>

--- a/extensions/resteasy-classic/resteasy-multipart/deployment/pom.xml
+++ b/extensions/resteasy-classic/resteasy-multipart/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-multipart-deployment</artifactId>
-    <name>Quarkus - RESTEasy - Multipart - Deployment</name>
+    <name>Quarkus - RESTEasy Classic - Multipart - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-multipart/pom.xml
+++ b/extensions/resteasy-classic/resteasy-multipart/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-multipart-parent</artifactId>
-    <name>Quarkus - RESTEasy - Multipart</name>
+    <name>Quarkus - RESTEasy Classic - Multipart</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-classic/resteasy-multipart/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-multipart/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-multipart</artifactId>
-    <name>Quarkus - RESTEasy - Multipart - Runtime</name>
+    <name>Quarkus - RESTEasy Classic - Multipart - Runtime</name>
     <description>Multipart support for RESTEasy Classic</description>
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-mutiny-common/deployment/pom.xml
+++ b/extensions/resteasy-classic/resteasy-mutiny-common/deployment/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>quarkus-resteasy-mutiny-common-deployment</artifactId>
-    <name>Quarkus - RESTEasy - Mutiny - Common - Deployment</name>
+    <name>Quarkus - RESTEasy Classic - Mutiny - Common - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-mutiny-common/pom.xml
+++ b/extensions/resteasy-classic/resteasy-mutiny-common/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>quarkus-resteasy-mutiny-common-parent</artifactId>
-    <name>Quarkus - RESTEasy - Mutiny - Common</name>
+    <name>Quarkus - RESTEasy Classic - Mutiny - Common</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/extensions/resteasy-classic/resteasy-mutiny-common/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-mutiny-common/runtime/pom.xml
@@ -10,9 +10,9 @@
     </parent>
 
     <artifactId>quarkus-resteasy-mutiny-common</artifactId>
-    <name>Quarkus - RESTEasy - Mutiny - Common - Runtime</name>
+    <name>Quarkus - RESTEasy Classic - Mutiny - Common - Runtime</name>
     <description>Mutiny components common to the RESTEasy server and the REST Client</description>
-    
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/resteasy-classic/resteasy-mutiny/deployment/pom.xml
+++ b/extensions/resteasy-classic/resteasy-mutiny/deployment/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
-    <name>Quarkus - RESTEasy - Mutiny - Deployment</name>
+    <name>Quarkus - RESTEasy Classic - Mutiny - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-mutiny/pom.xml
+++ b/extensions/resteasy-classic/resteasy-mutiny/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>quarkus-resteasy-mutiny-parent</artifactId>
-    <name>Quarkus - RESTEasy - Mutiny</name>
+    <name>Quarkus - RESTEasy Classic - Mutiny</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/extensions/resteasy-classic/resteasy-mutiny/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-mutiny/runtime/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>quarkus-resteasy-mutiny</artifactId>
-    <name>Quarkus - RESTEasy - Mutiny - Runtime</name>
+    <name>Quarkus - RESTEasy Classic - Mutiny - Runtime</name>
     <description>Mutiny support for RESTEasy Classic server</description>
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-qute/deployment/pom.xml
+++ b/extensions/resteasy-classic/resteasy-qute/deployment/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>quarkus-resteasy-qute-deployment</artifactId>
-    <name>Quarkus - RESTEasy - Qute - Deployment</name>
+    <name>Quarkus - RESTEasy Classic - Qute - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-qute/pom.xml
+++ b/extensions/resteasy-classic/resteasy-qute/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>quarkus-resteasy-qute-parent</artifactId>
-    <name>Quarkus - RESTEasy - Qute</name>
+    <name>Quarkus - RESTEasy Classic - Qute</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/extensions/resteasy-classic/resteasy-qute/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-qute/runtime/pom.xml
@@ -10,8 +10,8 @@
     </parent>
 
     <artifactId>quarkus-resteasy-qute</artifactId>
-    <name>Quarkus - RESTEasy - Qute - Runtime</name>
-    <description>Qute Templating integration for RESTEasy</description>
+    <name>Quarkus - RESTEasy Classic - Qute - Runtime</name>
+    <description>Qute Templating integration for RESTEasy Classic</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/resteasy-classic/resteasy-server-common/deployment/pom.xml
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-server-common-deployment</artifactId>
-    <name>Quarkus - RESTEasy - Server common - Deployment</name>
+    <name>Quarkus - RESTEasy Classic - Server common - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-server-common/pom.xml
+++ b/extensions/resteasy-classic/resteasy-server-common/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-server-common-parent</artifactId>
-    <name>Quarkus - RESTEasy - Server common</name>
+    <name>Quarkus - RESTEasy Classic - Server common</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-classic/resteasy-server-common/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy-server-common/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-server-common</artifactId>
-    <name>Quarkus - RESTEasy - Server common - Runtime</name>
+    <name>Quarkus - RESTEasy Classic - Server common - Runtime</name>
     <description>RESTEasy Server common</description>
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy-server-common/spi/pom.xml
+++ b/extensions/resteasy-classic/resteasy-server-common/spi/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>quarkus-resteasy-server-common-spi</artifactId>
-    <name>Quarkus - RESTEasy - Server common - SPI</name>
+    <name>Quarkus - RESTEasy Classic - Server common - SPI</name>
     <description>Extensions that provides RESTEasy Server related BuildItems</description>
 
     <dependencies>

--- a/extensions/resteasy-classic/resteasy/deployment/pom.xml
+++ b/extensions/resteasy-classic/resteasy/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-deployment</artifactId>
-    <name>Quarkus - RESTEasy - Deployment</name>
+    <name>Quarkus - RESTEasy Classic - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-classic/resteasy/pom.xml
+++ b/extensions/resteasy-classic/resteasy/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy-parent</artifactId>
-    <name>Quarkus - RESTEasy</name>
+    <name>Quarkus - RESTEasy Classic</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-classic/resteasy/runtime/pom.xml
+++ b/extensions/resteasy-classic/resteasy/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-resteasy</artifactId>
-    <name>Quarkus - RESTEasy - Runtime</name>
+    <name>Quarkus - RESTEasy Classic - Runtime</name>
     <description>REST endpoint framework implementing Jakarta REST and more</description>
 
     <dependencies>

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/pom.xml
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-jaxrs-client-reactive-deployment</artifactId>
-    <name>Quarkus - JAX-RS Client Reactive - Deployment</name>
+    <name>Quarkus - Jakarta REST Client Reactive - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "JAX-RS Client Reactive"
+name: "Jakarta REST Client Reactive"
 metadata:
   keywords:
   - "jax-rs client"

--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/deployment/pom.xml
@@ -9,7 +9,7 @@
         <version>999-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-rest-client-reactive-jackson-deployment</artifactId>
-    <name>Quarkus - REST Client Reactive Jackson - Deployment</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client Jackson - Deployment</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-reactive-jackson-parent</artifactId>
-    <name>Quarkus - REST Client Reactive Jackson</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client Jackson</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/pom.xml
@@ -9,7 +9,7 @@
         <version>999-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
-    <name>Quarkus - REST Client Reactive Jackson</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client Jackson</name>
     <description>Jackson serialization support for REST Client Reactive</description>
 
     <dependencies>

--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client Reactive Jackson"
+name: "RESTEasy Reactive's REST Client Jackson"
 metadata:
   keywords:
   - "rest-client-jackson"

--- a/extensions/resteasy-reactive/rest-client-reactive-jaxb/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive-jaxb/deployment/pom.xml
@@ -9,7 +9,7 @@
         <version>999-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-rest-client-reactive-jaxb-deployment</artifactId>
-    <name>Quarkus - REST Client Reactive JAXB - Deployment</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client JAXB - Deployment</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/resteasy-reactive/rest-client-reactive-jaxb/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive-jaxb/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-reactive-jaxb-parent</artifactId>
-    <name>Quarkus - REST Client Reactive JAXB</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client JAXB</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-reactive/rest-client-reactive-jaxb/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive-jaxb/runtime/pom.xml
@@ -9,7 +9,7 @@
         <version>999-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-rest-client-reactive-jaxb</artifactId>
-    <name>Quarkus - REST Client Reactive JAXB</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client JAXB</name>
     <description>JAXB serialization support for REST Client Reactive</description>
 
     <dependencies>

--- a/extensions/resteasy-reactive/rest-client-reactive-jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/rest-client-reactive-jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client Reactive JAXB"
+name: "RESTEasy Reactive's REST Client JAXB"
 metadata:
   keywords:
   - "rest-client-jaxb"

--- a/extensions/resteasy-reactive/rest-client-reactive-jsonb/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive-jsonb/deployment/pom.xml
@@ -9,7 +9,7 @@
         <version>999-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-rest-client-reactive-jsonb-deployment</artifactId>
-    <name>Quarkus - REST Client Reactive JSON-B - Deployment</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client JSON-B - Deployment</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/resteasy-reactive/rest-client-reactive-jsonb/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive-jsonb/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-reactive-jsonb-parent</artifactId>
-    <name>Quarkus - REST Client Reactive JSON-B</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client JSON-B</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-reactive/rest-client-reactive-jsonb/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive-jsonb/runtime/pom.xml
@@ -9,7 +9,7 @@
         <version>999-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-rest-client-reactive-jsonb</artifactId>
-    <name>Quarkus - REST Client Reactive JSON-B</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client JSON-B</name>
     <description>JSON-B serialization support for REST Client Reactive</description>
 
     <dependencies>

--- a/extensions/resteasy-reactive/rest-client-reactive-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/rest-client-reactive-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client Reactive JSON-B"
+name: "RESTEasy Reactive's REST Client JSON-B"
 metadata:
   keywords:
   - "rest-client-jsonb"

--- a/extensions/resteasy-reactive/rest-client-reactive-kotlin-serialization/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive-kotlin-serialization/deployment/pom.xml
@@ -9,7 +9,7 @@
         <version>999-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-rest-client-reactive-kotlin-serialization-deployment</artifactId>
-    <name>Quarkus - REST Client Reactive Kotlin Serialization - Deployment</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client Kotlin Serialization - Deployment</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/resteasy-reactive/rest-client-reactive-kotlin-serialization/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive-kotlin-serialization/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-reactive-kotlin-serialization-parent</artifactId>
-    <name>Quarkus - REST Client Reactive Kotlin Serialization Parent</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client Kotlin Serialization Parent</name>
     <packaging>pom</packaging>
     <modules>
         <module>runtime</module>

--- a/extensions/resteasy-reactive/rest-client-reactive-kotlin-serialization/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive-kotlin-serialization/runtime/pom.xml
@@ -10,7 +10,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>quarkus-rest-client-reactive-kotlin-serialization</artifactId>
-    <name>Quarkus - REST Client Reactive Kotlin Serialization</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client Kotlin Serialization</name>
     <description>Kotlin serialization support for REST Client Reactive</description>
 
     <dependencies>

--- a/extensions/resteasy-reactive/rest-client-reactive-kotlin-serialization/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/rest-client-reactive-kotlin-serialization/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client Reactive Kotlin Serialization"
+name: "RESTEasy Reactive's REST Client Kotlin Serialization"
 metadata:
   keywords:
   - "rest-client-kotlin-serialization"

--- a/extensions/resteasy-reactive/rest-client-reactive-kotlin-serialization/tests/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive-kotlin-serialization/tests/pom.xml
@@ -9,7 +9,7 @@
         <version>999-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-rest-client-reactive-kotlin-serialization-tests</artifactId>
-    <name>Quarkus - REST Client Reactive Kotlin Serialization - Tests</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client Kotlin Serialization - Tests</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-reactive-deployment</artifactId>
-    <name>Quarkus - REST Client Reactive - Deployment</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client - Deployment</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/resteasy-reactive/rest-client-reactive/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-reactive-parent</artifactId>
-    <name>Quarkus - REST Client Reactive</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client</name>
     <packaging>pom</packaging>
     <modules>
         <module>deployment</module>

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>quarkus-rest-client-reactive</artifactId>
-    <name>Quarkus - REST Client Reactive - Runtime</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client - Runtime</name>
     <description>Call REST services reactively</description>
 
     <dependencies>

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,4 +1,4 @@
-name: "REST Client Reactive"
+name: "RESTEasy Reactive's REST Client"
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   keywords:

--- a/extensions/resteasy-reactive/rest-client-reactive/spi-deployment/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive/spi-deployment/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>quarkus-rest-client-reactive-spi-deployment</artifactId>
-    <name>Quarkus - REST Client Reactive - SPI - Deployment</name>
+    <name>Quarkus - RESTEasy Reactive's REST Client - SPI - Deployment</name>
 
     <dependencies>
         <dependency>
@@ -23,5 +23,5 @@
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
     </dependencies>
-    
+
 </project>


### PR DESCRIPTION
This is a proposal, feel free to dismiss.

The idea is to have:
- RESTEasy Classic's REST Client
- RESTEasy Reactive's REST Client

so that what you need to use is extra clear.

(This PR is part of various things noted when I added the `:topics:` to the guides)

BTW, I didn't do it there but I also think we should move the `REST Client Config` extension, which is common to both RESTEasy Classic and RESTEasy Reactive IIUC, outside of the RESTEasy Classic folder. Let me know what you think, I can do it in a follow-up PR.