### PR TITLE
Docs - Add missing steps to Basic authentication how-to

### DIFF
--- a/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
@@ -15,23 +15,39 @@ Enable xref:security-basic-authentication.adoc[Basic authentication] for your Qu
 
 == Prerequisites
 
-* You have installed at least one extension that provides an `IdentityProvider` based on username and password, such as xref:security-jdbc.adoc[Elytron JDBC].
+* You have installed at least one extension that provides an `IdentityProvider` based on username and password.
+For example:
+
+** xref:security-jpa.adoc[Quarkus Security Jakarta Persistence extensions (`security-jpa` or `security-jpa-reactive`)]
+** xref:security-properties.adoc[Elytron security properties file extension `(quarkus-elytron-security-properties-file)`]
+** xref:security-jdbc.adoc[Elytron security JDBC extension `(quarkus-elytron-security-jdbc)`]
+
+The following procedure outlines how you can enable Basic authentication for your application by using the `elytron-security-properties-file` extension.
 
 == Procedure
 
-. Enable Basic authentication by setting the `quarkus.http.auth.basic` property to `true`.
+. In the `application.properties` file, set the `quarkus.http.auth.basic` property to `true`.
 +
 [source,properties]
 ----
 quarkus.http.auth.basic=true
 ----
 
-. For testing purposes, you can configure the required user credentials, user name, secret, and roles, in the `application.properties` file.
+. **Optional:** In a non-production environment only and purely for testing Quarkus Security in your applications:
+.. To enable authentication for the embedded realm, set the `quarkus.security.users.embedded.enabled` property to `true`.
++
+[source,properties]
+----
+security.users.embedded.enabled=true
+----
+
+.. You can also configure the required user credentials, user name, secret, and roles.
 For example:
 +
 [source,properties]
 ----
 quarkus.http.auth.basic=true
+quarkus.security.users.embedded.enabled=true
 quarkus.security.users.embedded.plain-text=true
 quarkus.security.users.embedded.users.alice=alice <1>
 quarkus.security.users.embedded.users.bob=bob <2>


### PR DESCRIPTION
The QE review of 3.2.8 product docs highlighted some missing content that would be helpful for folks unfamiliar with enabling Basic authentication in Quarkus.

This PR:
- Enhances the prereq to clarify two extensions that can be used to enable Basic authentication.
- Adds a new step (number 2) for setting the configuration option `(quarkus.security.users.embedded.enabled=true)` , which is needed to enable the security via the embedded realm.

:eyes:  @jsmrcka & @sberyozkin  (REF QUARKUS-3651)
