### PR TITLE
Stop removing `org.graalvm.polyglot:polyglot` artifact from native classpath

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -1011,7 +1011,6 @@ public class JarResultBuildStep {
             removedArtifacts.add("org.graalvm.sdk:nativeimage");
             removedArtifacts.add("org.graalvm.sdk:word");
             removedArtifacts.add("org.graalvm.sdk:collections");
-            removedArtifacts.add("org.graalvm.polyglot:polyglot");
 
             doLegacyThinJarGeneration(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses,
                     applicationArchivesBuildItem, applicationInfo, packageConfig, generatedResources, libDir, allClasses,


### PR DESCRIPTION
When https://github.com/quarkusio/quarkus/pull/35873 was merged
`org.graalvm.polyglot:polyglot` was part of the GraalVM dev
builds/releases, but was later completely removed from them.
