### PR TITLE
Deprecate the scala extension

### DIFF
--- a/extensions/scala/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/scala/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,7 +5,7 @@ metadata:
   - "scala"
   categories:
   - "alt-languages"
-  status: "preview"
+  status: "deprecated"
   codestart:
     name: "scala"
     kind: "core"


### PR DESCRIPTION
- https://github.com/quarkiverse/quarkus-scala3 should be preferred instead

I think it's a good idea to deprecate it before removing it.