### PR TITLE
Remove type from ResolverMapKey

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/ClientJacksonMessageBodyReader.java
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/ClientJacksonMessageBodyReader.java
@@ -33,7 +33,6 @@ public class ClientJacksonMessageBodyReader extends JacksonBasicMessageBodyReade
 
     private static final Logger log = Logger.getLogger(ClientJacksonMessageBodyReader.class);
 
-    private final ConcurrentMap<ResolverMapKey, ObjectMapper> contextResolverMap = new ConcurrentHashMap<>();
     private final ConcurrentMap<ObjectMapper, ObjectReader> objectReaderMap = new ConcurrentHashMap<>();
     private RestClientRequestContext context;
 
@@ -49,7 +48,7 @@ public class ClientJacksonMessageBodyReader extends JacksonBasicMessageBodyReade
             if (entityStream instanceof EmptyInputStream) {
                 return null;
             }
-            ObjectReader reader = getEffectiveReader(type, mediaType);
+            ObjectReader reader = getEffectiveReader(mediaType);
             return reader.forType(reader.getTypeFactory().constructType(genericType != null ? genericType : type))
                     .readValue(entityStream);
 
@@ -66,8 +65,8 @@ public class ClientJacksonMessageBodyReader extends JacksonBasicMessageBodyReade
         this.context = requestContext;
     }
 
-    private ObjectReader getEffectiveReader(Class<Object> type, MediaType responseMediaType) {
-        ObjectMapper effectiveMapper = getObjectMapperFromContext(type, responseMediaType, context, contextResolverMap);
+    private ObjectReader getEffectiveReader(MediaType responseMediaType) {
+        ObjectMapper effectiveMapper = getObjectMapperFromContext(responseMediaType, context);
         if (effectiveMapper == null) {
             return getEffectiveReader();
         }

--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/ClientJacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/ClientJacksonMessageBodyWriter.java
@@ -28,7 +28,6 @@ public class ClientJacksonMessageBodyWriter implements MessageBodyWriter<Object>
 
     protected final ObjectMapper originalMapper;
     protected final ObjectWriter defaultWriter;
-    private final ConcurrentMap<ResolverMapKey, ObjectMapper> contextResolverMap = new ConcurrentHashMap<>();
     private final ConcurrentMap<ObjectMapper, ObjectWriter> objectWriterMap = new ConcurrentHashMap<>();
     private RestClientRequestContext context;
 
@@ -46,7 +45,7 @@ public class ClientJacksonMessageBodyWriter implements MessageBodyWriter<Object>
     @Override
     public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
-        doLegacyWrite(o, annotations, httpHeaders, entityStream, getEffectiveWriter(type, mediaType));
+        doLegacyWrite(o, annotations, httpHeaders, entityStream, getEffectiveWriter(mediaType));
     }
 
     @Override
@@ -54,8 +53,8 @@ public class ClientJacksonMessageBodyWriter implements MessageBodyWriter<Object>
         this.context = requestContext;
     }
 
-    protected ObjectWriter getEffectiveWriter(Class<?> type, MediaType responseMediaType) {
-        ObjectMapper objectMapper = getObjectMapperFromContext(type, responseMediaType, context, contextResolverMap);
+    protected ObjectWriter getEffectiveWriter(MediaType responseMediaType) {
+        ObjectMapper objectMapper = getObjectMapperFromContext(responseMediaType, context);
         if (objectMapper == null) {
             return defaultWriter;
         }

--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/JacksonUtil.java
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/JacksonUtil.java
@@ -1,5 +1,6 @@
 package io.quarkus.rest.client.reactive.jackson.runtime.serialisers;
 
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
@@ -13,11 +14,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 final class JacksonUtil {
 
+    private static final ConcurrentMap<ResolverMapKey, ObjectMapper> contextResolverMap = new ConcurrentHashMap<>();
+
     private JacksonUtil() {
     }
 
-    static ObjectMapper getObjectMapperFromContext(Class<?> type, MediaType responseMediaType, RestClientRequestContext context,
-            ConcurrentMap<ResolverMapKey, ObjectMapper> contextResolverMap) {
+    static ObjectMapper getObjectMapperFromContext(MediaType responseMediaType, RestClientRequestContext context) {
         Providers providers = getProviders(context);
         if (providers == null) {
             return null;

--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/JacksonUtil.java
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/JacksonUtil.java
@@ -31,11 +31,11 @@ final class JacksonUtil {
         }
         if (contextResolver != null) {
             var cr = contextResolver;
-            var key = new ResolverMapKey(type, context.getConfiguration(), context.getInvokedMethod().getDeclaringClass());
+            var key = new ResolverMapKey(context.getConfiguration(), context.getInvokedMethod().getDeclaringClass());
             return contextResolverMap.computeIfAbsent(key, new Function<>() {
                 @Override
                 public ObjectMapper apply(ResolverMapKey resolverMapKey) {
-                    return cr.getContext(resolverMapKey.getType());
+                    return cr.getContext(resolverMapKey.getRestClientClass());
                 }
             });
         }

--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/ResolverMapKey.java
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/ResolverMapKey.java
@@ -10,19 +10,12 @@ import jakarta.ws.rs.core.Configuration;
  */
 public final class ResolverMapKey {
 
-    private final Class<?> type;
     private final Configuration configuration;
-
     private final Class<?> restClientClass;
 
-    public ResolverMapKey(Class<?> type, Configuration configuration, Class<?> restClientClass) {
-        this.type = type;
+    public ResolverMapKey(Configuration configuration, Class<?> restClientClass) {
         this.configuration = configuration;
         this.restClientClass = restClientClass;
-    }
-
-    public Class<?> getType() {
-        return type;
     }
 
     public Configuration getConfiguration() {
@@ -42,12 +35,12 @@ public final class ResolverMapKey {
             return false;
         }
         ResolverMapKey that = (ResolverMapKey) o;
-        return Objects.equals(type, that.type) && Objects.equals(configuration, that.configuration)
+        return Objects.equals(configuration, that.configuration)
                 && Objects.equals(restClientClass, that.restClientClass);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, configuration, restClientClass);
+        return Objects.hash(configuration, restClientClass);
     }
 }


### PR DESCRIPTION
This is an attempt to fix https://github.com/quarkusio/quarkus/issues/36067. The reproducer can still reproduce the issue by using different "types". Since the object mapper is per restclient, it should apply to any types used within it. The types should I believe not be checked.
With this attempt, the reproducer goes from 7 invocations to 2. I would appreciate help on finding out why it is still called twice.

reproducer: https://github.com/manofthepeace/quarkus-restclient-annotations-issue

Note: the type parameter is passed in a method chain that could potentially be cleaned up is this is the right approach, which I am not sure.

cc @geoand 

many thanks,
Alex