### PR TITLE
Fix rendering of documentation tooltip when enum description contains paragraphs

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemFinder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemFinder.java
@@ -495,7 +495,8 @@ class ConfigDocItemFinder {
                 if (rawJavaDoc != null && !rawJavaDoc.isBlank()) {
                     // Show enum constant description as a Tooltip
                     String javaDoc = enumJavaDocParser.parseConfigDescription(rawJavaDoc);
-                    acceptedValues.add(String.format(Constants.TOOLTIP, enumValue, javaDoc));
+                    acceptedValues.add(String.format(Constants.TOOLTIP, enumValue,
+                            javaDoc.replace("<p>", Constants.EMPTY).replace("</p>", Constants.EMPTY)));
                 } else {
                     acceptedValues.add(Constants.CODE_DELIMITER
                             + enumValue + Constants.CODE_DELIMITER);


### PR DESCRIPTION
fixes: #36401
supersedes: #36769