### PR TITLE
Doc enhancements to the security architecture guide

### DIFF
--- a/docs/src/main/asciidoc/security-architecture.adoc
+++ b/docs/src/main/asciidoc/security-architecture.adoc
@@ -57,7 +57,10 @@ For more information, see the xref:security-customization.adoc#security-identity
 
 == Supported authentication mechanisms
 
-To learn more about security authentication in Quarkus and the supported mechanisms and protocols, see the Quarkus xref:security-authentication-mechanisms.adoc[Authentication mechanisms in Quarkus] guide.
+The Quarkus Security framework supports multiple authentication mechanisms, which can also be combined.
+Some supported authentication mechanisms are built into Quarkus, while others require you to add an extension. 
+
+To learn about security authentication in Quarkus and the supported mechanisms and protocols, see the Quarkus xref:security-authentication-mechanisms.adoc[Authentication mechanisms in Quarkus] guide.
 
 == Proactive authentication
 
@@ -67,7 +70,7 @@ For more information, see the Quarkus xref:security-proactive-authentication.ado
 
 == Quarkus Security customization
 
-Quarkus Security is also highly customizable.
+Quarkus Security is customizable.
 You can customize the following core security components of Quarkus:
 
 * `HttpAuthenticationMechanism`


### PR DESCRIPTION
This PR fixes 2 issues that came up during the QE testing for product docs (RHBQ 3.2.8) and applies to upstream and downstream Quarkus docs to make the content more accurate and clearer for newer users ramping up on Quarkus Security.

Please approve these changes for both main, 3.2 upstream docs, and RHBQ 3.2.8 downstream docs. Thank you.