### PR TITLE
[3.2] Direct patch for the Datasource guide and related `.javadocs`

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -8,6 +8,8 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::_attributes.adoc[]
 :diataxis-type: reference
 :categories: data,getting-started,reactive
+:topics: data,database,datasource,sql,jdbc,reactive
+:extensions: io.quarkus:quarkus-agroal,io.quarkus:quarkus-reactive-mysql-client,io.quarkus:quarkus-reactive-oracle-client,io.quarkus:quarkus-reactive-pg-client,io.quarkus:quarkus-reactive-db2-client,io.quarkus:quarkus-reactive-pg-client,io.quarkus:quarkus-reactive-mssql-client,io.quarkus:quarkus-jdbc-db2,io.quarkus:quarkus-jdbc-derby,io.quarkus:quarkus-jdbc-h2,io.quarkus:quarkus-jdbc-mariadb,io.quarkus:quarkus-jdbc-mssql,io.quarkus:quarkus-jdbc-mysql,io.quarkus:quarkus-jdbc-oracle,io.quarkus:quarkus-jdbc-postgresql
 
 Use a unified configuration model to define data sources for Java Database Connectivity (JDBC) and Reactive drivers.
 
@@ -318,7 +320,6 @@ Be aware that setting the pool size too low might cause some requests to time ou
 
 For more information about pool size adjustment properties, see the <<reactive-configuration>> section.
 
-
 ==== JDBC and reactive datasources simultaneously
 
 When a JDBC extension - along with Agroal - and a reactive datasource extension handling the given database kind are included, they will both be created by default.
@@ -560,10 +561,11 @@ For more information, see the link:https://db.apache.org/derby/docs/10.8/devguid
 
 Example:: `jdbc:h2:tcp://localhost/~/test`, `jdbc:h2:mem:myDB`
 
-H2 is an embedded database that can run as a server, based on a file, or run completely in memory.
+H2 is a database that can run in embedded or server mode.
+It can use a file storage or run entirely in memory.
 All of these options are available as listed above.
 
-For more information, see the link:https://h2database.com/html/features.html?highlight=url&search=url#database_url[official documentation].
+For more information, see the link:https://h2database.com/html/features.html#database_url[official documentation].
 
 ==== MariaDB
 
@@ -591,7 +593,7 @@ hostDescription:: `<host>[:<portnumber>] or address=(host=<host>)[(port=<portnum
 
 Example:: `jdbc:mysql://localhost:3306/test`
 
-For more information, see the link:https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference.html[official documentation].
+For more information, see the link:https://dev.mysql.com/doc/connector-j/en/[official documentation].
 
 ===== MySQL limitations
 

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -63,7 +63,7 @@ public class DataSourceJdbcRuntimeConfig {
     /**
      * The interval at which we check for connection leaks.
      */
-    @ConfigItem
+    @ConfigItem(defaultValueDocumentation = "This feature is disabled by default.")
     public Optional<Duration> leakDetectionInterval = Optional.empty();
 
     /**
@@ -75,7 +75,7 @@ public class DataSourceJdbcRuntimeConfig {
     /**
      * The max lifetime of a connection.
      */
-    @ConfigItem
+    @ConfigItem(defaultValueDocumentation = "By default, there is no restriction on the lifespan of a connection.")
     public Optional<Duration> maxLifetime = Optional.empty();
 
     /**
@@ -97,7 +97,7 @@ public class DataSourceJdbcRuntimeConfig {
     public boolean flushOnClose;
 
     /**
-     * When enabled Agroal will be able to produce a warning when a connection is returned
+     * When enabled, Agroal will be able to produce a warning when a connection is returned
      * to the pool without the application having closed all open statements.
      * This is unrelated with tracking of open connections.
      * Disable for peak performance, but only when there's high confidence that
@@ -119,7 +119,7 @@ public class DataSourceJdbcRuntimeConfig {
     public Optional<String> validationQuerySql = Optional.empty();
 
     /**
-     * Disable pooling to prevent reuse of Connections. Use this with when an external pool manages the life-cycle
+     * Disable pooling to prevent reuse of Connections. Use this when an external pool manages the life-cycle
      * of Connections.
      */
     @ConfigItem(defaultValue = "true")

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
@@ -27,8 +27,8 @@ public class DataSourceReactiveRuntimeConfig {
      * The datasource URLs.
      * <p>
      * If multiple values are set, this datasource will create a pool with a list of servers instead of a single server.
-     * The pool uses a round-robin load balancing when a connection is created to select different servers.
-     * Note: some driver may not support multiple values here.
+     * The pool uses round-robin load balancing for server selection during connection establishment.
+     * Note that certain drivers might not accommodate multiple values in this context.
      */
     @ConfigItem
     public Optional<List<String>> url = Optional.empty();


### PR DESCRIPTION
Based on QE feedback, creating a separate PR for the 3.2 to update the Datasource guide and related `.javadocs`.

3.2 based version of https://github.com/quarkusio/quarkus/pull/37069