### PR TITLE
ArC: fix some corner cases in Build Compatible Extensions

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -286,7 +286,7 @@ public class BeanDeployment {
         buildContext.putInternal(Key.INJECTION_POINTS, Collections.unmodifiableList(this.injectionPoints));
 
         if (buildCompatibleExtensions != null) {
-            buildCompatibleExtensions.runRegistration(beanArchiveComputingIndex, beans, observers);
+            buildCompatibleExtensions.runRegistration(beanArchiveComputingIndex, beans, interceptors, observers);
         }
 
         return registerSyntheticBeans(beanRegistrars, buildContext);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/BeanInfoImpl.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/BeanInfoImpl.java
@@ -105,7 +105,7 @@ class BeanInfoImpl implements BeanInfo {
 
     @Override
     public Integer priority() {
-        return arcBeanInfo.getAlternativePriority();
+        return arcBeanInfo.getPriority();
     }
 
     @Override

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ClassInfoImpl.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ClassInfoImpl.java
@@ -166,7 +166,7 @@ class ClassInfoImpl extends DeclarationInfoImpl<org.jboss.jandex.ClassInfo> impl
             alreadySeen.add(clazz.name());
 
             DotName superClassName = clazz.superName();
-            if (!DotNames.OBJECT.equals(superClassName)) {
+            if (superClassName != null && !DotNames.OBJECT.equals(superClassName)) {
                 org.jboss.jandex.ClassInfo superClass = jandexIndex.getClassByName(superClassName);
                 workQueue.add(superClass);
             }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ExtensionInvoker.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ExtensionInvoker.java
@@ -16,6 +16,7 @@ import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 import jakarta.interceptor.Interceptor;
 
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.JandexReflection;
 
 // only this class uses reflection, everything else in this package is reflection-free
 class ExtensionInvoker {
@@ -83,43 +84,8 @@ class ExtensionInvoker {
             throws ReflectiveOperationException {
 
         Class<?>[] parameterTypes = new Class[arguments.size()];
-
         for (int i = 0; i < parameterTypes.length; i++) {
-            Object argument = arguments.get(i);
-            Class<?> argumentClass = argument.getClass();
-
-            // beware of ordering! subtypes must precede supertypes
-            if (jakarta.enterprise.lang.model.declarations.ClassInfo.class.isAssignableFrom(argumentClass)) {
-                parameterTypes[i] = jakarta.enterprise.lang.model.declarations.ClassInfo.class;
-            } else if (jakarta.enterprise.lang.model.declarations.MethodInfo.class.isAssignableFrom(argumentClass)) {
-                parameterTypes[i] = jakarta.enterprise.lang.model.declarations.MethodInfo.class;
-            } else if (jakarta.enterprise.lang.model.declarations.FieldInfo.class.isAssignableFrom(argumentClass)) {
-                parameterTypes[i] = jakarta.enterprise.lang.model.declarations.FieldInfo.class;
-            } else if (jakarta.enterprise.inject.build.compatible.spi.ScannedClasses.class.isAssignableFrom(argumentClass)) {
-                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.ScannedClasses.class;
-            } else if (jakarta.enterprise.inject.build.compatible.spi.MetaAnnotations.class.isAssignableFrom(argumentClass)) {
-                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.MetaAnnotations.class;
-            } else if (jakarta.enterprise.inject.build.compatible.spi.ClassConfig.class.isAssignableFrom(argumentClass)) {
-                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.ClassConfig.class;
-            } else if (jakarta.enterprise.inject.build.compatible.spi.MethodConfig.class.isAssignableFrom(argumentClass)) {
-                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.MethodConfig.class;
-            } else if (jakarta.enterprise.inject.build.compatible.spi.FieldConfig.class.isAssignableFrom(argumentClass)) {
-                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.FieldConfig.class;
-            } else if (jakarta.enterprise.inject.build.compatible.spi.BeanInfo.class.isAssignableFrom(argumentClass)) {
-                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.BeanInfo.class;
-            } else if (jakarta.enterprise.inject.build.compatible.spi.ObserverInfo.class.isAssignableFrom(argumentClass)) {
-                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.ObserverInfo.class;
-            } else if (jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents.class
-                    .isAssignableFrom(argumentClass)) {
-                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents.class;
-            } else if (jakarta.enterprise.inject.build.compatible.spi.Messages.class.isAssignableFrom(argumentClass)) {
-                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.Messages.class;
-            } else if (jakarta.enterprise.inject.build.compatible.spi.Types.class.isAssignableFrom(argumentClass)) {
-                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.Types.class;
-            } else {
-                // should never happen, internal error (or missing error handling) if it does
-                throw new IllegalArgumentException("Unexpected extension method argument: " + argument);
-            }
+            parameterTypes[i] = JandexReflection.loadRawType(method.parameterType(i));
         }
 
         Class<?> extensionClass = extensionClasses.get(method.extensionClass.name().toString());
@@ -136,7 +102,6 @@ class ExtensionInvoker {
     }
 
     /**
-     *
      * @return {@code true} if no {@link BuildCompatibleExtension} was found, {@code false} otherwise
      */
     boolean isEmpty() {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ExtensionMethod.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ExtensionMethod.java
@@ -25,6 +25,10 @@ class ExtensionMethod {
         return jandex.parameterTypes();
     }
 
+    org.jboss.jandex.Type parameterType(int index) {
+        return jandex.parameterType(index);
+    }
+
     @Override
     public String toString() {
         return jandex.declaringClass().simpleName() + "." + jandex.name() + "()";

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ExtensionsEntryPoint.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/bcextensions/ExtensionsEntryPoint.java
@@ -273,6 +273,7 @@ public class ExtensionsEntryPoint {
      */
     public void runRegistration(org.jboss.jandex.IndexView beanArchiveIndex,
             Collection<io.quarkus.arc.processor.BeanInfo> allBeans,
+            Collection<io.quarkus.arc.processor.InterceptorInfo> allInterceptors,
             Collection<io.quarkus.arc.processor.ObserverInfo> allObservers) {
         if (invoker.isEmpty()) {
             return;
@@ -282,7 +283,7 @@ public class ExtensionsEntryPoint {
 
         try {
             new ExtensionPhaseRegistration(invoker, beanArchiveIndex, errors, annotationOverlays,
-                    allBeans, allObservers).run();
+                    allBeans, allInterceptors, allObservers).run();
         } finally {
             BuildServicesImpl.reset();
         }
@@ -581,7 +582,7 @@ public class ExtensionsEntryPoint {
 
         try {
             new ExtensionPhaseRegistration(invoker, beanArchiveIndex, errors, annotationOverlays,
-                    syntheticBeans, syntheticObservers).run();
+                    syntheticBeans, Collections.emptyList(), syntheticObservers).run();
         } finally {
             BuildServicesImpl.reset();
         }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/cdi/bcextensions/RegistrationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/cdi/bcextensions/RegistrationTest.java
@@ -2,21 +2,30 @@ package io.quarkus.arc.test.cdi.bcextensions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Initialized;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.InterceptorInfo;
+import jakarta.enterprise.inject.build.compatible.spi.Messages;
 import jakarta.enterprise.inject.build.compatible.spi.ObserverInfo;
 import jakarta.enterprise.inject.build.compatible.spi.Registration;
 import jakarta.enterprise.inject.build.compatible.spi.Types;
 import jakarta.inject.Qualifier;
 import jakarta.inject.Singleton;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -26,7 +35,8 @@ import io.quarkus.arc.test.ArcTestContainer;
 public class RegistrationTest {
     @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
-            .beanClasses(MyQualifier.class, MyService.class, MyFooService.class, MyBarService.class, MyBarServiceProducer.class)
+            .beanClasses(MyQualifier.class, MyInterceptorBinding.class, MyInterceptor.class, MyService.class,
+                    MyFooService.class, MyBarService.class, MyBarServiceProducer.class)
             .buildCompatibleExtensions(new MyExtension())
             .build();
 
@@ -35,12 +45,14 @@ public class RegistrationTest {
         assertEquals(2, MyExtension.beanCounter.get());
         assertEquals(1, MyExtension.beanMyQualifierCounter.get());
         assertEquals(1, MyExtension.observerQualifierCounter.get());
+        assertEquals(2, MyExtension.interceptorCounter.get()); // one interceptor, counted twice
     }
 
     public static class MyExtension implements BuildCompatibleExtension {
         static final AtomicInteger beanCounter = new AtomicInteger();
         static final AtomicInteger beanMyQualifierCounter = new AtomicInteger();
         static final AtomicInteger observerQualifierCounter = new AtomicInteger();
+        static final AtomicInteger interceptorCounter = new AtomicInteger();
 
         @Registration(types = MyService.class)
         public void beans(BeanInfo bean) {
@@ -57,6 +69,19 @@ public class RegistrationTest {
                 observerQualifierCounter.addAndGet(observer.qualifiers().size());
             }
         }
+
+        @Registration(types = MyInterceptor.class)
+        public void interceptors(InterceptorInfo interceptor) {
+            interceptorCounter.incrementAndGet();
+        }
+
+        @Registration(types = MyInterceptor.class)
+        public void interceptorsAsBeans(BeanInfo interceptor, Messages msg) {
+            if (!interceptor.isInterceptor()) {
+                msg.error("Interceptor expected", interceptor);
+            }
+            interceptorCounter.incrementAndGet();
+        }
     }
 
     // ---
@@ -64,6 +89,22 @@ public class RegistrationTest {
     @Qualifier
     @Retention(RetentionPolicy.RUNTIME)
     public @interface MyQualifier {
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @InterceptorBinding
+    public @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Interceptor
+    @Priority(1)
+    public static class MyInterceptor {
+        @AroundInvoke
+        public Object intercept(InvocationContext ctx) throws Exception {
+            return ctx.proceed();
+        }
     }
 
     public interface MyService {


### PR DESCRIPTION
- support observing interceptors in `@Registration`
- fix reporting priority of beans that are not alternatives (not very useful in standard CDI, but in ArC, we go beyond the standard)
- fix NPE in `ClassInfo.methods()` (and `fields()`) for `java.lang.Object`
- fix (and simplify) invoking extension methods
