### PR TITLE
Introduce OidcRequestFilter

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication.adoc
@@ -279,6 +279,11 @@ quarkus.oidc.introspection-credentials.name=introspection-user-name
 quarkus.oidc.introspection-credentials.secret=introspection-user-secret
 ----
 
+[[oidc-client-filters]]
+==== OIDC client request customization
+
+You can customize OIDC client requests by registering one or more `OidcClientRequestFiler` implementations which can update or add new request headers, please see xref:security-openid-connect-client-reference#oidc-client-filters[Client request customization] for more information.
+
 ==== Redirecting to and from the OIDC provider
 
 When a user is redirected to the OpenID Connect provider to authenticate, the redirect URL includes a `redirect_uri` query parameter, which indicates to the provider where the user has to be redirected to when the authentication is complete.

--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -872,6 +872,42 @@ quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".level=T
 quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".min-level=TRACE
 ----
 
+[[oidc-client-filters]]
+== Client request customization
+
+You can customize OIDC client requests by registering one or more `OidcClientRequestFiler` implementations which can update or add new request headers, for example, a filter can analyze the request body and add its digest as a new header value:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcClientRequestFilter;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpRequest;
+
+@ApplicationScoped
+@Unremovable
+public class OidcClientRequestCustomizer implements OidcClientRequestFilter {
+
+    @Override
+    public void filter(HttpRequest<Buffer> request, Buffer buffer) {
+        HttpMethod method = request.method();
+        String uri = request.uri();
+        if (method == HttpMethod.POST && uri.endsWith("/service") && buffer != null) {
+            request.putHeader("Digest", calculateDigest(buffer.toString()));
+        }
+    }
+
+    private String calculateDigest(String bodyString) {
+        // Apply the required digest algorithm to the body string
+    }
+}
+----
+
 [[token-propagation-reactive]]
 == Token Propagation Reactive
 

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -16,6 +17,7 @@ import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.OidcClientConfig;
 import io.quarkus.oidc.client.OidcClientException;
 import io.quarkus.oidc.client.Tokens;
+import io.quarkus.oidc.common.OidcClientRequestFilter;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.smallrye.mutiny.Uni;
@@ -44,10 +46,12 @@ public class OidcClientImpl implements OidcClient {
     private final String clientSecretBasicAuthScheme;
     private final Key clientJwtKey;
     private final OidcClientConfig oidcConfig;
+    private final List<OidcClientRequestFilter> filters;
     private volatile boolean closed;
 
     public OidcClientImpl(WebClient client, String tokenRequestUri, String tokenRevokeUri, String grantType,
-            MultiMap tokenGrantParams, MultiMap commonRefreshGrantParams, OidcClientConfig oidcClientConfig) {
+            MultiMap tokenGrantParams, MultiMap commonRefreshGrantParams, OidcClientConfig oidcClientConfig,
+            List<OidcClientRequestFilter> filters) {
         this.client = client;
         this.tokenRequestUri = tokenRequestUri;
         this.tokenRevokeUri = tokenRevokeUri;
@@ -55,6 +59,7 @@ public class OidcClientImpl implements OidcClient {
         this.commonRefreshGrantParams = commonRefreshGrantParams;
         this.grantType = grantType;
         this.oidcConfig = oidcClientConfig;
+        this.filters = filters;
         this.clientSecretBasicAuthScheme = OidcCommonUtils.initClientSecretBasicAuth(oidcClientConfig);
         this.clientJwtKey = OidcCommonUtils.initClientJwtKey(oidcClientConfig);
     }
@@ -159,7 +164,8 @@ public class OidcClientImpl implements OidcClient {
             }
         }
         // Retry up to three times with a one-second delay between the retries if the connection is closed
-        Uni<HttpResponse<Buffer>> response = request.sendBuffer(OidcCommonUtils.encodeForm(body))
+        Buffer buffer = OidcCommonUtils.encodeForm(body);
+        Uni<HttpResponse<Buffer>> response = filter(request, buffer).sendBuffer(buffer)
                 .onFailure(ConnectException.class)
                 .retry()
                 .atMost(oidcConfig.connectionRetryCount)
@@ -251,5 +257,12 @@ public class OidcClientImpl implements OidcClient {
         if (closed) {
             throw new IllegalStateException("OidcClient " + oidcConfig.getId().get() + " is closed");
         }
+    }
+
+    private HttpRequest<Buffer> filter(HttpRequest<Buffer> request, Buffer body) {
+        for (OidcClientRequestFilter filter : filters) {
+            filter.filter(request, body);
+        }
+        return request;
     }
 }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcClientRequestFilter.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcClientRequestFilter.java
@@ -1,0 +1,17 @@
+package io.quarkus.oidc.common;
+
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpRequest;
+
+/**
+ * Request filter which can be used to customize OIDC client requests
+ */
+public interface OidcClientRequestFilter {
+    /**
+     * Filter OIDC client requests
+     *
+     * @param request HTTP request
+     * @param body request body, will be null for HTTP GET methods, may be null for other HTTP methods
+     */
+    void filter(HttpRequest<Buffer> request, Buffer body);
+}

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -14,18 +14,23 @@ import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.crypto.SecretKey;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
 import io.quarkus.credentials.CredentialsProvider;
 import io.quarkus.credentials.runtime.CredentialsProviderFinder;
