### PR TITLE
Build cache - Include the native executable -runner in failsafe input

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -115,6 +115,23 @@
                                         </fileSets>
                                     </inputs>
                                 </plugin>
+                                <plugin>
+                                    <artifactId>maven-failsafe-plugin</artifactId>
+                                    <inputs>
+                                        <fileSets combine.children="append">
+                                            <fileSet>
+                                                <name>native-runner</name>
+                                                <paths>
+                                                    <path>${project.build.directory}</path>
+                                                </paths>
+                                                <includes>
+                                                    <include>*-runner</include>
+                                                </includes>
+                                                <normalization>RELATIVE_PATH</normalization>
+                                            </fileSet>
+                                        </fileSets>
+                                    </inputs>
+                                </plugin>
                             </plugins>
                         </gradleEnterprise>
                     </configuration>


### PR DESCRIPTION
@jprinet could you check that it makes sense?

I want to include for instance `target/quarkus-integration-test-hibernate-validator-999-SNAPSHOT-runner` in the failsafe run of the HV IT module.