### PR TITLE
TransactionalUniAsserterTest: test that injected argument is used

### DIFF
--- a/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/TransactionalUniAsserterTest.java
+++ b/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/TransactionalUniAsserterTest.java
@@ -3,7 +3,11 @@ package io.quarkus.it.panache.reactive;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.hibernate.reactive.panache.Panache;
@@ -14,11 +18,14 @@ import io.quarkus.test.vertx.RunOnVertxContext;
 @QuarkusTest
 public class TransactionalUniAsserterTest {
 
+    private static final AtomicBoolean ASSERTER_USED = new AtomicBoolean();
+
     @RunOnVertxContext
     @Test
     public void testTransactionalUniAsserter(TransactionalUniAsserter asserter) {
         assertNotNull(asserter);
         asserter.assertThat(Panache::currentTransaction, transaction -> {
+            ASSERTER_USED.set(true);
             assertNotNull(transaction);
             assertFalse(transaction.isMarkedForRollback());
             asserter.putData("tx", transaction);
@@ -28,6 +35,11 @@ public class TransactionalUniAsserterTest {
             assertFalse(transaction.isMarkedForRollback());
             assertNotEquals(transaction, asserter.getData("tx"));
         });
+    }
+
+    @AfterAll
+    static void afterAll() {
+        assertTrue(ASSERTER_USED.get());
     }
 
 }

--- a/test-framework/vertx/src/test/java/io/quarkus/test/vertx/UniAsserterTest.java
+++ b/test-framework/vertx/src/test/java/io/quarkus/test/vertx/UniAsserterTest.java
@@ -12,6 +12,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 
 import io.smallrye.mutiny.Uni;
 
@@ -92,6 +93,11 @@ public class UniAsserterTest {
     public void testAssertThat() {
         testAsserter(ua -> ua.assertThat(() -> Uni.createFrom().item("foo"), foo -> assertEquals("foo", foo)));
         testAsserterFailure(ua -> ua.assertThat(() -> Uni.createFrom().item("foo"), foo -> assertEquals("bar", foo)));
+    }
+
+    @Test
+    public void testFail() {
+        testAsserterFailure(ua -> ua.fail(), t -> AssertionFailedError.class.isInstance(t));
     }
 
     @Test
@@ -238,7 +244,7 @@ public class UniAsserterTest {
             fail("No failure");
         } catch (ExecutionException e) {
             if (expected != null) {
-                assertTrue(expected.test(e.getCause()));
+                assertTrue(expected.test(e.getCause()), "Unexpected exception thrown: " + e.getCause());
             }
         } catch (InterruptedException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
- UniAsserterTest: add test for UniAsserter#fail()

This is a follow-up of https://github.com/quarkusio/quarkus/pull/36599.