### PR TITLE
Add docs/src/main/asciidoc/security-oidc-auth0-tutorial.adoc to the l…

### DIFF
--- a/docs/downstreamdoc.yaml
+++ b/docs/downstreamdoc.yaml
@@ -9,6 +9,7 @@ guides:
   - src/main/asciidoc/security-getting-started-tutorial.adoc
   - src/main/asciidoc/security-identity-providers.adoc
   - src/main/asciidoc/security-jpa.adoc
+  - src/main/asciidoc/security-oidc-auth0-tutorial.adoc
   - src/main/asciidoc/security-oidc-bearer-token-authentication.adoc
   - src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
   - src/main/asciidoc/security-oidc-code-flow-authentication.adoc


### PR DESCRIPTION
…ist of downstream files.

Purpose: Previously, `security-oidc-auth0-tutorial.adoc` was missing from the list of files to be automatically downstreamed, `docs/downstreamdoc.yaml`. With https://issues.redhat.com/browse/QDOCS-534, my task is to make final edits, QE and prepare that file for publishing in RHBQ.
