### PR TITLE
Disable MySQL OIDC DB token manager test due to limited Github CI resources

### DIFF
--- a/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/MySqlDbTokenStateManagerTest.java
+++ b/extensions/oidc-db-token-state-manager/deployment/src/test/java/io/quarkus/oidc/db/token/state/manager/MySqlDbTokenStateManagerTest.java
@@ -1,9 +1,12 @@
 package io.quarkus.oidc.db.token.state.manager;
 
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 
+// Becomes flaky in Github CI due to limited resources
+@EnabledIfSystemProperty(named = "run-mysql-db-token-state-manager-test", disabledReason = "Insufficient GH CI resources", matches = "true")
 public class MySqlDbTokenStateManagerTest extends AbstractDbTokenStateManagerTest {
 
     @RegisterExtension


### PR DESCRIPTION
This test unfortunately keeps failing, but we still have a few other DB tests in `deployment` plus an Oracle DB integration test