### PR TITLE
Housekeeping native-image build step

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -153,6 +153,7 @@ public final class GraalVM {
         public static final Version VERSION_22_2_0 = new Version("GraalVM 22.2.0", "22.2.0", Distribution.GRAALVM);
         public static final Version VERSION_23_0_0 = new Version("GraalVM 23.0.0", "23.0.0", Distribution.GRAALVM);
         public static final Version VERSION_23_1_0 = new Version("GraalVM 23.1.0", "23.1.0", Distribution.GRAALVM);
+        public static final Version VERSION_24_0_0 = new Version("GraalVM 24.0.0", "24.0.0", Distribution.GRAALVM);
 
         public static final Version MINIMUM = VERSION_22_2_0;
         public static final Version CURRENT = VERSION_23_1_0;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -749,22 +749,6 @@ public class NativeImageBuildStep {
                 }
                 nativeImageArgs.add("--features=" + String.join(",", featuresList));
 
-                if (graalVMVersion.isOlderThan(GraalVM.Version.VERSION_22_2_0)) {
-                    /*
-                     * Instruct GraalVM / Mandrel parse compiler graphs twice, once for the static analysis and once again
-                     * for the AOT compilation.
-                     *
-                     * We do this because single parsing significantly increases memory usage at build time
-                     * see https://github.com/oracle/graal/issues/3435 and
-                     * https://github.com/graalvm/mandrel/issues/304#issuecomment-952070568 for more details.
-                     *
-                     * Note: This option must come before the invocation of
-                     * {@code handleAdditionalProperties(nativeImageArgs)} to ensure that devs and advanced users can
-                     * override it by passing -Dquarkus.native.additional-build-args=-H:+ParseOnce
-                     */
-                    addExperimentalVMOption(nativeImageArgs, "-H:-ParseOnce");
-                }
-
                 if (nativeConfig.debug().enabled() && graalVMVersion.compareTo(GraalVM.Version.VERSION_23_0_0) >= 0) {
                     /*
                      * Instruct GraalVM / Mandrel to keep more accurate information about source locations when generating

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -814,9 +814,12 @@ public class NativeImageBuildStep {
                             "-H:BuildOutputJSONFile=" + nativeImageName + "-build-output-stats.json");
                 }
 
-                // only available in GraalVM 23.1.0+. Expected to become the default in GraalVM 24.0.0.
+                // only available in GraalVM 23.1.0+
                 if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_1_0) >= 0) {
-                    nativeImageArgs.add("--strict-image-heap");
+                    if (graalVMVersion.compareTo(GraalVM.Version.VERSION_24_0_0) < 0) {
+                        // Enabled by default in GraalVM 24.0.0.
+                        nativeImageArgs.add("--strict-image-heap");
+                    }
                 }
 
                 /*


### PR DESCRIPTION
- Pass --strict-image-heap only with Mandrel and GraalVM 23.1.x
- Mandrel and GraalVM versions older than 22.2.x are not supported
