### PR TITLE
Add error message to quarkus-resteasy-reactive-links and improve documentation

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -1636,7 +1636,34 @@ To enable Web Links support, add the `quarkus-resteasy-reactive-links` extension
 
 |===
 
-Importing this module will allow injecting web links into the response HTTP headers by just annotating your endpoint resources with the `@InjectRestLinks` annotation. To declare the web links that will be returned, you need to use the `@RestLink` annotation in the linked methods. An example of this could look like:
+Importing this module will allow injecting web links into the response HTTP headers by just annotating your endpoint resources with the `@InjectRestLinks` annotation. To declare the web links that will be returned, you must use the `@RestLink` annotation in the linked methods.
+Assuming a `Record` looks like:
+
+[source,java]
+----
+public class Record {
+
+    // the class must contain/inherit either and `id` field or an `@Id` annotated field
+    private int id;
+
+    public Record() {
+    }
+
+    protected Record(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}
+----
+
+An example of enabling Web Links support would look like:
 
 [source,java]
 ----
@@ -1654,7 +1681,7 @@ public class RecordsResource {
     @Path("/{id}")
     @RestLink(rel = "self")
     @InjectRestLinks(RestLinkType.INSTANCE)
-    public TestRecord get(@PathParam("id") int id) {
+    public Record get(@PathParam("id") int id) {
         // ...
     }
 
@@ -1662,14 +1689,14 @@ public class RecordsResource {
     @Path("/{id}")
     @RestLink
     @InjectRestLinks(RestLinkType.INSTANCE)
-    public TestRecord update(@PathParam("id") int id) {
+    public Record update(@PathParam("id") int id) {
         // ...
     }
 
     @DELETE
     @Path("/{id}")
     @RestLink
-    public TestRecord delete(@PathParam("id") int id) {
+    public Record delete(@PathParam("id") int id) {
         // ...
     }
 }
@@ -1771,7 +1798,7 @@ public class RecordsResource {
     @Path("/{id}")
     @RestLink(rel = "self")
     @InjectRestLinks(RestLinkType.INSTANCE)
-    public TestRecord get(@PathParam("id") int id) {
+    public Record get(@PathParam("id") int id) {
         // ...
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/AbstractEntity.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/AbstractEntity.java
@@ -1,8 +1,6 @@
 package io.quarkus.resteasy.reactive.links.deployment;
 
-public abstract class AbstractEntity {
-
-    private int id;
+public abstract class AbstractEntity extends AbstractId {
 
     private String slug;
 
@@ -10,16 +8,8 @@ public abstract class AbstractEntity {
     }
 
     protected AbstractEntity(int id, String slug) {
-        this.id = id;
+        super(id);
         this.slug = slug;
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
     }
 
     public String getSlug() {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/AbstractId.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/AbstractId.java
@@ -1,0 +1,21 @@
+package io.quarkus.resteasy.reactive.links.deployment;
+
+public abstract class AbstractId {
+
+    private int id;
+
+    public AbstractId() {
+    }
+
+    protected AbstractId(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/HalLinksWithJacksonTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/HalLinksWithJacksonTest.java
@@ -12,7 +12,7 @@ public class HalLinksWithJacksonTest extends AbstractHalLinksTest {
     @RegisterExtension
     static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(AbstractEntity.class, TestRecord.class, TestResource.class))
+                    .addClasses(AbstractId.class, AbstractEntity.class, TestRecord.class, TestResource.class))
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-resteasy-reactive-jackson", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-hal", Version.getVersion())))

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/HalLinksWithJsonbTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/HalLinksWithJsonbTest.java
@@ -12,7 +12,7 @@ public class HalLinksWithJsonbTest extends AbstractHalLinksTest {
     @RegisterExtension
     static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(AbstractEntity.class, TestRecord.class, TestResource.class))
+                    .addClasses(AbstractId.class, AbstractEntity.class, TestRecord.class, TestResource.class))
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-resteasy-reactive-jsonb", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-hal", Version.getVersion())))

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/RestLinksInjectionTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/RestLinksInjectionTest.java
@@ -19,7 +19,7 @@ public class RestLinksInjectionTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(AbstractEntity.class, TestRecord.class, TestResource.class));
+                    .addClasses(AbstractId.class, AbstractEntity.class, TestRecord.class, TestResource.class));
 
     @TestHTTPResource("records")
     String recordsUrl;

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/RestLinksWithFailureInjectionTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/RestLinksWithFailureInjectionTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.resteasy.reactive.links.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RestLinksWithFailureInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(TestRecordNoId.class, TestResourceNoId.class)).assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                assertThat(rootCause).isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("Cannot generate web links for the class " +
+                                "io.quarkus.resteasy.reactive.links.deployment.TestRecordNoId because is either " +
+                                "missing an `id` field or a field with an `@Id` annotation");
+            });
+
+    @Test
+    void validationFailed() {
+        // Should not be reached: verify
+        assertTrue(false);
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/TestRecordNoId.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/TestRecordNoId.java
@@ -1,0 +1,21 @@
+package io.quarkus.resteasy.reactive.links.deployment;
+
+public class TestRecordNoId {
+
+    private String name;
+
+    public TestRecordNoId() {
+    }
+
+    public TestRecordNoId(String value) {
+        this.name = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/TestResourceNoId.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/TestResourceNoId.java
@@ -1,0 +1,44 @@
+package io.quarkus.resteasy.reactive.links.deployment;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.common.util.RestMediaType;
+
+import io.quarkus.resteasy.reactive.links.InjectRestLinks;
+import io.quarkus.resteasy.reactive.links.RestLink;
+import io.quarkus.resteasy.reactive.links.RestLinkType;
+import io.smallrye.mutiny.Uni;
+
+@Path("/recordsNoId")
+@Produces({ MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_HAL_JSON })
+public class TestResourceNoId {
+
+    private static final List<TestRecordNoId> RECORDS = new LinkedList<>(Arrays.asList(
+            new TestRecordNoId("first_value"),
+            new TestRecordNoId("second_value")));
+
+    @GET
+
+    @RestLink(entityType = TestRecordNoId.class)
+    @InjectRestLinks
+    public Uni<List<TestRecordNoId>> getAll() {
+        return Uni.createFrom().item(RECORDS).onItem().delayIt().by(Duration.ofMillis(100));
+    }
+
+    @GET
+    @Path("/by-name/{name}")
+    @RestLink(entityType = TestRecordNoId.class)
+    @InjectRestLinks(RestLinkType.INSTANCE)
+    public TestRecordNoId getByNothing(@PathParam("name") String name) {
+        return RECORDS.stream()
+                .filter(record -> record.getName().equals(name))
+                .findFirst()
+                .orElseThrow(NotFoundException::new);
+    }
+}


### PR DESCRIPTION
This PR was triggered by the issue #36463

Goal is to clarify the error message the user gets when the class returned by the endpoint does not have and `id` field and also the documentation about [web links](https://quarkus.io/guides/resteasy-reactive#web-links-support)