### PR TITLE
Fix incorrect log dependency

### DIFF
--- a/test-framework/junit5-component/pom.xml
+++ b/test-framework/junit5-component/pom.xml
@@ -61,7 +61,7 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.jboss.logmanager</groupId>
-            <artifactId>jboss-logmanager-embedded</artifactId>
+            <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The only negative effect is a build warning, but it should still be corrected.