### PR TITLE
Codestarts: Add Entity annotation to Kotlin all-open

### DIFF
--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -174,7 +174,7 @@ Thus, the `all-open` Kotlin compiler plugin allows us to configure the compiler 
 we have specified that classes annotated with `jakarta.ws.rs.Path` should not be `final`.
 
 If your application contains Kotlin classes annotated with `jakarta.enterprise.context.ApplicationScoped`
-for example, then `<option>all-open:annotation=jakarta.enterprise.context.ApplicationScoped</option>` needs to be added as well. Same goes for any class that needs to have a dynamic proxy created at runtime.
+for example, then `<option>all-open:annotation=jakarta.enterprise.context.ApplicationScoped</option>` needs to be added as well. Same goes for any class that needs to have a dynamic proxy created at runtime, like a JPA Entity class.
 
 Future versions of Quarkus will configure the Kotlin compiler plugin in a way that will make it unnecessary to alter this configuration.
 
@@ -228,6 +228,7 @@ java {
 allOpen { // <2>
     annotation("jakarta.ws.rs.Path")
     annotation("jakarta.enterprise.context.ApplicationScoped")
+    annotation("jakarta.persistence.Entity")
     annotation("io.quarkus.test.junit.QuarkusTest")
 }
 
@@ -296,6 +297,7 @@ java {
 allOpen { // <2>
     annotation("jakarta.ws.rs.Path")
     annotation("jakarta.enterprise.context.ApplicationScoped")
+    annotation("jakarta.persistence.Entity")
     annotation("io.quarkus.test.junit.QuarkusTest")
 }
 

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/kotlin/build.tpl.qute.gradle.kts
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/kotlin/build.tpl.qute.gradle.kts
@@ -12,9 +12,11 @@ allOpen {
     {#if quarkus.platform.version.startsWith("2.") or quarkus.platform.version.startsWith("1.")}
     annotation("javax.ws.rs.Path")
     annotation("javax.enterprise.context.ApplicationScoped")
+    annotation("javax.persistence.Entity")
     {#else}
     annotation("jakarta.ws.rs.Path")
     annotation("jakarta.enterprise.context.ApplicationScoped")
+    annotation("jakarta.persistence.Entity")
     {/if}
     annotation("io.quarkus.test.junit.QuarkusTest")
 }

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/kotlin/build.tpl.qute.gradle
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/kotlin/build.tpl.qute.gradle
@@ -12,9 +12,11 @@ allOpen {
     {#if quarkus.platform.version.startsWith("2.") or quarkus.platform.version.startsWith("1.")}
     annotation("javax.ws.rs.Path")
     annotation("javax.enterprise.context.ApplicationScoped")
+    annotation("javax.persistence.Entity")
     {#else}
     annotation("jakarta.ws.rs.Path")
     annotation("jakarta.enterprise.context.ApplicationScoped")
+    annotation("jakarta.persistence.Entity")
     {/if}
     annotation("io.quarkus.test.junit.QuarkusTest")
 }

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/kotlin/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/kotlin/pom.tpl.qute.xml
@@ -51,9 +51,11 @@
                         {#if quarkus.platform.version.startsWith("2.") or quarkus.platform.version.startsWith("1.")}
                         <option>all-open:annotation=javax.ws.rs.Path</option>
                         <option>all-open:annotation=javax.enterprise.context.ApplicationScoped</option>
+                        <option>all-open:annotation=javax.persistence.Entity</option>
                         {#else}
                         <option>all-open:annotation=jakarta.ws.rs.Path</option>
                         <option>all-open:annotation=jakarta.enterprise.context.ApplicationScoped</option>
+                        <option>all-open:annotation=jakarta.persistence.Entity</option>
                         {/if}
                         <option>all-open:annotation=io.quarkus.test.junit.QuarkusTest</option>
                     </pluginOptions>

--- a/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
@@ -30,6 +30,7 @@ version '1.0.0-SNAPSHOT'
 allOpen {
     annotation("jakarta.ws.rs.Path")
     annotation("jakarta.enterprise.context.ApplicationScoped")
+    annotation("jakarta.persistence.Entity")
     annotation("io.quarkus.test.junit.QuarkusTest")
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies-kotlin/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies-kotlin/build.gradle.kts
@@ -41,6 +41,7 @@ java {
 allOpen {
     annotation("jakarta.ws.rs.Path")
     annotation("jakarta.enterprise.context.ApplicationScoped")
+    annotation("jakarta.persistence.Entity")
     annotation("io.quarkus.test.junit.QuarkusTest")
 }
 

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
@@ -32,6 +32,7 @@ version '1.0.0-SNAPSHOT'
 allOpen {
     annotation("jakarta.ws.rs.Path")
     annotation("jakarta.enterprise.context.ApplicationScoped")
+    annotation("jakarta.persistence.Entity")
     annotation("io.quarkus.test.junit.QuarkusTest")
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 allOpen {
     annotation("jakarta.ws.rs.Path")
     annotation("jakarta.enterprise.context.ApplicationScoped")
+    annotation("jakarta.persistence.Entity")
     annotation("io.quarkus.test.junit.QuarkusTest")
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
@@ -31,6 +31,7 @@ version '1.0.0-SNAPSHOT'
 allOpen {
     annotation("jakarta.ws.rs.Path")
     annotation("jakarta.enterprise.context.ApplicationScoped")
+    annotation("jakarta.persistence.Entity")
     annotation("io.quarkus.test.junit.QuarkusTest")
 }
 

--- a/integration-tests/hibernate-reactive-panache-kotlin/pom.xml
+++ b/integration-tests/hibernate-reactive-panache-kotlin/pom.xml
@@ -214,6 +214,7 @@
                     </compilerPlugins>
                     <pluginOptions>
                         <option>all-open:annotation=jakarta.ws.rs.Path</option>
+                        <option>all-open:annotation=jakarta.persistence.Entity</option>
                     </pluginOptions>
                 </configuration>
             </plugin>

--- a/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/pom.xml
+++ b/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/pom.xml
@@ -95,6 +95,7 @@
                         <!-- Each annotation is placed on its own line -->
                         <option>all-open:annotation=jakarta.enterprise.context.ApplicationScoped</option>
                         <option>all-open:annotation=jakarta.ws.rs.Path</option>
+                        <option>all-open:annotation=jakarta.persistence.Entity</option>
                     </pluginOptions>
                 </configuration>
                 <dependencies>

--- a/integration-tests/kotlin/src/test/resources/projects/external-reloadable-artifacts/app/pom.xml
+++ b/integration-tests/kotlin/src/test/resources/projects/external-reloadable-artifacts/app/pom.xml
@@ -82,6 +82,7 @@
                         <!-- Each annotation is placed on its own line -->
                         <option>all-open:annotation=jakarta.enterprise.context.ApplicationScoped</option>
                         <option>all-open:annotation=jakarta.ws.rs.Path</option>
+                        <option>all-open:annotation=jakarta.persistence.Entity</option>
                     </pluginOptions>
                 </configuration>
                 <dependencies>

--- a/integration-tests/kotlin/src/test/resources/projects/kotlin-compiler-args/pom.xml
+++ b/integration-tests/kotlin/src/test/resources/projects/kotlin-compiler-args/pom.xml
@@ -109,6 +109,7 @@
                         <!-- Each annotation is placed on its own line -->
                         <option>all-open:annotation=jakarta.enterprise.context.ApplicationScoped</option>
                         <option>all-open:annotation=jakarta.ws.rs.Path</option>
+                        <option>all-open:annotation=jakarta.persistence.Entity</option>
                     </pluginOptions>
                     <args>
                         <arg>-Xemit-jvm-type-annotations</arg>

--- a/integration-tests/logging-panache-kotlin/pom.xml
+++ b/integration-tests/logging-panache-kotlin/pom.xml
@@ -112,6 +112,7 @@
                     </compilerPlugins>
                     <pluginOptions>
                         <option>all-open:annotation=jakarta.ws.rs.Path</option>
+                        <option>all-open:annotation=jakarta.persistence.Entity</option>
                     </pluginOptions>
                 </configuration>
             </plugin>

--- a/integration-tests/resteasy-reactive-kotlin/prod-mode/pom.xml
+++ b/integration-tests/resteasy-reactive-kotlin/prod-mode/pom.xml
@@ -152,6 +152,7 @@
                     <pluginOptions>
                         <option>all-open:annotation=jakarta.ws.rs.Path</option>
                         <option>all-open:annotation=jakarta.enterprise.context.ApplicationScoped</option>
+                        <option>all-open:annotation=jakarta.persistence.Entity</option>
                         <option>all-open:annotation=io.quarkus.test.junit.QuarkusTest</option>
                     </pluginOptions>
                 </configuration>

--- a/integration-tests/resteasy-reactive-kotlin/standard/pom.xml
+++ b/integration-tests/resteasy-reactive-kotlin/standard/pom.xml
@@ -240,6 +240,7 @@
                     <pluginOptions>
                         <option>all-open:annotation=jakarta.ws.rs.Path</option>
                         <option>all-open:annotation=jakarta.enterprise.context.ApplicationScoped</option>
+                        <option>all-open:annotation=jakarta.persistence.Entity</option>
                         <option>all-open:annotation=io.quarkus.test.junit.QuarkusTest</option>
                     </pluginOptions>
                 </configuration>


### PR DESCRIPTION
The kotlin allopen plugin needs to be configured for entity classes when using panache.

This is a replacement for #36584

I also submitted https://github.com/quarkusio/quarkus-quickstarts/pull/1343 because that fails with this error if not done:

```
2023-10-19 14:16:55,283 WARN  [io.qua.hib.orm.run.pro.ProxyDefinitions] (Quarkus Main Thread) Could not generate an enhanced proxy for entity 'org.acme.hibernate.orm.panache.Fruit' (class='org.acme.hibernate.orm.panache.Fruit') as it's final. Your application might perform better if we're allowed to extend it.
2023-10-19 14:16:55,742 WARN  [org.hib.met.int.EntityRepresentationStrategyPojoStandard] (JPA Startup Thread) HHH000305: Could not create proxy factory for:org.acme.hibernate.orm.panache.Fruit: org.hibernate.HibernateException: Getter methods of lazy classes cannot be final: org.acme.hibernate.orm.panache.Fruit#getName
	at org.hibernate.proxy.pojo.ProxyFactoryHelper.validateGetterSetterMethodProxyability(ProxyFactoryHelper.java:80)
	at org.hibernate.metamodel.internal.EntityRepresentationStrategyPojoStandard.createProxyFactory(EntityRepresentationStrategyPojoStandard.java:229)
	at org.hibernate.metamodel.internal.EntityRepresentationStrategyPojoStandard.<init>(EntityRepresentationStrategyPojoStandard.java:147)
	at org.hibernate.metamodel.internal.ManagedTypeRepresentationResolverStandard.resolveStrategy(ManagedTypeRepresentationResolverStandard.java:62)
	at org.hibernate.persister.entity.AbstractEntityPersister.<init>(AbstractEntityPersister.java:510)
	at org.hibernate.persister.entity.SingleTableEntityPersister.<init>(SingleTableEntityPersister.java:140)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at org.hibernate.persister.internal.PersisterFactoryImpl.createEntityPersister(PersisterFactoryImpl.java:92)
	at org.hibernate.persister.internal.PersisterFactoryImpl.createEntityPersister(PersisterFactoryImpl.java:75)
	at org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl.processBootEntities(MappingMetamodelImpl.java:247)
	at org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl.finishInitialization(MappingMetamodelImpl.java:185)
	at org.hibernate.internal.SessionFactoryImpl.initializeMappingModel(SessionFactoryImpl.java:321)
	at org.hibernate.internal.SessionFactoryImpl.<init>(SessionFactoryImpl.java:271)
	at io.quarkus.hibernate.orm.runtime.boot.FastBootEntityManagerFactoryBuilder.build(FastBootEntityManagerFactoryBuilder.java:84)
	at io.quarkus.hibernate.orm.runtime.FastBootHibernatePersistenceProvider.createEntityManagerFactory(FastBootHibernatePersistenceProvider.java:74)
	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:80)
	at jakarta.persistence.Persistence.createEntityManagerFactory(Persistence.java:55)
	at io.quarkus.hibernate.orm.runtime.JPAConfig$LazyPersistenceUnit.get(JPAConfig.java:156)
	at io.quarkus.hibernate.orm.runtime.JPAConfig$1.run(JPAConfig.java:64)
	at java.base/java.lang.Thread.run(Thread.java:833)
```