### PR TITLE
Qute: consider synthetic parameter declarations during validation

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TemplatesAnalysisBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TemplatesAnalysisBuildItem.java
@@ -1,5 +1,7 @@
 package io.quarkus.qute.deployment;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -60,6 +62,23 @@ public final class TemplatesAnalysisBuildItem extends SimpleBuildItem {
                 }
             }
             return null;
+        }
+
+        /**
+         * Non-synthetic declarations go first, then sorted by the line.
+         *
+         * @return the sorted list of parameter declarations
+         */
+        public List<ParameterDeclaration> getSortedParameterDeclarations() {
+            List<ParameterDeclaration> ret = new ArrayList<>(parameterDeclarations);
+            ret.sort(new Comparator<ParameterDeclaration>() {
+                @Override
+                public int compare(ParameterDeclaration pd1, ParameterDeclaration pd2) {
+                    int ret = Boolean.compare(pd1.getOrigin().isSynthetic(), pd2.getOrigin().isSynthetic());
+                    return ret == 0 ? Integer.compare(pd1.getOrigin().getLine(), pd2.getOrigin().getLine()) : ret;
+                }
+            });
+            return ret;
         }
 
         @Override

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/TemplateAnalysisTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/TemplateAnalysisTest.java
@@ -1,0 +1,87 @@
+package io.quarkus.qute.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.qute.Expression;
+import io.quarkus.qute.ParameterDeclaration;
+import io.quarkus.qute.TemplateNode.Origin;
+import io.quarkus.qute.Variant;
+import io.quarkus.qute.deployment.TemplatesAnalysisBuildItem.TemplateAnalysis;
+
+public class TemplateAnalysisTest {
+
+    @Test
+    public void testSortedParamDeclarations() {
+        TemplateAnalysis analysis = new TemplateAnalysis(null, null, null, List.of(paramDeclaration("foo", -1),
+                paramDeclaration("bar", -1), paramDeclaration("qux", 10), paramDeclaration("baz", 1)), null, null);
+        List<ParameterDeclaration> sorted = analysis.getSortedParameterDeclarations();
+        assertEquals(4, sorted.size());
+        assertEquals("baz", sorted.get(0).getKey());
+        assertEquals("qux", sorted.get(1).getKey());
+        assertTrue(sorted.get(2).getKey().equals("foo") || sorted.get(2).getKey().equals("bar"));
+        assertTrue(sorted.get(3).getKey().equals("foo") || sorted.get(3).getKey().equals("bar"));
+    }
+
+    ParameterDeclaration paramDeclaration(String key, int line) {
+        return new ParameterDeclaration() {
+
+            @Override
+            public String getTypeInfo() {
+                return null;
+            }
+
+            @Override
+            public Origin getOrigin() {
+                return new Origin() {
+
+                    @Override
+                    public Optional<Variant> getVariant() {
+                        return Optional.empty();
+                    }
+
+                    @Override
+                    public String getTemplateId() {
+                        return null;
+                    }
+
+                    @Override
+                    public String getTemplateGeneratedId() {
+                        return null;
+                    }
+
+                    @Override
+                    public int getLineCharacterStart() {
+                        return 0;
+                    }
+
+                    @Override
+                    public int getLineCharacterEnd() {
+                        return 0;
+                    }
+
+                    @Override
+                    public int getLine() {
+                        return line;
+                    }
+                };
+            }
+
+            @Override
+            public String getKey() {
+                return key;
+            }
+
+            @Override
+            public Expression getDefaultValue() {
+                return null;
+            }
+        };
+    }
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParameterDeclaration.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParameterDeclaration.java
@@ -4,7 +4,7 @@ import io.quarkus.qute.Expression.Part;
 import io.quarkus.qute.TemplateNode.Origin;
 
 /**
- * Represents a parameter declaration, i.e. <code>{@org.acme.Foo foo}</code>.
+ * Represents a type parameter declaration, i.e. <code>{@org.acme.Foo foo}</code>.
  */
 public interface ParameterDeclaration {
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParserHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ParserHelper.java
@@ -16,8 +16,7 @@ public interface ParserHelper {
 
     /**
      * Adds an <em>implicit</em> parameter declaration. This is an alternative approach to <em>explicit</em> parameter
-     * declarations
-     * used directly in the templates, e.g. <code>{@org.acme.Foo foo}</code>.
+     * declarations used directly in the templates, e.g. <code>{@org.acme.Foo foo}</code>.
      *
      * @param name
      * @param type

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Scope.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Scope.java
@@ -38,6 +38,10 @@ public class Scope {
         return parentScope != null ? parentScope.getBinding(binding) : null;
     }
 
+    Map<String, String> getBindings() {
+        return bindings;
+    }
+
     public String getBindingTypeOrDefault(String binding, String defaultValue) {
         String type = getBinding(binding);
         return type != null ? type : defaultValue;

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Template.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Template.java
@@ -155,9 +155,12 @@ public interface Template {
     Optional<Variant> getVariant();
 
     /**
+     * Returns all type parameter declarations of the template, including the declarations added by a
+     * {@link io.quarkus.qute.ParserHook}.
+     * <p>
      * If invoked upon a fragment instance then delegate to the defining template.
      *
-     * @return an immutable list of all parameter declarations defined in the template
+     * @return an immutable list of all type parameter declarations defined in the template
      */
     List<ParameterDeclaration> getParameterDeclarations();
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateNode.java
@@ -107,6 +107,13 @@ public interface TemplateNode {
             }
         }
 
+        /**
+         * @return {@code true} if the template node was not part of the original template, {@code false} otherwise
+         */
+        default boolean isSynthetic() {
+            return getLine() == -1;
+        }
+
     }
 
 }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
@@ -3,6 +3,7 @@ package io.quarkus.qute;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -165,6 +166,10 @@ public class ParserTest {
         assertEquals(8, itemNameOrigin.getLine());
         assertEquals(1, itemNameOrigin.getLineCharacterStart());
         assertEquals(11, itemNameOrigin.getLineCharacterEnd());
+        ParameterDeclaration pd = template.getParameterDeclarations().get(0);
+        assertEquals(1, pd.getOrigin().getLine());
+        assertEquals("foo", pd.getKey());
+        assertNull(pd.getDefaultValue());
     }
 
     @Test
@@ -316,9 +321,16 @@ public class ParserTest {
             public void beforeParsing(ParserHelper parserHelper) {
                 parserHelper.addContentFilter(contents -> contents.replace("bard", "bar"));
                 parserHelper.addContentFilter(contents -> contents.replace("${", "$\\{"));
+                parserHelper.addParameter("foo", String.class.getName());
             }
         }).build().parse("${foo}::{bard}");
         assertEquals("${foo}::true", template.data("bar", true).render());
+        List<ParameterDeclaration> paramDeclarations = template.getParameterDeclarations();
+        assertEquals(1, paramDeclarations.size());
+        ParameterDeclaration pd = paramDeclarations.get(0);
+        assertEquals("foo", pd.getKey());
+        assertEquals("|java.lang.String|", pd.getTypeInfo());
+        assertTrue(pd.getOrigin().isSynthetic());
     }
 
     @Test


### PR DESCRIPTION
- Template#getParameterDeclarations() now also returns type param declarations defined by parser hooks (i.e. type-safe templates and globals)