### PR TITLE
Use empty string in Sse event when there is no data

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/sse/SseParserTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/sse/SseParserTest.java
@@ -37,14 +37,14 @@ public class SseParserTest {
         testParser("data:foo\ndata:\ndata:bar\n\n", "foo\n\nbar", null, null, null, SseEvent.RECONNECT_NOT_SET);
 
         // no data: no event
-        testParser("\n", null, null, null, null, SseEvent.RECONNECT_NOT_SET);
-        testParser("data:\n\n", null, null, null, null, SseEvent.RECONNECT_NOT_SET);
-        testParser("data\n\n", null, null, null, null, SseEvent.RECONNECT_NOT_SET);
+        testParser("\n", "", null, null, null, SseEvent.RECONNECT_NOT_SET);
+        testParser("data:\n\n", "", null, null, null, SseEvent.RECONNECT_NOT_SET);
+        testParser("data\n\n", "", null, null, null, SseEvent.RECONNECT_NOT_SET);
 
         // all fields
         testParser("data:DATA\nid:ID\n:COMMENT\nretry:23\nevent:NAME\n\n", "DATA", "COMMENT", "ID", "NAME", 23);
         // all fields and no data
-        testParser("id:ID\n:COMMENT\nretry:23\nevent:NAME\n\n", null, "COMMENT", "ID", "NAME", 23);
+        testParser("id:ID\n:COMMENT\nretry:23\nevent:NAME\n\n", "", "COMMENT", "ID", "NAME", 23);
 
         // optional space after colon
         testParser("data:foo\n\n", "foo", null, null, null, SseEvent.RECONNECT_NOT_SET);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/StreamTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/StreamTestCase.java
@@ -264,7 +264,7 @@ public class StreamTestCase {
             });
             sse.open();
             Assertions.assertTrue(latch.await(20, TimeUnit.SECONDS));
-            org.assertj.core.api.Assertions.assertThat(results).containsExactly(null, "uno", "dos", "tres");
+            org.assertj.core.api.Assertions.assertThat(results).containsExactly("", "uno", "dos", "tres");
             org.assertj.core.api.Assertions.assertThat(ids).containsExactly(null, "one", "two", "three");
             org.assertj.core.api.Assertions.assertThat(names).containsExactly(null, "eins", "zwei", "drei");
             org.assertj.core.api.Assertions.assertThat(comments).containsExactly("dummy", null, null, null);

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/SseParser.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/SseParser.java
@@ -158,7 +158,7 @@ public class SseParser implements Handler<Buffer> {
         event.setComment(commentBuffer.length() == 0 ? null : commentBuffer.toString());
         // SSE spec says empty string is the default, but JAX-RS says null if not specified
         event.setId(lastEventId);
-        event.setData(dataBuffer.length() == 0 ? null : dataBuffer.toString());
+        event.setData(dataBuffer.length() == 0 ? "" : dataBuffer.toString());
         // SSE spec says "message" is the default, but JAX-RS says null if not specified
         event.setName(eventType);
         event.setReconnectDelay(eventReconnectTime);


### PR DESCRIPTION
Using an empty string instead of null
is what the classic rest client does,
so let's align with it

Closes: #37033