### PR TITLE
ArC: fix in-application build compatible extensions

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -296,6 +296,11 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-arc-test-supplement</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>

--- a/extensions/arc/deployment/pom.xml
+++ b/extensions/arc/deployment/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-test-supplement</artifactId>
+        </dependency>
         <!-- Used to test wrong @Singleton detection -->
         <dependency>
             <groupId>jakarta.ejb</groupId>

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/cdi/bcextensions/SynthBeanForExternalClass.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/cdi/bcextensions/SynthBeanForExternalClass.java
@@ -1,0 +1,96 @@
+package io.quarkus.arc.test.cdi.bcextensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanDisposer;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.supplement.SomeClassInExternalLibrary;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SynthBeanForExternalClass {
+    // the test includes an _application_ that declares a build compatible extension
+    // (in the Runtime CL), which creates a synthetic bean for a class that is _outside_
+    // of the application (in the Base Runtime CL)
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class, MyExtension.class, MySyntheticBeanCreator.class)
+                    .addAsServiceProvider(BuildCompatibleExtension.class, MyExtension.class))
+            // we need a non-application archive, so cannot use `withAdditionalDependency()`
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-arc-test-supplement", Version.getVersion())));
+
+    @Inject
+    MyBean bean;
+
+    @Test
+    public void test() {
+        assertFalse(MySyntheticBeanCreator.created);
+        assertFalse(MySyntheticBeanDisposer.disposed);
+
+        assertEquals("OK", bean.doSomething());
+        assertTrue(MySyntheticBeanCreator.created);
+        assertTrue(MySyntheticBeanDisposer.disposed);
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+        @Inject
+        Instance<SomeClassInExternalLibrary> someClass;
+
+        public String doSomething() {
+            SomeClassInExternalLibrary instance = someClass.get();
+            instance.toString(); // force instantiating the bean
+            someClass.destroy(instance); // force destroying the instance
+            return "OK";
+        }
+    }
+
+    public static class MyExtension implements BuildCompatibleExtension {
+        @Synthesis
+        public void synthesis(SyntheticComponents syn) {
+            syn.addBean(SomeClassInExternalLibrary.class)
+                    .type(SomeClassInExternalLibrary.class)
+                    .scope(Dependent.class)
+                    .createWith(MySyntheticBeanCreator.class)
+                    .disposeWith(MySyntheticBeanDisposer.class);
+        }
+    }
+
+    public static class MySyntheticBeanCreator implements SyntheticBeanCreator<SomeClassInExternalLibrary> {
+        public static boolean created;
+
+        public SomeClassInExternalLibrary create(Instance<Object> lookup, Parameters params) {
+            SomeClassInExternalLibrary result = new SomeClassInExternalLibrary();
+            created = true;
+            return result;
+        }
+    }
+
+    public static class MySyntheticBeanDisposer implements SyntheticBeanDisposer<SomeClassInExternalLibrary> {
+        public static boolean disposed;
+
+        @Override
+        public void dispose(SomeClassInExternalLibrary instance, Instance<Object> lookup, Parameters params) {
+            disposed = true;
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/cdi/bcextensions/SynthObserverAsIfInExternalClass.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/cdi/bcextensions/SynthObserverAsIfInExternalClass.java
@@ -1,0 +1,79 @@
+package io.quarkus.arc.test.cdi.bcextensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticObserver;
+import jakarta.enterprise.inject.spi.EventContext;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.supplement.SomeClassInExternalLibrary;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SynthObserverAsIfInExternalClass {
+    // the test includes an _application_ that declares a build compatible extension
+    // (in the Runtime CL), which creates a synthetic observer which is "as if" declared
+    // in a class that is _outside_ of the application (in the Base Runtime CL)
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyBean.class, MyExtension.class, MySyntheticObserver.class)
+                    .addAsServiceProvider(BuildCompatibleExtension.class, MyExtension.class))
+            // we need a non-application archive, so cannot use `withAdditionalDependency()`
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-arc-test-supplement", Version.getVersion())));
+
+    @Inject
+    MyBean bean;
+
+    @Test
+    public void test() {
+        assertFalse(MySyntheticObserver.notified);
+
+        assertEquals("OK", bean.doSomething());
+        assertTrue(MySyntheticObserver.notified);
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+        @Inject
+        Event<String> event;
+
+        public String doSomething() {
+            event.fire(""); // force notifying the observer
+            return "OK";
+        }
+    }
+
+    public static class MyExtension implements BuildCompatibleExtension {
+        @Synthesis
+        public void synthesis(SyntheticComponents syn) {
+            syn.addObserver(String.class)
+                    .declaringClass(SomeClassInExternalLibrary.class)
+                    .observeWith(MySyntheticObserver.class);
+        }
+    }
+
+    public static class MySyntheticObserver implements SyntheticObserver<String> {
+        public static boolean notified;
+
+        @Override
+        public void observe(EventContext<String> event, Parameters params) {
+            notified = true;
+        }
+    }
+}

