### PR TITLE
Generate prometheus ServiceMonitor CR

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -161,7 +161,7 @@
         <kotlin.coroutine.version>1.7.3</kotlin.coroutine.version>
         <azure.toolkit-lib.version>0.27.0</azure.toolkit-lib.version>
         <kotlin-serialization.version>1.6.0</kotlin-serialization.version>
-        <dekorate.version>4.0.3</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
+        <dekorate.version>4.1.0</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>
         <jboss-logmanager.version>3.0.2.Final</jboss-logmanager.version>
@@ -3175,6 +3175,12 @@
             <dependency>
                 <groupId>io.dekorate</groupId>
                 <artifactId>kind-annotations</artifactId>
+                <version>${dekorate.version}</version>
+                <classifier>noapt</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.dekorate</groupId>
+                <artifactId>prometheus-annotations</artifactId>
                 <version>${dekorate.version}</version>
                 <classifier>noapt</classifier>
             </dependency>

--- a/extensions/kubernetes/vanilla/deployment/pom.xml
+++ b/extensions/kubernetes/vanilla/deployment/pom.xml
@@ -91,6 +91,26 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.dekorate</groupId>
+            <artifactId>prometheus-annotations</artifactId>
+            <classifier>noapt</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.sundr</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddServiceMonitorResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddServiceMonitorResourceDecorator.java
@@ -1,0 +1,46 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.kubernetes.decorator.ResourceProvidingDecorator;
+import io.dekorate.prometheus.model.ServiceMonitorBuilder;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+public class AddServiceMonitorResourceDecorator extends ResourceProvidingDecorator<KubernetesListBuilder> {
+
+    private final String scheme;
+    private final String targetPort;
+    private final String path;
+    private final int interval;
+    private final boolean honorLabels;
+
+    public AddServiceMonitorResourceDecorator(String scheme, String targetPort, String path, int interval,
+            boolean honorLabels) {
+        this.scheme = scheme;
+        this.targetPort = targetPort;
+        this.path = path;
+        this.interval = interval;
+        this.honorLabels = honorLabels;
+    }
+
+    @Override
+    public void visit(KubernetesListBuilder list) {
+        ObjectMeta meta = getMandatoryDeploymentMetadata(list, ANY);
+        list.addToItems(new ServiceMonitorBuilder()
+                .withNewMetadata()
+                .withName(meta.getName())
+                .withLabels(meta.getLabels())
+                .endMetadata()
+                .withNewSpec()
+                .withNewSelector()
+                .addToMatchLabels(meta.getLabels())
+                .endSelector()
+                .addNewEndpoint()
+                .withScheme(scheme)
+                .withNewTargetPort(targetPort)
+                .withPath(path)
+                .withInterval(interval + "s")
+                .withHonorLabels(honorLabels)
+                .endEndpoint()
+                .endSpec());
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PrometheusConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PrometheusConfig.java
@@ -26,6 +26,16 @@ public class PrometheusConfig {
     boolean annotations;
 
     /**
+     * When true (the default), emit a set of annotations to identify
+     * services that should be scraped by prometheus for metrics.
+     *
+     * In configurations that use the Prometheus operator with ServiceMonitor,
+     * annotations may not be necessary.
+     */
+    @ConfigItem(defaultValue = "true")
+    boolean generateServiceMonitor;
+
+    /**
      * Define the annotation prefix used for scrape values, this value will be used
      * as the base for other annotation name defaults. Altering the base for generated
      * annotations can make it easier to define re-labeling rules and avoid unexpected

--- a/integration-tests/kubernetes/quarkus-standard-way/pom.xml
+++ b/integration-tests/kubernetes/quarkus-standard-way/pom.xml
@@ -131,6 +131,17 @@
              </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.dekorate</groupId>
+            <artifactId>prometheus-annotations</artifactId>
+            <classifier>noapt</classifier>
+             <exclusions>
+                 <exclusion>
+                     <groupId>io.fabric8</groupId>
+                     <artifactId>kubernetes-client</artifactId>
+                 </exclusion>
+             </exclusions>
+        </dependency>
+        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
             <exclusions>

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsCustomRelativeTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsCustomRelativeTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.dekorate.prometheus.model.Endpoint;
+import io.dekorate.prometheus.model.ServiceMonitor;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.quarkus.builder.Version;
@@ -30,8 +32,12 @@ public class KubernetesWithMetricsCustomRelativeTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .setRun(true)
             .setLogFileName("k8s.log")
-            .withConfigurationResource("kubernetes-with-metrics-custom-relative.properties")
-            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-smallrye-metrics", Version.getVersion())));
+            .overrideConfigKey("quarkus.http.port", "9090")
+            .overrideConfigKey("quarkus.micrometer.export.prometheus.path", "met")
+            .overrideConfigKey("quarkus.kubernetes.prometheus.prefix", "example.io")
+            .overrideConfigKey("quarkus.kubernetes.prometheus.scrape", "example.io/should_be_scraped")
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-micrometer-registry-prometheus", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;
@@ -76,6 +82,22 @@ public class KubernetesWithMetricsCustomRelativeTest {
                 });
             });
         });
+
+        assertThat(kubernetesList).filteredOn(i -> i.getKind().equals("ServiceMonitor")).singleElement()
+                .isInstanceOfSatisfying(ServiceMonitor.class, s -> {
+                    assertThat(s.getMetadata()).satisfies(m -> {
+                        assertThat(m.getName()).isEqualTo("metrics");
+                    });
+
+                    assertThat(s.getSpec()).satisfies(spec -> {
+                        assertThat(spec.getEndpoints()).hasSize(1);
+                        assertThat(spec.getEndpoints().get(0)).isInstanceOfSatisfying(Endpoint.class, e -> {
+                            assertThat(e.getScheme()).isEqualTo("http");
+                            assertThat(e.getTargetPort().getStrVal()).isEqualTo("9090");
+                            assertThat(e.getPath()).isEqualTo("/q/met");
+                        });
+                    });
+                });
     }
 
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsNoAnnotationsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsNoAnnotationsTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.dekorate.prometheus.model.Endpoint;
+import io.dekorate.prometheus.model.ServiceMonitor;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.quarkus.builder.Version;
@@ -30,7 +32,10 @@ public class KubernetesWithMetricsNoAnnotationsTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .setRun(true)
             .setLogFileName("k8s.log")
-            .withConfigurationResource("kubernetes-with-metrics-no-annotations.properties")
+            .overrideConfigKey("quarkus.http.port", "9090")
+            .overrideConfigKey("quarkus.smallrye-metrics.path", "/met")
+            .overrideConfigKey("quarkus.kubernetes.prometheus.annotations", "false")
+            .overrideConfigKey("quarkus.kubernetes.prometheus.prefix", "example.io")
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-micrometer-registry-prometheus", Version.getVersion())));
 
@@ -76,6 +81,22 @@ public class KubernetesWithMetricsNoAnnotationsTest {
                 });
             });
         });
+
+        assertThat(kubernetesList).filteredOn(i -> i.getKind().equals("ServiceMonitor")).singleElement()
+                .isInstanceOfSatisfying(ServiceMonitor.class, s -> {
+                    assertThat(s.getMetadata()).satisfies(m -> {
+                        assertThat(m.getName()).isEqualTo("metrics");
+                    });
+
+                    assertThat(s.getSpec()).satisfies(spec -> {
+                        assertThat(spec.getEndpoints()).hasSize(1);
+                        assertThat(spec.getEndpoints().get(0)).isInstanceOfSatisfying(Endpoint.class, e -> {
+                            assertThat(e.getScheme()).isEqualTo("http");
+                            assertThat(e.getTargetPort().getStrVal()).isEqualTo("9090");
+                            assertThat(e.getPath()).isEqualTo("/q/metrics");
+                        });
+                    });
+                });
     }
 
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.dekorate.prometheus.model.Endpoint;
+import io.dekorate.prometheus.model.ServiceMonitor;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.quarkus.builder.Version;
@@ -30,7 +32,7 @@ public class KubernetesWithMetricsTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .setRun(true)
             .setLogFileName("k8s.log")
-            .withConfigurationResource("kubernetes-with-metrics.properties")
+            .overrideConfigKey("quarkus.http.port", "9090")
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-smallrye-metrics", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-kubernetes-client", Version.getVersion())));
@@ -82,6 +84,22 @@ public class KubernetesWithMetricsTest {
                     entry("prometheus.io/path", "/q/metrics"), entry("prometheus.io/port", "9090"),
                     entry("prometheus.io/scheme", "http"));
         });
+
+        assertThat(kubernetesList).filteredOn(i -> i.getKind().equals("ServiceMonitor")).singleElement()
+                .isInstanceOfSatisfying(ServiceMonitor.class, s -> {
+                    assertThat(s.getMetadata()).satisfies(m -> {
+                        assertThat(m.getName()).isEqualTo("metrics");
+                    });
+
+                    assertThat(s.getSpec()).satisfies(spec -> {
+                        assertThat(spec.getEndpoints()).hasSize(1);
+                        assertThat(spec.getEndpoints().get(0)).isInstanceOfSatisfying(Endpoint.class, e -> {
+                            assertThat(e.getScheme()).isEqualTo("http");
+                            assertThat(e.getTargetPort().getStrVal()).isEqualTo("9090");
+                            assertThat(e.getPath()).isEqualTo("/q/metrics");
+                        });
+                    });
+                });
 
         assertThat(kubernetesList).filteredOn(h -> "ServiceAccount".equals(h.getKind())).singleElement().satisfies(h -> {
             if (h.getMetadata().getAnnotations() != null) {

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMicrometerTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMicrometerTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.dekorate.prometheus.model.Endpoint;
+import io.dekorate.prometheus.model.ServiceMonitor;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.quarkus.builder.Version;
@@ -59,21 +61,39 @@ public class KubernetesWithMicrometerTest {
                 .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
         List<HasMetadata> kubernetesList = DeserializationUtil
                 .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
-        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
-            assertThat(d.getMetadata()).satisfies(m -> {
-                assertThat(m.getName()).isEqualTo("metrics");
-            });
 
-            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
-                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
-                    assertThat(t.getMetadata()).satisfies(meta -> {
-                        assertThat(meta.getAnnotations()).contains(entry("prometheus.io/scrape", "true"),
-                                entry("prometheus.io/path", "/q/metrics"), entry("prometheus.io/port", "8080"),
-                                entry("prometheus.io/scheme", "http"));
+        assertThat(kubernetesList).filteredOn(i -> i.getKind().equals("ServiceMonitor")).singleElement()
+                .isInstanceOfSatisfying(ServiceMonitor.class, s -> {
+                    assertThat(s.getMetadata()).satisfies(m -> {
+                        assertThat(m.getName()).isEqualTo("metrics");
+                    });
+
+                    assertThat(s.getSpec()).satisfies(spec -> {
+                        assertThat(spec.getEndpoints()).hasSize(1);
+                        assertThat(spec.getEndpoints().get(0)).isInstanceOfSatisfying(Endpoint.class, e -> {
+                            assertThat(e.getScheme()).isEqualTo("http");
+                            assertThat(e.getTargetPort().getStrVal()).isEqualTo("8080");
+                            assertThat(e.getPath()).isEqualTo("/q/metrics");
+                        });
                     });
                 });
-            });
-        });
+
+        assertThat(kubernetesList).filteredOn(i -> i instanceof Deployment).singleElement()
+                .isInstanceOfSatisfying(Deployment.class, d -> {
+                    assertThat(d.getMetadata()).satisfies(m -> {
+                        assertThat(m.getName()).isEqualTo("metrics");
+                    });
+
+                    assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                        assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                            assertThat(t.getMetadata()).satisfies(meta -> {
+                                assertThat(meta.getAnnotations()).contains(entry("prometheus.io/scrape", "true"),
+                                        entry("prometheus.io/path", "/q/metrics"), entry("prometheus.io/port", "8080"),
+                                        entry("prometheus.io/scheme", "http"));
+                            });
+                        });
+                    });
+                });
     }
 
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-metrics-custom-absolute.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-metrics-custom-absolute.properties
@@ -1,4 +1,0 @@
-quarkus.http.port=9090
-quarkus.micrometer.export.prometheus.path=/absolute-metrics
-quarkus.kubernetes.prometheus.prefix=example.io
-quarkus.kubernetes.prometheus.scrape=example.io/should_be_scraped

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-metrics-custom-relative.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-metrics-custom-relative.properties
@@ -1,4 +1,0 @@
-quarkus.http.port=9090
-quarkus.smallrye-metrics.path=met
-quarkus.kubernetes.prometheus.prefix=example.io
-quarkus.kubernetes.prometheus.scrape=example.io/should_be_scraped

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-metrics-no-annotations.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-metrics-no-annotations.properties
@@ -1,4 +1,0 @@
-quarkus.http.port=9090
-quarkus.smallrye-metrics.path=/met
-quarkus.kubernetes.prometheus.annotations=false
-quarkus.kubernetes.prometheus.prefix=example.io

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-metrics.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-metrics.properties
@@ -1,1 +1,0 @@
-quarkus.http.port=9090


### PR DESCRIPTION
Currently, we use Prometheus annotation, but it's recommended to use `ServiceMonitor` instead.
This pull request enables OOTB `ServiceMonitor` generation with the option to disable it.