### PR TITLE
Make it possible to acquire OIDC SecurityIdentity after HTTP request has completed

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
@@ -1023,6 +1023,92 @@ If you set `quarkus.oidc.client-id` but your endpoint does not require remote ac
 
 Note Quarkus `web-app` applications always require `quarkus.oidc.client-id` property.
 
+== Authentication after HTTP request has completed
+
+Sometimes, `SecurityIdentity` for a given token must be created when there is no active HTTP request context.
+The `quarkus-oidc` extension provides `io.quarkus.oidc.TenantIdentityProvider` to convert a token to a `SecurityIdentity` instance.
+For example, one situation when you must verify the token after HTTP request has completed is when you are
+processing messages with the xref:vertx.adoc#event-bus[Vert.x event bus].
+In the example below, the 'product-order' message is consumed within different CDI request context, therefore
+an injected `SecurityIdentity` would not correctly represent the verified identity and be anonymous.
+
+[source,java]
+----
+package org.acme.quickstart.oidc;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import io.vertx.core.eventbus.EventBus;
+
+@Path("order")
+public class OrderResource {
+
+    @Inject
+    EventBus eventBus;
+
+    @POST
+    public void order(String product, @HeaderParam(AUTHORIZATION) String bearer) {
+        String rawToken = bearer.substring("Bearer ".length()); <1>
+        eventBus.publish("product-order", new Product(product, 1, rawToken));
+    }
+}
+----
+<1> At this point, token is not verified when proactive authentication is disabled.
+
+[source,java]
+----
+package org.acme.quickstart.oidc;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.oidc.TenantFeature;
+import io.quarkus.oidc.TenantIdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.common.annotation.Blocking;
+
+@ApplicationScoped
+public class OrderService {
+
+    @TenantFeature("tenantId")
+    @Inject
+    TenantIdentityProvider identityProvider;
+
+    @Inject
+    TenantIdentityProvider defaultIdentityProvider; <1>
+
+    @Blocking
+    @ConsumeEvent("product-order")
+    void processOrder(Product product) {
+        String rawToken = product.customerAccessToken;
+        AccessTokenCredential token = new AccessTokenCredential(rawToken);
+        SecurityIdentity = identityProvider.authenticate(token).await().indefinitely(); <2>
+        ...
+    }
+
+}
+----
+<1> For default tenant, the `TenantFeature` qualifier is optional.
+<2> Executes token verification and converts the token to a `SecurityIdentity`.
+
+[NOTE]
+====
+When the provider is used during an HTTP request, the tenant configuration can be resolved as described in
+the xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect Multi-Tenancy] guide.
+However, when there is no active HTTP request, you need to select tenant explicitly with the `io.quarkus.oidc.TenantFeature` qualifier.
+====
+
+[WARNING]
+====
+xref:security-openid-connect-multitenancy.adoc#tenant-config-resolver[Dynamic tenant configuration resolution] is currently not supported.
+Authentication that requires dynamic tenant will fail.
+====
+
 == References
 
 * xref:security-oidc-configuration-properties-reference.adoc[OIDC configuration properties]
@@ -1038,3 +1124,4 @@ Note Quarkus `web-app` applications always require `quarkus.oidc.client-id` prop
 * xref:security-authentication-mechanisms.adoc#combining-authentication-mechanisms[Combining authentication mechanisms]
 * xref:security-overview.adoc[Quarkus Security overview]
 * xref:security-keycloak-admin-client.adoc[Quarkus Keycloak Admin Client]
+* xref:security-openid-connect-multitenancy.adoc[Using OpenID Connect Multi-Tenancy]

--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -274,6 +274,7 @@ workbag.”
 ...
 ----
 
+[[event-bus]]
 == Using the event bus
 
 One of the core features of Vert.x is the https://vertx.io/docs/vertx-core/java/#event_bus[event bus].

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -1,11 +1,15 @@
 package io.quarkus.oidc.deployment;
 
+import static io.quarkus.arc.processor.BuiltinScope.APPLICATION;
+import static io.quarkus.arc.processor.DotNames.DEFAULT;
+import static io.quarkus.oidc.runtime.OidcUtils.DEFAULT_TENANT_ID;
 import static io.quarkus.vertx.http.deployment.EagerSecurityInterceptorCandidateBuildItem.hasProperEndpointModifiers;
 import static org.jboss.jandex.AnnotationTarget.Kind.CLASS;
 import static org.jboss.jandex.AnnotationTarget.Kind.METHOD;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -21,8 +25,12 @@ import org.jboss.jandex.MethodInfo;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.BeanDiscoveryFinishedBuildItem;
+import io.quarkus.arc.deployment.QualifierRegistrarBuildItem;
 import io.quarkus.arc.deployment.SynthesisFinishedBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.arc.processor.InjectionPointInfo;
+import io.quarkus.arc.processor.QualifierRegistrar;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
@@ -38,6 +46,8 @@ import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.oidc.SecurityEvent;
 import io.quarkus.oidc.Tenant;
+import io.quarkus.oidc.TenantFeature;
+import io.quarkus.oidc.TenantIdentityProvider;
 import io.quarkus.oidc.TokenIntrospectionCache;
 import io.quarkus.oidc.UserInfoCache;
 import io.quarkus.oidc.runtime.BackChannelLogoutHandler;
