### PR TITLE
Let custom OIDC token propagation filters customize the exchange status

### DIFF
--- a/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/AccessTokenRequestReactiveFilter.java
+++ b/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/AccessTokenRequestReactiveFilter.java
@@ -59,13 +59,13 @@ public class AccessTokenRequestReactiveFilter implements ResteasyReactiveClientR
 
     @PostConstruct
     public void initExchangeTokenClient() {
-        if (exchangeToken) {
+        if (isExchangeToken()) {
             OidcClients clients = Arc.container().instance(OidcClients.class).get();
             String clientName = getClientName();
             exchangeTokenClient = clientName != null ? clients.getClient(clientName) : clients.getClient();
             Grant.Type exchangeTokenGrantType = ConfigProvider.getConfig()
                     .getValue(
-                            "quarkus.oidc-client." + (oidcClientName.isPresent() ? oidcClientName.get() + "." : "")
+                            "quarkus.oidc-client." + (clientName != null ? clientName + "." : "")
                                     + "grant.type",
                             Grant.Type.class);
             if (exchangeTokenGrantType == Grant.Type.EXCHANGE) {
@@ -77,6 +77,10 @@ public class AccessTokenRequestReactiveFilter implements ResteasyReactiveClientR
                         + "to use the " + exchangeTokenGrantType.getGrantType() + " grantType");
             }
         }
+    }
+
+    protected boolean isExchangeToken() {
+        return exchangeToken;
     }
 
     @Override

--- a/extensions/oidc-token-propagation/deployment/src/test/java/io/quarkus/oidc/token/propagation/CustomAccessTokenRequestFilter.java
+++ b/extensions/oidc-token-propagation/deployment/src/test/java/io/quarkus/oidc/token/propagation/CustomAccessTokenRequestFilter.java
@@ -1,0 +1,15 @@
+package io.quarkus.oidc.token.propagation;
+
+public class CustomAccessTokenRequestFilter extends AccessTokenRequestFilter {
+
+    @Override
+    protected String getClientName() {
+        return "exchange";
+    }
+
+    @Override
+    protected boolean isExchangeToken() {
+        return true;
+    }
+
+}

--- a/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/AccessTokenRequestFilter.java
+++ b/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/AccessTokenRequestFilter.java
@@ -52,13 +52,13 @@ public class AccessTokenRequestFilter extends AbstractTokenRequestFilter {
 
     @PostConstruct
     public void initExchangeTokenClient() {
-        if (exchangeToken) {
+        if (isExchangeToken()) {
             OidcClients clients = Arc.container().instance(OidcClients.class).get();
             String clientName = getClientName();
             exchangeTokenClient = clientName != null ? clients.getClient(clientName) : clients.getClient();
             Grant.Type exchangeTokenGrantType = ConfigProvider.getConfig()
                     .getValue(
-                            "quarkus.oidc-client." + (oidcClientName.isPresent() ? oidcClientName.get() + "." : "")
+                            "quarkus.oidc-client." + (clientName != null ? clientName + "." : "")
                                     + "grant.type",
                             Grant.Type.class);
             if (exchangeTokenGrantType == Grant.Type.EXCHANGE) {
@@ -70,6 +70,10 @@ public class AccessTokenRequestFilter extends AbstractTokenRequestFilter {
                         + "to use the " + exchangeTokenGrantType.getGrantType() + " grantType");
             }
         }
+    }
+
+    protected boolean isExchangeToken() {
+        return exchangeToken;
     }
 
     @Override

--- a/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/AccessTokenPropagationService.java
+++ b/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/AccessTokenPropagationService.java
@@ -3,12 +3,11 @@ package io.quarkus.it.keycloak;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-import io.quarkus.oidc.token.propagation.AccessToken;
-
 @RegisterRestClient(configKey = "access-token-propagation")
-@AccessToken
+@RegisterProvider(CustomAccessTokenRequestFilter.class)
 @Path("/")
 public interface AccessTokenPropagationService {
 

--- a/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/CustomAccessTokenRequestFilter.java
+++ b/integration-tests/oidc-token-propagation/src/main/java/io/quarkus/it/keycloak/CustomAccessTokenRequestFilter.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.keycloak;
+
+import io.quarkus.oidc.token.propagation.AccessTokenRequestFilter;
+
+public class CustomAccessTokenRequestFilter extends AccessTokenRequestFilter {
+    @Override
+    protected String getClientName() {
+        return "exchange-token";
+    }
+
+    @Override
+    protected boolean isExchangeToken() {
+        return true;
+    }
+}

--- a/integration-tests/oidc-token-propagation/src/main/resources/application.properties
+++ b/integration-tests/oidc-token-propagation/src/main/resources/application.properties
@@ -18,9 +18,6 @@ quarkus.oidc-client.exchange-token.credentials.secret=${quarkus.oidc.credentials
 quarkus.oidc-client.exchange-token.grant.type=exchange
 quarkus.oidc-client.exchange-token.grant-options.exchange.audience=quarkus-app-exchange
 
-quarkus.oidc-token-propagation.exchange-token=true
-quarkus.oidc-token-propagation.client-name=exchange-token
-
 quarkus.rest-client.jwt-token-propagation.uri=http://localhost:8081/protected
 quarkus.rest-client.jwt-token-propagation.verify-host=false
 quarkus.rest-client.access-token-propagation.uri=http://localhost:8081/protected


### PR DESCRIPTION
It follows #36459 (which in itself was correct but not complete), this time with a proper test, where both client name and now the token exchange requirement being customized at the custom filter level as opposed to in the properties. 

Both `oidc-token-propagation/deployment` and `oidc-token-propagation-reactive/deployment` already test the exchange requirement configured in the properties.

Relates to #36440 and #36458.


