### PR TITLE
[3.2] Direct patch for the Data source and Logging guide

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -4,14 +4,14 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="datasources"]
-= Configure data sources in Quarkus
+= Configure data sources
 include::_attributes.adoc[]
 :diataxis-type: reference
 :categories: data,getting-started,reactive
 :topics: data,database,datasource,sql,jdbc,reactive
 :extensions: io.quarkus:quarkus-agroal,io.quarkus:quarkus-reactive-mysql-client,io.quarkus:quarkus-reactive-oracle-client,io.quarkus:quarkus-reactive-pg-client,io.quarkus:quarkus-reactive-db2-client,io.quarkus:quarkus-reactive-pg-client,io.quarkus:quarkus-reactive-mssql-client,io.quarkus:quarkus-jdbc-db2,io.quarkus:quarkus-jdbc-derby,io.quarkus:quarkus-jdbc-h2,io.quarkus:quarkus-jdbc-mariadb,io.quarkus:quarkus-jdbc-mssql,io.quarkus:quarkus-jdbc-mysql,io.quarkus:quarkus-jdbc-oracle,io.quarkus:quarkus-jdbc-postgresql
 
-Use a unified configuration model to define data sources for Java Database Connectivity (JDBC) and Reactive drivers.
+Use a unified configuration model to define data sources for Java Database Connectivity (JDBC) and Reactive drivers in Quarkus.
 
 ////
 Note for contributors and writers:
@@ -593,7 +593,7 @@ hostDescription:: `<host>[:<portnumber>] or address=(host=<host>)[(port=<portnum
 
 Example:: `jdbc:mysql://localhost:3306/test`
 
-For more information, see the link:https://dev.mysql.com/doc/connector-j/en/[official documentation].
+For more information, see the link:https://dev.mysql.com/doc/connector-j/en/connector-j-reference-jdbc-url-format.html[official documentation].
 
 ===== MySQL limitations
 

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -9,7 +9,7 @@ include::_attributes.adoc[]
 :categories: core,getting-started,observability
 :diataxis-type: reference
 
-Read about the use of logging API in Quarkus, configuring logging output, and using logging adapters to unify the output from other logging APIs.
+Read about the use of logging APIs in Quarkus, configuring logging output, and using logging adapters for unified output.
 
 Quarkus uses the JBoss Log Manager logging backend for publishing application and framework logs.
 Quarkus supports the JBoss Logging API and multiple other logging APIs, seamlessly integrated with JBoss Log Manager.


### PR DESCRIPTION
Removing the `in Quarkus` part from the `Data source` guide. Asked some SMEs, it is not needed there.
Then, I tweaked slightly the Data source and Logging guide abstracts so that we can perform some RHBQ name postprocesing and they contain the proper grammar and information. 