### PR TITLE
Gradle: set all discovered quarkus.* properties as system properties in QuarkusWorker

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTask.java
@@ -20,8 +20,7 @@ import io.quarkus.gradle.extension.QuarkusPluginExtension;
 import io.quarkus.utilities.OS;
 
 public abstract class QuarkusTask extends DefaultTask {
-    private static final List<String> WORKER_BUILD_FORK_OPTIONS = List.of("quarkus.package.",
-            "quarkus.application.", "quarkus.gradle-worker.", "quarkus.analytics.");
+    private static final List<String> WORKER_BUILD_FORK_OPTIONS = List.of("quarkus.");
 
     private final transient QuarkusPluginExtension extension;
     protected final File projectDir;
@@ -89,7 +88,7 @@ public abstract class QuarkusTask extends DefaultTask {
         }
 
         // It's kind of a "very big hammer" here, but this way we ensure that all necessary properties
-        // ("quarkus.package.*","quarkus.application,*", "quarkus.gradle-worker.*") from all configuration sources
+        // "quarkus.*" from all configuration sources
         // are (forcefully) used in the Quarkus build - even properties defined on the QuarkusPluginExtension.
         // This prevents that settings from e.g. a application.properties takes precedence over an explicit
         // setting in Gradle project properties, the Quarkus extension or even via the environment or system

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/build.gradle
@@ -1,0 +1,32 @@
+plugins{
+    id "java"
+    id "io.quarkus"
+}
+
+
+
+group 'io.quarkus.test.application'
+version '1.0-SNAPSHOT'
+
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy-reactive'
+    implementation ('org.acme.extensions:example-extension')
+
+    testImplementation 'io.quarkus:quarkus-junit5'
+    testImplementation 'io.rest-assured:rest-assured'
+}
+
+test {
+    useJUnitPlatform()
+}
+
+quarkusIntTest {
+    environment "MY_RT_NAME", "genadiy"
+}

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/settings.gradle
@@ -1,0 +1,20 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    //noinspection GroovyAssignabilityCheck
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+includeBuild('../extensions/example-extension'){
+
+}
+rootProject.name='application'

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/src/integrationTest/java/org/acme/ExampleResourceIT.java
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/src/integrationTest/java/org/acme/ExampleResourceIT.java
@@ -1,0 +1,29 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusIntegrationTest
+public class ExampleResourceIT {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("hello cheburashka"));
+    }
+
+    @Test
+    public void testRuntimeName() {
+        given()
+          .when().get("/hello/runtime-name")
+          .then()
+             .statusCode(200)
+             .body(is("genadiy"));
+    }
+}

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/src/main/java/org/acme/quarkus/sample/HelloResource.java
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/src/main/java/org/acme/quarkus/sample/HelloResource.java
@@ -1,0 +1,33 @@
+package org.acme.quarkus.sample;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.acme.example.extension.runtime.ExampleBuildOptions;
+import org.acme.example.extension.runtime.ExampleRuntimeConfig;
+
+@Path("/hello")
+public class HelloResource {
+
+    @Inject
+    ExampleBuildOptions buildOptions;
+
+    @Inject
+    ExampleRuntimeConfig rtConfig;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello " + buildOptions.name;
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/runtime-name")
+    public String runtimeName() {
+        return rtConfig.runtimeName;
+    }
+}

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/application/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.example.runtime-name=${MY_RT_NAME:none}

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/build.gradle
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/build.gradle
@@ -1,0 +1,34 @@
+plugins{
+    id 'java-library'
+    id 'maven-publish'
+}
+subprojects {subProject->
+    apply plugin: 'java-library'
+    apply plugin: 'maven-publish'
+
+    group 'org.acme.extensions'
+    version '1.0-SNAPSHOT'
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                groupId = 'org.acme.extensions'
+                artifactId = subProject.name
+                version = '1.0-SNAPSHOT'
+                from components.java
+            }
+        }
+    }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = 'org.acme.extensions'
+            artifactId = rootProject.name
+            version = '1.0-SNAPSHOT'
+            from components.java
+        }
+    }
+}
+group 'org.acme.extensions'
+version '1.0-SNAPSHOT'

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/deployment/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'java'
+    id 'java-library'
+}
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    annotationProcessor "io.quarkus:quarkus-extension-processor:${quarkusPlatformVersion}"
+
+
+    api project(':example-extension')
+    implementation 'io.quarkus:quarkus-arc-deployment'
+}
+

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/deployment/src/main/java/org/acme/example/extension/deployment/ExampleConfig.java
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/deployment/src/main/java/org/acme/example/extension/deployment/ExampleConfig.java
@@ -1,0 +1,14 @@
+package org.acme.example.extension.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot
+public class ExampleConfig {
+
+    /**
+     * name
+     */
+    @ConfigItem(defaultValue = "none")
+    String name;
+}

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/deployment/src/main/java/org/acme/example/extension/deployment/ExampleProcessor.java
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/deployment/src/main/java/org/acme/example/extension/deployment/ExampleProcessor.java
@@ -1,0 +1,30 @@
+package org.acme.example.extension.deployment;
+
+import jakarta.inject.Singleton;
+
+import org.acme.example.extension.runtime.ExampleBuildOptions;
+import org.acme.example.extension.runtime.ExampleRecorder;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+class ExampleProcessor {
+
+    private static final String FEATURE = "example";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    SyntheticBeanBuildItem syntheticBean(ExampleRecorder recorder, ExampleConfig config) {
+        return SyntheticBeanBuildItem.configure(ExampleBuildOptions.class)
+                .scope(Singleton.class)
+                .runtimeValue(recorder.buildOptions(config.name))
+                .done();
+    }
+}

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/runtime/build.gradle
@@ -1,0 +1,20 @@
+
+plugins {
+    id 'io.quarkus.extension'
+}
+
+quarkusExtension {
+    deploymentModule = 'example-extension-deployment'
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    annotationProcessor "io.quarkus:quarkus-extension-processor:${quarkusPlatformVersion}"
+    implementation 'io.quarkus:quarkus-arc'
+}
+

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/runtime/src/main/java/org/acme/example/extension/runtime/ExampleBuildOptions.java
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/runtime/src/main/java/org/acme/example/extension/runtime/ExampleBuildOptions.java
@@ -1,0 +1,10 @@
+package org.acme.example.extension.runtime;
+
+public class ExampleBuildOptions {
+
+    public final String name;
+
+    public ExampleBuildOptions(String name) {
+        this.name = name;
+    }
+}

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/runtime/src/main/java/org/acme/example/extension/runtime/ExampleRecorder.java
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/runtime/src/main/java/org/acme/example/extension/runtime/ExampleRecorder.java
@@ -1,0 +1,13 @@
+package org.acme.example.extension.runtime;
+
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class ExampleRecorder {
+
+    public RuntimeValue<ExampleBuildOptions> buildOptions(String name) {
+        System.out.println("ExampleRecorder.buildOptions " + name);
+        return new RuntimeValue<>(new ExampleBuildOptions(name));
+    }
+}

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/runtime/src/main/java/org/acme/example/extension/runtime/ExampleRuntimeConfig.java
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/runtime/src/main/java/org/acme/example/extension/runtime/ExampleRuntimeConfig.java
@@ -1,0 +1,16 @@
+package org.acme.example.extension.runtime;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public class ExampleRuntimeConfig {
+
+    /**
+     * Whether the banner will be displayed
+     */
+    @ConfigItem(defaultValue = "none")
+    public String runtimeName;
+
+}

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/runtime/src/main/resources/META-INF/quarkus-extension.properties
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/runtime/src/main/resources/META-INF/quarkus-extension.properties
@@ -1,0 +1,1 @@
+deployment-artifact=org.acme.extensions\:example-extension-deployment\:1.0

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,12 @@
+---
+name: Quarkus Example Extension
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+metadata:
+  config:
+    - "quarkus.example.extension."
+  keywords:
+    - "logzio"
+    - "logging"
+  categories:
+    - "logging"
+description: "Quarkus example extension"

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/extensions/example-extension/settings.gradle
@@ -1,0 +1,21 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+    plugins {
+        id 'io.quarkus.extension' version "${quarkusPluginVersion}"
+    }
+}
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+
+}
+rootProject.name = 'example-extension-parent'
+include(':deployment')
+include(':runtime')
+project(':deployment').name='example-extension-deployment'
+project(':runtime').name='example-extension'

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/system-props-as-build-time-config-source/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    //noinspection GroovyAssignabilityCheck
+    plugins {
+        id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+
+includeBuild('extensions/example-extension')
+includeBuild('application')

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/SystemPropsAsBuildTimeConfigSourceTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/SystemPropsAsBuildTimeConfigSourceTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+public class SystemPropsAsBuildTimeConfigSourceTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testBasicMultiModuleBuild() throws Exception {
+
+        final File projectDir = getProjectDir("system-props-as-build-time-config-source");
+
+        final File appProperties = new File(projectDir, "application/gradle.properties");
+        final File extensionProperties = new File(projectDir, "extensions/example-extension/gradle.properties");
+
+        final Path projectProperties = projectDir.toPath().resolve("gradle.properties");
+
+        try {
+            Files.copy(projectProperties, appProperties.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(projectProperties, extensionProperties.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to copy gradle.properties file", e);
+        }
+
+        gradleConfigurationCache(false);
+        runGradleWrapper(projectDir,
+                "-Dquarkus.example.name=cheburashka",
+                "-Dquarkus.example.runtime-name=crocodile",
+                "-Dquarkus.package.type=mutable-jar",
+                ":example-extension:example-extension-deployment:build",
+                // this quarkusIntTest will make sure runtime config properties passed as env vars when launching the app are effective
+                ":application:quarkusIntTest");
+
+        final Path buildSystemPropsPath = projectDir.toPath().resolve("application").resolve("build").resolve("quarkus-app")
+                .resolve("quarkus").resolve("build-system.properties");
+        assertThat(buildSystemPropsPath).exists();
+        var props = new Properties();
+        try (var reader = Files.newBufferedReader(buildSystemPropsPath)) {
+            props.load(reader);
+        }
+        assertThat(props).doesNotContainKey("quarkus.example.name");
+        assertThat(props).doesNotContainKey("quarkus.example.runtime-name");
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/nativeimage/BasicJavaNativeBuildIT.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/nativeimage/BasicJavaNativeBuildIT.java
@@ -20,7 +20,7 @@ public class BasicJavaNativeBuildIT extends QuarkusNativeGradleITBase {
     public void shouldBuildNativeImage() throws Exception {
         final File projectDir = getProjectDir("basic-java-native-module");
 
-        final BuildResult build = runGradleWrapper(projectDir, "clean", "buildNative", "-Dquarkus.package.type=fast-jar");
+        final BuildResult build = runGradleWrapper(projectDir, "clean", "buildNative");
 
         assertThat(build.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
         final String buildOutput = build.getOutput();
@@ -48,7 +48,7 @@ public class BasicJavaNativeBuildIT extends QuarkusNativeGradleITBase {
     public void shouldBuildNativeImageWithCustomName() throws Exception {
         final File projectDir = getProjectDir("basic-java-native-module");
 
-        final BuildResult build = runGradleWrapper(projectDir, "clean", "buildNative", "-Dquarkus.package.type=fast-jar",
+        final BuildResult build = runGradleWrapper(projectDir, "clean", "buildNative",
                 "-Dquarkus.package.output-name=test");
 
         assertThat(build.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
@@ -78,7 +78,7 @@ public class BasicJavaNativeBuildIT extends QuarkusNativeGradleITBase {
     public void shouldBuildNativeImageWithCustomNameWithoutSuffix() throws Exception {
         final File projectDir = getProjectDir("basic-java-native-module");
 
-        final BuildResult build = runGradleWrapper(projectDir, "clean", "buildNative", "-Dquarkus.package.type=fast-jar",
+        final BuildResult build = runGradleWrapper(projectDir, "clean", "buildNative",
                 "-Dquarkus.package.output-name=test", "-Dquarkus.package.add-runner-suffix=false");
 
         assertThat(build.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);


### PR DESCRIPTION
Fix #36992
Fix #36969

This patch passes all `quarkus.*` properties from an application bootstrapping task to a QuarkusWorker as a parameter and sets them as system properties for the worker.

A tests for the mentioned issues above and https://github.com/quarkusio/quarkus/issues/33321 are included.

@snazy this kind of fix would be necessary as a follow up to removing effective config (including all system properties and env vars) serialization in case of mutable-jar packaging.