### PR TITLE
Enable quarkus:build outcome cache for the main integration test

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -998,6 +998,11 @@ jobs:
           path: .
       - name: Extract .m2/repository/io/quarkus
         run: tar -xzf m2-io-quarkus.tgz -C ~
+      - name: Cache Quarkus metadata
+        uses: actions/cache@v3
+        with:
+          path: '**/.quarkus/quarkus-prod-config-dump'
+          key: ${{ runner.os }}-quarkus-metadata
       - name: Build
         env:
           TEST_MODULES: ${{matrix.test-modules}}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -9,4 +9,9 @@
         <artifactId>common-custom-user-data-maven-extension</artifactId>
         <version>1.12.2</version>
     </extension>
+    <extension>
+        <groupId>com.gradle</groupId>
+        <artifactId>quarkus-build-caching-extension</artifactId>
+        <version>0.10</version>
+    </extension>
 </extensions>

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -23,6 +23,9 @@
 
         <!-- do not update this dependency, it is only used for testing -->
         <webjar.jquery-ui.version>1.13.0</webjar.jquery-ui.version>
+
+        <quarkus.config-tracking.enabled>true</quarkus.config-tracking.enabled>
+        <quarkus.native.container-build>true</quarkus.native.container-build>
     </properties>
 
     <dependencies>
@@ -507,6 +510,16 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>track-prod-config-changes</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>track-config-changes</goal>
+                        </goals>
+                        <configuration>
+                            <dumpCurrentWhenRecordedUnavailable>true</dumpCurrentWhenRecordedUnavailable>
+                        </configuration>
+                    </execution>
                     <execution>
                         <goals>
                             <goal>build</goal>


### PR DESCRIPTION
With the Gradle Enterprise caching enabled and this change the outcome of `quarkus:build` of the main integration test module will be cached after the third build.

FYI @jprinet 