### PR TITLE
Update gRPC Protoc to version 3.24.4 and the generator to 1.59.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -6046,6 +6046,20 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protoc</artifactId>
+                <classifier>linux-ppcle_64</classifier>
+                <type>exe</type>
+                <version>${protoc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protoc</artifactId>
+                <classifier>linux-s390_64</classifier>
+                <type>exe</type>
+                <version>${protoc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protoc</artifactId>
                 <classifier>linux-x86_32</classifier>
                 <type>exe</type>
                 <version>${protoc.version}</version>
@@ -6060,14 +6074,14 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protoc</artifactId>
-                <classifier>osx-x86_64</classifier>
+                <classifier>osx-aarch_64</classifier>
                 <type>exe</type>
                 <version>${protoc.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protoc</artifactId>
-                <classifier>osx-aarch_64</classifier>
+                <classifier>osx-x86_64</classifier>
                 <type>exe</type>
                 <version>${protoc.version}</version>
             </dependency>
@@ -6096,6 +6110,20 @@
                 <groupId>io.grpc</groupId>
                 <artifactId>protoc-gen-grpc-java</artifactId>
                 <type>exe</type>
+                <classifier>linux-ppcle_64</classifier>
+                <version>${grpc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>protoc-gen-grpc-java</artifactId>
+                <type>exe</type>
+                <classifier>linux-s390_64</classifier>
+                <version>${grpc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>protoc-gen-grpc-java</artifactId>
+                <type>exe</type>
                 <classifier>linux-x86_32</classifier>
                 <version>${grpc.version}</version>
             </dependency>
@@ -6110,14 +6138,14 @@
                 <groupId>io.grpc</groupId>
                 <artifactId>protoc-gen-grpc-java</artifactId>
                 <type>exe</type>
-                <classifier>osx-x86_64</classifier>
+                <classifier>osx-aarch_64</classifier>
                 <version>${grpc.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>protoc-gen-grpc-java</artifactId>
                 <type>exe</type>
-                <classifier>osx-aarch_64</classifier>
+                <classifier>osx-x86_64</classifier>
                 <version>${grpc.version}</version>
             </dependency>
             <dependency>

--- a/extensions/grpc/api/src/main/java/io/quarkus/grpc/GrpcClientUtils.java
+++ b/extensions/grpc/api/src/main/java/io/quarkus/grpc/GrpcClientUtils.java
@@ -29,10 +29,11 @@ public class GrpcClientUtils {
         client = getProxiedObject(client);
 
         if (client instanceof AbstractStub) {
-            return (T) MetadataUtils.attachHeaders((AbstractStub) client, extraHeaders);
+            return (T) ((AbstractStub) client).withInterceptors(MetadataUtils.newAttachHeadersInterceptor(extraHeaders));
         } else if (client instanceof MutinyClient) {
             MutinyClient mutinyClient = (MutinyClient) client;
-            AbstractStub stub = MetadataUtils.attachHeaders(mutinyClient.getStub(), extraHeaders);
+            AbstractStub stub = mutinyClient.getStub()
+                    .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(extraHeaders));
             return (T) ((MutinyClient) client).newInstanceWithStub(stub);
         } else {
             throw new IllegalArgumentException("Unsupported client type " + client.getClass());

--- a/extensions/grpc/codegen/pom.xml
+++ b/extensions/grpc/codegen/pom.xml
@@ -34,6 +34,18 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protoc</artifactId>
+            <classifier>linux-ppcle_64</classifier>
+            <type>exe</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protoc</artifactId>
+            <classifier>linux-s390_64</classifier>
+            <type>exe</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protoc</artifactId>
             <classifier>linux-x86_32</classifier>
             <type>exe</type>
         </dependency>
@@ -72,6 +84,18 @@
             <artifactId>protoc-gen-grpc-java</artifactId>
             <type>exe</type>
             <classifier>linux-aarch_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>protoc-gen-grpc-java</artifactId>
+            <type>exe</type>
+            <classifier>linux-ppcle_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>protoc-gen-grpc-java</artifactId>
+            <type>exe</type>
+            <classifier>linux-s390_64</classifier>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/extensions/grpc/inprocess/pom.xml
+++ b/extensions/grpc/inprocess/pom.xml
@@ -17,5 +17,27 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-inprocess</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.android</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/extensions/grpc/runtime/src/main/java/io/grpc/override/ContextStorageOverride.java
+++ b/extensions/grpc/runtime/src/main/java/io/grpc/override/ContextStorageOverride.java
@@ -36,7 +36,7 @@ public class ContextStorageOverride extends Context.Storage {
             }
         } else {
             if (dc != null && VertxContext.isDuplicatedContext(dc)) {
-                // Do nothing duplicated context are not shared.
+                // Do nothing - duplicated context are not shared.
             } else {
                 fallback.set(null);
             }
@@ -58,10 +58,5 @@ public class ContextStorageOverride extends Context.Storage {
             }
             return current;
         }
-    }
-
-    @Override
-    public void attach(Context toAttach) {
-        // do nothing, should not be called.
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
         <kubernetes-client.version>6.8.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
-        <grpc.version>1.57.2</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
+        <grpc.version>1.59.0</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
         <grpc-jprotoc.version>1.2.1</grpc-jprotoc.version>
-        <protoc.version>3.22.0</protoc.version>
+        <protoc.version>3.24.4</protoc.version>
         <protobuf-java.version>${protoc.version}</protobuf-java.version>
         <proto-google-common-protos.version>2.27.0</proto-google-common-protos.version>
 


### PR DESCRIPTION
- Add move architecture to cover ppcle64 and s390x
- Update code to handle deprecations and removed API


Fix #22418 