### PR TITLE
Option TraceServiceLoaderFeature removed in GraalVM 23.1

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -911,8 +911,10 @@ public class NativeImageBuildStep {
 
                 if (nativeConfig.autoServiceLoaderRegistration()) {
                     addExperimentalVMOption(nativeImageArgs, "-H:+UseServiceLoaderFeature");
-                    //When enabling, at least print what exactly is being added:
-                    nativeImageArgs.add("-H:+TraceServiceLoaderFeature");
+                    if (graalVMVersion.compareTo(GraalVM.Version.VERSION_23_1_0) < 0) {
+                        // When enabling, at least print what exactly is being added. Only possible in <23.1.0
+                        nativeImageArgs.add("-H:+TraceServiceLoaderFeature");
+                    }
                 } else {
                     addExperimentalVMOption(nativeImageArgs, "-H:-UseServiceLoaderFeature");
                 }


### PR DESCRIPTION
The option `TraceServiceLoaderFeature` is no longer available starting
with GraalVM 23.1 as part of a refactoring in how the
`ServiceLoaderFeature` works.

There is currently no option offering similar output.

Fixes https://github.com/quarkusio/quarkus/issues/36129
