### PR TITLE
Ability to generate gRPC descriptor set

### DIFF
--- a/docs/src/main/asciidoc/grpc-generation-reference.adoc
+++ b/docs/src/main/asciidoc/grpc-generation-reference.adoc
@@ -99,6 +99,21 @@ quarkus {
 }
 ----
 
+== Generating Descriptor Set
+Protocol Buffers do not contain descriptions of their own types. Thus, given only a raw message without the corresponding .proto file defining its type, it is difficult to extract any useful data. However, the contents of a .proto file can itself be https://protobuf.dev/programming-guides/techniques/#self-description[represented using protocol buffers].
+
+By default, Quarkus does not generate these descriptors. Quarkus does provide several configuration options for generating them. These would be added to your `application.properties` or `application.yml` file:
+
+* `quarkus.generate-code.grpc.descriptor-set.generate`
+** Set to `true` to enable generation
+* `quarkus.generate-code.grpc.descriptor-set.output-dir`
+** Set this to a value relative to the project's build directory (i.e. `target` for Maven, `build` for Gradle)
+** Maven default value: `target/generated-sources/grpc`
+** Gradle default value: `$buildDir/classes/java/quarkus-generated-sources/grpc`
+* `quarkus.generate-code.grpc.descriptor-set.name`
+** Name of the descriptor set file to generate
+** Default value: `descriptor_set.dsc`
+
 == Configuring gRPC code generation for dependencies
 
 You may have dependencies that contain `\*.proto` files you want to compile to Java sources.

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+            includeGroup 'org.hibernate.orm'
+        }
+    }
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+    implementation 'io.quarkus:quarkus-grpc'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name = 'grpc-descriptor-set-alternate-output-dir'

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/src/main/java/org/acme/quarkus/sample/HelloResource.java
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/src/main/java/org/acme/quarkus/sample/HelloResource.java
@@ -1,0 +1,21 @@
+package org.acme.quarkus.sample;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkus.example.HelloMsg;
+
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        Integer number = HelloMsg.Status.TEST_ONE.getNumber();
+        // return a thing from proto file (for devmode test)
+        return "hello " + number;
+    }
+}

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/src/main/proto/hello.proto
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/src/main/proto/hello.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+package io.quarkus.example;
+
+option java_multiple_files = true;
+option java_package = "io.quarkus.example";
+
+import "google/protobuf/timestamp.proto";
+
+
+message HelloMsg {
+  enum Status {
+    UNKNOWN = 0;
+    NOT_SERVING = 1;
+    TEST_ONE = 2;
+  }
+  string message = 1;
+  google.protobuf.Timestamp date_time = 2;
+  Status status = 3;
+}
+
+service DevModeService {
+  rpc Check(HelloMsg) returns (HelloMsg);
+}

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output-dir/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+quarkus.generate-code.grpc.descriptor-set.generate=true
+quarkus.generate-code.grpc.descriptor-set.name=hello.dsc
+quarkus.generate-code.grpc.descriptor-set.output-dir=proto

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+            includeGroup 'org.hibernate.orm'
+        }
+    }
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+    implementation 'io.quarkus:quarkus-grpc'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name = 'grpc-descriptor-set-alternate-output'

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/src/main/java/org/acme/quarkus/sample/HelloResource.java
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/src/main/java/org/acme/quarkus/sample/HelloResource.java
@@ -1,0 +1,21 @@
+package org.acme.quarkus.sample;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkus.example.HelloMsg;
+
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        Integer number = HelloMsg.Status.TEST_ONE.getNumber();
+        // return a thing from proto file (for devmode test)
+        return "hello " + number;
+    }
+}

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/src/main/proto/hello.proto
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/src/main/proto/hello.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+package io.quarkus.example;
+
+option java_multiple_files = true;
+option java_package = "io.quarkus.example";
+
+import "google/protobuf/timestamp.proto";
+
+
+message HelloMsg {
+  enum Status {
+    UNKNOWN = 0;
+    NOT_SERVING = 1;
+    TEST_ONE = 2;
+  }
+  string message = 1;
+  google.protobuf.Timestamp date_time = 2;
+  Status status = 3;
+}
+
+service DevModeService {
+  rpc Check(HelloMsg) returns (HelloMsg);
+}

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set-alternate-output/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.generate-code.grpc.descriptor-set.generate=true
+quarkus.generate-code.grpc.descriptor-set.name=hello.dsc

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+            includeGroup 'org.hibernate.orm'
+        }
+    }
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy'
+    implementation 'io.quarkus:quarkus-grpc'
+}
+
+group 'org.acme'
+version '1.0.0-SNAPSHOT'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+                includeGroup 'org.hibernate.orm'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name = 'grpc-descriptor-set'

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set/src/main/java/org/acme/quarkus/sample/HelloResource.java
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set/src/main/java/org/acme/quarkus/sample/HelloResource.java
@@ -1,0 +1,21 @@
+package org.acme.quarkus.sample;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.quarkus.example.HelloMsg;
+
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        Integer number = HelloMsg.Status.TEST_ONE.getNumber();
+        // return a thing from proto file (for devmode test)
+        return "hello " + number;
+    }
+}

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set/src/main/proto/hello.proto
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set/src/main/proto/hello.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+package io.quarkus.example;
+
+option java_multiple_files = true;
+option java_package = "io.quarkus.example";
+
+import "google/protobuf/timestamp.proto";
+
+
+message HelloMsg {
+  enum Status {
+    UNKNOWN = 0;
+    NOT_SERVING = 1;
+    TEST_ONE = 2;
+  }
+  string message = 1;
+  google.protobuf.Timestamp date_time = 2;
+  Status status = 3;
+}
+
+service DevModeService {
+  rpc Check(HelloMsg) returns (HelloMsg);
+}

