### PR TITLE
Use container urls for connecting to services by default

### DIFF
--- a/extensions/hibernate-reactive/deployment/pom.xml
+++ b/extensions/hibernate-reactive/deployment/pom.xml
@@ -12,9 +12,8 @@
     <artifactId>quarkus-hibernate-reactive-deployment</artifactId>
     <name>Quarkus - Hibernate Reactive - Deployment</name>
 
-    <!-- Defaults, to simplify local testing -->
     <properties>
-        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5432/hibernate_orm_test</postgres.reactive.url>
+        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
     </properties>
 
     <dependencies>
@@ -162,9 +161,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/extensions/oidc-client/deployment/pom.xml
+++ b/extensions/oidc-client/deployment/pom.xml
@@ -160,9 +160,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <keycloak.url>http://localhost:8180/auth</keycloak.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/extensions/panache/hibernate-reactive-panache-kotlin/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5432/hibernate_orm_test</postgres.reactive.url>
+        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
     </properties>
 
     <artifactId>quarkus-hibernate-reactive-panache-kotlin-deployment</artifactId>
@@ -198,9 +198,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5432/hibernate_orm_test</postgres.reactive.url>
+        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
     </properties>
 
     <artifactId>quarkus-hibernate-reactive-panache-deployment</artifactId>
@@ -141,9 +141,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/pom.xml
@@ -12,9 +12,8 @@
     <artifactId>quarkus-hibernate-reactive-rest-data-panache-deployment</artifactId>
     <name>Quarkus - Hibernate Reactive REST data with Panache - Deployment</name>
 
-    <!-- Defaults, to simplify local testing -->
     <properties>
-        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5432/hibernate_orm_test</postgres.reactive.url>
+        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
     </properties>
 
     <dependencies>
@@ -122,9 +121,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/extensions/reactive-mssql-client/deployment/pom.xml
+++ b/extensions/reactive-mssql-client/deployment/pom.xml
@@ -15,7 +15,7 @@
     <name>Quarkus - Reactive Microsoft SQL Server Client - Deployment</name>
 
     <properties>
-        <reactive-mssql.url>vertx-reactive:sqlserver://localhost:1433</reactive-mssql.url>
+        <reactive-mssql.url>vertx-reactive:sqlserver://localhost:1435</reactive-mssql.url>
     </properties>
 
     <dependencies>
@@ -132,9 +132,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <reactive-mssql.url>vertx-reactive:sqlserver://localhost:1435</reactive-mssql.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -32,7 +32,7 @@
     <name>Quarkus - Reactive MySQL Client - Deployment</name>
 
     <properties>
-        <reactive-mysql.url>vertx-reactive:mysql://localhost:3306/hibernate_orm_test</reactive-mysql.url>
+        <reactive-mysql.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test</reactive-mysql.url>
     </properties>
 
     <dependencies>
@@ -153,9 +153,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <reactive-mysql.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test</reactive-mysql.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/extensions/reactive-oracle-client/deployment/pom.xml
+++ b/extensions/reactive-oracle-client/deployment/pom.xml
@@ -136,9 +136,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <reactive-oracledb.url>vertx-reactive:oracle:thin:@localhost:1521/FREEPDB1</reactive-oracledb.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -15,7 +15,7 @@
     <name>Quarkus - Reactive PostgreSQL Client - Deployment</name>
 
     <properties>
-        <reactive-postgres.url>vertx-reactive:postgresql:///hibernate_orm_test</reactive-postgres.url>
+        <reactive-postgres.url>vertx-reactive:postgresql://:5431/hibernate_orm_test</reactive-postgres.url>
     </properties>
 
     <dependencies>
@@ -133,9 +133,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <reactive-postgres.url>vertx-reactive:postgresql://:5431/hibernate_orm_test</reactive-postgres.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/hibernate-orm-compatibility-5.6/mariadb/pom.xml
+++ b/integration-tests/hibernate-orm-compatibility-5.6/mariadb/pom.xml
@@ -14,7 +14,7 @@
     <name>Quarkus - Integration Tests - Hibernate ORM - Compatibility with databases meant for ORM 5.6 - MariaDB</name>
 
     <properties>
