### PR TITLE
Upgrade H2 to version 2.2.224

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -126,7 +126,7 @@
         <httpasync.version>4.1.5</httpasync.version>
         <cronutils.version>9.2.1</cronutils.version>
         <quartz.version>2.3.2</quartz.version>
-        <h2.version>2.2.220</h2.version> <!-- When updating, needs to be matched in io.quarkus.hibernate.orm.runtime.config.DialectVersions -->
+        <h2.version>2.2.224</h2.version> <!-- When updating, needs to be matched in io.quarkus.hibernate.orm.runtime.config.DialectVersions -->
         <postgresql-jdbc.version>42.6.0</postgresql-jdbc.version>
         <mariadb-jdbc.version>3.2.0</mariadb-jdbc.version>
         <mysql-jdbc.version>8.0.30</mysql-jdbc.version>

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/config/DialectVersions.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/config/DialectVersions.java
@@ -22,7 +22,7 @@ public final class DialectVersions {
         public static final String ORACLE = "12";
 
         // This must be aligned on the H2 version in the Quarkus BOM
-        public static final String H2 = "2.2.220";
+        public static final String H2 = "2.2.224";
 
         private Defaults() {
         }


### PR DESCRIPTION
Version 2.2.220 has data corruption issues, which were addressed in version 2.2.222. That version ended up introducing performance issues (as seen in the [release notes](https://github.com/h2database/h2database/releases)), which were fixed in 2.2.224.

In Keycloak we are also upgrading H2 as some users have reported issues that might be related to the issues in 2.2.220.