--- a/integration-tests/gradle/src/main/resources/grpc-descriptor-set/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/grpc-descriptor-set/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.generate-code.grpc.descriptor-set.generate=true

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcDescriptorSetAlternateOutputBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcDescriptorSetAlternateOutputBuildTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class GrpcDescriptorSetAlternateOutputBuildTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testGrpcDescriptorSetAlternateOutput() throws Exception {
+        var projectDir = getProjectDir("grpc-descriptor-set-alternate-output");
+        var buildResult = runGradleWrapper(projectDir, "clean", "build");
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":quarkusGenerateCode"))).isTrue();
+
+        var expectedOutputDir = projectDir.toPath()
+                .resolve("build")
+                .resolve("classes")
+                .resolve("java")
+                .resolve("quarkus-generated-sources")
+                .resolve("grpc");
+
+        assertThat(expectedOutputDir).exists();
+        assertThat(expectedOutputDir.resolve("hello.dsc"))
+                .exists()
+                .isNotEmptyFile();
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcDescriptorSetAlternateOutputDirBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcDescriptorSetAlternateOutputDirBuildTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class GrpcDescriptorSetAlternateOutputDirBuildTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testGrpcDescriptorSetAlternateOutputDir() throws Exception {
+        var projectDir = getProjectDir("grpc-descriptor-set-alternate-output-dir");
+        var buildResult = runGradleWrapper(projectDir, "clean", "build");
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":quarkusGenerateCode"))).isTrue();
+
+        var expectedOutputDir = projectDir.toPath()
+                .resolve("build")
+                .resolve("proto");
+
+        assertThat(expectedOutputDir).exists();
+        assertThat(expectedOutputDir.resolve("hello.dsc"))
+                .exists()
+                .isNotEmptyFile();
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcDescriptorSetBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/GrpcDescriptorSetBuildTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class GrpcDescriptorSetBuildTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testGrpcDescriptorSet() throws Exception {
+        var projectDir = getProjectDir("grpc-descriptor-set");
+        var buildResult = runGradleWrapper(projectDir, "clean", "build");
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":quarkusGenerateCode"))).isTrue();
+
+        var expectedOutputDir = projectDir.toPath()
+                .resolve("build")
+                .resolve("classes")
+                .resolve("java")
+                .resolve("quarkus-generated-sources")
+                .resolve("grpc");
+
+        assertThat(expectedOutputDir).exists();
+        assertThat(expectedOutputDir.resolve("descriptor_set.dsc"))
+                .exists()
+                .isNotEmptyFile();
+    }
+}

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output-dir/pom.xml
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output-dir/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-test-grpc-descriptor-sets-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-grpc-descriptor-sets-alternate-output-dir</artifactId>
+    <name>Quarkus - Integration Tests - gRPC - Descriptor Sets - Alternate Output Dir</name>
+
+        <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <build.dir>${project.build.directory}</build.dir>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output-dir/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldEndpoint.java
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output-dir/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldEndpoint.java
@@ -1,0 +1,41 @@
+package io.quarkus.grpc.examples.hello;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+import examples.GreeterGrpc;
+import examples.HelloReply;
+import examples.HelloRequest;
+import examples.MutinyGreeterGrpc;
+import io.quarkus.grpc.GrpcClient;
+import io.smallrye.mutiny.Uni;
+
+@Path("/hello")
+public class HelloWorldEndpoint {
+
+    @GrpcClient("hello")
+    GreeterGrpc.GreeterBlockingStub blockingHelloService;
+
+    @GrpcClient("hello")
+    MutinyGreeterGrpc.MutinyGreeterStub mutinyHelloService;
+
+    @GET
+    @Path("/blocking/{name}")
+    public String helloBlocking(@PathParam("name") String name) {
+        HelloReply reply = blockingHelloService.sayHello(HelloRequest.newBuilder().setName(name).build());
+        return generateResponse(reply);
+
+    }
+
+    @GET
+    @Path("/mutiny/{name}")
+    public Uni<String> helloMutiny(@PathParam("name") String name) {
+        return mutinyHelloService.sayHello(HelloRequest.newBuilder().setName(name).build())
+                .onItem().transform((reply) -> generateResponse(reply));
+    }
+
+    public String generateResponse(HelloReply reply) {
+        return String.format("%s! HelloWorldService has been called %d number of times.", reply.getMessage(), reply.getCount());
+    }
+}

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output-dir/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldService.java
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output-dir/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldService.java
@@ -1,0 +1,23 @@
+package io.quarkus.grpc.examples.hello;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import examples.HelloReply;
+import examples.HelloRequest;
+import examples.MutinyGreeterGrpc;
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class HelloWorldService extends MutinyGreeterGrpc.GreeterImplBase {
+
+    AtomicInteger counter = new AtomicInteger();
+
+    @Override
+    public Uni<HelloReply> sayHello(HelloRequest request) {
+        int count = counter.incrementAndGet();
+        String name = request.getName();
+        return Uni.createFrom().item("Hello " + name)
+                .map(res -> HelloReply.newBuilder().setMessage(res).setCount(count).build());
+    }
+}

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output-dir/src/main/proto/helloworld.proto
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output-dir/src/main/proto/helloworld.proto
@@ -1,0 +1,21 @@
+syntax = "proto2";
+
+option java_multiple_files = true;
+option java_package = "examples";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package helloworld;
+
+service Greeter {
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+    required string name = 1;
+}
+
+message HelloReply {
+    required  string message = 1;
+    optional int32 count = 2;
+}

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output-dir/src/main/resources/application.properties
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output-dir/src/main/resources/application.properties
@@ -1,0 +1,12 @@
+quarkus.generate-code.grpc.descriptor-set.generate=true
+quarkus.generate-code.grpc.descriptor-set.name=hello.dsc
+quarkus.generate-code.grpc.descriptor-set.output-dir=proto
+
+quarkus.grpc.server.port=9001
+
+quarkus.grpc.clients.hello.host=localhost
+quarkus.grpc.clients.hello.port=9001
+
+%vertx.quarkus.grpc.clients.hello.port=8081
+%vertx.quarkus.grpc.clients.hello.use-quarkus-grpc-client=true
+%vertx.quarkus.grpc.server.use-separate-server=false

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output-dir/src/test/java/io/quarkus/grpc/examples/hello/DescriptorSetExistsTest.java
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output-dir/src/test/java/io/quarkus/grpc/examples/hello/DescriptorSetExistsTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.grpc.examples.hello;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public class DescriptorSetExistsTest {
+
+    @Test
+    public void descriptorSetExists() {
+        var expectedOutputDir = Path.of(System.getProperty("build.dir"))
+                .resolve("proto");
+
+        assertThat(expectedOutputDir).exists();
+        assertThat(expectedOutputDir.resolve("hello.dsc"))
+                .exists()
+                .isNotEmptyFile();
+    }
+}

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output/pom.xml
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-test-grpc-descriptor-sets-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-grpc-descriptor-sets-alternate-output</artifactId>
+    <name>Quarkus - Integration Tests - gRPC - Descriptor Sets - Alternate Output</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <build.dir>${project.build.directory}</build.dir>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldEndpoint.java
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldEndpoint.java
@@ -1,0 +1,41 @@
+package io.quarkus.grpc.examples.hello;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+import examples.GreeterGrpc;
+import examples.HelloReply;
+import examples.HelloRequest;
+import examples.MutinyGreeterGrpc;
+import io.quarkus.grpc.GrpcClient;
+import io.smallrye.mutiny.Uni;
+
+@Path("/hello")
+public class HelloWorldEndpoint {
+
+    @GrpcClient("hello")
+    GreeterGrpc.GreeterBlockingStub blockingHelloService;
+
+    @GrpcClient("hello")
+    MutinyGreeterGrpc.MutinyGreeterStub mutinyHelloService;
+
+    @GET
+    @Path("/blocking/{name}")
+    public String helloBlocking(@PathParam("name") String name) {
+        HelloReply reply = blockingHelloService.sayHello(HelloRequest.newBuilder().setName(name).build());
+        return generateResponse(reply);
+
+    }
+
+    @GET
+    @Path("/mutiny/{name}")
+    public Uni<String> helloMutiny(@PathParam("name") String name) {
+        return mutinyHelloService.sayHello(HelloRequest.newBuilder().setName(name).build())
+                .onItem().transform((reply) -> generateResponse(reply));
+    }
+
+    public String generateResponse(HelloReply reply) {
+        return String.format("%s! HelloWorldService has been called %d number of times.", reply.getMessage(), reply.getCount());
+    }
+}

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldService.java
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldService.java
@@ -1,0 +1,23 @@
+package io.quarkus.grpc.examples.hello;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import examples.HelloReply;
+import examples.HelloRequest;
+import examples.MutinyGreeterGrpc;
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class HelloWorldService extends MutinyGreeterGrpc.GreeterImplBase {
+
+    AtomicInteger counter = new AtomicInteger();
+
+    @Override
+    public Uni<HelloReply> sayHello(HelloRequest request) {
+        int count = counter.incrementAndGet();
+        String name = request.getName();
+        return Uni.createFrom().item("Hello " + name)
+                .map(res -> HelloReply.newBuilder().setMessage(res).setCount(count).build());
+    }
+}

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output/src/main/proto/helloworld.proto
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output/src/main/proto/helloworld.proto
@@ -1,0 +1,21 @@
+syntax = "proto2";
+
+option java_multiple_files = true;
+option java_package = "examples";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package helloworld;
+
+service Greeter {
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+    required string name = 1;
+}
+
+message HelloReply {
+    required  string message = 1;
+    optional int32 count = 2;
+}

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output/src/main/resources/application.properties
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+quarkus.generate-code.grpc.descriptor-set.generate=true
+quarkus.generate-code.grpc.descriptor-set.name=hello.dsc
+
+quarkus.grpc.server.port=9001
+
+quarkus.grpc.clients.hello.host=localhost
+quarkus.grpc.clients.hello.port=9001
+
+%vertx.quarkus.grpc.clients.hello.port=8081
+%vertx.quarkus.grpc.clients.hello.use-quarkus-grpc-client=true
+%vertx.quarkus.grpc.server.use-separate-server=false

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output/src/test/java/io/quarkus/grpc/examples/hello/DescriptorSetExistsTest.java
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set-alternate-output/src/test/java/io/quarkus/grpc/examples/hello/DescriptorSetExistsTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.grpc.examples.hello;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public class DescriptorSetExistsTest {
+
+    @Test
+    public void descriptorSetExists() {
+        var expectedOutputDir = Path.of(System.getProperty("build.dir"))
+                .resolve("generated-sources")
+                .resolve("grpc");
+
+        assertThat(expectedOutputDir).exists();
+        assertThat(expectedOutputDir.resolve("hello.dsc"))
+                .exists()
+                .isNotEmptyFile();
+    }
+}

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set/pom.xml
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-test-grpc-descriptor-sets-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-grpc-descriptor-sets-descriptor-set</artifactId>
+    <name>Quarkus - Integration Tests - gRPC - Descriptor Sets - Descriptor Set</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <build.dir>${project.build.directory}</build.dir>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldEndpoint.java
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldEndpoint.java
@@ -1,0 +1,41 @@
+package io.quarkus.grpc.examples.hello;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+import examples.GreeterGrpc;
+import examples.HelloReply;
+import examples.HelloRequest;
+import examples.MutinyGreeterGrpc;
+import io.quarkus.grpc.GrpcClient;
+import io.smallrye.mutiny.Uni;
+
+@Path("/hello")
+public class HelloWorldEndpoint {
+
+    @GrpcClient("hello")
+    GreeterGrpc.GreeterBlockingStub blockingHelloService;
+
+    @GrpcClient("hello")
+    MutinyGreeterGrpc.MutinyGreeterStub mutinyHelloService;
+
+    @GET
+    @Path("/blocking/{name}")
+    public String helloBlocking(@PathParam("name") String name) {
+        HelloReply reply = blockingHelloService.sayHello(HelloRequest.newBuilder().setName(name).build());
+        return generateResponse(reply);
+
+    }
+
+    @GET
+    @Path("/mutiny/{name}")
+    public Uni<String> helloMutiny(@PathParam("name") String name) {
+        return mutinyHelloService.sayHello(HelloRequest.newBuilder().setName(name).build())
+                .onItem().transform((reply) -> generateResponse(reply));
+    }
+
+    public String generateResponse(HelloReply reply) {
+        return String.format("%s! HelloWorldService has been called %d number of times.", reply.getMessage(), reply.getCount());
+    }
+}

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldService.java
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldService.java
@@ -1,0 +1,23 @@
+package io.quarkus.grpc.examples.hello;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import examples.HelloReply;
+import examples.HelloRequest;
+import examples.MutinyGreeterGrpc;
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class HelloWorldService extends MutinyGreeterGrpc.GreeterImplBase {
+
+    AtomicInteger counter = new AtomicInteger();
+
+    @Override
+    public Uni<HelloReply> sayHello(HelloRequest request) {
+        int count = counter.incrementAndGet();
+        String name = request.getName();
+        return Uni.createFrom().item("Hello " + name)
+                .map(res -> HelloReply.newBuilder().setMessage(res).setCount(count).build());
+    }
+}

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set/src/main/proto/helloworld.proto
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set/src/main/proto/helloworld.proto
@@ -1,0 +1,21 @@
+syntax = "proto2";
+
+option java_multiple_files = true;
+option java_package = "examples";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package helloworld;
+
+service Greeter {
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+    required string name = 1;
+}
+
+message HelloReply {
+    required  string message = 1;
+    optional int32 count = 2;
+}

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set/src/main/resources/application.properties
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+quarkus.generate-code.grpc.descriptor-set.generate=true
+
+quarkus.grpc.server.port=9001
+
+quarkus.grpc.clients.hello.host=localhost
+quarkus.grpc.clients.hello.port=9001
+
+%vertx.quarkus.grpc.clients.hello.port=8081
+%vertx.quarkus.grpc.clients.hello.use-quarkus-grpc-client=true
+%vertx.quarkus.grpc.server.use-separate-server=false

