### PR TITLE
[RestEasy Reactive Client] Use AsyncInputStream for Posting InputStream

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
@@ -24,6 +24,7 @@ import io.vertx.ext.web.RoutingContext;
 public class VertxInputStream extends InputStream {
 
     public static final String CONTINUE = "100-continue";
+    public final byte[] oneByte = new byte[1];
     private final VertxBlockingInput exchange;
 
     private boolean closed;
@@ -59,12 +60,11 @@ public class VertxInputStream extends InputStream {
 
     @Override
     public int read() throws IOException {
-        byte[] b = new byte[1];
-        int read = read(b);
+        int read = read(oneByte);
         if (read == -1) {
             return -1;
         }
-        return b[0] & 0xff;
+        return oneByte[0] & 0xff;
     }
 
     @Override
@@ -76,6 +76,9 @@ public class VertxInputStream extends InputStream {
     public int read(final byte[] b, final int off, final int len) throws IOException {
         if (closed) {
             throw new IOException("Stream is closed");
+        }
+        if (b == null || b.length < off + len) {
+            throw new IOException("Incompatible Buffer size");
         }
         if (continueState == ContinueState.REQUIRED) {
             continueState = ContinueState.SENT;
@@ -135,6 +138,9 @@ public class VertxInputStream extends InputStream {
         if (finished) {
             return 0;
         }
+        if (pooled != null && pooled.isReadable()) {
+            return pooled.readableBytes();
+        }
 
         return exchange.readBytesAvailable();
     }
@@ -173,9 +179,11 @@ public class VertxInputStream extends InputStream {
         protected boolean eof = false;
         protected Throwable readException;
         private final long timeout;
+        private final int headerLen;
 
         public VertxBlockingInput(HttpServerRequest request, long timeout) {
             this.request = request;
+            this.headerLen = getLengthFromHeader();
             this.timeout = timeout;
             final ConnectionBase connection = (ConnectionBase) request.connection();
             synchronized (connection) {
@@ -227,6 +235,7 @@ public class VertxInputStream extends InputStream {
 
         protected ByteBuf readBlocking() throws IOException {
             long expire = System.currentTimeMillis() + timeout;
+            Buffer ret = null;
             synchronized (request.connection()) {
                 while (input1 == null && !eof && readException == null) {
                     long rem = expire - System.currentTimeMillis();
@@ -254,18 +263,16 @@ public class VertxInputStream extends InputStream {
                 if (readException != null) {
                     throw new IOException(readException);
                 }
-                Buffer ret = input1;
+                ret = input1;
                 input1 = null;
                 if (inputOverflow != null) {
                     input1 = inputOverflow.poll();
-                    if (input1 == null) {
-                        request.fetch(1);
-                    }
-                } else if (!eof) {
-                    request.fetch(1);
                 }
-                return ret == null ? null : ret.getByteBuf();
             }
+            if (!eof) {
+                request.fetch(1);
+            }
+            return ret == null ? null : ret.getByteBuf();
         }
 
         @Override
@@ -297,13 +304,14 @@ public class VertxInputStream extends InputStream {
             if (input1 != null) {
                 return input1.getByteBuf().readableBytes();
             }
+            return headerLen;
+        }
 
+        private int getLengthFromHeader() {
             String length = request.getHeader(HttpHeaders.CONTENT_LENGTH);
-
             if (length == null) {
                 return 0;
             }
-
             try {
                 return Integer.parseInt(length);
             } catch (NumberFormatException e) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.nio.channels.ClosedChannelException;
-import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -22,7 +22,6 @@ import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.ext.web.RoutingContext;
 
 public class VertxInputStream extends InputStream {
-
     public static final String CONTINUE = "100-continue";
     public final byte[] oneByte = new byte[1];
     private final VertxBlockingInput exchange;
@@ -34,6 +33,10 @@ public class VertxInputStream extends InputStream {
     private ContinueState continueState = ContinueState.NONE;
 
     public VertxInputStream(RoutingContext request, long timeout) {
+        this(request, timeout, null);
+    }
+
+    public VertxInputStream(RoutingContext request, long timeout, ByteBuf existing) {
         this.exchange = new VertxBlockingInput(request.request(), timeout);
         Long limitObj = request.get(VertxHttpRecorder.MAX_REQUEST_SIZE_KEY);
         if (limitObj == null) {
@@ -44,16 +47,6 @@ public class VertxInputStream extends InputStream {
         String expect = request.request().getHeader(HttpHeaderNames.EXPECT);
         if (expect != null && expect.equalsIgnoreCase(CONTINUE)) {
             continueState = ContinueState.REQUIRED;
-        }
-    }
-
-    public VertxInputStream(RoutingContext request, long timeout, ByteBuf existing) {
-        this.exchange = new VertxBlockingInput(request.request(), timeout);
-        Long limitObj = request.get(VertxHttpRecorder.MAX_REQUEST_SIZE_KEY);
-        if (limitObj == null) {
-            limit = -1;
-        } else {
-            limit = limitObj;
         }
         this.pooled = existing;
     }
@@ -94,12 +87,7 @@ public class VertxInputStream extends InputStream {
             } else {
                 response.setStatusCode(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE.code());
                 response.headers().add(HttpHeaderNames.CONNECTION, "close");
-                response.endHandler(new Handler<Void>() {
-                    @Override
-                    public void handle(Void event) {
-                        exchange.request.connection().close();
-                    }
-                });
+                response.endHandler(event -> exchange.request.connection().close());
                 response.end();
                 throw new IOException("Request too large");
             }
@@ -125,7 +113,6 @@ public class VertxInputStream extends InputStream {
             pooled = exchange.readBlocking();
             if (pooled == null) {
                 finished = true;
-                pooled = null;
             }
         }
     }
@@ -159,9 +146,6 @@ public class VertxInputStream extends InputStream {
                     pooled = null;
                 }
             }
-        } catch (IOException | RuntimeException e) {
-            //our exchange is all broken, just end it
-            throw e;
         } finally {
             if (pooled != null) {
                 pooled.release();
@@ -173,11 +157,10 @@ public class VertxInputStream extends InputStream {
 
     public static class VertxBlockingInput implements Handler<Buffer> {
         protected final HttpServerRequest request;
-        protected Buffer input1;
-        protected Deque<Buffer> inputOverflow;
-        protected boolean waiting = false;
-        protected boolean eof = false;
-        protected Throwable readException;
+        protected final Deque<Buffer> inputOverflow = new ConcurrentLinkedDeque<>();
+        private static final int INTERNAL_READ_WAIT_MS = 50;
+        protected boolean endOfWrite = false;
+        protected IOException readException;
         private final long timeout;
         private final int headerLen;
 
@@ -186,123 +169,116 @@ public class VertxInputStream extends InputStream {
             this.headerLen = getLengthFromHeader();
             this.timeout = timeout;
             final ConnectionBase connection = (ConnectionBase) request.connection();
-            synchronized (connection) {
-                if (!connection.channel().isOpen()) {
-                    readException = new ClosedChannelException();
-                } else if (!request.isEnded()) {
-                    request.pause();
-                    request.handler(this);
-                    request.endHandler(new Handler<Void>() {
-                        @Override
-                        public void handle(Void event) {
-                            synchronized (connection) {
-                                eof = true;
-                                if (waiting) {
-                                    connection.notifyAll();
-                                }
-                            }
-                        }
-                    });
-                    request.exceptionHandler(new Handler<Throwable>() {
-                        @Override
-                        public void handle(Throwable event) {
-                            synchronized (connection) {
-                                readException = new IOException(event);
-                                if (input1 != null) {
-                                    input1.getByteBuf().release();
-                                    input1 = null;
-                                }
-                                if (inputOverflow != null) {
-                                    Buffer d = inputOverflow.poll();
-                                    while (d != null) {
-                                        d.getByteBuf().release();
-                                        d = inputOverflow.poll();
-                                    }
-                                }
-                                if (waiting) {
-                                    connection.notifyAll();
-                                }
-                            }
-                        }
+            if (!connection.channel().isOpen()) {
+                readException = new ClosedChannelException();
+            } else if (!request.isEnded()) {
+                request.pause();
+                request.handler(this);
+                request.endHandler(event -> {
+                    endOfWrite = true;
+                    wakeupReader();
+                });
+                request.exceptionHandler(event -> {
+                    readException = new IOException(event);
+                    Buffer d = inputOverflow.poll();
+                    while (d != null) {
+                        d.getByteBuf().release();
+                        d = inputOverflow.poll();
+                    }
+                    wakeupReader();
+                });
+                request.fetch(3);
+            } else {
+                endOfWrite = true;
+            }
+        }
 
-                    });
-                    // More than 1 speedup retrieve while limited in memory
-                    request.fetch(3);
-                } else {
-                    eof = true;
+        private void wakeupReader() {
+            synchronized (request.connection()) {
+                request.connection().notifyAll();
+            }
+        }
+
+        private Buffer removeHead() throws IOException {
+            if (inputOverflow.isEmpty()) {
+                synchronized (request.connection()) {
+                    try {
+                        request.connection().wait(INTERNAL_READ_WAIT_MS);
+                    } catch (InterruptedException e) {
+                        throw new InterruptedIOException(e.getMessage());
+                    }
                 }
             }
+            return inputOverflow.poll();
         }
 
         protected ByteBuf readBlocking() throws IOException {
             long expire = System.currentTimeMillis() + timeout;
-            synchronized (request.connection()) {
-                while (input1 == null && !eof && readException == null) {
-                    long rem = expire - System.currentTimeMillis();
-                    if (rem <= 0) {
-                        //everything is broken, if read has timed out we can assume that the underling connection
-                        //is wrecked, so just close it
-                        request.connection().close();
-                        IOException throwable = new IOException("Read timed out");
-                        readException = throwable;
-                        throw throwable;
-                    }
-
-                    try {
-                        if (Context.isOnEventLoopThread()) {
-                            throw new BlockingOperationNotAllowedException("Attempting a blocking read on io thread");
-                        }
-                        waiting = true;
-                        request.connection().wait(rem);
-                    } catch (InterruptedException e) {
-                        throw new InterruptedIOException(e.getMessage());
-                    } finally {
-                        waiting = false;
-                    }
-                }
-                if (readException != null) {
-                    throw new IOException(readException);
-                }
-                Buffer ret = input1;
-                input1 = null;
-                if (inputOverflow != null) {
-                    input1 = inputOverflow.poll();
-                }
-                if (!eof) {
-                    request.fetch(1);
-                }
-                return ret == null ? null : ret.getByteBuf();
+            Buffer ret;
+            boolean status;
+            if (readException != null) {
+                throw readException;
             }
+            // Preemptive fetch
+            if (inputOverflow.isEmpty()) {
+                request.fetch(1);
+            }
+            // First read before testing endOfWrite
+            ret = removeHead();
+            status = ret == null && !endOfWrite && readException == null;
+            while (status) {
+                long rem = expire - System.currentTimeMillis();
+                if (rem <= 0) {
+                    //everything is broken, if read has timed out we can assume that the underling connection
+                    //is wrecked, so just close it
+                    request.connection().close();
+                    readException = new IOException("Read timed out");
+                    throw readException;
+                }
+
+                if (Context.isOnEventLoopThread()) {
+                    throw new BlockingOperationNotAllowedException("Attempting a blocking read on io thread");
+                }
+                ret = removeHead();
+                status = ret == null && !endOfWrite && readException == null;
+                Thread.yield();
+            }
+            if (readException != null) {
+                throw readException;
+            }
+            if (!endOfWrite && (inputOverflow.isEmpty())) {
+                request.fetch(1);
+            }
+            if (ret == null && !inputOverflow.isEmpty()) {
+                // Might not be the end yet if queue is not empty
+                ret = inputOverflow.poll();
+            }
+            return ret == null ? null : ret.getByteBuf();
         }
 
         @Override
         public void handle(Buffer event) {
-            synchronized (request.connection()) {
-                if (event.length() == 0 && request.version() == HttpVersion.HTTP_2) {
-                    // When using HTTP/2 H2, this indicates that we won't receive anymore data.
-                    eof = true;
-                    if (waiting) {
-                        request.connection().notifyAll();
-                    }
-                    return;
-                }
-                if (input1 == null) {
-                    input1 = event;
-                } else {
-                    if (inputOverflow == null) {
-                        inputOverflow = new ArrayDeque<>();
-                    }
-                    inputOverflow.add(event);
-                }
-                if (waiting) {
-                    request.connection().notifyAll();
-                }
+            if (event.length() == 0 && request.version() == HttpVersion.HTTP_2) {
+                // When using HTTP/2 H2, this indicates that we won't receive anymore data.
+                endOfWrite = true;
+                wakeupReader();
+                return;
             }
+            if (readException == null) {
+                inputOverflow.addLast(event);
+            } else {
+                event.getByteBuf().release();
+            }
+            wakeupReader();
         }
 
         public int readBytesAvailable() {
-            if (input1 != null) {
-                return input1.getByteBuf().readableBytes();
+            Buffer buf = inputOverflow.peek();
+            if (buf != null) {
+                int len = buf.getByteBuf().readableBytes();
+                if (len > 0) {
+                    return len;
+                }
             }
             return headerLen;
         }
@@ -310,7 +286,7 @@ public class VertxInputStream extends InputStream {
         private int getLengthFromHeader() {
             String length = request.getHeader(HttpHeaders.CONTENT_LENGTH);
             if (length == null) {
-                return 0;
+                return 8192;
             }
             try {
                 return Integer.parseInt(length);

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
@@ -226,7 +226,8 @@ public class VertxInputStream extends InputStream {
                         }
 
                     });
-                    request.fetch(1);
+                    // More than 1 speedup retrieve while limited in memory
+                    request.fetch(3);
                 } else {
                     eof = true;
                 }
@@ -266,10 +267,8 @@ public class VertxInputStream extends InputStream {
                 input1 = null;
                 if (inputOverflow != null) {
                     input1 = inputOverflow.poll();
-                    if (input1 == null) {
-                        request.fetch(1);
-                    }
-                } else if (!eof) {
+                }
+                if (!eof) {
                     request.fetch(1);
                 }
                 return ret == null ? null : ret.getByteBuf();

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
@@ -246,7 +246,7 @@ public class VertxInputStream extends InputStream {
             if (readException != null) {
                 throw readException;
             }
-            if (!endOfWrite && (inputOverflow.isEmpty())) {
+            if (!endOfWrite && inputOverflow.isEmpty()) {
                 request.fetch(1);
             }
             if (ret == null && !inputOverflow.isEmpty()) {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/AsyncInputStream.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/AsyncInputStream.java
@@ -1,5 +1,9 @@
 package org.jboss.resteasy.reactive.client.handlers;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -8,10 +12,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.impl.InboundBuffer;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Adapt an InputStream to a ReadStream that can be used with a Pump in Vertx.

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/AsyncInputStream.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/AsyncInputStream.java
@@ -285,7 +285,7 @@ public class AsyncInputStream implements ReadStream<Buffer>, AutoCloseable {
 
         /**
          * Drain the buffer.
-         * <p/>
+         * <p>
          * Calling this assumes {@code (demand > 0L && !pending.isEmpty()) == true}
          */
         private void drain() {
@@ -336,9 +336,9 @@ public class AsyncInputStream implements ReadStream<Buffer>, AutoCloseable {
 
         /**
          * Request a specific {@code amount} of elements to be fetched, the amount is added to the actual demand.
-         * <p/>
+         * <p>
          * Pending elements in the buffer will be delivered asynchronously on the context to the handler.
-         * <p/>
+         * <p>
          * This method can be called from any thread.
          *
          * @return {@code true} when the buffer will be drained
@@ -360,7 +360,7 @@ public class AsyncInputStream implements ReadStream<Buffer>, AutoCloseable {
 
         /**
          * Clear the buffer synchronously.
-         * <p/>
+         * <p>
          * No handler will be called.
          *
          * @return a reference to this, so the API can be used fluently
@@ -382,9 +382,9 @@ public class AsyncInputStream implements ReadStream<Buffer>, AutoCloseable {
 
         /**
          * Resume the buffer, and sets the buffer in {@code flowing} mode.
-         * <p/>
+         * <p>
          * Pending elements in the buffer will be delivered asynchronously on the context to the handler.
-         * <p/>
+         * <p>
          * This method can be called from any thread.
          */
         public void resume() {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/AsyncInputStream.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/AsyncInputStream.java
@@ -2,6 +2,8 @@ package org.jboss.resteasy.reactive.client.handlers;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Deque;
+import java.util.LinkedList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.vertx.core.AsyncResult;
@@ -10,8 +12,8 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.streams.ReadStream;
-import io.vertx.core.streams.impl.InboundBuffer;
 
 /**
  * Adapt an InputStream to a ReadStream that can be used with a Pump in Vertx.
@@ -21,7 +23,7 @@ public class AsyncInputStream implements ReadStream<Buffer>, AutoCloseable {
     // Based on the inputStream with the real data
     private final InputStream in;
     private final Context context;
-    private final InboundBuffer<Buffer> queue;
+    private final InboundBuffer queue;
     private final byte[] bytes;
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final AtomicBoolean readInProgress = new AtomicBoolean(false);
@@ -38,7 +40,7 @@ public class AsyncInputStream implements ReadStream<Buffer>, AutoCloseable {
         bytes = new byte[this.maxChunkSize];
         this.context = vertx.getOrCreateContext();
         this.in = in;
-        queue = new InboundBuffer<>(context, 0);
+        queue = new InboundBuffer(context);
         queue.handler(buff -> {
             if (buff.length() > 0) {
                 handleData(buff);
@@ -198,4 +200,343 @@ public class AsyncInputStream implements ReadStream<Buffer>, AutoCloseable {
         }
     }
 
+    /**
+     * To be not dependent from InboundBuffer Vertx implementation
+     */
+    public static class InboundBuffer {
+        private final ContextInternal context;
+        private final Deque<Buffer> pending = new LinkedList<>();
+        private final long highWaterMark;
+        private long demand;
+        private Handler<Buffer> handler;
+        private boolean overflow;
+        private Handler<Void> drainHandler;
+        private Handler<Void> emptyHandler;
+        private Handler<Throwable> exceptionHandler;
+        private boolean emitting;
+
+        public InboundBuffer(Context context) {
+            this(context, 16L);
+        }
+
+        public InboundBuffer(Context context, long highWaterMark) {
+            if (context == null) {
+                throw new NullPointerException("context must not be null");
+            }
+            if (highWaterMark < 0) {
+                throw new IllegalArgumentException("highWaterMark " + highWaterMark + " >= 0");
+            }
+            this.context = (ContextInternal) context;
+            this.highWaterMark = highWaterMark;
+            this.demand = Long.MAX_VALUE;
+        }
+
+        private void checkThread() {
+            if (!context.inThread()) {
+                throw new IllegalStateException("This operation must be called from a Vert.x thread");
+            }
+        }
+
+        /**
+         * Write an {@code element} to the buffer. The element will be delivered synchronously to the handler when
+         * it is possible, otherwise it will be queued for later delivery.
+         *
+         * @param element the element to add
+         * @return {@code false} when the producer should stop writing
+         */
+        public boolean write(Buffer element) {
+            checkThread();
+            Handler<Buffer> handlerTmp;
+            synchronized (this) {
+                if (demand == 0L || emitting) {
+                    pending.add(element);
+                    return checkWritable();
+                } else {
+                    if (demand != Long.MAX_VALUE) {
+                        --demand;
+                    }
+                    emitting = true;
+                    handlerTmp = this.handler;
+                }
+            }
+            handleEvent(handlerTmp, element);
+            return emitPending();
+        }
+
+        private boolean checkWritable() {
+            if (demand == Long.MAX_VALUE) {
+                return true;
+            } else {
+                long actual = size() - demand;
+                boolean writable = actual < highWaterMark;
+                overflow |= !writable;
+                return writable;
+            }
+        }
+
+        /**
+         * Write an {@code iterable} of {@code elements}.
+         *
+         * @param elements the elements to add
+         * @return {@code false} when the producer should stop writing
+         * @see #write(Buffer)
+         */
+        public boolean write(Iterable<Buffer> elements) {
+            checkThread();
+            synchronized (this) {
+                for (Buffer element : elements) {
+                    pending.add(element);
+                }
+                if (demand == 0L || emitting) {
+                    return checkWritable();
+                } else {
+                    emitting = true;
+                }
+            }
+            return emitPending();
+        }
+
+        private boolean emitPending() {
+            Buffer element;
+            Handler<Buffer> h;
+            while (true) {
+                synchronized (this) {
+                    int size = size();
+                    if (demand == 0L) {
+                        emitting = false;
+                        boolean writable = size < highWaterMark;
+                        overflow |= !writable;
+                        return writable;
+                    } else if (size == 0) {
+                        emitting = false;
+                        return true;
+                    }
+                    if (demand != Long.MAX_VALUE) {
+                        demand--;
+                    }
+                    element = pending.poll();
+                    h = this.handler;
+                }
+                handleEvent(h, element);
+            }
+        }
+
+        /**
+         * Drain the buffer.
+         * <p/>
+         * Calling this assumes {@code (demand > 0L && !pending.isEmpty()) == true}
+         */
+        private void drain() {
+            int emitted = 0;
+            Handler<Void> drainHandlerTmp;
+            Handler<Void> emptyHandlerTmp;
+            while (true) {
+                Buffer element;
+                Handler<Buffer> handlerTmp;
+                synchronized (this) {
+                    int size = size();
+                    if (size == 0) {
+                        emitting = false;
+                        if (overflow) {
+                            overflow = false;
+                            drainHandlerTmp = this.drainHandler;
+                        } else {
+                            drainHandlerTmp = null;
+                        }
+                        emptyHandlerTmp = emitted > 0 ? this.emptyHandler : null;
+                        break;
+                    } else if (demand == 0L) {
+                        emitting = false;
+                        return;
+                    }
+                    emitted++;
+                    if (demand != Long.MAX_VALUE) {
+                        demand--;
+                    }
+                    element = pending.poll();
+                    handlerTmp = this.handler;
+                }
+                handleEvent(handlerTmp, element);
+            }
+            if (drainHandlerTmp != null) {
+                handleEvent(drainHandlerTmp, null);
+            }
+            if (emptyHandlerTmp != null) {
+                handleEvent(emptyHandlerTmp, null);
+            }
+        }
+
+        private <T> void handleEvent(Handler<T> handler, T element) {
+            if (handler != null) {
+                try {
+                    handler.handle(element);
+                } catch (Throwable t) {
+                    handleException(t);
+                }
+            }
+        }
+
+        private void handleException(Throwable err) {
+            Handler<Throwable> handlerTmp;
+            synchronized (this) {
+                if ((handlerTmp = exceptionHandler) == null) {
+                    return;
+                }
+            }
+            handlerTmp.handle(err);
+        }
+
+        /**
+         * Request a specific {@code amount} of elements to be fetched, the amount is added to the actual demand.
+         * <p/>
+         * Pending elements in the buffer will be delivered asynchronously on the context to the handler.
+         * <p/>
+         * This method can be called from any thread.
+         *
+         * @return {@code true} when the buffer will be drained
+         */
+        public boolean fetch(long amount) {
+            if (amount < 0L) {
+                throw new IllegalArgumentException();
+            }
+            synchronized (this) {
+                demand += amount;
+                if (demand < 0L) {
+                    demand = Long.MAX_VALUE;
+                }
+                if (emitting || (isEmpty() && !overflow)) {
+                    return false;
+                }
+                emitting = true;
+            }
+            context.runOnContext(v -> drain());
+            return true;
+        }
+
+        /**
+         * Read the most recent element synchronously.
+         * <p/>
+         * No handler will be called.
+         *
+         * @return the most recent element or {@code null} if no element was in the buffer
+         */
+        public Buffer read() {
+            synchronized (this) {
+                if (isEmpty()) {
+                    return null;
+                }
+                return pending.poll();
+            }
+        }
+
+        /**
+         * Clear the buffer synchronously.
+         * <p/>
+         * No handler will be called.
+         *
+         * @return a reference to this, so the API can be used fluently
+         */
+        public synchronized InboundBuffer clear() {
+            if (isEmpty()) {
+                return this;
+            }
+            pending.clear();
+            return this;
+        }
+
+        /**
+         * Pause the buffer, it sets the buffer in {@code fetch} mode and clears the actual demand.
+         *
+         * @return a reference to this, so the API can be used fluently
+         */
+        public synchronized InboundBuffer pause() {
+            demand = 0L;
+            return this;
+        }
+
+        /**
+         * Resume the buffer, and sets the buffer in {@code flowing} mode.
+         * <p/>
+         * Pending elements in the buffer will be delivered asynchronously on the context to the handler.
+         * <p/>
+         * This method can be called from any thread.
+         *
+         * @return {@code true} when the buffer will be drained
+         */
+        public boolean resume() {
+            return fetch(Long.MAX_VALUE);
+        }
+
+        /**
+         * Set an {@code handler} to be called with elements available from this buffer.
+         *
+         * @param handler the handler
+         * @return a reference to this, so the API can be used fluently
+         */
+        public synchronized InboundBuffer handler(Handler<Buffer> handler) {
+            this.handler = handler;
+            return this;
+        }
+
+        /**
+         * Set an {@code handler} to be called when the buffer is drained and the producer can resume writing to the buffer.
+         *
+         * @param handler the handler to be called
+         * @return a reference to this, so the API can be used fluently
+         */
+        public synchronized InboundBuffer drainHandler(Handler<Void> handler) {
+            drainHandler = handler;
+            return this;
+        }
+
+        /**
+         * Set an {@code handler} to be called when the buffer becomes empty.
+         *
+         * @param handler the handler to be called
+         * @return a reference to this, so the API can be used fluently
+         */
+        public synchronized InboundBuffer emptyHandler(Handler<Void> handler) {
+            emptyHandler = handler;
+            return this;
+        }
+
+        /**
+         * Set an {@code handler} to be called when an exception is thrown by an handler.
+         *
+         * @param handler the handler
+         * @return a reference to this, so the API can be used fluently
+         */
+        public synchronized InboundBuffer exceptionHandler(Handler<Throwable> handler) {
+            exceptionHandler = handler;
+            return this;
+        }
+
+        /**
+         * @return whether the buffer is empty
+         */
+        public synchronized boolean isEmpty() {
+            return pending.isEmpty();
+        }
+
+        /**
+         * @return whether the buffer is writable
+         */
+        public synchronized boolean isWritable() {
+            return size() < highWaterMark;
+        }
+
+        /**
+         * @return whether the buffer is paused, i.e it is in {@code fetch} mode and the demand is {@code 0}.
+         */
+        public synchronized boolean isPaused() {
+            return demand == 0L;
+        }
+
+        /**
+         * @return the actual number of elements in the buffer
+         */
+        public synchronized int size() {
+            return pending.size();
+        }
+    }
 }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/AsyncInputStream.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/AsyncInputStream.java
@@ -1,0 +1,195 @@
+package org.jboss.resteasy.reactive.client.handlers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.vertx.core.*;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.impl.InboundBuffer;
+
+/**
+ * Adapt an InputStream to a ReadStream that can be used with a Pump in Vertx.
+ */
+public class AsyncInputStream implements ReadStream<Buffer>, AutoCloseable {
+    public static final String INPUTSTREAM_IS_CLOSED = "Inputstream is closed";
+    private static int BUF_SIZE = 8192;
+    // Based on the inputStream with the real data
+    private final InputStream in;
+    private final Context context;
+    private final InboundBuffer<Buffer> queue;
+    private final byte[] bytes = new byte[BUF_SIZE];
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final AtomicBoolean readInProgress = new AtomicBoolean(false);
+    private Handler<Buffer> dataHandler;
+    private Handler<Void> endHandler;
+    private Handler<Throwable> exceptionHandler;
+
+    /**
+     * Create a new Async InputStream that can we used with a Pump
+     */
+    public AsyncInputStream(final Vertx vertx, final InputStream in) {
+        this.context = vertx.getOrCreateContext();
+        this.in = in;
+        queue = new InboundBuffer<>(context, 0);
+        queue.handler(buff -> {
+            if (buff.length() > 0) {
+                handleData(buff);
+            } else {
+                handleEnd();
+            }
+        });
+        queue.drainHandler(v -> doRead());
+    }
+
+    @Override
+    public void close() {
+        closeInternal(null);
+    }
+
+    private synchronized void closeInternal(final Handler<AsyncResult<Void>> handler) {
+        checkClose();
+        closed.set(true);
+        doClose(handler);
+    }
+
+    private void doClose(final Handler<AsyncResult<Void>> handler) {
+        try {
+            in.close();
+        } catch (IOException ignored) {
+            // Ignore
+        }
+        if (handler != null) {
+            context.runOnContext(v -> handler.handle(Future.succeededFuture()));
+        }
+    }
+
+    /**
+     * Close using a specific handler.
+     */
+    public void close(final Handler<AsyncResult<Void>> handler) {
+        closeInternal(handler);
+    }
+
+    @Override
+    public synchronized AsyncInputStream exceptionHandler(final Handler<Throwable> exceptionHandler) {
+        checkClose();
+        this.exceptionHandler = exceptionHandler;
+        return this;
+    }
+
+    private void checkClose() {
+        if (closed.get()) {
+            throw new IllegalStateException(INPUTSTREAM_IS_CLOSED);
+        }
+    }
+
+    @Override
+    public AsyncInputStream handler(final Handler<Buffer> handler) {
+        checkClose();
+        dataHandler = handler;
+        if (dataHandler != null && !closed.get()) {
+            doRead();
+        } else {
+            queue.clear();
+        }
+        return this;
+    }
+
+    @Override
+    public AsyncInputStream pause() {
+        checkClose();
+        queue.pause();
+        return this;
+    }
+
+    @Override
+    public AsyncInputStream resume() {
+        if (closed.get()) {
+            return this;
+        }
+        queue.resume();
+        return this;
+    }
+
+    @Override
+    public ReadStream<Buffer> fetch(final long amount) {
+        queue.fetch(amount);
+        return this;
+    }
+
+    @Override
+    public synchronized AsyncInputStream endHandler(final Handler<Void> endHandler) {
+        checkClose();
+        this.endHandler = endHandler;
+        return this;
+    }
+
+    private void doRead() {
+        checkClose();
+        doRead(BUF_SIZE);
+    }
+
+    private void doRead(final int len) {
+        if (readInProgress.compareAndSet(false, true)) {
+            doRead(len, ar -> {
+                if (ar.succeeded()) {
+                    readInProgress.set(false);
+                    final var buffer = ar.result();
+                    // Empty buffer represents end of file
+                    if (queue.write(buffer) && buffer.length() > 0) {
+                        doRead(len);
+                    }
+                } else {
+                    handleException(ar.cause());
+                }
+            });
+        }
+    }
+
+    private void doRead(final int length, final Handler<AsyncResult<Buffer>> handler) {
+        try {
+            var bytesRead = 0;
+            while (true) {
+                bytesRead = in.read(bytes, 0, length);
+                if (bytesRead == -1) {
+                    //End of file
+                    context.runOnContext(v -> handler.handle(Future.succeededFuture(Buffer.buffer(0))));
+                    return;
+                } else if (bytesRead > 0) {
+                    // Lazy version
+                    final var readed = bytesRead;
+                    context.runOnContext(v -> {
+                        final var buff = Buffer.buffer(readed);
+                        buff.setBytes(0, bytes, 0, readed);
+                        handler.handle(Future.succeededFuture(buff));
+                    });
+                    return;
+                }
+            }
+        } catch (final Exception e) {
+            context.runOnContext(v -> handler.handle(Future.failedFuture(e)));
+        }
+    }
+
+    private void handleData(final Buffer buff) {
+        if (dataHandler != null) {
+            dataHandler.handle(buff);
+        }
+    }
+
+    private void handleEnd() {
+        dataHandler = null;
+        if (endHandler != null) {
+            endHandler.handle(null);
+        }
+    }
+
+    private void handleException(final Throwable t) {
+        if (exceptionHandler != null) {
+            exceptionHandler.handle(t);
+        }
+    }
+
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
@@ -593,7 +593,7 @@ public class ClientSendRequestHandler implements ClientRestHandler {
         InputStream inputStream = (InputStream) entity.getEntity();
         httpClientRequest.setChunked(true);
         Vertx vertx = Vertx.currentContext().owner();
-        ReadStream<Buffer> readStream = new AsyncInputStream(vertx, inputStream);
+        ReadStream<Buffer> readStream = new AsyncInputStream(vertx, inputStream, maxChunkSize);
         // set the Vertx headers after we've run the interceptors because they can modify them
         setVertxHeaders(httpClientRequest, headerMap);
         return readStream;

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/VertxClientInputStream.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/VertxClientInputStream.java
@@ -190,6 +190,7 @@ class VertxClientInputStream extends InputStream {
 
         protected ByteBuf readBlocking() throws IOException {
             long expire = System.currentTimeMillis() + timeout;
+            Buffer ret = null;
             synchronized (VertxBlockingInput.this) {
                 while (input1 == null && !eof && readException == null) {
                     long rem = expire - System.currentTimeMillis();
@@ -217,18 +218,16 @@ class VertxClientInputStream extends InputStream {
                 if (readException != null) {
                     throw new IOException(readException);
                 }
-                Buffer ret = input1;
+                ret = input1;
                 input1 = null;
                 if (inputOverflow != null) {
                     input1 = inputOverflow.poll();
-                    if (input1 == null) {
-                        request.fetch(1);
-                    }
-                } else if (!eof) {
-                    request.fetch(1);
                 }
-                return ret == null ? null : ret.getByteBuf();
             }
+            if (!eof) {
+                request.fetch(1);
+            }
+            return ret == null ? null : ret.getByteBuf();
         }
 
         @Override

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/VertxClientInputStream.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/VertxClientInputStream.java
@@ -181,7 +181,8 @@ class VertxClientInputStream extends InputStream {
                     }
 
                 });
-                response.fetch(1);
+                // More than 1 speedup retrieve while limited in memory
+                response.fetch(3);
             } catch (IllegalStateException e) {
                 //already ended
                 eof = true;
@@ -221,10 +222,8 @@ class VertxClientInputStream extends InputStream {
                 input1 = null;
                 if (inputOverflow != null) {
                     input1 = inputOverflow.poll();
-                    if (input1 == null) {
-                        request.fetch(1);
-                    }
-                } else if (!eof) {
+                }
+                if (!eof) {
                     request.fetch(1);
                 }
                 return ret == null ? null : ret.getByteBuf();

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/VertxClientInputStream.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/VertxClientInputStream.java
@@ -222,7 +222,7 @@ class VertxClientInputStream extends InputStream {
             if (readException != null) {
                 throw readException;
             }
-            if (!endOfWrite && (inputOverflow.isEmpty())) {
+            if (!endOfWrite && inputOverflow.isEmpty()) {
                 request.fetch(1);
             }
             if (ret == null && !inputOverflow.isEmpty()) {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
@@ -496,6 +496,10 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
         return File.class.equals(rawType) || Path.class.equals(rawType);
     }
 
+    public boolean isInputStream() {
+        return entity != null && entity.getEntity() instanceof InputStream;
+    }
+
     public boolean isInputStreamDownload() {
         if (responseType == null) {
             return false;

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxInputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxInputStream.java
@@ -127,7 +127,6 @@ public class VertxInputStream extends InputStream {
             pooled = exchange.readBlocking();
             if (pooled == null) {
                 finished = true;
-                pooled = null;
             }
         }
     }
@@ -270,7 +269,7 @@ public class VertxInputStream extends InputStream {
             if (readException != null) {
                 throw readException;
             }
-            if (!endOfWrite && (inputOverflow.isEmpty())) {
+            if (!endOfWrite && inputOverflow.isEmpty()) {
                 request.fetch(1);
             }
             if (ret == null && !inputOverflow.isEmpty()) {

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxInputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxInputStream.java
@@ -227,7 +227,8 @@ public class VertxInputStream extends InputStream {
                         }
 
                     });
-                    request.fetch(1);
+                    // More than 1 speedup retrieve while limited in memory
+                    request.fetch(3);
                 } else {
                     eof = true;
                 }
@@ -267,10 +268,8 @@ public class VertxInputStream extends InputStream {
                 input1 = null;
                 if (inputOverflow != null) {
                     input1 = inputOverflow.poll();
-                    if (input1 == null) {
-                        request.fetch(1);
-                    }
-                } else if (!eof) {
+                }
+                if (!eof) {
                     request.fetch(1);
                 }
                 return ret == null ? null : ret.getByteBuf();

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxInputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxInputStream.java
@@ -140,7 +140,7 @@ public class VertxInputStream extends InputStream {
             return 0;
         }
         if (pooled != null && pooled.isReadable()) {
-            return pooled.readableBytes();
+            return pooled.readableBytes() + exchange.readBytesAvailable();
         }
 
         return exchange.readBytesAvailable();
@@ -236,7 +236,6 @@ public class VertxInputStream extends InputStream {
 
         protected ByteBuf readBlocking() throws IOException {
             long expire = System.currentTimeMillis() + timeout;
-            Buffer ret = null;
             synchronized (request.connection()) {
                 while (input1 == null && !eof && readException == null) {
                     long rem = expire - System.currentTimeMillis();
@@ -264,16 +263,18 @@ public class VertxInputStream extends InputStream {
                 if (readException != null) {
                     throw new IOException(readException);
                 }
-                ret = input1;
+                Buffer ret = input1;
                 input1 = null;
                 if (inputOverflow != null) {
                     input1 = inputOverflow.poll();
+                    if (input1 == null) {
+                        request.fetch(1);
+                    }
+                } else if (!eof) {
+                    request.fetch(1);
                 }
+                return ret == null ? null : ret.getByteBuf();
             }
-            if (!eof) {
-                request.fetch(1);
-            }
-            return ret == null ? null : ret.getByteBuf();
         }
 
         @Override

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/FakeInputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/FakeInputStream.java
@@ -1,0 +1,153 @@
+package org.jboss.resteasy.reactive.server.vertx.test.inputstream;
+
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Random;
+
+/**
+ * Fake InputStream often used in various situation for testing:
+ * It does not really allocate the space in memory so big InputStream can be tested.
+ */
+public class FakeInputStream extends InputStream {
+    public static final int DEFAULT_BUFFER_SIZE = 131072;
+    private static final int MAX_AVAILABLE = 1024 * 1024 * 100;
+    private final byte b;
+    protected long toSend;
+    private final Random random;
+
+    /**
+     * Will generate a FakeInputStream with random values
+     *
+     * @param len the length of the virtual InputStream
+     */
+    public FakeInputStream(final long len) {
+        toSend = len;
+        this.b = 0;
+        random = new Random(System.nanoTime());
+    }
+
+    /**
+     * @param len the length of the virtual InputStream
+     * @param b   the byte to use for each and every byte
+     */
+    public FakeInputStream(final long len, final byte b) {
+        toSend = len;
+        this.b = b;
+        random = null;
+    }
+
+    /**
+     * @param inputStream the InputStream to consume completely
+     * @return the length read
+     * @throws IOException if an error occurs
+     */
+    public static long consumeAll(final InputStream inputStream) throws IOException {
+        long len = 0;
+        int read;
+        final var bytes = new byte[DEFAULT_BUFFER_SIZE];
+        while ((read = inputStream.read(bytes, 0, DEFAULT_BUFFER_SIZE)) >= 0) {
+            len += read;
+        }
+        return len;
+    }
+
+    /**
+     * @param inputStream the InputStream to consume completely
+     * @return the length read
+     * @throws IOException if an error occurs
+     */
+    public static long consumeAllLog(final InputStream inputStream) throws IOException {
+        long len = 0;
+        int read;
+        final var bytes = new byte[DEFAULT_BUFFER_SIZE];
+        System.out.print("Start " + DEFAULT_BUFFER_SIZE);// NOSONAR intentional for logging
+        while ((read = inputStream.read(bytes, 0, DEFAULT_BUFFER_SIZE)) >= 0) {
+            len += read;
+            System.out.print(".");// NOSONAR intentional for logging
+            System.out.flush();// NOSONAR intentional for logging
+        }
+        System.out.println("Done");// NOSONAR intentional for logging
+        System.out.flush();// NOSONAR intentional for logging
+        return len;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (toSend <= 0) {
+            return -1;
+        }
+        toSend--;
+        if (random != null) {
+            return random.nextInt() & 0xFF;
+        }
+        return b & 0xFF;
+    }
+
+    @Override
+    public int read(final byte[] bytes) throws IOException {
+        if (bytes == null) {
+            throw new IllegalArgumentException("bytes must not be null");
+        }
+        return read(bytes, 0, bytes.length);
+    }
+
+    @Override
+    public int read(final byte[] bytes, final int off, final int len) throws IOException {
+        if (bytes == null) {
+            throw new IllegalArgumentException("bytes must not be null");
+        }
+        if (toSend <= 0) {
+            return -1;
+        }
+        final var read = (int) Math.min(len, toSend);
+        if (random == null) {
+            Arrays.fill(bytes, off, off + read, b);
+        } else {
+            random.nextBytes(bytes);
+        }
+        toSend -= read;
+        return read;
+    }
+
+    @Override
+    public long skip(final long n) throws IOException {
+        final var read = Math.min(toSend, n);
+        toSend -= read;
+        return read;
+    }
+
+    @Override
+    public int available() throws IOException {
+        return (int) Math.min(Math.min(MAX_AVAILABLE, toSend), DEFAULT_BUFFER_SIZE);
+    }
+
+    @Override
+    public void close() throws IOException {
+        toSend = -1;
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    @Override
+    public long transferTo(final OutputStream out) throws IOException {
+        final var readFinal = toSend;
+        final var bytes = new byte[DEFAULT_BUFFER_SIZE];
+        if (random == null) {
+            Arrays.fill(bytes, b);
+        } else {
+            random.nextBytes(bytes);
+        }
+        var read = (int) skip(DEFAULT_BUFFER_SIZE);
+        while (read > 0) {
+            out.write(bytes, 0, read);
+            read = (int) skip(DEFAULT_BUFFER_SIZE);
+        }
+        return readFinal;
+    }
+}

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/FakeInputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/FakeInputStream.java
@@ -1,6 +1,5 @@
 package org.jboss.resteasy.reactive.server.vertx.test.inputstream;
 
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/FakeInputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/FakeInputStream.java
@@ -113,14 +113,14 @@ public class FakeInputStream extends InputStream {
 
     @Override
     public long skip(final long n) throws IOException {
-        final var read = Math.min(toSend, n);
+        final var read = Math.max(Math.min(toSend, n), 0);
         toSend -= read;
         return read;
     }
 
     @Override
     public int available() throws IOException {
-        return (int) Math.min(Math.min(MAX_AVAILABLE, toSend), DEFAULT_BUFFER_SIZE);
+        return (int) Math.max(Math.min(Math.min(MAX_AVAILABLE, toSend), DEFAULT_BUFFER_SIZE), 0);
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResource.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResource.java
@@ -1,6 +1,8 @@
 package org.jboss.resteasy.reactive.server.vertx.test.inputstream;
 
-import io.smallrye.common.annotation.Blocking;
+import java.io.IOException;
+import java.io.InputStream;
+
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -8,10 +10,10 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+
 import org.jboss.logging.Logger;
 
-import java.io.IOException;
-import java.io.InputStream;
+import io.smallrye.common.annotation.Blocking;
 
 @Path("/inputstreamtransfer")
 public class InputStreamPostGetResource {

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResource.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResource.java
@@ -1,0 +1,39 @@
+package org.jboss.resteasy.reactive.server.vertx.test.inputstream;
+
+import io.smallrye.common.annotation.Blocking;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Path("/inputstreamtransfer")
+public class InputStreamPostGetResource {
+    private static Logger LOG = Logger.getLogger(InputStreamPostGetResource.class);
+
+    @POST
+    @Path("/test")
+    @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+    @Blocking
+    public String test(InputStream is) throws IOException {
+        int read;
+        long size = 0;
+        byte[] b = new byte[65536];
+        while ((read = is.read(b)) > 0) {
+            size += read;
+        }
+        LOG.infof("Read %d", size);
+        return Long.toString(size);
+    }
+
+    @GET
+    @Path("/test/{len}")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    @Blocking
+    public InputStream test(@PathParam("len") long len) throws IOException {
+        LOG.infof("To Write %d", len);
+        return new FakeInputStream(len);
+    }
+
+}

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResource.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResource.java
@@ -1,7 +1,12 @@
 package org.jboss.resteasy.reactive.server.vertx.test.inputstream;
 
 import io.smallrye.common.annotation.Blocking;
-import jakarta.ws.rs.*;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.jboss.logging.Logger;
 
@@ -32,8 +37,9 @@ public class InputStreamPostGetResource {
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     @Blocking
     public InputStream test(@PathParam("len") long len) throws IOException {
-        LOG.infof("To Write %d", len);
-        return new FakeInputStream(len);
+        long lenMb = len * 1024 * 1024L;
+        LOG.infof("To Write %d", lenMb);
+        return new FakeInputStream(lenMb);
     }
 
 }

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResourceTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResourceTest.java
@@ -1,16 +1,21 @@
 package org.jboss.resteasy.reactive.server.vertx.test.inputstream;
 
+import java.io.InputStream;
+import java.util.function.Supplier;
+
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.server.vertx.test.framework.ResteasyReactiveUnitTest;
 import org.jboss.resteasy.reactive.server.vertx.test.simple.PortProviderUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -19,9 +24,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import java.io.InputStream;
-import java.util.function.Supplier;
 
 /**
  * @tpSubChapter Resources

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResourceTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResourceTest.java
@@ -1,0 +1,125 @@
+package org.jboss.resteasy.reactive.server.vertx.test.inputstream;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.server.vertx.test.framework.ResteasyReactiveUnitTest;
+import org.jboss.resteasy.reactive.server.vertx.test.simple.PortProviderUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.InputStream;
+import java.util.function.Supplier;
+
+/**
+ * @tpSubChapter Resources
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Regression test for RESTEasy issues about inputstream
+ */
+@DisplayName("InputStream Resource Test")
+public class InputStreamPostGetResourceTest {
+    private static Logger LOG = Logger.getLogger(InputStreamPostGetResourceTest.class);
+
+    static Client client;
+    static Runtime runtime;
+
+    @RegisterExtension
+    static ResteasyReactiveUnitTest testExtension = new ResteasyReactiveUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    JavaArchive war = ShrinkWrap.create(JavaArchive.class);
+                    war.addClasses(InputStreamPostGetResource.class,
+                            PortProviderUtil.class);
+                    return war;
+                }
+            });
+
+    @BeforeAll
+    public static void init() {
+        client = ClientBuilder.newClient();
+        runtime = Runtime.getRuntime();
+    }
+
+    @AfterAll
+    public static void close() {
+        client.close();
+        client = null;
+    }
+
+    @BeforeEach
+    public void releaseMemory() {
+        System.gc();
+    }
+
+    private String generateURL(String path) {
+        return PortProviderUtil.generateURL(path, InputStreamPostGetResourceTest.class.getSimpleName());
+    }
+
+    private long getCurrentlyAllocatedMemory() {
+        return (runtime.totalMemory() - runtime.freeMemory()) / (1024 * 1024);
+    }
+
+    /**
+     * Test for Get InputStream with no issue on size nor OOME
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {1, 100, 1024, 10 * 1024})
+    @DisplayName("Test Get InputStream")
+    public void testGetInputStream(int mb) throws Exception {
+        WebTarget base = client.target(generateURL("/inputstreamtransfer/test"));
+        long size = mb * 1024 * 1024L;
+        InputStream is = new FakeInputStream(size);
+        long before = getCurrentlyAllocatedMemory();
+        long start = System.nanoTime();
+        Response response = base.request().post(Entity.entity(is, MediaType.APPLICATION_OCTET_STREAM));
+        long stop = System.nanoTime();
+        long after = getCurrentlyAllocatedMemory();
+        Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        long remoteSize = response.readEntity(Long.class);
+        Assertions.assertEquals(size, remoteSize);
+        float time = (float) ((stop - start) / 1000000000.0);
+        long usedMemory = after - before;
+        LOG.infof("GET %d MB in %f s, %f MB/s using %d MB", mb, time, size / time / (1024 * 1024), usedMemory);
+        response.close();
+    }
+
+    /**
+     * Test for Post InputStream with no issue on size nor OOME
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {1, 100, 1024})
+    @DisplayName("Test Post InputStream")
+    public void testPostInputStream(int mb) throws Exception {
+        int size = mb * 1024 * 1024;
+        WebTarget base = client.target(generateURL("/inputstreamtransfer/test/" + size));
+        long before = getCurrentlyAllocatedMemory();
+        long start = System.nanoTime();
+        InputStream is = base.request().get(InputStream.class);
+        long len = 0;
+        int read = 0;
+        byte[] b = new byte[65536];
+        while ((read = is.read(b)) > 0) {
+            len += read;
+        }
+        long stop = System.nanoTime();
+        long after = getCurrentlyAllocatedMemory();
+        Assertions.assertEquals(size, len);
+        is.close();
+        float time = (float) ((stop - start) / 1000000000.0);
+        long usedMemory = after - before;
+        LOG.infof("POST %d MB in %f s, %f MB/s using %d MB", mb, time, size / time / (1024 * 1024), usedMemory);
+    }
+}

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResourceTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResourceTest.java
@@ -76,7 +76,7 @@ public class InputStreamPostGetResourceTest {
      * Test for Get InputStream with no issue on size nor OOME
      */
     @ParameterizedTest
-    @ValueSource(ints = {1, 100, 1024, 10 * 1024})
+    @ValueSource(ints = {1, 100, 1024})
     @DisplayName("Test Get InputStream")
     public void testGetInputStream(int mb) throws Exception {
         WebTarget base = client.target(generateURL("/inputstreamtransfer/test"));

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResourceTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/inputstream/InputStreamPostGetResourceTest.java
@@ -77,8 +77,8 @@ public class InputStreamPostGetResourceTest {
      */
     @ParameterizedTest
     @ValueSource(ints = {1, 100, 1024})
-    @DisplayName("Test Get InputStream")
-    public void testGetInputStream(int mb) throws Exception {
+    @DisplayName("Test Post InputStream")
+    public void testPostInputStream(int mb) throws Exception {
         WebTarget base = client.target(generateURL("/inputstreamtransfer/test"));
         long size = mb * 1024 * 1024L;
         InputStream is = new FakeInputStream(size);
@@ -101,10 +101,10 @@ public class InputStreamPostGetResourceTest {
      */
     @ParameterizedTest
     @ValueSource(ints = {1, 100, 1024})
-    @DisplayName("Test Post InputStream")
-    public void testPostInputStream(int mb) throws Exception {
-        int size = mb * 1024 * 1024;
-        WebTarget base = client.target(generateURL("/inputstreamtransfer/test/" + size));
+    @DisplayName("Test Get InputStream")
+    public void testGetInputStream(int mb) throws Exception {
+        long size = mb * 1024 * 1024L;
+        WebTarget base = client.target(generateURL("/inputstreamtransfer/test/" + mb));
         long before = getCurrentlyAllocatedMemory();
         long start = System.nanoTime();
         InputStream is = base.request().get(InputStream.class);


### PR DESCRIPTION
InputStream was not taking into account when using sending it with ReastEasy client to a Rest service.

Why:
The previous implementation was putting all bytes in one buffer, leading either to OOME or limit on acceptable Buffer size.

Change:
Add InputStream Async support such that it will not fill the memory and respect back pressure.

Note that, to work, quarkus.http.limits.max-body-size shall be set to a correct value (ex. 0), since currently VertxInputStream has soft limit on this value. The behavior is not changed here but could if necessary since it is no more in memory (not one buffer but chunked mode with back pressure). But as setting the value to 0 or enough is working. 

Add a test to check correctness (speed and memory) but this can be improved since it only checks at the end the status and/or the size of the inputstream.