### PR TITLE
Add Content-Range header to 206 Partial Content file response

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/providers/FileTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/providers/FileTestCase.java
@@ -45,17 +45,37 @@ public class FileTestCase {
                 .then()
                 .statusCode(206)
                 .header(HttpHeaders.CONTENT_LENGTH, "10")
+                .header("Content-Range", "bytes 0-9/" + contentLength)
                 .body(Matchers.equalTo(content.substring(0, 10)));
         RestAssured.given().header("Range", "bytes=10-19").get("/providers/file/file")
                 .then()
                 .statusCode(206)
                 .header(HttpHeaders.CONTENT_LENGTH, "10")
+                .header("Content-Range", "bytes 10-19/" + contentLength)
                 .body(Matchers.equalTo(content.substring(10, 20)));
         RestAssured.given().header("Range", "bytes=10-").get("/providers/file/file")
                 .then()
                 .statusCode(206)
                 .header(HttpHeaders.CONTENT_LENGTH, String.valueOf(content.length() - 10))
+                .header("Content-Range", "bytes 10-" + (content.length() - 1) + "/" + contentLength)
                 .body(Matchers.equalTo(content.substring(10)));
+        RestAssured.given().header("Range", "bytes=-10").get("/providers/file/file")
+                .then()
+                .statusCode(206)
+                .header(HttpHeaders.CONTENT_LENGTH, "10")
+                .header("Content-Range",
+                        "bytes " + (content.length() - 10) + "-" + (content.length() - 1) + "/" + contentLength)
+                .body(Matchers.equalTo(content.substring((content.length() - 10))));
+        RestAssured.given().header("Range", "bytes=" + (content.length() + 1) + "-").get("/providers/file/file")
+                .then()
+                .statusCode(200)
+                .header(HttpHeaders.CONTENT_LENGTH, contentLength)
+                .body(Matchers.equalTo(content));
+        RestAssured.given().header("Range", "bytes=0-1, 3-4").get("/providers/file/file")
+                .then()
+                .statusCode(200)
+                .header(HttpHeaders.CONTENT_LENGTH, contentLength)
+                .body(Matchers.equalTo(content));
         RestAssured.get("/providers/file/file-partial")
                 .then()
                 .statusCode(200)


### PR DESCRIPTION
This is a bug fix for #37205 / #37213, adding the required "Content-Range" header when returning a 206 Partial Content.
Also added support for suffix range.
Defaults to 200 with full content if starting range is out of bounds, or if multiple ranges are supplied.

Note: did not find the "Content-Range" header as a constant anywhere.

CC original author and reviewer: @geoand, @stuartwdouglas 