### PR TITLE
 Fix quarkus update regression on extensions

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ProjectInfoCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ProjectInfoCommandHandler.java
@@ -123,7 +123,7 @@ public class ProjectInfoCommandHandler implements QuarkusCommandHandler {
 
         if (projectState.getExtensions().isEmpty()) {
             log.info("");
-            log.info("No Quarkus extensions found among the project dependencies");
+            log.info("No Quarkus extensions were found among the project dependencies");
             return recommendationsAvailable;
         }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateProjectCommandHandler.java
@@ -156,7 +156,7 @@ public class UpdateProjectCommandHandler implements QuarkusCommandHandler {
             return;
         }
         if (currentState.getExtensions().isEmpty()) {
-            log.info("Quarkus extension were not found among the project dependencies");
+            log.info("No Quarkus extensions were found among the project dependencies");
             return;
         }
         if (currentState == recommendedState) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ProjectUpdateInfos.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/ProjectUpdateInfos.java
@@ -86,12 +86,6 @@ public final class ProjectUpdateInfos {
         if (currentState.getPlatformBoms().isEmpty()) {
             throw new IllegalStateException("The project does not import any Quarkus platform BOM");
         }
-        if (currentState.getExtensions().isEmpty()) {
-            throw new IllegalStateException("Quarkus extension were not found among the project dependencies");
-        }
-        if (currentState == recommendedState) {
-            throw new IllegalStateException("The project is up-to-date");
-        }
     }
 
     public static ProjectState resolveRecommendedState(ProjectState currentState, ExtensionCatalog recommendedCatalog,


### PR DESCRIPTION
This commit https://github.com/quarkusio/quarkus/commit/e9006c1f767abcb760c90574254c6175b0f1b070, changed the logic when running update to allow having the update info as a data structure. 

The checks added when building the structure were the same as when logging the info to update which is a bit too restrictive as it prevented from updating extensions.