### PR TITLE
Tiny tweaks based on QE feedback for Datasource guide

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -561,10 +561,11 @@ For more information, see the link:https://db.apache.org/derby/docs/10.8/devguid
 
 Example:: `jdbc:h2:tcp://localhost/~/test`, `jdbc:h2:mem:myDB`
 
-H2 is an embedded database that can run as a server, based on a file, or run completely in memory.
+H2 is a database that can run in embedded or server mode.
+It can use a file storage or run entirely in memory.
 All of these options are available as listed above.
 
-For more information, see the link:https://h2database.com/html/features.html?highlight=url&search=url#database_url[official documentation].
+For more information, see the link:https://h2database.com/html/features.html#database_url[official documentation].
 
 ==== MariaDB
 
@@ -592,7 +593,7 @@ hostDescription:: `<host>[:<portnumber>] or address=(host=<host>)[(port=<portnum
 
 Example:: `jdbc:mysql://localhost:3306/test`
 
-For more information, see the link:https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference.html[official documentation].
+For more information, see the link:https://dev.mysql.com/doc/connector-j/en/[official documentation].
 
 ===== MySQL limitations
 

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -61,6 +61,8 @@ public interface DataSourceJdbcRuntimeConfig {
     /**
      * The interval at which we check for connection leaks.
      */
+
+    @ConfigDocDefault("This feature is disabled by default.")
     Optional<Duration> leakDetectionInterval();
 
     /**
@@ -72,6 +74,7 @@ public interface DataSourceJdbcRuntimeConfig {
     /**
      * The max lifetime of a connection.
      */
+    @ConfigDocDefault("By default, there is no restriction on the lifespan of a connection.")
     Optional<Duration> maxLifetime();
 
     /**
@@ -92,7 +95,7 @@ public interface DataSourceJdbcRuntimeConfig {
     boolean flushOnClose();
 
     /**
-     * When enabled Agroal will be able to produce a warning when a connection is returned
+     * When enabled, Agroal will be able to produce a warning when a connection is returned
      * to the pool without the application having closed all open statements.
      * This is unrelated with tracking of open connections.
      * Disable for peak performance, but only when there's high confidence that
@@ -112,7 +115,7 @@ public interface DataSourceJdbcRuntimeConfig {
     Optional<String> validationQuerySql();
 
     /**
-     * Disable pooling to prevent reuse of Connections. Use this with when an external pool manages the life-cycle
+     * Disable pooling to prevent reuse of Connections. Use this when an external pool manages the life-cycle
      * of Connections.
      */
     @WithDefault("true")

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
@@ -27,8 +27,8 @@ public interface DataSourceReactiveRuntimeConfig {
      * The datasource URLs.
      * <p>
      * If multiple values are set, this datasource will create a pool with a list of servers instead of a single server.
-     * The pool uses a round-robin load balancing when a connection is created to select different servers.
-     * Note: some driver may not support multiple values here.
+     * The pool uses round-robin load balancing for server selection during connection establishment.
+     * Note that certain drivers might not accommodate multiple values in this context.
      */
     Optional<List<String>> url();
 


### PR DESCRIPTION
Based on the QE feedback for the Datasource guide, I am proposing tiny tweaks in the guide and its relevant Javadocs. These need to be backported to 3.2.

The QE request was to add default values or specify if the feature is disabled by default.
Quoting : _Properties `quarkus-agroal_quarkus.datasource."datasource-name".jdbc.leak-detection-interval` and `quarkus.datasource."datasource-name".jdbc.max-lifetime` do not have default duration._

I updated the Javadocs with the @ConfigDocDefault annotation on relevant methods after an SME consultation with @yrodiere , who shared with me the Agroal defaults we, in some cases, share or replace in Quarkus.

```
    Duration leakTimeout = ZERO;       ->      `@ConfigDocDefault("This feature is disabled by default.")`
    Duration validationTimeout = ZERO;      (backgroundValidationInterval)
    Duration reapTimeout = ZERO;               (idleRemovalInterval)
    Duration maxLifetime = ZERO;       ->     `@ConfigDocDefault("This feature is disabled by default.")`
```

Additionally, I updated some links here and there.