### PR TITLE
Revert "Unblock SmallRye Health exposed routes"

### DIFF
--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -216,6 +217,7 @@ class SmallRyeHealthProcessor {
                 .routeConfigKey("quarkus.smallrye-health.root-path")
                 .handler(new SmallRyeHealthHandler())
                 .displayOnNotFoundPage()
+                .blockingRoute()
                 .build());
 
         // Register the liveness handler
@@ -224,6 +226,7 @@ class SmallRyeHealthProcessor {
                 .nestedRoute(healthConfig.rootPath, healthConfig.livenessPath)
                 .handler(new SmallRyeLivenessHandler())
                 .displayOnNotFoundPage()
+                .blockingRoute()
                 .build());
 
         // Register the readiness handler
@@ -232,7 +235,21 @@ class SmallRyeHealthProcessor {
                 .nestedRoute(healthConfig.rootPath, healthConfig.readinessPath)
                 .handler(new SmallRyeReadinessHandler())
                 .displayOnNotFoundPage()
+                .blockingRoute()
                 .build());
+
+        // Find all health groups
+        Set<String> healthGroups = new HashSet<>();
+        // with simple @HealthGroup annotations
+        for (AnnotationInstance healthGroupAnnotation : index.getAnnotations(HEALTH_GROUP)) {
+            healthGroups.add(healthGroupAnnotation.value().asString());
+        }
+        // with @HealthGroups repeatable annotations
+        for (AnnotationInstance healthGroupsAnnotation : index.getAnnotations(HEALTH_GROUPS)) {
+            for (AnnotationInstance healthGroupAnnotation : healthGroupsAnnotation.value().asNestedArray()) {
+                healthGroups.add(healthGroupAnnotation.value().asString());
+            }
+        }
 
         // Register the health group handlers
         routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
@@ -240,6 +257,7 @@ class SmallRyeHealthProcessor {
                 .nestedRoute(healthConfig.rootPath, healthConfig.groupPath)
                 .handler(new SmallRyeHealthGroupHandler())
                 .displayOnNotFoundPage()
+                .blockingRoute()
                 .build());
 
         SmallRyeIndividualHealthGroupHandler handler = new SmallRyeIndividualHealthGroupHandler();
@@ -248,6 +266,7 @@ class SmallRyeHealthProcessor {
                 .nestedRoute(healthConfig.rootPath, healthConfig.groupPath + "/*")
                 .handler(handler)
                 .displayOnNotFoundPage()
+                .blockingRoute()
                 .build());
 
         // Register the wellness handler
@@ -256,6 +275,7 @@ class SmallRyeHealthProcessor {
                 .nestedRoute(healthConfig.rootPath, healthConfig.wellnessPath)
                 .handler(new SmallRyeWellnessHandler())
                 .displayOnNotFoundPage()
+                .blockingRoute()
                 .build());
 
         // Register the startup handler
@@ -264,6 +284,7 @@ class SmallRyeHealthProcessor {
                 .nestedRoute(healthConfig.rootPath, healthConfig.startupPath)
                 .handler(new SmallRyeStartupHandler())
                 .displayOnNotFoundPage()
+                .blockingRoute()
                 .build());
 
     }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthGroupHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthGroupHandler.java
