### PR TITLE
Start MongoDB 4.4 instead of 4.0

### DIFF
--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoTestBase.java
@@ -42,7 +42,7 @@ public class MongoTestBase {
         String uri = getConfiguredConnectionString();
         // This switch allow testing against a running mongo database.
         if (uri == null) {
-            Version.Main version = Version.Main.V4_0;
+            Version.Main version = Version.Main.V4_4;
             int port = 27018;
             LOGGER.infof("Starting Mongo %s on port %s", version, port);
 

--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoWithReplicasTestBase.java
@@ -47,7 +47,7 @@ public class MongoWithReplicasTestBase {
 
         // This switch allow testing against a running mongo database.
         if (uri == null) {
-            startedServers = startReplicaSet(Version.Main.V4_0, 27018, "test001");
+            startedServers = startReplicaSet(Version.Main.V4_4, 27018, "test001");
         } else {
             LOGGER.infof("Using existing Mongo %s", uri);
         }

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoTestBase.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoTestBase.java
@@ -55,7 +55,7 @@ public class MongoTestBase {
         String uri = getConfiguredConnectionString();
         // This switch allow testing against a running mongo database.
         if (uri == null) {
-            Version.Main version = Version.Main.V4_0;
+            Version.Main version = Version.Main.V4_4;
             int port = 27018;
             LOGGER.infof("Starting Mongo %s on port %s", version, port);
 

--- a/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoWithReplicasTestBase.java
+++ b/extensions/mongodb-client/runtime/src/test/java/io/quarkus/mongodb/reactive/MongoWithReplicasTestBase.java
@@ -46,7 +46,7 @@ public class MongoWithReplicasTestBase {
 
         // This switch allow testing against a running mongo database.
         if (uri == null) {
-            startedServers = startReplicaSet(Version.Main.V4_0, 27018, "test001");
+            startedServers = startReplicaSet(Version.Main.V4_4, 27018, "test001");
         } else {
             LOGGER.infof("Using existing Mongo %s", uri);
         }

--- a/test-framework/mongodb/src/main/java/io/quarkus/test/mongodb/MongoTestResource.java
+++ b/test-framework/mongodb/src/main/java/io/quarkus/test/mongodb/MongoTestResource.java
@@ -39,7 +39,7 @@ public class MongoTestResource implements QuarkusTestResourceLifecycleManager {
         return versionArg.<IFeatureAwareVersion> map(Version.Main::valueOf)
                 .orElseGet(() -> versionArg.map(
                         versionStr -> Versions.withFeatures(de.flapdoodle.embed.process.distribution.Version.of(versionStr)))
-                        .orElse(Version.Main.V4_0));
+                        .orElse(Version.Main.V4_4));
     }
 
     public static void forceExtendedSocketOptionsClassInit() {


### PR DESCRIPTION
It's now impossible to start MongoDB 4.0 on a Fedora 38 so let's move to a more modern version for our tests.

FWIW, I have been unable to run the tests for a while and it's really blocking my work on the build cache atm. This is a band aid but it seems to work. I'm wondering if we should switch this to a Testcontainers-based infrastructure if we can but I'm not sure how to handle the replica tests.