### PR TITLE
Exclude resteasy-client from lra-proxy-api in narayana-lra extension

### DIFF
--- a/extensions/narayana-lra/runtime/pom.xml
+++ b/extensions/narayana-lra/runtime/pom.xml
@@ -36,6 +36,12 @@
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>lra-proxy-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>


### PR DESCRIPTION
As originally reported in https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/LRA.20with.20reactive.20REST.20extensions.2E, narayana-lra extension is not usable with reactive REST and REST client extensions. This fixes the transitive bringing of classic resteasy-client from Narayana.