### PR TITLE
Update quarkus-scheduler startMode documentation

### DIFF
--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerRuntimeConfig.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerRuntimeConfig.java
@@ -38,17 +38,15 @@ public class SchedulerRuntimeConfig {
         NORMAL,
 
         /**
-         * The scheduler will be started even if no scheduled business methods are found.
-         * <p>
-         * This is necessary for "pure" programmatic scheduling.
+         * The scheduler will be started even if no scheduled business methods are found. This is necessary for "pure"
+         * programmatic scheduling.
          */
         FORCED,
 
         /**
          * Just like the {@link #FORCED} mode but the scheduler will not start triggering jobs until {@link Scheduler#resume()}
-         * is called.
-         * <p>
-         * This can be useful to run some initialization logic that needs to be performed before the scheduler starts.
+         * is called. This can be useful to run some initialization logic that needs to be performed before the scheduler
+         * starts.
          */
         HALTED;
     }


### PR DESCRIPTION
* removed the paragraph tags from the enum javadoc because they don't translate well into asciidoc and subsequently HTML tooltips
* potential fix for https://github.com/quarkusio/quarkus/issues/36401 
 
Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>