### PR TITLE
Qute: make the global variables accessible via "global:" namespace

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -2425,7 +2425,11 @@ TIP: Quarkus detects possible namespace collisions and fails the build if a spec
 === Global Variables
 
 The `io.quarkus.qute.TemplateGlobal` annotation can be used to denote static fields and methods that supply _global variables_ which are accessible in any template.
-Internally, each global variable is added to the data map of any `TemplateInstance` via the `TemplateInstance#data(String, Object)` method.
+
+Global variables are:
+
+* added to the data map of any `TemplateInstance` during initialization,
+* accessible with the `global:` namespace.
 
 .Global Variables Definition
 [source,java]
@@ -2454,11 +2458,11 @@ public class Globals {
 [source,html]
 ----
 User: {currentUser} <1>
-Age:  {age} <2>
+Age:  {global:age} <2>
 Colors: {#each myColors}{it}{#if it_hasNext}, {/if}{/each} <3>
 ----
 <1> `currentUser` resolves to `Globals#user()`.
-<2> `age` resolves to `Globals#age`.
+<2> The `global:` namespace is used; `age` resolves to `Globals#age`.
 <3> `myColors` resolves to `Globals#myColors()`.
 
 NOTE: Note that global variables implicitly add <<typesafe_expressions,parameter declarations>> to all templates and so any expression that references a global variable is validated during build.
@@ -2473,7 +2477,7 @@ Colors: RED, BLUE
 
 ==== Resolving Conflicts
 
-Global variables may conflict with regular data objects.
+If not accessed via the `global:` namespace the global variables may conflict with regular data objects.
 <<typesafe_templates,Type-safe templates>> override the global variables automatically.
 For example, the following definition overrides the global variable supplied by the `Globals#user()` method:
 

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -435,7 +435,8 @@ public class MessageBundleProcessor {
             List<CheckedTemplateBuildItem> checkedTemplates,
             BeanDiscoveryFinishedBuildItem beanDiscovery,
             List<TemplateDataBuildItem> templateData,
-            QuteConfig config) {
+            QuteConfig config,
+            List<TemplateGlobalBuildItem> globals) {
 
         IndexView index = beanArchiveIndex.getIndex();
         Function<String, String> templateIdToPathFun = new Function<String, String>() {
@@ -585,7 +586,7 @@ public class MessageBundleProcessor {
                                             implicitClassToMembersUsed, templateIdToPathFun, generatedIdsToMatches,
                                             extensionMethodExcludes, checkedTemplate, lookupConfig, namedBeans,
                                             namespaceTemplateData, regularExtensionMethods, namespaceExtensionMethods,
-                                            assignabilityCheck);
+                                            assignabilityCheck, globals);
                                     MatchResult match = results.get(param.toOriginalString());
                                     if (match != null && !match.isEmpty() && !assignabilityCheck.isAssignableFrom(match.type(),
                                             methodParams.get(idx))) {

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TemplateGlobalProviderBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TemplateGlobalProviderBuildItem.java
@@ -2,11 +2,11 @@ package io.quarkus.qute.deployment;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
-public final class GeneratedTemplateInitializerBuildItem extends MultiBuildItem {
+public final class TemplateGlobalProviderBuildItem extends MultiBuildItem {
 
     private final String className;
 
-    public GeneratedTemplateInitializerBuildItem(String className) {
+    public TemplateGlobalProviderBuildItem(String className) {
         this.className = className;
     }
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/globals/TemplateGlobalNamespaceValidationFailureTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/globals/TemplateGlobalNamespaceValidationFailureTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.qute.deployment.globals;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.TemplateException;
+import io.quarkus.qute.TemplateGlobal;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TemplateGlobalNamespaceValidationFailureTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(Globals.class)
+                    .addAsResource(new StringAsset(
+                            "Hello {global:user.name}!"),
+                            "templates/hello.txt"))
+            .assertException(t -> {
+                Throwable e = t;
+                TemplateException te = null;
+                while (e != null) {
+                    if (e instanceof TemplateException) {
+                        te = (TemplateException) e;
+                        break;
+                    }
+                    e = e.getCause();
+                }
+                assertNotNull(te);
+                assertTrue(
+                        te.getMessage().contains("Found incorrect expressions (1)"), te.getMessage());
+                assertTrue(
+                        te.getMessage().contains(
+                                "Property/method [name] not found on class [java.lang.String] nor handled by an extension method"),
+                        te.getMessage());
+            });
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    public static class Globals {
+
+        @TemplateGlobal
+        static String user = "Fu";
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/globals/TemplateGlobalTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/globals/TemplateGlobalTest.java
@@ -20,7 +20,7 @@ public class TemplateGlobalTest {
             .withApplicationRoot(root -> root
                     .addClasses(Globals.class, NextGlobals.class)
                     .addAsResource(new StringAsset(
-                            "Hello {currentUser}! Your name is {_name}. You're {age} years old."),
+                            "Hello {currentUser}|{global:currentUser}! Your name is {_name}|{global:_name}. You're {age}|{global:age} years old."),
                             "templates/hello.txt"));
 
     @Inject
@@ -28,15 +28,19 @@ public class TemplateGlobalTest {
 
     @Test
     public void testTemplateData() {
-        assertEquals("Hello Fu! Your name is Lu. You're 40 years old.", hello.render());
-        assertEquals("Hello Fu! Your name is Lu. You're 40 years old.",
-                Qute.fmt("Hello {currentUser}! Your name is {_name}. You're {age} years old.").render());
+        assertEquals("Hello Fu|Fu! Your name is Lu|Lu. You're 40|40 years old.", hello.render());
+        assertEquals("Hello Fu|Fu! Your name is Lu|Lu. You're 40|40 years old.",
+                Qute.fmt(
+                        "Hello {currentUser}|{global:currentUser}! Your name is {_name}|{global:_name}. You're {age}|{global:age} years old.")
+                        .render());
         Globals.user = "Hu";
-        assertEquals("Hello Hu! Your name is Lu. You're 20 years old.", hello.render());
-        assertEquals("Hello Hu! Your name is Lu. You're 20 years old.",
-                Qute.fmt("Hello {currentUser}! Your name is {_name}. You're {age} years old.").render());
+        assertEquals("Hello Hu|Hu! Your name is Lu|Lu. You're 20|20 years old.", hello.render());
+        assertEquals("Hello Hu|Hu! Your name is Lu|Lu. You're 20|20 years old.",
+                Qute.fmt(
+                        "Hello {currentUser}|{global:currentUser}! Your name is {_name}|{global:_name}. You're {age}|{global:age} years old.")
+                        .render());
 
-        assertEquals("First color is: RED", Qute.fmt("First color is: {colors[0]}").render());
+        assertEquals("First color is: RED|RED", Qute.fmt("First color is: {colors[0]}|{global:colors[0]}").render());
     }
 
     public static class Globals {

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/QuteRecorder.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/QuteRecorder.java
@@ -12,7 +12,7 @@ public class QuteRecorder {
 
     public Supplier<Object> createContext(List<String> resolverClasses,
             List<String> templatePaths, List<String> tags, Map<String, List<String>> variants,
-            List<String> templateInstanceInitializerClasses, Set<String> templateRoots) {
+            List<String> templateGlobalProviderClasses, Set<String> templateRoots) {
         return new Supplier<Object>() {
 
             @Override
@@ -40,8 +40,8 @@ public class QuteRecorder {
                     }
 
                     @Override
-                    public List<String> getTemplateInstanceInitializerClasses() {
-                        return templateInstanceInitializerClasses;
+                    public List<String> getTemplateGlobalProviderClasses() {
+                        return templateGlobalProviderClasses;
                     }
 
                     @Override
@@ -63,7 +63,7 @@ public class QuteRecorder {
 
         Map<String, List<String>> getVariants();
 
-        List<String> getTemplateInstanceInitializerClasses();
+        List<String> getTemplateGlobalProviderClasses();
 
         Set<String> getTemplateRoots();
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateGlobalProvider.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateGlobalProvider.java
@@ -1,0 +1,10 @@
+package io.quarkus.qute;
+
+/**
+ * An implementation is generated for each class declaring a template global.
+ *
+ * @see TemplateGlobal
+ */
+public interface TemplateGlobalProvider extends TemplateInstance.Initializer, NamespaceResolver {
+
+}

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/AbstractGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/AbstractGenerator.java
@@ -1,0 +1,180 @@
+package io.quarkus.qute.generator;
+
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.PrimitiveType.Primitive;
+import org.jboss.jandex.Type;
+
+import io.quarkus.gizmo.BranchResult;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.Gizmo;
+import io.quarkus.gizmo.IfThenElse;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.qute.CompletedStage;
+
+public abstract class AbstractGenerator {
+
+    protected final Set<String> generatedTypes;
+    protected final IndexView index;
+    protected final ClassOutput classOutput;
+
+    protected AbstractGenerator(IndexView index, ClassOutput classOutput) {
+        this.generatedTypes = new HashSet<>();
+        this.index = index;
+        this.classOutput = classOutput;
+    }
+
+    public Set<String> getGeneratedTypes() {
+        return generatedTypes;
+    }
+
+    protected void completeBoolean(BytecodeCreator bc, ResultHandle result) {
+        BranchResult isTrue = bc.ifTrue(result);
+        BytecodeCreator trueBranch = isTrue.trueBranch();
+        trueBranch.returnValue(trueBranch.readStaticField(Descriptors.RESULTS_TRUE));
+        BytecodeCreator falseBranch = isTrue.falseBranch();
+        falseBranch.returnValue(falseBranch.readStaticField(Descriptors.RESULTS_FALSE));
+    }
+
+    protected boolean isEnum(Type returnType) {
+        if (returnType.kind() != org.jboss.jandex.Type.Kind.CLASS) {
+            return false;
+        }
+        ClassInfo maybeEnum = index.getClassByName(returnType.name());
+        return maybeEnum != null && maybeEnum.isEnum();
+    }
+
+    protected boolean hasCompletionStage(Type type) {
+        return !skipMemberType(type) && hasCompletionStageInTypeClosure(index.getClassByName(type.name()), index);
+    }
+
+    protected boolean hasCompletionStageInTypeClosure(ClassInfo classInfo,
+            IndexView index) {
+        return hasClassInTypeClosure(classInfo, DotNames.COMPLETION_STAGE, index);
+    }
+
+    protected boolean hasClassInTypeClosure(ClassInfo classInfo, DotName className,
+            IndexView index) {
+
+        if (classInfo == null) {
+            // TODO cannot perform analysis
+            return false;
+        }
+        if (classInfo.name().equals(className)) {
+            return true;
+        }
+        // Interfaces
+        for (Type interfaceType : classInfo.interfaceTypes()) {
+            ClassInfo interfaceClassInfo = index.getClassByName(interfaceType.name());
+            if (interfaceClassInfo != null && hasCompletionStageInTypeClosure(interfaceClassInfo, index)) {
+                return true;
+            }
+        }
+        // Superclass
+        if (classInfo.superClassType() != null) {
+            ClassInfo superClassInfo = index.getClassByName(classInfo.superName());
+            if (superClassInfo != null && hasClassInTypeClosure(superClassInfo, className, index)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected void processReturnVal(BytecodeCreator bc, Type type, ResultHandle ret, ClassCreator classCreator) {
+        if (hasCompletionStage(type)) {
+            bc.returnValue(ret);
+        } else {
+            // Try to use some shared CompletedStage constants
+            if (type.kind() == org.jboss.jandex.Type.Kind.PRIMITIVE
+                    && type.asPrimitiveType().primitive() == Primitive.BOOLEAN) {
+                completeBoolean(bc, ret);
+            } else if (type.name().equals(DotNames.BOOLEAN)) {
+                BytecodeCreator isNull = bc.ifNull(ret).trueBranch();
+                isNull.returnValue(isNull.readStaticField(Descriptors.RESULTS_NULL));
+                completeBoolean(bc, bc.invokeVirtualMethod(Descriptors.BOOLEAN_VALUE, ret));
+            } else if (isEnum(type)) {
+                BytecodeCreator isNull = bc.ifNull(ret).trueBranch();
+                isNull.returnValue(isNull.readStaticField(Descriptors.RESULTS_NULL));
+                completeEnum(index.getClassByName(type.name()), classCreator, ret, bc);
+            } else {
+                bc.returnValue(bc.invokeStaticMethod(Descriptors.COMPLETED_STAGE_OF, ret));
+            }
+        }
+    }
+
+    protected boolean completeEnum(ClassInfo enumClass, ClassCreator valueResolver, ResultHandle result, BytecodeCreator bc) {
+        IfThenElse ifThenElse = null;
+        for (FieldInfo enumConstant : enumClass.enumConstants()) {
+            String name = enumClass.name().toString().replace(".", "_") + "$$"
+                    + enumConstant.name();
+            FieldDescriptor enumConstantField = FieldDescriptor.of(enumClass.name().toString(),
+                    enumConstant.name(), enumClass.name().toString());
+
+            // Additional methods and fields are generated for enums that are part of the index
+            // We don't care about visibility and atomicity here
+            // private CompletedStage org_acme_MyEnum$$CONSTANT;
+            FieldDescriptor csField = valueResolver
+                    .getFieldCreator(name, CompletedStage.class).setModifiers(ACC_PRIVATE)
+                    .getFieldDescriptor();
+            // private CompletedStage org_acme_MyEnum$$CONSTANT() {
+            //    if (org_acme_MyEnum$$CONSTANT == null) {
+            //        org_acme_MyEnum$$CONSTANT = CompletedStage.of(MyEnum.CONSTANT);
+            //    }
+            //    return org_acme_MyEnum$$CONSTANT;
+            // }
+            MethodCreator enumConstantMethod = valueResolver.getMethodCreator(name,
+                    CompletedStage.class).setModifiers(ACC_PRIVATE);
+            BytecodeCreator isNull = enumConstantMethod.ifNull(enumConstantMethod
+                    .readInstanceField(csField, enumConstantMethod.getThis()))
+                    .trueBranch();
+            ResultHandle val = isNull.readStaticField(enumConstantField);
+            isNull.writeInstanceField(csField, enumConstantMethod.getThis(),
+                    isNull.invokeStaticMethod(Descriptors.COMPLETED_STAGE_OF, val));
+            enumConstantMethod.returnValue(enumConstantMethod
+                    .readInstanceField(csField, enumConstantMethod.getThis()));
+
+            // Unfortunately, we can't use the BytecodeCreator#enumSwitch() here because the enum class is not loaded
+            // if(val.equals(MyEnum.CONSTANT))
+            //    return org_acme_MyEnum$$CONSTANT();
+            BytecodeCreator match;
+            if (ifThenElse == null) {
+                ifThenElse = bc.ifThenElse(
+                        Gizmo.equals(bc, bc.readStaticField(enumConstantField), result));
+                match = ifThenElse.then();
+            } else {
+                match = ifThenElse.elseIf(
+                        b -> Gizmo.equals(b, b.readStaticField(enumConstantField), result));
+            }
+            match.returnValue(match.invokeVirtualMethod(
+                    enumConstantMethod.getMethodDescriptor(), match.getThis()));
+        }
+        return true;
+    }
+
+    protected boolean skipMemberType(Type type) {
+        switch (type.kind()) {
+            case VOID:
+            case PRIMITIVE:
+            case ARRAY:
+            case TYPE_VARIABLE:
+            case UNRESOLVED_TYPE_VARIABLE:
+            case TYPE_VARIABLE_REFERENCE:
+            case WILDCARD_TYPE:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+}

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ExtensionMethodGenerator.java
@@ -14,7 +14,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -60,7 +59,7 @@ import io.quarkus.qute.ValueResolver;
  * @see ValueResolver
  * @see NamespaceResolver
  */
-public class ExtensionMethodGenerator {
+public class ExtensionMethodGenerator extends AbstractGenerator {
 
     public static final DotName TEMPLATE_EXTENSION = DotName.createSimple(TemplateExtension.class.getName());
     public static final DotName TEMPLATE_ATTRIBUTE = DotName.createSimple(TemplateExtension.TemplateAttribute.class.getName());
@@ -74,14 +73,8 @@ public class ExtensionMethodGenerator {
     public static final String NAMESPACE = "namespace";
     public static final String PATTERN = "pattern";
 
-    private final Set<String> generatedTypes;
-    private final ClassOutput classOutput;
-    private final IndexView index;
-
     public ExtensionMethodGenerator(IndexView index, ClassOutput classOutput) {
-        this.index = index;
-        this.classOutput = classOutput;
-        this.generatedTypes = new HashSet<>();
+        super(index, classOutput);
     }
 
     public Set<String> getGeneratedTypes() {
@@ -235,8 +228,7 @@ public class ExtensionMethodGenerator {
         ResultHandle evalContext = resolve.getMethodParam(0);
         ResultHandle base = resolve.invokeInterfaceMethod(Descriptors.GET_BASE, evalContext);
         boolean isNameParamRequired = patternField != null || !matchNames.isEmpty() || matchName.equals(TemplateExtension.ANY);
-        boolean returnsCompletionStage = method.returnType().kind() != Kind.PRIMITIVE && ValueResolverGenerator
-                .hasCompletionStageInTypeClosure(index.getClassByName(method.returnType().name()), index);
+        boolean returnsCompletionStage = hasCompletionStage(method.returnType());
 
         ResultHandle ret;
         if (!params.needsEvaluation()) {

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/TemplateGlobalGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/TemplateGlobalGenerator.java
@@ -6,43 +6,50 @@ import static io.quarkus.qute.generator.ValueResolverGenerator.simpleName;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 
 import java.lang.reflect.Modifier;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
 
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type.Kind;
 
+import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.Switch.StringSwitch;
+import io.quarkus.qute.EvalContext;
 import io.quarkus.qute.TemplateGlobal;
+import io.quarkus.qute.TemplateGlobalProvider;
 import io.quarkus.qute.TemplateInstance;
 
 /**
  * Generates {@link TemplateInstance.Initializer}s for {@link TemplateGlobal} annotations.
  */
-public class TemplateGlobalGenerator {
+public class TemplateGlobalGenerator extends AbstractGenerator {
 
     public static final DotName TEMPLATE_GLOBAL = DotName.createSimple(TemplateGlobal.class.getName());
     public static final String NAME = "name";
 
     public static final String SUFFIX = "_Globals";
 
-    private final Set<String> generatedTypes;
-    private final ClassOutput classOutput;
+    private final String namespace;
+    private int priority;
 
-    public TemplateGlobalGenerator(ClassOutput classOutput) {
-        this.generatedTypes = new HashSet<>();
-        this.classOutput = classOutput;
+    public TemplateGlobalGenerator(ClassOutput classOutput, String namespace, int priority, IndexView index) {
+        super(index, classOutput);
+        this.namespace = namespace;
+        this.priority = priority;
     }
 
     public void generate(ClassInfo declaringClass, Map<String, AnnotationTarget> targets) {
@@ -58,10 +65,11 @@ public class TemplateGlobalGenerator {
         String generatedName = generatedNameFromTarget(targetPackage, baseName, SUFFIX);
         generatedTypes.add(generatedName.replace('/', '.'));
 
-        ClassCreator initializer = ClassCreator.builder().classOutput(classOutput).className(generatedName)
-                .interfaces(TemplateInstance.Initializer.class).build();
+        ClassCreator provider = ClassCreator.builder().classOutput(classOutput).className(generatedName)
+                .interfaces(TemplateGlobalProvider.class).build();
 
-        MethodCreator accept = initializer.getMethodCreator("accept", void.class, Object.class)
+        // TemplateInstance.Initializer#accept()
+        MethodCreator accept = provider.getMethodCreator("accept", void.class, Object.class)
                 .setModifiers(ACC_PUBLIC);
 
         for (Entry<String, AnnotationTarget> entry : targets.entrySet()) {
@@ -84,7 +92,48 @@ public class TemplateGlobalGenerator {
             accept.invokeInterfaceMethod(Descriptors.TEMPLATE_INSTANCE_DATA, accept.getMethodParam(0), name, global);
         }
         accept.returnValue(null);
-        initializer.close();
+
+        // NamespaceResolver#getNamespace()
+        MethodCreator getNamespace = provider.getMethodCreator("getNamespace", String.class);
+        getNamespace.returnValue(getNamespace.load(namespace));
+
+        // WithPriority#getPriority()
+        MethodCreator getPriority = provider.getMethodCreator("getPriority", int.class);
+        // Namespace resolvers for the same namespace may not share the same priority
+        // So we increase the initial priority for each provider
+        getPriority.returnValue(getPriority.load(priority++));
+
+        // Resolver#resolve()
+        MethodCreator resolve = provider.getMethodCreator("resolve", CompletionStage.class, EvalContext.class)
+                .setModifiers(ACC_PUBLIC);
+        ResultHandle evalContext = resolve.getMethodParam(0);
+        ResultHandle name = resolve.invokeInterfaceMethod(Descriptors.GET_NAME, evalContext);
+        StringSwitch nameSwitch = resolve.stringSwitch(name);
+        for (Entry<String, AnnotationTarget> e : targets.entrySet()) {
+            Consumer<BytecodeCreator> readGlobal = new Consumer<BytecodeCreator>() {
+                @Override
+                public void accept(BytecodeCreator bc) {
+                    switch (e.getValue().kind()) {
+                        case FIELD:
+                            FieldInfo field = e.getValue().asField();
+                            processReturnVal(bc, field.type(), bc.readStaticField(FieldDescriptor.of(field)), provider);
+                            break;
+                        case METHOD:
+                            MethodInfo method = e.getValue().asMethod();
+                            processReturnVal(bc, method.returnType(), bc.invokeStaticMethod(MethodDescriptor.of(method)),
+                                    provider);
+                            break;
+                        default:
+                            throw new IllegalStateException("Unsupported target: " + e.getValue());
+                    }
+
+                }
+            };
+            nameSwitch.caseOf(e.getKey(), readGlobal);
+        }
+        resolve.returnValue(resolve.invokeStaticMethod(Descriptors.RESULTS_NOT_FOUND_EC, evalContext));
+
+        provider.close();
     }
 
     public Set<String> getGeneratedTypes() {

--- a/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
+++ b/independent-projects/qute/generator/src/main/java/io/quarkus/qute/generator/ValueResolverGenerator.java
@@ -1,7 +1,6 @@
 package io.quarkus.qute.generator;
 
 import static java.util.function.Predicate.not;
-import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 
 import java.lang.reflect.Modifier;
@@ -34,7 +33,6 @@ import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.PrimitiveType;
-import org.jboss.jandex.PrimitiveType.Primitive;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
@@ -48,13 +46,11 @@ import io.quarkus.gizmo.DescriptorUtils;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.FunctionCreator;
 import io.quarkus.gizmo.Gizmo;
-import io.quarkus.gizmo.IfThenElse;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.gizmo.Switch;
 import io.quarkus.gizmo.TryBlock;
-import io.quarkus.qute.CompletedStage;
 import io.quarkus.qute.EvalContext;
 import io.quarkus.qute.EvaluatedParams;
 import io.quarkus.qute.NamespaceResolver;
@@ -66,7 +62,7 @@ import io.quarkus.qute.ValueResolver;
  *
  * @see ValueResolver
  */
-public class ValueResolverGenerator {
+public class ValueResolverGenerator extends AbstractGenerator {
 
     public static Builder builder() {
         return new Builder();
@@ -92,9 +88,6 @@ public class ValueResolverGenerator {
 
     public static final int DEFAULT_PRIORITY = 10;
 
-    private final Set<String> generatedTypes;
-    private final IndexView index;
-    private final ClassOutput classOutput;
     private final Map<DotName, ClassInfo> nameToClass;
     private final Map<DotName, AnnotationInstance> nameToTemplateData;
 
@@ -103,16 +96,10 @@ public class ValueResolverGenerator {
     ValueResolverGenerator(IndexView index, ClassOutput classOutput, Map<DotName, ClassInfo> nameToClass,
             Map<DotName, AnnotationInstance> nameToTemplateData,
             Function<ClassInfo, Function<FieldInfo, String>> forceGettersFunction) {
-        this.generatedTypes = new HashSet<>();
-        this.classOutput = classOutput;
-        this.index = index;
+        super(index, classOutput);
         this.nameToClass = new HashMap<>(nameToClass);
         this.nameToTemplateData = new HashMap<>(nameToTemplateData);
         this.forceGettersFunction = forceGettersFunction;
-    }
-
-    public Set<String> getGeneratedTypes() {
-        return generatedTypes;
     }
 
     /**
@@ -377,33 +364,13 @@ public class ValueResolverGenerator {
                     @Override
                     public void accept(BytecodeCreator bc) {
                         Type returnType = method.returnType();
-                        boolean hasCompletionStage = !skipMemberType(returnType)
-                                && hasCompletionStageInTypeClosure(index.getClassByName(method.returnType().name()), index);
                         ResultHandle invokeRet;
                         if (Modifier.isInterface(clazz.flags())) {
                             invokeRet = bc.invokeInterfaceMethod(MethodDescriptor.of(method), base);
                         } else {
                             invokeRet = bc.invokeVirtualMethod(MethodDescriptor.of(method), base);
                         }
-                        if (hasCompletionStage) {
-                            bc.returnValue(invokeRet);
-                        } else {
-                            // Try to use some shared CompletedStage constants
-                            if (returnType.kind() == org.jboss.jandex.Type.Kind.PRIMITIVE
-                                    && returnType.asPrimitiveType().primitive() == Primitive.BOOLEAN) {
-                                completeBoolean(bc, invokeRet);
-                            } else if (method.returnType().name().equals(DotNames.BOOLEAN)) {
-                                BytecodeCreator isNull = bc.ifNull(invokeRet).trueBranch();
-                                isNull.returnValue(isNull.readStaticField(Descriptors.RESULTS_NULL));
-                                completeBoolean(bc, bc.invokeVirtualMethod(Descriptors.BOOLEAN_VALUE, invokeRet));
-                            } else if (isEnum(returnType)) {
-                                BytecodeCreator isNull = bc.ifNull(invokeRet).trueBranch();
-                                isNull.returnValue(isNull.readStaticField(Descriptors.RESULTS_NULL));
-                                completeEnum(index.getClassByName(returnType.name()), valueResolver, invokeRet, bc);
-                            } else {
-                                bc.returnValue(bc.invokeStaticMethod(Descriptors.COMPLETED_STAGE_OF, invokeRet));
-                            }
-                        }
+                        processReturnVal(bc, returnType, invokeRet, valueResolver);
                     }
                 };
                 nameSwitch.caseOf(matchingNames, invokeMethod);
@@ -487,71 +454,6 @@ public class ValueResolverGenerator {
         return true;
     }
 
-    private void completeBoolean(BytecodeCreator bc, ResultHandle result) {
-        BranchResult isTrue = bc.ifTrue(result);
-        BytecodeCreator trueBranch = isTrue.trueBranch();
-        trueBranch.returnValue(trueBranch.readStaticField(Descriptors.RESULTS_TRUE));
-        BytecodeCreator falseBranch = isTrue.falseBranch();
-        falseBranch.returnValue(falseBranch.readStaticField(Descriptors.RESULTS_FALSE));
-    }
-
-    private boolean isEnum(Type returnType) {
-        if (returnType.kind() != org.jboss.jandex.Type.Kind.CLASS) {
-            return false;
-        }
-        ClassInfo maybeEnum = index.getClassByName(returnType.name());
-        return maybeEnum != null && maybeEnum.isEnum();
-    }
-
-    private boolean completeEnum(ClassInfo enumClass, ClassCreator valueResolver, ResultHandle result, BytecodeCreator bc) {
-        IfThenElse ifThenElse = null;
-        for (FieldInfo enumConstant : enumClass.enumConstants()) {
-            String name = enumClass.name().toString().replace(".", "_") + "$$"
-                    + enumConstant.name();
-            FieldDescriptor enumConstantField = FieldDescriptor.of(enumClass.name().toString(),
-                    enumConstant.name(), enumClass.name().toString());
-
-            // Additional methods and fields are generated for enums that are part of the index
-            // We don't care about visibility and atomicity here
-            // private CompletedStage org_acme_MyEnum$$CONSTANT;
-            FieldDescriptor csField = valueResolver
-                    .getFieldCreator(name, CompletedStage.class).setModifiers(ACC_PRIVATE)
-                    .getFieldDescriptor();
-            // private CompletedStage org_acme_MyEnum$$CONSTANT() {
-            //    if (org_acme_MyEnum$$CONSTANT == null) {
-            //        org_acme_MyEnum$$CONSTANT = CompletedStage.of(MyEnum.CONSTANT);
-            //    }
-            //    return org_acme_MyEnum$$CONSTANT;
-            // }
-            MethodCreator enumConstantMethod = valueResolver.getMethodCreator(name,
-                    CompletedStage.class).setModifiers(ACC_PRIVATE);
-            BytecodeCreator isNull = enumConstantMethod.ifNull(enumConstantMethod
-                    .readInstanceField(csField, enumConstantMethod.getThis()))
-                    .trueBranch();
-            ResultHandle val = isNull.readStaticField(enumConstantField);
-            isNull.writeInstanceField(csField, enumConstantMethod.getThis(),
-                    isNull.invokeStaticMethod(Descriptors.COMPLETED_STAGE_OF, val));
-            enumConstantMethod.returnValue(enumConstantMethod
-                    .readInstanceField(csField, enumConstantMethod.getThis()));
-
-            // Unfortunately, we can't use the BytecodeCreator#enumSwitch() here because the enum class is not loaded
-            // if(val.equals(MyEnum.CONSTANT))
-            //    return org_acme_MyEnum$$CONSTANT();
-            BytecodeCreator match;
-            if (ifThenElse == null) {
-                ifThenElse = bc.ifThenElse(
-                        Gizmo.equals(bc, bc.readStaticField(enumConstantField), result));
-                match = ifThenElse.then();
-            } else {
-                match = ifThenElse.elseIf(
-                        b -> Gizmo.equals(b, b.readStaticField(enumConstantField), result));
-            }
-            match.returnValue(match.invokeVirtualMethod(
-                    enumConstantMethod.getMethodDescriptor(), match.getThis()));
-        }
-        return true;
-    }
-
     private boolean implementNamespaceResolve(ClassCreator valueResolver, String clazzName, ClassInfo clazz,
             Predicate<AnnotationTarget> filter) {
         MethodCreator resolve = valueResolver.getMethodCreator("resolve", CompletionStage.class, EvalContext.class)
@@ -611,15 +513,13 @@ public class ValueResolverGenerator {
                     try (BytecodeCreator matchScope = createMatchScope(resolve, method.name(), 0, method.returnType(), name,
                             params, paramsCount)) {
                         ResultHandle ret;
-                        boolean hasCompletionStage = !skipMemberType(method.returnType())
-                                && hasCompletionStageInTypeClosure(index.getClassByName(method.returnType().name()), index);
                         ResultHandle invokeRet;
                         if (Modifier.isInterface(clazz.flags())) {
                             invokeRet = matchScope.invokeStaticInterfaceMethod(MethodDescriptor.of(method));
                         } else {
                             invokeRet = matchScope.invokeStaticMethod(MethodDescriptor.of(method));
                         }
-                        if (hasCompletionStage) {
+                        if (hasCompletionStage(method.returnType())) {
                             ret = invokeRet;
                         } else {
                             ret = matchScope.invokeStaticMethod(Descriptors.COMPLETED_STAGE_OF, invokeRet);
@@ -702,11 +602,8 @@ public class ValueResolverGenerator {
                 paramsCount);
 
         // Invoke the method
-        ResultHandle ret;
-        boolean hasCompletionStage = !skipMemberType(method.returnType())
-                && hasCompletionStageInTypeClosure(index.getClassByName(method.returnType().name()), index);
         // Evaluate the params first
-        ret = matchScope
+        ResultHandle ret = matchScope
                 .newInstance(MethodDescriptor.ofConstructor(CompletableFuture.class));
 
         // The CompletionStage upon which we invoke whenComplete()
@@ -809,7 +706,7 @@ public class ValueResolverGenerator {
             }
         }
 
-        if (hasCompletionStage) {
+        if (hasCompletionStage(method.returnType())) {
             FunctionCreator invokeWhenCompleteFun = tryCatch.createFunction(BiConsumer.class);
             tryCatch.invokeInterfaceMethod(Descriptors.CF_WHEN_COMPLETE, invokeRet,
                     invokeWhenCompleteFun.getInstance());
@@ -908,9 +805,6 @@ public class ValueResolverGenerator {
                                 whenEvaluatedParams, paramMatchScope.load(isVarArgs), paramTypesHandle))
                         .falseBranch().breakScope(paramMatchScope);
 
-                boolean hasCompletionStage = !skipMemberType(method.returnType())
-                        && hasCompletionStageInTypeClosure(index.getClassByName(method.returnType().name()), index);
-
                 AssignableResultHandle invokeRet = paramMatchScope.createVariable(Object.class);
                 // try
                 TryBlock tryCatch = paramMatchScope.tryBlock();
@@ -958,7 +852,7 @@ public class ValueResolverGenerator {
                     }
                 }
 
-                if (hasCompletionStage) {
+                if (hasCompletionStage(method.returnType())) {
                     FunctionCreator invokeWhenCompleteFun = tryCatch.createFunction(BiConsumer.class);
                     tryCatch.invokeInterfaceMethod(Descriptors.CF_WHEN_COMPLETE, invokeRet,
                             invokeWhenCompleteFun.getInstance());
@@ -1119,21 +1013,6 @@ public class ValueResolverGenerator {
             return new ValueResolverGenerator(index, classOutput, nameToClass, nameToTemplateData, forceGettersFunction);
         }
 
-    }
-
-    private boolean skipMemberType(Type type) {
-        switch (type.kind()) {
-            case VOID:
-            case PRIMITIVE:
-            case ARRAY:
-            case TYPE_VARIABLE:
-            case UNRESOLVED_TYPE_VARIABLE:
-            case TYPE_VARIABLE_REFERENCE:
-            case WILDCARD_TYPE:
-                return true;
-            default:
-                return false;
-        }
     }
 
     private Predicate<AnnotationTarget> initFilters(AnnotationInstance templateData) {
@@ -1330,38 +1209,6 @@ public class ValueResolverGenerator {
             }
         }
         return true;
-    }
-
-    public static boolean hasCompletionStageInTypeClosure(ClassInfo classInfo,
-            IndexView index) {
-        return hasClassInTypeClosure(classInfo, DotNames.COMPLETION_STAGE, index);
-    }
-
-    public static boolean hasClassInTypeClosure(ClassInfo classInfo, DotName className,
-            IndexView index) {
-
-        if (classInfo == null) {
-            // TODO cannot perform analysis
-            return false;
-        }
-        if (classInfo.name().equals(className)) {
-            return true;
-        }
-        // Interfaces
-        for (Type interfaceType : classInfo.interfaceTypes()) {
-            ClassInfo interfaceClassInfo = index.getClassByName(interfaceType.name());
-            if (interfaceClassInfo != null && hasCompletionStageInTypeClosure(interfaceClassInfo, index)) {
-                return true;
-            }
-        }
-        // Superclass
-        if (classInfo.superClassType() != null) {
-            ClassInfo superClassInfo = index.getClassByName(classInfo.superName());
-            if (superClassInfo != null && hasClassInTypeClosure(superClassInfo, className, index)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     public static boolean isVarArgs(MethodInfo method) {


### PR DESCRIPTION
- this way a global variable can be accessed even if it's overriden by a regular data object/type-safe template argument