### PR TITLE
ModuleBuildDurationReport: Fix help message for sort

### DIFF
--- a/.github/ModuleBuildDurationReport.java
+++ b/.github/ModuleBuildDurationReport.java
@@ -49,9 +49,11 @@ public class ModuleBuildDurationReport implements Runnable {
       required = true)
   private String logFilePath;
 
-  @CommandLine.Option(names = { "-s",
-      "--sort" }, description = "Sort order"
-          + "%Possible values: ${COMPLETION-CANDIDATES}", defaultValue = "execution")
+  @CommandLine.Option(
+      names = { "-s", "--sort" },
+      description = "Sort order"
+          + "%nPossible values: ${COMPLETION-CANDIDATES}",
+      defaultValue = "execution")
   private Sort sort;
 
   public static void main(String... args) {


### PR DESCRIPTION
ModuleBuildDurationReport: Fix help message for sort

Main change: `%` => `%n`, also adjusted indentation

BEFORE:
```
  -s, --sort=<sort>          Sort order%Possible values: execution, name,
                               duration
```
AFTER:
```
  -s, --sort=<sort>          Sort order
                             Possible values: execution, name, duration
```