### PR TITLE
Use 3.2 as the example stream for update-quarkus.adoc

### DIFF
--- a/docs/src/main/asciidoc/update-quarkus.adoc
+++ b/docs/src/main/asciidoc/update-quarkus.adoc
@@ -50,7 +50,7 @@ Confirm the version number using `quarkus -v`.
 ----
 quarkus update
 ----
-Optional: To specify a particular stream, use the `stream` option; for example: `--stream=3.0`
+Optional: To specify a particular stream, use the `--stream` option; for example: `--stream=3.2`
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]
 ****
@@ -63,7 +63,7 @@ ifdef::devtools-wrapped[+]
 ----
 ./mvnw {quarkus-platform-groupid}:quarkus-maven-plugin:{quarkus-version}:update -N
 ----
-Optional: To specify a particular stream, use the `Dstream` option; for example: `-Dstream=3.0`
+Optional: To specify a particular stream, use the `-Dstream` option; for example: `-Dstream=3.2`
 endif::[]
 ifndef::devtools-no-gradle[]
 ifdef::devtools-wrapped[+]


### PR DESCRIPTION
It makes little sense to use 3.0 now but 3.2 makes perfect sense as it is an LTS version.