### PR TITLE
Update MAX_LTS_SUPPORTED_BY_KOTLIN to 21

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/JavaVersion.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/JavaVersion.java
@@ -66,7 +66,7 @@ public final class JavaVersion {
     public static final int DEFAULT_JAVA_VERSION = 11;
     // we want to maximize the compatibility of extensions with the Quarkus ecosystem so let's stick to 11 by default
     public static final String DEFAULT_JAVA_VERSION_FOR_EXTENSION = "11";
-    public static final int MAX_LTS_SUPPORTED_BY_KOTLIN = 17;
+    public static final int MAX_LTS_SUPPORTED_BY_KOTLIN = 21;
     public static final String DETECT_JAVA_RUNTIME_VERSION = "<<detect java runtime version>>";
     public static final Pattern JAVA_VERSION_PATTERN = Pattern.compile("(\\d+)(?:\\..*)?");
 


### PR DESCRIPTION
Kotlin 1.9.20 supports Java 21.