### PR TITLE
Security doc fix: Fix links in Protect a web application topic

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-code-flow-authentication-tutorial.adoc
@@ -18,7 +18,7 @@ To learn more about the OIDC authorization code flow mechanism, see xref:securit
 To learn about how well-known social providers such as Apple, Facebook, GitHub, Google, Mastodon, Microsoft, Twitch, Twitter (X), and Spotify can be used with Quarkus OIDC, see xref:security-openid-connect-providers.adoc[Configuring Well-Known OpenID Connect Providers].
 See also, xref:security-authentication-mechanisms.adoc#other-supported-authentication-mechanisms[Authentication mechanisms in Quarkus].
 
-If you want to protect your service applications by using OIDC Bearer token authentication, see xref:security-oidc-bearer-token-authentication-concept.adoc[OIDC Bearer token authentication].
+If you want to protect your service applications by using OIDC Bearer token authentication, see xref:security-oidc-bearer-token-authentication.adoc[OIDC Bearer token authentication].
 
 == Prerequisites
 
@@ -177,7 +177,7 @@ The `quarkus.oidc.application-type` property is set to `web-app` in order to tel
 
 Finally, the `quarkus.http.auth.permission.authenticated` permission is set to tell Quarkus about the paths you want to protect.
 In this case, all paths are being protected by a policy that ensures that only `authenticated` users are allowed to access.
-For more information, see xref:security-authorization-of-web-endpoints-reference.adoc[Security Authorization Guide].
+For more information, see xref:security-authorize-web-endpoints-reference.adoc[Security Authorization Guide].
 
 === Start and configure the Keycloak server
 
@@ -274,4 +274,3 @@ After you have completed this tutorial, explore xref:security-oidc-bearer-token-
 * xref:security-oidc-auth0-tutorial.adoc[Protect Quarkus web application by using Auth0 OpenID Connect provider]
 * https://openid.net/connect/[OpenID Connect]
 * https://tools.ietf.org/html/rfc7519[JSON Web Token]
-


### PR DESCRIPTION
This PR fixes two broken links that showed up when I was verifying security-oidc-code-flow-authentication-tutorial.adoc ("Protect a web application by using OpenID Connect (OIDC) authorization code flow") for product docs (RHBQ 3.2.8). 
The first link depended on a redirect and didn't work in the product docs because PV2 doesn't support redirects.
The second link referenced an obsolete filename, and was broken both upstream and downstream.

@sberyozkin, please approve these changes for `main` only.
Because these changes might not backport cleanly to `3.2`, I have manually cherry-picked these changes to `3.2` and created a separate MR for them: https://github.com/quarkusio/quarkus/pull/37089

References [QDOCS-534](https://issues.redhat.com/browse/QDOCS-534).

