### PR TITLE
Allow using a random test port within Google Cloud Function tests

### DIFF
--- a/docs/src/main/asciidoc/funqy-gcp-functions.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions.adoc
@@ -385,6 +385,8 @@ To use it, you must add the following test dependency in your `pom.xml`.
 This extension provides a `@WithFunction` annotation that can be used to annotate `@QuarkusTest` test cases to start a Cloud Function invoker before you test cases and stop it at the end.
 This annotation must be configured with the type of the function you want to launch, and optionally the name of the function in case you have multiple functions inside your application.
 
+The default Quarkus test port configuration (`quarkus.http.test-port`) will be honored and if you set it to 0 a random port will be assigned to the function invoker.
+
 === Background Functions - PubSub
 
 [source,java]

--- a/docs/src/main/asciidoc/gcp-functions.adoc
+++ b/docs/src/main/asciidoc/gcp-functions.adoc
@@ -490,6 +490,8 @@ To use it, you must add the following test dependency in your `pom.xml`.
 This extension provides a `@WithFunction` annotation that can be used to annotate `@QuarkusTest` test cases to start a Cloud Function invoker before you test cases and stop it at the end.
 This annotation must be configured with the type of the function you want to launch, and optionally the name of the function in case you have multiple functions inside your application.
 
+The default Quarkus test port configuration (`quarkus.http.test-port`) will be honored and if you set it to 0 a random port will be assigned to the function invoker.
+
 === The HttpFunction
 
 [source,java]

--- a/integration-tests/google-cloud-functions/src/test/java/io/quarkus/gcp/function/test/HttpFunctionRandomPortTestCase.java
+++ b/integration-tests/google-cloud-functions/src/test/java/io/quarkus/gcp/function/test/HttpFunctionRandomPortTestCase.java
@@ -1,0 +1,31 @@
+package io.quarkus.gcp.function.test;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.google.cloud.functions.test.FunctionType;
+import io.quarkus.google.cloud.functions.test.WithFunction;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@WithFunction(FunctionType.HTTP)
+class HttpFunctionRandomPortTestCase {
+
+    @BeforeAll
+    public static void setup() {
+        System.setProperty("quarkus.http.test-port", "0");
+    }
+
+    @Test
+    public void test() {
+        // test the function using RestAssured
+        when()
+                .get()
+                .then()
+                .statusCode(200)
+                .body(is("Hello World!"));
+    }
+}

--- a/test-framework/google-cloud-functions/src/main/java/io/quarkus/google/cloud/functions/test/CloudFunctionsInvoker.java
+++ b/test-framework/google-cloud-functions/src/main/java/io/quarkus/google/cloud/functions/test/CloudFunctionsInvoker.java
@@ -11,8 +11,12 @@ class CloudFunctionsInvoker {
     }
 
     CloudFunctionsInvoker(FunctionType functionType, int port) {
+        int realPort = port == 0 ? SocketUtil.findAvailablePort() : port;
+        if (realPort != port) {
+            System.setProperty("quarkus.http.test-port", String.valueOf(realPort));
+        }
         this.invoker = new Invoker(
-                port,
+                realPort,
                 functionType.getTarget(),
                 functionType.getSignatureType(),
                 Thread.currentThread().getContextClassLoader());

--- a/test-framework/google-cloud-functions/src/main/java/io/quarkus/google/cloud/functions/test/SocketUtil.java
+++ b/test-framework/google-cloud-functions/src/main/java/io/quarkus/google/cloud/functions/test/SocketUtil.java
@@ -1,0 +1,29 @@
+package io.quarkus.google.cloud.functions.test;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+// copied from the mailer extension: io.quarkus.mailer.runtime.SocketUtil
+final class SocketUtil {
+
+    private SocketUtil() {
+    }
+
+    static int findAvailablePort() {
+        ServerSocket serverSocket = null;
+        try {
+            serverSocket = new ServerSocket(0);
+            return serverSocket.getLocalPort();
+        } catch (Exception e) {
+            // return a default port
+            return 25347;
+        } finally {
+            if (serverSocket != null) {
+                try {
+                    serverSocket.close();
+                } catch (IOException e) {
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #35476

I duplicated a `SocketUtil` class from the mailer extension, it may be a good idea to copy it to the `quarkus-test-common` module and share it between this extension and the mailer extension.