--- a/extensions/arc/test-supplement/pom.xml
+++ b/extensions/arc/test-supplement/pom.xml
@@ -3,20 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-extensions-parent</artifactId>
+        <artifactId>quarkus-arc-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-arc-parent</artifactId>
-    <name>Quarkus - ArC</name>
-    <packaging>pom</packaging>
-    <modules>
-        <module>deployment</module>
-        <module>runtime</module>
-        <module>test-supplement</module>
-    </modules>
+    <artifactId>quarkus-arc-test-supplement</artifactId>
+    <name>Quarkus - ArC - Test Supplement</name>
+    <description>Supplement archive for ArC tests</description>
 
 </project>

--- a/extensions/arc/test-supplement/src/main/java/io/quarkus/arc/test/supplement/SomeClassInExternalLibrary.java
+++ b/extensions/arc/test-supplement/src/main/java/io/quarkus/arc/test/supplement/SomeClassInExternalLibrary.java
@@ -1,0 +1,4 @@
+package io.quarkus.arc.test.supplement;
+
+public class SomeClassInExternalLibrary {
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DecoratorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DecoratorGenerator.java
@@ -83,7 +83,8 @@ public class DecoratorGenerator extends BeanGenerator {
             return Collections.emptyList();
         }
 
-        boolean isApplicationClass = applicationClassPredicate.test(decorator.getBeanClass());
+        boolean isApplicationClass = applicationClassPredicate.test(decorator.getBeanClass())
+                || decorator.isForceApplicationClass();
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
                 name -> name.equals(generatedName) ? SpecialType.DECORATOR_BEAN : null, generateSources);
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
@@ -108,7 +108,7 @@ public class InterceptorGenerator extends BeanGenerator {
             return Collections.emptyList();
         }
 
-        boolean isApplicationClass = applicationClassPredicate.test(creatorClassName);
+        boolean isApplicationClass = applicationClassPredicate.test(creatorClassName) || interceptor.isForceApplicationClass();
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
                 name -> name.equals(generatedName) ? SpecialType.INTERCEPTOR_BEAN : null, generateSources);
 
@@ -168,7 +168,8 @@ public class InterceptorGenerator extends BeanGenerator {
             return Collections.emptyList();
         }
 
-        boolean isApplicationClass = applicationClassPredicate.test(interceptor.getBeanClass());
+        boolean isApplicationClass = applicationClassPredicate.test(interceptor.getBeanClass())
+                || interceptor.isForceApplicationClass();
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
                 name -> name.equals(generatedName) ? SpecialType.INTERCEPTOR_BEAN : null, generateSources);
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverConfigurator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverConfigurator.java
@@ -35,6 +35,7 @@ public final class ObserverConfigurator extends ConfiguratorBase<ObserverConfigu
     boolean isAsync;
     TransactionPhase transactionPhase;
     Consumer<MethodCreator> notifyConsumer;
