### PR TITLE
Support for @JsonView on Method Parameters in Resteasy Reactive Jackson

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
@@ -23,6 +23,7 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.common.model.ResourceMethod;
@@ -410,10 +411,16 @@ public class ResteasyReactiveJacksonProcessor {
             return getClassId(target.asClass());
         } else if (target.kind() == AnnotationTarget.Kind.METHOD) {
             return getMethodId(target.asMethod());
+        } else if (target.kind() == AnnotationTarget.Kind.METHOD_PARAMETER) {
+            return getMethodParameterId(target.asMethodParameter());
         }
 
         throw new UnsupportedOperationException("The `@CustomSerialization` and `@CustomDeserialization` annotations can only "
-                + "be used in methods or classes.");
+                + "be used in methods, classes or method parameters.");
+    }
+
+    private String getMethodParameterId(MethodParameterInfo methodParameterInfo) {
+        return getMethodId(methodParameterInfo.method(), methodParameterInfo.method().declaringClass());
     }
 
     private String getClassId(ClassInfo classInfo) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/JsonViewOnClassTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/JsonViewOnClassTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.not;
 import java.util.function.Supplier;
 
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -46,6 +47,13 @@ class JsonViewOnClassTest {
                 .then()
                 .statusCode(200)
                 .body(containsString("1"), containsString("test"));
+
+        given().accept("application/json").contentType("application/json")
+                .body(User.testUser())
+                .post("param")
+                .then()
+                .statusCode(200)
+                .body(not(containsString("1")), containsString("test"));
     }
 
     @JsonView(Views.Public.class)
@@ -66,6 +74,11 @@ class JsonViewOnClassTest {
         public User get() {
             return User.testUser();
         }
+
+        @POST
+        public User post(@JsonView(Views.Public.class) User user) {
+            return user;
+        }
     }
 
     @JsonView(Views.Public.class)
@@ -76,6 +89,15 @@ class JsonViewOnClassTest {
         @JsonView(Views.Private.class)
         public User get() {
             return User.testUser();
+        }
+    }
+
+    @Path("param")
+    public static class Param {
+
+        @POST
+        public User get(@JsonView(Views.Public.class) User user) {
+            return user;
         }
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/JsonViewOnClassTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/JsonViewOnClassTest.java
@@ -74,11 +74,6 @@ class JsonViewOnClassTest {
         public User get() {
             return User.testUser();
         }
-
-        @POST
-        public User post(@JsonView(Views.Public.class) User user) {
-            return user;
-        }
     }
 
     @JsonView(Views.Public.class)
@@ -96,7 +91,7 @@ class JsonViewOnClassTest {
     public static class Param {
 
         @POST
-        public User get(@JsonView(Views.Public.class) User user) {
+        public User post(@JsonView(Views.Public.class) User user) {
             return user;
         }
     }


### PR DESCRIPTION
**Problem**:
Previously, in the `resteasy-reactive/quarkus-resteasy-reactive-jackson` extension, the use of `@CustomSerialization` and `@CustomDeserialization` annotations was restricted to only classes and methods. This posed limitations when developers wanted to use Jackson's `@JsonView` directly on method parameters to customize the serialization/deserialization behavior based on the given input.

**Solution**:
This PR enhances the `ResteasyReactiveJacksonProcessor` to support the `@JsonView` annotation on method parameters. The changes include:
- Extended the `getTargetId` method to recognize method parameters and retrieve their IDs.
- Added relevant tests to ensure that the `@JsonView` annotation works as expected on method parameters.

By introducing this feature, developers have more flexibility and finer-grained control over serialization/deserialization behavior directly in the resource method signatures.
