### PR TITLE
Arc - change hashing function to use base64 to shorten resulting String

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -200,7 +200,7 @@ public class BeanGenerator extends AbstractGenerator {
         }
 
         String baseName = declaringClassBase + PRODUCER_METHOD_SUFFIX + UNDERSCORE + producerMethod.name() + UNDERSCORE
-                + Hashes.sha1(sigBuilder.toString());
+                + Hashes.sha1_base64(sigBuilder.toString());
         this.beanToGeneratedBaseName.put(bean, baseName);
         String targetPackage = DotNames.packageName(declaringClass.name());
         String generatedName = generatedNameFromTarget(targetPackage, baseName, BEAN_SUFFIX);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -141,7 +141,7 @@ public class BeanInfo implements InjectionTargetInfo {
         this.removable = isRemovable;
         this.params = params;
         // Identifier must be unique for a specific deployment
-        this.identifier = Hashes.sha1((identifier != null ? identifier : "") + toString() + beanDeployment.toString());
+        this.identifier = Hashes.sha1_base64((identifier != null ? identifier : "") + toString() + beanDeployment.toString());
         this.interceptedMethods = Collections.emptyMap();
         this.decoratedMethods = Collections.emptyMap();
         this.lifecycleInterceptors = Collections.emptyMap();

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Hashes.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Hashes.java
@@ -3,21 +3,29 @@ package io.quarkus.arc.processor;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 
 final class Hashes {
 
-    static String sha1(String value) {
+    /**
+     * A hashing function that uses {@link MessageDigest} and {@link Base64} to encode a {@link String} input.
+     * Arc doesn't need SHA-1, we just need a deterministic and unique String that's as short as possible because
+     * resulting String values are used as keys and for equals checks.
+     * <p>
+     * We deliberately use Base64 URL variant, which in addition to A-Za-z0-9 uses the - and _ chars.
+     * We also disable padding, so there's no =.
+     * This is important, because the generated strings are also used as identifiers in class files.
+     *
+     * @param value String for encoding
+     * @return Unique and deterministic String identifier, encoded with Base64 URL encoder
+     */
+    static String sha1_base64(String value) {
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-1");
             byte[] digest = md.digest(value.getBytes(StandardCharsets.UTF_8));
-            StringBuilder sb = new StringBuilder(40);
-            for (int i = 0; i < digest.length; ++i) {
-                sb.append(Integer.toHexString((digest[i] & 0xFF) | 0x100).substring(1, 3));
-            }
-            return sb.toString();
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(e);
         }
     }
-
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -139,7 +139,7 @@ public class ObserverGenerator extends AbstractGenerator {
         } else {
             baseNameBuilder.append(observer.getObserverMethod().name());
         }
-        baseNameBuilder.append(UNDERSCORE).append(Hashes.sha1(sigBuilder.toString()));
+        baseNameBuilder.append(UNDERSCORE).append(Hashes.sha1_base64(sigBuilder.toString()));
         String baseName = baseNameBuilder.toString();
         this.observerToGeneratedBaseName.put(observer, baseName);
 

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/HashTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/HashTest.java
@@ -1,0 +1,17 @@
+package io.quarkus.arc.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class HashTest {
+
+    @Test
+    public void testDeterministicHashing() {
+        // a simple test to verify that repeatedly creating hash from the same String is deterministic
+        String someString = "test123FooBar";
+        String hash1 = Hashes.sha1_base64(someString);
+        String hash2 = Hashes.sha1_base64(someString);
+        assertEquals(hash1, hash2);
+    }
+}


### PR DESCRIPTION
This is a follow up on a recent discussion we had with @mkouba and @Ladicek.

Arc doesn't need exactly SHA-1, we just need a deterministic and unique string identifier.
These identifiers are used as keys or for equals checks throughout the codebase, so the shorter the better.
Replacing current SHA-1 + hex string with base64 shortens the string length from 40 symbols to 27.

Note that Arc used to use Base64 until it was changed in a PR by @gsmet that centralized these - https://github.com/quarkusio/quarkus/pull/929
But there isn't much information on why that was needed especially given that Arc doesn't need actual SHA1 and Quarkus core has SHA 256 and 512 these days anyway.

I am not sure if we should mark this as breaking change as that should only matter if someone tried to build app on older Quarkus version and then execute on version including this change.