### PR TITLE
Fix MQTT devService always start even if the host/port channel is set

### DIFF
--- a/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/MqttDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-mqtt/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/mqtt/deployment/MqttDevServicesProcessor.java
@@ -203,17 +203,16 @@ public class MqttDevServicesProcessor {
             boolean isIncoming = name.startsWith("mp.messaging.incoming.");
             boolean isOutgoing = name.startsWith("mp.messaging.outgoing.");
             boolean isConnector = name.endsWith(".connector");
-            boolean isConfigured = false;
+            boolean isConfigured;
             if ((isIncoming || isOutgoing) && isConnector) {
                 String connectorValue = config.getValue(name, String.class);
                 boolean isMqtt = connectorValue.equalsIgnoreCase("smallrye-mqtt");
                 boolean hasHost = ConfigUtils.isPropertyPresent(name.replace(".connector", ".host"));
                 boolean hasPort = ConfigUtils.isPropertyPresent(name.replace(".connector", ".port"));
                 isConfigured = isMqtt && (hasHost || hasPort);
-            }
-
-            if (!isConfigured) {
-                return true;
+                if (!isConfigured) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
Fix: #32463 

Need to be backported to Quarkus 2.x

## Description: 

Currently, Mqtt devService is always triggered, even if the host/port is defined. 
IMO the issue is located on `MqttDevServicesProcessor`, more in detail we are not checking all the `applications.properties` because the `host/port` verification is in the wrong place (will always break the loop on the first iterations). 