### PR TITLE
Support for dynamic OIDC JWK set resolution

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcRequestContextProperties.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcRequestContextProperties.java
@@ -4,13 +4,25 @@ import java.util.Map;
 
 public class OidcRequestContextProperties {
 
+    public static String TOKEN = "token";
+    public static String TOKEN_CREDENTIAL = "token_credential";
+
     private final Map<String, Object> properties;
 
     public OidcRequestContextProperties(Map<String, Object> properties) {
         this.properties = properties;
     }
 
-    public Object getProperty(String name) {
+    public Object get(String name) {
         return properties.get(name);
     }
+
+    public String getString(String name) {
+        return (String) get(name);
+    }
+
+    public <T> T get(String name, Class<T> type) {
+        return type.cast(get(name));
+    }
+
 }

--- a/extensions/oidc/runtime/pom.xml
+++ b/extensions/oidc/runtime/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -381,6 +381,81 @@ public class OidcTenantConfig extends OidcCommonConfig {
         }
     }
 
+    /**
+     * Configuration for controlling how JsonWebKeySet containing verification keys should be acquired and managed.
+     */
+    @ConfigItem
+    public Jwks jwks = new Jwks();
+
+    @ConfigGroup
+    public static class Jwks {
+
+        /**
+         * If JWK verification keys should be fetched at the moment a connection to the OIDC provider
+         * is initialized.
+         * <p/>
+         * Disabling this property will delay the key acquisition until the moment the current token
+         * has to be verified. Typically it can only be necessary if the token or other telated request properties
+         * provide an additional context which is required to resolve the keys correctly.
+         */
+        @ConfigItem(defaultValue = "true")
+        public boolean resolveEarly = true;
+
+        /**
+         * Maximum number of JWK keys that can be cached.
+         * This property will be ignored if the {@link #resolveEarly} property is set to true.
+         */
+        @ConfigItem(defaultValue = "10")
+        public int cacheSize = 10;
+
+        /**
+         * Number of minutes a JWK key can be cached for.
+         * This property will be ignored if the {@link #resolveEarly} property is set to true.
+         */
+        @ConfigItem(defaultValue = "10M")
+        public Duration cacheTimeToLive = Duration.ofMinutes(10);
+
+        /**
+         * Cache timer interval.
+         * If this property is set then a timer will check and remove the stale entries periodically.
+         * This property will be ignored if the {@link #resolveEarly} property is set to true.
+         */
+        @ConfigItem
+        public Optional<Duration> cleanUpTimerInterval = Optional.empty();
+
+        public int getCacheSize() {
+            return cacheSize;
+        }
+
+        public void setCacheSize(int cacheSize) {
+            this.cacheSize = cacheSize;
+        }
+
+        public Duration getCacheTimeToLive() {
+            return cacheTimeToLive;
+        }
+
+        public void setCacheTimeToLive(Duration cacheTimeToLive) {
+            this.cacheTimeToLive = cacheTimeToLive;
+        }
+
+        public Optional<Duration> getCleanUpTimerInterval() {
+            return cleanUpTimerInterval;
+        }
+
+        public void setCleanUpTimerInterval(Duration cleanUpTimerInterval) {
+            this.cleanUpTimerInterval = Optional.of(cleanUpTimerInterval);
+        }
+
+        public boolean isResolveEarly() {
+            return resolveEarly;
+        }
+
+        public void setResolveEarly(boolean resolveEarly) {
+            this.resolveEarly = resolveEarly;
+        }
+    }
+
     @ConfigGroup
     public static class Frontchannel {
         /**

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutTokenCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutTokenCache.java
@@ -1,103 +1,33 @@
 package io.quarkus.oidc.runtime;
 
-import java.util.Iterator;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import jakarta.enterprise.event.Observes;
 
 import io.quarkus.oidc.OidcTenantConfig;
-import io.vertx.core.Handler;
+import io.quarkus.runtime.ShutdownEvent;
 import io.vertx.core.Vertx;
 
 public class BackChannelLogoutTokenCache {
-    private OidcTenantConfig oidcConfig;
 
-    private Map<String, CacheEntry> cacheMap = new ConcurrentHashMap<>();;
-    private AtomicInteger size = new AtomicInteger();
+    final MemoryCache<TokenVerificationResult> cache;
 
     public BackChannelLogoutTokenCache(OidcTenantConfig oidcTenantConfig, Vertx vertx) {
-        this.oidcConfig = oidcTenantConfig;
-        init(vertx);
-    }
-
-    private void init(Vertx vertx) {
-        cacheMap = new ConcurrentHashMap<>();
-        if (oidcConfig.logout.backchannel.cleanUpTimerInterval.isPresent()) {
-            vertx.setPeriodic(oidcConfig.logout.backchannel.cleanUpTimerInterval.get().toMillis(), new Handler<Long>() {
-                @Override
-                public void handle(Long event) {
-                    // Remove all the entries which have expired
-                    removeInvalidEntries();
-                }
-            });
-        }
+        cache = new MemoryCache<TokenVerificationResult>(vertx, oidcTenantConfig.logout.backchannel.cleanUpTimerInterval,
+                oidcTenantConfig.logout.backchannel.tokenCacheTimeToLive, oidcTenantConfig.logout.backchannel.tokenCacheSize);
     }
 
     public void addTokenVerification(String token, TokenVerificationResult result) {
-        if (!prepareSpaceForNewCacheEntry()) {
-            clearCache();
-        }
-        cacheMap.put(token, new CacheEntry(result));
+        cache.add(token, result);
     }
 
     public TokenVerificationResult removeTokenVerification(String token) {
-        CacheEntry entry = removeCacheEntry(token);
-        return entry == null ? null : entry.result;
+        return cache.remove(token);
     }
 
     public boolean containsTokenVerification(String token) {
-        return cacheMap.containsKey(token);
+        return cache.containsKey(token);
     }
 
-    public void clearCache() {
-        cacheMap.clear();
-        size.set(0);
-    }
-
-    private void removeInvalidEntries() {
-        long now = now();
-        for (Iterator<Map.Entry<String, CacheEntry>> it = cacheMap.entrySet().iterator(); it.hasNext();) {
-            Map.Entry<String, CacheEntry> next = it.next();
-            if (isEntryExpired(next.getValue(), now)) {
-                it.remove();
-                size.decrementAndGet();
-            }
-        }
-    }
-
-    private boolean prepareSpaceForNewCacheEntry() {
-        int currentSize;
-        do {
-            currentSize = size.get();
-            if (currentSize == oidcConfig.logout.backchannel.tokenCacheSize) {
-                return false;
-            }
-        } while (!size.compareAndSet(currentSize, currentSize + 1));
-        return true;
-    }
-
-    private CacheEntry removeCacheEntry(String token) {
-        CacheEntry entry = cacheMap.remove(token);
-        if (entry != null) {
-            size.decrementAndGet();
-        }
-        return entry;
-    }
-
-    private boolean isEntryExpired(CacheEntry entry, long now) {
-        return entry.createdTime + oidcConfig.logout.backchannel.tokenCacheTimeToLive.toMillis() < now;
-    }
-
-    private static long now() {
-        return System.currentTimeMillis();
-    }
-
-    private static class CacheEntry {
-        volatile TokenVerificationResult result;
-        long createdTime = System.currentTimeMillis();
-
-        public CacheEntry(TokenVerificationResult result) {
-            this.result = result;
-        }
+    void shutdown(@Observes ShutdownEvent event, Vertx vertx) {
+        cache.stopTimer(vertx);
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DynamicVerificationKeyResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DynamicVerificationKeyResolver.java
@@ -1,0 +1,177 @@
+package io.quarkus.oidc.runtime;
+
+import java.security.Key;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import jakarta.enterprise.event.Observes;
+
+import org.jboss.logging.Logger;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwx.HeaderParameterNames;
+import org.jose4j.jwx.JsonWebStructure;
+import org.jose4j.keys.resolvers.VerificationKeyResolver;
+import org.jose4j.lang.UnresolvableKeyException;
+
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.common.OidcRequestContextProperties;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.security.credential.TokenCredential;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+public class DynamicVerificationKeyResolver {
+    private static final Logger LOG = Logger.getLogger(DynamicVerificationKeyResolver.class);
+
+    private final OidcProviderClient client;
+    private final MemoryCache<Key> cache;
+
+    public DynamicVerificationKeyResolver(OidcProviderClient client, OidcTenantConfig config) {
+        this.client = client;
+        this.cache = new MemoryCache<Key>(client.getVertx(), config.jwks.cleanUpTimerInterval,
+                config.jwks.cacheTimeToLive, config.jwks.cacheSize);
+    }
+
+    public Uni<VerificationKeyResolver> resolve(TokenCredential tokenCred) {
+        JsonObject headers = OidcUtils.decodeJwtHeaders(tokenCred.getToken());
+        Key key = findKeyInTheCache(headers);
+        if (key != null) {
+            return Uni.createFrom().item(new SingleKeyVerificationKeyResolver(key));
+        }
+
+        return client.getJsonWebKeySet(new OidcRequestContextProperties(
+                Map.of(OidcRequestContextProperties.TOKEN, tokenCred.getToken(),
+                        OidcRequestContextProperties.TOKEN_CREDENTIAL, tokenCred)))
+                .onItem().transformToUni(new Function<JsonWebKeySet, Uni<? extends VerificationKeyResolver>>() {
+
+                    @Override
+                    public Uni<? extends VerificationKeyResolver> apply(JsonWebKeySet jwks) {
+                        Key newKey = null;
+                        // Try 'kid' first
+                        String kid = headers.getString(HeaderParameterNames.KEY_ID);
+                        if (kid != null) {
+                            newKey = getKeyWithId(jwks, kid);
+                            if (newKey == null) {
+                                // if `kid` was set then the key must exist
+                                return Uni.createFrom().failure(
+                                        new UnresolvableKeyException(String.format("JWK with kid '%s' is not available", kid)));
+                            } else {
+                                cache.add(kid, newKey);
+                            }
+                        }
+
+                        String thumbprint = null;
+                        if (newKey == null) {
+                            thumbprint = headers.getString(HeaderParameterNames.X509_CERTIFICATE_SHA256_THUMBPRINT);
+                            if (thumbprint != null) {
+                                newKey = getKeyWithS256Thumbprint(jwks, thumbprint);
+                                if (newKey == null) {
+                                    // if only `x5tS256` was set then the key must exist
+                                    return Uni.createFrom().failure(
+                                            new UnresolvableKeyException(String.format(
+                                                    "JWK with the SHA256 certificate thumbprint '%s' is not available",
+                                                    thumbprint)));
+                                } else {
+                                    cache.add(thumbprint, newKey);
+                                }
+                            }
+                        }
+
+                        if (newKey == null) {
+                            thumbprint = headers.getString(HeaderParameterNames.X509_CERTIFICATE_THUMBPRINT);
+                            if (thumbprint != null) {
+                                newKey = getKeyWithThumbprint(jwks, thumbprint);
+                                if (newKey == null) {
+                                    // if only `x5t` was set then the key must exist
+                                    return Uni.createFrom().failure(new UnresolvableKeyException(
+                                            String.format("JWK with the certificate thumbprint '%s' is not available",
+                                                    thumbprint)));
+                                } else {
+                                    cache.add(thumbprint, newKey);
+                                }
+                            }
+                        }
+
+                        if (newKey == null && kid == null && thumbprint == null) {
+                            newKey = jwks.getKeyWithoutKeyIdAndThumbprint("RSA");
+                        }
+
+                        if (newKey == null) {
+                            return Uni.createFrom().failure(new UnresolvableKeyException(
+                                    String.format(
+                                            "JWK is not available, neither 'kid' nor 'x5t#S256' nor 'x5t' token headers are set",
+                                            kid)));
+                        } else {
+                            return Uni.createFrom().item(new SingleKeyVerificationKeyResolver(newKey));
+                        }
+                    }
+
+                });
+    }
+
+    private static Key getKeyWithId(JsonWebKeySet jwks, String kid) {
+        if (kid != null) {
+            return jwks.getKeyWithId(kid);
+        } else {
+            LOG.debug("Token 'kid' header is not set");
+            return null;
+        }
+    }
+
+    private Key getKeyWithThumbprint(JsonWebKeySet jwks, String thumbprint) {
+        if (thumbprint != null) {
+            return jwks.getKeyWithThumbprint(thumbprint);
+        } else {
+            LOG.debug("Token 'x5t' header is not set");
+            return null;
+        }
+    }
+
+    private Key getKeyWithS256Thumbprint(JsonWebKeySet jwks, String thumbprint) {
+        if (thumbprint != null) {
+            return jwks.getKeyWithS256Thumbprint(thumbprint);
+        } else {
+            LOG.debug("Token 'x5tS256' header is not set");
+            return null;
+        }
+    }
+
+    private Key findKeyInTheCache(JsonObject headers) {
+        String kid = headers.getString(HeaderParameterNames.KEY_ID);
+        if (kid != null && cache.containsKey(kid)) {
+            return cache.get(kid);
+        }
+        String thumbprint = headers.getString(HeaderParameterNames.X509_CERTIFICATE_SHA256_THUMBPRINT);
+        if (thumbprint != null && cache.containsKey(thumbprint)) {
+            return cache.get(thumbprint);
+        }
+
+        thumbprint = headers.getString(HeaderParameterNames.X509_CERTIFICATE_THUMBPRINT);
+        if (thumbprint != null && cache.containsKey(thumbprint)) {
+            return cache.get(thumbprint);
+        }
+
+        return null;
+    }
+
+    static class SingleKeyVerificationKeyResolver implements VerificationKeyResolver {
+
+        private Key key;
+
+        SingleKeyVerificationKeyResolver(Key key) {
+            this.key = key;
+        }
+
+        @Override
+        public Key resolveKey(JsonWebSignature jws, List<JsonWebStructure> nestingContext)
+                throws UnresolvableKeyException {
+            return key;
+        }
+    }
+
+    void shutdown(@Observes ShutdownEvent event, Vertx vertx) {
+        cache.stopTimer(vertx);
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/JsonWebKeySet.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/JsonWebKeySet.java
@@ -9,11 +9,8 @@ import java.util.Set;
 
 import org.jose4j.jwk.JsonWebKey;
 import org.jose4j.jwk.PublicJsonWebKey;
-import org.jose4j.jws.JsonWebSignature;
-import org.jose4j.lang.InvalidAlgorithmException;
 import org.jose4j.lang.JoseException;
 
-import io.quarkus.logging.Log;
 import io.quarkus.oidc.OIDCException;
 
 public class JsonWebKeySet {
@@ -86,13 +83,8 @@ public class JsonWebKeySet {
         return keysWithS256Thumbprints.get(x5tS256);
     }
 
-    public Key getKeyWithoutKeyIdAndThumbprint(JsonWebSignature jws) {
-        try {
-            List<Key> keys = keysWithoutKeyIdAndThumbprint.get(jws.getKeyType());
-            return keys == null || keys.size() != 1 ? null : keys.get(0);
-        } catch (InvalidAlgorithmException ex) {
-            Log.debug("Token 'alg'(algorithm) header value is invalid", ex);
-            return null;
-        }
+    public Key getKeyWithoutKeyIdAndThumbprint(String keyType) {
+        List<Key> keys = keysWithoutKeyIdAndThumbprint.get(keyType);
+        return keys == null || keys.size() != 1 ? null : keys.get(0);
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/MemoryCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/MemoryCache.java
@@ -1,0 +1,135 @@
+package io.quarkus.oidc.runtime;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+
+public class MemoryCache<T> {
+    private volatile Long timerId = null;
+
+    private final Map<String, CacheEntry<T>> cacheMap = new ConcurrentHashMap<>();
+    private AtomicInteger size = new AtomicInteger();
+    private final Duration cacheTimeToLive;
+    private final int cacheSize;
+
+    public MemoryCache(Vertx vertx, Optional<Duration> cleanUpTimerInterval,
+            Duration cacheTimeToLive, int cacheSize) {
+        this.cacheTimeToLive = cacheTimeToLive;
+        this.cacheSize = cacheSize;
+        init(vertx, cleanUpTimerInterval);
+    }
+
+    private void init(Vertx vertx, Optional<Duration> cleanUpTimerInterval) {
+        if (cleanUpTimerInterval.isPresent()) {
+            timerId = vertx.setPeriodic(cleanUpTimerInterval.get().toMillis(), new Handler<Long>() {
+                @Override
+                public void handle(Long event) {
+                    // Remove all the entries which have expired
+                    removeInvalidEntries();
+                }
+            });
+        }
+    }
+
+    public void add(String key, T result) {
+        if (cacheSize > 0) {
+            if (!prepareSpaceForNewCacheEntry()) {
+                clearCache();
+            }
+            cacheMap.put(key, new CacheEntry<T>(result));
+        }
+    }
+
+    public T remove(String key) {
+        CacheEntry<T> entry = removeCacheEntry(key);
+        return entry == null ? null : entry.result;
+    }
+
+    public T get(String key) {
+        CacheEntry<T> entry = cacheMap.get(key);
+        return entry == null ? null : entry.result;
+    }
+
+    public boolean containsKey(String key) {
+        return cacheMap.containsKey(key);
+    }
+
+    private void removeInvalidEntries() {
+        long now = now();
+        for (Iterator<Map.Entry<String, CacheEntry<T>>> it = cacheMap.entrySet().iterator(); it.hasNext();) {
+            Map.Entry<String, CacheEntry<T>> next = it.next();
+            if (next != null) {
+                if (isEntryExpired(next.getValue(), now)) {
+                    try {
+                        it.remove();
+                        size.decrementAndGet();
+                    } catch (IllegalStateException ex) {
+                        // continue
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean prepareSpaceForNewCacheEntry() {
+        int currentSize;
+        do {
+            currentSize = size.get();
+            if (currentSize == cacheSize) {
+                return false;
+            }
+        } while (!size.compareAndSet(currentSize, currentSize + 1));
+        return true;
+    }
+
+    private CacheEntry<T> removeCacheEntry(String token) {
+        CacheEntry<T> entry = cacheMap.remove(token);
+        if (entry != null) {
+            size.decrementAndGet();
+        }
+        return entry;
+    }
+
+    private boolean isEntryExpired(CacheEntry<T> entry, long now) {
+        return entry.createdTime + cacheTimeToLive.toMillis() < now;
+    }
+
+    private static long now() {
+        return System.currentTimeMillis();
+    }
+
+    private static class CacheEntry<T> {
+        volatile T result;
+        long createdTime = System.currentTimeMillis();
+
+        public CacheEntry(T result) {
+            this.result = result;
+        }
+    }
+
+    public int getCacheSize() {
+        return cacheMap.size();
+    }
+
+    public void clearCache() {
+        cacheMap.clear();
+        size.set(0);
+    }
+
+    public void stopTimer(Vertx vertx) {
+        if (timerId != null && vertx.cancelTimer(timerId)) {
+            timerId = null;
+        }
+    }
+
+    public boolean isTimerRunning() {
+        return timerId != null;
+    }
+
+}

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/MemoryCacheTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/MemoryCacheTest.java
@@ -1,0 +1,101 @@
+package io.quarkus.oidc.runtime;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.Vertx;
+
+public class MemoryCacheTest {
+
+    static Vertx vertx = Vertx.vertx();
+
+    @AfterAll
+    public static void closeVertxClient() {
+        if (vertx != null) {
+            vertx.close().toCompletionStage().toCompletableFuture().join();
+            vertx = null;
+        }
+    }
+
+    @Test
+    public void testCache() throws Exception {
+
+        MemoryCache<Bean> cache = new MemoryCache<Bean>(vertx,
+                // timer interval
+                Optional.of(Duration.ofSeconds(1)),
+                // entry is valid for 3 seconds
+                Duration.ofSeconds(2),
+                // max cache size
+                2);
+        cache.add("1", new Bean("1"));
+        cache.add("2", new Bean("2"));
+        assertEquals(2, cache.getCacheSize());
+
+        assertEquals("1", cache.get("1").name);
+        assertEquals("2", cache.get("2").name);
+
+        assertEquals("1", cache.remove("1").name);
+        assertNull(cache.get("1"));
+        assertEquals("2", cache.get("2").name);
+        assertEquals(1, cache.getCacheSize());
+
+        assertTrue(cache.isTimerRunning());
+
+        await().atMost(Duration.ofSeconds(5)).until(new Callable<Boolean>() {
+
+            @Override
+            public Boolean call() throws Exception {
+                return cache.getCacheSize() == 0;
+            }
+
+        });
+
+        cache.stopTimer(vertx);
+        assertFalse(cache.isTimerRunning());
+    }
+
+    @Test
+    public void testAddWhenMaxCacheSizeIsReached() throws Exception {
+
+        MemoryCache<Bean> cache = new MemoryCache<Bean>(vertx,
+                // timer interval
+                Optional.empty(),
+                // entry is valid for 3 seconds
+                Duration.ofSeconds(3),
+                // max cache size
+                2);
+        assertFalse(cache.isTimerRunning());
+
+        cache.add("1", new Bean("1"));
+        cache.add("2", new Bean("2"));
+        assertEquals(2, cache.getCacheSize());
+
+        // Currently, if the cache is full and a new entry has to be added, then the whole cache is cleared
+        // It can be optimized to remove the oldest entry only in the future
+
+        cache.add("3", new Bean("3"));
+        assertEquals(1, cache.getCacheSize());
+
+        assertNull(cache.get("1"));
+        assertNull(cache.get("2"));
+        assertEquals("3", cache.get("3").name);
+    }
+
+    static class Bean {
+        String name;
+
+        Bean(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcRequestCustomizer.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcRequestCustomizer.java
@@ -3,6 +3,7 @@ package io.quarkus.it.keycloak;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import io.quarkus.arc.Unremovable;
+import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.common.OidcRequestContextProperties;
 import io.quarkus.oidc.common.OidcRequestFilter;
 import io.vertx.core.http.HttpMethod;
@@ -18,7 +19,22 @@ public class OidcRequestCustomizer implements OidcRequestFilter {
         HttpMethod method = request.method();
         String uri = request.uri();
         if (method == HttpMethod.GET && uri.endsWith("/auth/azure/jwk")) {
-            request.putHeader("Authorization", "ID token");
+            String token = contextProps.getString(OidcRequestContextProperties.TOKEN);
+            AccessTokenCredential tokenCred = contextProps.get(OidcRequestContextProperties.TOKEN_CREDENTIAL,
+                    AccessTokenCredential.class);
+            // or
+            // IdTokenCredential tokenCred = contextProps.get(OidcRequestContextProperties.TOKEN_CREDENTIAL,
+            //                                                 IdTokenCredential.class);
+            // or
+            // TokenCredential tokenCred = contextProps.get(OidcRequestContextProperties.TOKEN_CREDENTIAL,
+            //                                                 TokenCredential.class);
+            // if either access or ID token has to be verified and check is it an instanceof
+            // AccessTokenCredential or IdTokenCredential
+            // or simply
+            // String token = contextProps.getString(OidcRequestContextProperties.TOKEN);
+            if (token.equals(tokenCred.getToken())) {
+                request.putHeader("Authorization", "Access token: " + token);
+            }
         }
     }
 

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -130,6 +130,7 @@ quarkus.oidc.bearer-azure.provider=microsoft
 quarkus.oidc.bearer-azure.application-type=service
 quarkus.oidc.bearer-azure.discovery-enabled=false
 quarkus.oidc.bearer-azure.jwks-path=${keycloak.url}/azure/jwk
+quarkus.oidc.bearer-azure.jwks.resolve-early=false
 quarkus.oidc.bearer-azure.token.lifespan-grace=2147483647
 quarkus.oidc.bearer-azure.token.customizer-name=azure-access-token-customizer
 

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -50,11 +50,11 @@ public class BearerTokenAuthorizationTest {
 
     @Test
     public void testAccessResourceAzure() throws Exception {
+        String azureToken = readFile("token.txt");
         String azureJwk = readFile("jwks.json");
         wireMockServer.stubFor(WireMock.get("/auth/azure/jwk")
-                .withHeader("Authorization", matching("ID token"))
+                .withHeader("Authorization", matching("Access token: " + azureToken))
                 .willReturn(WireMock.aResponse().withBody(azureJwk)));
-        String azureToken = readFile("token.txt");
         RestAssured.given().auth().oauth2(azureToken)
                 .when().get("/api/admin/bearer-azure")
                 .then()


### PR DESCRIPTION
Fixes #36563

PR to support resolving keys at the moment when the token is available, with token claims or headers containing the information required to fetch correct verification keys as well as additionally affect an optional JWKS endpoint specific authentication.

Typically, JSON web keys are resolved early from the `public` endpoint, when the OIDC connection is established, when the JWKS endpoint address is discovered or manually configured. In the use case which this PR targeting, it is impossible because  the JWKS endpoint authentication is required and the authentication credentials for the key retrieval is derived from the token - which is not available. 

So this PR does the following:

* Adds `quarkus.oidc.jwks.resolve-early` configuration property, `true` by default, setting it to `false`enables a dynamic, just in time JWK resolution. 
* Since the  JWK resolution is driven by the current token, as opposed to the `read-once` approach at the initialization time, caching resolved keys is necessary, so the defautt in-memory cache support is provided
* The actual OIDC logic changes are barely affected,  `quarkus.oidc.jwks.resolve-early=false` then the keys are simply resolved at the token verification time
* Test confirming the use case is now supported is provided, I've just updated the existing test but more tests will follow incrementally, it is hard to cover all the variations from the start, the important point, it is not enabled by default as well.  
* As it happens TokenIntrospection/UserInfo cache but also BackChannel logout cache had the same code I added to thus dynamic resolver, so it was a good opportunity to refactor it all into a single `MemoryCache` class and remove a ton of duplicated code - this is also an early step toward supporting customizing cache support only for all of these features


CC @calvernaz