### PR TITLE
Fix the major version of Java 21

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/CompiledJavaVersionBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/CompiledJavaVersionBuildItem.java
@@ -76,7 +76,7 @@ public final class CompiledJavaVersionBuildItem extends SimpleBuildItem {
             private static final int JAVA_11_MAJOR = 55;
             private static final int JAVA_17_MAJOR = 61;
             private static final int JAVA_19_MAJOR = 63;
-            private static final int JAVA_21_MAJOR = 66;
+            private static final int JAVA_21_MAJOR = 65;
 
             private final int determinedMajor;
 


### PR DESCRIPTION
66 is Java 22. 65 is Java 21.
