### PR TITLE
Runtime (re)initialize Netty's PlatformDependent classes

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -162,6 +162,9 @@ class NettyProcessor {
             log.debug("Not registering Netty native kqueue classes as they were not found");
         }
 
+        builder.addRuntimeReinitializedClass("io.netty.util.internal.PlatformDependent");
+        builder.addRuntimeReinitializedClass("io.netty.util.internal.PlatformDependent0");
+
         return builder //TODO: make configurable
                 .build();
     }


### PR DESCRIPTION
Closes https://github.com/quarkusio/quarkus/issues/17839