### PR TITLE
Documentation: Fix OIDC credentials reference to secret key

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -180,7 +180,7 @@ public class OidcCommonConfig {
             }
 
             /**
-             * The client secret value - it will be ignored if 'secret.key' is set
+             * The client secret value - it will be ignored if 'credentials.secret' is set
              */
             @ConfigItem
             public Optional<String> value = Optional.empty();


### PR DESCRIPTION
@fedinskiy mentioned `secret.key` does not exist anywhere in `quarkus.oidc.credentials.*` namespace. I realize it is common to use relative config key names in the `io.quarkus.oidc.common.runtime.OidcCommonConfig` and also it uses term _secret key_, but I don't think it's clear enough to use relative path for config key from parent config group, hence using absolute config property name.