### PR TITLE
[3.2] Drop Java 19 from CI as it's not an LTS version

### DIFF
--- a/.github/matrix-jvm-tests.json
+++ b/.github/matrix-jvm-tests.json
@@ -13,13 +13,6 @@
   "os-name": "ubuntu-latest"
 }
 , {
-  "name": "19",
-  "java-version": 19,
-  "maven_args": "$JVM_TEST_MAVEN_ARGS",
-  "maven_opts": "-Xmx2g -XX:MaxMetaspaceSize=1g",
-  "os-name": "ubuntu-latest"
-}
-, {
   "name": "17 Windows",
   "java-version": 17,
   "maven_args": "-DskipDocs -Dformat.skip",


### PR DESCRIPTION
Drop Java 19 from 3.2 CI as it's not an LTS version

CC @gsmet @aloubyansky 