### PR TITLE
Use `--interactive` option when using docker inside Windows' WSL

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
@@ -1,7 +1,7 @@
 
 package io.quarkus.deployment;
 
-import static io.quarkus.runtime.util.ContainerRuntimeUtil.ContainerRuntime.UNAVAILABLE;
+import static io.quarkus.deployment.util.ContainerRuntimeUtil.ContainerRuntime.UNAVAILABLE;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -22,7 +22,7 @@ import java.util.function.Supplier;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.console.StartupLogCompressor;
-import io.quarkus.runtime.util.ContainerRuntimeUtil;
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
 
 public class IsDockerWorking implements BooleanSupplier {
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -5,12 +5,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
-import io.quarkus.runtime.util.ContainerRuntimeUtil;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/AppCDSBuildStep.java
@@ -1,7 +1,7 @@
 package io.quarkus.deployment.pkg.steps;
 
 import static io.quarkus.deployment.pkg.steps.LinuxIDUtil.getLinuxID;
-import static io.quarkus.runtime.util.ContainerRuntimeUtil.detectContainerRuntime;
+import static io.quarkus.deployment.util.ContainerRuntimeUtil.detectContainerRuntime;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,8 +28,8 @@ import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem;
 import io.quarkus.deployment.pkg.builditem.JarBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.steps.MainClassBuildStep;
+import io.quarkus.deployment.util.ContainerRuntimeUtil.ContainerRuntime;
 import io.quarkus.runtime.LaunchMode;
-import io.quarkus.runtime.util.ContainerRuntimeUtil.ContainerRuntime;
 import io.quarkus.utilities.JavaBinFinder;
 
 public class AppCDSBuildStep {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -14,8 +14,8 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.pkg.NativeConfig;
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.deployment.util.ProcessUtil;
-import io.quarkus.runtime.util.ContainerRuntimeUtil;
 
 public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRunner {
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -19,6 +19,9 @@ public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContai
         super(nativeConfig);
         if (SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_MAC) {
             final ArrayList<String> containerRuntimeArgs = new ArrayList<>(Arrays.asList(baseContainerRuntimeArgs));
+            if (containerRuntime.isInWindowsWSL()) {
+                containerRuntimeArgs.add("--interactive");
+            }
             if (containerRuntime.isDocker() && containerRuntime.isRootless()) {
                 Collections.addAll(containerRuntimeArgs, "--user", String.valueOf(0));
             } else {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
@@ -21,9 +21,9 @@ import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageRunnerBuildItem;
 import io.quarkus.deployment.pkg.builditem.UpxCompressedBuildItem;
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.deployment.util.ProcessUtil;
-import io.quarkus.runtime.util.ContainerRuntimeUtil;
 
 public class UpxCompressionBuildStep {
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ContainerRuntimeUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ContainerRuntimeUtil.java
@@ -10,6 +10,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
@@ -27,6 +28,10 @@ public final class ContainerRuntimeUtil {
      * runtime and the container runtime would be detected again and again unnecessarily.
      */
     private static final String CONTAINER_RUNTIME_SYS_PROP = "quarkus-local-container-runtime";
+    /**
+     * Defines the maximum number of characters to read from the output of the `docker info` command.
+     */
+    private static final int MAX_ANTICIPATED_CHARACTERS_IN_DOCKER_INFO = 3000;
 
     private ContainerRuntimeUtil() {
     }
@@ -112,14 +117,69 @@ public final class ContainerRuntimeUtil {
     }
 
     private static ContainerRuntime fullyResolveContainerRuntime(ContainerRuntime containerRuntimeEnvironment) {
-        boolean rootless = getRootlessStateFor(containerRuntimeEnvironment);
+        boolean rootless = false;
+        boolean isInWindowsWSL = false;
+        Process rootlessProcess = null;
+        ProcessBuilder pb = null;
+        try {
+            pb = new ProcessBuilder(containerRuntimeEnvironment.getExecutableName(), "info").redirectErrorStream(true);
+            rootlessProcess = pb.start();
+            int exitCode = rootlessProcess.waitFor();
+            if (exitCode != 0) {
+                log.warnf("Command \"%s\" exited with error code %d. " +
+                        "Rootless container runtime detection might not be reliable or the container service is not running at all.",
+                        String.join(" ", pb.command()), exitCode);
+            }
+            try (InputStream inputStream = rootlessProcess.getInputStream();
+                    InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
+                    BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+                bufferedReader.mark(MAX_ANTICIPATED_CHARACTERS_IN_DOCKER_INFO);
+                if (exitCode != 0) {
+                    log.debugf("Command \"%s\" output: %s", String.join(" ", pb.command()),
+                            bufferedReader.lines().collect(Collectors.joining(System.lineSeparator())));
+                } else {
+                    Predicate<String> stringPredicate;
+                    // Docker includes just "rootless" under SecurityOptions, while podman includes "rootless: <boolean>"
+                    if (containerRuntimeEnvironment.isDocker()) {
+                        // We also treat Docker Desktop as "rootless" since the way it binds mounts does not
+                        // transparently map the host user ID and GID
+                        // see https://docs.docker.com/desktop/faqs/linuxfaqs/#how-do-i-enable-file-sharing
+                        stringPredicate = line -> line.trim().equals("rootless") || line.contains("Docker Desktop")
+                                || line.contains("desktop-linux");
+                    } else {
+                        stringPredicate = line -> line.trim().equals("rootless: true");
+                    }
+                    rootless = bufferedReader.lines().anyMatch(stringPredicate);
 
-        if (!rootless) {
-            return containerRuntimeEnvironment;
+                    if (SystemUtils.IS_OS_LINUX && containerRuntimeEnvironment.isDocker()) {
+                        stringPredicate = line -> line.trim().contains("WSL");
+                        bufferedReader.reset();
+                        isInWindowsWSL = bufferedReader.lines().anyMatch(stringPredicate);
+                    }
+                }
+            }
+        } catch (IOException | InterruptedException e) {
+            // If an exception is thrown in the process, assume we are not running rootless (default docker installation)
+            log.debugf(e, "Failure to read info output from %s", String.join(" ", pb.command()));
+        } finally {
+            if (rootlessProcess != null) {
+                rootlessProcess.destroy();
+            }
         }
 
-        return containerRuntimeEnvironment == ContainerRuntime.DOCKER ? ContainerRuntime.DOCKER_ROOTLESS
-                : ContainerRuntime.PODMAN_ROOTLESS;
+        if (rootless) {
+            if (isInWindowsWSL) {
+                return ContainerRuntime.WSL_ROOTLESS;
+            }
+            return containerRuntimeEnvironment == ContainerRuntime.DOCKER ? ContainerRuntime.DOCKER_ROOTLESS
+                    : ContainerRuntime.PODMAN_ROOTLESS;
+        }
+
+        if (isInWindowsWSL) {
+            return ContainerRuntime.WSL;
+        }
+
+        return containerRuntimeEnvironment;
     }
 
     private static ContainerRuntime loadContainerRuntimeFromSystemProperty() {
@@ -168,57 +228,14 @@ public final class ContainerRuntimeUtil {
         }
     }
 
-    private static boolean getRootlessStateFor(ContainerRuntime containerRuntime) {
-        Process rootlessProcess = null;
-        ProcessBuilder pb = null;
-        try {
-            pb = new ProcessBuilder(containerRuntime.getExecutableName(), "info").redirectErrorStream(true);
-            rootlessProcess = pb.start();
-            int exitCode = rootlessProcess.waitFor();
-            if (exitCode != 0) {
-                log.warnf("Command \"%s\" exited with error code %d. " +
-                        "Rootless container runtime detection might not be reliable or the container service is not running at all.",
-                        String.join(" ", pb.command()), exitCode);
-            }
-            try (InputStream inputStream = rootlessProcess.getInputStream();
-                    InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
-                    BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
-                if (exitCode != 0) {
-                    log.debugf("Command \"%s\" output: %s", String.join(" ", pb.command()),
-                            bufferedReader.lines().collect(Collectors.joining(System.lineSeparator())));
-                    return false;
-                } else {
-                    final Predicate<String> stringPredicate;
-                    // Docker includes just "rootless" under SecurityOptions, while podman includes "rootless: <boolean>"
-                    if (containerRuntime == ContainerRuntime.DOCKER) {
-                        // We also treat Docker Desktop as "rootless" since the way it binds mounts does not
-                        // transparently map the host user ID and GID
-                        // see https://docs.docker.com/desktop/faqs/linuxfaqs/#how-do-i-enable-file-sharing
-                        stringPredicate = line -> line.trim().equals("rootless") || line.contains("Docker Desktop")
-                                || line.contains("desktop-linux");
-                    } else {
-                        stringPredicate = line -> line.trim().equals("rootless: true");
-                    }
-                    return bufferedReader.lines().anyMatch(stringPredicate);
-                }
-            }
-        } catch (IOException | InterruptedException e) {
-            // If an exception is thrown in the process, assume we are not running rootless (default docker installation)
-            log.debugf(e, "Failure to read info output from %s", String.join(" ", pb.command()));
-            return false;
-        } finally {
-            if (rootlessProcess != null) {
-                rootlessProcess.destroy();
-            }
-        }
-    }
-
     /**
      * Supported Container runtimes
      */
     public enum ContainerRuntime {
         DOCKER("docker", false),
         DOCKER_ROOTLESS("docker", true),
+        WSL("docker", false),
+        WSL_ROOTLESS("docker", false),
         PODMAN("podman", false),
         PODMAN_ROOTLESS("podman", true),
         UNAVAILABLE(null, false);
@@ -245,7 +262,11 @@ public final class ContainerRuntimeUtil {
         }
 
         public boolean isPodman() {
-            return this == PODMAN || this == PODMAN_ROOTLESS;
+            return this.executableName.equals("docker");
+        }
+
+        public boolean isInWindowsWSL() {
+            return this == WSL || this == WSL_ROOTLESS;
         }
 
         public boolean isRootless() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ContainerRuntimeUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ContainerRuntimeUtil.java
@@ -1,4 +1,4 @@
-package io.quarkus.runtime.util;
+package io.quarkus.deployment.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/TestNativeConfig.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/TestNativeConfig.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.util.ContainerRuntimeUtil;
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
 
 public class TestNativeConfig implements NativeConfig {
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.TestNativeConfig;
-import io.quarkus.runtime.util.ContainerRuntimeUtil;
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
 
 class NativeImageBuildContainerRunnerTest {
 

--- a/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
+++ b/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
@@ -4,7 +4,7 @@ package io.quarkus.container.image.docker.deployment;
 import static io.quarkus.container.image.deployment.util.EnablementUtil.buildContainerImageNeeded;
 import static io.quarkus.container.image.deployment.util.EnablementUtil.pushContainerImageNeeded;
 import static io.quarkus.container.util.PathsUtil.findMainSourcesRoot;
-import static io.quarkus.runtime.util.ContainerRuntimeUtil.detectContainerRuntime;
+import static io.quarkus.deployment.util.ContainerRuntimeUtil.detectContainerRuntime;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -80,9 +80,9 @@ import io.quarkus.deployment.pkg.builditem.UberJarRequiredBuildItem;
 import io.quarkus.deployment.pkg.builditem.UpxCompressedBuildItem;
 import io.quarkus.deployment.pkg.steps.JarResultBuildStep;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.fs.util.ZipUtils;
 import io.quarkus.maven.dependency.ResolvedDependency;
-import io.quarkus.runtime.util.ContainerRuntimeUtil;
 
 public class JibProcessor {
 

--- a/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
+++ b/extensions/devservices/deployment/src/main/java/io/quarkus/devservices/deployment/DevServicesProcessor.java
@@ -42,9 +42,9 @@ import io.quarkus.deployment.console.ConsoleCommand;
 import io.quarkus.deployment.console.ConsoleStateManager;
 import io.quarkus.deployment.dev.devservices.ContainerInfo;
 import io.quarkus.deployment.dev.devservices.DevServiceDescriptionBuildItem;
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
+import io.quarkus.deployment.util.ContainerRuntimeUtil.ContainerRuntime;
 import io.quarkus.dev.spi.DevModeType;
-import io.quarkus.runtime.util.ContainerRuntimeUtil;
-import io.quarkus.runtime.util.ContainerRuntimeUtil.ContainerRuntime;
 
 public class DevServicesProcessor {
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jboss.logging.Logger;
 
-import io.quarkus.runtime.util.ContainerRuntimeUtil;
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
 import io.smallrye.config.common.utils.StringUtil;
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -1,6 +1,6 @@
 package io.quarkus.test.junit;
 
-import static io.quarkus.runtime.util.ContainerRuntimeUtil.detectContainerRuntime;
+import static io.quarkus.deployment.util.ContainerRuntimeUtil.detectContainerRuntime;
 import static io.quarkus.test.common.PathTestHelper.getAppClassLocationForTestLocation;
 import static io.quarkus.test.common.PathTestHelper.getTestClassesLocation;
 import static java.lang.ProcessBuilder.Redirect.DISCARD;
@@ -49,10 +49,10 @@ import io.quarkus.bootstrap.utils.BuildToolHelper;
 import io.quarkus.bootstrap.workspace.ArtifactSources;
 import io.quarkus.bootstrap.workspace.SourceDir;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.paths.PathList;
 import io.quarkus.runtime.configuration.ProfileManager;
 import io.quarkus.runtime.logging.LoggingSetupRecorder;
-import io.quarkus.runtime.util.ContainerRuntimeUtil;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.LauncherUtil;
 import io.quarkus.test.common.PathTestHelper;


### PR DESCRIPTION
There seems to be an issue with docker printing output when running in Windows' WSL without `--interactive`.

Closes https://github.com/quarkusio/quarkus/issues/37272
Closes https://github.com/quarkusio/quarkus/issues/32215