### PR TITLE
HTTP reference guide - HTTP/2 section update, drop JDK 8 note

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -183,7 +183,7 @@ As with the certificate/key file combination, Quarkus will first try to resolve 
 
 Add the following property to your `application.properties`:
 
-[source,bash]
+[source,properties]
 ----
 quarkus.http.ssl.certificate.key-store-file=/path/to/keystore
 ----
@@ -307,9 +307,8 @@ quarkus.http.handle-100-continue-automatically=true
 
 == HTTP/2 Support
 
-HTTP/2 is enabled by default, and will be used by browsers if SSL is in use on JDK11 or higher. JDK8 does not support
-ALPN so cannot be used to run HTTP/2 over SSL. Even if SSL is not in use HTTP/2 via cleartext upgrade is supported,
-and may be used by non-browser clients.
+HTTP/2 is enabled by default, and will be used by browsers if SSL is in use. Even if SSL is not in use
+HTTP/2 via cleartext upgrade is supported, and may be used by non-browser clients.
 
 If you want to disable HTTP/2 you can set:
 


### PR DESCRIPTION
http-reference guide - HTTP/2 section update, drop JDK 8 note

Quarkus is by default supported on JDK 11 and above atm. Having a note specific to JDK 8 seems irrelevant.

Also minor fix for formatting of one code example