### PR TITLE
Support Docker Desktop for building native executables

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java
@@ -191,7 +191,10 @@ public final class ContainerRuntimeUtil {
                     final Predicate<String> stringPredicate;
                     // Docker includes just "rootless" under SecurityOptions, while podman includes "rootless: <boolean>"
                     if (containerRuntime == ContainerRuntime.DOCKER) {
-                        stringPredicate = line -> line.trim().equals("rootless");
+                        // We also treat Docker Desktop as "rootless" since the way it binds mounts does not
+                        // transparently map the host user ID and GID
+                        // see https://docs.docker.com/desktop/faqs/linuxfaqs/#how-do-i-enable-file-sharing
+                        stringPredicate = line -> line.trim().equals("rootless") || line.contains("desktop-linux");
                     } else {
                         stringPredicate = line -> line.trim().equals("rootless: true");
                     }


### PR DESCRIPTION
Treat Docker Desktop as "rootless" since the way it binds mounts does
not transparently map the host user ID and GID see
https://docs.docker.com/desktop/faqs/linuxfaqs/#how-do-i-enable-file-sharing

Closes https://github.com/quarkusio/quarkus/issues/37193
