### PR TITLE
Fix typo configMapRefKey -> configMapKeyRef

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -506,7 +506,7 @@ This would generate the following in the `env` section of your container:
 - env:
   - name: FOO
     valueFrom:
-      configMapRefKey:
+      configMapKeyRef:
         key: keyName
         name: my-configmap
         optional: false

--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -367,7 +367,7 @@ This would generate the following in the `env` section of your container:
 - env:
   - name: FOO
     valueFrom:
-      configMapRefKey:
+      configMapKeyRef:
         key: keyName
         name: my-configmap
         optional: false


### PR DESCRIPTION
The guides Deploying on OpenShift and Kubernetes Extension both contain an error in the example for creating environment variables from config maps. It needs to be ```configMapKeyRef``` and not ```configMapRefKey```

Documentation : https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#define-container-environment-variables-using-configmap-data