### PR TITLE
Add `use layer 7 proxy` for reactive pg client

### DIFF
--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/DataSourceReactivePostgreSQLConfig.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/DataSourceReactivePostgreSQLConfig.java
@@ -5,6 +5,7 @@ import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
 import io.vertx.pgclient.SslMode;
 
 @ConfigGroup
@@ -23,4 +24,13 @@ public interface DataSourceReactivePostgreSQLConfig {
      */
     @ConfigDocDefault("disable")
     Optional<SslMode> sslMode();
+
+    /**
+     * Level 7 proxies can load balance queries on several connections to the actual database.
+     * When it happens, the client can be confused by the lack of session affinity and unwanted errors can happen like
+     * ERROR: unnamed prepared statement does not exist (26000).
+     * See <a href="https://vertx.io/docs/vertx-pg-client/java/#_using_a_level_7_proxy">Using a level 7 proxy</a>
+     */
+    @WithDefault("false")
+    boolean useLayer7Proxy();
 }

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
@@ -207,6 +207,8 @@ public class PgPoolRecorder {
                 }
             }
 
+            pgConnectOptions.setUseLayer7Proxy(dataSourceReactivePostgreSQLConfig.useLayer7Proxy());
+
             pgConnectOptions.setTrustAll(dataSourceReactiveRuntimeConfig.trustAll());
 
             configurePemTrustOptions(pgConnectOptions, dataSourceReactiveRuntimeConfig.trustCertificatePem());


### PR DESCRIPTION
This enables configuration of the new `setUseLayer7Proxy` value provided by Vert.x.

> Level 7 proxies can load balance queries on several connections to the actual database. When it happens, the client can be confused by the lack of session affinity and unwanted errors can happen like ERROR: unnamed prepared statement does not exist (26000).

See more information in [Using a level 7 Proxy](https://vertx.io/docs/vertx-pg-client/java/#_using_a_level_7_proxy)