### PR TITLE
3.2.8 backports 3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -62,7 +62,7 @@
         <smallrye-context-propagation.version>2.1.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.1</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.5.0</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.7.2</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.6.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.2.1</smallrye-stork.version>
         <jakarta.activation.version>2.1.2</jakarta.activation.version>
@@ -123,7 +123,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.2.1.Final</wildfly-elytron.version>
         <jboss-threads.version>3.5.0.Final</jboss-threads.version>
-        <vertx.version>4.4.5</vertx.version>
+        <vertx.version>4.4.6</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -34,7 +34,7 @@
         <opentelemetry.version>1.25.0</opentelemetry.version>
         <opentelemetry-alpha.version>1.25.0-alpha</opentelemetry-alpha.version>
         <jaeger.version>1.8.1</jaeger.version>
-        <quarkus-http.version>5.0.2.Final</quarkus-http.version>
+        <quarkus-http.version>5.0.3.Final</quarkus-http.version>
         <micrometer.version>1.11.1</micrometer.version><!-- keep in sync with hdrhistogram -->
         <hdrhistogram.version>2.1.12</hdrhistogram.version><!-- keep in sync with micrometer -->
         <google-auth.version>0.22.0</google-auth.version>
@@ -123,7 +123,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.2.1.Final</wildfly-elytron.version>
         <jboss-threads.version>3.5.0.Final</jboss-threads.version>
-        <vertx.version>4.4.4</vertx.version>
+        <vertx.version>4.4.5</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -190,7 +190,7 @@
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.10.1</antlr.version><!-- needs to align with same property in build-parent/pom.xml -->
         <quarkus-security.version>2.0.2.Final</quarkus-security.version>
-        <keycloak.version>22.0.1</keycloak.version>
+        <keycloak.version>22.0.5</keycloak.version>
         <logstash-gelf.version>1.15.1</logstash-gelf.version>
         <checker-qual.version>3.34.0</checker-qual.version>
         <error-prone-annotations.version>2.19.1</error-prone-annotations.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -103,7 +103,7 @@
 
         <!-- The image to use for tests that run Keycloak -->
         <!-- IMPORTANT: If this is changed you must also update bom/application/pom.xml and KeycloakBuildTimeConfig/DevServicesConfig in quarkus-oidc/deployment to match the version -->
-        <keycloak.version>22.0.1</keycloak.version>
+        <keycloak.version>22.0.5</keycloak.version>
         <keycloak.wildfly.version>19.0.3</keycloak.wildfly.version>
         <keycloak.docker.image>quay.io/keycloak/keycloak:${keycloak.version}</keycloak.docker.image>
         <keycloak.docker.legacy.image>quay.io/keycloak/keycloak:${keycloak.wildfly.version}-legacy</keycloak.docker.legacy.image>

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -14,7 +14,7 @@ include::_attributes.adoc[]
 :httpspec: https://tools.ietf.org/html/rfc7231
 :jsonpapi: https://javadoc.io/doc/jakarta.json/jakarta.json-api/1.1.4
 :injectapi: https://javadoc.io/static/jakarta.inject/jakarta.inject-api/2.0.1
-:vertxapi: https://javadoc.io/doc/io.vertx/vertx-core/latest/index.html
+:vertxapi: https://javadoc.io/doc/io.vertx/vertx-core/4.4.6
 :resteasy-reactive-api: https://javadoc.io/doc/io.quarkus.resteasy.reactive/resteasy-reactive/{quarkus-version}
 :resteasy-reactive-common-api: https://javadoc.io/doc/io.quarkus.resteasy.reactive/resteasy-reactive-common/{quarkus-version}
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -222,7 +222,7 @@ For more information, see xref:security-oidc-bearer-token-authentication.adoc#in
 [[keycloak-initialization]]
 === Keycloak Initialization
 
