### PR TITLE
Remove unsupported Jakarta Persistence Security extension guides from downstream YAML file

### DIFF
--- a/docs/downstreamdoc.yaml
+++ b/docs/downstreamdoc.yaml
@@ -6,9 +6,7 @@ guides:
   - src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
   - src/main/asciidoc/security-basic-authentication.adoc
   - src/main/asciidoc/security-basic-authentication-howto.adoc
-  - src/main/asciidoc/security-basic-authentication-tutorial.adoc
   - src/main/asciidoc/security-identity-providers.adoc
-  - src/main/asciidoc/security-jpa.adoc
   - src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
   - src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
   - src/main/asciidoc/security-oidc-code-flow-authentication.adoc


### PR DESCRIPTION
The RHBQ 3.2 release does not support the Quarkus Security Jakarta Persistence extension and we have been requested by CCS management and Product Management to not publish content and guidance about an unsupported feature.

This PR updates the 3.2 version of the downstream doc import list yaml file in the upstream community to remove the unrequired unsupported content so that our downstream import script does not automatically add the content downstream, which is the case today.

Specifically removes the following 3.2 guides from the downstream doc list:
 
src/main/asciidoc/security-basic-authentication-tutorial.adoc
src/main/asciidoc/security-jpa.adoc

@gsmet / @gastaldi / @maxandersen - 

Please note, I deliberately targeted the 3.2  branch instead of `main` because the version of this file on `main` has diverged significantly. Several files have been renamed/restructured requiring a massive backport, most of which seems to be currently outside the scope of the 3.2 docs both upstream and downstream. Thanks.