### PR TITLE
Allow to create named HTTP Security policies referenced in the application.properties path matching rules as CDI beans

### DIFF
--- a/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
+++ b/docs/src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
@@ -68,6 +68,52 @@ It is an exact path match because it does not end with `*`.
 <3> This permission set references the previously defined policy.
 `roles1` is an example name; you can call the permission sets whatever you want.
 
+=== Custom HttpSecurityPolicy
+
+Sometimes it might be useful to register your own named policy. You can get it done by creating application scoped CDI
+bean that implements the `io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy` interface like in the example below:
+
+[source,java]
+----
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class CustomNamedHttpSecPolicy implements HttpSecurityPolicy {
+    @Override
+    public Uni<CheckResult> checkPermission(RoutingContext request, Uni<SecurityIdentity> identity,
+            AuthorizationRequestContext requestContext) {
+        if (customRequestAuthorization(request)) {
+            return Uni.createFrom().item(CheckResult.PERMIT);
+        }
+        return Uni.createFrom().item(CheckResult.DENY);
+    }
+
+    @Override
+    public String name() {
+        return "custom"; <1>
+    }
+}
+----
+<1> Named HTTP Security policy will only be applied to requests matched by the `application.properties` path matching rules.
+
+.Example of custom named HttpSecurityPolicy referenced from configuration file
+[source,properties]
+----
+quarkus.http.auth.permission.custom1.paths=/custom/*
+quarkus.http.auth.permission.custom1.policy=custom                              <1>
+----
+<1> Custom policy name must match the value returned by the `io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy.name` method.
+
+[TIP]
+====
+You can also create global `HttpSecurityPolicy` invoked on every request.
+Just do not implement the `io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy.name` method and leave the policy nameless.
+====
 
 === Matching on paths and methods
 
@@ -642,19 +688,22 @@ Similarly to the `CRUDResource` example, the following example shows how you can
 ----
 package org.acme.library;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.security.Permission;
 import java.util.Arrays;
 import java.util.Set;
 
+@RegisterForReflection <1>
 public class MediaLibraryPermission extends LibraryPermission {
 
     public MediaLibraryPermission(String libraryName, String[] actions) {
-        super(libraryName, actions, new MediaLibrary());    <1>
+        super(libraryName, actions, new MediaLibrary());    <2>
     }
 
 }
 ----
-<1> We want to pass the `MediaLibrary` instance to the `LibraryPermission` constructor.
+<1> When building a native executable, the permission class must be registered for reflection unless it is also used in at least one `io.quarkus.security.PermissionsAllowed#name` parameter.
+<2> We want to pass the `MediaLibrary` instance to the `LibraryPermission` constructor.
 
 [source,properties]
 ----

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityPolicyBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpSecurityPolicyBuildItem.java
@@ -5,6 +5,11 @@ import java.util.function.Supplier;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy;
 
+/**
+ * @deprecated Define {@link io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy} CDI bean with {@link #name}
+ *             set as the {@link HttpSecurityPolicy#name()}.
+ */
+@Deprecated
 public final class HttpSecurityPolicyBuildItem extends MultiBuildItem {
 
     final String name;

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/CustomNamedHttpSecPolicy.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/CustomNamedHttpSecPolicy.java
@@ -1,0 +1,29 @@
+package io.quarkus.vertx.http.security;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityPolicy;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class CustomNamedHttpSecPolicy implements HttpSecurityPolicy {
+    @Override
+    public Uni<CheckResult> checkPermission(RoutingContext request, Uni<SecurityIdentity> identity,
+            AuthorizationRequestContext requestContext) {
+        if (isRequestAuthorized(request)) {
+            return Uni.createFrom().item(CheckResult.PERMIT);
+        }
+        return Uni.createFrom().item(CheckResult.DENY);
+    }
+
+    private static boolean isRequestAuthorized(RoutingContext request) {
+        return request.request().headers().contains("hush-hush");
+    }
+
+    @Override
+    public String name() {
+        return "custom123";
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/CustomNamedHttpSecPolicyTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/CustomNamedHttpSecPolicyTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.vertx.http.security;
+
+import java.util.function.Supplier;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class CustomNamedHttpSecPolicyTest {
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles().add("test", "test", "test");
+    }
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.auth.permission.authenticated.paths=admin\n" +
+            "quarkus.http.auth.permission.authenticated.policy=custom123\n";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestIdentityController.class, TestIdentityProvider.class, AdminPathHandler.class,
+                            CustomNamedHttpSecPolicy.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties");
+        }
+    });
+
+    @Test
+    public void testAdminPath() {
+        RestAssured
+                .given()
+                .when()
+                .get("/admin")
+                .then()
+                .assertThat()
+                .statusCode(401);
+        RestAssured
+                .given()
+                .when()
+                .header("hush-hush", "ignored")
+                .get("/admin")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(Matchers.equalTo(":/admin"));
+        RestAssured
+                .given()
+                .auth()
+                .preemptive()
+                .basic("test", "test")
+                .when()
+                .header("hush-hush", "ignored")
+                .get("/admin")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(Matchers.equalTo("test:/admin"));
+        RestAssured
+                .given()
+                .auth()
+                .preemptive()
+                .basic("test", "test")
+                .when()
+                .get("/admin")
+                .then()
+                .assertThat()
+                .statusCode(403);
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthorizer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthorizer.java
@@ -23,10 +23,12 @@ public class HttpAuthorizer extends AbstractHttpAuthorizer {
     }
 
     private static List<HttpSecurityPolicy> toList(Instance<HttpSecurityPolicy> installedPolicies) {
-        List<HttpSecurityPolicy> policies = new ArrayList<>();
+        List<HttpSecurityPolicy> globalPolicies = new ArrayList<>();
         for (HttpSecurityPolicy i : installedPolicies) {
-            policies.add(i);
+            if (i.name() == null) {
+                globalPolicies.add(i);
+            }
         }
-        return policies;
+        return globalPolicies;
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityPolicy.java
@@ -8,17 +8,26 @@ import io.vertx.ext.web.RoutingContext;
 
 /**
  * An HTTP Security policy, that controls which requests are allowed to proceed.
- *
- * There are two different ways these policies can be installed. The easiest is to just create a CDI bean, in which
- * case the policy will be invoked on every request.
- *
- * Alternatively HttpSecurityPolicyBuildItem can be used to create a named policy. This policy can then be referenced
- * in the application.properties path matching rules, which allows this policy to be applied to specific requests.
+ * CDI beans implementing this interface are invoked on every request unless they define {@link #name()}.
+ * The policy with {@link #name()} can then be referenced in the application.properties path matching rules,
+ * which allows this policy to be applied only to specific requests.
  */
 public interface HttpSecurityPolicy {
 
     Uni<CheckResult> checkPermission(RoutingContext request, Uni<SecurityIdentity> identity,
             AuthorizationRequestContext requestContext);
+
+    /**
+     * HTTP Security policy name referenced in the application.properties path matching rules, which allows this
+     * policy to be applied to specific requests. The name must not be blank. When the name is {@code null}, policy
+     * will be applied to every request.
+     *
+     * @return policy name
+     */
+    default String name() {
+        // null == global policy
+        return null;
+    }
 
     /**
      * The results of a permission check

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementPathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/ManagementPathMatchingHttpSecurityPolicy.java
@@ -1,7 +1,6 @@
 package io.quarkus.vertx.http.runtime.security;
 
-import java.util.Map;
-
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Singleton;
 
 import io.quarkus.runtime.Startup;
@@ -18,8 +17,8 @@ import io.quarkus.vertx.http.runtime.management.ManagementInterfaceConfiguration
 public class ManagementPathMatchingHttpSecurityPolicy extends AbstractPathMatchingHttpSecurityPolicy {
 
     ManagementPathMatchingHttpSecurityPolicy(ManagementInterfaceBuildTimeConfig buildTimeConfig,
-            ManagementInterfaceConfiguration runTimeConfig) {
-        super(runTimeConfig.auth.permissions, runTimeConfig.auth.rolePolicy, buildTimeConfig.rootPath, Map.of());
+            ManagementInterfaceConfiguration runTimeConfig, Instance<HttpSecurityPolicy> installedPolicies) {
+        super(runTimeConfig.auth.permissions, runTimeConfig.auth.rolePolicy, buildTimeConfig.rootPath, installedPolicies);
     }
 
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
@@ -1,8 +1,6 @@
 package io.quarkus.vertx.http.runtime.security;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Singleton;
 
 import io.quarkus.runtime.Startup;
@@ -18,17 +16,9 @@ import io.quarkus.vertx.http.runtime.HttpConfiguration;
 @Singleton
 public class PathMatchingHttpSecurityPolicy extends AbstractPathMatchingHttpSecurityPolicy implements HttpSecurityPolicy {
 
-    // this map is planned for removal very soon as runtime named policies will make it obsolete
-    private static final Map<String, HttpSecurityPolicy> HTTP_SECURITY_BUILD_TIME_POLICIES = new HashMap<>();
-
-    PathMatchingHttpSecurityPolicy(HttpConfiguration httpConfig, HttpBuildTimeConfig buildTimeConfig) {
-        super(httpConfig.auth.permissions, httpConfig.auth.rolePolicy, buildTimeConfig.rootPath,
-                HTTP_SECURITY_BUILD_TIME_POLICIES);
-    }
-
-    static synchronized void replaceNamedBuildTimePolicies(Map<String, HttpSecurityPolicy> newPolicies) {
-        HTTP_SECURITY_BUILD_TIME_POLICIES.clear();
-        HTTP_SECURITY_BUILD_TIME_POLICIES.putAll(newPolicies);
+    PathMatchingHttpSecurityPolicy(HttpConfiguration httpConfig, HttpBuildTimeConfig buildTimeConfig,
+            Instance<HttpSecurityPolicy> installedPolicies) {
+        super(httpConfig.auth.permissions, httpConfig.auth.rolePolicy, buildTimeConfig.rootPath, installedPolicies);
     }
 
 }


### PR DESCRIPTION
Now that HTTP permissions and policies are configurable at runtime #36874, it makes sense to also allow users to configure named HTTP Security policies as CDI beans. Until now, it was only possible with build items (which this PR deprecates), but that only made sense for configuration properties were also build-time initialized.