### PR TITLE
Config: detect injected config value mismatch for missing values

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/staticinit/StaticInitConfigInjectionMissingValueFailureTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/config/staticinit/StaticInitConfigInjectionMissingValueFailureTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.arc.test.config.staticinit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class StaticInitConfigInjectionMissingValueFailureTest {
+
+    static final String PROPERTY_NAME = "static.init.missing.apfelstrudel";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(StaticInitBean.class))
+            .assertException(t -> {
+                assertThat(t).isInstanceOf(IllegalStateException.class)
+                        .hasMessageContainingAll(
+                                "A runtime config property value differs from the value that was injected during the static intialization phase",
+                                "the runtime value of '" + PROPERTY_NAME
+                                        + "' is [gizmo] but the value [null] was injected into io.quarkus.arc.test.config.staticinit.StaticInitConfigInjectionMissingValueFailureTest$StaticInitBean#value");
+            });
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    @Singleton
+    public static class StaticInitBean {
+
+        @ConfigProperty(name = PROPERTY_NAME)
+        Optional<String> value;
+
+        // bean is instantiated during STATIC_INIT
+        void onInit(@Observes @Initialized(ApplicationScoped.class) Object event) {
+            System.setProperty(PROPERTY_NAME, "gizmo");
+        }
+
+    }
+
+    @AfterAll
+    static void afterAll() {
+        System.clearProperty(PROPERTY_NAME);
+    }
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigStaticInitCheckInterceptor.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigStaticInitCheckInterceptor.java
@@ -69,8 +69,7 @@ public class ConfigStaticInitCheckInterceptor {
             value = getDefaultValue(injectionPoint, configProperty);
         }
         if (value == null) {
-            LOG.debugf("No config value found for %s", propertyName);
-            return;
+            LOG.debugf("No config value found for %s - recording <null> value", propertyName);
         }
         if (configValues == null) {
             configValues = Arc.container().instance(ConfigStaticInitValues.class).get();

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigStaticInitValues.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ConfigStaticInitValues.java
@@ -3,6 +3,7 @@ package io.quarkus.arc.runtime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.event.Observes;
@@ -43,7 +44,9 @@ public class ConfigStaticInitValues {
         List<String> mismatches = new ArrayList<>();
         for (InjectedValue injectedValue : injectedValues) {
             ConfigValue currentValue = config.getConfigValue(injectedValue.name);
-            if (currentValue.getValue() != null && !injectedValue.value.equals(currentValue.getValue())) {
+            if (currentValue.getValue() != null
+                    && !Objects.equals(currentValue.getValue(), injectedValue.value)) {
+                // Config property is set at runtime and the value differs from the value injected during STATIC_INIT bootstrap phase
                 mismatches.add(
                         " - the runtime value of '" + injectedValue.name + "' is [" + currentValue.getValue()
                                 + "] but the value [" + injectedValue.value


### PR DESCRIPTION
- resolves #37444
- follow-up of https://github.com/quarkusio/quarkus/pull/36281