+    boolean forceApplicationClass;
 
     public ObserverConfigurator(Consumer<ObserverConfigurator> consumer) {
         this.consumer = consumer;
@@ -115,6 +116,15 @@ public final class ObserverConfigurator extends ConfiguratorBase<ObserverConfigu
 
     public ObserverConfigurator notify(Consumer<MethodCreator> notifyConsumer) {
         this.notifyConsumer = notifyConsumer;
+        return this;
+    }
+
+    /**
+     * Forces the observer to be considered an 'application class', so it will be defined in the runtime
+     * ClassLoader and re-created on each redeployment.
+     */
+    public ObserverConfigurator forceApplicationClass() {
+        this.forceApplicationClass = true;
         return this;
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -181,7 +181,8 @@ public class ObserverGenerator extends AbstractGenerator {
             return Collections.emptyList();
         }
 
-        boolean isApplicationClass = applicationClassPredicate.test(observer.getBeanClass());
+        boolean isApplicationClass = applicationClassPredicate.test(observer.getBeanClass())
+                || observer.isForceApplicationClass();
         ResourceClassOutput classOutput = new ResourceClassOutput(isApplicationClass,
                 name -> name.equals(generatedName) ? SpecialType.OBSERVER : null, generateSources);
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
@@ -87,7 +87,7 @@ public class ObserverInfo implements InjectionTargetInfo {
                 initQualifiers(beanDeployment, observerMethod, eventParameter),
                 reception,
                 initTransactionPhase(isAsync, beanDeployment, observerMethod), isAsync, priority, transformers,
-                buildContext, jtaCapabilities, null, Collections.emptyMap());
+                buildContext, jtaCapabilities, null, Collections.emptyMap(), false);
     }
 
     static ObserverInfo create(String id, BeanDeployment beanDeployment, DotName beanClass, BeanInfo declaringBean,
@@ -95,7 +95,7 @@ public class ObserverInfo implements InjectionTargetInfo {
             MethodParameterInfo eventParameter, Type observedType, Set<AnnotationInstance> qualifiers, Reception reception,
             TransactionPhase transactionPhase, boolean isAsync, int priority,
             List<ObserverTransformer> transformers, BuildContext buildContext, boolean jtaCapabilities,
-            Consumer<MethodCreator> notify, Map<String, Object> params) {
+            Consumer<MethodCreator> notify, Map<String, Object> params, boolean forceApplicationClass) {
 
         if (!transformers.isEmpty()) {
             // Transform attributes if needed
@@ -141,7 +141,8 @@ public class ObserverInfo implements InjectionTargetInfo {
                     info, transactionPhase);
         }
         return new ObserverInfo(id, beanDeployment, beanClass, declaringBean, observerMethod, injection, eventParameter,
-                isAsync, priority, reception, transactionPhase, observedType, qualifiers, notify, params);
+                isAsync, priority, reception, transactionPhase, observedType, qualifiers, notify, params,
+                forceApplicationClass);
     }
 
     private final String id;
@@ -178,11 +179,15 @@ public class ObserverInfo implements InjectionTargetInfo {
 
     private final Map<String, Object> params;
 
-    ObserverInfo(String id, BeanDeployment beanDeployment, DotName beanClass, BeanInfo declaringBean, MethodInfo observerMethod,
+    private final boolean forceApplicationClass;
+
+    private ObserverInfo(String id, BeanDeployment beanDeployment, DotName beanClass, BeanInfo declaringBean,
+            MethodInfo observerMethod,
             Injection injection,
             MethodParameterInfo eventParameter,
             boolean isAsync, int priority, Reception reception, TransactionPhase transactionPhase,
-            Type observedType, Set<AnnotationInstance> qualifiers, Consumer<MethodCreator> notify, Map<String, Object> params) {
+            Type observedType, Set<AnnotationInstance> qualifiers, Consumer<MethodCreator> notify,
+            Map<String, Object> params, boolean forceApplicationClass) {
         this.id = id;
         this.beanDeployment = beanDeployment;
         this.beanClass = beanClass;
@@ -199,6 +204,7 @@ public class ObserverInfo implements InjectionTargetInfo {
         this.qualifiers = qualifiers;
         this.notify = notify;
         this.params = params;
+        this.forceApplicationClass = forceApplicationClass;
     }
 
     @Override
@@ -295,6 +301,10 @@ public class ObserverInfo implements InjectionTargetInfo {
 
     Map<String, Object> getParams() {
         return params;
+    }
+
+    boolean isForceApplicationClass() {
+        return forceApplicationClass;
     }
 
     void init(List<Throwable> errors) {


### PR DESCRIPTION
In case the _application_ contains a build compatible extension that registers a synthetic bean for a _non-application_ class, or a synthetic observer declared "as if" in a _non-application_ class, the generated classes must be forced to also be application classes. If the generated classes were non-application classes (as they were prior to this commit), they would not see the creator/disposer/observer classes in Quarkus dev mode and test mode (where application classes are in a different class loader than non-application classes).

Before this commit, it has already been possible to force ArC to generate synthetic bean classes as application classes, but this was not possible for synthetic observers. This commit adds that, too.

Fixes #37337