### PR TITLE
Remove `smallrye-opentracing` from native tests modules in CI

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -111,7 +111,7 @@
         {
             "category": "Misc3",
             "timeout": 80,
-            "test-modules": "kubernetes-client, openshift-client, kubernetes-service-binding-jdbc, smallrye-config, smallrye-graphql, smallrye-graphql-client, smallrye-metrics, smallrye-opentracing",
+            "test-modules": "kubernetes-client, openshift-client, kubernetes-service-binding-jdbc, smallrye-config, smallrye-graphql, smallrye-graphql-client, smallrye-metrics",
             "os-name": "ubuntu-latest"
         },
         {


### PR DESCRIPTION
The test was removed in https://github.com/quarkusio/quarkus/pull/36602
