### PR TITLE
Properly handle authority-pseudo header in the ForwardedParser

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedParser.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedParser.java
@@ -121,7 +121,7 @@ class ForwardedParser {
         calculated = true;
         remoteAddress = delegate.remoteAddress();
         scheme = delegate.scheme();
-        setHostAndPort(delegate.getHeader(HttpHeaders.HOST), port);
+        setHostAndPort(delegate.host(), port);
         uri = delegate.uri();
 
         if (trustedProxyCheck.isProxyAllowed()) {


### PR DESCRIPTION
Fix #37045 