### PR TITLE
Remove custom Keycloak image code from the keycloak-authorization tests

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -85,6 +85,20 @@ public class DevServicesConfig {
     public Optional<List<String>> realmPath;
 
     /**
+     * Aliases to additional class or file system resources which will be used to initialize Keycloak.
+     * Each map entry represents a mapping between an alias and a class or file system resource path.
+     */
+    @ConfigItem
+    public Map<String, String> resourceAliases;
+    /**
+     * Additional class or file system resources which will be used to initialize Keycloak.
+     * Each map entry represents a mapping between a class or file system resource path alias and the Keycloak container
+     * location.
+     */
+    @ConfigItem
+    public Map<String, String> resourceMappings;
+
+    /**
      * The JAVA_OPTS passed to the keycloak JVM
      */
     @ConfigItem

--- a/integration-tests/keycloak-authorization/pom.xml
+++ b/integration-tests/keycloak-authorization/pom.xml
@@ -13,11 +13,6 @@
     <name>Quarkus - Integration Tests - Keycloak Policy Enforcer</name>
     <description>Module that contains Keycloak Policy Enforcer related tests</description>
 
-    <properties>
-        <keycloak.url>http://localhost:8180/auth</keycloak.url>
-        <nashorn-core.version>15.3</nashorn-core.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -38,8 +33,8 @@
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-keycloak-server</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -116,37 +111,29 @@
             <artifactId>htmlunit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.openjdk.nashorn</groupId>
-            <artifactId>nashorn-core</artifactId>
-            <version>${nashorn-core.version}</version>
-        </dependency>
     </dependencies>
 
     <build>
-        <testResources>
-            <testResource>
-                <directory>src/test/resources</directory>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
                 <filtering>true</filtering>
-            </testResource>
-        </testResources>
+            </resource>
+            <resource>
+                <directory>src/main/resources/policies</directory>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
-                    <systemPropertyVariables>
-                        <keycloak.image.version>${keycloak.image.version}</keycloak.image.version>
-                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
-                    <systemPropertyVariables>
-                        <keycloak.image.version>${keycloak.image.version}</keycloak.image.version>
-                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>
@@ -162,19 +149,24 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
+                <artifactId>maven-jar-plugin</artifactId>
                 <executions>
-                    <execution>
-                        <id>copy-dependencies-quarkus</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
-                            <includeArtifactIds>nashorn-core,asm,asm-util,asm-commons</includeArtifactIds>
-                        </configuration>
-                    </execution>
+		    <execution>
+		        <phase>process-resources</phase>
+		        <goals>
+		            <goal>jar</goal>
+		        </goals>
+		        <configuration>
+		            <classifier>policies</classifier>
+		            <includes>
+		                <include>*.js</include>
+		                <include>META-INF/*</include>
+		            </includes>
+		            <excludes>
+		                <exclude>/policies</exclude>
+		            </excludes>
+		        </configuration>
+		    </execution>
                 </executions>
             </plugin>
         </plugins>
@@ -194,18 +186,12 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.version>${keycloak.version}</keycloak.version>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
-                                <keycloak.version>${keycloak.version}</keycloak.version>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/AdminClientResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/AdminClientResource.java
@@ -10,7 +10,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
@@ -21,9 +20,6 @@ import org.keycloak.representations.idm.UserRepresentation;
 
 @Path("/admin-client")
 public class AdminClientResource {
-
-    @ConfigProperty(name = "admin-url")
-    String url;
 
     @Inject
     Keycloak keycloak;

--- a/integration-tests/keycloak-authorization/src/main/resources/application.properties
+++ b/integration-tests/keycloak-authorization/src/main/resources/application.properties
@@ -1,9 +1,11 @@
+quarkus.keycloak.devservices.create-realm=false
+quarkus.keycloak.devservices.resource-aliases.policies=${project.build.directory}/${project.build.finalName}-policies.jar
+quarkus.keycloak.devservices.resource-mappings.policies=/opt/keycloak/providers/policies.jar
 # Enable Policy Enforcement
 quarkus.keycloak.policy-enforcer.enable=true
 
 # Default Tenant
 # Configuration file
-quarkus.oidc.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
 

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/KeycloakLifecycleManager.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/KeycloakLifecycleManager.java
@@ -1,24 +1,12 @@
 package io.quarkus.it.keycloak;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
-import org.jboss.logging.Logger;
-import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -28,108 +16,21 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.authorization.PolicyRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
-import org.keycloak.util.JsonSerialization;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.images.builder.ImageFromDockerfile;
-import org.testcontainers.images.builder.Transferable;
 
+import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.restassured.RestAssured;
-import io.restassured.specification.RequestSpecification;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
 
-public class KeycloakLifecycleManager implements QuarkusTestResourceLifecycleManager {
-    private static final Logger LOGGER = Logger.getLogger(KeycloakLifecycleManager.class);
-    private GenericContainer<?> keycloak;
-
-    protected static String KEYCLOAK_SERVER_URL;
+public class KeycloakLifecycleManager implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
     private static final String KEYCLOAK_REALM = "quarkus";
-    private static final String KEYCLOAK_SERVICE_CLIENT = "quarkus-service-app";
-    private static final String KEYCLOAK_IMAGE = System.getProperty("keycloak.docker.image");
+    final KeycloakTestClient client = new KeycloakTestClient();
 
-    @SuppressWarnings("resource")
     @Override
     public Map<String, String> start() {
-        try {
-            keycloak = new GenericContainer<>(
-                    new ImageFromDockerfile().withDockerfile(Paths.get(getClass().getResource("/Dockerfile").toURI()))
-                            .withBuildArg("KEYCLOAK_IMAGE", KEYCLOAK_IMAGE))
-                    .withExposedPorts(8080)
-                    .withEnv("KEYCLOAK_ADMIN", "admin")
-                    .withEnv("KEYCLOAK_ADMIN_PASSWORD", "admin")
-                    .waitingFor(Wait.forLogMessage(".*Keycloak.*started.*", 1));
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-
-        keycloak = keycloak
-                .withCopyToContainer(Transferable.of(createPoliciesJar().toByteArray()), "/opt/keycloak/providers/policies.jar")
-                .withCommand("start-dev");
-        keycloak.start();
-        LOGGER.info(keycloak.getLogs());
-
-        KEYCLOAK_SERVER_URL = "http://localhost:" + keycloak.getMappedPort(8080);
-
         RealmRepresentation realm = createRealm(KEYCLOAK_REALM);
 
-        postRealm(realm);
-
-        Map<String, String> properties = new HashMap<>();
-
-        properties.put("quarkus.oidc.auth-server-url", KEYCLOAK_SERVER_URL + "/realms/" + KEYCLOAK_REALM);
-        properties.put("keycloak.url", KEYCLOAK_SERVER_URL);
-
-        return properties;
-    }
-
-    private ByteArrayOutputStream createPoliciesJar() {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-        try (
-                ZipOutputStream zos = new ZipOutputStream(out);) {
-
-            List<URL> entryUrls = List.of(
-                    getClass().getResource("/policies/admin-policy.js"),
-                    getClass().getResource("/policies/always-grant.js"),
-                    getClass().getResource("/policies/body-claim-based-policy.js"),
-                    getClass().getResource("/policies/claim-based-policy.js"),
-                    getClass().getResource("/policies/confidential-policy.js"),
-                    getClass().getResource("/policies/http-claim-based-policy.js"),
-                    getClass().getResource("/policies/superuser-policy.js"));
-
-            addZipEntry("META-INF/keycloak-scripts.json", getClass().getResource("/policies/META-INF/keycloak-scripts.json"),
-                    zos);
-
-            for (URL entryUrl : entryUrls) {
-                File entryFile = Paths.get(entryUrl.toURI()).toFile();
-                addZipEntry(entryFile.getName(), entryUrl, zos);
-            }
-        } catch (Exception cause) {
-            throw new RuntimeException("Failed to create policies file", cause);
-        }
-
-        return out;
-    }
-
-    private void addZipEntry(String entryName, URL entryUrl, ZipOutputStream zos) throws URISyntaxException, IOException {
-        ZipEntry zipEntry = new ZipEntry(entryName);
-
-        zos.putNextEntry(zipEntry);
-        zos.write(Files.readAllBytes(Paths.get(entryUrl.toURI())));
-        zos.closeEntry();
-    }
-
-    private static void postRealm(RealmRepresentation realm) {
-        try {
-            createRequestSpec().auth().oauth2(getAdminAccessToken())
-                    .contentType("application/json")
-                    .body(JsonSerialization.writeValueAsBytes(realm))
-                    .when()
-                    .post(KEYCLOAK_SERVER_URL + "/admin/realms").then()
-                    .statusCode(201);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        client.createRealm(realm);
+        return Map.of();
     }
 
     private static RealmRepresentation createRealm(String name) {
@@ -159,30 +60,6 @@ public class KeycloakLifecycleManager implements QuarkusTestResourceLifecycleMan
         realm.getUsers().add(createUser("jdoe", "user", "confidential"));
 
         return realm;
-    }
-
-    private static String getAdminAccessToken() {
-        return createRequestSpec()
-                .param("grant_type", "password")
-                .param("username", "admin")
-                .param("password", "admin")
-                .param("client_id", "admin-cli")
-                .when()
-                .post(KEYCLOAK_SERVER_URL + "/realms/master/protocol/openid-connect/token")
-                .as(AccessTokenResponse.class).getToken();
-    }
-
-    private static ClientRepresentation createServiceClient(String clientId) {
-        ClientRepresentation client = new ClientRepresentation();
-
-        client.setClientId(clientId);
-        client.setPublicClient(false);
-        client.setSecret("secret");
-        client.setDirectAccessGrantsEnabled(true);
-        client.setServiceAccountsEnabled(true);
-        client.setEnabled(true);
-
-        return client;
     }
 
     private static ClientRepresentation createClient(String clientId) {
@@ -342,38 +219,13 @@ public class KeycloakLifecycleManager implements QuarkusTestResourceLifecycleMan
         return user;
     }
 
-    public static String getAccessToken(String userName) {
-        return createRequestSpec().param("grant_type", "password")
-                .param("username", userName)
-                .param("password", userName)
-                .param("client_id", KEYCLOAK_SERVICE_CLIENT)
-                .param("client_secret", "secret")
-                .when()
-                .post(KEYCLOAK_SERVER_URL + "/realms/" + KEYCLOAK_REALM + "/protocol/openid-connect/token")
-                .as(AccessTokenResponse.class).getToken();
-    }
-
-    public static String getRefreshToken(String userName) {
-        return createRequestSpec().param("grant_type", "password")
-                .param("username", userName)
-                .param("password", userName)
-                .param("client_id", KEYCLOAK_SERVICE_CLIENT)
-                .param("client_secret", "secret")
-                .when()
-                .post(KEYCLOAK_SERVER_URL + "/realms/" + KEYCLOAK_REALM + "/protocol/openid-connect/token")
-                .as(AccessTokenResponse.class).getRefreshToken();
+    @Override
+    public void stop() {
+        //client.deleteRealm(KEYCLOAK_REALM);
     }
 
     @Override
-    public void stop() {
-        createRequestSpec().auth().oauth2(getAdminAccessToken())
-                .when()
-                .delete(KEYCLOAK_SERVER_URL + "/admin/realms/" + KEYCLOAK_REALM).then().statusCode(204);
-
-        keycloak.stop();
-    }
-
-    private static RequestSpecification createRequestSpec() {
-        return RestAssured.given().relaxedHTTPSValidation();
+    public void setIntegrationTestContext(DevServicesContext context) {
+        client.setIntegrationTestContext(context);
     }
 }

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
@@ -10,7 +10,6 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.keycloak.representations.AccessTokenResponse;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
@@ -22,7 +21,7 @@ import com.gargoylesoftware.htmlunit.util.Cookie;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
@@ -34,10 +33,11 @@ import io.vertx.ext.web.client.WebClient;
 @QuarkusTestResource(KeycloakLifecycleManager.class)
 public class PolicyEnforcerTest {
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
-    private static final String KEYCLOAK_REALM = "quarkus";
 
     @TestHTTPResource
     URL url;
+
+    final KeycloakTestClient keycloakClient = new KeycloakTestClient();
 
     static Vertx vertx = Vertx.vertx();
     static WebClient client = WebClient.create(vertx);
@@ -239,17 +239,7 @@ public class PolicyEnforcerTest {
     }
 
     protected String getAccessToken(String userName) {
-        return RestAssured
-                .given()
-                .param("grant_type", "password")
-                .param("username", userName)
-                .param("password", userName)
-                .param("client_id", "quarkus-app")
-                .param("client_secret", "secret")
-                .when()
-                .post(KeycloakLifecycleManager.KEYCLOAK_SERVER_URL + "/realms/" + KEYCLOAK_REALM
-                        + "/protocol/openid-connect/token")
-                .as(AccessTokenResponse.class).getToken();
+        return keycloakClient.getAccessToken(userName);
     }
 
     private void assureGetPath(String path, int expectedStatusCode, String token, String body) {

--- a/integration-tests/keycloak-authorization/src/test/resources/Dockerfile
+++ b/integration-tests/keycloak-authorization/src/test/resources/Dockerfile
@@ -1,8 +1,0 @@
-FROM ${keycloak.docker.image} as builder
-
-COPY ./*.jar /opt/keycloak/providers/
-
-FROM ${keycloak.docker.image}
-COPY --from=builder /opt/keycloak/ /opt/keycloak/
-
-ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]


### PR DESCRIPTION
Fixes #37684.

@pedroigor added it with #31525 because back then the scripting engine was not available in the official Keycloak image, but it is no longer necessary since the scripting engine is shipped in Keycloak images again.
