### PR TITLE
Fix formatting in the datasource docs

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -412,7 +412,7 @@ AgroalDataSource inventoryDataSource;
 If you use the link:https://quarkus.io/extensions/io.quarkus/quarkus-smallrye-health[`quarkus-smallrye-health`] extension, the `quarkus-agroal` and reactive client extensions automatically add a readiness health check to validate the datasource.
 
 When you access your application’s health readiness endpoint, `/q/health/ready` by default, you receive information about the datasource validation status.
-If you have multiple datasources, all datasources are checked, and if a single datasource validation failure occurs, the status changes to`DOWN`.
+If you have multiple datasources, all datasources are checked, and if a single datasource validation failure occurs, the status changes to `DOWN`.
 
 This behavior can be disabled by using the `quarkus.datasource.health.enabled` property.
 
@@ -420,7 +420,7 @@ To exclude only a particular datasource from the health check, use:
 
 [source,properties]
 ----
- `quarkus.datasource."datasource-name".health-exclude=true`
+quarkus.datasource."datasource-name".health-exclude=true
 ----
 
 === Datasource metrics


### PR DESCRIPTION
Making some small tweaks to fix some formatting in the docs here: 
https://quarkus.io/guides/datasource#datasource-health-check

<details>
<summary>Before</summary>

![image](https://github.com/quarkusio/quarkus/assets/7545665/87ba0c6b-833f-44b3-8500-0185da5f0f75)

</details>