### PR TITLE
SmallRye GraphQL 2.5.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -55,7 +55,7 @@
         <smallrye-health.version>4.0.4</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>3.6.2</smallrye-open-api.version>
-        <smallrye-graphql.version>2.5.0</smallrye-graphql.version>
+        <smallrye-graphql.version>2.5.1</smallrye-graphql.version>
         <smallrye-opentracing.version>3.0.3</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>6.2.6</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.3.1</smallrye-jwt.version>

--- a/extensions/oidc-client-graphql/deployment/src/test/java/io/quarkus/oidc/client/graphql/GraphQLClientUsingOidcClientTest.java
+++ b/extensions/oidc-client-graphql/deployment/src/test/java/io/quarkus/oidc/client/graphql/GraphQLClientUsingOidcClientTest.java
@@ -2,7 +2,6 @@ package io.quarkus.oidc.client.graphql;
 
 import static org.hamcrest.Matchers.equalTo;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -12,7 +11,6 @@ import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 import io.restassured.RestAssured;
 
 @QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
-@Disabled
 public class GraphQLClientUsingOidcClientTest {
 
     private static final Class<?>[] testClasses = {


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/36469
For the record, the actual fix for the failing test was: https://github.com/smallrye/smallrye-graphql/commit/2640bc9f82edc9e8722f3f0264d8c3e26a9bcea6 . No other changes from 2.5.0.