### PR TITLE
Allow for setting logging scope programmatically

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/QuarkusRestClientBuilder.java
@@ -17,6 +17,7 @@ import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
 import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener;
 import org.jboss.resteasy.reactive.client.api.ClientLogger;
+import org.jboss.resteasy.reactive.client.api.LoggingScope;
 
 import io.quarkus.rest.client.reactive.runtime.QuarkusRestClientBuilderImpl;
 import io.quarkus.rest.client.reactive.runtime.RestClientBuilderImpl;
@@ -258,6 +259,14 @@ public interface QuarkusRestClientBuilder extends Configurable<QuarkusRestClient
      * @return the current builder
      */
     QuarkusRestClientBuilder clientLogger(ClientLogger clientLogger);
+
+    /**
+     * Specifies the client logger to use.
+     *
+     * @param loggingScope to use
+     * @return the current builder
+     */
+    QuarkusRestClientBuilder loggingScope(LoggingScope loggingScope);
 
     /**
      * Based on the configured QuarkusRestClientBuilder, creates a new instance of the given REST interface to invoke API calls

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/QuarkusRestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/QuarkusRestClientBuilderImpl.java
@@ -15,6 +15,7 @@ import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
 import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.jboss.resteasy.reactive.client.api.ClientLogger;
+import org.jboss.resteasy.reactive.client.api.LoggingScope;
 
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.quarkus.rest.client.reactive.runtime.context.ClientHeadersFactoryContextResolver;
@@ -221,6 +222,12 @@ public class QuarkusRestClientBuilderImpl implements QuarkusRestClientBuilder {
     @Override
     public QuarkusRestClientBuilder clientLogger(ClientLogger clientLogger) {
         proxy.clientLogger(clientLogger);
+        return this;
+    }
+
+    @Override
+    public QuarkusRestClientBuilder loggingScope(LoggingScope loggingScope) {
+        proxy.loggingScope(loggingScope);
         return this;
     }
 

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -70,6 +70,7 @@ public class RestClientBuilderImpl implements RestClientBuilder {
     private String nonProxyHosts;
 
     private ClientLogger clientLogger;
+    private LoggingScope loggingScope;
 
     @Override
     public RestClientBuilderImpl baseUrl(URL url) {
@@ -164,6 +165,11 @@ public class RestClientBuilderImpl implements RestClientBuilder {
 
     public RestClientBuilderImpl clientLogger(ClientLogger clientLogger) {
         this.clientLogger = clientLogger;
+        return this;
+    }
+
+    public RestClientBuilderImpl loggingScope(LoggingScope loggingScope) {
+        this.loggingScope = loggingScope;
         return this;
     }
 
@@ -333,10 +339,15 @@ public class RestClientBuilderImpl implements RestClientBuilder {
         RestClientsConfig restClientsConfig = arcContainer.instance(RestClientsConfig.class).get();
 
         RestClientLoggingConfig logging = restClientsConfig.logging;
-        LoggingScope loggingScope = logging != null ? logging.scope.map(LoggingScope::forName).orElse(LoggingScope.NONE)
-                : LoggingScope.NONE;
+
+        LoggingScope effectiveLoggingScope = loggingScope; // if a scope was specified programmatically, it takes precedence
+        if (effectiveLoggingScope == null) {
+            effectiveLoggingScope = logging != null ? logging.scope.map(LoggingScope::forName).orElse(LoggingScope.NONE)
+                    : LoggingScope.NONE;
+        }
+
         Integer loggingBodySize = logging != null ? logging.bodyLimit : 100;
-        clientBuilder.loggingScope(loggingScope);
+        clientBuilder.loggingScope(effectiveLoggingScope);
         clientBuilder.loggingBodySize(loggingBodySize);
         if (clientLogger != null) {
             clientBuilder.clientLogger(clientLogger);


### PR DESCRIPTION
Without this change, the logger that can be
provided programmatically is totally useful
unless the user also configures a Quarkus
config property.
This change allows for logging to actually
be useful in a programmatically
created client