### PR TITLE
Do not report unused deprecated runtime props with default value as used

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/DeprecatedRuntimePropertiesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/DeprecatedRuntimePropertiesRecorder.java
@@ -7,6 +7,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.annotations.Recorder;
+import io.smallrye.config.SmallRyeConfig;
 
 @Recorder
 public class DeprecatedRuntimePropertiesRecorder {
@@ -17,6 +18,11 @@ public class DeprecatedRuntimePropertiesRecorder {
         Config config = ConfigProvider.getConfig();
         for (String property : config.getPropertyNames()) {
             if (deprecatedRuntimeProperties.contains(property)) {
+                String configSourceName = ((SmallRyeConfig) config).getConfigValue(property).getConfigSourceName();
+                // this condition can be removed when support of the @ConfigRoot annotation on classes is removed
+                if ("DefaultValuesConfigSource".equals(configSourceName)) {
+                    continue;
+                }
                 log.warnf("The '%s' config property is deprecated and should not be used anymore", property);
             }
         }


### PR DESCRIPTION
fixes: #37072
fixes: #36775

@radcortez I really tried to create test, but it can only be tested by asserting logs with `QuarkusProdModeTest` when `@ConfigRoot` class (not `@ConfigMapping` interface) is provided by extension (I suppose, even than I could not see it in `io.quarkus.test.ProdModeTestResults#retainedBuildLogRecords` or `io.quarkus.test.QuarkusProdModeTest#inMemoryLogHandler`). I could not reproduce it when setting config class via `org.jboss.shrinkwrap.api.container.ClassContainer#addClasses`, so I tested it with reproducer and QE apps that logs same deprecation warning. I'm open to suggestions anyway.