-The `quay.io/keycloak/keycloak:22.0.1` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
+The `quay.io/keycloak/keycloak:22.0.5` image which contains a Keycloak distribution powered by Quarkus is used to start a container by default.
 `quarkus.keycloak.devservices.image-name` can be used to change the Keycloak image name. For example, set it to `quay.io/keycloak/keycloak:19.0.3-legacy` to use a Keycloak distribution powered by WildFly.
 Note that only a Quarkus based Keycloak distribution is available starting from Keycloak `20.0.0`.
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -35,7 +35,7 @@ public class DevServicesConfig {
      * string.
      * Set 'quarkus.keycloak.devservices.keycloak-x-image' to override this check.
      */
-    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:22.0.1")
+    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:22.0.5")
     public String imageName;
 
     /**

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MoneyTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/MoneyTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.reactive.pg.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.pgclient.data.Money;
+
+/**
+ * Reproduce <a href="https://github.com/quarkusio/quarkus/issues/36144">PG Reactive Client: Cannot create Money value in Range
+ * (-1.00, 0.00)</a>.
+ */
+public class MoneyTest {
+
+    @Test
+    void testMoney() {
+        Money money = new Money(new BigDecimal("-1.11"));
+        assertEquals(BigDecimal.valueOf(-1.11), money.bigDecimalValue());
+
+        money = new Money(new BigDecimal("-0.11"));
+        assertEquals(BigDecimal.valueOf(-0.11), money.bigDecimalValue());
+    }
+
+}

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxUtil.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxUtil.java
@@ -37,11 +37,12 @@ public class VertxUtil {
         if (uri.startsWith(protocol + "://")) {
             uriString = uri;
         } else {
-            String host = req.host();
-            if (host == null) {
-                host = "unknown";
+            var authority = req.authority();
+            if (authority == null) {
+                uriString = protocol + "//unknown" + uri;
+            } else {
+                uriString = protocol + "://" + authority + uri;
             }
-            uriString = protocol + "://" + host + uri;
         }
 
         // ResteasyUriInfo expects a context path to start with a "/" character

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/EmptyHostTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/EmptyHostTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.vertx.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.ext.web.Router;
+
+/**
+ * Reproduce <a href="https://github.com/quarkusio/quarkus/issues/36234">NullPointerException for request with empty Host
+ * header</a>.
+ */
+public class EmptyHostTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(BeanRegisteringRouteUsingObserves.class));
+
+    @Test
+    public void testWithEmptyHost() {
+        assertEquals(RestAssured
+                .given()
+                .header("Host", "")
+                .get("/hello")
+                .asString(), "Hello World! ");
+
+    }
+
+    @ApplicationScoped
+    static class BeanRegisteringRouteUsingObserves {
+
+        public void register(@Observes Router router) {
+
+            router.route("/hello").handler(ctx -> ctx.response().end("Hello World! " + ctx.request().host()));
+        }
+
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2RSTFloodProtectionConfigTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/http2/Http2RSTFloodProtectionConfigTest.java
@@ -1,0 +1,105 @@
+package io.quarkus.vertx.http.http2;
+
+import static io.vertx.core.http.HttpMethod.GET;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.core.runtime.VertxCoreRecorder;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.net.JdkSSLEngineOptions;
+import io.vertx.ext.web.Router;
+
+/**
+ * Configuration of the RST flood protection (CVE-2023-44487)
+ */
+public class Http2RSTFloodProtectionConfigTest {
+
+    @TestHTTPResource(value = "/ping", ssl = true)
+    URL sslUrl;
+
+    @TestHTTPResource(value = "/ping")
+    URL url;
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class)
+                    .addAsResource(new File("src/test/resources/conf/ssl-jks-rst-flood-protection.conf"),
+                            "application.properties")
+                    .addAsResource(new File("src/test/resources/conf/server-keystore.jks"), "server-keystore.jks"));
+
+    @Test
+    void testRstFloodProtectionWithTlsEnabled() throws Exception {
+        Assumptions.assumeTrue(JdkSSLEngineOptions.isAlpnAvailable()); //don't run on JDK8
+        HttpClientOptions options = new HttpClientOptions()
+                .setUseAlpn(true)
+                .setProtocolVersion(HttpVersion.HTTP_2)
+                .setSsl(true)
+                .setTrustAll(true);
+
+        var client = VertxCoreRecorder.getVertx().get().createHttpClient(options);
+        int port = sslUrl.getPort();
+        run(client, port, false);
+    }
+
+    @Test
+    public void testRstFloodProtection() throws InterruptedException {
+        HttpClientOptions options = new HttpClientOptions()
+                .setProtocolVersion(HttpVersion.HTTP_2)
+                .setHttp2ClearTextUpgrade(true);
+        var client = VertxCoreRecorder.getVertx().get().createHttpClient(options);
+        run(client, url.getPort(), true);
+    }
+
+    void run(HttpClient client, int port, boolean plain) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        client.connectionHandler(conn -> conn.goAwayHandler(ga -> {
+            Assertions.assertEquals(11, ga.getErrorCode());
+            latch.countDown();
+        }));
+
+        if (plain) {
+            // Emit a first request to establish a connection.
+            // It's HTTP/1 so, does not count in the number of requests.
+            client.request(GET, port, "localhost", "/ping")
+                    .compose(HttpClientRequest::send);
+        }
+
+        for (int i = 0; i < 20; i++) {
+            client.request(GET, port, "localhost", "/ping")
+                    .onSuccess(req -> req.end().onComplete(v -> req.reset()));
+        }
+
+        if (!latch.await(10, TimeUnit.SECONDS)) {
+            fail("RST flood protection failed");
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+
+        public void register(@Observes Router router) {
+            router.get("/ping").handler(rc -> {
+                // Do nothing.
+            });
+        }
+
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/resources/conf/ssl-jks-rst-flood-protection.conf
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/ssl-jks-rst-flood-protection.conf
@@ -1,0 +1,6 @@
+
+quarkus.http.ssl.certificate.key-store-file=server-keystore.jks
+quarkus.http.ssl.certificate.key-store-password=secret
+
+ quarkus.http.limits.rst-flood-max-rst-frame-per-window=10
+ quarkus.http.limits.rst-flood-window-duration=10s

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedServerRequestWrapper.java
@@ -26,6 +26,7 @@ import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.StreamPriority;
 import io.vertx.core.http.impl.HttpServerRequestInternal;
 import io.vertx.core.http.impl.HttpServerRequestWrapper;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 
@@ -189,6 +190,11 @@ public class ForwardedServerRequestWrapper extends HttpServerRequestWrapper impl
     @Override
     public SocketAddress remoteAddress() {
         return forwardedParser.remoteAddress();
+    }
+
+    @Override
+    public HostAndPort authority() {
+        return forwardedParser.authority();
     }
 
     @Override

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ServerLimitsConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.vertx.http.runtime;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -85,5 +86,21 @@ public class ServerLimitsConfig {
      */
     @ConfigItem
     public OptionalLong maxHeaderListSize;
+
+    /**
+     * Set the max number of RST frame allowed per time window, this is used to prevent
+     * <a href="https://github.com/netty/netty/security/advisories/GHSA-xpw8-rcwv-8f8p">HTTP/2 RST frame flood DDOS
+     * attacks</a>. The default value is {@code 200}, setting zero or a negative value, disables flood protection.
+     */
+    @ConfigItem
+    public OptionalInt rstFloodMaxRstFramePerWindow;
+
+    /**
+     * Set the duration of the time window when checking the max number of RST frames, this is used to prevent
+     * <a href="https://github.com/netty/netty/security/advisories/GHSA-xpw8-rcwv-8f8p">HTTP/2 RST frame flood DDOS
+     * attacks</a>.. The default value is {@code 30 s}, setting zero or a negative value, disables flood protection.
+     */
+    @ConfigItem
+    public Optional<Duration> rstFloodWindowDuration;
 
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/AbstractResponseWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/AbstractResponseWrapper.java
@@ -12,6 +12,7 @@ import io.vertx.core.http.HttpFrame;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.StreamPriority;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.streams.ReadStream;
 
 class AbstractResponseWrapper implements HttpServerResponse {
@@ -323,6 +324,7 @@ class AbstractResponseWrapper implements HttpServerResponse {
     }
 
     @Override
+    @Deprecated
     public void close() {
         delegate.close();
     }
@@ -376,7 +378,7 @@ class AbstractResponseWrapper implements HttpServerResponse {
 
     @Override
     public Future<HttpServerResponse> push(HttpMethod method, String host, String path) {
-        return null;
+        return delegate.push(method, host, path);
     }
 
     @Override
@@ -389,7 +391,7 @@ class AbstractResponseWrapper implements HttpServerResponse {
 
     @Override
     public Future<HttpServerResponse> push(HttpMethod method, String path, MultiMap headers) {
-        return null;
+        return delegate.push(method, path, headers);
     }
 
     @Override
@@ -401,7 +403,7 @@ class AbstractResponseWrapper implements HttpServerResponse {
 
     @Override
     public Future<HttpServerResponse> push(HttpMethod method, String path) {
-        return null;
+        return delegate.push(method, path);
     }
 
     @Override
@@ -413,8 +415,14 @@ class AbstractResponseWrapper implements HttpServerResponse {
     }
 
     @Override
+    @Deprecated
     public Future<HttpServerResponse> push(HttpMethod method, String host, String path, MultiMap headers) {
-        return null;
+        return delegate.push(method, host, path, headers);
+    }
+
+    @Override
+    public Future<HttpServerResponse> push(HttpMethod method, HostAndPort authority, String path, MultiMap headers) {
+        return delegate.push(method, authority, path, headers);
     }
 
     @Override

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/HttpServerOptionsUtils.java
@@ -289,6 +289,18 @@ public class HttpServerOptionsUtils {
                 settings.setMaxHeaderListSize(httpConfiguration.limits.maxHeaderListSize.getAsLong());
             }
             httpServerOptions.setInitialSettings(settings);
+
+            // RST attack protection - https://github.com/netty/netty/security/advisories/GHSA-xpw8-rcwv-8f8p
+            if (httpConfiguration.limits.rstFloodMaxRstFramePerWindow.isPresent()) {
+                httpServerOptions
+                        .setHttp2RstFloodMaxRstFramePerWindow(httpConfiguration.limits.rstFloodMaxRstFramePerWindow.getAsInt());
+            }
+            if (httpConfiguration.limits.rstFloodWindowDuration.isPresent()) {
+                httpServerOptions.setHttp2RstFloodWindowDuration(
+                        (int) httpConfiguration.limits.rstFloodWindowDuration.get().toSeconds());
+                httpServerOptions.setHttp2RstFloodWindowDurationTimeUnit(TimeUnit.SECONDS);
+            }
+
         }
     }
 

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -64,7 +64,7 @@
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <mutiny.version>2.3.1</mutiny.version>
         <smallrye-common.version>2.1.0</smallrye-common.version>
-        <vertx.version>4.4.4</vertx.version>
+        <vertx.version>4.4.5</vertx.version>
         <rest-assured.version>5.3.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.15.2</jackson-bom.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -64,7 +64,7 @@
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <mutiny.version>2.3.1</mutiny.version>
         <smallrye-common.version>2.1.0</smallrye-common.version>
-        <vertx.version>4.4.5</vertx.version>
+        <vertx.version>4.4.6</vertx.version>
         <rest-assured.version>5.3.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.15.2</jackson-bom.version>


### PR DESCRIPTION
@rsvoboda @gastaldi @gsmet this PR bumps Vert.X to 4.4.6 (including the commit bumping it to 4.4.5 to fix conflicts) and Keycloak to 22.0.5.