### PR TITLE
Update OpenSearch container test configuration

### DIFF
--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -268,7 +268,11 @@ public class DevServicesElasticsearchProcessor {
 
         container.addEnv("bootstrap.memory_lock", "true");
         container.addEnv("plugins.index_state_management.enabled", "false");
-
+        // Disable disk-based shard allocation thresholds: on large, relatively full disks (>90% used),
+        // it will lead to index creation to get stuck waiting for other nodes to join the cluster,
+        // which will never happen since we only have one node.
+        // See https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/
+        container.addEnv("cluster.routing.allocation.disk.threshold_enabled", "false");
         container.addEnv("OPENSEARCH_JAVA_OPTS", config.javaOpts);
         return container;
     }

--- a/integration-tests/hibernate-search-orm-opensearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-opensearch/pom.xml
@@ -189,6 +189,13 @@
                                                  See https://opensearch.org/docs/latest/im-plugin/ism/settings/
                                              -->
                                             <plugins.index_state_management.enabled>false</plugins.index_state_management.enabled>
+                                            <OPENSEARCH_JAVA_OPTS>-Xms512m -Xmx512m</OPENSEARCH_JAVA_OPTS>
+                                            <!-- Disable disk-based shard allocation thresholds: on large, relatively full disks (>90% used),
+                                                 it will lead to index creation to get stuck waiting for other nodes to join the cluster,
+                                                 which will never happen since we only have one node.
+                                                 See https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/
+                                             -->
+                                            <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>


### PR DESCRIPTION
- Limit OpenSearch memory usage
- Disable disk-based shard allocation thresholds