### PR TITLE
Build cache - Various small adjustments

### DIFF
--- a/core/launcher/pom.xml
+++ b/core/launcher/pom.xml
@@ -92,6 +92,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
+                    <outputTimestamp>2023-10-17T10:15:30Z</outputTimestamp>
                     <excludes>
                         <exclude>**/LauncherShader.class</exclude>
                     </excludes>

--- a/core/launcher/src/main/java/io/quarkus/launcher/LauncherShader.java
+++ b/core/launcher/src/main/java/io/quarkus/launcher/LauncherShader.java
@@ -3,6 +3,7 @@ package io.quarkus.launcher;
 import java.io.BufferedWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.stream.Stream;
 
 /**
@@ -56,7 +57,7 @@ public class LauncherShader {
                                 continue;
                             }
                             Files.createDirectories(destPath.getParent());
-                            Files.copy(p, destPath);
+                            Files.copy(p, destPath, StandardCopyOption.COPY_ATTRIBUTES);
                         }
                     }
                 }

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -552,6 +552,9 @@
                                                 <name>baseDir</name>
                                                 <excludes>
                                                     <exclude>.idea/*</exclude>
+                                                    <exclude>.classpath</exclude>
+                                                    <exclude>.project</exclude>
+                                                    <exclude>.settings/*</exclude>
                                                     <exclude>target/*</exclude>
                                                 </excludes>
                                                 <normalization>

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -420,6 +420,11 @@
                                         <ignore>maven.settings</ignore>
                                     </ignoredKeys>
                                 </systemProperties>
+                                <runtimeClassPath>
+                                    <ignoredFiles>
+                                        <ignoredFile>**/quarkus-ide-launcher-*.jar</ignoredFile>
+                                    </ignoredFiles>
+                                </runtimeClassPath>
                             </normalization>
                             <plugins>
                                 <plugin>


### PR DESCRIPTION
By adding an output timestamp, we can get it to be binary identical when the content is identical.
Obviously, the date needs to be forged to be consistent between two separate builds and the output to be cachable.