### PR TITLE
Avoid @TempDir in RestClientCDIDelegateBuilderTest

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
@@ -1,9 +1,10 @@
 package io.quarkus.rest.client.reactive.runtime;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -19,9 +20,9 @@ import jakarta.ws.rs.client.ClientResponseFilter;
 import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import io.netty.handler.codec.http.multipart.HttpPostRequestEncoder;
@@ -35,25 +36,46 @@ public class RestClientCDIDelegateBuilderTest {
     private static final String TRUSTSTORE_PASSWORD = "truststorePassword";
     private static final String KEYSTORE_PASSWORD = "keystorePassword";
 
-    @TempDir
-    static File tempDir;
-    private static File truststoreFile;
-    private static File keystoreFile;
+    private static Path truststorePath;
+    private static Path keystorePath;
 
     @BeforeAll
     public static void beforeAll() throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException {
         // prepare keystore and truststore
 
-        truststoreFile = new File(tempDir, "truststore.jks");
-        keystoreFile = new File(tempDir, "keystore.jks");
+        truststorePath = Files.createTempFile("truststore", ".jks");
 
-        KeyStore truststore = KeyStore.getInstance("JKS");
-        truststore.load(null, TRUSTSTORE_PASSWORD.toCharArray());
-        truststore.store(new FileOutputStream(truststoreFile), TRUSTSTORE_PASSWORD.toCharArray());
+        try (OutputStream truststoreOs = Files.newOutputStream(truststorePath)) {
+            KeyStore truststore = KeyStore.getInstance("JKS");
+            truststore.load(null, TRUSTSTORE_PASSWORD.toCharArray());
+            truststore.store(truststoreOs, TRUSTSTORE_PASSWORD.toCharArray());
+        }
 
-        KeyStore keystore = KeyStore.getInstance("JKS");
-        keystore.load(null, KEYSTORE_PASSWORD.toCharArray());
-        keystore.store(new FileOutputStream(keystoreFile), KEYSTORE_PASSWORD.toCharArray());
+        keystorePath = Files.createTempFile("keystore", ".jks");
+
+        try (OutputStream keystoreOs = Files.newOutputStream(keystorePath)) {
+            KeyStore keystore = KeyStore.getInstance("JKS");
+            keystore.load(null, KEYSTORE_PASSWORD.toCharArray());
+            keystore.store(keystoreOs, KEYSTORE_PASSWORD.toCharArray());
+        }
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        if (truststorePath != null) {
+            try {
+                Files.deleteIfExists(truststorePath);
+            } catch (IOException e) {
+                // ignore it
+            }
+        }
+        if (keystorePath != null) {
+            try {
+                Files.deleteIfExists(keystorePath);
+            } catch (IOException e) {
+                // ignore it
+            }
+        }
     }
 
     @Test
@@ -171,10 +193,10 @@ public class RestClientCDIDelegateBuilderTest {
                 .of("io.quarkus.rest.client.reactive.runtime.RestClientCDIDelegateBuilderTest$MyResponseFilter2");
         configRoot.queryParamStyle = Optional.of(QueryParamStyle.MULTI_PAIRS);
 
-        configRoot.trustStore = Optional.of(truststoreFile.getAbsolutePath());
+        configRoot.trustStore = Optional.of(truststorePath.toAbsolutePath().toString());
         configRoot.trustStorePassword = Optional.of("truststorePassword");
         configRoot.trustStoreType = Optional.of("JKS");
-        configRoot.keyStore = Optional.of(keystoreFile.getAbsolutePath());
+        configRoot.keyStore = Optional.of(keystorePath.toAbsolutePath().toString());
         configRoot.keyStorePassword = Optional.of("keystorePassword");
         configRoot.keyStoreType = Optional.of("JKS");
 
@@ -210,10 +232,10 @@ public class RestClientCDIDelegateBuilderTest {
                 .of("io.quarkus.rest.client.reactive.runtime.RestClientCDIDelegateBuilderTest$MyResponseFilter1");
         clientConfig.queryParamStyle = Optional.of(QueryParamStyle.COMMA_SEPARATED);
 
-        clientConfig.trustStore = Optional.of(truststoreFile.getAbsolutePath());
+        clientConfig.trustStore = Optional.of(truststorePath.toAbsolutePath().toString());
         clientConfig.trustStorePassword = Optional.of("truststorePassword");
         clientConfig.trustStoreType = Optional.of("JKS");
-        clientConfig.keyStore = Optional.of(keystoreFile.getAbsolutePath());
+        clientConfig.keyStore = Optional.of(keystorePath.toAbsolutePath().toString());
         clientConfig.keyStorePassword = Optional.of("keystorePassword");
         clientConfig.keyStoreType = Optional.of("JKS");
 


### PR DESCRIPTION
Unfortunately, using @TempDir on Windows CI is not working very well and this test has been failing from time to time for a few days now.

Applying the same trick as in https://github.com/quarkusio/quarkus/pull/31996