### PR TITLE
Create a quarkus wrapper script for the Quarkus CLI and add it to the codestarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,4 @@ nb-configuration.xml
 .envrc
 .jekyll-cache
 .mvn/.gradle-enterprise
-.quarkus
+/.quarkus

--- a/independent-projects/tools/base-codestarts/src/main/filtered/codestarts/quarkus/tooling/quarkus-cli-wrapper/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/filtered/codestarts/quarkus/tooling/quarkus-cli-wrapper/codestart.yml
@@ -1,0 +1,9 @@
+name: tooling-quarkus-cli-wrapper
+type: tooling
+output-strategy:
+  "quarkusw": "executable"
+language:
+  base:
+    data:
+      quarkus-cli:
+        version: ${project.version}

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/quarkus-cli-wrapper/base/.quarkus/cli/wrapper/QuarkusCliWrapperDownloader.tpl.qute.java
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/quarkus-cli-wrapper/base/.quarkus/cli/wrapper/QuarkusCliWrapperDownloader.tpl.qute.java
@@ -1,0 +1,80 @@
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+// An adapted version of the Maven MavenWrapperDownloader for the Quarkus CLI
+public final class MavenWrapperDownloader
+{
+    private static final String WRAPPER_VERSION = "{quarkus-cli.version}";
+
+    private static final boolean VERBOSE = Boolean.parseBoolean( System.getenv( "QUARKUSW_VERBOSE" ) );
+
+    public static void main( String[] args )
+    {
+        log( "Quarkus CLI Wrapper Downloader " + WRAPPER_VERSION );
+
+        if ( args.length != 2 )
+        {
+            System.err.println( " - ERROR wrapperUrl or wrapperJarPath parameter missing" );
+            System.exit( 1 );
+        }
+
+        try
+        {
+            log( " - Downloader started" );
+            final URL wrapperUrl = new URL( args[0] );
+            final String jarPath = args[1].replace( "..", "" ); // Sanitize path
+            final Path wrapperJarPath = Paths.get( jarPath ).toAbsolutePath().normalize();
+            downloadFileFromURL( wrapperUrl, wrapperJarPath );
+            log( "Done" );
+        }
+        catch ( IOException e )
+        {
+            System.err.println( "- Error downloading: " + e.getMessage() );
+            if ( VERBOSE )
+            {
+                e.printStackTrace();
+            }
+            System.exit( 1 );
+        }
+    }
+
+    private static void downloadFileFromURL( URL wrapperUrl, Path wrapperJarPath )
+        throws IOException
+    {
+        log( " - Downloading to: " + wrapperJarPath );
+        if ( System.getenv( "QUARKUSW_USERNAME" ) != null && System.getenv( "QUARKUSW_PASSWORD" ) != null )
+        {
+            final String username = System.getenv( "QUARKUSW_USERNAME" );
+            final char[] password = System.getenv( "QUARKUSW_PASSWORD" ).toCharArray();
+            Authenticator.setDefault( new Authenticator()
+            {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication()
+                {
+                    return new PasswordAuthentication( username, password );
+                }
+            } );
+        }
+        try ( InputStream inStream = wrapperUrl.openStream() )
+        {
+            Files.copy( inStream, wrapperJarPath, StandardCopyOption.REPLACE_EXISTING );
+        }
+        log( " - Downloader complete" );
+    }
+
+    private static void log( String msg )
+    {
+        if ( VERBOSE )
+        {
+            System.out.println( msg );
+        }
+    }
+
+}

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/quarkus-cli-wrapper/base/.quarkus/cli/wrapper/quarkus-cli.tpl.qute.properties
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/quarkus-cli-wrapper/base/.quarkus/cli/wrapper/quarkus-cli.tpl.qute.properties
@@ -1,0 +1,1 @@
+wrapperUrl=https://repo.maven.apache.org/maven2/io/quarkus/quarkus-cli/{quarkus-cli.version}/quarkus-cli-{quarkus-cli.version}-runner.jar

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/quarkus-cli-wrapper/base/quarkusw.tpl.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/quarkus-cli-wrapper/base/quarkusw.tpl.qute
@@ -1,0 +1,264 @@
+#!/bin/sh
+
+# ----------------------------------------------------------------------------
+# Quarkus CLI Wrapper startup batch script, version {quarkus-cli.version}
+#
+# This script an adapted version of the Apache Maven Wrapper to work for the Quarkus CLI
+#
+# Required ENV vars:
+# ------------------
+#   JAVA_HOME - location of a JDK home dir
+#
+# Optional ENV vars
+# -----------------
+#   QUARKUS_OPTS - parameters passed to the Java VM when running Maven
+#     e.g. to debug Maven itself, use
+#       set QUARKUS_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+# ----------------------------------------------------------------------------
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+mingw=false
+case "$(uname)" in
+  CYGWIN*) cygwin=true ;;
+  MINGW*) mingw=true;;
+  Darwin*) darwin=true
+    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+    if [ -z "$JAVA_HOME" ]; then
+      if [ -x "/usr/libexec/java_home" ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"; export JAVA_HOME
+      else
+        JAVA_HOME="/Library/Java/Home"; export JAVA_HOME
+      fi
+    fi
+    ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=$(java-config --jre-home)
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
+fi
+
+# For Mingw, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$JAVA_HOME" ] && [ -d "$JAVA_HOME" ] &&
+    JAVA_HOME="$(cd "$JAVA_HOME" || (echo "cannot cd into $JAVA_HOME."; exit 1); pwd)"
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  javaExecutable="$(which javac)"
+  if [ -n "$javaExecutable" ] && ! [ "$(expr "\"$javaExecutable\"" : '\([^ ]*\)')" = "no" ]; then
+    # readlink(1) is not available as standard on Solaris 10.
+    readLink=$(which readlink)
+    if [ ! "$(expr "$readLink" : '\([^ ]*\)')" = "no" ]; then
+      if $darwin ; then
+        javaHome="$(dirname "\"$javaExecutable\"")"
+        javaExecutable="$(cd "\"$javaHome\"" && pwd -P)/javac"
+      else
+        javaExecutable="$(readlink -f "\"$javaExecutable\"")"
+      fi
+      javaHome="$(dirname "\"$javaExecutable\"")"
+      javaHome=$(expr "$javaHome" : '\(.*\)/bin')
+      JAVA_HOME="$javaHome"
+      export JAVA_HOME
+    fi
+  fi
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="$(\unset -f command 2>/dev/null; \command -v java)"
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute $JAVACMD" >&2
+  exit 1
+fi
+
+if [ -z "$JAVA_HOME" ] ; then
+  echo "Warning: JAVA_HOME environment variable is not set."
+fi
+
+# traverses directory structure from process work directory to filesystem root
+# first directory with quarkus/cli subdirectory is considered project base directory
+find_quarkus_basedir() {
+  if [ -z "$1" ]
+  then
+    echo "Path not specified to find_quarkus_basedir"
+    return 1
+  fi
+
+  basedir="$1"
+  wdir="$1"
+  while [ "$wdir" != '/' ] ; do
+    if [ -d "$wdir"/.quarkus ] ; then
+      basedir=$wdir
+      break
+    fi
+    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+    if [ -d "$\{wdir}" ]; then
+      wdir=$(cd "$wdir/.." || exit 1; pwd)
+    fi
+    # end of workaround
+  done
+  printf '%s' "$(cd "$basedir" || exit 1; pwd)"
+}
+
+# concatenates all lines of a file
+concat_lines() {
+  if [ -f "$1" ]; then
+    # Remove \r in case we run on Windows within Git Bash
+    # and check out the repository with auto CRLF management
+    # enabled. Otherwise, we may read lines that are delimited with
+    # \r\n and produce $'-Xarg\r' rather than -Xarg due to word
+    # splitting rules.
+    tr -s '\r\n' ' ' < "$1"
+  fi
+}
+
+log() {
+  if [ "$QUARKUSW_VERBOSE" = true ]; then
+    printf '%s\n' "$1"
+  fi
+}
+
+BASE_DIR=$(find_quarkus_basedir "$(dirname "$0")")
+if [ -z "$BASE_DIR" ]; then
+  exit 1;
+fi
+
+QUARKUS_PROJECTBASEDIR=$\{QUARKUS_BASEDIR:-"$BASE_DIR"}; export QUARKUS_PROJECTBASEDIR
+log "$QUARKUS_PROJECTBASEDIR"
+
+##########################################################################################
+# Extension to allow automatically downloading the quarkus-cli.jar from Maven-central
+# This allows using the maven wrapper in projects that prohibit checking in binary data.
+##########################################################################################
+wrapperJarPath="$QUARKUS_PROJECTBASEDIR/.quarkus/cli/wrapper/quarkus-cli.jar"
+if [ -r "$wrapperJarPath" ]; then
+    log "Found $wrapperJarPath"
+else
+    log "Couldn't find $wrapperJarPath, downloading it ..."
+
+    if [ -n "$QUARKUSW_REPOURL" ]; then
+      wrapperUrl="$QUARKUSW_REPOURL/io/quarkus/quarkus-cli/{quarkus-cli.version}/quarkus-cli-{quarkus-cli.version}-runner.jar"
+    else
+      wrapperUrl="https://repo.maven.apache.org/maven2/io/quarkus/quarkus-cli/{quarkus-cli.version}/qarkus-cli-{quarkus-cli.version}-runner.jar"
+    fi
+    while IFS="=" read -r key value; do
+      # Remove '\r' from value to allow usage on windows as IFS does not consider '\r' as a separator ( considers space, tab, new line ('\n'), and custom '=' )
+      safeValue=$(echo "$value" | tr -d '\r')
+      case "$key" in (wrapperUrl) wrapperUrl="$safeValue"; break ;;
+      esac
+    done < "$QUARKUS_PROJECTBASEDIR/.quarkus/cli/wrapper/quarkus-cli.properties"
+    log "Downloading from: $wrapperUrl"
+
+    if $cygwin; then
+      wrapperJarPath=$(cygpath --path --windows "$wrapperJarPath")
+    fi
+
+    if [ -f "$HOME/.m2/repository/io/quarkus/quarkus-cli/{quarkus-cli.version}/quarkus-cli-{quarkus-cli.version}-runner.jar" ]; then
+      cp "$HOME/.m2/repository/io/quarkus/quarkus-cli/{quarkus-cli.version}/quarkus-cli-{quarkus-cli.version}-runner.jar" $wrapperJarPath
+    elif command -v wget > /dev/null; then
+        log "Found wget ... using wget"
+        [ "$QUARKUSW_VERBOSE" = true ] && QUIET="" || QUIET="--quiet"
+        if [ -z "$QUARKUSW_USERNAME" ] || [ -z "$QUARKUSW_PASSWORD" ]; then
+            wget $QUIET "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        else
+            wget $QUIET --http-user="$QUARKUSW_USERNAME" --http-password="$QUARKUSW_PASSWORD" "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        fi
+    elif command -v curl > /dev/null; then
+        log "Found curl ... using curl"
+        [ "$QUARKUSW_VERBOSE" = true ] && QUIET="" || QUIET="--silent"
+        if [ -z "$QUARKUSW_USERNAME" ] || [ -z "$QUARKUSW_PASSWORD" ]; then
+            curl $QUIET -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        else
+            curl $QUIET --user "$QUARKUSW_USERNAME:$QUARKUSW_PASSWORD" -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        fi
+    else
+        log "Falling back to using Java to download"
+        javaSource="$QUARKUS_PROJECTBASEDIR/.quarkus/cli/wrapper/QuarkusCliWrapperDownloader.java"
+        javaClass="$QUARKUS_PROJECTBASEDIR/.quarkus/cli/wrapper/QuarkusCliWrapperDownloader.class"
+        # For Cygwin, switch paths to Windows format before running javac
+        if $cygwin; then
+          javaSource=$(cygpath --path --windows "$javaSource")
+          javaClass=$(cygpath --path --windows "$javaClass")
+        fi
+        if [ -e "$javaSource" ]; then
+            if [ ! -e "$javaClass" ]; then
+                log " - Compiling QuarkusCliWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/javac" "$javaSource")
+            fi
+            if [ -e "$javaClass" ]; then
+                log " - Running QuarkusCliWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/java" -cp .quarkus/cli/wrapper QuarkusCliWrapperDownloader "$wrapperUrl" "$wrapperJarPath") || rm -f "$wrapperJarPath"
+            fi
+        fi
+    fi
+fi
+##########################################################################################
+# End of extension
+##########################################################################################
+
+# If specified, validate the SHA-256 sum of the Quarkus CLI wrapper jar file
+wrapperSha256Sum=""
+while IFS="=" read -r key value; do
+  case "$key" in (wrapperSha256Sum) wrapperSha256Sum=$value; break ;;
+  esac
+done < "$QUARKUS_PROJECTBASEDIR/.quarkus/cli/wrapper/quarkus-cli-wrapper.properties"
+if [ -n "$wrapperSha256Sum" ]; then
+  wrapperSha256Result=false
+  if command -v sha256sum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  elif command -v shasum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | shasum -a 256 -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available."
+    echo "Please install either command, or disable validation by removing 'wrapperSha256Sum' from your quarkus-cli.properties."
+    exit 1
+  fi
+  if [ $wrapperSha256Result = false ]; then
+    echo "Error: Failed to validate Quarkus CLI wrapper SHA-256, your Quarkus CLI wrapper might be compromised." >&2
+    echo "Investigate or delete $wrapperJarPath to attempt a clean download." >&2
+    echo "If you updated your Quarkus CLI version, you need to update the specified wrapperSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --path --windows "$JAVA_HOME")
+  [ -n "$QUARKUS_PROJECTBASEDIR" ] &&
+    QUARKUS_PROJECTBASEDIR=$(cygpath --path --windows "$QUARKUS_PROJECTBASEDIR")
+fi
+
+# shellcheck disable=SC2086 # safe args
+exec "$JAVACMD" \
+  "-jar" \
+  "$wrapperJarPath" \
+  "$@"

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/quarkus-cli-wrapper/base/quarkusw.tpl.qute.cmd
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/quarkus-cli-wrapper/base/quarkusw.tpl.qute.cmd
@@ -1,0 +1,155 @@
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version {quarkus.version}
+@REM
+@REM Required ENV vars:
+@REM JAVA_HOME - location of a JDK home dir
+@REM
+@REM Optional ENV vars
+@REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
+@REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
+@REM     e.g. to debug Maven itself, use
+@REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+@REM MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+@REM ----------------------------------------------------------------------------
+
+@REM Begin all REM lines with '@' in case MAVEN_BATCH_ECHO is 'on'
+@echo off
+@REM set title of command window
+title %0
+@REM enable echoing by setting MAVEN_BATCH_ECHO to 'on'
+@if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
+
+@REM set %HOME% to equivalent of $HOME
+if "%HOME%" == "" (set "HOME=%HOMEDRIVE%%HOMEPATH%")
+
+@setlocal
+
+set ERROR_CODE=0
+
+@REM To isolate internal variables from possible post scripts, we use another setlocal
+@setlocal
+
+@REM ==== START VALIDATION ====
+if not "%JAVA_HOME%" == "" goto OkJHome
+
+echo.
+echo Error: JAVA_HOME not found in your environment. >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+:OkJHome
+if exist "%JAVA_HOME%\bin\java.exe" goto init
+
+echo.
+echo Error: JAVA_HOME is set to an invalid directory. >&2
+echo JAVA_HOME = "%JAVA_HOME%" >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+@REM ==== END VALIDATION ====
+
+:init
+
+@REM Find the project base dir, i.e. the directory that contains the folder ".quarkus".
+@REM Fallback to current working directory if not found.
+
+set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
+IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
+
+set EXEC_DIR=%CD%
+set WDIR=%EXEC_DIR%
+:findBaseDir
+IF EXIST "%WDIR%"\.quarkus goto baseDirFound
+cd ..
+IF "%WDIR%"=="%CD%" goto baseDirNotFound
+set WDIR=%CD%
+goto findBaseDir
+
+:baseDirFound
+set MAVEN_PROJECTBASEDIR=%WDIR%
+cd "%EXEC_DIR%"
+goto endDetectBaseDir
+
+:baseDirNotFound
+set MAVEN_PROJECTBASEDIR=%EXEC_DIR%
+cd "%EXEC_DIR%"
+
+:endDetectBaseDir
+
+SET QUARKUS_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
+set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.quarkus\cli\wrapper\quarkus-cli.jar"
+
+set WRAPPER_URL="https://repo.maven.apache.org/maven2/io/quarkus/quarkus-cli/{quarkus.version}/quarkus-cli-{quarkus.version}-runner.jar"
+
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.quarkus\cli\wrapper\quarkus-cli.properties") DO (
+    IF "%%A"=="wrapperUrl" SET WRAPPER_URL=%%B
+)
+
+@REM Extension to allow automatically downloading the quarkus-cli.jar from Maven-central
+@REM This allows using the maven wrapper in projects that prohibit checking in binary data.
+if exist %WRAPPER_JAR% (
+    if "%QUARKUSW_VERBOSE%" == "true" (
+        echo Found %WRAPPER_JAR%
+    )
+) else if exist "%USERPROFILE%\.m2\repository\io\quarkus\quarkus-cli\{quarkus.version}\quarkus-cli-{quarkus.version}-runner.jar" (
+  copy "%USERPROFILE%\.m2\repository\io\quarkus\quarkus-cli\{quarkus.version}\quarkus-cli-{quarkus.version}-runner.jar" %WRAPPER_JAR%
+) else (
+    if not "%QUARKUSW_REPOURL%" == "" (
+        SET WRAPPER_URL="%QUARKUSW_REPOURL%/io/quarkus/quarkus-cli/{quarkus.version}/quarkus-cli-{quarkus.version}-runner.jar"
+    )
+    if "%QUARKUSW_VERBOSE%" == "true" (
+        echo Couldn't find %WRAPPER_JAR%, downloading it ...
+        echo Downloading from: %WRAPPER_URL%
+    )
+
+    powershell -Command "&{"^
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%QUARKUSW_USERNAME%') -and [string]::IsNullOrEmpty('%QUARKUSW_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%QUARKUSW_USERNAME%', '%QUARKUSW_PASSWORD%');"^
+		"}"^
+		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%WRAPPER_URL%', '%WRAPPER_JAR%')"^
+		"}"
+    if "%QUARKUSW_VERBOSE%" == "true" (
+        echo Finished downloading %WRAPPER_JAR%
+    )
+)
+@REM End of extension
+
+@REM If specified, validate the SHA-256 sum of the Maven wrapper jar file
+SET WRAPPER_SHA_256_SUM=""
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.quarkus\cli\wrapper\quarkus-cli.properties") DO (
+    IF "%%A"=="wrapperSha256Sum" SET WRAPPER_SHA_256_SUM=%%B
+)
+IF NOT %WRAPPER_SHA_256_SUM%=="" (
+    powershell -Command "&{"^
+       "$hash = (Get-FileHash \"%WRAPPER_JAR%\" -Algorithm SHA256).Hash.ToLower();"^
+       "If('%WRAPPER_SHA_256_SUM%' -ne $hash){"^
+       "  Write-Output 'Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised.';"^
+       "  Write-Output 'Investigate or delete %WRAPPER_JAR% to attempt a clean download.';"^
+       "  Write-Output 'If you updated your Maven version, you need to update the specified wrapperSha256Sum property.';"^
+       "  exit 1;"^
+       "}"^
+       "}"
+    if ERRORLEVEL 1 goto error
+)
+
+%QUARKUS_JAVA_EXE% ^
+  -jar %WRAPPER_JAR% ^
+  %*
+if ERRORLEVEL 1 goto error
+goto end
+
+:error
+set ERROR_CODE=1
+
+:end
+@endlocal & set ERROR_CODE=%ERROR_CODE%
+
+if "%QUARKUS_TERMINATE_CMD%"=="on" exit %ERROR_CODE%
+
+cmd /C exit /B %ERROR_CODE%

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
@@ -71,6 +71,7 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
     public enum Tooling implements DataKey {
         TOOLING_GRADLE_WRAPPER,
         TOOLING_MAVEN_WRAPPER,
+        TOOLING_QUARKUS_CLI_WRAPPER,
         TOOLING_DOCKERFILES,
         TOOLING_GITHUB_ACTION
     }
