### PR TITLE
 Docs [3.2] Remove 'Authentication mechanisms' from downstreamdoc.yml config file for product

### DIFF
--- a/docs/downstreamdoc.yaml
+++ b/docs/downstreamdoc.yaml
@@ -2,7 +2,6 @@ guides:
   - src/main/asciidoc/datasource.adoc
   - src/main/asciidoc/logging.adoc
   - src/main/asciidoc/security-architecture.adoc
-  - src/main/asciidoc/security-authentication-mechanisms.adoc
   - src/main/asciidoc/security-authorize-web-endpoints-reference.adoc
   - src/main/asciidoc/security-basic-authentication.adoc
   - src/main/asciidoc/security-basic-authentication-howto.adoc


### PR DESCRIPTION
We are no longer single-sourcing authentication mechanisms for the 3.2 upcoming product doc publish.

This PR moves the guide from the config file so that other guides that link to this guide as an xref get post-processed as an external link by the upstream doc build process.



