### PR TITLE
Fix deprecated dev-v1 url with dev-ui in a few places

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/grpc-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/grpc-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
@@ -1,3 +1,3 @@
 {#include index-entry}
-{#body}<br />&rsaquo; It can be tested in the <a href="/q/dev-v1/io.quarkus.quarkus-grpc/services">Dev UI</a> (available in dev mode only).
+{#body}<br />&rsaquo; It can be tested in the <a href="/q/dev-ui/io.quarkus.quarkus-grpc/services">Dev UI</a> (available in dev mode only).
 {/include}

--- a/docs/src/main/asciidoc/dev-mode-differences.adoc
+++ b/docs/src/main/asciidoc/dev-mode-differences.adoc
@@ -50,7 +50,7 @@ Examples of such operations are:
 ====
 A new Dev UI has been implemented in Quarkus 3.x.
 Not all the features are available yet.
-You can still access the previous version of the Dev UI using: http://localhost:8080/q/dev-v1/.
+You can still access the previous version of the Dev UI using: http://localhost:8080/q/dev-ui/.
 ====
 
 === Error pages

--- a/docs/src/main/asciidoc/grpc-service-implementation.adoc
+++ b/docs/src/main/asciidoc/grpc-service-implementation.adoc
@@ -359,7 +359,7 @@ public class HelloServiceTest implements Greeter {
 
 == Trying out your services manually
 In the dev mode, you can try out your gRPC services in the Quarkus Dev UI.
-Just go to http://localhost:8080/q/dev-v1 and click on _Services_ under the gRPC tile.
+Just go to http://localhost:8080/q/dev-ui and click on _Services_ under the gRPC tile.
 
 Please note that your application needs to expose the "normal" HTTP port for the Dev UI to be accessible. If your application does not expose any HTTP endpoints, you can create a dedicated profile with a dependency on `quarkus-vertx-http`:
 [source,xml]

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -235,7 +235,7 @@ include::{includes}/devtools/dev.adoc[]
 
 xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak] will launch a Keycloak container and import a `quarkus-realm.json`.
 
-Open a xref:dev-ui.adoc[Dev UI] available at http://localhost:8080/q/dev-v1[/q/dev-v1] and click on a `Provider: Keycloak` link in an `OpenID Connect` `Dev UI` card.
+Open a xref:dev-ui.adoc[Dev UI] available at http://localhost:8080/q/dev-ui[/q/dev-ui] and click on a `Provider: Keycloak` link in an `OpenID Connect` `Dev UI` card.
 
 You will be asked to log in into a `Single Page Application` provided by `OpenID Connect Dev UI`:
 

--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
@@ -263,7 +263,7 @@ For more information, see the link:{url-quarkusio-guides}security-keycloak-admin
 include::{includes}/devtools/dev.adoc[]
 ====
 * link:{quarkusio-guides}/security-openid-connect-dev-services[Dev Services for Keycloak] will start a Keycloak container and import a `quarkus-realm.json`.
-. Open a link:{url-quarkusio-guides}dev-ui[Dev UI], which you can find at http://localhost:8080/q/dev-v1[/q/dev-v1], then click a `Provider: Keycloak` link in an `OpenID Connect` `Dev UI` card.
+. Open a link:{url-quarkusio-guides}dev-ui[Dev UI], which you can find at http://localhost:8080/q/dev-ui[/q/dev-ui], then click a `Provider: Keycloak` link in an `OpenID Connect` `Dev UI` card.
 . When prompted to log in to a `Single Page Application` provided by `OpenID Connect Dev UI`, do the following steps:
 
  * Log in as `alice` (password: `alice`), who has a `user` role.

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -363,7 +363,7 @@ include::{includes}/devtools/dev.adoc[]
 
 xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak] will launch a Keycloak container and import a `quarkus-realm.json`.
 
-Open a xref:dev-ui.adoc[Dev UI] available at http://localhost:8080/q/dev-v1[/q/dev-v1] and click on a `Provider: Keycloak` link in an `OpenID Connect` `Dev UI` card.
+Open a xref:dev-ui.adoc[Dev UI] available at http://localhost:8080/q/dev-ui[/q/dev-ui] and click on a `Provider: Keycloak` link in an `OpenID Connect` `Dev UI` card.
 
 You will be asked to log in into a `Single Page Application` provided by `OpenID Connect Dev UI`:
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -419,7 +419,7 @@ Please follow the xref:dev-ui.adoc[Dev UI] tutorial as well as check the `extens
 
 == Non Application Root Path Considerations
 
-This document refers to the `http://localhost:8080/q/dev-v1` Dev UI URL in several places where `q` is a default non application root path. If you customize `quarkus.http.root-path` and/or `quarkus.http.non-application-root-path` properties then replace `q` accordingly, please see https://quarkus.io/blog/path-resolution-in-quarkus/[Path Resolution in Quarkus] for more information.
+This document refers to the `http://localhost:8080/q/dev-ui` Dev UI URL in several places where `q` is a default non application root path. If you customize `quarkus.http.root-path` and/or `quarkus.http.non-application-root-path` properties then replace `q` accordingly, please see https://quarkus.io/blog/path-resolution-in-quarkus/[Path Resolution in Quarkus] for more information.
 
 == References
 


### PR DESCRIPTION
deprecated url is replaced by the new one in docs.