### PR TITLE
Add a custom OIDC identity provider test

### DIFF
--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomIdentityProvider.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomIdentityProvider.java
@@ -1,0 +1,58 @@
+package io.quarkus.oidc.test;
+
+import java.security.Principal;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+
+import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
+import io.quarkus.security.AuthenticationCompletionException;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.credential.TokenCredential;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.TokenAuthenticationRequest;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+@Priority(1)
+public class CustomIdentityProvider implements IdentityProvider<TokenAuthenticationRequest> {
+
+    @Override
+    public Class<TokenAuthenticationRequest> getRequestType() {
+        return TokenAuthenticationRequest.class;
+    }
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(TokenAuthenticationRequest request, AuthenticationRequestContext context) {
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
+
+        TokenCredential credential = request.getToken();
+        try {
+            JwtClaims jwtClaims = new JwtConsumerBuilder()
+                    .setSkipSignatureVerification()
+                    .setSkipAllValidators()
+                    .build().processToClaims(credential.getToken());
+            jwtClaims.setClaim(Claims.raw_token.name(), credential.getToken());
+
+            Principal principal = new OidcJwtCallerPrincipal(jwtClaims, credential);
+            if ("jdoe".equals(principal.getName())) {
+                throw new AuthenticationCompletionException();
+            }
+            builder.setPrincipal(principal);
+        } catch (InvalidJwtException e) {
+            throw new AuthenticationFailedException(e);
+        }
+
+        return Uni.createFrom().item(builder.build());
+
+    }
+
+}

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomIdentityProviderTestCase.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomIdentityProviderTestCase.java
@@ -1,0 +1,88 @@
+package io.quarkus.oidc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+
+@QuarkusTestResource(KeycloakTestResourceLifecycleManager.class)
+public class CustomIdentityProviderTestCase {
+
+    private static Class<?>[] testClasses = {
+            ProtectedResource.class,
+            CustomIdentityProvider.class
+    };
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(testClasses)
+                    .addAsResource("application-introspection-disabled.properties", "application.properties"));
+
+    @Test
+    public void testCustomIdentityProviderSuccess() throws IOException, InterruptedException {
+
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8080/protected");
+
+            assertEquals("Sign in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            page = loginForm.getInputByName("login").click();
+
+            assertEquals("alice", page.getBody().asNormalizedText());
+
+            webClient.getCookieManager().clearCookies();
+        }
+
+    }
+
+    @Test
+    public void testCustomIdentityProviderFailure() throws IOException, InterruptedException {
+
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8080/protected");
+
+            assertEquals("Sign in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("jdoe");
+            loginForm.getInputByName("password").setValueAttribute("jdoe");
+
+            try {
+                loginForm.getInputByName("login").click();
+                fail("Exception is expected because `jdoe` is not allowed to access the service");
+            } catch (FailingHttpStatusCodeException ex) {
+                assertEquals(401, ex.getStatusCode());
+            }
+
+            webClient.getCookieManager().clearCookies();
+        }
+
+    }
+
+    private WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+
+}

--- a/extensions/oidc/deployment/src/test/resources/application-introspection-disabled.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-introspection-disabled.properties
@@ -1,0 +1,7 @@
+quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
+quarkus.oidc.application-type=web-app
+quarkus.oidc.client-id=quarkus-web-app
+quarkus.oidc.credentials.secret=secret
+
+#It blocks an attempt to fetch JWK set at the start up
+quarkus.oidc.token.require-jwt-introspection-only=true


### PR DESCRIPTION
This PR adds a test confirming a custom OIDC identity provider can be used instead of the default `OidcIdentityProvider`, showing along the way how to tell Quarkus OIDC for it not to attempt to resolve the JWK set itself (for example, in #36563, a custom authentication is required to fetch the keys).

I'm planning to close the linked issue after some further discussions there and deal with the enhancement ideas discussed there in a separate issue 