### PR TITLE
Escape column names with backticks in order by clause of hql query

### DIFF
--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/JpaOperationsSortTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/JpaOperationsSortTest.java
@@ -2,9 +2,11 @@ package io.quarkus.hibernate.orm.panache.deployment.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.panache.common.Sort;
+import io.quarkus.panache.common.exception.PanacheQueryException;
 import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 
 public class JpaOperationsSortTest {
@@ -18,7 +20,7 @@ public class JpaOperationsSortTest {
     @Test
     public void testSortBy() {
         Sort sort = Sort.by("foo", "bar");
-        assertEquals(" ORDER BY foo , bar", PanacheJpaUtil.toOrderBy(sort));
+        assertEquals(" ORDER BY `foo` , `bar`", PanacheJpaUtil.toOrderBy(sort));
     }
 
     @Test
@@ -29,14 +31,27 @@ public class JpaOperationsSortTest {
 
     @Test
     public void testSortByNullsFirst() {
-        Sort emptySort = Sort.by("foo", Sort.Direction.Ascending, Sort.NullPrecedence.NULLS_FIRST);
-        assertEquals(" ORDER BY foo NULLS FIRST", PanacheJpaUtil.toOrderBy(emptySort));
+        Sort sort = Sort.by("foo", Sort.Direction.Ascending, Sort.NullPrecedence.NULLS_FIRST);
+        assertEquals(" ORDER BY `foo` NULLS FIRST", PanacheJpaUtil.toOrderBy(sort));
     }
 
     @Test
     public void testSortByNullsLast() {
-        Sort emptySort = Sort.by("foo", Sort.Direction.Descending, Sort.NullPrecedence.NULLS_LAST);
-        assertEquals(" ORDER BY foo DESC NULLS LAST", PanacheJpaUtil.toOrderBy(emptySort));
+        Sort sort = Sort.by("foo", Sort.Direction.Descending, Sort.NullPrecedence.NULLS_LAST);
+        assertEquals(" ORDER BY `foo` DESC NULLS LAST", PanacheJpaUtil.toOrderBy(sort));
+    }
+
+    @Test
+    public void testSortByColumnWithBacktick() {
+        Sort sort = Sort.by("jeanne", "d`arc");
+        Assertions.assertThrowsExactly(PanacheQueryException.class, () -> PanacheJpaUtil.toOrderBy(sort),
+                "Sort column name cannot have backticks");
+    }
+
+    @Test
+    public void testSortByQuotedColumn() {
+        Sort sort = Sort.by("`foo`", "bar");
+        assertEquals(" ORDER BY `foo` , `bar`", PanacheJpaUtil.toOrderBy(sort));
     }
 
 }

--- a/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
+++ b/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
@@ -175,7 +175,7 @@ public class PanacheJpaUtil {
             Sort.Column column = sort.getColumns().get(i);
             if (i > 0)
                 sb.append(" , ");
-            sb.append(column.getName());
+            sb.append('`').append(unquoteColumnName(column)).append('`');
             if (column.getDirection() != Sort.Direction.Ascending) {
                 sb.append(" DESC");
             }
@@ -190,5 +190,21 @@ public class PanacheJpaUtil {
 
         }
         return sb.toString();
+    }
+
+    private static String unquoteColumnName(Sort.Column column) {
+        String columnName = column.getName();
+        String unquotedColumnName;
+        //Note HQL uses backticks to escape/quote special words that are used as identifiers
+        if (columnName.charAt(0) == '`' && columnName.charAt(columnName.length() - 1) == '`') {
+            unquotedColumnName = columnName.substring(1, columnName.length() - 1);
+        } else {
+            unquotedColumnName = columnName;
+        }
+        // Note we're not dealing with columns but with entity attributes so no backticks expected in unquoted column name
+        if (unquotedColumnName.indexOf('`') >= 0) {
+            throw new PanacheQueryException("Sort column name cannot have backticks");
+        }
+        return unquotedColumnName;
     }
 }


### PR DESCRIPTION
Closes #1120

The initial idea was to get hibernate dialect to do proper escape column names for each database. Still, after implementation and testing I've realized that panache generates hibernate query, not SQL query and hibernate actually has a code that transforms identifiers in \`backticks\` to proper quotes used by particular SQL dialect. 
So the final commit is small and neat, just using backticks for hibernate queries. I thought a bit about mongoDB part that is not touched in this pull request and decided that it is ok since Mongo does not actually have escaping quotes analogy and is not prone to injections in sorting clauses to my (very limited) knowledge of mongoDB.
There is a tricky bit with the column names containing backticks - I guess it won't work with the databases that use backticks as their escaping quotes. But reading through hibernate code convinced me it is a hibernate issue, not quarkus-panache one. I am referring to org.hibernate.dialect.Dialect#quote where the name inside the backtick quotes is taken as a substring(1, len-1) without an attempt to properly escape database-specific quote characters.