-        <mariadb.url>jdbc:mariadb://localhost:3306/hibernate_orm_test</mariadb.url>
+        <mariadb.url>jdbc:mariadb://localhost:3308/hibernate_orm_test</mariadb.url>
         <!-- We test features in Hibernate ORM that are timezone-sensitive, e.g. ZoneOffsetDateTime normalization -->
         <surefire.argLine.additional>-Duser.timezone=Europe/Paris</surefire.argLine.additional>
     </properties>
@@ -197,9 +197,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <mariadb.url>jdbc:mariadb://localhost:3308/hibernate_orm_test</mariadb.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/hibernate-orm-compatibility-5.6/postgresql/pom.xml
+++ b/integration-tests/hibernate-orm-compatibility-5.6/postgresql/pom.xml
@@ -14,6 +14,7 @@
     <name>Quarkus - Integration Tests - Hibernate ORM - Compatibility with databases meant for ORM 5.6 - PostgreSQL</name>
 
     <properties>
+        <postgres.url>jdbc:postgresql://localhost:5431/hibernate_orm_test</postgres.url>
         <!-- We test features in Hibernate ORM that are timezone-sensitive, e.g. ZoneOffsetDateTime normalization -->
         <surefire.argLine.additional>-Duser.timezone=Europe/Paris</surefire.argLine.additional>
     </properties>
@@ -192,9 +193,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <postgres.url>jdbc:postgresql://localhost:5431/hibernate_orm_test</postgres.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/pom.xml
@@ -18,7 +18,7 @@
     </description>
 
     <properties>
-        <mariadb.base_url>jdbc:mariadb://localhost:3306</mariadb.base_url>
+        <mariadb.base_url>jdbc:mariadb://localhost:3308</mariadb.base_url>
     </properties>
 
     <dependencies>
@@ -195,9 +195,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <mariadb.base_url>jdbc:mariadb://localhost:3308</mariadb.base_url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver/pom.xml
@@ -16,7 +16,7 @@
     </description>
 
     <properties>
-        <mariadb.base_url>jdbc:mariadb://localhost:3306</mariadb.base_url>
+        <mariadb.base_url>jdbc:mariadb://localhost:3308</mariadb.base_url>
     </properties>
 
     <dependencies>
@@ -193,9 +193,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <mariadb.base_url>jdbc:mariadb://localhost:3308</mariadb.base_url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
@@ -15,7 +15,7 @@
     <description>Tests for Hibernate ORM Multitenancy using one datasource per tenant, running with the MariaDB database</description>
 
     <properties>
-        <mariadb.base_url>jdbc:mariadb://localhost:3306</mariadb.base_url>
+        <mariadb.base_url>jdbc:mariadb://localhost:3308</mariadb.base_url>
     </properties>
 
     <dependencies>
@@ -208,9 +208,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <mariadb.base_url>jdbc:mariadb://localhost:3308</mariadb.base_url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/hibernate-reactive-db2/pom.xml
+++ b/integration-tests/hibernate-reactive-db2/pom.xml
@@ -14,8 +14,9 @@
     <description>Hibernate Reactive related tests running with the DB2 database</description>
 
     <properties>
-        <reactive-db2.url>vertx-reactive:db2://localhost:50000/hreact</reactive-db2.url>
+        <reactive-db2.url>vertx-reactive:db2://localhost:50005/hreact</reactive-db2.url>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -157,9 +158,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <reactive-db2.url>vertx-reactive:db2://localhost:50005/hreact</reactive-db2.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/hibernate-reactive-mariadb/pom.xml
+++ b/integration-tests/hibernate-reactive-mariadb/pom.xml
@@ -14,7 +14,7 @@
     <description>Hibernate Reactive related tests running with the MariaDB database</description>
 
     <properties>
-        <reactive-mariadb.url>vertx-reactive:mysql://localhost:3306/hibernate_orm_test</reactive-mariadb.url>
+        <reactive-mariadb.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test</reactive-mariadb.url>
     </properties>
 
     <dependencies>
@@ -158,9 +158,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <reactive-mariadb.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test</reactive-mariadb.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/hibernate-reactive-mysql-agroal-flyway/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql-agroal-flyway/pom.xml
@@ -14,8 +14,8 @@
     <description>Hibernate Reactive related tests running with the MySQL database and also using Agroal and Flyway</description>
 
     <properties>
