### PR TITLE
Fixes workspace discovery based on effective POMs

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapModelResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapModelResolver.java
@@ -38,7 +38,7 @@ import io.quarkus.maven.dependency.ArtifactCoords;
 
 public class BootstrapModelResolver implements ModelResolver {
 
-    public static ModelResolver newInstance(BootstrapMavenContext ctx, WorkspaceReader workspace)
+    public static BootstrapModelResolver newInstance(BootstrapMavenContext ctx, WorkspaceReader workspace)
             throws BootstrapMavenException {
         final RepositorySystem repoSystem = ctx.getRepositorySystem();
         final RepositorySystemSession session = workspace == null
@@ -100,6 +100,10 @@ public class BootstrapModelResolver implements ModelResolver {
         this.repositories = new ArrayList<>(original.repositories);
         this.externalRepositories = original.externalRepositories;
         this.repositoryIds = new HashSet<>(original.repositoryIds);
+    }
+
+    public RepositorySystemSession getSession() {
+        return session;
     }
 
     @Override

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
@@ -305,7 +305,7 @@ public class MavenArtifactResolver {
             throws BootstrapMavenException {
         try {
             return repoSystem.collectDependencies(repoSession,
-                    newCollectManagedRequest(artifact, List.of(), managedDeps, mainRepos, exclusions, Set.of(excludedScopes)));
+                    newCollectManagedRequest(artifact, directDeps, managedDeps, mainRepos, exclusions, Set.of(excludedScopes)));
         } catch (DependencyCollectionException e) {
             throw new BootstrapMavenException("Failed to collect dependencies for " + artifact, e);
         }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalProject.java
@@ -165,7 +165,7 @@ public class LocalProject {
         }
     }
 
-    LocalProject(Model rawModel, LocalWorkspace workspace) throws BootstrapMavenException {
+    LocalProject(Model rawModel, LocalWorkspace workspace) {
         this.modelBuildingResult = null;
         this.rawModel = rawModel;
         this.dir = rawModel.getProjectDirectory().toPath();

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/WorkspaceLoader.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/WorkspaceLoader.java
@@ -2,13 +2,17 @@ package io.quarkus.bootstrap.resolver.maven.workspace;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.apache.maven.model.Model;
@@ -16,10 +20,7 @@ import org.apache.maven.model.Parent;
 import org.apache.maven.model.Profile;
 import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuilder;
-import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelCache;
-import org.apache.maven.model.resolution.ModelResolver;
-import org.apache.maven.model.resolution.UnresolvableModelException;
 import org.apache.maven.model.resolution.WorkspaceModelResolver;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.repository.WorkspaceReader;
@@ -31,6 +32,8 @@ import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
 import io.quarkus.bootstrap.resolver.maven.BootstrapModelBuilderFactory;
 import io.quarkus.bootstrap.resolver.maven.BootstrapModelResolver;
 import io.quarkus.bootstrap.resolver.maven.options.BootstrapMavenOptions;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.GAV;
 
 public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader {
 
@@ -38,23 +41,7 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
 
     private static final String POM_XML = "pom.xml";
 
-    static final Model readModel(Path pom) throws BootstrapMavenException {
-        try {
-            final Model model = ModelUtils.readModel(pom);
-            model.setPomFile(pom.toFile());
-            return model;
-        } catch (NoSuchFileException e) {
-            // some projects may be missing pom.xml relying on Maven extensions (e.g. tycho-maven-plugin) to build them,
-            // which we don't support in this workspace loader
-            log.warn("Module(s) under " + pom.getParent() + " will be handled as thirdparty dependencies because " + pom
-                    + " does not exist");
-            return null;
-        } catch (IOException e) {
-            throw new BootstrapMavenException("Failed to read " + pom, e);
-        }
-    }
-
-    static Path locateCurrentProjectPom(Path path, boolean required) throws BootstrapMavenException {
+    private static Path locateCurrentProjectPom(Path path) throws BootstrapMavenException {
         Path p = path;
         while (p != null) {
             final Path pom = p.resolve(POM_XML);
@@ -63,21 +50,20 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
             }
             p = p.getParent();
         }
-        if (required) {
-            throw new BootstrapMavenException("Failed to locate project pom.xml for " + path);
-        }
-        return null;
+        throw new BootstrapMavenException("Failed to locate project pom.xml for " + path);
     }
 
+    private final List<RawModule> moduleQueue = new ArrayList<>();
+    private final Map<Path, Model> loadedPoms = new HashMap<>();
+
+    private final Function<Path, Model> modelProvider;
+    private final Map<GAV, Model> loadedModules = new HashMap<>();
+
     private final LocalWorkspace workspace = new LocalWorkspace();
-    private final Map<Path, Model> rawModelCache = new HashMap<>();
-    private final Map<Path, LocalProject> projectCache = new HashMap<>();
     private final Path currentProjectPom;
-    private Path workspaceRootPom;
-    private Function<Path, Model> modelProvider;
 
     private ModelBuilder modelBuilder;
-    private ModelResolver modelResolver;
+    private BootstrapModelResolver modelResolver;
     private ModelCache modelCache;
     private List<String> activeProfileIds;
     private List<String> inactiveProfileIds;
@@ -85,11 +71,20 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
 
     WorkspaceLoader(BootstrapMavenContext ctx, Path currentProjectPom, Function<Path, Model> modelProvider)
             throws BootstrapMavenException {
-        this.modelProvider = modelProvider;
+        try {
+            final BasicFileAttributes fileAttributes = Files.readAttributes(currentProjectPom, BasicFileAttributes.class);
+            this.currentProjectPom = fileAttributes.isDirectory() ? locateCurrentProjectPom(currentProjectPom)
+                    : currentProjectPom;
+        } catch (IOException e) {
+            throw new IllegalArgumentException(currentProjectPom + " does not exist", e);
+        }
+        addModulePom(this.currentProjectPom);
+        this.modelProvider = modelProvider == null ? pom -> null : modelProvider;
+
         if (ctx != null && ctx.isEffectiveModelBuilder()) {
             modelBuilder = BootstrapModelBuilderFactory.getDefaultModelBuilder();
             modelResolver = BootstrapModelResolver.newInstance(ctx, this);
-            modelCache = new BootstrapModelCache(ctx.getRepositorySystemSession());
+            modelCache = new BootstrapModelCache(modelResolver.getSession());
 
             profiles = ctx.getActiveSettingsProfiles();
             final BootstrapMavenOptions cliOptions = ctx.getCliOptions();
@@ -101,185 +96,126 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
             inactiveProfileIds = cliOptions.getInactiveProfileIds();
         }
         workspace.setBootstrapMavenContext(ctx);
-        this.currentProjectPom = isPom(currentProjectPom) ? currentProjectPom
-                : locateCurrentProjectPom(currentProjectPom, true);
     }
 
-    private boolean isPom(Path p) {
-        if (Files.exists(p) && !Files.isDirectory(p)) {
-            try {
-                rawModel(p);
-                return true;
-            } catch (BootstrapMavenException e) {
-                // not a POM file
-            }
+    private void addModulePom(Path pom) {
+        if (pom != null) {
+            moduleQueue.add(new RawModule(pom));
         }
-        return false;
-    }
-
-    private LocalProject project(Path pomFile) throws BootstrapMavenException {
-        final LocalProject project = projectCache.get(pomFile.getParent());
-        return project == null ? loadAndCacheProject(pomFile) : project;
-    }
-
-    private LocalProject loadAndCacheProject(Path pomFile) throws BootstrapMavenException {
-        final Model rawModel = rawModel(pomFile);
-        if (rawModel == null) {
-            return null;
-        }
-        final LocalProject project;
-        if (modelBuilder != null) {
-            ModelBuildingRequest req = new DefaultModelBuildingRequest();
-            req.setPomFile(pomFile.toFile());
-            req.setModelResolver(modelResolver);
-            req.setSystemProperties(System.getProperties());
-            req.setUserProperties(System.getProperties());
-            req.setModelCache(modelCache);
-            req.setActiveProfileIds(activeProfileIds);
-            req.setInactiveProfileIds(inactiveProfileIds);
-            req.setProfiles(profiles);
-            req.setRawModel(rawModel);
-            req.setWorkspaceModelResolver(this);
-            try {
-                project = new LocalProject(modelBuilder.build(req), workspace);
-            } catch (Exception e) {
-                throw new BootstrapMavenException("Failed to resolve the effective model for " + pomFile, e);
-            }
-        } else {
-            project = new LocalProject(rawModel, workspace);
-        }
-        projectCache.put(pomFile.getParent(), project);
-        return project;
-    }
-
-    private Model rawModel(Path pomFile) throws BootstrapMavenException {
-        var moduleDir = pomFile.getParent();
-        if (moduleDir != null) {
-            // the path might not be normalized, while the modelProvider below would typically recognize normalized absolute paths
-            moduleDir = moduleDir.normalize().toAbsolutePath();
-        }
-        Model rawModel = rawModelCache.get(moduleDir);
-        if (rawModel != null) {
-            return rawModel;
-        }
-        rawModel = modelProvider == null ? null : modelProvider.apply(moduleDir);
-        if (rawModel == null) {
-            rawModel = readModel(pomFile);
-        }
-        rawModelCache.put(moduleDir, rawModel);
-        return rawModel;
     }
 
     void setWorkspaceRootPom(Path rootPom) {
-        this.workspaceRootPom = rootPom;
-    }
-
-    private LocalProject loadProject(Path projectPom, String skipModule) throws BootstrapMavenException {
-        final Model rawModel = rawModel(projectPom);
-        if (rawModel == null) {
-            return null;
-        }
-        final LocalProject parentProject = loadParentProject(projectPom, rawModel);
-        final LocalProject project = project(projectPom);
-        if (project == null) {
-            return null;
-        }
-        if (parentProject != null) {
-            parentProject.modules.add(project);
-        }
-        loadProjectModules(project, skipModule);
-        return project;
-    }
-
-    private LocalProject loadParentProject(Path projectPom, final Model rawModel) throws BootstrapMavenException {
-        final Path parentPom = getParentPom(projectPom, rawModel);
-        return parentPom == null || rawModelCache.containsKey(parentPom.getParent()) ? null
-                : loadProject(parentPom, parentPom.getParent().relativize(projectPom.getParent()).toString());
-    }
-
-    private Path getParentPom(Path projectPom, Model rawModel) {
-        if (rawModel == null) {
-            return null;
-        }
-        Path parentPom = null;
-        final Path projectDir = projectPom.getParent();
-        final Parent parent = rawModel.getParent();
-        if (parent != null && parent.getRelativePath() != null && !parent.getRelativePath().isEmpty()) {
-            parentPom = projectDir.resolve(parent.getRelativePath()).normalize();
-            if (Files.isDirectory(parentPom)) {
-                parentPom = parentPom.resolve(POM_XML);
-            }
-        } else {
-            final Path parentDir = projectDir.getParent();
-            if (parentDir != null) {
-                parentPom = parentDir.resolve(POM_XML);
-            }
-        }
-        return parentPom != null && Files.exists(parentPom) ? parentPom : null;
-    }
-
-    private LocalProject loadProjectModules(LocalProject project, String skipModule) throws BootstrapMavenException {
-        final List<String> modules;
-        if (project.getModelBuildingResult() == null) {
-            var projectModel = project.getRawModel();
-            List<String> combinedList = null;
-            for (var profile : projectModel.getProfiles()) {
-                if (!profile.getModules().isEmpty()) {
-                    if (combinedList == null) {
-                        combinedList = new ArrayList<>(projectModel.getModules());
-                    }
-                    combinedList.addAll(profile.getModules());
-                }
-            }
-            modules = combinedList == null ? projectModel.getModules() : combinedList;
-        } else {
-            modules = project.getModelBuildingResult().getEffectiveModel().getModules();
-        }
-        if (!modules.isEmpty()) {
-            for (String module : modules) {
-                if (module.equals(skipModule)) {
-                    continue;
-                }
-                final Path modulePom = project.getDir().resolve(module).resolve(POM_XML);
-                // some modules use different parent POMs than those that referred to them as their modules
-                // so make sure the parent project has been loaded, before resolving the effective model of the module
-                loadParentProject(modulePom, rawModel(modulePom));
-                final LocalProject childProject = project(modulePom);
-                if (childProject != null) {
-                    project.modules.add(loadProjectModules(childProject, null));
-                }
-            }
-        }
-        return project;
+        addModulePom(rootPom);
     }
 
     LocalProject load() throws BootstrapMavenException {
-        if (workspaceRootPom != null) {
-            loadProject(workspaceRootPom, null);
+        final AtomicReference<LocalProject> currentProject = new AtomicReference<>();
+        final Consumer<Model> processor;
+        if (modelBuilder == null) {
+            processor = rawModel -> {
+                var project = new LocalProject(rawModel, workspace);
+                if (currentProject.get() == null && project.getDir().equals(currentProjectPom.getParent())) {
+                    currentProject.set(project);
+                }
+            };
+        } else {
+            processor = rawModel -> {
+                var req = new DefaultModelBuildingRequest();
+                req.setPomFile(rawModel.getPomFile());
+                req.setModelResolver(modelResolver);
+                req.setSystemProperties(System.getProperties());
+                req.setUserProperties(System.getProperties());
+                req.setModelCache(modelCache);
+                req.setActiveProfileIds(activeProfileIds);
+                req.setInactiveProfileIds(inactiveProfileIds);
+                req.setProfiles(profiles);
+                req.setRawModel(rawModel);
+                req.setWorkspaceModelResolver(this);
+                LocalProject project;
+                try {
+                    project = new LocalProject(modelBuilder.build(req), workspace);
+                } catch (Exception e) {
+                    throw new RuntimeException("Failed to resolve the effective model for " + rawModel.getPomFile(), e);
+                }
+                if (currentProject.get() == null && project.getDir().equals(currentProjectPom.getParent())) {
+                    currentProject.set(project);
+                }
+                for (var module : project.getModelBuildingResult().getEffectiveModel().getModules()) {
+                    addModulePom(project.getDir().resolve(module).resolve(POM_XML));
+                }
+            };
         }
-        LocalProject currentProject = projectCache.get(currentProjectPom.getParent());
-        if (currentProject == null) {
-            currentProject = loadProject(currentProjectPom, null);
+
+        int i = 0;
+        while (i < moduleQueue.size()) {
+            var newModules = new ArrayList<RawModule>();
+            while (i < moduleQueue.size()) {
+                loadModule(moduleQueue.get(i++), newModules);
+            }
+            for (var newModule : newModules) {
+                newModule.process(processor);
+            }
         }
-        if (workspace != null) {
-            workspace.setCurrentProject(currentProject);
+
+        if (currentProject.get() == null) {
+            throw new BootstrapMavenException("Failed to load project " + currentProjectPom);
         }
-        return currentProject;
+        return currentProject.get();
+    }
+
+    private void loadModule(RawModule rawModule, List<RawModule> newModules) {
+        var moduleDir = rawModule.pom.getParent();
+        if (moduleDir == null) {
+            moduleDir = Path.of("/");
+        }
+        if (loadedPoms.containsKey(moduleDir)) {
+            return;
+        }
+
+        rawModule.model = modelProvider == null ? null : modelProvider.apply(moduleDir);
+        if (rawModule.model == null) {
+            rawModule.model = readModel(rawModule.pom);
+        }
+        loadedPoms.put(moduleDir, rawModule.model);
+        if (rawModule.model == null) {
+            return;
+        }
+        newModules.add(rawModule);
+
+        var added = loadedModules.putIfAbsent(
+                new GAV(ModelUtils.getGroupId(rawModule.model), rawModule.model.getArtifactId(),
+                        ModelUtils.getVersion(rawModule.model)),
+                rawModule.model);
+        if (added != null) {
+            return;
+        }
+        for (var module : rawModule.model.getModules()) {
+            moduleQueue.add(
+                    new RawModule(rawModule, rawModule.model.getProjectDirectory().toPath().resolve(module).resolve(POM_XML)));
+        }
+        for (var profile : rawModule.model.getProfiles()) {
+            for (var module : profile.getModules()) {
+                moduleQueue.add(new RawModule(rawModule,
+                        rawModule.model.getProjectDirectory().toPath().resolve(module).resolve(POM_XML)));
+            }
+        }
+        if (rawModule.parent == null) {
+            final Path parentPom = rawModule.getParentPom();
+            if (parentPom != null) {
+                var parent = new RawModule(parentPom);
+                rawModule.parent = parent;
+                moduleQueue.add(parent);
+            }
+        }
     }
 
     @Override
-    public Model resolveRawModel(String groupId, String artifactId, String versionConstraint)
-            throws UnresolvableModelException {
-        final LocalProject project = workspace.getProject(groupId, artifactId);
-        // we are comparing the raw version here because in case of a CI-friendly version (e.g. ${revision}) the versionConstraint will be an expression
-        return project != null && ModelUtils.getRawVersion(project.getRawModel()).equals(versionConstraint)
-                ? project.getRawModel()
-                : null;
+    public Model resolveRawModel(String groupId, String artifactId, String versionConstraint) {
+        return loadedModules.get(new GAV(groupId, artifactId, versionConstraint));
     }
 
     @Override
-    public Model resolveEffectiveModel(String groupId, String artifactId, String versionConstraint)
-            throws UnresolvableModelException {
+    public Model resolveEffectiveModel(String groupId, String artifactId, String versionConstraint) {
         final LocalProject project = workspace.getProject(groupId, artifactId);
         return project != null && project.getVersion().equals(versionConstraint)
                 ? project.getModelBuildingResult().getEffectiveModel()
@@ -293,11 +229,81 @@ public class WorkspaceLoader implements WorkspaceModelResolver, WorkspaceReader 
 
     @Override
     public File findArtifact(Artifact artifact) {
-        return workspace.findArtifact(artifact);
+        if (!ArtifactCoords.TYPE_POM.equals(artifact.getExtension())) {
+            return null;
+        }
+        var model = loadedModules.get(new GAV(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion()));
+        return model == null ? null : model.getPomFile();
     }
 
     @Override
     public List<String> findVersions(Artifact artifact) {
-        return workspace.findVersions(artifact);
+        var model = loadedModules.get(new GAV(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion()));
+        return model == null ? List.of() : List.of(ModelUtils.getVersion(model));
+    }
+
+    private static Model readModel(Path pom) {
+        try {
+            final Model model = ModelUtils.readModel(pom);
+            model.setPomFile(pom.toFile());
+            return model;
+        } catch (NoSuchFileException e) {
+            // some projects may be missing pom.xml relying on Maven extensions (e.g. tycho-maven-plugin) to build them,
+            // which we don't support in this workspace loader
+            log.warn("Module(s) under " + pom.getParent() + " will be handled as thirdparty dependencies because " + pom
+                    + " does not exist");
+            return null;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load POM from " + pom, e);
+        }
+    }
+
+    private static class RawModule {
+        final Path pom;
+        Model model;
+        RawModule parent;
+        boolean processed;
+
+        private RawModule(Path pom) {
+            this(null, pom);
+        }
+
+        private RawModule(RawModule parent, Path pom) {
+            this.pom = pom.normalize().toAbsolutePath();
+            this.parent = parent;
+        }
+
+        private Path getParentPom() {
+            if (model == null) {
+                return null;
+            }
+            Path parentPom = null;
+            final Parent parent = model.getParent();
+            if (parent != null && parent.getRelativePath() != null && !parent.getRelativePath().isEmpty()) {
+                parentPom = pom.getParent().resolve(parent.getRelativePath()).normalize();
+                if (Files.isDirectory(parentPom)) {
+                    parentPom = parentPom.resolve(POM_XML);
+                }
+            } else {
+                final Path parentDir = pom.getParent().getParent();
+                if (parentDir != null) {
+                    parentPom = parentDir.resolve(POM_XML);
+                }
+            }
+            return parentPom != null && Files.exists(parentPom) ? parentPom : null;
+        }
+
+        private void process(Consumer<Model> consumer) {
+            if (processed) {
+                return;
+            }
+            processed = true;
+            if (parent != null) {
+                parent.process(consumer);
+            }
+            if (model != null) {
+                consumer.accept(model);
+            }
+        }
     }
 }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
@@ -67,7 +67,7 @@ public class DependencyUtils {
     private static Artifact toArtifact(String str, int offset) {
         String groupId = null;
         String artifactId = null;
-        String classifier = "";
+        String classifier = ArtifactCoords.DEFAULT_CLASSIFIER;
         String type = ArtifactCoords.TYPE_JAR;
         String version = null;
 

--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
@@ -222,7 +222,8 @@ public class LocalWorkspaceDiscoveryTest {
         assertNotNull(ws.getProject("org.acme", "quarkus-quickstart-multimodule-rest"));
         assertNotNull(ws.getProject("org.acme", "acme-integration-tests"));
         assertNotNull(ws.getProject("org.acme", "acme-rest-tests"));
-        assertEquals(6, ws.getProjects().size());
+        assertNotNull(ws.getProject("org.acme", "other"));
+        assertEquals(7, ws.getProjects().size());
     }
 
     @Test
@@ -535,7 +536,8 @@ public class LocalWorkspaceDiscoveryTest {
     @Test
     public void loadNonModuleChildProject() throws Exception {
         final LocalProject project = LocalProject
-                .loadWorkspace(workDir.resolve("root").resolve("non-module-child").resolve("target").resolve("classes"));
+                .loadWorkspace(IoUtils
+                        .mkdirs(workDir.resolve("root").resolve("non-module-child").resolve("target").resolve("classes")));
         assertNotNull(project);
         assertNotNull(project.getWorkspace());
         assertEquals("non-module-child", project.getArtifactId());


### PR DESCRIPTION
This change fixes Maven workspace loading during bootstrap when `quarkus.bootstrap.effective-model-builder` is enabled by making sure all the raw POMs of each module are available to the effective model builder resolving effective POMs for each module.
This also seems to make it a tiny bit more efficient.

This change is critical for the upcoming improvements in Quarkus info and update commands.