### PR TITLE
Make basic realm and form authentication configuration properties only used during runtime the runtime properties

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
@@ -26,12 +26,6 @@ public class AuthConfig {
     public FormAuthConfig form;
 
     /**
-     * The authentication realm
-     */
-    @ConfigItem
-    public Optional<String> realm;
-
-    /**
      * If this is true and credentials are present then a user will always be authenticated
      * before the request progresses.
      *

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthRuntimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthRuntimeConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http.runtime;
 
 import java.util.Map;
+import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -22,4 +23,16 @@ public class AuthRuntimeConfig {
      */
     @ConfigItem(name = "policy")
     public Map<String, PolicyConfig> rolePolicy;
+
+    /**
+     * The authentication realm
+     */
+    @ConfigItem
+    public Optional<String> realm;
+
+    /**
+     * Form Auth config
+     */
+    @ConfigItem
+    public FormAuthRuntimeConfig form;
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
@@ -1,8 +1,5 @@
 package io.quarkus.vertx.http.runtime;
 
-import java.time.Duration;
-import java.util.Optional;
-
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -11,14 +8,6 @@ import io.quarkus.runtime.annotations.ConfigItem;
  */
 @ConfigGroup
 public class FormAuthConfig {
-    /**
-     * SameSite attribute values for the session and location cookies.
-     */
-    public enum CookieSameSite {
-        STRICT,
-        LAX,
-        NONE
-    }
 
     /**
      * If form authentication is enabled.
@@ -27,108 +16,9 @@ public class FormAuthConfig {
     public boolean enabled;
 
     /**
-     * The login page. Redirect to login page can be disabled by setting `quarkus.http.auth.form.login-page=`.
-     */
-    @ConfigItem(defaultValue = "/login.html")
-    public Optional<String> loginPage;
-
-    /**
      * The post location.
      */
     @ConfigItem(defaultValue = "/j_security_check")
     public String postLocation;
 
-    /**
-     * The username field name.
-     */
-    @ConfigItem(defaultValue = "j_username")
-    public String usernameParameter;
-
-    /**
-     * The password field name.
-     */
-    @ConfigItem(defaultValue = "j_password")
-    public String passwordParameter;
-
-    /**
-     * The error page. Redirect to error page can be disabled by setting `quarkus.http.auth.form.error-page=`.
-     */
-    @ConfigItem(defaultValue = "/error.html")
-    public Optional<String> errorPage;
-
-    /**
-     * The landing page to redirect to if there is no saved page to redirect back to.
-     * Redirect to landing page can be disabled by setting `quarkus.http.auth.form.landing-page=`.
-     */
-    @ConfigItem(defaultValue = "/index.html")
-    public Optional<String> landingPage;
-
-    /**
-     * Option to disable redirect to landingPage if there is no saved page to redirect back to. Form Auth POST is followed
-     * by redirect to landingPage by default.
-     *
-     * @deprecated redirect to landingPage can be disabled by removing default landing page
-     *             (via `quarkus.http.auth.form.landing-page=`). Quarkus will ignore this configuration property
-     *             if there is no landing page.
-     */
-    @ConfigItem(defaultValue = "true")
-    @Deprecated
-    public boolean redirectAfterLogin;
-
-    /**
-     * Option to control the name of the cookie used to redirect the user back
-     * to where he wants to get access to.
-     */
-    @ConfigItem(defaultValue = "quarkus-redirect-location")
-    public String locationCookie;
-
-    /**
-     * The inactivity (idle) timeout
-     *
-     * When inactivity timeout is reached, cookie is not renewed and a new login is enforced.
-     */
-    @ConfigItem(defaultValue = "PT30M")
-    public Duration timeout;
-
-    /**
-     * How old a cookie can get before it will be replaced with a new cookie with an updated timeout, also
-     * referred to as "renewal-timeout".
-     *
-     * Note that smaller values will result in slightly more server load (as new encrypted cookies will be
-     * generated more often), however larger values affect the inactivity timeout as the timeout is set
-     * when a cookie is generated.
-     *
-     * For example if this is set to 10 minutes, and the inactivity timeout is 30m, if a users last request
-     * is when the cookie is 9m old then the actual timeout will happen 21m after the last request, as the timeout
-     * is only refreshed when a new cookie is generated.
-     *
-     * In other words no timeout is tracked on the server side; the timestamp is encoded and encrypted in the cookie itself,
-     * and it is decrypted and parsed with each request.
-     */
-    @ConfigItem(defaultValue = "PT1M")
-    public Duration newCookieInterval;
-
-    /**
-     * The cookie that is used to store the persistent session
-     */
-    @ConfigItem(defaultValue = "quarkus-credential")
-    public String cookieName;
-
-    /**
-     * The cookie path for the session and location cookies.
-     */
-    @ConfigItem(defaultValue = "/")
-    public Optional<String> cookiePath = Optional.of("/");
-
-    /**
-     * Set the HttpOnly attribute to prevent access to the cookie via JavaScript.
-     */
-    @ConfigItem(defaultValue = "false")
-    public boolean httpOnlyCookie;
-
-    /**
-     * SameSite attribute for the session and location cookies.
-     */
-    @ConfigItem(defaultValue = "strict")
-    public CookieSameSite cookieSameSite = CookieSameSite.STRICT;
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthRuntimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthRuntimeConfig.java
@@ -1,0 +1,122 @@
+package io.quarkus.vertx.http.runtime;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * config for the form authentication mechanism
+ */
+@ConfigGroup
+public class FormAuthRuntimeConfig {
+    /**
+     * SameSite attribute values for the session and location cookies.
+     */
+    public enum CookieSameSite {
+        STRICT,
+        LAX,
+        NONE
+    }
+
+    /**
+     * The login page. Redirect to login page can be disabled by setting `quarkus.http.auth.form.login-page=`.
+     */
+    @ConfigItem(defaultValue = "/login.html")
+    public Optional<String> loginPage;
+
+    /**
+     * The username field name.
+     */
+    @ConfigItem(defaultValue = "j_username")
+    public String usernameParameter;
+
+    /**
+     * The password field name.
+     */
+    @ConfigItem(defaultValue = "j_password")
+    public String passwordParameter;
+
+    /**
+     * The error page. Redirect to error page can be disabled by setting `quarkus.http.auth.form.error-page=`.
+     */
+    @ConfigItem(defaultValue = "/error.html")
+    public Optional<String> errorPage;
+
+    /**
+     * The landing page to redirect to if there is no saved page to redirect back to.
+     * Redirect to landing page can be disabled by setting `quarkus.http.auth.form.landing-page=`.
+     */
+    @ConfigItem(defaultValue = "/index.html")
+    public Optional<String> landingPage;
+
+    /**
+     * Option to disable redirect to landingPage if there is no saved page to redirect back to. Form Auth POST is followed
+     * by redirect to landingPage by default.
+     *
+     * @deprecated redirect to landingPage can be disabled by removing default landing page
+     *             (via `quarkus.http.auth.form.landing-page=`). Quarkus will ignore this configuration property
+     *             if there is no landing page.
+     */
+    @ConfigItem(defaultValue = "true")
+    @Deprecated
+    public boolean redirectAfterLogin;
+
+    /**
+     * Option to control the name of the cookie used to redirect the user back
+     * to where he wants to get access to.
+     */
+    @ConfigItem(defaultValue = "quarkus-redirect-location")
+    public String locationCookie;
+
+    /**
+     * The inactivity (idle) timeout
+     *
+     * When inactivity timeout is reached, cookie is not renewed and a new login is enforced.
+     */
+    @ConfigItem(defaultValue = "PT30M")
+    public Duration timeout;
+
+    /**
+     * How old a cookie can get before it will be replaced with a new cookie with an updated timeout, also
+     * referred to as "renewal-timeout".
+     *
+     * Note that smaller values will result in slightly more server load (as new encrypted cookies will be
+     * generated more often), however larger values affect the inactivity timeout as the timeout is set
+     * when a cookie is generated.
+     *
+     * For example if this is set to 10 minutes, and the inactivity timeout is 30m, if a users last request
+     * is when the cookie is 9m old then the actual timeout will happen 21m after the last request, as the timeout
+     * is only refreshed when a new cookie is generated.
+     *
+     * In other words no timeout is tracked on the server side; the timestamp is encoded and encrypted in the cookie itself,
+     * and it is decrypted and parsed with each request.
+     */
+    @ConfigItem(defaultValue = "PT1M")
+    public Duration newCookieInterval;
+
+    /**
+     * The cookie that is used to store the persistent session
+     */
+    @ConfigItem(defaultValue = "quarkus-credential")
+    public String cookieName;
+
+    /**
+     * The cookie path for the session and location cookies.
+     */
+    @ConfigItem(defaultValue = "/")
+    public Optional<String> cookiePath = Optional.of("/");
+
+    /**
+     * Set the HttpOnly attribute to prevent access to the cookie via JavaScript.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean httpOnlyCookie;
+
+    /**
+     * SameSite attribute for the session and location cookies.
+     */
+    @ConfigItem(defaultValue = "strict")
+    public CookieSameSite cookieSameSite = CookieSameSite.STRICT;
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/FormAuthenticationMechanism.java
@@ -23,6 +23,7 @@ import io.quarkus.security.identity.request.AuthenticationRequest;
 import io.quarkus.security.identity.request.TrustedAuthenticationRequest;
 import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
 import io.quarkus.vertx.http.runtime.FormAuthConfig;
+import io.quarkus.vertx.http.runtime.FormAuthRuntimeConfig;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.smallrye.mutiny.Uni;
@@ -74,22 +75,23 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
             key = httpConfiguration.encryptionKey.get();
         }
         FormAuthConfig form = buildTimeConfig.auth.form;
-        this.loginManager = new PersistentLoginManager(key, form.cookieName, form.timeout.toMillis(),
-                form.newCookieInterval.toMillis(), form.httpOnlyCookie, form.cookieSameSite.name(),
-                form.cookiePath.orElse(null));
-        this.loginPage = startWithSlash(form.loginPage.orElse(null));
-        this.errorPage = startWithSlash(form.errorPage.orElse(null));
-        this.landingPage = startWithSlash(form.landingPage.orElse(null));
+        FormAuthRuntimeConfig runtimeForm = httpConfiguration.auth.form;
+        this.loginManager = new PersistentLoginManager(key, runtimeForm.cookieName, runtimeForm.timeout.toMillis(),
+                runtimeForm.newCookieInterval.toMillis(), runtimeForm.httpOnlyCookie, runtimeForm.cookieSameSite.name(),
+                runtimeForm.cookiePath.orElse(null));
+        this.loginPage = startWithSlash(runtimeForm.loginPage.orElse(null));
+        this.errorPage = startWithSlash(runtimeForm.errorPage.orElse(null));
+        this.landingPage = startWithSlash(runtimeForm.landingPage.orElse(null));
         this.postLocation = startWithSlash(form.postLocation);
-        this.usernameParameter = form.usernameParameter;
-        this.passwordParameter = form.passwordParameter;
-        this.locationCookie = form.locationCookie;
-        this.cookiePath = form.cookiePath.orElse(null);
-        boolean redirectAfterLogin = form.redirectAfterLogin;
+        this.usernameParameter = runtimeForm.usernameParameter;
+        this.passwordParameter = runtimeForm.passwordParameter;
+        this.locationCookie = runtimeForm.locationCookie;
+        this.cookiePath = runtimeForm.cookiePath.orElse(null);
+        boolean redirectAfterLogin = runtimeForm.redirectAfterLogin;
         this.redirectToLandingPage = landingPage != null && redirectAfterLogin;
         this.redirectToLoginPage = loginPage != null;
         this.redirectToErrorPage = errorPage != null;
-        this.cookieSameSite = CookieSameSite.valueOf(form.cookieSameSite.name());
+        this.cookieSameSite = CookieSameSite.valueOf(runtimeForm.cookieSameSite.name());
     }
 
     public FormAuthenticationMechanism(String loginPage, String postLocation,

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -21,7 +21,6 @@ import io.quarkus.security.AuthenticationRedirectException;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AnonymousAuthenticationRequest;
 import io.quarkus.security.spi.runtime.MethodDescription;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
@@ -51,16 +50,6 @@ public class HttpSecurityRecorder {
                     authorizer = CDI.current().select(HttpAuthorizer.class).get();
                 }
                 authorizer.checkPermission(event);
-            }
-        };
-    }
-
-    public Supplier<?> setupBasicAuth(HttpBuildTimeConfig buildTimeConfig) {
-        return new Supplier<BasicAuthenticationMechanism>() {
-            @Override
-            public BasicAuthenticationMechanism get() {
-                return new BasicAuthenticationMechanism(buildTimeConfig.auth.realm.orElse(null),
-                        buildTimeConfig.auth.form.enabled);
             }
         };
     }


### PR DESCRIPTION
There is no reason to have properties only used at runtime defined as build time properties. `BasicAuthenticationMechanism` constructors have been deprecated for 3 years now.