### PR TITLE
Redis vector fields and arguments

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisCommandExtraArguments.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisCommandExtraArguments.java
@@ -8,17 +8,17 @@ import io.quarkus.redis.datasource.codecs.Codec;
 public interface RedisCommandExtraArguments {
 
     /**
-     * @return the list of arguments, encoded as a list of String.
+     * @return the list of arguments.
      */
-    default List<String> toArgs() {
+    default List<Object> toArgs() {
         return toArgs(null);
     }
 
     /**
      * @param encoder an optional encoder to encode some of the values
-     * @return the list of arguments, encoded as a list of String.
+     * @return the list of arguments.
      */
-    default List<String> toArgs(Codec encoder) {
+    default List<Object> toArgs(Codec encoder) {
         return Collections.emptyList();
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/SortArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/SortArgs.java
@@ -131,8 +131,8 @@ public class SortArgs implements RedisCommandExtraArguments {
         return this;
     }
 
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
         if (by != null && !by.isBlank()) {
             args.add("BY");
             args.add(by);

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/autosuggest/GetArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/autosuggest/GetArgs.java
@@ -47,8 +47,8 @@ public class GetArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         if (fuzzy) {
             list.add("FUZZY");
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bitmap/BitFieldArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bitmap/BitFieldArgs.java
@@ -88,7 +88,7 @@ public class BitFieldArgs implements RedisCommandExtraArguments {
 
     }
 
-    private final List<String> commands = new ArrayList<>();
+    private final List<Object> commands = new ArrayList<>();
     private BitFieldType previousBitFieldType;
 
     /**
@@ -351,7 +351,7 @@ public class BitFieldArgs implements RedisCommandExtraArguments {
         }
     }
 
-    public List<String> toArgs() {
+    public List<Object> toArgs() {
         return commands;
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/BfInsertArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/BfInsertArgs.java
@@ -82,8 +82,8 @@ public class BfInsertArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
 
         if (capacity > 0) {
             list.add("CAPACITY");

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/BfReserveArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/BfReserveArgs.java
@@ -41,8 +41,8 @@ public class BfReserveArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         if (expansion > 0) {
             list.add("EXPANSION");
             list.add(Integer.toString(expansion));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/CfInsertArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/CfInsertArgs.java
@@ -36,8 +36,8 @@ public class CfInsertArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         if (capacity > 0) {
             list.add("CAPACITY");
             list.add(Long.toString(capacity));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/CfReserveArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/CfReserveArgs.java
@@ -51,8 +51,8 @@ public class CfReserveArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         if (bucketSize > 0) {
             list.add("BUCKETSIZE");
             list.add(Long.toString(bucketSize));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoAddArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoAddArgs.java
@@ -42,11 +42,11 @@ public class GeoAddArgs implements RedisCommandExtraArguments {
         return this;
     }
 
-    public List<String> toArgs() {
+    public List<Object> toArgs() {
         if (xx && nx) {
             throw new IllegalArgumentException("Cannot set XX and NX together");
         }
-        List<String> args = new ArrayList<>();
+        List<Object> args = new ArrayList<>();
         if (xx) {
             args.add("XX");
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoRadiusArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoRadiusArgs.java
@@ -101,13 +101,13 @@ public class GeoRadiusArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
+    public List<Object> toArgs() {
         // Validation
         if (any && count == -1) {
             throw new IllegalArgumentException("ANY can only be used if COUNT is also set");
         }
 
-        List<String> list = new ArrayList<>();
+        List<Object> list = new ArrayList<>();
         if (withDistance) {
             list.add("WITHDIST");
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoRadiusStoreArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoRadiusStoreArgs.java
@@ -127,7 +127,7 @@ public class GeoRadiusStoreArgs<K> implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs(Codec codec) {
+    public List<Object> toArgs(Codec codec) {
         // Validation
         if (any && count == -1) {
             throw new IllegalArgumentException("ANY can only be used if COUNT is also set");
@@ -136,7 +136,7 @@ public class GeoRadiusStoreArgs<K> implements RedisCommandExtraArguments {
             throw new IllegalArgumentException("At least `STORE` or `STOREDIST` must be set");
         }
 
-        List<String> list = new ArrayList<>();
+        List<Object> list = new ArrayList<>();
         if (withDistance) {
             list.add("WITHDIST");
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoSearchArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoSearchArgs.java
@@ -184,7 +184,7 @@ public class GeoSearchArgs<V> implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs(Codec codec) {
+    public List<Object> toArgs(Codec codec) {
         // Validation
         if (any && count == -1) {
             throw new IllegalArgumentException("ANY can only be used if COUNT is also set");
@@ -198,7 +198,7 @@ public class GeoSearchArgs<V> implements RedisCommandExtraArguments {
             throw new IllegalArgumentException("FROMMEMBER and FROMLONLAT cannot be used together");
         }
 
-        List<String> list = new ArrayList<>();
+        List<Object> list = new ArrayList<>();
         if (member != null) {
             list.add("FROMMEMBER");
             list.add(new String(codec.encode(member), StandardCharsets.UTF_8));
@@ -249,7 +249,7 @@ public class GeoSearchArgs<V> implements RedisCommandExtraArguments {
         return withCoordinates;
     }
 
-    private void putFlag(List<String> list, boolean flag, String value) {
+    private void putFlag(List<Object> list, boolean flag, String value) {
         if (flag) {
             list.add(value);
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoSearchStoreArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoSearchStoreArgs.java
@@ -146,7 +146,7 @@ public class GeoSearchStoreArgs<V> implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs(Codec codec) {
+    public List<Object> toArgs(Codec codec) {
         // Validation
         if (any && count == -1) {
             throw new IllegalArgumentException("ANY can only be used if COUNT is also set");
@@ -160,7 +160,7 @@ public class GeoSearchStoreArgs<V> implements RedisCommandExtraArguments {
             throw new IllegalArgumentException("FROMMEMBER and FROMLONLAT cannot be used together");
         }
 
-        List<String> list = new ArrayList<>();
+        List<Object> list = new ArrayList<>();
         if (member != null) {
             list.add("FROMMEMBER");
             list.add(new String(codec.encode(member), StandardCharsets.UTF_8));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/json/JsonSetArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/json/JsonSetArgs.java
@@ -31,11 +31,11 @@ public class JsonSetArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
+    public List<Object> toArgs() {
         if (xx && nx) {
             throw new IllegalArgumentException("Cannot set XX and NX together");
         }
-        List<String> args = new ArrayList<>();
+        List<Object> args = new ArrayList<>();
         if (xx) {
             args.add("XX");
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/CopyArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/CopyArgs.java
@@ -37,8 +37,8 @@ public class CopyArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
         if (destinationDb != -1) {
             args.add("DB");
             args.add(Long.toString(destinationDb));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/ExpireArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/ExpireArgs.java
@@ -55,8 +55,8 @@ public class ExpireArgs implements RedisCommandExtraArguments {
         return this;
     }
 
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
 
         boolean exclusion = false;
         if (nx) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/LPosArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/LPosArgs.java
@@ -40,8 +40,8 @@ public class LPosArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         if (rank != 0) {
             list.add("RANK");
             list.add(Long.toString(rank));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/AggregateArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/AggregateArgs.java
@@ -242,8 +242,8 @@ public class AggregateArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         if (verbatim) {
             list.add("VERBATIM");
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/CreateArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/CreateArgs.java
@@ -288,8 +288,8 @@ public class CreateArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
 
         if (onHash) {
             if (onJson) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/DistanceMetric.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/DistanceMetric.java
@@ -1,0 +1,10 @@
+package io.quarkus.redis.datasource.search;
+
+/**
+ * Metric for computing the distance between two vectors.
+ */
+public enum DistanceMetric {
+    L2,
+    IP,
+    COSINE
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/FieldOptions.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/FieldOptions.java
@@ -17,6 +17,12 @@ public class FieldOptions {
     private char separator;
     private boolean caseSensitive;
     private boolean withSuffixTrie;
+    private VectorAlgorithm vectorAlgorithm;
+    private VectorType vectorType;
+    private Integer dimension;
+    private DistanceMetric distanceMetric;
+    private Integer initialCap;
+    private Integer blockSize;
 
     /**
      * Numeric, tag (not supported with JSON) or text attributes can have the optional SORTABLE argument.
@@ -125,8 +131,98 @@ public class FieldOptions {
         return this;
     }
 
+    /**
+     * For vector fields, specifies the vector algorithm to use when searching k most similar vectors in an index.
+     *
+     * @param vectorAlgorithm the vector algorithm
+     * @return the current {@code FieldOptions}
+     */
+    public FieldOptions vectorAlgorithm(VectorAlgorithm vectorAlgorithm) {
+        this.vectorAlgorithm = vectorAlgorithm;
+        return this;
+    }
+
+    /**
+     * For vector fields, specifies the vector type.
+     *
+     * @param vectorType the vector type
+     * @return the current {@code FieldOptions}
+     */
+    public FieldOptions vectorType(VectorType vectorType) {
+        this.vectorType = vectorType;
+        return this;
+    }
+
+    /**
+     * For vector fields, specifies the dimension.
+     *
+     * @param dimension the dimension
+     * @return the current {@code FieldOptions}
+     */
+    public FieldOptions dimension(int dimension) {
+        this.dimension = dimension;
+        return this;
+    }
+
+    /**
+     * For vector fields, specifies the distance metric.
+     *
+     * @param distanceMetric the distance metric
+     * @return the current {@code FieldOptions}
+     */
+    public FieldOptions distanceMetric(DistanceMetric distanceMetric) {
+        this.distanceMetric = distanceMetric;
+        return this;
+    }
+
+    /**
+     * For vector fields, specifies the initial vector capacity in the index.
+     *
+     * @param initialCap the initial capacity
+     * @return the current {@code FieldOptions}
+     */
+    public FieldOptions initialCap(int initialCap) {
+        this.initialCap = initialCap;
+        return this;
+    }
+
+    /**
+     * For vector fields, specifies the block size (the amount of vectors to store in a contiguous array).
+     *
+     * @param blockSize the block size
+     * @return the current {@code FieldOptions}
+     */
+    public FieldOptions blockSize(int blockSize) {
+        this.blockSize = blockSize;
+        return this;
+    }
+
     public List<String> toArgs() {
         List<String> list = new ArrayList<>();
+        if (vectorAlgorithm != null) {
+            list.add(vectorAlgorithm.name());
+            list.add(String.valueOf(vectorSimilarityArgumentsCount()));
+        }
+        if (vectorType != null) {
+            list.add("TYPE");
+            list.add(vectorType.name());
+        }
+        if (dimension != null) {
+            list.add("DIM");
+            list.add(dimension.toString());
+        }
+        if (distanceMetric != null) {
+            list.add("DISTANCE_METRIC");
+            list.add(distanceMetric.name());
+        }
+        if (initialCap != null) {
+            list.add("INITIAL_CAP");
+            list.add(initialCap.toString());
+        }
+        if (blockSize != null) {
+            list.add("BLOCK_SIZE");
+            list.add(blockSize.toString());
+        }
         if (sortable) {
             list.add("SORTABLE");
         }
@@ -161,5 +257,25 @@ public class FieldOptions {
             list.add("WITHSUFFIXTRIE");
         }
         return list;
+    }
+
+    private int vectorSimilarityArgumentsCount() {
+        int count = 0;
+        if (vectorType != null) {
+            count += 2;
+        }
+        if (dimension != null) {
+            count += 2;
+        }
+        if (distanceMetric != null) {
+            count += 2;
+        }
+        if (initialCap != null) {
+            count += 2;
+        }
+        if (blockSize != null) {
+            count += 2;
+        }
+        return count;
     }
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/HighlightArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/HighlightArgs.java
@@ -49,8 +49,8 @@ public class HighlightArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         list.add("HIGHLIGHT");
         if (fields != null && fields.length > 0) {
             list.add("FIELDS");

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/IndexedField.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/IndexedField.java
@@ -40,8 +40,8 @@ public class IndexedField implements RedisCommandExtraArguments {
         this.options = options;
     }
 
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         list.add(field);
         if (alias != null) {
             list.add("AS");

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/QueryArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/QueryArgs.java
@@ -8,6 +8,8 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
 import static io.smallrye.mutiny.helpers.ParameterValidation.positiveOrZero;
 import static io.smallrye.mutiny.helpers.ParameterValidation.validate;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,6 +55,7 @@ public class QueryArgs implements RedisCommandExtraArguments {
     private int count = -1;
     private Duration timeout;
     private final Map<String, String> params = new HashMap<>();
+    private final Map<String, byte[]> byteArrayParams = new HashMap<>();
     private int dialect = -1;
 
     /**
@@ -360,6 +363,61 @@ public class QueryArgs implements RedisCommandExtraArguments {
     }
 
     /**
+     * Defines a parameter with a byte array value.
+     * @param name the parameter name
+     * @param value the parameter value as byte array
+     * @return the current {@code QueryArgs}
+     */
+    public QueryArgs param(String name, byte[] value) {
+        this.byteArrayParams.put(notNullOrBlank(name, "name"), notNullOrEmpty(value, "value"));
+        return this;
+    }
+
+    /**
+     * Defines a parameter with a float array value.
+     * @param name the parameter name
+     * @param value the parameter value as array of floats
+     * @return the current {@code QueryArgs}
+     */
+    public QueryArgs param(String name, float[] value) {
+        this.byteArrayParams.put(notNullOrBlank(name, "name"), toByteArray(notNullOrEmpty(value, "value")));
+        return this;
+    }
+
+    /**
+     * Defines a parameter with a double array value.
+     * @param name the parameter name
+     * @param value the parameter value as array of doubles
+     * @return the current {@code QueryArgs}
+     */
+    public QueryArgs param(String name, double[] value) {
+        this.byteArrayParams.put(notNullOrBlank(name, "name"), toByteArray(notNullOrEmpty(value, "value")));
+        return this;
+    }
+
+    /**
+     * Defines a parameter with an int array value.
+     * @param name the parameter name
+     * @param value the parameter value as array of ints
+     * @return the current {@code QueryArgs}
+     */
+    public QueryArgs param(String name, int[] value) {
+        this.byteArrayParams.put(notNullOrBlank(name, "name"), toByteArray(notNullOrEmpty(value, "value")));
+        return this;
+    }
+
+    /**
+     * Defines a parameter with a long array value.
+     * @param name the parameter name
+     * @param value the parameter value as array of longs
+     * @return the current {@code QueryArgs}
+     */
+    public QueryArgs param(String name, long[] value) {
+        this.byteArrayParams.put(notNullOrBlank(name, "name"), toByteArray(notNullOrEmpty(value, "value")));
+        return this;
+    }
+
+    /**
      * Selects the dialect version under which to execute the query.
      * If not specified, the query will execute under the default dialect version set during module initial loading.
      *
@@ -372,8 +430,8 @@ public class QueryArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs(Codec encoder) {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs(Codec encoder) {
+        List<Object> list = new ArrayList<>();
 
         if (nocontent) {
             list.add("NOCONTENT");
@@ -480,9 +538,13 @@ public class QueryArgs implements RedisCommandExtraArguments {
             list.add(Long.toString(timeout.toMillis()));
         }
 
-        if (!params.isEmpty()) {
+        if (!params.isEmpty() || !byteArrayParams.isEmpty()) {
             list.add("PARAMS");
-            list.add(Integer.toString(params.size()));
+            list.add(Integer.toString(params.size() + byteArrayParams.size()));
+            for (Map.Entry<String, byte[]> entry : byteArrayParams.entrySet()) {
+                list.add(entry.getKey());
+                list.add(entry.getValue());
+            }
             for (Map.Entry<String, String> entry : params.entrySet()) {
                 list.add(entry.getKey());
                 list.add(entry.getValue());
@@ -527,4 +589,29 @@ public class QueryArgs implements RedisCommandExtraArguments {
     public boolean containsSortKeys() {
         return withSortKeys;
     }
+
+    private byte[] toByteArray(float[] input) {
+        byte[] bytes = new byte[Float.BYTES * input.length];
+        ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer().put(input);
+        return bytes;
+    }
+
+    private byte[] toByteArray(double[] input) {
+        byte[] bytes = new byte[Double.BYTES * input.length];
+        ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).asDoubleBuffer().put(input);
+        return bytes;
+    }
+
+    private byte[] toByteArray(int[] input) {
+        byte[] bytes = new byte[Integer.BYTES * input.length];
+        ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer().put(input);
+        return bytes;
+    }
+
+    private byte[] toByteArray(long[] input) {
+        byte[] bytes = new byte[Long.BYTES * input.length];
+        ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).asLongBuffer().put(input);
+        return bytes;
+    }
+
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/QueryArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/QueryArgs.java
@@ -364,6 +364,7 @@ public class QueryArgs implements RedisCommandExtraArguments {
 
     /**
      * Defines a parameter with a byte array value.
+     *
      * @param name the parameter name
      * @param value the parameter value as byte array
      * @return the current {@code QueryArgs}
@@ -375,6 +376,7 @@ public class QueryArgs implements RedisCommandExtraArguments {
 
     /**
      * Defines a parameter with a float array value.
+     *
      * @param name the parameter name
      * @param value the parameter value as array of floats
      * @return the current {@code QueryArgs}
@@ -386,6 +388,7 @@ public class QueryArgs implements RedisCommandExtraArguments {
 
     /**
      * Defines a parameter with a double array value.
+     *
      * @param name the parameter name
      * @param value the parameter value as array of doubles
      * @return the current {@code QueryArgs}
@@ -397,6 +400,7 @@ public class QueryArgs implements RedisCommandExtraArguments {
 
     /**
      * Defines a parameter with an int array value.
+     *
      * @param name the parameter name
      * @param value the parameter value as array of ints
      * @return the current {@code QueryArgs}
@@ -408,6 +412,7 @@ public class QueryArgs implements RedisCommandExtraArguments {
 
     /**
      * Defines a parameter with a long array value.
+     *
      * @param name the parameter name
      * @param value the parameter value as array of longs
      * @return the current {@code QueryArgs}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/SpellCheckArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/SpellCheckArgs.java
@@ -68,8 +68,8 @@ public class SpellCheckArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         if (distance != 0) {
             list.add("DISTANCE");
             list.add(Integer.toString(distance));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/SummarizeArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/SummarizeArgs.java
@@ -75,8 +75,8 @@ public class SummarizeArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         list.add("SUMMARIZE");
         if (fields != null && fields.length > 0) {
             list.add("FIELDS");

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/VectorAlgorithm.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/VectorAlgorithm.java
@@ -1,0 +1,18 @@
+package io.quarkus.redis.datasource.search;
+
+/**
+ * The vector algorithm to use when searching k most similar vectors in an index.
+ */
+public enum VectorAlgorithm {
+
+    /**
+     * Brute force algorithm.
+     */
+    FLAT,
+
+    /**
+     * Hierarchical Navigable Small World Graph algorithm.
+     */
+    HNSW
+
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/VectorType.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/search/VectorType.java
@@ -1,0 +1,15 @@
+package io.quarkus.redis.datasource.search;
+
+/**
+ * Type of vector stored in a vector field.
+ */
+public enum VectorType {
+    /**
+     * A 32-bit floating point number.
+     */
+    FLOAT32,
+    /**
+     * A 64-bit floating point number.
+     */
+    FLOAT64
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ZAddArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ZAddArgs.java
@@ -69,7 +69,7 @@ public class ZAddArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
+    public List<Object> toArgs() {
         if (xx && nx) {
             throw new IllegalArgumentException("Cannot use XX and NX together");
         }
@@ -77,7 +77,7 @@ public class ZAddArgs implements RedisCommandExtraArguments {
             throw new IllegalArgumentException("Cannot use LT and GT together");
         }
 
-        List<String> args = new ArrayList<>();
+        List<Object> args = new ArrayList<>();
         putFlag(args, nx, "NX");
         putFlag(args, xx, "XX");
         putFlag(args, lt, "LT");
@@ -86,7 +86,7 @@ public class ZAddArgs implements RedisCommandExtraArguments {
         return args;
     }
 
-    public void putFlag(List<String> args, boolean value, String flag) {
+    public void putFlag(List<Object> args, boolean value, String flag) {
         if (value) {
             args.add(flag);
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ZAggregateArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ZAggregateArgs.java
@@ -80,8 +80,8 @@ public class ZAggregateArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
         if (!weights.isEmpty()) {
             args.add("WEIGHTS");
             for (double w : weights) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ZMpopArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ZMpopArgs.java
@@ -45,12 +45,12 @@ public class ZMpopArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
+    public List<Object> toArgs() {
         if (min && max) {
             throw new IllegalArgumentException("Cannot use MIN and MAX together");
         }
 
-        List<String> args = new ArrayList<>();
+        List<Object> args = new ArrayList<>();
         if (min) {
             args.add("MIN");
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ZRangeArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ZRangeArgs.java
@@ -37,8 +37,8 @@ public class ZRangeArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         if (rev) {
             list.add("REV");
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/StreamRange.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/StreamRange.java
@@ -25,8 +25,8 @@ public class StreamRange implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         list.add(lowerBound);
         list.add(higherBound);
         return list;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XAddArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XAddArgs.java
@@ -93,8 +93,8 @@ public class XAddArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
         if (nomkstream) {
             args.add("NOMKSTREAM");
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XClaimArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XClaimArgs.java
@@ -97,8 +97,8 @@ public class XClaimArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
 
         if (idle != null) {
             args.add("IDLE");

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XGroupCreateArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XGroupCreateArgs.java
@@ -40,8 +40,8 @@ public class XGroupCreateArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
         if (mkstream) {
             args.add("MKSTREAM");
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XGroupSetIdArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XGroupSetIdArgs.java
@@ -29,8 +29,8 @@ public class XGroupSetIdArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
         if (entriesRead > 0) {
             args.add("ENTRIESREAD");
             args.add(Long.toString(entriesRead));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XPendingArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XPendingArgs.java
@@ -39,8 +39,8 @@ public class XPendingArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
 
         if (owner != null) {
             args.add(owner);

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XReadArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XReadArgs.java
@@ -38,8 +38,8 @@ public class XReadArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
         if (count > 0) {
             args.add("COUNT");
             args.add(Integer.toString(count));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XReadGroupArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XReadGroupArgs.java
@@ -51,8 +51,8 @@ public class XReadGroupArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
         if (count > 0) {
             args.add("COUNT");
             args.add(Integer.toString(count));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XTrimArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/stream/XTrimArgs.java
@@ -63,8 +63,8 @@ public class XTrimArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
 
         if (maxlen > 0) {
             if (minid != null) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/GetExArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/GetExArgs.java
@@ -128,8 +128,8 @@ public class GetExArgs extends io.quarkus.redis.datasource.value.GetExArgs imple
         return this;
     }
 
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
         if (ex >= 0) {
             args.add("EX");
             args.add(Long.toString(ex));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/SetArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/SetArgs.java
@@ -168,8 +168,8 @@ public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implement
         return this;
     }
 
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
         if (ex >= 0) {
             args.add("EX");
             args.add(Long.toString(ex));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/AddArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/AddArgs.java
@@ -97,8 +97,8 @@ public class AddArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         if (retention != null) {
             list.add("RETENTION");
             if (retention == Duration.ZERO) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/AlterArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/AlterArgs.java
@@ -92,8 +92,8 @@ public class AlterArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         if (retention != null) {
             list.add("RETENTION");
             if (retention == Duration.ZERO) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/CreateArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/CreateArgs.java
@@ -123,8 +123,8 @@ public class CreateArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         if (retention != null) {
             list.add("RETENTION");
             if (retention == Duration.ZERO) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/IncrementArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/IncrementArgs.java
@@ -95,8 +95,8 @@ public class IncrementArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         if (timestamp >= 0) {
             list.add("TIMESTAMP");
             list.add(Long.toString(timestamp));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/MGetArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/MGetArgs.java
@@ -56,8 +56,8 @@ public class MGetArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
         if (latest) {
             list.add("LATEST");
         }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/MRangeArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/MRangeArgs.java
@@ -203,8 +203,8 @@ public class MRangeArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
 
         if (latest) {
             list.add("LATEST");

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/RangeArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/timeseries/RangeArgs.java
@@ -154,8 +154,8 @@ public class RangeArgs implements RedisCommandExtraArguments {
     }
 
     @Override
-    public List<String> toArgs() {
-        List<String> list = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> list = new ArrayList<>();
 
         if (latest) {
             list.add("LATEST");

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/GetExArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/GetExArgs.java
@@ -125,8 +125,8 @@ public class GetExArgs implements RedisCommandExtraArguments {
         return this;
     }
 
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
         if (ex >= 0) {
             args.add("EX");
             args.add(Long.toString(ex));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/SetArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/SetArgs.java
@@ -165,8 +165,8 @@ public class SetArgs implements RedisCommandExtraArguments {
         return this;
     }
 
-    public List<String> toArgs() {
-        List<String> args = new ArrayList<>();
+    public List<Object> toArgs() {
+        List<Object> args = new ArrayList<>();
         if (ex >= 0) {
             args.add("EX");
             args.add(Long.toString(ex));

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/Validation.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/Validation.java
@@ -19,6 +19,56 @@ public class Validation {
         return array;
     }
 
+    public static float[] notNullOrEmpty(float[] array, String name) {
+        if (array == null) {
+            throw new IllegalArgumentException("`" + name + "` must not be `null`");
+        }
+        if (array.length == 0) {
+            throw new IllegalArgumentException("`" + name + "` must not be empty");
+        }
+        return array;
+    }
+
+    public static double[] notNullOrEmpty(double[] array, String name) {
+        if (array == null) {
+            throw new IllegalArgumentException("`" + name + "` must not be `null`");
+        }
+        if (array.length == 0) {
+            throw new IllegalArgumentException("`" + name + "` must not be empty");
+        }
+        return array;
+    }
+
+    public static int[] notNullOrEmpty(int[] array, String name) {
+        if (array == null) {
+            throw new IllegalArgumentException("`" + name + "` must not be `null`");
+        }
+        if (array.length == 0) {
+            throw new IllegalArgumentException("`" + name + "` must not be empty");
+        }
+        return array;
+    }
+
+    public static long[] notNullOrEmpty(long[] array, String name) {
+        if (array == null) {
+            throw new IllegalArgumentException("`" + name + "` must not be `null`");
+        }
+        if (array.length == 0) {
+            throw new IllegalArgumentException("`" + name + "` must not be empty");
+        }
+        return array;
+    }
+
+    public static byte[] notNullOrEmpty(byte[] array, String name) {
+        if (array == null) {
+            throw new IllegalArgumentException("`" + name + "` must not be `null`");
+        }
+        if (array.length == 0) {
+            throw new IllegalArgumentException("`" + name + "` must not be empty");
+        }
+        return array;
+    }
+
     public static String notNullOrBlank(String v, String name) {
         if (v == null) {
             throw new IllegalArgumentException("`" + name + "` must not be `null`");

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SearchCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SearchCommandsTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.redis.datasource.hash.HashCommands;
 import io.quarkus.redis.datasource.search.AggregateArgs;
 import io.quarkus.redis.datasource.search.CreateArgs;
+import io.quarkus.redis.datasource.search.DistanceMetric;
 import io.quarkus.redis.datasource.search.Document;
 import io.quarkus.redis.datasource.search.FieldOptions;
 import io.quarkus.redis.datasource.search.FieldType;
@@ -28,11 +29,11 @@ import io.quarkus.redis.datasource.search.QueryArgs;
 import io.quarkus.redis.datasource.search.SearchCommands;
 import io.quarkus.redis.datasource.search.SearchQueryResponse;
 import io.quarkus.redis.datasource.search.SpellCheckArgs;
+import io.quarkus.redis.datasource.search.VectorAlgorithm;
+import io.quarkus.redis.datasource.search.VectorType;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.redis.client.Command;
-import io.vertx.mutiny.redis.client.Request;
 
 /**
  * Lots of tests are using await().untilAsserted as the indexing process runs in the background.
@@ -852,13 +853,16 @@ public class SearchCommandsTest extends DatasourceTestBase {
 
     @Test
     void testKNearestNeighborsDouble() {
-        redis.sendAndAwait(Request.cmd(Command.FT_CREATE)
-                .arg("IDX:double")
-                .arg("ON").arg("JSON")
-                .arg("PREFIX").arg("1").arg("indexed:")
-                .arg("SCHEMA")
-                .arg("$.vector").arg("AS").arg("vector").arg("VECTOR").arg("HNSW")
-                .arg("6").arg("DIM").arg("6").arg("DISTANCE_METRIC").arg("COSINE").arg("TYPE").arg("FLOAT64"));
+        ds.search().ftCreate("IDX:double",
+                new CreateArgs()
+                        .onJson()
+                        .prefixes("indexed:")
+                        .indexedField("$.vector", "vector", FieldType.VECTOR,
+                                new FieldOptions()
+                                        .vectorAlgorithm(VectorAlgorithm.HNSW)
+                                        .dimension(6)
+                                        .distanceMetric(DistanceMetric.COSINE)
+                                        .vectorType(VectorType.FLOAT64)));
 
         double[] queryVector = new double[] { 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 };
 
@@ -881,13 +885,16 @@ public class SearchCommandsTest extends DatasourceTestBase {
 
     @Test
     void testKNearestNeighborsFloat() {
-        redis.sendAndAwait(Request.cmd(Command.FT_CREATE)
-                .arg("IDX:float")
-                .arg("ON").arg("JSON")
-                .arg("PREFIX").arg("1").arg("indexed:")
-                .arg("SCHEMA")
-                .arg("$.vector").arg("AS").arg("vector").arg("VECTOR").arg("HNSW")
-                .arg("6").arg("DIM").arg("6").arg("DISTANCE_METRIC").arg("COSINE").arg("TYPE").arg("FLOAT32"));
+        ds.search().ftCreate("IDX:float",
+                new CreateArgs()
+                        .onJson()
+                        .prefixes("indexed:")
+                        .indexedField("$.vector", "vector", FieldType.VECTOR,
+                                new FieldOptions()
+                                        .vectorAlgorithm(VectorAlgorithm.HNSW)
+                                        .dimension(6)
+                                        .distanceMetric(DistanceMetric.COSINE)
+                                        .vectorType(VectorType.FLOAT32)));
 
         float[] queryVector = new float[] { 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f };
 


### PR DESCRIPTION
- Support byte array arguments in the data source api
- Support for supplying vector field parameters when creating vector fields with `FT_CREATE` with the data source api