-        <reactive-mysql.url>vertx-reactive:mysql://localhost:3306/hibernate_orm_test</reactive-mysql.url>
-        <mysql.jdbc.url>jdbc:mysql://localhost:3306/hibernate_orm_test</mysql.jdbc.url>
+        <reactive-mysql.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test?allowPublicKeyRetrieval=true</reactive-mysql.url>
+        <mysql.jdbc.url>jdbc:mysql://localhost:3308/hibernate_orm_test</mysql.jdbc.url>
     </properties>
 
     <dependencies>
@@ -214,10 +214,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <reactive-mysql.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test?allowPublicKeyRetrieval=true</reactive-mysql.url>
-                <mysql.jdbc.url>jdbc:mysql://localhost:3308/hibernate_orm_test</mysql.jdbc.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/hibernate-reactive-mysql/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql/pom.xml
@@ -14,7 +14,7 @@
     <description>Hibernate Reactive related tests running with the MySQL database</description>
 
     <properties>
-        <reactive-mysql.url>vertx-reactive:mysql://localhost:3306/hibernate_orm_test</reactive-mysql.url>
+        <reactive-mysql.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test?allowPublicKeyRetrieval=true</reactive-mysql.url>
     </properties>
 
     <dependencies>
@@ -160,9 +160,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <reactive-mysql.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test?allowPublicKeyRetrieval=true</reactive-mysql.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/hibernate-reactive-panache-kotlin/pom.xml
+++ b/integration-tests/hibernate-reactive-panache-kotlin/pom.xml
@@ -13,7 +13,7 @@
     <name>Quarkus - Integration Tests - Hibernate Reactive with Panache and Kotlin</name>
 
     <properties>
-        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5432/hibernate_orm_test</postgres.reactive.url>
+        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
     </properties>
 
     <dependencies>
@@ -281,9 +281,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/hibernate-reactive-panache/pom.xml
+++ b/integration-tests/hibernate-reactive-panache/pom.xml
@@ -17,7 +17,7 @@
         PanacheQuery.project(Class) needs it.
     -->
     <properties>
-        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5432/hibernate_orm_test</postgres.reactive.url>
+        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
     </properties>
 
     <dependencies>
@@ -268,9 +268,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/hibernate-reactive-postgresql/pom.xml
+++ b/integration-tests/hibernate-reactive-postgresql/pom.xml
@@ -14,7 +14,7 @@
     <description>Hibernate Reactive related tests running with the PostgreSQL database</description>
 
     <properties>
-        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5432/hibernate_orm_test</postgres.reactive.url>
+        <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
     </properties>
 
     <dependencies>
@@ -175,9 +175,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <postgres.reactive.url>vertx-reactive:postgresql://localhost:5431/hibernate_orm_test</postgres.reactive.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/jpa-db2/README.md
+++ b/integration-tests/jpa-db2/README.md
@@ -28,7 +28,7 @@ docker run \
   -e AUTOCONFIG=false \
   -e ARCHIVE_LOGS=false \
   -e LICENSE=accept \
-  -p 50000:50000 \
+  -p 50005:50000 \
   --privileged \
   ibmcom/db2:11.5.5.0
 ```
@@ -36,5 +36,5 @@ docker run \
 2. Run the test, specifying the JDBC URL for the container you started in the previous step
 
 ```
-mvn verify -Dtest-containers -Djdbc-db2.url=jdbc:db2://localhost:50000/hreact
+mvn verify -Dtest-containers
 ```

--- a/integration-tests/jpa-db2/pom.xml
+++ b/integration-tests/jpa-db2/pom.xml
@@ -14,7 +14,7 @@
     <description>Module that contains JPA related tests running with the DB2 database</description>
 
     <properties>
-        <jdbc-db2.url>jdbc:db2://localhost:50000/hreact</jdbc-db2.url>
+        <jdbc-db2.url>jdbc:db2://localhost:50005/hreact</jdbc-db2.url>
     </properties>
 
     <dependencies>
@@ -161,9 +161,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <jdbc-db2.url>jdbc:db2://localhost:50005/hreact</jdbc-db2.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/jpa-mariadb/README.md
+++ b/integration-tests/jpa-mariadb/README.md
@@ -19,7 +19,7 @@ Additionally, you can generate a native image and run the tests for this native 
 mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
-If you don't want to run MariaDB as a Docker container, you can start your own MariaDB server. It needs to listen on the default port and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
+If you don't want to run MariaDB as a Docker container, you can start your own MariaDB server. It needs to listen on port 3308 and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
 
 You can then run the tests as follows (either with `-Dnative` or not):
 
@@ -32,13 +32,13 @@ If you have specific requirements, you can define a specific connection URL with
 To run the MariaDB server "manually" via command line for testing, the following command line could be useful:
 
 ```
-docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test_mariadb -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_RANDOM_ROOT_PASSWORD=true -p 3306:3306 mariadb:10.4
+docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test_mariadb -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_RANDOM_ROOT_PASSWORD=true -p 3308:3306 mariadb:10.4
 ```
 
 or if you prefer podman, this won't need root permissions:
 
 ```
-podman run --rm=true --net=host --memory-swappiness=0 --tmpfs /var/lib/mysql:rw --tmpfs /var/log:rw --name mariadb_demo -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_ROOT_PASSWORD=secret -p 3306:3306 mariadb:10.4
+podman run --rm=true --net=host --memory-swappiness=0 --tmpfs /var/lib/mysql:rw --tmpfs /var/log:rw --name mariadb_demo -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_ROOT_PASSWORD=secret -p 3308:3306 mariadb:10.4
 ```
 
 N.B. it takes a while for MariaDB to be actually booted and accepting connections.

--- a/integration-tests/jpa-mariadb/pom.xml
+++ b/integration-tests/jpa-mariadb/pom.xml
@@ -14,7 +14,7 @@
     <description>Module that contains JPA related tests running with the MariaDB database</description>
 
     <properties>
-        <mariadb.url>jdbc:mariadb://localhost:3306/hibernate_orm_test</mariadb.url>
+        <mariadb.url>jdbc:mariadb://localhost:3308/hibernate_orm_test</mariadb.url>
     </properties>
 
     <dependencies>
@@ -162,9 +162,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <mariadb.url>jdbc:mariadb://localhost:3308/hibernate_orm_test</mariadb.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/jpa-mssql/README.md
+++ b/integration-tests/jpa-mssql/README.md
@@ -25,7 +25,7 @@ you'll probably want to change the authentication password too: `-Dmssqldb.sa-pa
 If you prefer to run the MSSQL Server container via podman, use:
 
 ```
-podman run --rm=true --net=host --memory-swappiness=0 --name mssql_testing -e SA_PASSWORD=yourStrong(!)Password -e ACCEPT_EULA=Y -p 1433:1433 mcr.microsoft.com/mssql/2022-latest
+podman run --rm=true --net=host --memory-swappiness=0 --name mssql_testing -e SA_PASSWORD=yourStrong(!)Password -e ACCEPT_EULA=Y -p 1435:1433 mcr.microsoft.com/mssql/2022-latest
 ```
 
 ## Limitations

--- a/integration-tests/jpa-mssql/pom.xml
+++ b/integration-tests/jpa-mssql/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <mssqldb.url>jdbc:sqlserver://localhost:1433;databaseName=tempdb</mssqldb.url>
+        <!-- Careful: SQL Server refuses to work with trivial passwords. -->
         <mssqldb.sa-password>yourStrong(!)Password</mssqldb.sa-password>
     </properties>
 
@@ -184,11 +185,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <mssqldb.url>jdbc:sqlserver://localhost:1433;databaseName=tempdb</mssqldb.url>
-                <!-- Careful: SQL Server refuses to work with trivial passwords. -->
-                <mssqldb.sa-password>yourStrong(!)Password</mssqldb.sa-password>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/jpa-mysql/README.md
+++ b/integration-tests/jpa-mysql/README.md
@@ -32,13 +32,13 @@ If you have specific requirements, you can define a specific connection URL with
 To run the MySQL server "manually" via command line for testing, the following command line could be useful:
 
 ```
-docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test_mysql -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_RANDOM_ROOT_PASSWORD=true -p 3306:3306 mysql:8.0.22
+docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test_mysql -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_RANDOM_ROOT_PASSWORD=true -p 3308:3306 mysql:8.0.22
 ```
 
 Alternatively to docker, with podman:
 
 ```
-podman run -it --rm=true --name quarkus_test_mysql -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_RANDOM_ROOT_PASSWORD=true -p 3306:3306 mysql:8.0.22
+podman run -it --rm=true --name quarkus_test_mysql -e MYSQL_USER=hibernate_orm_test -e MYSQL_PASSWORD=hibernate_orm_test -e MYSQL_DATABASE=hibernate_orm_test -e MYSQL_RANDOM_ROOT_PASSWORD=true -p 3308:3306 mysql:8.0.22
 ```
 
 To connect with a CLI client and inspect the database content:

