### PR TITLE
Add information about new sponsor field

### DIFF
--- a/docs/src/main/asciidoc/extension-metadata.adoc
+++ b/docs/src/main/asciidoc/extension-metadata.adoc
@@ -103,13 +103,15 @@ description: "A Jakarta REST implementation utilizing build time processing and 
   \ the extensions that depend on it." <4>
 scm:
   url: "https://github.com/quarkusio/quarkus" <5>
+sponsor: A Sponsoring Organisation <6>
 ----
 
 <1> Quarkus version the extension was built with
 <2> https://quarkus.io/guides/capabilities[Capabilities] this extension provides
 <3> Direct dependencies on other extensions
 <4> Description that can be displayed to users. In this case, the description was copied from the `pom.xml` of the extension module but it could also be provided in the template file.
-<5> The source code repository of this extension. In GitHub Actions builds, it will be determined automatically. For other GitHub repositories, it can be controlled by setting a `GITHUB_REPOSITORY` environment variable.
+<5> The source code repository of this extension. Optional, and will often be set automatically. In GitHub Actions builds, it will be inferred from the CI environment. For other GitHub repositories, it can be controlled by setting a `GITHUB_REPOSITORY` environment variable.
+<6> The sponsor(s) of this extension. Optional, and will sometimes be determined automatically from commit history.
 
 [[quarkus-extension-properties]]
 == META-INF/quarkus-extension.properties


### PR DESCRIPTION
See https://quarkus.io/extensions/io.quarkiverse.mailpit/quarkus-mailpit of an extension using this field (and how we render it in the extensions UI). 

See https://groups.google.com/g/quarkus-dev/c/ez3d5MqNm7k/m/VKW78oSVAwAJ for a longer discussion of the rules for what we show where and how to control it. Including all of this information in the extension metadata docs doesn't seem right, so I will include some of it in the quarkiverse hub pages, and some of it in the readme for the extension catalog. I may also write a blog. I will also include it next to the contributors graphs in the extensions UI, and, once I implement it, in hover help in the UI for the sponsors field.