### PR TITLE
Fix doc extension-add.adoc

### DIFF
--- a/docs/src/main/asciidoc/_includes/devtools/extension-add.adoc
+++ b/docs/src/main/asciidoc/_includes/devtools/extension-add.adoc
@@ -1,7 +1,7 @@
 [source,bash,subs=attributes+, role="primary asciidoc-tabs-sync-cli"]
 .CLI
 ----
-quarkus extension add '{add-extension-extensions}'
+quarkus extension add {add-extension-extensions}
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]

--- a/docs/src/main/asciidoc/getting-started-dev-services.adoc
+++ b/docs/src/main/asciidoc/getting-started-dev-services.adoc
@@ -79,7 +79,7 @@ Once the application is up, visit http://localhost:8080/hello. It should show a 
 === Accepting user input
 
 Let's make the application a bit more interactive.
-Open the project in your IDE and navigate to `src/main/java/org/acme/GreetingResource.java'
+Open the project in your IDE and navigate to `src/main/java/org/acme/GreetingResource.java`
 Add a query param in the `hello` method.
 (The `org.jboss.resteasy.reactive.RestQuery` annotation is like the Jakarta REST `@QueryParam`
 annotation, except you don't need to duplicate the parameter name.)


### PR DESCRIPTION
Going through the `getting-started-dev-services` page I was not able to run the quarkus command to install extensions without removing the single quotes. I'm using Quarkus CLI version 3.4.2 on macOs.

I also noticed a small error in the text format so I also fixed that.