### PR TITLE
Fix bad numbering format (.1.) for section numbers (sectnums) and some...

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
@@ -19,6 +19,8 @@ For more information about OIDC Bearer token authentication, see the Quarkus xre
 
 If you want to protect web applications by using OIDC Authorization Code Flow authentication, see the xref:security-oidc-code-flow-authentication.adoc[OpenID Connect authorization code flow mechanism for protecting web applications] guide.
 
+:sectnums!:
+
 == Prerequisites
 
 :prerequisites-docker:
@@ -52,12 +54,10 @@ You can clone the Git repository by running the command `git clone {quickstarts-
 
 The solution is located in the `security-openid-connect-quickstart` link:{quickstarts-tree-url}/security-openid-connect-quickstart[directory].
 
-== Procedure
-
 :sectnums:
 :sectnumlevels: 3
 
-=== Create the Maven project
+== Create the Maven project
 
 You can either create a new Maven project with the `oidc` extension or you can add the extension to an existing Maven project.
 Complete one of the following commands:
@@ -84,7 +84,6 @@ The following configuration gets added to your build file:
 * Using Maven (pom.xml):
 +
 ====
---
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 ----
 <dependency>
@@ -92,7 +91,6 @@ The following configuration gets added to your build file:
     <artifactId>quarkus-oidc</artifactId>
 </dependency>
 ----
---
 ====
 +
 * Using Gradle (build.gradle):
@@ -106,7 +104,7 @@ implementation("io.quarkus:quarkus-oidc")
 --
 ====
 
-=== Write the application
+== Write the application
 
 . Implement the `/api/users/me` endpoint as shown in the following example, which is a regular Jakarta REST resource:
 +
@@ -185,7 +183,7 @@ The main difference in this example is that the `@RolesAllowed` annotation is us
 
 Injection of the `SecurityIdentity` is supported in both `@RequestScoped` and `@ApplicationScoped` contexts.
 
-=== Configure the application
+== Configure the application
 
 * Configure the Quarkus OpenID Connect (OIDC) extension by setting the following configuration properties in the `src/main/resources/application.properties` file.
 +
@@ -215,7 +213,7 @@ For more information, see the <<keycloak-dev-mode>> section.
 For more information, see the Quarkus xref:security-oidc-configuration-properties-reference.adoc[OpenID Connect (OIDC) configuration properties] guide.
 
 
-=== Start and configure the Keycloak server
+== Start and configure the Keycloak server
 
 . Put the link:{quickstarts-tree-url}/security-openid-connect-quickstart/config/quarkus-realm.json[realm configuration file] on the classpath (`target/classes` directory) so that it gets imported automatically when running in dev mode.
 You do not need to do this if you have already built a link:{quickstarts-tree-url}/security-openid-connect-quickstart[complete solution], in which case, this realm file is added to the classpath during the build.
@@ -255,7 +253,7 @@ For more information, see the link:{url-quarkusio-guides}security-keycloak-admin
 
 
 [[keycloak-dev-mode]]
-=== Run the application in dev mode
+== Run the application in dev mode
 
 . To run the application in dev mode, run the following commands:
 +
@@ -273,7 +271,7 @@ include::{includes}/devtools/dev.adoc[]
  ** Accessing `/api/admin` returns `200`.
  ** Accessing `/api/users/me` returns `200`.
 
-=== Run the Application in JVM mode
+== Run the Application in JVM mode
 
 When you are done with dev mode, you can run the application as a standard Java application.
 
@@ -291,7 +289,7 @@ java -jar target/quarkus-app/quarkus-run.jar
 ----
 ====
 
-=== Run the application in native mode
+== Run the application in native mode
 
 You can compile this same demo as-is into native mode without needing any modifications.
 This implies that you no longer need to install a JVM on your production environment.
@@ -314,7 +312,7 @@ include::{includes}/devtools/build-native.adoc[]
 ----
 ====
 
-=== Test the application
+== Test the application
 
 For information about testing your application in dev mode, see the preceding <<keycloak-dev-mode>> section.
 

--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -20,6 +20,8 @@ See also, xref:security-authentication-mechanisms.adoc#other-supported-authentic
 
 If you want to protect your service applications by using OIDC Bearer token authentication, see xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication].
 
+:sectnums!:
+
 == Prerequisites
 
 :prerequisites-docker:
@@ -42,9 +44,10 @@ Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {q
 
 The solution is located in the `security-openid-connect-web-authentication-quickstart` link:{quickstarts-tree-url}/security-openid-connect-web-authentication-quickstart[directory].
 
-== Procedure
+:sectnums:
+:sectnumlevels: 3
 
-=== Create the Maven project
+== Create the Maven project
 
 First, we need a new project.
 Create a new project with the following command:
@@ -75,7 +78,7 @@ This will add the following to your build file:
 implementation("io.quarkus:quarkus-oidc")
 ----
 
-=== Write the application
+== Write the application
 
 Let's write a simple Jakarta REST resource which has all the tokens returned in the authorization code grant response injected:
 
@@ -155,7 +158,7 @@ Note that you do not have to inject the tokens - it is only required if the endp
 
 // SJ: TO DO - update link to point to new reference guide. For more information, see <<access_id_and_access_tokens,Access ID and Access Tokens>> section.
 
-=== Configure the application
+== Configure the application
 
 The OIDC extension allows you to define the configuration using the `application.properties` file which should be located at the `src/main/resources` directory.
 
@@ -179,7 +182,7 @@ Finally, the `quarkus.http.auth.permission.authenticated` permission is set to t
 In this case, all paths are being protected by a policy that ensures that only `authenticated` users are allowed to access.
 For more information, see xref:security-authorize-web-endpoints-reference.adoc[Security Authorization Guide].
 
-=== Start and configure the Keycloak server
+== Start and configure the Keycloak server
 
 To start a Keycloak server, use Docker and run the following command:
 
@@ -198,7 +201,7 @@ Username should be `admin` and password `admin`.
 Import the link:{quickstarts-tree-url}/security-openid-connect-web-authentication-quickstart/config/quarkus-realm.json[realm configuration file] to create a new realm.
 For more information, see the Keycloak documentation about how to https://www.keycloak.org/docs/latest/server_admin/index.html#_create-realm[create a new realm].
 
-=== Run the application in dev and JVM modes
+== Run the application in dev and JVM modes
 
 To run the application in a dev mode, use:
 
@@ -217,7 +220,7 @@ Then, run it:
 java -jar target/quarkus-app/quarkus-run.jar
 ----
 
-=== Run the application in Native mode
+== Run the application in Native mode
 
 This same demo can be compiled into native code.
 No modifications are required.
@@ -237,7 +240,7 @@ After getting a cup of coffee, you can run this binary directly:
 ./target/security-openid-connect-web-authentication-quickstart-runner
 ----
 
-=== Test the application
+== Test the application
 
 To test the application, open your browser and access the following URL:
 
@@ -254,6 +257,8 @@ To authenticate to the application, type the following credentials when at the K
 After clicking the `Login` button, you are redirected back to the application.
 
 For more information about writing the integration tests that depend on `Dev Services for Keycloak`, see the <<security-oidc-code-flow-authentication.adoc#integration-testing-keycloak-devservices, Dev Services for Keycloak>> section.
+
+:sectnums!:
 
 == Summary
 


### PR DESCRIPTION
This PR fixes the problem of an extra dot (.) before each section number, which appears in tutorials with `:sectnums:` enabled.

![image](https://github.com/quarkusio/quarkus/assets/92924207/65ce10d7-9c79-4a7b-83b6-c6dc3c642a7d)

and 

![image](https://github.com/quarkusio/quarkus/assets/92924207/dd2a8d88-23dc-4fb4-a6fa-dd165a607404)

This update:

- Adds the `:numbered:` AsciiDoc attribute to the doc header of a tutorial and the tutorial template file to enforce the Arabic number format of 1. 2. 3. etc etc instead of .1.  .2. .3.  etc, which sometimes occurs depending on the markup.
- Fixes the two OIDC security tutorials, which have bad numbering rendered on the doc site.

![image](https://github.com/quarkusio/quarkus/assets/92924207/4e4aba84-25ae-4834-97c8-3b699688c64a)
 - Also fixes a code snippet rendering issue spotted by @gsmet during this review.


