### PR TITLE
OpenAPI: enable auto security filter for auth policy via configuration

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OIDCSecurityAutoAddTestTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OIDCSecurityAutoAddTestTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+class OIDCSecurityAutoAddTestTest extends OIDCSecurityTestBase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(OpenApiResource.class, ResourceBean.class)
+                    .addAsResource(
+                            new StringAsset(""
+                                    + "quarkus.smallrye-openapi.security-scheme-name=OIDCCompanyAuthentication\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-description=OIDC Authentication\n"
+                                    + "quarkus.http.auth.permission.\"oidc\".policy=authenticated\n"
+                                    + "quarkus.http.auth.permission.\"oidc\".paths=/resource/*\n"
+                                    + "quarkus.oidc.auth-server-url=http://localhost:8081/auth/realms/OpenAPIOIDC"),
+                            "application.properties"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-oidc", Version.getVersion())));
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OIDCSecurityTestBase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OIDCSecurityTestBase.java
@@ -1,0 +1,24 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
+
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+
+abstract class OIDCSecurityTestBase {
+
+    @Test
+    void testOIDCAuthentication() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get("/q/openapi")
+                .then().body("components.securitySchemes.OIDCCompanyAuthentication",
+                        allOf(
+                                hasEntry("type", "openIdConnect"),
+                                hasEntry("description", "OIDC Authentication"),
+                                hasEntry("openIdConnectUrl",
+                                        "http://localhost:8081/auth/realms/OpenAPIOIDC/.well-known/openid-configuration")));
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OIDCSecurityWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OIDCSecurityWithConfigTestCase.java
@@ -1,14 +1,12 @@
 package io.quarkus.smallrye.openapi.test.jaxrs;
 
-import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.restassured.RestAssured;
 
-public class OIDCSecurityWithConfigTestCase {
+class OIDCSecurityWithConfigTestCase extends OIDCSecurityTestBase {
+
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
@@ -18,18 +16,6 @@ public class OIDCSecurityWithConfigTestCase {
                                     + "quarkus.smallrye-openapi.security-scheme-name=OIDCCompanyAuthentication\n"
                                     + "quarkus.smallrye-openapi.security-scheme-description=OIDC Authentication\n"
                                     + "quarkus.smallrye-openapi.oidc-open-id-connect-url=http://localhost:8081/auth/realms/OpenAPIOIDC/.well-known/openid-configuration"),
-
                             "application.properties"));
 
-    @Test
-    public void testOIDCAuthentication() {
-        RestAssured.given().header("Accept", "application/json")
-                .when().get("/q/openapi")
-                .then().body("components.securitySchemes.OIDCCompanyAuthentication", Matchers.hasEntry("type", "openIdConnect"))
-                .and()
-                .body("components.securitySchemes.OIDCCompanyAuthentication",
-                        Matchers.hasEntry("description", "OIDC Authentication"))
-                .and().body("components.securitySchemes.OIDCCompanyAuthentication", Matchers.hasEntry("openIdConnectUrl",
-                        "http://localhost:8081/auth/realms/OpenAPIOIDC/.well-known/openid-configuration"));
-    }
 }


### PR DESCRIPTION
Allow the OpenAPI to have auto-added security scheme when an enabled HTTP auth policy is present. Currently, it requires auth to be enabled via `@RolesAllowed` or `@Authenticated`.