### PR TITLE
Add note that endpointdisabled does not work native

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -2982,6 +2982,10 @@ public class RuntimeResource {
      }
 }
 ----
+[IMPORTANT]
+====
+This feature does not work when using native build.
+====
 
 
 == RESTEasy Reactive client


### PR DESCRIPTION
relates to https://github.com/quarkusio/quarkus/issues/34738.

Ultimately it does not seem to wotk native both ways (enabled -->disabled, disabled-->enabled). Reproducer in the issue still valid (tried with latest quarkus as well).

I have spend few hours trying to debug and fix but got nowhere.

Additional note from what I've seen.  I have added logs in `ResteasyReactiveRecorder::disableIfPropertyMatches` is never called at runtime when using native build. This is used with `serverEndpointIndexerBuilder`in a static_init recording. I do not know how to move it elsewhere.