### PR TITLE
Codestarts: Add Entity annotation to Kotlin all-open

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache-kotlin.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache-kotlin.adoc
@@ -103,6 +103,65 @@ implementation("io.quarkus:quarkus-hibernate-orm-panache-kotlin") <1>
 <1>  Note the addition of `-kotlin` on the end. Generally you'll only need this version but if your project will be using
 both Java and Kotlin code, you can safely include both artifacts.
 
+Additionally, you need to configure the Kotlin `all-open` plugin according to your build tool:
+
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<plugin>
+  <groupId>org.jetbrains.kotlin</groupId>
+  <artifactId>kotlin-maven-plugin</artifactId>
+  <version>${kotlin.version}</version>
+  <executions>
+    <execution>
+      <id>compile</id>
+      <goals>
+        <goal>compile</goal>
+      </goals>
+    </execution>
+    <execution>
+      <id>test-compile</id>
+      <goals>
+        <goal>test-compile</goal>
+      </goals>
+    </execution>
+  </executions>
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-maven-allopen</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+  </dependencies>
+  <configuration>
+    <javaParameters>true</javaParameters>
+    <jvmTarget>${maven.compiler.release}</jvmTarget>
+    <compilerPlugins>
+      <plugin>all-open</plugin>
+    </compilerPlugins>
+    <pluginOptions>
+      <option>all-open:annotation=jakarta.ws.rs.Path</option>
+      <option>all-open:annotation=jakarta.enterprise.context.ApplicationScoped</option>
+      <option>all-open:annotation=jakarta.persistence.Entity</option> <1>
+      <option>all-open:annotation=io.quarkus.test.junit.QuarkusTest</option>
+    </pluginOptions>
+  </configuration>
+</plugin>
+----
+<1>  Note the addition of the `all-open:annotation=jakarta.persistence.Entity` option.
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+allOpen {
+  annotation("jakarta.ws.rs.Path")
+  annotation("jakarta.enterprise.context.ApplicationScoped")
+  annotation("jakarta.persistence.Entity") <1>
+  annotation("io.quarkus.test.junit.QuarkusTest")
+}
+----
+<1>  Note the addition of the `jakarta.persistence.Entity` annotation.
+
 == Using the repository pattern
 
 


### PR DESCRIPTION
The kotlin allopen plugin needs to be configured for entity classes when using panache.

I also submitted https://github.com/quarkusio/quarkus-quickstarts/pull/1343 because that fails with this error if not done:

```
2023-10-19 14:16:55,283 WARN  [io.qua.hib.orm.run.pro.ProxyDefinitions] (Quarkus Main Thread) Could not generate an enhanced proxy for entity 'org.acme.hibernate.orm.panache.Fruit' (class='org.acme.hibernate.orm.panache.Fruit') as it's final. Your application might perform better if we're allowed to extend it.
2023-10-19 14:16:55,742 WARN  [org.hib.met.int.EntityRepresentationStrategyPojoStandard] (JPA Startup Thread) HHH000305: Could not create proxy factory for:org.acme.hibernate.orm.panache.Fruit: org.hibernate.HibernateException: Getter methods of lazy classes cannot be final: org.acme.hibernate.orm.panache.Fruit#getName
	at org.hibernate.proxy.pojo.ProxyFactoryHelper.validateGetterSetterMethodProxyability(ProxyFactoryHelper.java:80)
	at org.hibernate.metamodel.internal.EntityRepresentationStrategyPojoStandard.createProxyFactory(EntityRepresentationStrategyPojoStandard.java:229)
	at org.hibernate.metamodel.internal.EntityRepresentationStrategyPojoStandard.<init>(EntityRepresentationStrategyPojoStandard.java:147)
	at org.hibernate.metamodel.internal.ManagedTypeRepresentationResolverStandard.resolveStrategy(ManagedTypeRepresentationResolverStandard.java:62)
	at org.hibernate.persister.entity.AbstractEntityPersister.<init>(AbstractEntityPersister.java:510)
	at org.hibernate.persister.entity.SingleTableEntityPersister.<init>(SingleTableEntityPersister.java:140)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at org.hibernate.persister.internal.PersisterFactoryImpl.createEntityPersister(PersisterFactoryImpl.java:92)
	at org.hibernate.persister.internal.PersisterFactoryImpl.createEntityPersister(PersisterFactoryImpl.java:75)
	at org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl.processBootEntities(MappingMetamodelImpl.java:247)
	at org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl.finishInitialization(MappingMetamodelImpl.java:185)
	at org.hibernate.internal.SessionFactoryImpl.initializeMappingModel(SessionFactoryImpl.java:321)
	at org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:271)
	at io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder.build(FastBootEntityManagerFactoryBuilder.java:84)
	at io.quarkus.hibernate.orm.runtime.FastBootHibernatePersistenceProvider.createEntityManagerFactory(FastBootHibernatePersistenceProvider.java:74)
	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:80)
	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:55)
	at io.quarkus.hibernate.orm.runtime.JPAConfig$LazyPersistenceUnit.get(JPAConfig.java:156)
	at io.quarkus.hibernate.orm.runtime.JPAConfig$1.run(JPAConfig.java:64)
	at java.base/java.lang.Thread.run(Thread.java:833)
```