### PR TITLE
[3.2] Bump smallrye-reactive-messaging.version from 4.6.0 to 4.6.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -63,7 +63,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.1</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.7.2</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>4.6.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>4.6.1</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.2.1</smallrye-stork.version>
         <jakarta.activation.version>2.1.2</jakarta.activation.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>


### PR DESCRIPTION
Contains fix for: https://github.com/smallrye/smallrye-reactive-messaging/issues/2338