### PR TITLE
Improve Docker Desktop detection

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java
@@ -194,7 +194,8 @@ public final class ContainerRuntimeUtil {
                         // We also treat Docker Desktop as "rootless" since the way it binds mounts does not
                         // transparently map the host user ID and GID
                         // see https://docs.docker.com/desktop/faqs/linuxfaqs/#how-do-i-enable-file-sharing
-                        stringPredicate = line -> line.trim().equals("rootless") || line.contains("desktop-linux");
+                        stringPredicate = line -> line.trim().equals("rootless") || line.contains("Docker Desktop")
+                                || line.contains("desktop-linux");
                     } else {
                         stringPredicate = line -> line.trim().equals("rootless: true");
                     }


### PR DESCRIPTION
During some experiments I noticed that when setting DOCKER_HOST, `docker
info` no longer reports the context as `desktop-linux`. Looking for
"Docker Desktop" as the docker server operating system seems more
reliable.

I am keeping the `desktop-linux` filter as a fallback nevertheless.

Improves https://github.com/quarkusio/quarkus/pull/37242
