### PR TITLE
ArC: performance optimizations related to client proxy invocations

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
@@ -223,6 +223,15 @@ public class ArcConfig {
     @ConfigItem
     public ArcContextPropagationConfig contextPropagation;
 
+    /**
+     * If set to {@code true}, the container should try to optimize the contexts for some of the scopes.
+     * <p>
+     * Typically, some implementation parts of the context for {@link jakarta.enterprise.context.ApplicationScoped} could be
+     * pregenerated during build.
+     */
+    @ConfigItem(defaultValue = "true", generateDocumentation = false)
+    public boolean optimizeContexts;
+
     public final boolean isRemoveUnusedBeansFieldValid() {
         return ALLOWED_REMOVE_UNUSED_BEANS_VALUES.contains(removeUnusedBeans.toLowerCase());
     }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -396,6 +396,7 @@ public class ArcProcessor {
         }
 
         builder.setBuildCompatibleExtensions(buildCompatibleExtensions.entrypoint);
+        builder.setOptimizeContexts(arcConfig.optimizeContexts);
 
         BeanProcessor beanProcessor = builder.build();
         ContextRegistrar.RegistrationContext context = beanProcessor.registerCustomContexts();
@@ -516,6 +517,12 @@ public class ArcProcessor {
         ExecutorService executor = parallelResourceGeneration ? buildExecutor : null;
         List<ResourceOutput.Resource> resources;
         resources = beanProcessor.generateResources(new ReflectionRegistration() {
+
+            @Override
+            public void registerMethod(String declaringClass, String name, String... params) {
+                reflectiveMethods.produce(new ReflectiveMethodBuildItem(declaringClass, name, params));
+            }
+
             @Override
             public void registerMethod(MethodInfo methodInfo) {
                 reflectiveMethods.produce(new ReflectiveMethodBuildItem(methodInfo));
@@ -591,7 +598,7 @@ public class ArcProcessor {
             throws Exception {
         ArcContainer container = recorder.initContainer(shutdown,
                 currentContextFactory.isPresent() ? currentContextFactory.get().getFactory() : null,
-                config.strictCompatibility);
+                config.strictCompatibility, config.optimizeContexts);
         return new ArcContainerBuildItem(container);
     }
 

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
@@ -42,11 +42,13 @@ public class ArcRecorder {
     public static volatile Map<String, Function<SyntheticCreationalContext<?>, ?>> syntheticBeanProviders;
 
     public ArcContainer initContainer(ShutdownContext shutdown, RuntimeValue<CurrentContextFactory> currentContextFactory,
-            boolean strictCompatibility)
+            boolean strictCompatibility, boolean optimizeContexts)
             throws Exception {
-        ArcContainer container = Arc.initialize(ArcInitConfig.builder()
-                .setCurrentContextFactory(currentContextFactory != null ? currentContextFactory.getValue() : null)
-                .setStrictCompatibility(strictCompatibility).build());
+        ArcInitConfig.Builder builder = ArcInitConfig.builder();
+        builder.setCurrentContextFactory(currentContextFactory != null ? currentContextFactory.getValue() : null);
+        builder.setStrictCompatibility(strictCompatibility);
+        builder.setOptimizeContexts(optimizeContexts);
+        ArcContainer container = Arc.initialize(builder.build());
         shutdown.addShutdownTask(new Runnable() {
             @Override
             public void run() {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -57,7 +57,7 @@ public class BeanDeployment {
 
     private static final Logger LOGGER = Logger.getLogger(BeanDeployment.class);
 
-    private final String name;
+    final String name;
     private final BuildContextImpl buildContext;
 
     private final IndexView beanArchiveComputingIndex;
@@ -99,7 +99,7 @@ public class BeanDeployment {
 
     private final List<InjectionPointInfo> injectionPoints;
 
-    private final boolean removeUnusedBeans;
+    final boolean removeUnusedBeans;
 
     private final List<Predicate<BeanInfo>> unusedExclusions;
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -78,6 +78,7 @@ public class BeanProcessor {
     private final boolean generateSources;
     private final boolean allowMocking;
     private final boolean transformUnproxyableClasses;
+    private final boolean optimizeContexts;
     private final List<Function<BeanInfo, Consumer<BytecodeCreator>>> suppressConditionGenerators;
 
     // This predicate is used to filter annotations for InjectionPoint metadata
@@ -107,6 +108,7 @@ public class BeanProcessor {
                 applicationClassPredicate);
         this.generateSources = builder.generateSources;
         this.allowMocking = builder.allowMocking;
+        this.optimizeContexts = builder.optimizeContexts;
         this.transformUnproxyableClasses = builder.transformUnproxyableClasses;
         this.suppressConditionGenerators = builder.suppressConditionGenerators;
 
@@ -189,6 +191,7 @@ public class BeanProcessor {
         // These maps are precomputed and then used in the ComponentsProviderGenerator which is generated first
         Map<BeanInfo, String> beanToGeneratedName = new HashMap<>();
         Map<ObserverInfo, String> observerToGeneratedName = new HashMap<>();
+        Map<DotName, String> scopeToGeneratedName = new HashMap<>();
 
         BeanGenerator beanGenerator = new BeanGenerator(annotationLiterals, applicationClassPredicate, privateMembers,
                 generateSources, refReg, existingClasses, beanToGeneratedName,
@@ -229,6 +232,13 @@ public class BeanProcessor {
             observerGenerator.precomputeGeneratedName(observer);
         }
 
+        ContextInstancesGenerator contextInstancesGenerator = new ContextInstancesGenerator(generateSources,
+                reflectionRegistration, beanDeployment, scopeToGeneratedName);
+        if (optimizeContexts) {
+            contextInstancesGenerator.precomputeGeneratedName(BuiltinScope.APPLICATION.getName());
+            contextInstancesGenerator.precomputeGeneratedName(BuiltinScope.REQUEST.getName());
+        }
+
         CustomAlterableContextsGenerator alterableContextsGenerator = new CustomAlterableContextsGenerator(generateSources);
         List<CustomAlterableContextInfo> alterableContexts = customAlterableContexts.getRegistered();
 
@@ -251,7 +261,8 @@ public class BeanProcessor {
                                     name,
                                     beanDeployment,
                                     beanToGeneratedName,
-                                    observerToGeneratedName);
+                                    observerToGeneratedName,
+                                    scopeToGeneratedName);
                 }
             }));
 
@@ -350,6 +361,20 @@ public class BeanProcessor {
                 }));
             }
 
+            if (optimizeContexts) {
+                // Generate _ContextInstances
+                primaryTasks.add(executor.submit(new Callable<Collection<Resource>>() {
+
+                    @Override
+                    public Collection<Resource> call() throws Exception {
+                        Collection<Resource> resources = new ArrayList<>();
+                        resources.addAll(contextInstancesGenerator.generate(BuiltinScope.APPLICATION.getName()));
+                        resources.addAll(contextInstancesGenerator.generate(BuiltinScope.REQUEST.getName()));
+                        return resources;
+                    }
+                }));
+            }
+
             for (Future<Collection<Resource>> future : primaryTasks) {
                 resources.addAll(future.get());
             }
@@ -419,7 +444,14 @@ public class BeanProcessor {
                             name,
                             beanDeployment,
                             beanToGeneratedName,
-                            observerToGeneratedName));
+                            observerToGeneratedName,
+                            scopeToGeneratedName));
+
+            if (optimizeContexts) {
+                // Generate _ContextInstances
+                resources.addAll(contextInstancesGenerator.generate(BuiltinScope.APPLICATION.getName()));
+                resources.addAll(contextInstancesGenerator.generate(BuiltinScope.REQUEST.getName()));
+            }
         }
 
         // Generate AnnotationLiterals - at this point all annotation literals must be processed
@@ -469,7 +501,7 @@ public class BeanProcessor {
         initialize(unsupportedBytecodeTransformer, Collections.emptyList());
         ValidationContext validationContext = validate(unsupportedBytecodeTransformer);
         processValidationErrors(validationContext);
-        generateResources(null, new HashSet<>(), unsupportedBytecodeTransformer, true, null);
+        generateResources(null, new HashSet<>(), unsupportedBytecodeTransformer, beanDeployment.removeUnusedBeans, null);
         return beanDeployment;
     }
 
@@ -510,6 +542,7 @@ public class BeanProcessor {
         boolean failOnInterceptedPrivateMethod;
         boolean allowMocking;
         boolean strictCompatibility;
+        boolean optimizeContexts;
 
         AlternativePriorities alternativePriorities;
         final List<Predicate<ClassInfo>> excludeTypes;
@@ -545,6 +578,7 @@ public class BeanProcessor {
             failOnInterceptedPrivateMethod = false;
             allowMocking = false;
             strictCompatibility = false;
+            optimizeContexts = false;
 
             excludeTypes = new ArrayList<>();
 
@@ -777,6 +811,16 @@ public class BeanProcessor {
          */
         public Builder setStrictCompatibility(boolean strictCompatibility) {
             this.strictCompatibility = strictCompatibility;
+            return this;
+        }
+
+        /**
+         *
+         * @param value
+         * @return self
+         */
+        public Builder setOptimizeContexts(boolean value) {
+            this.optimizeContexts = value;
             return this;
         }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ContextInstancesGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ContextInstancesGenerator.java
@@ -1,0 +1,267 @@
+package io.quarkus.arc.processor;
+
+import static org.objectweb.asm.Opcodes.ACC_FINAL;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_VOLATILE;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.arc.ContextInstanceHandle;
+import io.quarkus.arc.impl.ContextInstances;
+import io.quarkus.arc.processor.ResourceOutput.Resource;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.CatchBlockCreator;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.Switch.StringSwitch;
+import io.quarkus.gizmo.TryBlock;
+
+public class ContextInstancesGenerator extends AbstractGenerator {
+
+    static final String APP_CONTEXT_INSTANCES_SUFFIX = "_ContextInstances";
+
+    private final BeanDeployment beanDeployment;
+    private final Map<DotName, String> scopeToGeneratedName;
+
+    public ContextInstancesGenerator(boolean generateSources, ReflectionRegistration reflectionRegistration,
+            BeanDeployment beanDeployment, Map<DotName, String> scopeToGeneratedName) {
+        super(generateSources, reflectionRegistration);
+        this.beanDeployment = beanDeployment;
+        this.scopeToGeneratedName = scopeToGeneratedName;
+    }
+
+    void precomputeGeneratedName(DotName scope) {
+        String generatedName = DEFAULT_PACKAGE + "." + beanDeployment.name + UNDERSCORE
+                + scope.toString().replace(".", UNDERSCORE)
+                + APP_CONTEXT_INSTANCES_SUFFIX;
+        scopeToGeneratedName.put(scope, generatedName);
+    }
+
+    Collection<Resource> generate(DotName scope) {
+        List<BeanInfo> beans = new BeanStream(beanDeployment.getBeans()).withScope(scope).collect();
+        ResourceClassOutput classOutput = new ResourceClassOutput(true, generateSources);
+        String generatedName = scopeToGeneratedName.get(scope);
+        reflectionRegistration.registerMethod(generatedName, MethodDescriptor.INIT);
+
+        ClassCreator contextInstances = ClassCreator.builder().classOutput(classOutput).className(generatedName)
+                .interfaces(ContextInstances.class).build();
+
+        // Add fields for all beans
+        // The name of the field is a generated index
+        // For example:
+        // private volatile ContextInstanceHandle 1;
+        Map<String, FieldDescriptor> idToField = new HashMap<>();
+        int fieldIndex = 0;
+        for (BeanInfo bean : beans) {
+            FieldCreator fc = contextInstances.getFieldCreator("" + fieldIndex++, ContextInstanceHandle.class)
+                    .setModifiers(ACC_PRIVATE | ACC_VOLATILE);
+            idToField.put(bean.getIdentifier(), fc.getFieldDescriptor());
+        }
+
+        FieldCreator lockField = contextInstances.getFieldCreator("lock", Lock.class)
+                .setModifiers(ACC_PRIVATE | ACC_FINAL);
+
+        MethodCreator constructor = contextInstances.getMethodCreator(MethodDescriptor.INIT, "V");
+        constructor.invokeSpecialMethod(MethodDescriptors.OBJECT_CONSTRUCTOR, constructor.getThis());
+        constructor.writeInstanceField(lockField.getFieldDescriptor(), constructor.getThis(),
+                constructor.newInstance(MethodDescriptor.ofConstructor(ReentrantLock.class)));
+        constructor.returnVoid();
+
+        implementComputeIfAbsent(contextInstances, beans, idToField,
+                lockField.getFieldDescriptor());
+        implementGetIfPresent(contextInstances, beans, idToField);
+        implementRemove(contextInstances, beans, idToField, lockField.getFieldDescriptor());
+        implementClear(contextInstances, idToField, lockField.getFieldDescriptor());
+        implementGetAllPresent(contextInstances, idToField, lockField.getFieldDescriptor());
+
+        contextInstances.close();
+
+        return classOutput.getResources();
+    }
+
+    private void implementGetAllPresent(ClassCreator contextInstances, Map<String, FieldDescriptor> idToField,
+            FieldDescriptor lockField) {
+        MethodCreator getAllPresent = contextInstances.getMethodCreator("getAllPresent", Set.class)
+                .setModifiers(ACC_PUBLIC);
+        // lock.lock();
+        // try {
+        //    Set<ContextInstanceHandle<?>> ret = new HashSet<>();
+        //    ContextInstanceHandle<?> copy = this.1;
+        //    if (copy != null) {
+        //       ret.add(copy);
+        //    }
+        //    return ret;
+        // } catch(Throwable t) {
+        //    lock.unlock();
+        //    throw t;
+        // }
+        ResultHandle lock = getAllPresent.readInstanceField(lockField, getAllPresent.getThis());
+        getAllPresent.invokeInterfaceMethod(MethodDescriptors.LOCK_LOCK, lock);
+        TryBlock tryBlock = getAllPresent.tryBlock();
+        ResultHandle ret = tryBlock.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
+        for (FieldDescriptor field : idToField.values()) {
+            ResultHandle copy = tryBlock.readInstanceField(field, tryBlock.getThis());
+            tryBlock.ifNotNull(copy).trueBranch().invokeInterfaceMethod(MethodDescriptors.SET_ADD, ret, copy);
+        }
+        tryBlock.invokeInterfaceMethod(MethodDescriptors.LOCK_UNLOCK, lock);
+        tryBlock.returnValue(ret);
+        CatchBlockCreator catchBlock = tryBlock.addCatch(Throwable.class);
+        catchBlock.invokeInterfaceMethod(MethodDescriptors.LOCK_UNLOCK, lock);
+        catchBlock.throwException(catchBlock.getCaughtException());
+    }
+
+    private void implementClear(ClassCreator applicationContextInstances, Map<String, FieldDescriptor> idToField,
+            FieldDescriptor lockField) {
+        MethodCreator clear = applicationContextInstances.getMethodCreator("clear", void.class).setModifiers(ACC_PUBLIC);
+        // lock.lock();
+        // try {
+        //    this.1 = null;
+        //    lock.unlock();
+        // } catch(Throwable t) {
+        //    lock.unlock();
+        //    throw t;
+        // }
+        ResultHandle lock = clear.readInstanceField(lockField, clear.getThis());
+        clear.invokeInterfaceMethod(MethodDescriptors.LOCK_LOCK, lock);
+        TryBlock tryBlock = clear.tryBlock();
+        for (FieldDescriptor field : idToField.values()) {
+            tryBlock.writeInstanceField(field, tryBlock.getThis(), tryBlock.loadNull());
+        }
+        tryBlock.invokeInterfaceMethod(MethodDescriptors.LOCK_UNLOCK, lock);
+        tryBlock.returnVoid();
+        CatchBlockCreator catchBlock = tryBlock.addCatch(Throwable.class);
+        catchBlock.invokeInterfaceMethod(MethodDescriptors.LOCK_UNLOCK, lock);
+        catchBlock.throwException(catchBlock.getCaughtException());
+    }
+
+    private void implementRemove(ClassCreator contextInstances, List<BeanInfo> applicationScopedBeans,
+            Map<String, FieldDescriptor> idToField, FieldDescriptor lockField) {
+        MethodCreator remove = contextInstances
+                .getMethodCreator("remove", ContextInstanceHandle.class, String.class)
+                .setModifiers(ACC_PUBLIC);
+
+        StringSwitch strSwitch = remove.stringSwitch(remove.getMethodParam(0));
+        // https://github.com/quarkusio/gizmo/issues/164
+        strSwitch.fallThrough();
+        for (BeanInfo bean : applicationScopedBeans) {
+            FieldDescriptor instanceField = idToField.get(bean.getIdentifier());
+            // There is a separate remove method for every bean instance field
+            MethodCreator removeBean = contextInstances.getMethodCreator("r" + instanceField.getName(),
+                    ContextInstanceHandle.class).setModifiers(ACC_PRIVATE);
+            // lock.lock();
+            // try {
+            //    ContextInstanceHandle<?> copy = this.1;
+            //    if (copy != null) {
+            //       this.1 = null;
+            //    }
+            //    lock.unlock();
+            //    return copy;
+            // } catch(Throwable t) {
+            //    lock.unlock();
+            //    throw t;
+            // }
+
+            ResultHandle lock = removeBean.readInstanceField(lockField, removeBean.getThis());
+            removeBean.invokeInterfaceMethod(MethodDescriptors.LOCK_LOCK, lock);
+            TryBlock tryBlock = removeBean.tryBlock();
+            ResultHandle copy = tryBlock.readInstanceField(instanceField, tryBlock.getThis());
+            BytecodeCreator isNotNull = tryBlock.ifNotNull(copy).trueBranch();
+            isNotNull.writeInstanceField(instanceField, isNotNull.getThis(), isNotNull.loadNull());
+            tryBlock.invokeInterfaceMethod(MethodDescriptors.LOCK_UNLOCK, lock);
+            tryBlock.returnValue(copy);
+            CatchBlockCreator catchBlock = tryBlock.addCatch(Throwable.class);
+            catchBlock.invokeInterfaceMethod(MethodDescriptors.LOCK_UNLOCK, lock);
+            catchBlock.throwException(catchBlock.getCaughtException());
+
+            strSwitch.caseOf(bean.getIdentifier(), bc -> {
+                bc.returnValue(bc.invokeVirtualMethod(removeBean.getMethodDescriptor(), bc.getThis()));
+            });
+        }
+        strSwitch.defaultCase(bc -> bc.throwException(IllegalArgumentException.class, "Unknown bean identifier"));
+    }
+
+    private void implementGetIfPresent(ClassCreator contextInstances, List<BeanInfo> applicationScopedBeans,
+            Map<String, FieldDescriptor> idToField) {
+        MethodCreator getIfPresent = contextInstances
+                .getMethodCreator("getIfPresent", ContextInstanceHandle.class, String.class)
+                .setModifiers(ACC_PUBLIC);
+
+        StringSwitch strSwitch = getIfPresent.stringSwitch(getIfPresent.getMethodParam(0));
+        // https://github.com/quarkusio/gizmo/issues/164
+        strSwitch.fallThrough();
+        for (BeanInfo bean : applicationScopedBeans) {
+            strSwitch.caseOf(bean.getIdentifier(), bc -> {
+                bc.returnValue(bc.readInstanceField(idToField.get(bean.getIdentifier()), bc.getThis()));
+            });
+        }
+        strSwitch.defaultCase(bc -> bc.throwException(IllegalArgumentException.class, "Unknown bean identifier"));
+    }
+
+    private void implementComputeIfAbsent(ClassCreator contextInstances, List<BeanInfo> applicationScopedBeans,
+            Map<String, FieldDescriptor> idToField, FieldDescriptor lockField) {
+        MethodCreator computeIfAbsent = contextInstances
+                .getMethodCreator("computeIfAbsent", ContextInstanceHandle.class, String.class, Supplier.class)
+                .setModifiers(ACC_PUBLIC);
+
+        StringSwitch strSwitch = computeIfAbsent.stringSwitch(computeIfAbsent.getMethodParam(0));
+        // https://github.com/quarkusio/gizmo/issues/164
+        strSwitch.fallThrough();
+        for (BeanInfo bean : applicationScopedBeans) {
+            FieldDescriptor instanceField = idToField.get(bean.getIdentifier());
+            // There is a separate compute method for every bean instance field
+            MethodCreator compute = contextInstances.getMethodCreator("c" + instanceField.getName(),
+                    ContextInstanceHandle.class, Supplier.class).setModifiers(ACC_PRIVATE);
+            // ContextInstanceHandle<?> copy = this.1;
+            // if (copy != null) {
+            //    return copy;
+            // }
+            // lock.lock();
+            // try {
+            //    if (this.1 == null) {
+            //       this.1 = supplier.get();
+            //    }
+            //    lock.unlock();
+            //    return this.1;
+            // } catch(Throwable t) {
+            //    lock.unlock();
+            //    throw t;
+            // }
+            ResultHandle copy = compute.readInstanceField(instanceField, compute.getThis());
+            compute.ifNotNull(copy).trueBranch().returnValue(copy);
+            ResultHandle lock = compute.readInstanceField(lockField, compute.getThis());
+            compute.invokeInterfaceMethod(MethodDescriptors.LOCK_LOCK, lock);
+            TryBlock tryBlock = compute.tryBlock();
+            ResultHandle val = tryBlock.readInstanceField(instanceField, compute.getThis());
+            BytecodeCreator isNull = tryBlock.ifNull(val).trueBranch();
+            ResultHandle newVal = isNull.invokeInterfaceMethod(MethodDescriptors.SUPPLIER_GET,
+                    compute.getMethodParam(0));
+            isNull.writeInstanceField(instanceField, compute.getThis(), newVal);
+            tryBlock.invokeInterfaceMethod(MethodDescriptors.LOCK_UNLOCK, lock);
+            CatchBlockCreator catchBlock = tryBlock.addCatch(Throwable.class);
+            catchBlock.invokeInterfaceMethod(MethodDescriptors.LOCK_UNLOCK, lock);
+            catchBlock.throwException(catchBlock.getCaughtException());
+            compute.returnValue(compute.readInstanceField(instanceField, compute.getThis()));
+
+            strSwitch.caseOf(bean.getIdentifier(), bc -> {
+                bc.returnValue(bc.invokeVirtualMethod(compute.getMethodDescriptor(), bc.getThis(), bc.getMethodParam(1)));
+            });
+        }
+        strSwitch.defaultCase(bc -> bc.throwException(IllegalArgumentException.class, "Unknown bean identifier"));
+    }
+
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/CustomAlterableContexts.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/CustomAlterableContexts.java
@@ -1,5 +1,6 @@
 package io.quarkus.arc.processor;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,11 +20,12 @@ public class CustomAlterableContexts {
         this.applicationClassPredicate = applicationClassPredicate;
     }
 
-    public CustomAlterableContextInfo add(Class<? extends AlterableContext> contextClass, Boolean isNormal) {
+    public CustomAlterableContextInfo add(Class<? extends AlterableContext> contextClass, Boolean isNormal,
+            Class<? extends Annotation> scopeAnnotation) {
         String generatedName = contextClass.getName() + "_InjectableContext";
         boolean isApplicationClass = applicationClassPredicate.test(DotName.createSimple(contextClass));
         CustomAlterableContextInfo result = new CustomAlterableContextInfo(contextClass, isNormal, generatedName,
-                isApplicationClass);
+                isApplicationClass, scopeAnnotation);
         registered.add(result);
         return result;
     }
@@ -52,13 +54,15 @@ public class CustomAlterableContexts {
         public final Boolean isNormal;
         public final String generatedName;
         public final boolean isApplicationClass;
+        public final Class<? extends Annotation> scopeAnnotation;
 
         CustomAlterableContextInfo(Class<? extends AlterableContext> contextClass, Boolean isNormal,
-                String generatedName, boolean isApplicationClass) {
+                String generatedName, boolean isApplicationClass, Class<? extends Annotation> scopeAnnotation) {
             this.contextClass = contextClass;
             this.isNormal = isNormal;
             this.generatedName = generatedName;
             this.isApplicationClass = isApplicationClass;
+            this.scopeAnnotation = scopeAnnotation;
         }
     }
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -240,6 +240,9 @@ public final class MethodDescriptors {
     public static final MethodDescriptor ARC_CONTAINER_GET_ACTIVE_CONTEXT = MethodDescriptor.ofMethod(ArcContainer.class,
             "getActiveContext", InjectableContext.class, Class.class);
 
+    public static final MethodDescriptor ARC_CONTAINER_GET_CONTEXTS = MethodDescriptor.ofMethod(ArcContainer.class,
+            "getContexts", List.class, Class.class);
+
     public static final MethodDescriptor CONTEXT_GET = MethodDescriptor.ofMethod(Context.class, "get", Object.class,
             Contextual.class,
             CreationalContext.class);
@@ -272,6 +275,10 @@ public final class MethodDescriptors {
 
     public static final MethodDescriptor CLIENT_PROXIES_GET_APP_SCOPED_DELEGATE = MethodDescriptor.ofMethod(ClientProxies.class,
             "getApplicationScopedDelegate", Object.class, InjectableContext.class, InjectableBean.class);
+
+    public static final MethodDescriptor CLIENT_PROXIES_GET_SINGLE_CONTEXT_DELEGATE = MethodDescriptor.ofMethod(
+            ClientProxies.class,
+            "getSingleContextDelegate", Object.class, InjectableContext.class, InjectableBean.class);
 
     public static final MethodDescriptor CLIENT_PROXIES_GET_DELEGATE = MethodDescriptor.ofMethod(ClientProxies.class,
             "getDelegate", Object.class, InjectableBean.class);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -306,6 +307,9 @@ public final class MethodDescriptors {
 
     public static final MethodDescriptor INTERCEPT_FUNCTION_INTERCEPT = MethodDescriptor.ofMethod(InterceptFunction.class,
             "intercept", Object.class, ArcInvocationContext.class);
+
+    public static final MethodDescriptor LOCK_LOCK = MethodDescriptor.ofMethod(Lock.class, "lock", void.class);
+    public static final MethodDescriptor LOCK_UNLOCK = MethodDescriptor.ofMethod(Lock.class, "unlock", void.class);
 
     private MethodDescriptors() {
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ReflectionRegistration.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ReflectionRegistration.java
@@ -6,6 +6,8 @@ import org.jboss.jandex.MethodInfo;
 
 public interface ReflectionRegistration {
 
+    void registerMethod(String declaringClass, String name, String... params);
+
     void registerMethod(MethodInfo methodInfo);
 
     void registerField(FieldInfo fieldInfo);
@@ -29,6 +31,11 @@ public interface ReflectionRegistration {
     }
 
     ReflectionRegistration NOOP = new ReflectionRegistration() {
+
+        @Override
+        public void registerMethod(String declaringClass, String name, String... params) {
+        }
+
         @Override
         public void registerMethod(MethodInfo methodInfo) {
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ExtensionsEntryPoint.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ExtensionsEntryPoint.java
@@ -221,7 +221,8 @@ public class ExtensionsEntryPoint {
                         if (InjectableContext.class.isAssignableFrom(contextClass)) {
                             config.contextClass((Class<? extends InjectableContext>) contextClass);
                         } else {
-                            CustomAlterableContextInfo info = customAlterableContexts.add(contextClass, context.isNormal);
+                            CustomAlterableContextInfo info = customAlterableContexts.add(contextClass, context.isNormal,
+                                    scopeAnnotation);
                             config.creator(bytecode -> {
                                 return bytecode.newInstance(MethodDescriptor.ofConstructor(info.generatedName));
                             });

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Arc.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Arc.java
@@ -24,19 +24,19 @@ public final class Arc {
 
     /**
      *
-     * @param arcInitConfig
+     * @param config
      * @return the container instance
      * @see #initialize()
      */
-    public static ArcContainer initialize(ArcInitConfig arcInitConfig) {
+    public static ArcContainer initialize(ArcInitConfig config) {
         ArcContainerImpl container = INSTANCE.get();
         if (container == null) {
             synchronized (INSTANCE) {
                 container = INSTANCE.get();
                 if (container == null) {
                     // Set the container instance first because Arc.container() can be used within ArcContainerImpl.init()
-                    container = new ArcContainerImpl(arcInitConfig.getCurrentContextFactory(),
-                            arcInitConfig.isStrictCompatibility());
+                    container = new ArcContainerImpl(config.getCurrentContextFactory(),
+                            config.isStrictCompatibility(), config.isOptimizeContexts());
                     INSTANCE.set(container);
                     container.init();
                 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcInitConfig.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcInitConfig.java
@@ -24,10 +24,12 @@ public final class ArcInitConfig {
     private ArcInitConfig(Builder builder) {
         this.currentContextFactory = builder.currentContextFactory;
         this.strictCompatibility = builder.strictCompatibility;
+        this.optimizeContexts = builder.optimizeContexts;
     }
 
     private final boolean strictCompatibility;
     private final CurrentContextFactory currentContextFactory;
+    private final boolean optimizeContexts;
 
     public boolean isStrictCompatibility() {
         return strictCompatibility;
@@ -37,14 +39,20 @@ public final class ArcInitConfig {
         return currentContextFactory;
     }
 
+    public boolean isOptimizeContexts() {
+        return optimizeContexts;
+    }
+
     public static class Builder {
         private boolean strictCompatibility;
         private CurrentContextFactory currentContextFactory;
+        private boolean optimizeContexts;
 
         private Builder() {
             // init all values with their defaults
             this.strictCompatibility = false;
             this.currentContextFactory = null;
+            this.optimizeContexts = false;
         }
 
         public Builder setStrictCompatibility(boolean strictCompatibility) {
@@ -54,6 +62,11 @@ public final class ArcInitConfig {
 
         public Builder setCurrentContextFactory(CurrentContextFactory currentContextFactory) {
             this.currentContextFactory = currentContextFactory;
+            return this;
+        }
+
+        public Builder setOptimizeContexts(boolean value) {
+            optimizeContexts = value;
             return this;
         }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Components.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Components.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import io.quarkus.arc.impl.ContextInstances;
+
 public final class Components {
 
     private final Collection<InjectableBean<?>> beans;
@@ -16,13 +18,15 @@ public final class Components {
     private final Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings;
     private final Map<String, Set<String>> qualifierNonbindingMembers;
     private final Set<String> qualifiers;
+    private final Map<Class<? extends Annotation>, Supplier<ContextInstances>> contextInstances;
 
     public Components(Collection<InjectableBean<?>> beans, Collection<InjectableObserverMethod<?>> observers,
             Collection<InjectableContext> contexts,
             Set<String> interceptorBindings,
             Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings,
             Supplier<Collection<RemovedBean>> removedBeans, Map<String, Set<String>> qualifierNonbindingMembers,
-            Set<String> qualifiers) {
+            Set<String> qualifiers,
+            Map<Class<? extends Annotation>, Supplier<ContextInstances>> contextInstances) {
         this.beans = beans;
         this.observers = observers;
         this.contexts = contexts;
@@ -31,6 +35,7 @@ public final class Components {
         this.removedBeans = removedBeans;
         this.qualifierNonbindingMembers = qualifierNonbindingMembers;
         this.qualifiers = qualifiers;
+        this.contextInstances = contextInstances;
     }
 
     public Collection<InjectableBean<?>> getBeans() {
@@ -73,6 +78,10 @@ public final class Components {
      */
     public Set<String> getQualifiers() {
         return qualifiers;
+    }
+
+    public Map<Class<? extends Annotation>, Supplier<ContextInstances>> getContextInstances() {
+        return contextInstances;
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ApplicationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ApplicationContext.java
@@ -6,6 +6,14 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 class ApplicationContext extends AbstractSharedContext {
 
+    ApplicationContext() {
+        super();
+    }
+
+    ApplicationContext(ContextInstances instances) {
+        super(instances);
+    }
+
     @Override
     public Class<? extends Annotation> getScope() {
         return ApplicationScoped.class;

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ComputingCacheContextInstances.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ComputingCacheContextInstances.java
@@ -1,0 +1,41 @@
+package io.quarkus.arc.impl;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+import io.quarkus.arc.ContextInstanceHandle;
+
+class ComputingCacheContextInstances implements ContextInstances {
+
+    protected final ComputingCache<String, ContextInstanceHandle<?>> instances;
+
+    ComputingCacheContextInstances() {
+        instances = new ComputingCache<>();
+    }
+
+    @Override
+    public ContextInstanceHandle<?> computeIfAbsent(String id, Supplier<ContextInstanceHandle<?>> supplier) {
+        return instances.computeIfAbsent(id, supplier);
+    }
+
+    @Override
+    public ContextInstanceHandle<?> getIfPresent(String id) {
+        return instances.getValueIfPresent(id);
+    }
+
+    @Override
+    public ContextInstanceHandle<?> remove(String id) {
+        return instances.remove(id);
+    }
+
+    @Override
+    public Set<ContextInstanceHandle<?>> getAllPresent() {
+        return instances.getPresentValues();
+    }
+
+    @Override
+    public void clear() {
+        instances.clear();
+    }
+
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ContextInstances.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ContextInstances.java
@@ -1,0 +1,20 @@
+package io.quarkus.arc.impl;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+import io.quarkus.arc.ContextInstanceHandle;
+
+public interface ContextInstances {
+
+    ContextInstanceHandle<?> computeIfAbsent(String id, Supplier<ContextInstanceHandle<?>> supplier);
+
+    ContextInstanceHandle<?> getIfPresent(String id);
+
+    ContextInstanceHandle<?> remove(String id);
+
+    Set<ContextInstanceHandle<?>> getAllPresent();
+
+    void clear();
+
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
@@ -6,9 +6,8 @@ import java.lang.invoke.VarHandle;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ContextNotActiveException;
@@ -38,13 +37,16 @@ class RequestContext implements ManagedContext {
     private final Notifier<Object> initializedNotifier;
     private final Notifier<Object> beforeDestroyedNotifier;
     private final Notifier<Object> destroyedNotifier;
+    private final Supplier<ContextInstances> contextInstances;
 
     public RequestContext(CurrentContext<RequestContextState> currentContext, Notifier<Object> initializedNotifier,
-            Notifier<Object> beforeDestroyedNotifier, Notifier<Object> destroyedNotifier) {
+            Notifier<Object> beforeDestroyedNotifier, Notifier<Object> destroyedNotifier,
+            Supplier<ContextInstances> contextInstances) {
         this.currentContext = currentContext;
         this.initializedNotifier = initializedNotifier;
         this.beforeDestroyedNotifier = beforeDestroyedNotifier;
         this.destroyedNotifier = destroyedNotifier;
+        this.contextInstances = contextInstances;
     }
 
     @Override
@@ -66,13 +68,17 @@ class RequestContext implements ManagedContext {
             // Context is not active!
             return null;
         }
-        ContextInstanceHandle<T> instance = (ContextInstanceHandle<T>) ctxState.map.get(contextual);
+        ContextInstances contextInstances = ctxState.contextInstances;
+        ContextInstanceHandle<T> instance = (ContextInstanceHandle<T>) contextInstances.getIfPresent(bean.getIdentifier());
         if (instance == null) {
             CreationalContext<T> creationalContext = creationalContextFun.apply(contextual);
-            // Bean instance does not exist - create one if we have CreationalContext
-            instance = new ContextInstanceHandleImpl<T>((InjectableBean<T>) contextual,
-                    contextual.create(creationalContext), creationalContext);
-            ctxState.map.put(contextual, instance);
+            return (T) contextInstances.computeIfAbsent(bean.getIdentifier(), new Supplier<ContextInstanceHandle<?>>() {
+
+                @Override
+                public ContextInstanceHandle<?> get() {
+                    return new ContextInstanceHandleImpl<>(bean, contextual.create(creationalContext), creationalContext);
+                }
+            }).get();
         }
         return instance.get();
     }
@@ -99,7 +105,8 @@ class RequestContext implements ManagedContext {
         if (state == null) {
             throw notActive();
         }
-        ContextInstanceHandle<T> instance = (ContextInstanceHandle<T>) state.map.get(contextual);
+        ContextInstanceHandle<T> instance = (ContextInstanceHandle<T>) state.contextInstances
+                .getIfPresent(bean.getIdentifier());
         return instance == null ? null : instance.get();
     }
 
@@ -115,7 +122,8 @@ class RequestContext implements ManagedContext {
             // Context is not active
             throw notActive();
         }
-        ContextInstanceHandle<?> instance = state.map.remove(contextual);
+        InjectableBean<?> bean = (InjectableBean<?>) contextual;
+        ContextInstanceHandle<?> instance = state.contextInstances.remove(bean.getIdentifier());
         if (instance != null) {
             instance.destroy();
         }
@@ -127,7 +135,7 @@ class RequestContext implements ManagedContext {
             traceActivate(initialState);
         }
         if (initialState == null) {
-            RequestContextState state = new RequestContextState(new ConcurrentHashMap<>());
+            RequestContextState state = new RequestContextState(contextInstances.get());
             currentContext.set(state);
             // Fire an event with qualifier @Initialized(RequestScoped.class) if there are any observers for it
             fireIfNotEmpty(initializedNotifier);
@@ -202,12 +210,8 @@ class RequestContext implements ManagedContext {
             if (reqState.invalidate()) {
                 // Fire an event with qualifier @BeforeDestroyed(RequestScoped.class) if there are any observers for it
                 fireIfNotEmpty(beforeDestroyedNotifier);
-                Map<Contextual<?>, ContextInstanceHandle<?>> map = ((RequestContextState) state).map;
-                if (!map.isEmpty()) {
-                    //Performance: avoid an iterator on the map elements
-                    map.forEach(this::destroyContextElement);
-                    map.clear();
-                }
+                reqState.contextInstances.getAllPresent().forEach(this::destroyContextElement);
+                reqState.contextInstances.clear();
                 // Fire an event with qualifier @Destroyed(RequestScoped.class) if there are any observers for it
                 fireIfNotEmpty(destroyedNotifier);
             }
@@ -225,7 +229,7 @@ class RequestContext implements ManagedContext {
         LOG.tracef("Destroy %s%s\n\t...", state != null ? Integer.toHexString(state.hashCode()) : "", stack);
     }
 
-    private void destroyContextElement(Contextual<?> contextual, ContextInstanceHandle<?> contextInstanceHandle) {
+    private void destroyContextElement(ContextInstanceHandle<?> contextInstanceHandle) {
         try {
             contextInstanceHandle.destroy();
         } catch (Exception e) {
@@ -269,16 +273,16 @@ class RequestContext implements ManagedContext {
             }
         }
 
-        private final Map<Contextual<?>, ContextInstanceHandle<?>> map;
+        private final ContextInstances contextInstances;
         private volatile int isValid;
 
-        RequestContextState(ConcurrentMap<Contextual<?>, ContextInstanceHandle<?>> value) {
-            this.map = Objects.requireNonNull(value);
+        RequestContextState(ContextInstances contextInstances) {
+            this.contextInstances = Objects.requireNonNull(contextInstances);
         }
 
         @Override
         public Map<InjectableBean<?>, Object> getContextualInstances() {
-            return map.values().stream()
+            return contextInstances.getAllPresent().stream()
                     .collect(Collectors.toUnmodifiableMap(ContextInstanceHandle::getBean, ContextInstanceHandle::get));
         }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/SingletonContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/SingletonContext.java
@@ -16,7 +16,7 @@ class SingletonContext extends AbstractSharedContext {
 
     void destroyInstance(Object instance) {
         InstanceHandle<?> handle = null;
-        for (ContextInstanceHandle<?> contextInstance : instances.getPresentValues()) {
+        for (ContextInstanceHandle<?> contextInstance : instances.getAllPresent()) {
             if (contextInstance.get() == instance) {
                 handle = contextInstance;
                 break;

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/application/optimized/ApplicationContextInstancesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/application/optimized/ApplicationContextInstancesTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.arc.test.contexts.application.optimized;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.UUID;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InjectableContext;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class ApplicationContextInstancesTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Boom.class)
+            .optimizeContexts(true)
+            .build();
+
+    @Test
+    public void testContext() {
+        ArcContainer container = Arc.container();
+        InstanceHandle<Boom> handle = container.instance(Boom.class);
+        Boom boom = handle.get();
+        String id1 = boom.ping();
+        assertEquals(id1, boom.ping());
+
+        handle.destroy();
+        String id2 = boom.ping();
+        assertNotEquals(id1, id2);
+        assertEquals(id2, boom.ping());
+
+        InjectableContext appContext = container.getActiveContext(ApplicationScoped.class);
+        appContext.destroy();
+        assertNotEquals(id2, boom.ping());
+    }
+
+    @ApplicationScoped
+    public static class Boom {
+
+        private String id;
+
+        String ping() {
+            return id;
+        }
+
+        @PostConstruct
+        void init() {
+            id = UUID.randomUUID().toString();
+        }
+
+    }
+}


### PR DESCRIPTION
The first commit introduces the `ContextInstances` abstraction and generates the implementations for application and request contexts by default. The main goal is to avoid `ConcurrentHashMap`  lookups in the hot path (i.e. for every client proxy invocation).

The generated implementation of an application context for [config-quickstart](https://github.com/quarkusio/quarkus-quickstarts/tree/main/config-quickstart) looks like:
https://gist.github.com/mkouba/df6526fe8f3c76d4b773b814e1359555

Our benchmarks show that for application context the throughput has increased significantly: I've observed ~ 75% for 1 bean and ~ 25% for 200 beans. The size of the generated class is ~ 3KB for one bean and ~ 200KB for 200 beans. The numbers are lower for request context because in this case the container has to do much more (e.g. check if the context is active). This optimization can be disabled with `quarkus.arc.optimize-contexts=false`.

The second commit is similar to how we optimize the client proxy delegate access for the application context. However for the request context, we can only do this optimization if a single request context implementation is registered. I've observed ~ 20% improvement in the [RequestScopedProxyInvocationBenchmark](https://github.com/mkouba/arc-benchmarks/blob/master/src/main/java/io/quarkus/arc/benchmarks/RequestScopedProxyInvocationBenchmark.java).