### PR TITLE
Add label area/native-image to issues mentioning mandrel

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -407,7 +407,7 @@ triage:
         - extensions/google-cloud-functions
         - integration-tests/google-cloud-functions
     - id: mandrel
-      labels: [area/mandrel]
+      labels: [area/native-image]
       titleBody: "mandrel"
       notify: [galderz, zakkak, Karm]
     - id: native-image

--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -413,7 +413,7 @@ triage:
     - id: native-image
       labels: [area/native-image]
       title: "\\bnative\\b"
-      notify: []
+      notify: [zakkak]
     - id: awt
       labels: [area/graphics]
       expression: |
@@ -421,7 +421,7 @@ triage:
               || matches("sun.java2d", titleBody)
               || matches("javax.imageio", titleBody)
               || matches("sun.awt", titleBody)
-      notify: [galderz, zakkak, Karm]
+      notify: [galderz, Karm]
       notifyInPullRequest: true
       directories:
         - extensions/awt/


### PR DESCRIPTION
- Add label area/native-image to issues mentioning mandrel
  
  As mandrel is now the default builder image, most issues about native contain mandrel in the body even if they are not mandrel specific.

  Start labeling the issues as `area/native-image` and let the mandrel team decide whether it's mandrel specific or not.

- Notify @zakkak about native-image issues and not graphics
