### PR TITLE
Reactive REST Client: check for ClientRequestFilter when skipping @Provider auto-discovery

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -9,6 +9,8 @@ import static io.quarkus.rest.client.reactive.deployment.DotNames.CLIENT_HEADER_
 import static io.quarkus.rest.client.reactive.deployment.DotNames.CLIENT_QUERY_PARAM;
 import static io.quarkus.rest.client.reactive.deployment.DotNames.CLIENT_QUERY_PARAMS;
 import static io.quarkus.rest.client.reactive.deployment.DotNames.CLIENT_REDIRECT_HANDLER;
+import static io.quarkus.rest.client.reactive.deployment.DotNames.CLIENT_REQUEST_FILTER;
+import static io.quarkus.rest.client.reactive.deployment.DotNames.CLIENT_RESPONSE_FILTER;
 import static io.quarkus.rest.client.reactive.deployment.DotNames.REGISTER_CLIENT_HEADERS;
 import static io.quarkus.rest.client.reactive.deployment.DotNames.REGISTER_PROVIDER;
 import static io.quarkus.rest.client.reactive.deployment.DotNames.REGISTER_PROVIDERS;
@@ -297,16 +299,8 @@ class RestClientReactiveProcessor {
                         }
                     }
 
-                    List<DotName> providerInterfaceNames = providerClass.interfaceNames();
-                    // don't register server specific types
-                    if (providerInterfaceNames.contains(ResteasyReactiveDotNames.CONTAINER_REQUEST_FILTER)
-                            || providerInterfaceNames.contains(ResteasyReactiveDotNames.CONTAINER_RESPONSE_FILTER)
-                            || providerInterfaceNames.contains(ResteasyReactiveDotNames.EXCEPTION_MAPPER)) {
+                    if (skipAutoDiscoveredProvider(providerClass.interfaceNames())) {
                         continue;
-                    }
-
-                    if (providerInterfaceNames.contains(ResteasyReactiveDotNames.FEATURE)) {
-                        continue; // features should not be automatically registered for the client, see javadoc for Feature
                     }
 
                     DotName providerDotName = providerClass.name();
@@ -578,6 +572,29 @@ class RestClientReactiveProcessor {
         if (LaunchMode.current() == LaunchMode.DEVELOPMENT) {
             recorder.setConfigKeys(configKeys);
         }
+    }
+
+    /**
+     * Based on a list of interfaces implemented by @Provider class, determine if registration
+     * should be skipped or not. Server-specific types should be omitted unless implementation
+     * of a <code>ClientRequestFilter</code> exists on the same class explicitly.
+     * Features should always be omitted.
+     */
+    private boolean skipAutoDiscoveredProvider(List<DotName> providerInterfaceNames) {
+        if (providerInterfaceNames.contains(ResteasyReactiveDotNames.FEATURE)) {
+            return true;
+        }
+        if (providerInterfaceNames.contains(ResteasyReactiveDotNames.CONTAINER_REQUEST_FILTER)
+                || providerInterfaceNames.contains(ResteasyReactiveDotNames.CONTAINER_RESPONSE_FILTER)
+                || providerInterfaceNames.contains(ResteasyReactiveDotNames.EXCEPTION_MAPPER)) {
+            if (providerInterfaceNames.contains(CLIENT_REQUEST_FILTER)
+                    || providerInterfaceNames.contains(CLIENT_RESPONSE_FILTER)) {
+                return false;
+            } else {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Map<String, GeneratedClassResult> populateClientExceptionMapperFromAnnotations(


### PR DESCRIPTION
From release 3.5.2, auto-discovery was skipped for @Provider classes that implements server-specific filters. Unfortunately this means that filters implementing all three interfaces in one class are also skipped. In this case the result is that client request filter is never invoked:

```java
@Provider
public class MyFilter implements ContainerRequestFilter, ContainerResponseFilter, ClientRequestFilter {

    @Override
    public void filter(ContainerRequestContext requestContext) throws IOException {
        // server request filter
    }
    
    @Override
    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
        // server response filter
    }
    
    @Override
    public void filter(ClientRequestContext requestContext) {
        // client request filter - NOT working for Quarkus >= 3.5.2
    }    
}
```

This PR fixes that regression and aims to enhance readability.

Unfortunately `ResteasyReactiveDotNames` does not have a constant defined for `ClientRequestContext`, so a `.class.getName()` was necessary.