--- a/integration-tests/grpc-descriptor-sets/grpc-descriptor-set/src/test/java/io/quarkus/grpc/examples/hello/DescriptorSetExistsTest.java
+++ b/integration-tests/grpc-descriptor-sets/grpc-descriptor-set/src/test/java/io/quarkus/grpc/examples/hello/DescriptorSetExistsTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.grpc.examples.hello;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public class DescriptorSetExistsTest {
+
+    @Test
+    public void descriptorSetExists() {
+        var expectedOutputDir = Path.of(System.getProperty("build.dir"))
+                .resolve("generated-sources")
+                .resolve("grpc");
+
+        assertThat(expectedOutputDir).exists();
+        assertThat(expectedOutputDir.resolve("descriptor_set.dsc"))
+                .exists()
+                .isNotEmptyFile();
+    }
+}

--- a/integration-tests/grpc-descriptor-sets/pom.xml
+++ b/integration-tests/grpc-descriptor-sets/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-grpc-descriptor-sets-parent</artifactId>
+    <name>Quarkus - Integration Tests - gRPC - Descriptor Sets - Parent</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>grpc-descriptor-set</module>
+        <module>grpc-descriptor-set-alternate-output</module>
+        <module>grpc-descriptor-set-alternate-output-dir</module>
+    </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-grpc</artifactId>
+            <version>${project.version}</version> <!--kept here to not pollute the BOM-->
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-code</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -373,6 +373,7 @@
                 <module>locales</module>
                 <module>redis-devservices</module>
                 <!-- gRPC tests -->
+                <module>grpc-descriptor-sets</module>
                 <module>grpc-inprocess</module>
                 <module>grpc-vertx</module>
                 <module>grpc-tls</module>


### PR DESCRIPTION
Ability to generate gRPC descriptor sets.

@cescoffier please take a look. In the code gen I needed a way to get access to the project root directory so that the user could specify an output directory relative to that. I modified the Maven & Gradle plugins to provide that info into the generation. I also added a bunch of tests to both plugins.

Fixes #36897 