### PR TITLE
Vert.x: fix NPE in ForwardedProxyHandler

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedProxyHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedProxyHandler.java
@@ -79,7 +79,7 @@ public class ForwardedProxyHandler implements Handler<HttpServerRequest> {
                     new Handler<AsyncResult<String>>() {
                         @Override
                         public void handle(AsyncResult<String> stringAsyncResult) {
-                            if (stringAsyncResult.succeeded()) {
+                            if (stringAsyncResult.succeeded() && stringAsyncResult.result() != null) {
                                 var trustedIP = Inet.parseInetAddress(stringAsyncResult.result());
                                 if (trustedIP != null) {
                                     // create proxy check for resolved IP and proceed with the lookup


### PR DESCRIPTION
The test `TrustedXForwarderProxiesUnknownHostnameFailureTest` sometimes fail in CI due to a NPE in `ForwardedProxyHandler`. This shows an actual bug: per the documentation, `io.vertx.core.dns.DnsClient.lookup()` may succeed with a `null` value when no record was found. The `ForwardedProxyHandler` ignores the possibility of a `null` result, which this commit fixes. We deal with a `null` result just like with a failure, because it's equivalent to a NXDOMAIN error.

Fixes #36656