### PR TITLE
Do not fail the request in OidcClient filters if OidcClient is disabled

### DIFF
--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/AbstractOidcClientRequestFilter.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/AbstractOidcClientRequestFilter.java
@@ -25,8 +25,8 @@ public class AbstractOidcClientRequestFilter extends AbstractTokensProducer impl
             final String accessToken = getAccessToken();
             requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, BEARER_SCHEME_WITH_SPACE + accessToken);
         } catch (DisabledOidcClientException ex) {
-            LOG.debug("Client is disabled, aborting the request");
-            throw ex;
+            LOG.debug("Client is disabled, acquiring and propagating the token is not necessary");
+            return;
         } catch (Exception ex) {
             LOG.debugf("Access token is not available, cause: %s, aborting the request", ex.getMessage());
             throw (ex instanceof RuntimeException) ? (RuntimeException) ex : new RuntimeException(ex);

--- a/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/AbstractOidcClientRequestReactiveFilter.java
+++ b/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/AbstractOidcClientRequestReactiveFilter.java
@@ -39,11 +39,12 @@ public class AbstractOidcClientRequestReactiveFilter extends AbstractTokensProdu
             @Override
             public void accept(Throwable t) {
                 if (t instanceof DisabledOidcClientException) {
-                    LOG.debug("Client is disabled, aborting the request");
+                    LOG.debug("Client is disabled, acquiring and propagating the token is not necessary");
+                    requestContext.resume();
                 } else {
                     LOG.debugf("Access token is not available, cause: %s, aborting the request", t.getMessage());
+                    requestContext.resume((t instanceof RuntimeException) ? t : new RuntimeException(t));
                 }
-                requestContext.resume((t instanceof RuntimeException) ? t : new RuntimeException(t));
             }
         });
     }


### PR DESCRIPTION
Fixes #37360

Currently OIDC client filters fail if the user disabled the clients but they should just let the requests go