@@ -2,13 +2,12 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
-import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeHealthGroupHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
-        return reporter.getHealthGroupsAsync();
+    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
+        return reporter.getHealthGroups();
     }
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandler.java
@@ -2,13 +2,12 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
-import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeHealthHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
-        return reporter.getHealthAsync();
+    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
+        return reporter.getHealth();
     }
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandlerBase.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeHealthHandlerBase.java
@@ -10,11 +10,7 @@ import io.quarkus.vertx.core.runtime.BufferOutputStream;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
-import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.vertx.MutinyHelper;
-import io.vertx.core.Context;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
@@ -22,7 +18,7 @@ import io.vertx.ext.web.RoutingContext;
 
 abstract class SmallRyeHealthHandlerBase implements Handler<RoutingContext> {
 
-    protected abstract Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext routingContext);
+    protected abstract SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext routingContext);
 
     @Override
     public void handle(RoutingContext ctx) {
@@ -45,21 +41,19 @@ abstract class SmallRyeHealthHandlerBase implements Handler<RoutingContext> {
             Arc.container().instance(CurrentIdentityAssociation.class).get().setIdentity(user.getSecurityIdentity());
         }
         SmallRyeHealthReporter reporter = Arc.container().instance(SmallRyeHealthReporter.class).get();
-        Context context = Vertx.currentContext();
-        getHealth(reporter, ctx).emitOn(MutinyHelper.executor(context))
-                .subscribe().with(health -> {
-                    HttpServerResponse resp = ctx.response();
-                    if (health.isDown()) {
-                        resp.setStatusCode(503);
-                    }
-                    resp.headers().set(HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8");
-                    Buffer buffer = Buffer.buffer(256); // this size seems to cover the basic health checks
-                    try (BufferOutputStream outputStream = new BufferOutputStream(buffer);) {
-                        reporter.reportHealth(outputStream, health);
-                        resp.end(buffer);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                });
+        SmallRyeHealth health = getHealth(reporter, ctx);
+        HttpServerResponse resp = ctx.response();
+        if (health.isDown()) {
+            resp.setStatusCode(503);
+        }
+        resp.headers().set(HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8");
+        Buffer buffer = Buffer.buffer(256); // this size seems to cover the basic health checks
+        try (BufferOutputStream outputStream = new BufferOutputStream(buffer);) {
+            reporter.reportHealth(outputStream, health);
+            resp.end(buffer);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
+
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeIndividualHealthGroupHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeIndividualHealthGroupHandler.java
@@ -2,14 +2,13 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
-import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeIndividualHealthGroupHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
+    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
         String group = ctx.normalizedPath().substring(ctx.normalizedPath().lastIndexOf("/") + 1);
-        return reporter.getHealthGroupAsync(group);
+        return reporter.getHealthGroup(group);
     }
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeLivenessHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeLivenessHandler.java
@@ -2,13 +2,12 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
-import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeLivenessHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
-        return reporter.getLivenessAsync();
+    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
+        return reporter.getLiveness();
     }
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeReadinessHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeReadinessHandler.java
@@ -2,13 +2,12 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
-import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeReadinessHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
-        return reporter.getReadinessAsync();
+    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext routingContext) {
+        return reporter.getReadiness();
     }
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeStartupHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeStartupHandler.java
@@ -2,13 +2,12 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
-import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeStartupHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
-        return reporter.getStartupAsync();
+    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext routingContext) {
+        return reporter.getStartup();
     }
 }

--- a/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeWellnessHandler.java
+++ b/extensions/smallrye-health/runtime/src/main/java/io/quarkus/smallrye/health/runtime/SmallRyeWellnessHandler.java
@@ -2,13 +2,12 @@ package io.quarkus.smallrye.health.runtime;
 
 import io.smallrye.health.SmallRyeHealth;
 import io.smallrye.health.SmallRyeHealthReporter;
-import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 public class SmallRyeWellnessHandler extends SmallRyeHealthHandlerBase {
 
     @Override
-    protected Uni<SmallRyeHealth> getHealth(SmallRyeHealthReporter reporter, RoutingContext ctx) {
-        return reporter.getWellnessAsync();
+    protected SmallRyeHealth getHealth(SmallRyeHealthReporter reporter, RoutingContext routingContext) {
+        return reporter.getWellness();
     }
 }


### PR DESCRIPTION
This reverts commit 2c21a99aaf8fa61bbd7332f980e222ea1928fa32.

I will revert this change. It's causing issues in 3.5.1:
https://github.com/quarkusio/quarkus/issues/36977

We need to understand the issues and fix them. We also need to make sure it won't introduce issues for custom health checks in user applications.

/cc @cescoffier @xstefank 