### PR TITLE
Use Mandrel 23.1 in windows CI

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -908,8 +908,8 @@ jobs:
         if: startsWith(matrix.os-name, 'windows')
         with:
           version: 'mandrel-latest'
-          java-version: '17'
-          components: 'native-image'
+          java-version: '21'
+          distribution: 'mandrel'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       # We do this so we can get better analytics for the downloaded version of the build images
       - name: Update Docker Client User Agent


### PR DESCRIPTION
Note: The [`Error: Unexpected HTTP response: 404`](https://github.com/quarkusio/quarkus/actions/runs/6536852774/job/17753580056#step:9:76) is an https://github.com/graalvm/setup-graalvm issue that will be handled separately (see https://github.com/graalvm/setup-graalvm/issues/64).

