### PR TITLE
Removed DependencyFlags.REMOVED

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludedArtifactsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludedArtifactsTest.java
@@ -78,13 +78,5 @@ public class ExcludedArtifactsTest extends BootstrapFromOriginalJarTestBase {
         expected.add(new ArtifactDependency(ArtifactCoords.jar("io.quarkus.bootstrap.test", "dep-g", "1"),
                 DependencyFlags.RUNTIME_CP, DependencyFlags.DEPLOYMENT_CP));
         assertEquals(expected, getDependenciesWithFlag(model, DependencyFlags.RUNTIME_CP));
-
-        expected = new HashSet<>();
-        expected.add(new ArtifactDependency(ArtifactCoords.jar("io.quarkus.bootstrap.test", "ext-a-dep", "1"),
-                DependencyFlags.REMOVED));
-        expected.add(new ArtifactDependency(ArtifactCoords.jar("org.banned", "dep-e", "1"), DependencyFlags.REMOVED));
-        expected.add(new ArtifactDependency(ArtifactCoords.jar("org.banned.too", "dep-d", "1"), DependencyFlags.REMOVED));
-        expected.add(new ArtifactDependency(ArtifactCoords.jar("org.banned", "dep-f", "1"), DependencyFlags.REMOVED));
-        assertEquals(expected, getDependenciesWithFlag(model, DependencyFlags.REMOVED));
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModelBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModelBuilder.java
@@ -240,31 +240,28 @@ public class ApplicationModelBuilder {
     List<ResolvedDependency> buildDependencies() {
         for (ArtifactKey key : parentFirstArtifacts) {
             final ResolvedDependencyBuilder d = dependencies.get(key);
-            if (d != null && !d.isFlagSet(DependencyFlags.REMOVED)) {
+            if (d != null) {
                 d.setFlags(DependencyFlags.CLASSLOADER_PARENT_FIRST);
             }
         }
         for (ArtifactKey key : runnerParentFirstArtifacts) {
             final ResolvedDependencyBuilder d = dependencies.get(key);
-            if (d != null && !d.isFlagSet(DependencyFlags.REMOVED)) {
+            if (d != null) {
                 d.setFlags(DependencyFlags.CLASSLOADER_RUNNER_PARENT_FIRST);
             }
         }
         for (ArtifactKey key : lesserPriorityArtifacts) {
             final ResolvedDependencyBuilder d = dependencies.get(key);
-            if (d != null && !d.isFlagSet(DependencyFlags.REMOVED)) {
+            if (d != null) {
                 d.setFlags(DependencyFlags.CLASSLOADER_LESSER_PRIORITY);
             }
         }
 
         final List<ResolvedDependency> result = new ArrayList<>(dependencies.size());
         for (ResolvedDependencyBuilder db : this.dependencies.values()) {
-            if (isExcluded(db.getArtifactCoords())) {
-                db.setFlags(DependencyFlags.REMOVED);
-                db.clearFlag(DependencyFlags.DEPLOYMENT_CP);
-                db.clearFlag(DependencyFlags.RUNTIME_CP);
+            if (!isExcluded(db.getArtifactCoords())) {
+                result.add(db.build());
             }
-            result.add(db.build());
         }
         return result;
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/DependencyFlags.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/DependencyFlags.java
@@ -23,13 +23,6 @@ public interface DependencyFlags {
     // once the processing of the whole tree has completed.
     int VISITED                              = 0b00100000000000;
 
-    /**
-     * Dependencies that were removed from the application model
-     * following {@code removed-artifacts}
-     * configuration properties collected from extension metadata.
-     */
-    int REMOVED                              = 0b01000000000000;
-
     /* @formatter:on */
 
 }


### PR DESCRIPTION
This change removes `DependencyFlags.REMOVED` introduced in 3.6.0.CR1 for the web bundler extension, which at the end doesn't need it.
I am not reverting the complete change that introduced this flag since it will be useful for the upcoming changes.