### PR TITLE
Bump Jackson to 2.16.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -157,7 +157,7 @@
         <scala.version>2.13.12</scala.version>
         <aws-lambda-java.version>1.2.3</aws-lambda-java.version>
         <aws-lambda-java-events.version>3.11.3</aws-lambda-java-events.version>
-        <aws-xray.version>2.14.0</aws-xray.version>
+        <aws-xray.version>2.15.0</aws-xray.version>
         <azure-functions-java-library.version>2.2.0</azure-functions-java-library.version>
         <azure-functions-java-spi.version>1.0.0</azure-functions-java-spi.version>
         <kotlin.version>1.9.21</kotlin.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -91,7 +91,7 @@
         <plexus-component-annotations.version>2.1.0</plexus-component-annotations.version>
         <graal-sdk.version>23.0.1</graal-sdk.version>
         <gizmo.version>1.7.0</gizmo.version>
-        <jackson-bom.version>2.15.3</jackson-bom.version>
+        <jackson-bom.version>2.16.0</jackson-bom.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.14.0</commons-lang3.version>
         <commons-codec.version>1.16.0</commons-codec.version>

--- a/extensions/resteasy-classic/rest-client-jackson/deployment/src/test/java/io/quarkus/restclient/jackson/deployment/ZonedDateTimeObjectMapperCustomizer.java
+++ b/extensions/resteasy-classic/rest-client-jackson/deployment/src/test/java/io/quarkus/restclient/jackson/deployment/ZonedDateTimeObjectMapperCustomizer.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
 
 import io.quarkus.jackson.ObjectMapperCustomizer;
@@ -22,8 +22,13 @@ import io.quarkus.jackson.ObjectMapperCustomizer;
 public class ZonedDateTimeObjectMapperCustomizer implements ObjectMapperCustomizer {
 
     @Override
+    public int priority() {
+        return MINIMUM_PRIORITY;
+    }
+
+    @Override
     public void customize(ObjectMapper objectMapper) {
-        JavaTimeModule customDateModule = new JavaTimeModule();
+        SimpleModule customDateModule = new SimpleModule();
         customDateModule.addSerializer(ZonedDateTime.class, new ZonedDateTimeSerializer(
                 new DateTimeFormatterBuilder().appendInstant(0).toFormatter().withZone(ZoneId.of("Z"))));
         customDateModule.addDeserializer(ZonedDateTime.class, new ZonedDateTimeEuropeLondonDeserializer());

--- a/extensions/vertx-http/deployment/pom.xml
+++ b/extensions/vertx-http/deployment/pom.xml
@@ -60,6 +60,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
         
         <!-- Test dependencies -->
         <dependency>

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/jsonrpc/DevUIDatabindCodec.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/devui/deployment/jsonrpc/DevUIDatabindCodec.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 import io.quarkus.devui.runtime.jsonrpc.json.JsonMapper;
 import io.quarkus.devui.runtime.jsonrpc.json.JsonTypeAdapter;
@@ -141,6 +142,7 @@ public class DevUIDatabindCodec implements JsonMapper {
             module.addSerializer(ByteArrayInputStream.class, new ByteArrayInputStreamSerializer());
             module.addDeserializer(ByteArrayInputStream.class, new ByteArrayInputStreamDeserializer());
             mapper.registerModule(module);
+            mapper.registerModule(new Jdk8Module());
 
             SimpleModule runtimeModule = new SimpleModule("vertx-module-runtime");
             addAdapterToObject(runtimeModule, jsonObjectAdapter);

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -42,7 +42,7 @@
         <version.enforcer.plugin>3.2.1</version.enforcer.plugin>
         <version.surefire.plugin>3.1.2</version.surefire.plugin>
         <maven-plugin-plugin.version>3.10.2</maven-plugin-plugin.version>
-        <jackson-bom.version>2.15.3</jackson-bom.version>
+        <jackson-bom.version>2.16.0</jackson-bom.version>
         <smallrye-beanbag.version>1.3.2</smallrye-beanbag.version>
         <junit.jupiter.version>5.10.1</junit.jupiter.version>
     </properties>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -63,7 +63,7 @@
         <vertx.version>4.4.6</vertx.version>
         <rest-assured.version>5.3.2</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
-        <jackson-bom.version>2.15.3</jackson-bom.version>
+        <jackson-bom.version>2.16.0</jackson-bom.version>
         <smallrye-stork.version>2.4.0</smallrye-stork.version>
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
         <yasson.version>3.0.3</yasson.version>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -49,7 +49,7 @@
 
         <!-- Versions -->
         <assertj.version>3.24.2</assertj.version>
-        <jackson-bom.version>2.15.3</jackson-bom.version>
+        <jackson-bom.version>2.16.0</jackson-bom.version>
         <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
         <junit.version>5.10.1</junit.version>
         <commons-compress.version>1.25.0</commons-compress.version>


### PR DESCRIPTION
Also includes the necessary bump aws xray to 2.15.0

Replaces #37188