@@ -242,6 +243,7 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
         final List<String> codestarts = new ArrayList<>();
         codestarts.add(projectInput.getBuildTool().getKey());
         if (projectInput.getAppContent().contains(AppContent.BUILD_TOOL_WRAPPER)) {
+            codestarts.add(Tooling.TOOLING_QUARKUS_CLI_WRAPPER.key());
             switch (projectInput.getBuildTool()) {
                 case GRADLE:
                 case GRADLE_KOTLIN_DSL:

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalogTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalogTest.java
@@ -83,6 +83,7 @@ class QuarkusCodestartCatalogTest {
         assertThat(projectDefinition.getBaseCodestarts()).hasSize(4);
         assertThat(projectDefinition.getExtraCodestarts()).extracting(Codestart::getName)
                 .containsExactlyInAnyOrder("tooling-dockerfiles",
+                        "tooling-quarkus-cli-wrapper",
                         "tooling-maven-wrapper");
     }
 
@@ -138,6 +139,7 @@ class QuarkusCodestartCatalogTest {
                 .containsExactlyInAnyOrder(
                         "tooling-dockerfiles",
                         "tooling-maven-wrapper",
+                        "tooling-quarkus-cli-wrapper",
                         "resteasy-codestart");
     }
 


### PR DESCRIPTION
It's really handy to have a quarkus-cli wrapper script that can be used OOTB in environments like:

- tekton tasks
- dev spaces
- workshops

without requiring additional installation tasks, custom container images etc.