### PR TITLE
Revert "Make Dependabot group micro updates"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,6 @@ updates:
     open-pull-requests-limit: 6
     labels:
       - area/dependencies
-    groups:
-      patches:
-        update-types:
-        - "patch"
     allow:
       - dependency-name: org.jboss:jboss-parent
       - dependency-name: org.jboss.resteasy:*


### PR DESCRIPTION
This reverts commit 8833e356b50798c8de11e80afb72ab62de9a2e97.

Given we still time out and we haven't seen any Dependabot update since then, my guess is that grouping is made at the very end of the process and we don't get there.