### PR TITLE
Dev UI Filter by any config source

### DIFF
--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration.js
@@ -13,6 +13,7 @@ import '@vaadin/integer-field';
 import '@vaadin/text-field';
 import '@vaadin/select';
 import '@vaadin/details';
+import '@vaadin/combo-box';
 import { notifier } from 'notifier';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { gridRowDetailsRenderer } from '@vaadin/grid/lit.js';
@@ -84,6 +85,10 @@ export class QwcConfiguration extends observeState(LitElement) {
         pointer-events: none;
         opacity: 0.4;
       }
+      .config-source-dropdown {
+        padding-left: 5px;
+        width: 300px;
+      }
     `;
 
     static properties = {
@@ -93,17 +98,18 @@ export class QwcConfiguration extends observeState(LitElement) {
         _values: {state: true},
         _detailsOpenedItem: {state: true, type: Array},
         _busy: {state: true},
-        _showOnlyOwnProperties: {state: true},
-        _searchTerm: {state: true}
+        _showOnlyConfigSource: {state: true},
+        _searchTerm: {state: true},
+        _configSourceSet: {state: true}
     };
 
     constructor() {
         super();
-
+        this._configSourceSet = new Map();
         this._detailsOpenedItem = [];
         this._busy = null;
 
-        this._showOnlyOwnProperties = false;
+        this._showOnlyConfigSource = null;
         this._searchTerm = '';
     }
 
@@ -118,10 +124,37 @@ export class QwcConfiguration extends observeState(LitElement) {
             this._allConfiguration = e.result;
             this._visibleConfiguration = e.result;
             this._filtered = e.result;
+            
+            for (const configItem of this._allConfiguration) {
+                let configSourceName = this._getConfigSourceName(configItem.configValue);
+                if(configSourceName && !this._configSourceSet.has(configSourceName)){
+                    this._configSourceSet.set(configSourceName, this._createConfigSourceObject(configSourceName, configItem.configValue));
+                }
+            }
         });
         this.jsonRpc.getAllValues().then(e => {
             this._values = e.result;
         });
+    }
+
+    _getConfigSourceName(configValue){
+        if(configValue.sourceName){
+            return configValue.configSourceName;
+        }
+        return null;
+    }
+
+    _createConfigSourceObject(configSourceName,configValue){
+        
+        let displayName = configSourceName;
+        
+        if(configSourceName.startsWith("PropertiesConfigSource[source")
+                    && configSourceName.endsWith("/application.properties]")){
+            displayName = "My properties";
+        }
+        
+        let configSourceObject = {name:configSourceName, display: displayName, position:configValue.configSourcePosition, ordinal:configValue.configSourceOrdinal};
+        return configSourceObject;
     }
 
     render() {
@@ -177,25 +210,31 @@ export class QwcConfiguration extends observeState(LitElement) {
                         <vaadin-icon slot="prefix" icon="font-awesome-solid:filter"></vaadin-icon>
                         <qui-badge slot="suffix"><span>${this._filtered.length}</span></qui-badge>
                     </vaadin-text-field>
-                    <vaadin-checkbox theme="small" label="Show only my properties"
-                                    @change="${(event) => {
-                                        this._toggleShowOnlyOwnProperties(event.target.checked);
-                                    }}"
-                                    .checked=${this._showOnlyOwnProperties}>
-                    </vaadin-checkbox>
+      
+                    <vaadin-combo-box class="config-source-dropdown"
+                        @change="${(event) => {
+                            this._toggleFilterByConfigSource(event);
+                        }}"
+                        placeholder="Filter by config sources"
+                        item-label-path="display"
+                        item-value-path="name"
+                        .items="${Array.from(this._configSourceSet.values())}"
+                        clear-button-visible
+                    ></vaadin-combo-box>
+    
                 </div>
                 ${this._renderGrid()}
                 </div>`;
     }
 
-    _toggleShowOnlyOwnProperties(onlyMine){
-        this._showOnlyOwnProperties = onlyMine;
-        if(this._showOnlyOwnProperties){
+    _toggleFilterByConfigSource(event){
+        if(event.target.value){
+            this._showOnlyConfigSource = event.target.value;
             this._visibleConfiguration = this._allConfiguration.filter((prop) => {
-                return (prop.configValue.sourceName && prop.configValue.sourceName.startsWith("PropertiesConfigSource[source")
-                    && prop.configValue.sourceName.endsWith("/application.properties]"));
+                return prop.configValue.sourceName && prop.configValue.sourceName === this._showOnlyConfigSource;
             });
-        }else {
+        }else{
+            this._showOnlyConfigSource = null;
             this._visibleConfiguration = this._allConfiguration;
         }
         return this._filterGrid();
@@ -383,7 +422,11 @@ export class QwcConfiguration extends observeState(LitElement) {
         if (prop.defaultValue) {
             def = "<strong>Default value: </strong>" + prop.defaultValue;
         }
-        let src = "<strong>Config source: </strong> " + prop.configValue.sourceName;
+        let configSourceName = "Unknown";
+        if(prop.configValue.sourceName){
+            configSourceName = prop.configValue.sourceName;
+        }
+        let src = "<strong>Config source: </strong> " + configSourceName;
         return html`<div class="description">
                         <p>${unsafeHTML(prop.description)}</p>
                         <div>


### PR DESCRIPTION
This PR replace the `Show only my properties` checkbox with a dropdown that allow filtering by any config source:

Fix #37217

![config_filter](https://github.com/quarkusio/quarkus/assets/6836179/cf567e68-f33b-4112-9b45-2f85ba04cf31)
