### PR TITLE
QuarkusTest: handle beans declared on test profile specifically

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/TestProfileBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/TestProfileBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * This is an optional build item that represents the current test profile.
+ * <p>
+ * It is only available during tests.
+ */
+public final class TestProfileBuildItem extends SimpleBuildItem {
+
+    private final String testProfileClassName;
+
+    public TestProfileBuildItem(String testProfileClassName) {
+        this.testProfileClassName = testProfileClassName;
+    }
+
+    public String getTestProfileClassName() {
+        return testProfileClassName;
+    }
+}

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -504,6 +504,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import jakarta.enterprise.inject.Produces;
+
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.QuarkusTestProfile.TestResourceEntry;
 
@@ -601,9 +603,15 @@ public class MockGreetingProfile implements QuarkusTestProfile { <1>
     public boolean disableApplicationLifecycleObservers() {
         return false;
     }
+    
+    @Produces <2>
+    public ExternalService mockExternalService() {
+       return new ExternalService("mock");
+    }
 }
 ----
 <1> All these methods have default implementations so just override the ones you need to override.
+<2> If a test profile implementation declares a CDI bean (via producer method/field or nested static class) then this bean is only taken into account if the test profile is used, i.e. it's ignored for any other test profile.
 
 Now we have defined our profile we need to include it on our test class.
 We do this by annotating the test class with `@TestProfile(MockGreetingProfile.class)`.

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/TestsAsBeansProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/TestsAsBeansProcessor.java
@@ -1,13 +1,28 @@
 package io.quarkus.arc.deployment;
 
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.ClassInfo.NestingType;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
 
+import io.quarkus.arc.processor.Annotations;
+import io.quarkus.arc.processor.AnnotationsTransformer;
+import io.quarkus.arc.processor.DotNames;
+import io.quarkus.deployment.IsTest;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.TestAnnotationBuildItem;
 import io.quarkus.deployment.builditem.TestClassBeanBuildItem;
