### PR TITLE
Upgrade Jackson version to 2.15.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -92,7 +92,7 @@
         <plexus-component-annotations.version>2.1.0</plexus-component-annotations.version>
         <graal-sdk.version>23.0.1</graal-sdk.version>
         <gizmo.version>1.7.0</gizmo.version>
-        <jackson-bom.version>2.15.2</jackson-bom.version>
+        <jackson-bom.version>2.15.3</jackson-bom.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.16.0</commons-codec.version>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -56,7 +56,7 @@
         <httpcore.version>4.4.16</httpcore.version><!-- Keep in sync with maven-wagon.version (wagon-http 3.4.3 brings in 4.4.13 and 4.4.14) -->
         <httpclient.version>4.5.14</httpclient.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
-        <jackson-bom.version>2.15.2</jackson-bom.version>
+        <jackson-bom.version>2.15.3</jackson-bom.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -42,7 +42,7 @@
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.1.2</version.surefire.plugin>
         <maven-plugin-plugin.version>3.8.1</maven-plugin-plugin.version>
-        <jackson-bom.version>2.15.2</jackson-bom.version>
+        <jackson-bom.version>2.15.3</jackson-bom.version>
         <smallrye-beanbag.version>1.3.2</smallrye-beanbag.version>
         <junit.jupiter.version>5.10.0</junit.jupiter.version>
     </properties>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -66,7 +66,7 @@
         <vertx.version>4.4.6</vertx.version>
         <rest-assured.version>5.3.2</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
-        <jackson-bom.version>2.15.2</jackson-bom.version>
+        <jackson-bom.version>2.15.3</jackson-bom.version>
         <smallrye-stork.version>2.4.0</smallrye-stork.version>
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
         <yasson.version>3.0.3</yasson.version>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -52,7 +52,7 @@
 
         <!-- Versions -->
         <assertj.version>3.24.2</assertj.version>
-        <jackson-bom.version>2.15.2</jackson-bom.version>
+        <jackson-bom.version>2.15.3</jackson-bom.version>
         <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
         <junit.version>5.10.0</junit.version>
         <commons-compress.version>1.24.0</commons-compress.version>


### PR DESCRIPTION
This pull request is aiming to update the version of Jackson into the latest stable one 2.15.3
