### PR TITLE
Revert "Bump io.strimzi:kafka-oauth-client from 0.12.0 to 0.14.0"

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -218,7 +218,7 @@
         <jansi.version>2.4.0</jansi.version> <!-- Keep in sync with aesh-readline and dekorate -->
         <jgit.version>6.6.1.202309021850-r</jgit.version>
         <!-- these two artifacts needs to be compatible together -->
-        <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.12.0</strimzi-oauth.version>
         <strimzi-oauth.nimbus.version>9.34</strimzi-oauth.nimbus.version>
         <java-buildpack-client.version>0.0.6</java-buildpack-client.version>
         <org-crac.version>0.1.3</org-crac.version>


### PR DESCRIPTION
This reverts commit 09a13e64a50f07daac648b0cab5b51b8ee876f30.

Fixes #36653