### PR TITLE
Fix typos and a forgot backtick in the doc files

### DIFF
--- a/docs/src/main/asciidoc/cassandra.adoc
+++ b/docs/src/main/asciidoc/cassandra.adoc
@@ -144,7 +144,7 @@ TIP: `@DaoFactory` method names are irrelevant.
 `@DaoFactory` methods should return beans of the following types:
 
 - Any `@Dao`-annotated interface, e.g. `FruitDao`;
-- A `CompletationStage` of any `@Dao`-annotated interface, e.g. `CompletionStage<FruitDao>`.
+- A `CompletionStage` of any `@Dao`-annotated interface, e.g. `CompletionStage<FruitDao>`.
 - A `Uni` of any `@Dao`-annotated interface, e.g. `Uni<FruitDao>`.
 
 TIP: `Uni` is a type from the Mutiny library, which is the reactive programming library used by
@@ -254,7 +254,7 @@ link:https://javadoc.io/doc/com.datastax.oss.quarkus/cassandra-quarkus-client/la
 bean: this application-scoped, singleton bean is your main entry point to the Cassandra client; it
 is a specialized Cassandra driver session instance with a few methods tailored especially for
 Quarkus. Read its javadocs carefully!
-- You can also inject `CompletationStage<QuarkusCqlSession>` or `Uni<QuarkusCqlSession>`.
+- You can also inject `CompletionStage<QuarkusCqlSession>` or `Uni<QuarkusCqlSession>`.
 
 In our example, both `FruitMapper` and `FruitDao` could be injected anywhere. We chose to inject
 `FruitDao` in `FruitService`.

--- a/docs/src/main/asciidoc/cdi.adoc
+++ b/docs/src/main/asciidoc/cdi.adoc
@@ -81,7 +81,7 @@ This is very useful because your application fails fast whenever the container i
 
 [TIP]
 ====
-Your can use programmatic lookup via  `jakarta.enterprise.inject.Instance` to resolve ambiguities at runtime and even iterate over all beans implementing a given type:
+You can use programmatic lookup via  `jakarta.enterprise.inject.Instance` to resolve ambiguities at runtime and even iterate over all beans implementing a given type:
 
 [source,java]
 ----
@@ -204,7 +204,7 @@ when a method is invoked upon an injected instance for the first time.
 Furthermore, client proxies only delegate method invocations and thus you should never read/write fields of an injected `@ApplicationScoped` bean directly.
 You can read/write fields of an injected `@Singleton` safely.
 
-`@Singleton` should have a slightly better performance because the is no indirection (no proxy that delegates to the current instance from the context).
+`@Singleton` should have a slightly better performance because there is no indirection (no proxy that delegates to the current instance from the context).
 
 On the other hand, you cannot mock `@Singleton` beans using <<getting-started-testing.adoc#quarkus_mock,QuarkusMock>>.
 

--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -706,9 +706,9 @@ options exposed by a `org.eclipse.microprofile.config.Config` instance. Which me
 build configuration options since MicroProfile Config specification allows configuration sources not to expose all the property names they provide to users.
 ====
 
-== Config property values injected during static intialization phase
+== Config property values injected during static initialization phase
 
-Quarkus collects the config property values injected in CDI beans during xref:writing-extensions.adoc#bootstrap-three-phases[static intialization phase].
+Quarkus collects the config property values injected in CDI beans during xref:writing-extensions.adoc#bootstrap-three-phases[static initialization phase].
 The collected values are then compared with their runtime initialization counterparts and if a mismatch is detected the application startup fails.
 How can it happen?
 For example, let's have a CDI bean `org.acme.MyBean`.
@@ -739,9 +739,9 @@ public class MyBean {
 }
 ----
 <1> The config property is injected when the bean is created and the value is fixed.
-<2> In this particular case, the observer `@Initialized(ApplicationScoped.class)` caused the initialization of the bean. However, there are other possibilities. For example, some extensions initialize components during static intialization phase.
+<2> In this particular case, the observer `@Initialized(ApplicationScoped.class)` caused the initialization of the bean. However, there are other possibilities. For example, some extensions initialize components during static initialization phase.
 
-You can annotate an injected field/parameter with `@io.quarkus.runtime.annotations.StaticInitSafe` to mark the injected configuration object as safe to be initialized during the static intialization phase.
+You can annotate an injected field/parameter with `@io.quarkus.runtime.annotations.StaticInitSafe` to mark the injected configuration object as safe to be initialized during the static initialization phase.
 
 [source,java]
 ----

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -315,7 +315,7 @@ type: kubernetes.io/dockerconfigjson
 
 ----
 
-And also `test-quarkus-app-pull-secret is added to the `imagePullSecrets` list.
+And also `test-quarkus-app-pull-secret` is added to the `imagePullSecrets` list.
 
 
 === Labels and Annotations
@@ -791,7 +791,7 @@ quarkus.kubernetes.ingress.rules.1.path=/dev
 quarkus.kubernetes.ingress.rules.1.path-type=ImplementationSpecific
 # by default, path type is Prefix
 
-# Exmple to add a new rule that use another service binding
+# Example to add a new rule that use another service binding
 quarkus.kubernetes.ingress.rules.2.host=alt.svc.url
 quarkus.kubernetes.ingress.rules.2.path=/ea
 quarkus.kubernetes.ingress.rules.2.service-name=updated-service


### PR DESCRIPTION
A few typos here and there noticed while going through the getting started docs, fixed them in this PR.