+import io.quarkus.deployment.builditem.TestProfileBuildItem;
 
 public class TestsAsBeansProcessor {
 
@@ -29,6 +44,94 @@ public class TestsAsBeansProcessor {
             builder.addBeanClass(item.getTestClassName());
         }
         producer.produce(builder.build());
+    }
+
+    @BuildStep(onlyIf = IsTest.class)
+    AnnotationsTransformerBuildItem vetoTestProfileBeans(Optional<TestProfileBuildItem> testProfile,
+            CustomScopeAnnotationsBuildItem customScopes, CombinedIndexBuildItem index) {
+        if (index.getIndex().getAllKnownImplementors(QUARKUS_TEST_PROFILE).isEmpty()) {
+            // No test profiles found
+            return null;
+        }
+
+        Set<DotName> currentTestProfileHierarchy = initTestProfileHierarchy(testProfile, index.getComputingIndex());
+        return new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
+
+            @Override
+            public void transform(TransformationContext context) {
+                AnnotationTarget target = context.getTarget();
+                if (target.kind() == Kind.METHOD) {
+                    vetoProducerIfNecessary(target.asMethod().declaringClass(), context);
+                } else if (target.kind() == Kind.FIELD) {
+                    vetoProducerIfNecessary(target.asField().declaringClass(), context);
+                } else if (target.kind() == Kind.CLASS) {
+                    ClassInfo clazz = target.asClass();
+                    if (clazz.nestingType() == NestingType.INNER && Modifier.isStatic(clazz.flags())) {
+                        ClassInfo enclosing = index.getComputingIndex().getClassByName(clazz.enclosingClass());
+                        if (customScopes.isScopeIn(context.getAnnotations())
+                                && isTestProfileClass(enclosing, index.getComputingIndex())
+                                && !currentTestProfileHierarchy.contains(enclosing.name())) {
+                            // Veto static nested class declared on a test profile class
+                            context.transform().add(DotNames.VETOED).done();
+                        }
+                    }
+                }
+            }
+
+            private void vetoProducerIfNecessary(ClassInfo declaringClass, TransformationContext context) {
+                if (Annotations.contains(context.getAnnotations(), DotNames.PRODUCES)
+                        && isTestProfileClass(declaringClass, index.getComputingIndex())
+                        && !currentTestProfileHierarchy.contains(declaringClass.name())) {
+                    // Veto producer method/field declared on a test profile class
+                    context.transform().add(DotNames.VETOED_PRODUCER).done();
+                }
+            }
+        });
+    }
+
+    private static final DotName QUARKUS_TEST_PROFILE = DotName.createSimple("io.quarkus.test.junit.QuarkusTestProfile");
+
+    private static Set<DotName> initTestProfileHierarchy(Optional<TestProfileBuildItem> testProfile, IndexView index) {
+        Set<DotName> ret = Set.of();
+        if (testProfile.isPresent()) {
+            DotName testProfileClassName = DotName.createSimple(testProfile.get().getTestProfileClassName());
+            ret = Set.of(testProfileClassName);
+            ClassInfo testProfileClass = index.getClassByName(testProfile.get().getTestProfileClassName());
+            if (testProfileClass != null && !testProfileClass.superName().equals(DotName.OBJECT_NAME)) {
+                ret = new HashSet<>();
+                ret.add(testProfileClassName);
+                DotName superName = testProfileClass.superName();
+                while (superName != null && !superName.equals(DotNames.OBJECT)) {
+                    ret.add(superName);
+                    ClassInfo superClass = index.getClassByName(superName);
+                    if (superClass != null) {
+                        superName = superClass.superName();
+                    } else {
+                        superName = null;
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    private static boolean isTestProfileClass(ClassInfo clazz, IndexView index) {
+        if (clazz.interfaceNames().contains(QUARKUS_TEST_PROFILE)) {
+            return true;
+        }
+        DotName superName = clazz.superName();
+        while (superName != null && !superName.equals(DotNames.OBJECT)) {
+            ClassInfo superClass = index.getClassByName(superName);
+            if (superClass != null) {
+                if (superClass.interfaceNames().contains(QUARKUS_TEST_PROFILE)) {
+                    return true;
+                }
+                superName = superClass.superName();
+            } else {
+                superName = null;
+            }
+        }
+        return false;
     }
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/SharedProfileTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/SharedProfileTestCase.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.main;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 import java.util.List;
@@ -9,9 +10,16 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.it.rest.ExternalService;
+import io.quarkus.it.rest.GreetingService;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
@@ -24,6 +32,12 @@ import io.restassured.RestAssured;
 @QuarkusTest
 @TestProfile(SharedProfileTestCase.MyProfile.class)
 public class SharedProfileTestCase {
+
+    @Inject
+    GreetingService greetingService;
+
+    @Inject
+    ExternalService externalService;
 
     @Test
     public void included() {
@@ -48,6 +62,12 @@ public class SharedProfileTestCase {
     @Test
     public void testContext() {
         Assertions.assertEquals(MyProfile.class.getName(), DummyTestResource.testProfile.get());
+    }
+
+    @Test
+    public void testProfileBeans() {
+        assertEquals("Bonjour Foo", greetingService.greet("Foo"));
+        assertEquals("profile", externalService.service());
     }
 
     public static class MyProfile implements QuarkusTestProfile {
@@ -76,6 +96,18 @@ public class SharedProfileTestCase {
         @Override
         public boolean runMainMethod() {
             return true;
+        }
+
+        @Priority(1000) // Must be higher than priority of MockExternalService
+        @Alternative
+        @Produces
+        public ExternalService externalService() {
+            return new ExternalService() {
+                @Override
+                public String service() {
+                    return "profile";
+                }
+            };
         }
     }
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
@@ -46,6 +46,7 @@ public class AbstractJvmQuarkusTestExtension extends AbstractQuarkusTestWithCont
 
     protected static final String TEST_LOCATION = "test-location";
     protected static final String TEST_CLASS = "test-class";
+    protected static final String TEST_PROFILE = "test-profile";
 
     protected ClassLoader originalCl;
 
@@ -202,6 +203,9 @@ public class AbstractJvmQuarkusTestExtension extends AbstractQuarkusTestWithCont
         final Map<String, Object> props = new HashMap<>();
         props.put(TEST_LOCATION, testClassLocation);
         props.put(TEST_CLASS, requiredTestClass);
+        if (profile != null) {
+            props.put(TEST_PROFILE, profile.getName());
+        }
         quarkusTestProfile = profile;
         return new PrepareResult(curatedApplication
                 .createAugmentor(QuarkusTestExtension.TestBuildChainFunction.class.getName(), props), profileInstance,

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -83,6 +83,7 @@ import io.quarkus.deployment.builditem.ApplicationClassPredicateBuildItem;
 import io.quarkus.deployment.builditem.TestAnnotationBuildItem;
 import io.quarkus.deployment.builditem.TestClassBeanBuildItem;
 import io.quarkus.deployment.builditem.TestClassPredicateBuildItem;
+import io.quarkus.deployment.builditem.TestProfileBuildItem;
 import io.quarkus.dev.testing.ExceptionReporting;
 import io.quarkus.dev.testing.TracingHandler;
 import io.quarkus.runtime.ApplicationLifecycleManager;
@@ -582,8 +583,6 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
     }
 
     private QuarkusTestExtensionState ensureStarted(ExtensionContext extensionContext) {
-        ExtensionContext.Store store = getStoreFromContext(extensionContext);
-
         QuarkusTestExtensionState state = getState(extensionContext);
         Class<? extends QuarkusTestProfile> selectedProfile = getQuarkusTestProfile(extensionContext);
         boolean wrongProfile = !Objects.equals(selectedProfile, quarkusTestProfile);
@@ -1355,6 +1354,16 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                         }).produces(TestClassBeanBuildItem.class)
                                 .build();
                     }
+
+                    buildChainBuilder.addBuildStep(new BuildStep() {
+                        @Override
+                        public void execute(BuildContext context) {
+                            Object testProfile = stringObjectMap.get(TEST_PROFILE);
+                            if (testProfile != null) {
+                                context.produce(new TestProfileBuildItem(testProfile.toString()));
+                            }
+                        }
+                    }).produces(TestProfileBuildItem.class).build();
 
                 }
             };

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestProfile.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestProfile.java
@@ -10,7 +10,10 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 /**
  * Defines a 'test profile'. Tests run under a test profile
  * will have different configuration options to other tests.
- *
+ * <p>
+ * If an implementation of this interface declares CDI beans, via producer methods/fields and nested static classes, then those
+ * beans are only taken into account if this test profile is used. In other words, the beans are ignored for any other test
+ * profile.
  */
 public interface QuarkusTestProfile {
 


### PR DESCRIPTION
- beans declared on a test profile implementation are only taken into account if the test profile is used
- resolves #36554