+import io.quarkus.oidc.common.OidcClientRequestFilter;
 import io.quarkus.oidc.common.runtime.OidcCommonConfig.Credentials;
 import io.quarkus.oidc.common.runtime.OidcCommonConfig.Credentials.Provider;
 import io.quarkus.oidc.common.runtime.OidcCommonConfig.Credentials.Secret;
@@ -45,6 +50,7 @@ import io.vertx.core.net.KeyStoreOptions;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.mutiny.core.MultiMap;
 import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.WebClient;
 
 public class OidcCommonUtils {
@@ -421,9 +427,14 @@ public class OidcCommonUtils {
                 || (t instanceof OidcEndpointAccessException && ((OidcEndpointAccessException) t).getErrorStatus() == 404));
     }
 
-    public static Uni<JsonObject> discoverMetadata(WebClient client, String authServerUrl, long connectionDelayInMillisecs) {
+    public static Uni<JsonObject> discoverMetadata(WebClient client, List<OidcClientRequestFilter> filters,
+            String authServerUrl, long connectionDelayInMillisecs) {
         final String discoveryUrl = authServerUrl + OidcConstants.WELL_KNOWN_CONFIGURATION;
-        return client.getAbs(discoveryUrl).send().onItem().transform(resp -> {
+        HttpRequest<Buffer> request = client.getAbs(discoveryUrl);
+        for (OidcClientRequestFilter filter : filters) {
+            filter.filter(request, null);
+        }
+        return request.send().onItem().transform(resp -> {
             if (resp.statusCode() == 200) {
                 return resp.bodyAsJsonObject();
             } else {
@@ -465,5 +476,14 @@ public class OidcCommonUtils {
             out.write(buf, 0, r);
         }
         return out.toByteArray();
+    }
+
+    public static List<OidcClientRequestFilter> getClientRequestCustomizer() {
+        ArcContainer container = Arc.container();
+        if (container != null) {
+            return container.listAll(OidcClientRequestFilter.class).stream().map(handle -> handle.get())
+                    .collect(Collectors.toList());
+        }
+        return List.of();
     }
 }

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/OidcRequestCustomizer.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/OidcRequestCustomizer.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcClientRequestFilter;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpRequest;
+
+@ApplicationScoped
+@Unremovable
+public class OidcRequestCustomizer implements OidcClientRequestFilter {
+
+    @Override
+    public void filter(HttpRequest<Buffer> request, Buffer buffer) {
+        String uri = request.uri();
+        if (uri.endsWith("/non-standard-tokens")) {
+            request.putHeader("GrantType", getGrantType(buffer.toString()));
+        }
+    }
+
+    private String getGrantType(String formString) {
+        for (String formValue : formString.split("&")) {
+            if (formValue.startsWith("grant_type=")) {
+                return formValue.substring("grant_type=".length());
+            }
+        }
+        return "";
+    }
+}

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -44,6 +44,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                                 "{\"access_token\":\"access_token_public_client\", \"expires_in\":20}")));
         server.stubFor(WireMock.post("/non-standard-tokens")
                 .withHeader("X-Custom", matching("XCustomHeaderValue"))
+                .withHeader("GrantType", matching("password"))
                 .withRequestBody(matching("grant_type=password&username=alice&password=alice&extra_param=extra_param_value"))
                 .willReturn(WireMock
                         .aResponse()

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcRequestCustomizer.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcRequestCustomizer.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.keycloak;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.common.OidcClientRequestFilter;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpRequest;
+
+@ApplicationScoped
+@Unremovable
+public class OidcRequestCustomizer implements OidcClientRequestFilter {
+
+    @Override
+    public void filter(HttpRequest<Buffer> request, Buffer buffer) {
+        HttpMethod method = request.method();
+        String uri = request.uri();
+        if (method == HttpMethod.GET && uri.endsWith("/auth/azure/jwk")) {
+            request.putHeader("Authorization", "ID token");
+        }
+    }
+
+}

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -49,6 +49,7 @@ public class BearerTokenAuthorizationTest {
     public void testAccessResourceAzure() throws Exception {
         String azureJwk = readFile("jwks.json");
         wireMockServer.stubFor(WireMock.get("/auth/azure/jwk")
+                .withHeader("Authorization", matching("ID token"))
                 .willReturn(WireMock.aResponse().withBody(azureJwk)));
         String azureToken = readFile("token.txt");
         RestAssured.given().auth().oauth2(azureToken)


### PR DESCRIPTION
Fixes #22432.

Related to #36563.

This PR adds an option to customize OIDC client requests made by either `quarkus-oidc-client` or `quarkus-oidc` extensions, where users can add new headers, bby analyzing the request `Buffer` body if necessary along the way.

Two tests have been added:
* Test that the request body can be analyzed (use case #22432)
* Test that a custom `Authorization` scheme can be added for GET (JWKS endpoint etc requests, use case #36563)