### PR TITLE
Manage Jose4j dependency in the bom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -181,6 +181,7 @@ updates:
       - dependency-name: org.apache.groovy:*
       - dependency-name: org.apache.qpid:*
       - dependency-name: biz.paluch.logging:logstash-gelf
+      - dependency-name: org.bitbucket.b_c:jose4j
     ignore:
       # this one cannot be upgraded due to the usage of proxies in new versions
       # the proxy implements interfaces in a random order which causes issues

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -219,6 +219,7 @@
         <!-- these two artifacts needs to be compatible together -->
         <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
         <strimzi-oauth.nimbus.version>9.37.3</strimzi-oauth.nimbus.version>
+        <jose4j.version>0.9.6</jose4j.version>
         <java-buildpack-client.version>0.0.6</java-buildpack-client.version>
         <org-crac.version>0.1.3</org-crac.version>
         <sshd-common.version>2.12.0</sshd-common.version>
@@ -4248,6 +4249,11 @@
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>${strimzi-oauth.nimbus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bitbucket.b_c</groupId>
+                <artifactId>jose4j</artifactId>
+                <version>${jose4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
It will be easier to deal with some Jose4j issues whenever they occur, without having to depend on smallrye-jwt bringing an up to date version - as smallrye-jwt updates may not be always backportable