--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -186,9 +186,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <oracledb.url>jdbc:oracle:thin:@localhost:1521/FREEPDB1</oracledb.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/jpa-postgresql-withxml/pom.xml
+++ b/integration-tests/jpa-postgresql-withxml/pom.xml
@@ -13,6 +13,10 @@
     <name>Quarkus - Integration Tests - JPA - PostgreSQL</name>
     <description>Module that contains JPA related tests running with the PostgreSQL database</description>
 
+    <properties>
+        <postgres.url>jdbc:postgresql://localhost:5431/hibernate_orm_test</postgres.url>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -148,9 +152,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <postgres.url>jdbc:postgresql://localhost:5431/hibernate_orm_test</postgres.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/jpa-postgresql/pom.xml
+++ b/integration-tests/jpa-postgresql/pom.xml
@@ -13,6 +13,10 @@
     <name>Quarkus - Integration Tests - JPA - PostgreSQL</name>
     <description>Module that contains JPA related tests running with the PostgreSQL database</description>
 
+    <properties>
+        <postgres.url>jdbc:postgresql://localhost:5431/hibernate_orm_test</postgres.url>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -158,9 +162,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <postgres.url>jdbc:postgresql://localhost:5431/hibernate_orm_test</postgres.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/oidc-client/pom.xml
+++ b/integration-tests/oidc-client/pom.xml
@@ -192,10 +192,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <keycloak.url>http://localhost:8180/auth</keycloak.url>
-                <keycloak.ssl.url>https://localhost:8543/auth</keycloak.ssl.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/reactive-db2-client/README.md
+++ b/integration-tests/reactive-db2-client/README.md
@@ -16,7 +16,7 @@ Additionally, you can generate a native image and run the tests for this native 
 mvn verify -Dtest-containers -Dstart-containers -Dnative
 ```
 
-If you don't want to run DB2 as a Docker container, you can start your own DB2 server. It needs to listen on the default port (50000) and have a database called `hreact` accessible to the user `hreact` with the password `hreact`.
+If you don't want to run DB2 as a Docker container, you can start your own DB2 server. It needs to listen on the default port (50005) and have a database called `hreact` accessible to the user `hreact` with the password `hreact`.
 
 You can then run the tests as follows (either with `-Dnative` or not):
 

--- a/integration-tests/reactive-db2-client/pom.xml
+++ b/integration-tests/reactive-db2-client/pom.xml
@@ -15,7 +15,7 @@
     <name>Quarkus - Integration Tests - Reactive DB2 Client</name>
 
     <properties>
-        <reactive-db2.url>vertx-reactive:db2://localhost:50000/hreact</reactive-db2.url>
+        <reactive-db2.url>vertx-reactive:db2://localhost:50005/hreact</reactive-db2.url>
     </properties>
 
     <dependencies>
@@ -152,9 +152,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <reactive-db2.url>vertx-reactive:db2://localhost:50005/hreact</reactive-db2.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/reactive-mssql-client/README.md
+++ b/integration-tests/reactive-mssql-client/README.md
@@ -17,7 +17,7 @@ mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
 If you don't want to run MS SQL as a Docker container, you can start your own.
-It needs to listen on the default port and be accessible to the user `sa` with the password `yourStrong(!)Password`.
+It needs to listen on port 1435 and be accessible to the user `sa` with the password `yourStrong(!)Password`.
 
 You can then run the tests as follows (either with `-Dnative` or not):
 

--- a/integration-tests/reactive-mssql-client/pom.xml
+++ b/integration-tests/reactive-mssql-client/pom.xml
@@ -15,7 +15,7 @@
     <name>Quarkus - Integration Tests - Reactive MS SQL Client</name>
 
     <properties>
-        <reactive-mssql.url>vertx-reactive:sqlserver://localhost:1433</reactive-mssql.url>
+        <reactive-mssql.url>vertx-reactive:sqlserver://localhost:1435</reactive-mssql.url>
     </properties>
 
     <dependencies>
@@ -151,9 +151,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <reactive-mssql.url>vertx-reactive:sqlserver://localhost:1435</reactive-mssql.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/reactive-mysql-client/README.md
+++ b/integration-tests/reactive-mysql-client/README.md
@@ -16,7 +16,7 @@ Additionally, you can generate a native image and run the tests for this native 
 mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
-If you don't want to run MariaDB as a Docker container, you can start your own MariaDB or MySQL server. It needs to listen on the default port and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
+If you don't want to run MariaDB as a Docker container, you can start your own MariaDB or MySQL server. It needs to listen on port 3308 and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
 
 You can then run the tests as follows (either with `-Dnative` or not):
 

--- a/integration-tests/reactive-mysql-client/pom.xml
+++ b/integration-tests/reactive-mysql-client/pom.xml
@@ -31,7 +31,7 @@
     <name>Quarkus - Integration Tests - Reactive MySQL Client</name>
 
     <properties>
-        <reactive-mysql.url>vertx-reactive:mysql://localhost:3306/hibernate_orm_test</reactive-mysql.url>
+        <reactive-mysql.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test</reactive-mysql.url>
     </properties>
 
     <dependencies>
@@ -168,9 +168,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <reactive-mysql.url>vertx-reactive:mysql://localhost:3308/hibernate_orm_test</reactive-mysql.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/reactive-oracle-client/pom.xml
+++ b/integration-tests/reactive-oracle-client/pom.xml
@@ -151,9 +151,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <reactive-oracledb.url>vertx-reactive:oracle:thin:@localhost:1521/FREEPDB1</reactive-oracledb.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/reactive-pg-client/README.md
+++ b/integration-tests/reactive-pg-client/README.md
@@ -16,7 +16,7 @@ Additionally, you can generate a native image and run the tests for this native 
 mvn clean install -Dtest-containers -Dstart-containers -Dnative
 ```
 
