### PR TITLE
Fixed testRegistryClientJsonConfig by comparing maps

### DIFF
--- a/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/config/DevToolsConfigSerializationTest.java
+++ b/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/config/DevToolsConfigSerializationTest.java
@@ -13,9 +13,12 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.maven.dependency.ArtifactCoords;
 
@@ -345,8 +348,11 @@ public class DevToolsConfigSerializationTest {
 
         String expectedContents = Files.readString(expectedFile);
         String actualContents = Files.readString(actualFile);
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> expectedContentsMap = objectMapper.readValue(expectedContents, Map.class);
+        Map<String, Object> actualContentsMap = objectMapper.readValue(actualContents, Map.class);
 
-        assertThat(actualContents).isEqualTo(expectedContents);
+        assertThat(actualContentsMap).isEqualTo(expectedContentsMap);
     }
 
     @Test


### PR DESCRIPTION
Created this PR to fix 1 flaky test - [testRegistryClientJsonConfig](https://github.com/quarkusio/quarkus/blob/main/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/config/DevToolsConfigSerializationTest.java#L324)
--------------
1. **How were these test identified as flaky?**
This test was identified as flaky by using an open-source research tool named [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is responsible for finding and diagnosing non-deterministic runtime exceptions in Java programs.

2. **What was the error?**
The test reads from files and stores it in String format in `expectedContents` and `actualContents` variables. By the time, the value is stored in these string variables, the order of keys may get shuffled i.e the order of keys is non-deterministic. Thus, when we compare this String variables expectedContents and actualContents, it may fail sometimes because the order of keys could be different in the string representation. One of the error logs has been pasted below where you can see that the keys "disabled" and "artifact" have got shuffled. 
```
[ERROR] Failures: 
[ERROR]   DevToolsConfigSerializationTest.testRegistryClientJsonConfig:349 
expected: 
  "{
    "descriptor" : {
      "artifact" : "registry.quarkus.test:quarkus-registry-descriptor::json:1.0-SNAPSHOT"
    },
    "platforms" : {
      "artifact" : "registry.quarkus.test:quarkus-platforms::json:1.0-SNAPSHOT",
      "extension-catalogs-included" : true
    },
    "non-platform-extensions" : {
      "disabled" : true,
      "artifact" : "registry.quarkus.test:quarkus-non-platform-extensions::json:1.0-SNAPSHOT"
    }
  }"
 but was: 
  "{
    "descriptor" : {
      "artifact" : "registry.quarkus.test:quarkus-registry-descriptor::json:1.0-SNAPSHOT"
    },
    "platforms" : {
      "artifact" : "registry.quarkus.test:quarkus-platforms::json:1.0-SNAPSHOT",
      "extension-catalogs-included" : true
    },
    "non-platform-extensions" : {
      "artifact" : "registry.quarkus.test:quarkus-non-platform-extensions::json:1.0-SNAPSHOT",
      "disabled" : true
    }
  }"

```
3. **What is the fix?**
Instead of comparing json strings, we can convert json strings to Map and then compare the maps. This PR proposes to compare Maps instead of json strings in the test. 

--------------
You can run the following commands to run the test using NonDex tool:
```
mvn -pl independent-projects/tools/registry-client edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=io.quarkus.registry.config.DevToolsConfigSerializationTest#testRegistryClientJsonConfig
```

Test Environment:
```
java version 11.0.19
Apache Maven 3.9.5
```
Kindly let me know if this fix is acceptable.
Thank you