### PR TITLE
Add auth mechanism to the Liquibase MongoDB connection string

### DIFF
--- a/docs/src/main/asciidoc/liquibase-mongodb.adoc
+++ b/docs/src/main/asciidoc/liquibase-mongodb.adoc
@@ -81,6 +81,8 @@ quarkus.liquibase-mongodb.migrate-at-start=true
 # quarkus.liquibase-mongodb.default-schema-name=DefaultSchema
 ----
 
+NOTE: Liquibase MongoDB is configured using a connection string, we do our best to craft a connection string that matches the MongoDB client configuration but if some configuration properties are not working you may consider adding them directly into the `quarkus.mongodb.connection-string` config property.
+
 Add a changeLog file to the default folder following the Liquibase naming conventions: `{change-log}`
 YAML, JSON and XML formats are supported for the changeLog.
 

--- a/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/LiquibaseMongodbFactory.java
+++ b/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/LiquibaseMongodbFactory.java
@@ -37,6 +37,9 @@ public class LiquibaseMongodbFactory {
                 Thread.currentThread().getContextClassLoader())) {
             String connectionString = this.mongoClientConfig.connectionString.orElse("mongodb://localhost:27017");
 
+            // Every MongoDB client configuration must be added to the connection string, we didn't add all as it would be too much to support.
+            // For reference, all connections string options can be found here: https://www.mongodb.com/docs/manual/reference/connection-string/#connection-string-options.
+
             Matcher matcher = HAS_DB.matcher(connectionString);
             if (!matcher.matches() || matcher.group("db") == null || matcher.group("db").isEmpty()) {
                 connectionString = matcher.replaceFirst(
@@ -50,6 +53,17 @@ public class LiquibaseMongodbFactory {
                 boolean alreadyHasQueryParams = connectionString.contains("?");
                 connectionString += (alreadyHasQueryParams ? "&" : "?") + "authSource="
                         + mongoClientConfig.credentials.authSource.get();
+            }
+            if (mongoClientConfig.credentials.authMechanism.isPresent()) {
+                boolean alreadyHasQueryParams = connectionString.contains("?");
+                connectionString += (alreadyHasQueryParams ? "&" : "?") + "authMechanism="
+                        + mongoClientConfig.credentials.authMechanism.get();
+            }
+            if (!mongoClientConfig.credentials.authMechanismProperties.isEmpty()) {
+                boolean alreadyHasQueryParams = connectionString.contains("?");
+                connectionString += (alreadyHasQueryParams ? "&" : "?") + "authMechanismProperties="
+                        + mongoClientConfig.credentials.authMechanismProperties.entrySet().stream()
+                                .map(prop -> prop.getKey() + ":" + prop.getValue()).collect(Collectors.joining(","));
             }
 
             Database database = DatabaseFactory.getInstance().openDatabase(connectionString,


### PR DESCRIPTION
Fixes #35666

I only added support for auth mechanism, I didn't check all other possible configuration properties for candidates but almost all can be added as connection properties as did in this PR.