-If you don't want to run PostgreSQL as a Docker container, you can start your own PostgreSQL server. It needs to listen on the default port and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
+If you don't want to run PostgreSQL as a Docker container, you can start your own PostgreSQL server. It needs to listen on port 5431 and have a database called `hibernate_orm_test` accessible to the user `hibernate_orm_test` with the password `hibernate_orm_test`.
 
 You can then run the tests as follows (either with `-Dnative` or not):
 

--- a/integration-tests/reactive-pg-client/pom.xml
+++ b/integration-tests/reactive-pg-client/pom.xml
@@ -15,7 +15,7 @@
     <name>Quarkus - Integration Tests - Reactive Pg Client</name>
 
     <properties>
-        <reactive-postgres.url>vertx-reactive:postgresql:///hibernate_orm_test</reactive-postgres.url>
+        <reactive-postgres.url>vertx-reactive:postgresql://:5431/hibernate_orm_test</reactive-postgres.url>
     </properties>
 
     <dependencies>
@@ -162,9 +162,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <reactive-postgres.url>vertx-reactive:postgresql://:5431/hibernate_orm_test</reactive-postgres.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/redis-cache/pom.xml
+++ b/integration-tests/redis-cache/pom.xml
@@ -149,9 +149,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <redis.url>localhost:6379</redis.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/redis-client/pom.xml
+++ b/integration-tests/redis-client/pom.xml
@@ -149,9 +149,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <redis.url>localhost:6379</redis.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/integration-tests/smallrye-jwt-oidc-webapp/pom.xml
+++ b/integration-tests/smallrye-jwt-oidc-webapp/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <keycloak.url>http://localhost:8180/auth</keycloak.url>
+        <reactive-oracledb.url>vertx-reactive:oracle:thin:@localhost:1521/FREEPDB1</reactive-oracledb.url>
     </properties>
 
     <dependencies>
@@ -225,10 +226,6 @@
                     <name>start-containers</name>
                 </property>
             </activation>
-            <properties>
-                <keycloak.url>http://localhost:8180/auth</keycloak.url>
-                <reactive-oracledb.url>vertx-reactive:oracle:thin:@localhost:1521/FREEPDB1</reactive-oracledb.url>
-            </properties>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
It is better for the build cache and for local testing, nowadays, there is a good chance people will use containers anyway.

See [this thread](https://groups.google.com/g/quarkus-dev/c/0SY7pJ4NEiQ) for more information.