@@ -69,6 +79,8 @@ import io.vertx.ext.web.RoutingContext;
 public class OidcBuildStep {
     public static final DotName DOTNAME_SECURITY_EVENT = DotName.createSimple(SecurityEvent.class.getName());
     private static final DotName TENANT_NAME = DotName.createSimple(Tenant.class);
+    private static final DotName TENANT_FEATURE_NAME = DotName.createSimple(TenantFeature.class);
+    private static final DotName TENANT_IDENTITY_PROVIDER_NAME = DotName.createSimple(TenantIdentityProvider.class);
     private static final Logger LOG = Logger.getLogger(OidcBuildStep.class);
 
     @BuildStep
@@ -127,6 +139,74 @@ public class OidcBuildStep {
     @BuildStep
     ExtensionSslNativeSupportBuildItem enableSslInNative() {
         return new ExtensionSslNativeSupportBuildItem(Feature.OIDC);
+    }
+
+    @BuildStep
+    QualifierRegistrarBuildItem addQualifiers() {
+        // this seems to be necessary; I think it's because sometimes we only access beans
+        // annotated with @TenantFeature programmatically and no injection point is annotated with it
+        return new QualifierRegistrarBuildItem(new QualifierRegistrar() {
+            @Override
+            public Map<DotName, Set<String>> getAdditionalQualifiers() {
+                return Map.of(TENANT_FEATURE_NAME, Set.of());
+            }
+        });
+    }
+
+    /**
+     * Produce {@link OidcIdentityProvider} with already selected tenant for each {@link OidcIdentityProvider}
+     * injection point annotated with {@link TenantFeature} annotation.
+     * For example, we produce {@link OidcIdentityProvider} with pre-selected tenant 'my-tenant' for injection point:
+     *
+     * <code>
+     *  &#064;Inject
+     *  &#064;TenantFeature("my-tenant")
+     *  OidcIdentityProvider identityProvider;
+     * </code>
+     */
+    @Record(ExecutionTime.STATIC_INIT)
+    @BuildStep
+    void produceTenantIdentityProviders(BuildProducer<SyntheticBeanBuildItem> syntheticBeanProducer,
+            OidcRecorder recorder, BeanDiscoveryFinishedBuildItem beans, CombinedIndexBuildItem combinedIndex) {
+        // create TenantIdentityProviders for tenants selected with @TenantFeature like: @TenantFeature("my-tenant")
+        if (!combinedIndex.getIndex().getAnnotations(TENANT_FEATURE_NAME).isEmpty()) {
+            // create TenantIdentityProviders for tenants selected with @TenantFeature like: @TenantFeature("my-tenant")
+            beans
+                    .getInjectionPoints()
+                    .stream()
+                    .filter(ip -> ip.getRequiredQualifier(TENANT_FEATURE_NAME) != null)
+                    .filter(OidcBuildStep::isTenantIdentityProviderType)
+                    .map(ip -> ip.getRequiredQualifier(TENANT_FEATURE_NAME).value().asString())
+                    .distinct()
+                    .forEach(tenantName -> syntheticBeanProducer.produce(
+                            SyntheticBeanBuildItem
+                                    .configure(TenantIdentityProvider.class)
+                                    .addQualifier().annotation(TENANT_FEATURE_NAME).addValue("value", tenantName).done()
+                                    .scope(APPLICATION.getInfo())
+                                    .supplier(recorder.createTenantIdentityProvider(tenantName))
+                                    .unremovable()
+                                    .done()));
+        }
+        // create TenantIdentityProvider for default tenant when tenant is not explicitly selected via @TenantFeature
+        boolean createTenantIdentityProviderForDefaultTenant = beans
+                .getInjectionPoints()
+                .stream()
+                .filter(InjectionPointInfo::hasDefaultedQualifier)
+                .anyMatch(OidcBuildStep::isTenantIdentityProviderType);
+        if (createTenantIdentityProviderForDefaultTenant) {
+            syntheticBeanProducer.produce(
+                    SyntheticBeanBuildItem
+                            .configure(TenantIdentityProvider.class)
+                            .addQualifier(DEFAULT)
+                            .scope(APPLICATION.getInfo())
+                            .supplier(recorder.createTenantIdentityProvider(DEFAULT_TENANT_ID))
+                            .unremovable()
+                            .done());
+        }
+    }
+
+    private static boolean isTenantIdentityProviderType(InjectionPointInfo ip) {
+        return TENANT_IDENTITY_PROVIDER_NAME.equals(ip.getRequiredType().name());
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantFeature.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantFeature.java
@@ -1,19 +1,54 @@
 package io.quarkus.oidc;
 
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
 /**
- * Annotation which can be used to associate one or more OIDC features with a named tenant.
+ * Qualifier used to specify which named tenant is associated with one or more OIDC feature.
  */
-@Target({ TYPE })
-@Retention(RetentionPolicy.RUNTIME)
+@Target({ METHOD, FIELD, PARAMETER, TYPE })
+@Retention(RUNTIME)
+@Documented
+@Qualifier
 public @interface TenantFeature {
     /**
      * Identifies an OIDC tenant to which a given feature applies.
      */
     String value();
+
+    /**
+     * Supports inline instantiation of the {@link TenantFeature} qualifier.
+     */
+    final class TenantFeatureLiteral extends AnnotationLiteral<TenantFeature> implements TenantFeature {
+
+        private final String value;
+
+        private TenantFeatureLiteral(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return "TenantFeatureLiteral [value=" + value + "]";
+        }
+
+        public static TenantFeature of(String value) {
+            return new TenantFeatureLiteral(value);
+        }
+    }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantIdentityProvider.java
@@ -1,0 +1,15 @@
+package io.quarkus.oidc;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Tenant-specific {@link SecurityIdentity} provider. Associated tenant configuration needs to be selected
+ * with the {@link TenantFeature} qualifier. When injection point is not annotated with the {@link TenantFeature}
+ * qualifier, default tenant is selected.
+ */
+public interface TenantIdentityProvider {
+
+    Uni<SecurityIdentity> authenticate(AccessTokenCredential token);
+
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -1,8 +1,10 @@
 package io.quarkus.oidc.runtime;
 
 import static io.quarkus.oidc.runtime.OidcUtils.validateAndCreateIdentity;
+import static io.quarkus.vertx.http.runtime.security.HttpSecurityUtils.getRoutingContextAttribute;
 
 import java.security.Principal;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -32,10 +34,8 @@ import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.TokenAuthenticationRequest;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
-import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.RoutingContext;
 
 @ApplicationScoped
 public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticationRequest> {
@@ -48,12 +48,12 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     private static final Uni<TokenVerificationResult> NULL_CODE_ACCESS_TOKEN_UNI = Uni.createFrom().nullItem();
     private static final String CODE_ACCESS_TOKEN_RESULT = "code_flow_access_token_result";
 
-    private final DefaultTenantConfigResolver tenantResolver;
+    protected final DefaultTenantConfigResolver tenantResolver;
     private final BlockingTaskRunner<Void> uniVoidOidcContext;
     private final BlockingTaskRunner<TokenIntrospection> getIntrospectionRequestContext;
     private final BlockingTaskRunner<UserInfo> getUserInfoRequestContext;
 
-    public OidcIdentityProvider(DefaultTenantConfigResolver tenantResolver, BlockingSecurityExecutor blockingExecutor) {
+    OidcIdentityProvider(DefaultTenantConfigResolver tenantResolver, BlockingSecurityExecutor blockingExecutor) {
         this.tenantResolver = tenantResolver;
         this.uniVoidOidcContext = new BlockingTaskRunner<>(blockingExecutor);
         this.getIntrospectionRequestContext = new BlockingTaskRunner<>(blockingExecutor);
@@ -72,65 +72,69 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             return Uni.createFrom().nullItem();
         }
         LOG.debug("Starting creating SecurityIdentity");
-        RoutingContext vertxContext = HttpSecurityUtils.getRoutingContextAttribute(request);
-        vertxContext.put(AuthenticationRequestContext.class.getName(), context);
 
-        Uni<TenantConfigContext> tenantConfigContext = tenantResolver.resolveContext(vertxContext);
-
-        return tenantConfigContext.onItem()
+        return resolveTenantConfigContext(request, context).onItem()
                 .transformToUni(new Function<TenantConfigContext, Uni<? extends SecurityIdentity>>() {
                     @Override
                     public Uni<SecurityIdentity> apply(TenantConfigContext tenantConfigContext) {
                         return Uni.createFrom().deferred(new Supplier<Uni<? extends SecurityIdentity>>() {
                             @Override
                             public Uni<SecurityIdentity> get() {
-                                return authenticate(request, vertxContext, tenantConfigContext);
+                                return authenticate(request, getRequestData(request), tenantConfigContext);
                             }
                         });
                     }
                 });
     }
 
-    private Uni<SecurityIdentity> authenticate(TokenAuthenticationRequest request,
-            RoutingContext vertxContext,
+    protected Uni<TenantConfigContext> resolveTenantConfigContext(TokenAuthenticationRequest request,
+            AuthenticationRequestContext context) {
+        return tenantResolver.resolveContext(
+                getRoutingContextAttribute(request).put(AuthenticationRequestContext.class.getName(), context));
+    }
+
+    protected Map<String, Object> getRequestData(TokenAuthenticationRequest request) {
+        return getRoutingContextAttribute(request).data();
+    }
+
+    private Uni<SecurityIdentity> authenticate(TokenAuthenticationRequest request, Map<String, Object> requestData,
             TenantConfigContext resolvedContext) {
         if (resolvedContext.oidcConfig.publicKey.isPresent()) {
             LOG.debug("Performing token verification with a configured public key");
             return validateTokenWithoutOidcServer(request, resolvedContext);
         } else {
-            return validateAllTokensWithOidcServer(vertxContext, request, resolvedContext);
+            return validateAllTokensWithOidcServer(requestData, request, resolvedContext);
         }
     }
 
-    private Uni<SecurityIdentity> validateAllTokensWithOidcServer(RoutingContext vertxContext,
-            TokenAuthenticationRequest request,
-            TenantConfigContext resolvedContext) {
+    private Uni<SecurityIdentity> validateAllTokensWithOidcServer(Map<String, Object> requestData,
+            TokenAuthenticationRequest request, TenantConfigContext resolvedContext) {
 
         if (resolvedContext.oidcConfig.token.verifyAccessTokenWithUserInfo.orElse(false)
-                && isOpaqueAccessToken(vertxContext, request, resolvedContext)) {
+                && isOpaqueAccessToken(requestData, request, resolvedContext)) {
             // UserInfo has to be acquired first as a precondition for verifying opaque access tokens.
             // Typically it will be done for bearer access tokens therefore even if the access token has expired
             // the client will be able to refresh if needed, no refresh token is available to Quarkus during the
             // bearer access token verification
             if (resolvedContext.oidcConfig.authentication.isUserInfoRequired().orElse(false)) {
-                return getUserInfoUni(vertxContext, request, resolvedContext).onItemOrFailure().transformToUni(
+                return getUserInfoUni(requestData, request, resolvedContext).onItemOrFailure().transformToUni(
                         new BiFunction<UserInfo, Throwable, Uni<? extends SecurityIdentity>>() {
                             @Override
                             public Uni<SecurityIdentity> apply(UserInfo userInfo, Throwable t) {
                                 if (t != null) {
                                     return Uni.createFrom().failure(new AuthenticationFailedException(t));
                                 }
-                                return validateTokenWithUserInfoAndCreateIdentity(vertxContext, request, resolvedContext,
+                                return validateTokenWithUserInfoAndCreateIdentity(requestData, request, resolvedContext,
                                         userInfo);
                             }
                         });
             } else {
-                return validateTokenWithUserInfoAndCreateIdentity(vertxContext, request, resolvedContext, null);
+                return validateTokenWithUserInfoAndCreateIdentity(requestData, request, resolvedContext, null);
             }
         } else {
             final Uni<TokenVerificationResult> primaryTokenUni;
             if (isInternalIdToken(request)) {
-                if (vertxContext.get(NEW_AUTHENTICATION) == Boolean.TRUE) {
+                if (requestData.get(NEW_AUTHENTICATION) == Boolean.TRUE) {
                     // No need to verify it in this case as 'CodeAuthenticationMechanism' has just created it
                     primaryTokenUni = Uni.createFrom()
                             .item(new TokenVerificationResult(OidcUtils.decodeJwtContent(request.getToken().getToken()), null));
@@ -138,13 +142,13 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                     primaryTokenUni = verifySelfSignedTokenUni(resolvedContext, request.getToken().getToken());
                 }
             } else {
-                primaryTokenUni = verifyTokenUni(vertxContext, resolvedContext, request.getToken().getToken(),
+                primaryTokenUni = verifyTokenUni(requestData, resolvedContext, request.getToken().getToken(),
                         isIdToken(request), null);
             }
 
             // Verify Code Flow access token first if it is available and has to be verified.
             // It may be refreshed if it has or has nearly expired
-            Uni<TokenVerificationResult> codeAccessTokenUni = verifyCodeFlowAccessTokenUni(vertxContext, request,
+            Uni<TokenVerificationResult> codeAccessTokenUni = verifyCodeFlowAccessTokenUni(requestData, request,
                     resolvedContext,
                     null);
             return codeAccessTokenUni.onItemOrFailure().transformToUni(
@@ -156,23 +160,23 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                                         : new AuthenticationFailedException(t));
                             }
                             if (codeAccessTokenResult != null) {
-                                if (tokenAutoRefreshPrepared(codeAccessTokenResult, vertxContext,
+                                if (tokenAutoRefreshPrepared(codeAccessTokenResult, requestData,
                                         resolvedContext.oidcConfig)) {
                                     return Uni.createFrom().failure(new TokenAutoRefreshException(null));
                                 }
-                                vertxContext.put(CODE_ACCESS_TOKEN_RESULT, codeAccessTokenResult);
+                                requestData.put(CODE_ACCESS_TOKEN_RESULT, codeAccessTokenResult);
                             }
-                            return getUserInfoAndCreateIdentity(primaryTokenUni, vertxContext, request, resolvedContext);
+                            return getUserInfoAndCreateIdentity(primaryTokenUni, requestData, request, resolvedContext);
                         }
                     });
 
         }
     }
 
-    private Uni<SecurityIdentity> validateTokenWithUserInfoAndCreateIdentity(RoutingContext vertxContext,
+    private Uni<SecurityIdentity> validateTokenWithUserInfoAndCreateIdentity(Map<String, Object> requestData,
             TokenAuthenticationRequest request,
             TenantConfigContext resolvedContext, UserInfo userInfo) {
-        Uni<TokenVerificationResult> codeAccessTokenUni = verifyCodeFlowAccessTokenUni(vertxContext, request, resolvedContext,
+        Uni<TokenVerificationResult> codeAccessTokenUni = verifyCodeFlowAccessTokenUni(requestData, request, resolvedContext,
                 userInfo);
 
         return codeAccessTokenUni.onItemOrFailure().transformToUni(
@@ -184,10 +188,10 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                         }
 
                         if (codeAccessToken != null) {
-                            vertxContext.put(CODE_ACCESS_TOKEN_RESULT, codeAccessToken);
+                            requestData.put(CODE_ACCESS_TOKEN_RESULT, codeAccessToken);
                         }
 
-                        Uni<TokenVerificationResult> tokenUni = verifyTokenUni(vertxContext, resolvedContext,
+                        Uni<TokenVerificationResult> tokenUni = verifyTokenUni(requestData, resolvedContext,
                                 request.getToken().getToken(),
                                 false, userInfo);
 
@@ -200,7 +204,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                                                     return Uni.createFrom().failure(new AuthenticationFailedException(t));
                                                 }
 
-                                                return createSecurityIdentityWithOidcServer(result, vertxContext, request,
+                                                return createSecurityIdentityWithOidcServer(result, requestData, request,
                                                         resolvedContext, userInfo);
                                             }
                                         });
@@ -210,7 +214,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     }
 
     private Uni<SecurityIdentity> getUserInfoAndCreateIdentity(Uni<TokenVerificationResult> tokenUni,
-            RoutingContext vertxContext, TokenAuthenticationRequest request,
+            Map<String, Object> requestData, TokenAuthenticationRequest request,
             TenantConfigContext resolvedContext) {
 
         return tokenUni.onItemOrFailure()
@@ -221,19 +225,19 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                             return Uni.createFrom().failure(new AuthenticationFailedException(t));
                         }
                         if (resolvedContext.oidcConfig.authentication.isUserInfoRequired().orElse(false)) {
-                            return getUserInfoUni(vertxContext, request, resolvedContext).onItemOrFailure().transformToUni(
+                            return getUserInfoUni(requestData, request, resolvedContext).onItemOrFailure().transformToUni(
                                     new BiFunction<UserInfo, Throwable, Uni<? extends SecurityIdentity>>() {
                                         @Override
                                         public Uni<SecurityIdentity> apply(UserInfo userInfo, Throwable t) {
                                             if (t != null) {
                                                 return Uni.createFrom().failure(new AuthenticationFailedException(t));
                                             }
-                                            return createSecurityIdentityWithOidcServer(result, vertxContext, request,
+                                            return createSecurityIdentityWithOidcServer(result, requestData, request,
                                                     resolvedContext, userInfo);
                                         }
                                     });
                         } else {
-                            return createSecurityIdentityWithOidcServer(result, vertxContext, request, resolvedContext, null);
+                            return createSecurityIdentityWithOidcServer(result, requestData, request, resolvedContext, null);
                         }
 
                     }
@@ -241,21 +245,21 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
 
     }
 
-    private boolean isOpaqueAccessToken(RoutingContext vertxContext, TokenAuthenticationRequest request,
+    private boolean isOpaqueAccessToken(Map<String, Object> requestData, TokenAuthenticationRequest request,
             TenantConfigContext resolvedContext) {
         if (request.getToken() instanceof AccessTokenCredential) {
             return ((AccessTokenCredential) request.getToken()).isOpaque();
         } else if (request.getToken() instanceof IdTokenCredential
                 && (resolvedContext.oidcConfig.authentication.verifyAccessToken
                         || resolvedContext.oidcConfig.roles.source.orElse(null) == Source.accesstoken)) {
-            final String codeAccessToken = (String) vertxContext.get(OidcConstants.ACCESS_TOKEN_VALUE);
+            final String codeAccessToken = (String) requestData.get(OidcConstants.ACCESS_TOKEN_VALUE);
             return OidcUtils.isOpaqueToken(codeAccessToken);
         }
         return false;
     }
 
     private Uni<SecurityIdentity> createSecurityIdentityWithOidcServer(TokenVerificationResult result,
-            RoutingContext vertxContext, TokenAuthenticationRequest request, TenantConfigContext resolvedContext,
+            Map<String, Object> requestData, TokenAuthenticationRequest request, TenantConfigContext resolvedContext,
             final UserInfo userInfo) {
 
         // Token has been verified, as a JWT or an opaque token, possibly involving
@@ -279,14 +283,14 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                     return Uni.createFrom().failure(new AuthenticationCompletionException(errorMessage));
                 }
 
-                JsonObject rolesJson = getRolesJson(vertxContext, resolvedContext, tokenCred, tokenJson,
+                JsonObject rolesJson = getRolesJson(requestData, resolvedContext, tokenCred, tokenJson,
                         userInfo);
-                SecurityIdentity securityIdentity = validateAndCreateIdentity(vertxContext, tokenCred,
-                        resolvedContext, tokenJson, rolesJson, userInfo, result.introspectionResult);
+                SecurityIdentity securityIdentity = validateAndCreateIdentity(requestData, tokenCred,
+                        resolvedContext, tokenJson, rolesJson, userInfo, result.introspectionResult, request);
                 // If the primary token is a bearer access token then there's no point of checking if
                 // it should be refreshed as RT is only available for the code flow tokens
                 if (isIdToken(request)
-                        && tokenAutoRefreshPrepared(result, vertxContext, resolvedContext.oidcConfig)) {
+                        && tokenAutoRefreshPrepared(result, requestData, resolvedContext.oidcConfig)) {
                     return Uni.createFrom().failure(new TokenAutoRefreshException(securityIdentity));
                 } else {
                     return Uni.createFrom().item(securityIdentity);
@@ -344,14 +348,15 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 OidcUtils.setSecurityIdentityRoles(builder, resolvedContext.oidcConfig, rolesJson);
                 OidcUtils.setSecurityIdentityPermissions(builder, resolvedContext.oidcConfig, rolesJson);
             }
-            OidcUtils.setBlockingApiAttribute(builder, vertxContext);
             OidcUtils.setTenantIdAttribute(builder, resolvedContext.oidcConfig);
+            var vertxContext = getRoutingContextAttribute(request);
+            OidcUtils.setBlockingApiAttribute(builder, vertxContext);
             OidcUtils.setRoutingContextAttribute(builder, vertxContext);
             SecurityIdentity identity = builder.build();
             // If the primary token is a bearer access token then there's no point of checking if
             // it should be refreshed as RT is only available for the code flow tokens
             if (isIdToken(request)
-                    && tokenAutoRefreshPrepared(result, vertxContext, resolvedContext.oidcConfig)) {
+                    && tokenAutoRefreshPrepared(result, requestData, resolvedContext.oidcConfig)) {
                 return Uni.createFrom().failure(new TokenAutoRefreshException(identity));
             }
             return Uni.createFrom().item(identity);
@@ -367,12 +372,12 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
         return request.getToken() instanceof IdTokenCredential;
     }
 
-    private static boolean tokenAutoRefreshPrepared(TokenVerificationResult result, RoutingContext vertxContext,
+    private static boolean tokenAutoRefreshPrepared(TokenVerificationResult result, Map<String, Object> requestData,
             OidcTenantConfig oidcConfig) {
         if (result != null && oidcConfig.token.refreshExpired
                 && oidcConfig.token.getRefreshTokenTimeSkew().isPresent()
-                && vertxContext.get(REFRESH_TOKEN_GRANT_RESPONSE) != Boolean.TRUE
-                && vertxContext.get(NEW_AUTHENTICATION) != Boolean.TRUE) {
+                && requestData.get(REFRESH_TOKEN_GRANT_RESPONSE) != Boolean.TRUE
+                && requestData.get(NEW_AUTHENTICATION) != Boolean.TRUE) {
             Long expiry = null;
             if (result.localVerificationResult != null) {
                 expiry = result.localVerificationResult.getLong(Claims.exp.name());
@@ -388,7 +393,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
         return false;
     }
 
-    private static JsonObject getRolesJson(RoutingContext vertxContext, TenantConfigContext resolvedContext,
+    private static JsonObject getRolesJson(Map<String, Object> requestData, TenantConfigContext resolvedContext,
             TokenCredential tokenCred,
             JsonObject tokenJson, UserInfo userInfo) {
         JsonObject rolesJson = tokenJson;
@@ -397,32 +402,32 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 rolesJson = new JsonObject(userInfo.getJsonObject().toString());
             } else if (tokenCred instanceof IdTokenCredential
                     && resolvedContext.oidcConfig.roles.source.get() == Source.accesstoken) {
-                rolesJson = ((TokenVerificationResult) vertxContext.get(CODE_ACCESS_TOKEN_RESULT)).localVerificationResult;
+                rolesJson = ((TokenVerificationResult) requestData.get(CODE_ACCESS_TOKEN_RESULT)).localVerificationResult;
                 if (rolesJson == null) {
                     // JSON token representation may be null not only if it is an opaque access token
                     // but also if it is JWT and no JWK with a matching kid is available, asynchronous
                     // JWK refresh has not finished yet, but the fallback introspection request has succeeded.
-                    rolesJson = OidcUtils.decodeJwtContent((String) vertxContext.get(OidcConstants.ACCESS_TOKEN_VALUE));
+                    rolesJson = OidcUtils.decodeJwtContent((String) requestData.get(OidcConstants.ACCESS_TOKEN_VALUE));
                 }
             }
         }
         return rolesJson;
     }
 
-    private Uni<TokenVerificationResult> verifyCodeFlowAccessTokenUni(RoutingContext vertxContext,
+    private Uni<TokenVerificationResult> verifyCodeFlowAccessTokenUni(Map<String, Object> requestData,
             TokenAuthenticationRequest request,
             TenantConfigContext resolvedContext, UserInfo userInfo) {
         if (request.getToken() instanceof IdTokenCredential
                 && (resolvedContext.oidcConfig.authentication.verifyAccessToken
                         || resolvedContext.oidcConfig.roles.source.orElse(null) == Source.accesstoken)) {
-            final String codeAccessToken = (String) vertxContext.get(OidcConstants.ACCESS_TOKEN_VALUE);
-            return verifyTokenUni(vertxContext, resolvedContext, codeAccessToken, false, userInfo);
+            final String codeAccessToken = (String) requestData.get(OidcConstants.ACCESS_TOKEN_VALUE);
+            return verifyTokenUni(requestData, resolvedContext, codeAccessToken, false, userInfo);
         } else {
             return NULL_CODE_ACCESS_TOKEN_UNI;
         }
     }
 
-    private Uni<TokenVerificationResult> verifyTokenUni(RoutingContext vertxContext, TenantConfigContext resolvedContext,
+    private Uni<TokenVerificationResult> verifyTokenUni(Map<String, Object> requestData, TenantConfigContext resolvedContext,
             String token, boolean enforceAudienceVerification, UserInfo userInfo) {
         if (OidcUtils.isOpaqueToken(token)) {
             if (!resolvedContext.oidcConfig.token.allowOpaqueTokenIntrospection) {
@@ -449,7 +454,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             return introspectTokenUni(resolvedContext, token, false);
         } else {
             // Verify JWT token with the local JWK keys with a possible remote introspection fallback
-            final String nonce = vertxContext.get(OidcConstants.NONCE);
+            final String nonce = (String) requestData.get(OidcConstants.NONCE);
             try {
                 LOG.debug("Verifying the JWT token with the local JWK keys");
                 return Uni.createFrom()
@@ -541,14 +546,14 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             TokenVerificationResult result = resolvedContext.provider.verifyJwtToken(request.getToken().getToken(), false,
                     false, null);
             return Uni.createFrom()
-                    .item(validateAndCreateIdentity(null, request.getToken(), resolvedContext,
-                            result.localVerificationResult, result.localVerificationResult, null, null));
+                    .item(validateAndCreateIdentity(Map.of(), request.getToken(), resolvedContext,
+                            result.localVerificationResult, result.localVerificationResult, null, null, request));
         } catch (Throwable t) {
             return Uni.createFrom().failure(new AuthenticationFailedException(t));
         }
     }
 
-    private Uni<UserInfo> getUserInfoUni(RoutingContext vertxContext, TokenAuthenticationRequest request,
+    private Uni<UserInfo> getUserInfoUni(Map<String, Object> requestData, TokenAuthenticationRequest request,
             TenantConfigContext resolvedContext) {
         if (isInternalIdToken(request) && resolvedContext.oidcConfig.cacheUserInfoInIdtoken) {
             JsonObject userInfo = OidcUtils.decodeJwtContent(request.getToken().getToken())
@@ -559,7 +564,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
         }
 
         LOG.debug("Requesting UserInfo");
-        String contextAccessToken = vertxContext.get(OidcConstants.ACCESS_TOKEN_VALUE);
+        String contextAccessToken = (String) requestData.get(OidcConstants.ACCESS_TOKEN_VALUE);
         final String accessToken = contextAccessToken != null ? contextAccessToken : request.getToken().getToken();
 
         UserInfoCache userInfoCache = tenantResolver.getUserInfoCache();

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -1,5 +1,8 @@
 package io.quarkus.oidc.runtime;
 
+import static io.quarkus.oidc.runtime.OidcUtils.DEFAULT_TENANT_ID;
+import static io.quarkus.vertx.http.runtime.security.HttpSecurityUtils.getRoutingContextAttribute;
+
 import java.security.Key;
 import java.util.HashMap;
 import java.util.List;
@@ -18,6 +21,7 @@ import org.jose4j.jwk.PublicJsonWebKey;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
+import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcConfigurationMetadata;
 import io.quarkus.oidc.OidcTenantConfig;
@@ -25,6 +29,7 @@ import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.OidcTenantConfig.Roles.Source;
 import io.quarkus.oidc.OidcTenantConfig.TokenStateManager.Strategy;
 import io.quarkus.oidc.TenantConfigResolver;
+import io.quarkus.oidc.TenantIdentityProvider;
 import io.quarkus.oidc.common.OidcClientRequestFilter;
 import io.quarkus.oidc.common.runtime.OidcCommonConfig;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
@@ -33,6 +38,10 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.TlsConfig;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.TokenAuthenticationRequest;
+import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
 import io.quarkus.security.spi.runtime.MethodDescription;
 import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.smallrye.jwt.util.KeyUtils;
@@ -63,7 +72,7 @@ public class OidcRecorder {
     public Supplier<TenantConfigBean> setup(OidcConfig config, Supplier<Vertx> vertx, TlsConfig tlsConfig) {
         final Vertx vertxValue = vertx.get();
 
-        String defaultTenantId = config.defaultTenant.getTenantId().orElse(OidcUtils.DEFAULT_TENANT_ID);
+        String defaultTenantId = config.defaultTenant.getTenantId().orElse(DEFAULT_TENANT_ID);
         TenantConfigContext defaultTenantContext = createStaticTenantContext(vertxValue, config.defaultTenant,
                 !config.namedTenants.isEmpty(), tlsConfig, defaultTenantId);
 
@@ -177,7 +186,7 @@ public class OidcRecorder {
 
         try {
             if (!oidcConfig.getAuthServerUrl().isPresent()) {
-                if (OidcUtils.DEFAULT_TENANT_ID.equals(oidcConfig.tenantId.get())) {
+                if (DEFAULT_TENANT_ID.equals(oidcConfig.tenantId.get())) {
                     ArcContainer container = Arc.container();
                     if (container != null
                             && (container.instance(TenantConfigResolver.class).isAvailable() || checkNamedTenants)) {
@@ -497,5 +506,67 @@ public class OidcRecorder {
                 routingContext.put(OidcUtils.TENANT_ID_ATTRIBUTE, tenantId);
             }
         };
+    }
+
+    public Supplier<TenantIdentityProvider> createTenantIdentityProvider(String tenantName) {
+        return new Supplier<TenantIdentityProvider>() {
+            @Override
+            public TenantIdentityProvider get() {
+                return new TenantSpecificOidcIdentityProvider(tenantName);
+            }
+        };
+    }
+
+    private static final class TenantSpecificOidcIdentityProvider extends OidcIdentityProvider
+            implements TenantIdentityProvider {
+
+        private final String tenantId;
+        private final BlockingSecurityExecutor blockingExecutor;
+
+        private TenantSpecificOidcIdentityProvider(String tenantId) {
+            super(Arc.container().instance(DefaultTenantConfigResolver.class).get(),
+                    Arc.container().instance(BlockingSecurityExecutor.class).get());
+            this.blockingExecutor = Arc.container().instance(BlockingSecurityExecutor.class).get();
+            if (tenantId.equals(DEFAULT_TENANT_ID)) {
+                OidcConfig config = Arc.container().instance(OidcConfig.class).get();
+                this.tenantId = config.defaultTenant.getTenantId().orElse(OidcUtils.DEFAULT_TENANT_ID);
+            } else {
+                this.tenantId = tenantId;
+            }
+        }
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(AccessTokenCredential token) {
+            return authenticate(new TokenAuthenticationRequest(token));
+        }
+
+        @Override
+        protected Uni<TenantConfigContext> resolveTenantConfigContext(TokenAuthenticationRequest request,
+                AuthenticationRequestContext context) {
+            return tenantResolver.resolveContext(tenantId).onItem().ifNull().failWith(new Supplier<Throwable>() {
+                @Override
+                public Throwable get() {
+                    return new OIDCException("Failed to resolve tenant context");
+                }
+            });
+        }
+
+        @Override
+        protected Map<String, Object> getRequestData(TokenAuthenticationRequest request) {
+            RoutingContext context = getRoutingContextAttribute(request);
+            if (context != null) {
+                return context.data();
+            }
+            return new HashMap<>();
+        }
+
+        private Uni<SecurityIdentity> authenticate(TokenAuthenticationRequest request) {
+            return authenticate(request, new AuthenticationRequestContext() {
+                @Override
+                public Uni<SecurityIdentity> runBlocking(Supplier<SecurityIdentity> function) {
+                    return blockingExecutor.executeBlocking(function);
+                }
+            });
+        }
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TokenCustomizerFinder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TokenCustomizerFinder.java
@@ -28,13 +28,10 @@ public class TokenCustomizerFinder {
                 } else {
                     throw new OIDCException("Unable to find TokenCustomizer " + customizerName);
                 }
-            } else {
-                for (InstanceHandle<TokenCustomizer> tokenCustomizer : container.listAll(TokenCustomizer.class)) {
-                    TenantFeature tenantAnn = tokenCustomizer.get().getClass().getAnnotation(TenantFeature.class);
-                    if (tenantAnn != null && oidcConfig.tenantId.get().equals(tenantAnn.value())) {
-                        return tokenCustomizer.get();
-                    }
-                }
+            } else if (oidcConfig.tenantId.isPresent()) {
+                return container
+                        .instance(TokenCustomizer.class, TenantFeature.TenantFeatureLiteral.of(oidcConfig.tenantId.get()))
+                        .get();
             }
         }
         return null;

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OrderResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OrderResource.java
@@ -1,0 +1,39 @@
+package io.quarkus.it.keycloak;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.security.UnauthorizedException;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.vertx.core.eventbus.EventBus;
+
+@Path("order/bearer")
+public class OrderResource {
+
+    @Inject
+    EventBus eventBus;
+
+    @Inject
+    SecurityIdentity identity;
+
+    @POST
+    public void order(String product, @HeaderParam(AUTHORIZATION) String bearer) {
+        if (!"alice".equals(identity.getPrincipal().getName())) {
+            // point here is to make sure that identity is resolved and later, when the event is consumed
+            // this identity won't be available as it will be brand-new request context
+            throw new UnauthorizedException("Only Alice is allowed to access this endpoint");
+        }
+        String rawToken = bearer.substring("Bearer ".length());
+        eventBus.publish("product-order", new Product(product, 1, rawToken));
+    }
+
+    @GET
+    public String acquiredIdentities() {
+        return String.join(" ", OrderService.IDENTITY_REPOSITORY);
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OrderService.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OrderService.java
@@ -1,0 +1,40 @@
+package io.quarkus.it.keycloak;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.oidc.TenantFeature;
+import io.quarkus.oidc.TenantIdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.ConsumeEvent;
+import io.smallrye.common.annotation.Blocking;
+
+@ApplicationScoped
+public class OrderService {
+
+    static final Set<String> IDENTITY_REPOSITORY = ConcurrentHashMap.newKeySet();
+
+    @Inject
+    SecurityIdentity identity;
+
+    @TenantFeature("bearer")
+    @Inject
+    TenantIdentityProvider identityProvider;
+
+    @Blocking
+    @ConsumeEvent("product-order")
+    void processOrder(Product product) {
+        if (!identity.isAnonymous()) {
+            // this condition establish need for OIDCIdentityProvider with pre-selected tenant
+            throw new IllegalStateException("Event is expected to be consumed on new request context");
+        }
+        var principal = identityProvider.authenticate(new AccessTokenCredential(product.accessToken)).await().indefinitely()
+                .getPrincipal().getName();
+        IDENTITY_REPOSITORY.add(principal);
+    }
+
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/Product.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/Product.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.keycloak;
+
+public class Product {
+
+    final String name;
+    final int quantity;
+    final String accessToken;
+
+    Product(String name, int quantity, String accessToken) {
+        this.name = name;
+        this.quantity = quantity;
+        this.accessToken = accessToken;
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/StartupResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/StartupResource.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.keycloak;
+
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@PermitAll
+@Path("startup-service")
+public class StartupResource {
+
+    private final StartupService startupService;
+
+    public StartupResource(StartupService startupService) {
+        this.startupService = startupService;
+    }
+
+    @GET
+    public Map<String, Map<String, Set<String>>> tenantToIdentityWithRole() {
+        return startupService.getTenantToIdentityWithRole();
+    }
+
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/StartupService.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/StartupService.java
@@ -1,0 +1,135 @@
+package io.quarkus.it.keycloak;
+
+import static io.quarkus.oidc.runtime.OidcUtils.DEFAULT_TENANT_ID;
+import static io.quarkus.oidc.runtime.OidcUtils.TENANT_ID_ATTRIBUTE;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.oidc.OIDCException;
+import io.quarkus.oidc.TenantFeature;
+import io.quarkus.oidc.TenantIdentityProvider;
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.jwt.algorithm.SignatureAlgorithm;
+import io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipal;
+import io.smallrye.jwt.build.Jwt;
+
+@Singleton
+public class StartupService {
+
+    private static final String ISSUER = "https://server.example.com";
+
+    @TenantFeature("bearer")
+    TenantIdentityProvider identityProviderBearer;
+
+    @TenantFeature("bearer-role-claim-path")
+    TenantIdentityProvider identityProviderBearerRoleClaimPath;
+
+    private final Map<String, Map<String, Set<String>>> tenantToIdentityWithRole = new ConcurrentHashMap<>();
+
+    void onStartup(@Observes StartupEvent event,
+            @TenantFeature(DEFAULT_TENANT_ID) TenantIdentityProvider defaultTenantProvider,
+            TenantIdentityProvider defaultTenantProviderDefaultQualifier) {
+        assertDefaultTenantProviderInjection(defaultTenantProvider);
+        assertDefaultTenantProviderInjection(defaultTenantProviderDefaultQualifier);
+        String accessToken;
+        String tenant;
+
+        tenant = "bearer";
+        accessToken = getAccessToken("alice", Set.of("user", "admin"), ISSUER);
+        acquireSecurityIdentity(accessToken, tenant, identityProviderBearer);
+
+        boolean wrongIssuerFailed = false;
+        try {
+            accessToken = getAccessToken("admin", Set.of("user", "admin"), "https://wrong-server.example.com");
+            acquireSecurityIdentity(accessToken, tenant, identityProviderBearer);
+        } catch (AuthenticationFailedException ignored) {
+            wrongIssuerFailed = true;
+        }
+        if (!wrongIssuerFailed) {
+            throw new IllegalStateException("User 'admin' shouldn't be able to acquire identity with wrong issuer");
+        }
+
+        tenant = "bearer-role-claim-path";
+
+        // first prove this is indeed bearer-role-claim-path tenant
+        accessToken = getAccessToken("admin", Set.of("admin"), ISSUER);
+        acquireSecurityIdentity(accessToken, tenant, identityProviderBearerRoleClaimPath);
+        var roles = tenantToIdentityWithRole.get(tenant).get("admin");
+        if (!roles.isEmpty()) {
+            throw new IllegalStateException(
+                    "User 'admin' should have empty roles because wrong role path was used, but got: " + roles);
+        }
+
+        accessToken = getAccessTokenWithCustomRolePath("admin", Set.of("admin"));
+        acquireSecurityIdentity(accessToken, tenant, identityProviderBearerRoleClaimPath);
+    }
+
+    private void assertDefaultTenantProviderInjection(TenantIdentityProvider defaultTenantProvider) {
+        String tenant = DEFAULT_TENANT_ID;
+        String accessToken = getAccessToken("bob", Set.of("user", "admin"), ISSUER);
+        boolean oidcServerNotAvailable = false;
+        try {
+            acquireSecurityIdentity(accessToken, tenant, defaultTenantProvider);
+        } catch (OIDCException exception) {
+            if (exception.getMessage().contains("OIDC Server is not available")) {
+                oidcServerNotAvailable = true;
+            }
+        }
+        if (!oidcServerNotAvailable) {
+            throw new IllegalStateException("Default OIDC tenant should have incorrect auth server URL");
+        }
+    }
+
+    private void acquireSecurityIdentity(String accessToken, String tenant, TenantIdentityProvider identityProvider) {
+        SecurityIdentity identity = identityProvider.authenticate(new AccessTokenCredential(accessToken)).await()
+                .indefinitely();
+
+        // validate identity
+        if (!identity.getAttribute(TENANT_ID_ATTRIBUTE).equals(tenant)) {
+            throw new IllegalStateException(
+                    "SecurityIdentity should contain '" + tenant + "' as '" + TENANT_ID_ATTRIBUTE + "' attribute");
+        }
+        String issuer = ((DefaultJWTCallerPrincipal) identity.getPrincipal()).getIssuer();
+        if (!ISSUER.equals(issuer)) {
+            throw new IllegalStateException("Expected issuer '" + ISSUER + "' but got '" + issuer + "'");
+        }
+
+        Set<String> roles = identity.getRoles();
+        String username = identity.getPrincipal().getName();
+        tenantToIdentityWithRole.computeIfAbsent(tenant, s -> new HashMap<>()).put(username, roles);
+    }
+
+    Map<String, Map<String, Set<String>>> getTenantToIdentityWithRole() {
+        return tenantToIdentityWithRole;
+    }
+
+    private static String getAccessToken(String userName, Set<String> groups, String issuer) {
+        return getAccessToken(userName, groups, SignatureAlgorithm.RS256, issuer);
+    }
+
+    private static String getAccessToken(String userName, Set<String> groups, SignatureAlgorithm alg, String issuer) {
+        return Jwt.preferredUserName(userName)
+                .groups(groups)
+                .issuer(issuer)
+                .audience("https://service.example.com")
+                .jws().algorithm(alg)
+                .sign();
+    }
+
+    private static String getAccessTokenWithCustomRolePath(String userName, Set<String> groups) {
+        return Jwt.preferredUserName(userName)
+                .claim("https://roles.example.com", groups)
+                .issuer("https://server.example.com")
+                .audience("https://service.example.com")
+                .sign();
+    }
+}


### PR DESCRIPTION
closes: https://github.com/quarkusio/quarkus/issues/24069

Use `TenantFeature` qualifier to select tenant configuration used by `OidcIdentityProvider`.

