### PR TITLE
Send host.name in all spans

### DIFF
--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryResourceTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryResourceTest.java
@@ -4,6 +4,7 @@ import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.quarkus.opentelemetry.deployment.common.TestSpanExporter.getSpanByKindAndParentId;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
@@ -54,6 +55,7 @@ public class OpenTelemetryResourceTest {
         assertEquals("authservice", server.getResource().getAttribute(AttributeKey.stringKey("service.name")));
         assertEquals(config.getRawValue("quarkus.uuid"),
                 server.getResource().getAttribute(AttributeKey.stringKey("service.instance.id")));
+        assertNotNull(server.getResource().getAttribute(AttributeKey.stringKey("host.name")));
     }
 
     @Path("/hello")

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtil.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtil.java
@@ -1,5 +1,6 @@
 package io.quarkus.opentelemetry.runtime.tracing;
 
+import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.HOST_NAME;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
 
 import java.util.List;
@@ -14,7 +15,7 @@ public class TracerUtil {
     private TracerUtil() {
     }
 
-    public static Resource mapResourceAttributes(List<String> resourceAttributes, String serviceName) {
+    public static Resource mapResourceAttributes(List<String> resourceAttributes, String serviceName, String hostname) {
         final AttributesBuilder attributesBuilder = Attributes.builder();
 
         if (!resourceAttributes.isEmpty()) {
@@ -25,6 +26,10 @@ public class TracerUtil {
 
         if (serviceName != null) {
             attributesBuilder.put(SERVICE_NAME.getKey(), serviceName);
+        }
+
+        if (hostname != null) {
+            attributesBuilder.put(HOST_NAME, hostname);
         }
 
         return Resource.create(attributesBuilder.build());

--- a/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtilTest.java
+++ b/extensions/opentelemetry/runtime/src/test/java/io/quarkus/opentelemetry/runtime/tracing/TracerUtilTest.java
@@ -19,7 +19,7 @@ public class TracerUtilTest {
                 "service.namespace=mynamespace",
                 "service.version=1.0",
                 "deployment.environment=production");
-        Resource resource = TracerUtil.mapResourceAttributes(resourceAttributes, null);
+        Resource resource = TracerUtil.mapResourceAttributes(resourceAttributes, null, null);
         Attributes attributes = resource.getAttributes();
         Assertions.assertThat(attributes.size()).isEqualTo(4);
         Assertions.assertThat(attributes.get(ResourceAttributes.SERVICE_NAME)).isEqualTo("myservice");


### PR DESCRIPTION
This is important to resolve the pod producing the span.
This fix comes from a question on Stack Overflow: https://stackoverflow.com/questions/77441049/quarkus-opentelemetry-kuberbetes-pod-name