### PR TITLE
Docs: add keywords to Vert.x guides

### DIFF
--- a/docs/src/main/asciidoc/reactive-event-bus.adoc
+++ b/docs/src/main/asciidoc/reactive-event-bus.adoc
@@ -6,6 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using the event bus
 include::_attributes.adoc[]
 :categories: messaging
+:keywords: vertx vert.x
 :summary: This guide explains how different beans can interact using the event bus.
 :topics: messaging,event-bus,vert.x
 :extensions: io.quarkus:quarkus-vertx

--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -6,6 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Vert.x Reference Guide
 include::_attributes.adoc[]
 :categories: miscellaneous
+:keywords: vertx event verticle
 :summary: This reference guide provides advanced details about the usage and the configuration of the Vert.x instance used by Quarkus.
 
 https://vertx.io[Vert.x] is a toolkit for building reactive applications.

--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -6,6 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using Eclipse Vert.x API from a Quarkus Application
 include::_attributes.adoc[]
 :categories: miscellaneous
+:keywords: vertx event verticle
 :summary: This guide explains how to use Vert.x in Quarkus to build reactive applications.
 
 https://vertx.io[Vert.x] is a toolkit for building reactive applications.


### PR DESCRIPTION
- so that it's possible to filter guides via "vertx" instead of "vert.x"

https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/.E2.9C.94.20How.20exactly.20does.20filtering.20work.20on.20the.20Guides.20page.3F