### PR TITLE
Add a warning for how to report security vulnerability

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,12 @@ name: Bug Report
 description: Report a bug in Quarkus
 labels: kind/bug
 body:
+  - type: markdown
+    attributes:
+      value: |
+        **To report a Quarkus security vulnerability, please [send an email to `security@quarkus.io`](mailto:security@quarkus.io) with all the details.**
+
+        :warning: Do **NOT** create a public issue on GitHub for security vulnerabilities. See our [security policy](https://github.com/quarkusio/quarkus/security/policy) for more details. :warning:
   - type: textarea
     id: description
     validations:
@@ -35,8 +41,8 @@ body:
         Reproducer:
 
         Steps to reproduce the behavior:
-        1. 
-        2. 
+        1.
+        2.
         3.
   - type: markdown
     id: environment

--- a/.github/ISSUE_TEMPLATE/bug_report_native.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_native.yml
@@ -4,6 +4,12 @@ labels:
   - kind/bug
   - area/native-image
 body:
+  - type: markdown
+    attributes:
+      value: |
+        **To report a Quarkus security vulnerability, please [send an email to `security@quarkus.io`](mailto:security@quarkus.io) with all the details.**
+
+        :warning: Do **NOT** create a public issue on GitHub for security vulnerabilities. See our [security policy](https://github.com/quarkusio/quarkus/security/policy) for more details. :warning:
   - type: textarea
     id: description
     validations:


### PR DESCRIPTION
It looks like this:

![2023-10-18 18 13 09 github com b39fd114b5b8](https://github.com/quarkusio/quarkus/assets/1279749/31435ace-1adb-457b-aebe-7b90986ed1df)

I will let you bikeshed on the content, adding some Markdown content on top is the best we can do for now.
