### PR TITLE
Add relocation artifacts for quarkus-hibernate-search-orm-coordination-outbox-polling renaming

### DIFF
--- a/relocations/pom.xml
+++ b/relocations/pom.xml
@@ -24,6 +24,8 @@
         <module>quarkus-jaeger-deployment</module>
         <module>quarkus-smallrye-opentracing</module>
         <module>quarkus-smallrye-opentracing-deployment</module>
+        <module>quarkus-hibernate-search-orm-coordination-outbox-polling</module>
+        <module>quarkus-hibernate-search-orm-coordination-outbox-polling-deployment</module>
     </modules>
 
 </project>

--- a/relocations/quarkus-hibernate-search-orm-coordination-outbox-polling-deployment/pom.xml
+++ b/relocations/quarkus-hibernate-search-orm-coordination-outbox-polling-deployment/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-relocations-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-hibernate-search-orm-coordination-outbox-polling-deployment</artifactId>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-search-orm-outbox-polling-deployment</artifactId>
+            <version>${project.version}</version>
+            <message>${project.groupId}:${project.artifactId}:${project.version} was relocated to io.quarkus:quarkus-hibernate-search-orm-outbox-polling-deployment:${project.version}. Please update the artifactId of the dependency in your project configuration. For more information about this change, please refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.7#quarkus-hibernate-search-orm-coordination-outbox-polling-was-renamed</message>
+        </relocation>
+    </distributionManagement>
+</project>

--- a/relocations/quarkus-hibernate-search-orm-coordination-outbox-polling/pom.xml
+++ b/relocations/quarkus-hibernate-search-orm-coordination-outbox-polling/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-relocations-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-hibernate-search-orm-coordination-outbox-polling</artifactId>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-search-orm-outbox-polling</artifactId>
+            <version>${project.version}</version>
+            <message>${project.groupId}:${project.artifactId}:${project.version} was relocated to io.quarkus:quarkus-hibernate-search-orm-outbox-polling:${project.version}. Please update the artifactId of the dependency in your project configuration. For more information about this change, please refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.7#quarkus-hibernate-search-orm-coordination-outbox-polling-was-renamed</message>
+        </relocation>
+    </distributionManagement>
+</project>


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.7#quarkus-hibernate-search-orm-coordination-outbox-polling-was-renamed

Follows up on #36978

See also https://github.com/quarkusio/quarkus/pull/36978#pullrequestreview-1752865989