### PR TITLE
Automatically disable the HTTP port when client certs are required

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -151,7 +151,7 @@ Refer to the xref:./management-interface-reference.adoc[management interface ref
 ====
 
 [[ssl]]
-== Supporting secure connections with SSL/TLS
+== Supporting secure connections with TLS/SSL
 
 To have Quarkus support secure connections, you must either provide a certificate and associated key file, or supply a keystore.
 

--- a/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
+++ b/docs/src/main/asciidoc/security-authentication-mechanisms.adoc
@@ -194,6 +194,7 @@ quarkus.http.ssl.certificate.trust-store-password=the_trust_store_secret
 quarkus.http.ssl.client-auth=required                                      <3>
 quarkus.http.auth.permission.default.paths=/*                              <4>
 quarkus.http.auth.permission.default.policy=authenticated
+quarkus.http.insecure-requests=disabled                                    <5>
 ----
 <1> The keystore where the server's private key is located.
 <2> The truststore from which the trusted certificates are loaded.
@@ -201,6 +202,7 @@ quarkus.http.auth.permission.default.policy=authenticated
 To relax this requirement so that the server accepts requests without a certificate, set the value to `REQUEST`.
 This option is useful when you are also supporting authentication methods other than mTLS.
 <4> Defines a policy where only authenticated users should have access to resources from your application.
+<5> Optionally,explicitly disable the plain HTTP protocol, and consequently require all requests to be made over HTTPS. If `quarkus.http.ssl.client-auth` is set to `required`, the `quarkus.http.insecure-requests` property is automatically set to `disabled`.
 
 When the incoming request matches a valid certificate in the truststore, your application can obtain the subject by injecting a `SecurityIdentity` as follows:
 

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/devui/GrpcJsonRPCService.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/devui/GrpcJsonRPCService.java
@@ -13,6 +13,8 @@ import io.quarkus.dev.console.DevConsoleManager;
 import io.quarkus.grpc.runtime.config.GrpcConfiguration;
 import io.quarkus.grpc.runtime.config.GrpcServerConfiguration;
 import io.quarkus.grpc.runtime.devmode.GrpcServices;
+import io.quarkus.vertx.http.runtime.CertificateConfig;
+import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -31,6 +33,9 @@ public class GrpcJsonRPCService {
 
     @Inject
     HttpConfiguration httpConfiguration;
+
+    @Inject
+    HttpBuildTimeConfig httpBuildTimeConfig;
 
     @Inject
     GrpcConfiguration grpcConfiguration;
@@ -52,8 +57,14 @@ public class GrpcJsonRPCService {
         } else {
             this.host = httpConfiguration.host;
             this.port = httpConfiguration.port;
-            this.ssl = httpConfiguration.insecureRequests != HttpConfiguration.InsecureRequests.ENABLED;
+            this.ssl = isTLSConfigured(httpConfiguration.ssl.certificate);
         }
+    }
+
+    private boolean isTLSConfigured(CertificateConfig certificate) {
+        return certificate.files.isPresent()
+                || certificate.keyFiles.isPresent()
+                || certificate.keyStoreFile.isPresent();
     }
 
     public JsonArray getServices() {

--- a/extensions/vertx-http/deployment/src/test/resources/conf/mtls/mtls-jks.conf
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/mtls/mtls-jks.conf
@@ -3,6 +3,7 @@ quarkus.http.ssl.certificate.key-store-password=secret
 quarkus.http.ssl.certificate.trust-store-file=server-truststore.jks
 quarkus.http.ssl.certificate.trust-store-password=password
 quarkus.http.ssl.client-auth=REQUIRED
+quarkus.http.insecure-requests=enabled
 
 quarkus.http.auth.permission.default.paths=/*
 quarkus.http.auth.permission.default.policy=authenticated

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java
@@ -28,7 +28,11 @@ public class HttpBuildTimeConfig {
 
     /**
      * Configures the engine to require/request client authentication.
-     * NONE, REQUEST, REQUIRED
+     * {@code NONE, REQUEST, REQUIRED}.
+     * <p>
+     * When set to {@code REQUIRED}, it's recommended to also set `quarkus.http.insecure-requests=disabled` to disable the
+     * plain HTTP port. If `quarkus.http.insecure-requests` is not set, but this parameter is set to {@code REQUIRED}, then,
+     * `quarkus.http.insecure-requests` is automatically set to `disabled`.
      */
     @ConfigItem(name = "ssl.client-auth", defaultValue = "NONE")
     public ClientAuth tlsClientAuth;
@@ -43,7 +47,7 @@ public class HttpBuildTimeConfig {
     /**
      * A common root path for non-application endpoints. Various extension-provided endpoints such as metrics, health,
      * and openapi are deployed under this path by default.
-     *
+     * <p>
      * * Relative path (Default, `q`) ->
      * Non-application endpoints will be served from
      * `${quarkus.http.root-path}/${quarkus.http.non-application-root-path}`.
@@ -51,7 +55,7 @@ public class HttpBuildTimeConfig {
      * Non-application endpoints will be served from the specified path.
      * * `${quarkus.http.root-path}` -> Setting this path to the same value as HTTP root path disables
      * this root path. All extension-provided endpoints will be served from `${quarkus.http.root-path}`.
-     *
+     * <p>
      * If the management interface is enabled, the root path for the endpoints exposed on the management interface
      * is configured using the `quarkus.management.root-path` property instead of this property.
      *
@@ -69,7 +73,7 @@ public class HttpBuildTimeConfig {
     /**
      * If enabled then the response body is compressed if the {@code Content-Type} header is set and the value is a compressed
      * media type as configured via {@link #compressMediaTypes}.
-     *
+     * <p>
      * Note that the RESTEasy Reactive and Reactive Routes extensions also make it possible to enable/disable compression
      * declaratively using the annotations {@link io.quarkus.vertx.http.Compressed} and
      * {@link io.quarkus.vertx.http.Uncompressed}.
@@ -79,7 +83,7 @@ public class HttpBuildTimeConfig {
 
     /**
      * When enabled, vert.x will decompress the request's body if it's compressed.
-     *
+     * <p>
      * Note that the compression format (e.g., gzip) must be specified in the Content-Encoding header
      * in the request.
      */

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -39,9 +39,9 @@ public class HttpConfiguration {
 
     /**
      * The HTTP host
-     *
+     * <p>
      * In dev/test mode this defaults to localhost, in prod mode this defaults to 0.0.0.0
-     *
+     * <p>
      * Defaulting to 0.0.0.0 makes it easier to deploy Quarkus to container, however it
      * is not suitable for dev/test mode as other people on the network can connect to your
      * development machine.
@@ -86,13 +86,17 @@ public class HttpConfiguration {
      * then http works as normal. {@code redirect} will still open the http port, but
      * all requests will be redirected to the HTTPS port. {@code disabled} will prevent the HTTP
      * port from opening at all.
+     * <p>
+     * Default is {@code enabled} except when client auth is set to {@code required} (configured using
+     * {@code quarkus.http.ssl.client-auth=required}).
+     * In this case, the default is {@code disabled}.
      */
-    @ConfigItem(defaultValue = "enabled")
-    public InsecureRequests insecureRequests;
+    @ConfigItem
+    public Optional<InsecureRequests> insecureRequests;
 
     /**
      * If this is true (the default) then HTTP/2 will be enabled.
-     *
+     * <p>
      * Note that for browsers to be able to use it HTTPS must be enabled,
      * and you must be running on JDK11 or above, as JDK8 does not support
      * ALPN.
@@ -134,7 +138,7 @@ public class HttpConfiguration {
      * The number if IO threads used to perform IO. This will be automatically set to a reasonable value based on
      * the number of CPU cores if it is not provided. If this is set to a higher value than the number of Vert.x event
      * loops then it will be capped at the number of event loops.
-     *
+     * <p>
      * In general this should be controlled by setting quarkus.vertx.event-loops-pool-size, this setting should only
      * be used if you want to limit the number of HTTP io threads to a smaller number than the total number of IO threads.
      */
@@ -156,7 +160,6 @@ public class HttpConfiguration {
      * Http connection read timeout for blocking IO. This is the maximum amount of time
      * a thread will wait for data, before an IOException will be thrown and the connection
      * closed.
-     *
      */
     @ConfigItem(defaultValue = "60s", name = "read-timeout")
     public Duration readTimeout;
@@ -169,7 +172,7 @@ public class HttpConfiguration {
     /**
      * The encryption key that is used to store persistent logins (e.g. for form auth). Logins are stored in a persistent
      * cookie that is encrypted with AES-256 using a key derived from a SHA-256 hash of the key that is provided here.
-     *
+     * <p>
      * If no key is provided then an in-memory one will be generated, this will change on every restart though so it
      * is not suitable for production environments. This must be more than 16 characters long for security reasons
      */
@@ -228,7 +231,7 @@ public class HttpConfiguration {
 
     /**
      * If this is true then the request start time will be recorded to enable logging of total request time.
-     *
+     * <p>
      * This has a small performance penalty, so is disabled by default.
      */
     @ConfigItem

--- a/integration-tests/mtls-certificates/src/test/java/io/quarkus/it/vertx/CertificateRoleMappingTest.java
+++ b/integration-tests/mtls-certificates/src/test/java/io/quarkus/it/vertx/CertificateRoleMappingTest.java
@@ -2,7 +2,9 @@ package io.quarkus.it.vertx;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.net.ConnectException;
 import java.net.URL;
 
 import org.junit.jupiter.api.Test;
@@ -44,9 +46,15 @@ public class CertificateRoleMappingTest {
 
     @Test
     public void testNoClientCertificate() {
-        given().get("/protected/authenticated").then().statusCode(401);
-        given().get("/protected/authorized-user").then().statusCode(401);
-        given().get("/protected/authorized-admin").then().statusCode(401);
+        assertThrows(ConnectException.class,
+                () -> given().get("/protected/authenticated"),
+                "Insecure requests must fail at the transport level");
+        assertThrows(ConnectException.class,
+                () -> given().get("/protected/authorized-user"),
+                "Insecure requests must fail at the transport level");
+        assertThrows(ConnectException.class,
+                () -> given().get("/protected/authorized-admin"),
+                "Insecure requests must fail at the transport level");
     }
 
     private RequestSpecification getMtlsRequestSpec(String clientKeyStore) {

--- a/integration-tests/vertx-http/src/main/resources/application.properties
+++ b/integration-tests/vertx-http/src/main/resources/application.properties
@@ -7,6 +7,7 @@ quarkus.http.ssl.certificate.trust-store-file=server-truststore.jks
 quarkus.http.ssl.certificate.trust-store-password=password
 quarkus.http.ssl.certificate.trust-store-cert-alias=mykey-1
 quarkus.http.ssl.client-auth=REQUIRED
+quarkus.http.insecure-requests=ENABLED
 quarkus.http.access-log.enabled=true
 quarkus.http.access-log.log-to-file=true
 quarkus.http.access-log.base-file-name=quarkus-access-log


### PR DESCRIPTION
This is particularly important when mTLS is used.
