### PR TITLE
Core: ignore attempts to on-demand index primitive types and arrays

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/index/IndexWrapper.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/IndexWrapper.java
@@ -26,14 +26,22 @@ import org.jboss.jandex.ModuleInfo;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
-import io.quarkus.deployment.steps.CombinedIndexBuildStep;
-
 /**
  * This wrapper is used to index JDK classes on demand.
  */
 public class IndexWrapper implements IndexView {
 
-    private static final Logger LOGGER = Logger.getLogger(CombinedIndexBuildStep.class);
+    private static final Logger LOGGER = Logger.getLogger(IndexWrapper.class);
+
+    private static final Set<String> PRIMITIVE_TYPES = Set.of(
+            "boolean",
+            "byte",
+            "short",
+            "int",
+            "long",
+            "float",
+            "double",
+            "char");
 
     private final IndexView index;
     private final ClassLoader deploymentClassLoader;
@@ -300,6 +308,10 @@ public class IndexWrapper implements IndexView {
 
     static boolean index(Indexer indexer, String className, ClassLoader classLoader) {
         boolean result = false;
+        if (PRIMITIVE_TYPES.contains(className) || className.startsWith("[")) {
+            // Ignore primitives and arrays
+            return false;
+        }
         try (InputStream stream = classLoader
                 .getResourceAsStream(className.replace('.', '/') + ".class")) {
             if (stream != null) {


### PR DESCRIPTION
This is to avoid a warning log message in cases that cannot possibly succeed; there are no class files for primitive types and arrays.

Also fix the logger name in `IndexWrapper`.

Fixes #37452