### PR TITLE
Reset databases/users for each Hibernate ORM tenancy test module

### DIFF
--- a/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/custom-mariadbconfig/init.sql
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/custom-mariadbconfig/init.sql
@@ -1,13 +1,13 @@
-CREATE DATABASE IF NOT EXISTS base;
-CREATE DATABASE IF NOT EXISTS mycompany;
-CREATE DATABASE IF NOT EXISTS inventory;
-CREATE DATABASE IF NOT EXISTS inventorymycompany;
+CREATE OR REPLACE DATABASE base;
+CREATE OR REPLACE DATABASE mycompany;
+CREATE OR REPLACE DATABASE inventory;
+CREATE OR REPLACE DATABASE inventorymycompany;
 
-CREATE USER IF NOT EXISTS 'jane'@'%' IDENTIFIED BY 'abc';
+CREATE OR REPLACE USER 'jane'@'%' IDENTIFIED BY 'abc';
 GRANT ALL privileges ON base.* TO 'jane'@'%';
 GRANT ALL privileges ON mycompany.* TO 'jane'@'%';
 
-CREATE USER IF NOT EXISTS 'john'@'%' IDENTIFIED BY 'def';
+CREATE OR REPLACE USER 'john'@'%' IDENTIFIED BY 'def';
 GRANT ALL privileges ON inventory.* TO 'john'@'%';
 GRANT ALL privileges ON inventorymycompany.* TO 'john'@'%';
 

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver/custom-mariadbconfig/init.sql
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver/custom-mariadbconfig/init.sql
@@ -1,13 +1,13 @@
-CREATE DATABASE IF NOT EXISTS base;
-CREATE DATABASE IF NOT EXISTS mycompany;
-CREATE DATABASE IF NOT EXISTS inventory;
-CREATE DATABASE IF NOT EXISTS inventorymycompany;
+CREATE OR REPLACE DATABASE base;
+CREATE OR REPLACE DATABASE mycompany;
+CREATE OR REPLACE DATABASE inventory;
+CREATE OR REPLACE DATABASE inventorymycompany;
 
-CREATE USER IF NOT EXISTS 'jane'@'%' IDENTIFIED BY 'abc';
+CREATE OR REPLACE USER 'jane'@'%' IDENTIFIED BY 'abc';
 GRANT ALL privileges ON base.* TO 'jane'@'%';
 GRANT ALL privileges ON mycompany.* TO 'jane'@'%';
 
-CREATE USER IF NOT EXISTS 'john'@'%' IDENTIFIED BY 'def';
+CREATE OR REPLACE USER 'john'@'%' IDENTIFIED BY 'def';
 GRANT ALL privileges ON inventory.* TO 'john'@'%';
 GRANT ALL privileges ON inventorymycompany.* TO 'john'@'%';
 

--- a/integration-tests/hibernate-orm-tenancy/datasource/custom-mariadbconfig/init.sql
+++ b/integration-tests/hibernate-orm-tenancy/datasource/custom-mariadbconfig/init.sql
@@ -1,17 +1,14 @@
-CREATE DATABASE IF NOT EXISTS base;
-CREATE USER IF NOT EXISTS 'jane'@'%' IDENTIFIED BY 'abc';
+CREATE OR REPLACE DATABASE base;
+CREATE OR REPLACE DATABASE mycompany;
+CREATE OR REPLACE DATABASE inventory;
+CREATE OR REPLACE DATABASE inventorymycompany;
+
+CREATE OR REPLACE USER 'jane'@'%' IDENTIFIED BY 'abc';
 GRANT ALL privileges ON base.* TO 'jane'@'%';
-
-CREATE DATABASE IF NOT EXISTS mycompany;
-CREATE USER IF NOT EXISTS 'john'@'%' IDENTIFIED BY 'def';
-GRANT ALL privileges ON mycompany.* TO 'john'@'%';
-
-CREATE DATABASE IF NOT EXISTS inventory;
-CREATE USER IF NOT EXISTS 'jane'@'%' IDENTIFIED BY 'abc';
 GRANT ALL privileges ON inventory.* TO 'jane'@'%';
 
-CREATE DATABASE IF NOT EXISTS inventorymycompany;
-CREATE USER IF NOT EXISTS 'john'@'%' IDENTIFIED BY 'def';
+CREATE OR REPLACE USER 'john'@'%' IDENTIFIED BY 'def';
+GRANT ALL privileges ON mycompany.* TO 'john'@'%';
 GRANT ALL privileges ON inventorymycompany.* TO 'john'@'%';
 
 FLUSH PRIVILEGES;


### PR DESCRIPTION
We don't want configuration from one affecting the other, when the same database is reused from one run to the next.

This is an attempt at solving https://github.com/quarkusio/quarkus/pull/36908#issuecomment-1798116862 , but TBH my hopes are low. Can't hurt though :shrug: 