### PR TITLE
Remove more Docker images and other stuff before starting CI

### DIFF
--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -32,14 +32,20 @@
 # alpine           3.14        dd53f409bf0b   4 months ago   5.6MB
 # alpine           3.15        c4fc93816858   4 months ago   5.58MB
 
-time docker rmi node:14 node:16 node:18 node:14-alpine node:16-alpine node:18-alpine buildpack-deps:buster buildpack-deps:bullseye
+time sudo docker image prune --all --force || true
 # That is 979M
-time sudo rm -rf /usr/share/dotnet
+time sudo rm -rf /usr/share/dotnet || true
 # That is 1.7G
-time sudo rm -rf /usr/share/swift
+time sudo rm -rf /usr/share/swift || true
 # Remove Android
-time sudo rm -rf /usr/local/lib/android
+time sudo rm -rf /usr/local/lib/android || true
 # Remove Haskell
-time sudo rm -rf /opt/ghc
+time sudo rm -rf /opt/ghc || true
 # Remove pipx
-time sudo rm -rf /opt/pipx
+time sudo rm -rf /opt/pipx || true
+
+# Remove infrastructure things that are unused and take a lot of space
+time sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+time sudo rm -rf /imagegeneration/installers/go-* || true
+time sudo rm -rf /imagegeneration/installers/node-* || true
+time sudo rm -rf /imagegeneration/installers/python-* || true


### PR DESCRIPTION
FYI @rsvoboda @gsmet @gastaldi 

@gsmet suggested this change to get rid of unnecessary data on the disk before the CI, which is what we do in main. The same change will be applied to the 2.13 branch.