### PR TITLE
Update builder images to jdk-21

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -771,11 +771,11 @@ jobs:
           path: .
       - name: Extract .m2/repository/io/quarkus
         run: tar -xzf m2-io-quarkus.tgz -C ~
-      - name: Set up JDK 20
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 20
+          java-version: 21
       # We do this so we can get better analytics for the downloaded version of the build images
       - name: Update Docker Client User Agent
         run: |
@@ -785,7 +785,7 @@ jobs:
           TEST_MODULES: ${{matrix.test-modules}}
           CONTAINER_BUILD: ${{startsWith(matrix.os-name, 'windows') && 'false' || 'true'}}
         run: |
-          export LANG=en_US && ./mvnw $COMMON_MAVEN_ARGS -f integration-tests/virtual-threads -pl "$TEST_MODULES" $NATIVE_TEST_MAVEN_ARGS -Dextra-args=--enable-preview -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-20
+          export LANG=en_US && ./mvnw $COMMON_MAVEN_ARGS -f integration-tests/virtual-threads -pl "$TEST_MODULES" $NATIVE_TEST_MAVEN_ARGS -Dextra-args=--enable-preview -Dquarkus.native.container-build=true
       - name: Upload build reports (if build failed)
         uses: actions/upload-artifact@v3
         if: ${{ failure() || cancelled() }}

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -20,8 +20,8 @@ import io.smallrye.config.WithParentName;
 @ConfigMapping(prefix = "quarkus.native")
 public interface NativeConfig {
 
-    String DEFAULT_GRAALVM_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:jdk-17";
-    String DEFAULT_MANDREL_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17";
+    String DEFAULT_GRAALVM_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:jdk-21";
+    String DEFAULT_MANDREL_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21";
 
     /**
      * Comma-separated, additional arguments to pass to the build process.
@@ -225,7 +225,7 @@ public interface NativeConfig {
     interface BuilderImageConfig {
         /**
          * The docker image to use to do the image build. It can be one of `graalvm`, `mandrel`, or the full image path, e.g.
-         * {@code quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17}.
+         * {@code quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21}.
          */
         @WithParentName
         @WithDefault("${platform.quarkus.native.builder-image}")

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -155,7 +155,7 @@ public final class GraalVM {
         public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", Distribution.GRAALVM);
 
         public static final Version MINIMUM = VERSION_22_2_0;
-        public static final Version CURRENT = VERSION_23_0_0;
+        public static final Version CURRENT = VERSION_23_1_0;
         public static final int UNDEFINED = -1;
 
         final String fullVersion;

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/NativeConfigTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/NativeConfigTest.java
@@ -9,20 +9,20 @@ class NativeConfigTest {
     @Test
     public void testBuilderImageProperlyDetected() {
         assertThat(createConfig("graalvm").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
-                .contains("jdk-17");
+                .contains("jdk-21");
         assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
-                .contains("jdk-17");
+                .contains("jdk-21");
         assertThat(createConfig("GraalVM").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
-                .contains("jdk-17");
+                .contains("jdk-21");
         assertThat(createConfig("GRAALVM").builderImage().getEffectiveImage()).contains("ubi-quarkus-graalvmce-builder-image")
-                .contains("jdk-17");
+                .contains("jdk-21");
 
         assertThat(createConfig("mandrel").builderImage().getEffectiveImage()).contains("ubi-quarkus-mandrel-builder-image")
-                .contains("jdk-17");
+                .contains("jdk-21");
         assertThat(createConfig("Mandrel").builderImage().getEffectiveImage()).contains("ubi-quarkus-mandrel-builder-image")
-                .contains("jdk-17");
+                .contains("jdk-21");
         assertThat(createConfig("MANDREL").builderImage().getEffectiveImage()).contains("ubi-quarkus-mandrel-builder-image")
-                .contains("jdk-17");
+                .contains("jdk-21");
 
         assertThat(createConfig("aRandomString").builderImage().getEffectiveImage()).isEqualTo("aRandomString");
     }

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -17,10 +17,10 @@
     <properties>
         <!-- The Graal version we suggest using in documentation - as that's
            what we work with by self downloading it: -->
-        <graal-community.version-for-documentation>for JDK 17</graal-community.version-for-documentation>
-        <graal-community.tag-for-documentation>jdk17</graal-community.tag-for-documentation>
-        <graal-community.image-tag-for-documentation>jdk-17</graal-community.image-tag-for-documentation>
-        <mandrel.image-tag-for-documentation>jdk-17</mandrel.image-tag-for-documentation>
+        <graal-community.version-for-documentation>for JDK 21</graal-community.version-for-documentation>
+        <graal-community.tag-for-documentation>jdk21</graal-community.tag-for-documentation>
+        <graal-community.image-tag-for-documentation>jdk-21</graal-community.image-tag-for-documentation>
+        <mandrel.image-tag-for-documentation>jdk-21</mandrel.image-tag-for-documentation>
 
         <assembly-maven-plugin.version>3.5.0</assembly-maven-plugin.version>
         <asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -430,17 +430,6 @@ The reason for this is that the local build driver invoked through `-Dquarkus.na
 
 [TIP]
 ====
-The builder image used by default supports Java 17 as it is the latest LTS version.
-
-If your application uses Java 18 or later, you need to specify a builder image supporting Java 20:
-
-:build-additional-parameters: -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-20
-include::{includes}/devtools/build-native-container-parameters.adoc[]
-:!build-additional-parameters:
-====
-
-[TIP]
-====
 Building with GraalVM instead of Mandrel requires a custom builder image parameter to be passed additionally:
 
 :build-additional-parameters: -Dquarkus.native.builder-image=graalvm

--- a/docs/src/main/asciidoc/virtual-threads.adoc
+++ b/docs/src/main/asciidoc/virtual-threads.adoc
@@ -386,15 +386,10 @@ Then, add to your `application.properties` file:
 
 [source, properties]
 ----
-quarkus.native.additional-build-args=--enable-preview <1>
-
 # In-container build to get a linux 64 executable
-quarkus.native.container-build=true <2>
-quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-20 <3>
+quarkus.native.container-build=true <1>
 ----
-<1> The `enable-preview` flag in only necessary until Java 21.
-<2> Enables the in-container build
-<3> The builder container to use. Make sure it supports virtual threads
+<1> Enables the in-container build
 
 [IMPORTANT]
 .From ARM/64 to AMD/64

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -70,7 +70,7 @@
         <jboss-logmanager.version>3.0.2.Final</jboss-logmanager.version>
         <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
-        <graal-sdk.version>23.0.1</graal-sdk.version>
+        <graal-sdk.version>23.1.0</graal-sdk.version>
         <plexus-classworlds.version>2.6.0</plexus-classworlds.version> <!-- not actually used but ClassRealm class is referenced from the API used in BootstrapWagonConfigurator -->
         <plexus-cipher.version>2.0</plexus-cipher.version>
         <plexus-interpolation.version>1.26</plexus-interpolation.version>

--- a/integration-tests/virtual-threads/amqp-virtual-threads/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/amqp-virtual-threads/src/main/resources/application.properties
@@ -3,5 +3,3 @@ mp.messaging.incoming.prices.broadcast=true
 mp.messaging.outgoing.prices-out.address=prices
 
 smallrye.messaging.worker.<virtual-thread>.max-concurrency=10
-
-quarkus.native.additional-build-args=--enable-preview

--- a/integration-tests/virtual-threads/grpc-virtual-threads/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/grpc-virtual-threads/src/main/resources/application.properties
@@ -3,7 +3,5 @@ quarkus.grpc.clients.service.port=9001
 
 %vertx.quarkus.grpc.server.use-separate-server=false
 
-quarkus.native.additional-build-args=--enable-preview
-
 %vertx.quarkus.grpc.clients.service.port=8081
 %vertx.quarkus.grpc.clients.service.use-quarkus-grpc-client=true

--- a/integration-tests/virtual-threads/jms-virtual-threads/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/jms-virtual-threads/src/main/resources/application.properties
@@ -4,7 +4,5 @@ mp.messaging.outgoing.prices-out.destination=prices
 
 smallrye.messaging.worker.<virtual-thread>.max-concurrency=5
 
-quarkus.native.additional-build-args=--enable-preview
-
 quarkus.artemis.devservices.enabled=true
 quarkus.artemis.devservices.image-name=quay.io/artemiscloud/activemq-artemis-broker:1.0.18

--- a/integration-tests/virtual-threads/kafka-virtual-threads/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/kafka-virtual-threads/src/main/resources/application.properties
@@ -4,5 +4,3 @@ mp.messaging.incoming.prices.auto.offset.reset=earliest
 mp.messaging.outgoing.prices-out.topic=prices
 
 smallrye.messaging.worker.<virtual-thread>.max-concurrency=10
-
-quarkus.native.additional-build-args=--enable-preview

--- a/integration-tests/virtual-threads/mailer-virtual-threads/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/mailer-virtual-threads/src/main/resources/application.properties
@@ -1,3 +1,2 @@
-quarkus.native.additional-build-args=--enable-preview
 quarkus.mailer.mock=false
 quarkus.mailer.from=roger-the-robot@quarkus.io

--- a/integration-tests/virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/pom.xml
@@ -103,7 +103,7 @@
                             <maven.home>${maven.home}</maven.home>
                         </systemPropertyVariables>
                         <!-- gradle scan capture test logging disabled: System.out in virtual threads cause pinning when enabled. -->
-                        <argLine>--enable-preview -Djdk.tracePinnedThreads -Dgradle.scan.captureTestLogging=false</argLine>
+                        <argLine>-Djdk.tracePinnedThreads -Dgradle.scan.captureTestLogging=false</argLine>
                         <skipTests>${skipTests}</skipTests>
                     </configuration>
                 </plugin>
@@ -130,7 +130,6 @@
                     <version>${version.compiler.plugin}</version>
                     <configuration>
                         <compilerArgs>
-                            <arg>--enable-preview</arg>
                             <arg>-parameters</arg>
                         </compilerArgs>
                     </configuration>

--- a/integration-tests/virtual-threads/quartz-virtual-threads/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/quartz-virtual-threads/src/main/resources/application.properties
@@ -1,3 +1,0 @@
-quarkus.native.additional-build-args=--enable-preview
-
-quarkus.package.quiltflower.enabled=true

--- a/integration-tests/virtual-threads/redis-virtual-threads/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/redis-virtual-threads/src/main/resources/application.properties
@@ -1,4 +1,2 @@
-quarkus.native.additional-build-args=--enable-preview
-
 quarkus.cache.redis.value-type=java.lang.String
 quarkus.cache.redis.ttl=10s

--- a/integration-tests/virtual-threads/rest-client-reactive-virtual-threads/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/rest-client-reactive-virtual-threads/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-quarkus.native.additional-build-args=--enable-preview

--- a/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-quarkus.native.additional-build-args=--enable-preview

--- a/integration-tests/virtual-threads/scheduler-virtual-threads/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/scheduler-virtual-threads/src/main/resources/application.properties
@@ -1,3 +1,0 @@
-quarkus.native.additional-build-args=--enable-preview
-
-quarkus.package.quiltflower.enabled=true

--- a/integration-tests/virtual-threads/vertx-event-bus-virtual-threads/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/vertx-event-bus-virtual-threads/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-quarkus.native.additional-build-args=--enable-preview

--- a/integration-tests/virtual-threads/virtual-threads-disabled/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/virtual-threads-disabled/src/main/resources/application.properties
@@ -1,2 +1,1 @@
-quarkus.native.additional-build-args=--enable-preview
 quarkus.virtual-threads.enabled=false


### PR DESCRIPTION
- Update the GraalVM Community builder image to the tag `jdk-21`
- Update the Mandrel builder image to the tag `jdk-21`(Mandrel 23.1)
- Update GraalVM SDK version to 23.1 (yes, it does not follow the same version scheme)

Draft till the Mandrel images get [pushed to quay.io](https://github.com/quarkusio/quarkus-images/actions/runs/6498335260).
