### PR TITLE
Allow default exporter with additional Quarkiverse exporters

### DIFF
--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterProcessor.java
@@ -68,8 +68,8 @@ public class OtlpExporterProcessor {
             CoreVertxBuildItem vertxBuildItem,
             List<ExternalOtelExporterBuildItem> externalOtelExporterBuildItem,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
-        if (!externalOtelExporterBuildItem.isEmpty()) {
-            // if there is an external exporter, we don't want to create the default one
+        if (!exporterRuntimeConfig.activateDefaultExporter() && !externalOtelExporterBuildItem.isEmpty()) {
+            // unless explicitly configured, if there is an external exporter we don't want to create the default one
             return;
         }
         syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterConfigTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/exporter/otlp/OtlpExporterConfigTest.java
@@ -17,6 +17,7 @@ public class OtlpExporterConfigTest {
             .withEmptyApplication()
             .overrideConfigKey("otel.traces.exporter", "cdi")
             .overrideConfigKey("otel.exporter.otlp.traces.protocol", "http/protobuf")
+            .overrideConfigKey("quarkus.otel.exporter.otlp.experimental.dependent.default.enable", "true")
             .overrideConfigKey("quarkus.opentelemetry.tracer.exporter.otlp.endpoint", "http://localhost ")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "50")
             .overrideConfigKey("quarkus.otel.bsp.export.timeout", "PT1S");
@@ -28,5 +29,6 @@ public class OtlpExporterConfigTest {
     void config() {
         assertTrue(config.traces().legacyEndpoint().isPresent());
         assertEquals("http://localhost", config.traces().legacyEndpoint().get().trim());
+        assertTrue(config.activateDefaultExporter());
     }
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterRuntimeConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/runtime/exporter/OtlpExporterRuntimeConfig.java
@@ -6,6 +6,7 @@ import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 /**
  * From <a href=
@@ -26,6 +27,17 @@ public interface OtlpExporterRuntimeConfig {
      */
     @WithDefault(DEFAULT_GRPC_BASE_URI)
     Optional<String> endpoint();
+
+    /**
+     * If true, the Quarkus default OpenTelemetry exporter will always be instantiated, even when other exporters are present.
+     * This will allow OTel data to be sent simultaneously to multiple destinations, including the default one. If false, the
+     * Quarkus default OpenTelemetry exporter will not be instantiated if other exporters are present.
+     * <p>
+     * Defaults to <code>false</code>.
+     */
+    @WithName("experimental.dependent.default.enable")
+    @WithDefault("false")
+    boolean activateDefaultExporter();
 
     /**
      * OTLP traces exporter configuration.

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpExporterProviderTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/exporter/otlp/OtlpExporterProviderTest.java
@@ -78,6 +78,11 @@ class OtlpExporterProviderTest {
             }
 
             @Override
+            public boolean activateDefaultExporter() {
+                return false;
+            }
+
+            @Override
             public OtlpExporterTracesConfig traces() {
                 return new OtlpExporterTracesConfig() {
                     @Override


### PR DESCRIPTION
#36500 Currently, when custom exporters are present the default exporter is not instantiated, this provides a configuration to always do so.