### PR TITLE
Fix vale error in grpc, oidc, and vertx areas > 3.5

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/SslServerConfig.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/config/SslServerConfig.java
@@ -29,21 +29,21 @@ public class SslServerConfig {
     public Optional<Path> key;
 
     /**
-     * An optional key store which holds the certificate information instead of specifying separate files.
-     * The key store can be either on classpath or an external file.
+     * An optional keystore that holds the certificate information instead of specifying separate files.
+     * The keystore can be either on classpath or an external file.
      */
     @ConfigItem
     public Optional<Path> keyStore;
 
     /**
-     * An optional parameter to specify the type of the key store file. If not given, the type is automatically detected
+     * An optional parameter to specify the type of the keystore file. If not given, the type is automatically detected
      * based on the file name.
      */
     @ConfigItem
     public Optional<String> keyStoreType;
 
     /**
-     * A parameter to specify the password of the key store file. If not given, the default ("password") is used.
+     * A parameter to specify the password of the keystore file. If not given, the default ("password") is used.
      */
     @ConfigItem
     public Optional<String> keyStorePassword;

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -252,7 +252,7 @@ public class OidcCommonConfig {
             public Optional<String> keyFile = Optional.empty();
 
             /**
-             * If provided, indicates that JWT is signed using a private key from a keystore
+             * If provided, indicates that JWT is signed using a private key from a keystore.
              */
             @ConfigItem
             public Optional<String> keyStoreFile = Optional.empty();
@@ -448,7 +448,7 @@ public class OidcCommonConfig {
         public Optional<Verification> verification = Optional.empty();
 
         /**
-         * An optional keystore which holds the certificate information instead of specifying separate files.
+         * An optional keystore that holds the certificate information instead of specifying separate files.
          */
         @ConfigItem
         public Optional<Path> keyStoreFile = Optional.empty();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CertificateConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CertificateConfig.java
@@ -59,27 +59,27 @@ public class CertificateConfig {
     public Optional<List<Path>> keyFiles;
 
     /**
-     * An optional key store that holds the certificate information instead of specifying separate files.
+     * An optional keystore that holds the certificate information instead of specifying separate files.
      */
     @ConfigItem
     public Optional<Path> keyStoreFile;
 
     /**
-     * An optional parameter to specify the type of the key store file.
+     * An optional parameter to specify the type of the keystore file.
      * If not given, the type is automatically detected based on the file name.
      */
     @ConfigItem
     public Optional<String> keyStoreFileType;
 
     /**
-     * An optional parameter to specify a provider of the key store file.
-     * If not given, the provider is automatically detected based on the key store file type.
+     * An optional parameter to specify a provider of the keystore file.
+     * If not given, the provider is automatically detected based on the keystore file type.
      */
     @ConfigItem
     public Optional<String> keyStoreProvider;
 
     /**
-     * A parameter to specify the password of the key store file.
+     * A parameter to specify the password of the keystore file.
      * If not given, and if it can not be retrieved from {@linkplain CredentialsProvider}.
      *
      * @see {@link #credentialsProvider}
@@ -98,8 +98,8 @@ public class CertificateConfig {
     public Optional<String> keyStorePasswordKey;
 
     /**
-     * An optional parameter to select a specific key in the key store.
-     * When SNI is disabled, and the key store contains multiple
+     * An optional parameter to select a specific key in the keystore.
+     * When SNI is disabled, and the keystore contains multiple
      * keys and no alias is specified; the behavior is undefined.
      */
     @ConfigItem


### PR DESCRIPTION
Cherrry picked https://github.com/quarkusio/quarkus/pull/36960 to `3.5` because it might not backport cleanly.
Used SHA https://github.com/quarkusio/quarkus/commit/224f10f9c802e5ac16e8b587f81cff00d859b2cd.