### PR TITLE
Fix vale errors in Security Authentication mechanisms

### DIFF
--- a/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRunTimeConfig.java
+++ b/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRunTimeConfig.java
@@ -213,14 +213,14 @@ public class WebAuthnRunTimeConfig {
      * referred to as "renewal-timeout".
      *
      * Note that smaller values will result in slightly more server load (as new encrypted cookies will be
-     * generated more often), however larger values affect the inactivity timeout as the timeout is set
+     * generated more often); however, larger values affect the inactivity timeout because the timeout is set
      * when a cookie is generated.
      *
-     * For example if this is set to 10 minutes, and the inactivity timeout is 30m, if a users last request
-     * is when the cookie is 9m old then the actual timeout will happen 21m after the last request, as the timeout
+     * For example if this is set to 10 minutes, and the inactivity timeout is 30m, if a user's last request
+     * is when the cookie is 9m old then the actual timeout will happen 21m after the last request because the timeout
      * is only refreshed when a new cookie is generated.
      *
-     * In other words, no timeout is tracked on the server side; the timestamp is encoded and encrypted in the cookie
+     * That is, no timeout is tracked on the server side; the timestamp is encoded and encrypted in the cookie
      * itself, and it is decrypted and parsed with each request.
      */
     @ConfigItem(defaultValue = "PT1M")

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthRuntimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthRuntimeConfig.java
@@ -65,7 +65,7 @@ public class FormAuthRuntimeConfig {
 
     /**
      * Option to control the name of the cookie used to redirect the user back
-     * to where he wants to get access to.
+     * to the location they want to access.
      */
     @ConfigItem(defaultValue = "quarkus-redirect-location")
     public String locationCookie;
@@ -83,15 +83,15 @@ public class FormAuthRuntimeConfig {
      * referred to as "renewal-timeout".
      *
      * Note that smaller values will result in slightly more server load (as new encrypted cookies will be
-     * generated more often), however larger values affect the inactivity timeout as the timeout is set
+     * generated more often); however, larger values affect the inactivity timeout because the timeout is set
      * when a cookie is generated.
      *
-     * For example if this is set to 10 minutes, and the inactivity timeout is 30m, if a users last request
-     * is when the cookie is 9m old then the actual timeout will happen 21m after the last request, as the timeout
+     * For example if this is set to 10 minutes, and the inactivity timeout is 30m, if a user's last request
+     * is when the cookie is 9m old then the actual timeout will happen 21m after the last request because the timeout
      * is only refreshed when a new cookie is generated.
      *
-     * In other words no timeout is tracked on the server side; the timestamp is encoded and encrypted in the cookie itself,
-     * and it is decrypted and parsed with each request.
+     * That is, no timeout is tracked on the server side; the timestamp is encoded and encrypted in the cookie
+     * itself, and it is decrypted and parsed with each request.
      */
     @ConfigItem(defaultValue = "PT1M")
     public Duration newCookieInterval;


### PR DESCRIPTION
Here, I've fixed vale errors in the Java doc that appears in the generated "Configuration property" table in the [Authentication mechanisms in Quarkus](https://quarkus.io/version/main/guides/security-authentication-mechanisms) guide on `main`.
Do not backport this to 3.2. I will cherry-pick separate PRs for 3.2 and 3.5:
- For 3.2: https://github.com/quarkusio/quarkus/pull/37132
- ~For 3.5 https://github.com/quarkusio/quarkus/pull/37133~