### PR TITLE
Register server exception mapper method of the Rest-Interface implementation class

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/ImplClassExceptionMapperTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/ImplClassExceptionMapperTest.java
@@ -1,0 +1,100 @@
+package io.quarkus.resteasy.reactive.server.test.customexceptions;
+
+import static io.quarkus.resteasy.reactive.server.test.ExceptionUtil.removeStackTrace;
+
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.resteasy.reactive.server.test.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ImplClassExceptionMapperTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(CustomResourceImpl.class,
+                                    CustomResource.class,
+                                    GlobalCustomResourceImpl.class,
+                                    GlobalCustomResource.class,
+                                    DefaultCustomResource.class,
+                                    ExceptionUtil.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        RestAssured.get("/custom/error")
+                .then().statusCode(416);
+        RestAssured.get("/stock/error")
+                .then().statusCode(500);
+        RestAssured.get("/default/error")
+                .then().statusCode(417);
+    }
+
+    @Path("default")
+    public static class DefaultCustomResource {
+
+        @ServerExceptionMapper
+        public Response handleThrowable(RuntimeException t) {
+            return Response.status(417).build();
+        }
+
+        @GET
+        @Path("error")
+        @Produces("text/plain")
+        public String throwsException() {
+            throw removeStackTrace(new RuntimeException());
+        }
+    }
+
+    public static class CustomResourceImpl implements CustomResource {
+
+        @ServerExceptionMapper
+        public Response handleThrowable(RuntimeException t) {
+            return Response.status(416).build();
+        }
+
+        public String throwsException() {
+            throw removeStackTrace(new RuntimeException());
+        }
+    }
+
+    @Path("custom")
+    public interface CustomResource {
+        @GET
+        @Path("error")
+        @Produces("text/plain")
+        String throwsException();
+    }
+
+    public static class GlobalCustomResourceImpl implements GlobalCustomResource {
+
+        public String throwsException() {
+            throw removeStackTrace(new RuntimeException());
+        }
+    }
+
+    @Path("stock")
+    public interface GlobalCustomResource {
+
+        @GET
+        @Path("error")
+        @Produces("text/plain")
+        String throwsException();
+    }
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveScanner.java
@@ -284,6 +284,18 @@ public class ResteasyReactiveScanner {
                         if (!scannedResources.containsKey(clazz.name())) {
                             scannedResources.put(clazz.name(), clazz);
                             scannedResourcePaths.put(clazz.name(), i.getValue());
+
+                            // check for server exception mapper method in implementation class of the interface.
+                            List<AnnotationInstance> exceptionMapperAnnotationInstances = clazz.annotationsMap()
+                                    .get(ResteasyReactiveDotNames.SERVER_EXCEPTION_MAPPER);
+                            if (exceptionMapperAnnotationInstances != null) {
+                                for (AnnotationInstance instance : exceptionMapperAnnotationInstances) {
+                                    if (instance.target().kind() != AnnotationTarget.Kind.METHOD) {
+                                        continue;
+                                    }
+                                    methodExceptionMappers.add(instance.target().asMethod());
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Motivation: 
We generate server endpoints for our Rest-Interfaces from openapi.yaml files. Generator generates interfaces, and we need to write only the implementation classes. We do have multiple versions (v1, v2, ...) of rest interface (multiple openapi.yaml files) in one application. We would like to have a custom server exception mapper for each version, which will create a valid response to the corresponding version.

Closes: #36872