### PR TITLE
Support custom Authorization schemes for OIDC bearer tokens

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1403,6 +1403,12 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public Optional<String> header = Optional.empty();
 
         /**
+         * HTTP Authorization header scheme.
+         */
+        @ConfigItem(defaultValue = OidcConstants.BEARER_SCHEME)
+        public String authorizationScheme = OidcConstants.BEARER_SCHEME;
+
+        /**
          * Required signature algorithm.
          * OIDC providers support many signature algorithms but if necessary you can restrict
          * Quarkus application to accept tokens signed only using an algorithm configured with this property.
@@ -1621,6 +1627,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setSubjectRequired(boolean subjectRequired) {
             this.subjectRequired = subjectRequired;
+        }
+
+        public String getAuthorizationScheme() {
+            return authorizationScheme;
+        }
+
+        public void setAuthorizationScheme(String authorizationScheme) {
+            this.authorizationScheme = authorizationScheme;
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
@@ -23,8 +23,6 @@ import io.vertx.ext.web.RoutingContext;
 
 @ApplicationScoped
 public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism {
-    private static HttpCredentialTransport OIDC_SERVICE_TRANSPORT = new HttpCredentialTransport(
-            HttpCredentialTransport.Type.AUTHORIZATION, OidcConstants.BEARER_SCHEME);
     private static HttpCredentialTransport OIDC_WEB_APP_TRANSPORT = new HttpCredentialTransport(
             HttpCredentialTransport.Type.AUTHORIZATION_CODE, OidcConstants.CODE_FLOW_CODE);
 
@@ -105,7 +103,8 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
                     return null;
                 }
                 return isWebApp(context, oidcTenantConfig) ? OIDC_WEB_APP_TRANSPORT
-                        : OIDC_SERVICE_TRANSPORT;
+                        : new HttpCredentialTransport(
+                                HttpCredentialTransport.Type.AUTHORIZATION, oidcTenantConfig.token.authorizationScheme);
             }
         });
     }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -44,6 +44,9 @@ public class CustomTenantResolver implements TenantResolver {
         if (path.endsWith("bearer")) {
             return "bearer";
         }
+        if (path.endsWith("bearer-id")) {
+            return "bearer-id";
+        }
         if (path.endsWith("bearer-required-algorithm")) {
             return "bearer-required-algorithm";
         }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/UsersResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/UsersResource.java
@@ -30,6 +30,14 @@ public class UsersResource {
     }
 
     @GET
+    @Path("/me/bearer-id")
+    @RolesAllowed("user")
+    @Produces(MediaType.APPLICATION_JSON)
+    public User principalNameId() {
+        return new User(identity.getPrincipal().getName());
+    }
+
+    @GET
     @Path("/preferredUserName/bearer")
     @RolesAllowed("user")
     @Produces(MediaType.APPLICATION_JSON)

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -121,6 +121,12 @@ quarkus.oidc.bearer.credentials.secret=secret
 quarkus.oidc.bearer.token.audience=https://service.example.com
 quarkus.oidc.bearer.allow-token-introspection-cache=false
 
+quarkus.oidc.bearer-id.auth-server-url=${keycloak.url}/realms/quarkus/
+quarkus.oidc.bearer-id.client-id=quarkus-app
+quarkus.oidc.bearer-id.credentials.secret=secret
+quarkus.oidc.bearer-id.allow-token-introspection-cache=false
+quarkus.oidc.bearer-id.token.authorization-scheme=ID
+
 quarkus.oidc.bearer-required-algorithm.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.bearer-required-algorithm.client-id=quarkus-app
 quarkus.oidc.bearer-required-algorithm.credentials.secret=secret

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -263,6 +263,17 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testBearerToken() {
+        String token = getAccessToken("alice", Set.of("user"));
+
+        RestAssured.given().auth().oauth2(token).when()
+                .get("/api/users/me/bearer")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("alice"));
+    }
+
+    @Test
     public void testBearerTokenWrongIssuer() {
         String token = getAccessTokenWrongIssuer("alice", Set.of("user"));
 
@@ -282,6 +293,38 @@ public class BearerTokenAuthorizationTest {
                 .then()
                 .statusCode(401)
                 .header("WWW-Authenticate", equalTo("Bearer"));
+    }
+
+    @Test
+    public void testBearerTokenIdScheme() {
+        String token = getAccessToken("alice", Set.of("user"));
+
+        RestAssured.given().header("Authorization", "ID " + token).when()
+                .get("/api/users/me/bearer-id")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("alice"));
+    }
+
+    @Test
+    public void testBearerTokenIdSchemeButBearerSchemeIsUsed() {
+        String token = getAccessToken("alice", Set.of("user"));
+
+        RestAssured.given().auth().oauth2(token).when()
+                .get("/api/users/me/bearer-id")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void testBearerTokenIdSchemeWrongIssuer() {
+        String token = getAccessTokenWrongIssuer("alice", Set.of("user"));
+
+        RestAssured.given().auth().oauth2(token).when()
+                .get("/api/users/me/bearer-id")
+                .then()
+                .statusCode(401)
+                .header("WWW-Authenticate", equalTo("ID"));
     }
 
     @Test


### PR DESCRIPTION
Simple PR to support custom HTTP Authorization header schemes. Typically it is `Bearer` but there could be cases, where a different scheme is used.
FYI, Quarkus OIDC already supports custom headers (different to `Authorization`), this PR allows to fine tune how `Authorization` headers are handled

/cc @calvernaz.

Note there will be a dedicated enhancement to support propagating using the custom schemes, as well as ID tokens 