### PR TITLE
Dependency fixes for Hibernate extensions

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -98,7 +98,7 @@
         <classmate.version>1.5.1</classmate.version>
         <!-- WARNING: When updating, also align other properties on this version:
              bytebuddy.version (just below), hibernate-orm.version-for-documentation (in docs/pom.xml)
-             and antlr.version.version in build-parent/pom.xml
+             and both hibernate-orm.version and antlr.version in build-parent/pom.xml
              WARNING again for diffs that don't provide enough context: when updating, see above -->
         <hibernate-orm.version>6.4.0.Final</hibernate-orm.version>
         <bytebuddy.version>1.14.7</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5010,8 +5010,9 @@
                 <artifactId>hibernate-core</artifactId>
                 <version>${hibernate-orm.version}</version>
                 <exclusions>
+                    <!-- We don't want Jandex at runtime -->
                     <exclusion>
-                        <groupId>org.jboss</groupId>
+                        <groupId>io.smallrye</groupId>
                         <artifactId>jandex</artifactId>
                     </exclusion>
                 </exclusions>
@@ -5075,10 +5076,6 @@
                 <exclusions>
                     <!-- We don't want Jandex at runtime -->
                     <exclusion>
-                        <groupId>org.jboss</groupId>
-                        <artifactId>jandex</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>io.smallrye</groupId>
                         <artifactId>jandex</artifactId>
                     </exclusion>
@@ -5091,10 +5088,6 @@
                 <exclusions>
                     <!-- We don't want Jandex at runtime -->
                     <exclusion>
-                        <groupId>org.jboss</groupId>
-                        <artifactId>jandex</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>io.smallrye</groupId>
                         <artifactId>jandex</artifactId>
                     </exclusion>
@@ -5106,10 +5099,6 @@
                 <version>${hibernate-search.version}</version>
                 <exclusions>
                     <!-- We don't want Jandex at runtime -->
-                    <exclusion>
-                        <groupId>org.jboss</groupId>
-                        <artifactId>jandex</artifactId>
-                    </exclusion>
                     <exclusion>
                         <groupId>io.smallrye</groupId>
                         <artifactId>jandex</artifactId>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -71,6 +71,9 @@
 
         <!-- MicroProfile TCK versions used to be defined here but have moved to the concrete tck modules -->
 
+        <!-- Panache needs to run the hibernate-jpamodelgen annotation processor,
+             and unfortunately annotation processors are not covered by dependency management -->
+        <hibernate-orm.version>6.4.0.Final</hibernate-orm.version>
         <!-- Antlr 4 is used by the PanacheQL parser but also needs to match the requirements of Hibernate ORM 6.x-->
         <antlr.version>4.13.0</antlr.version>
 

--- a/extensions/hibernate-envers/runtime/pom.xml
+++ b/extensions/hibernate-envers/runtime/pom.xml
@@ -18,20 +18,6 @@
         <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-envers</artifactId>
-            <!-- We need to repeat the same exclusions applied on hibernate-core -->
-            <exclusions>
-                <!-- These XML parsers are banned in the project as we use the new package -->
-                <exclusion>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>jaxb-runtime</artifactId>
-                </exclusion>
-
-                <!-- Following dependencies are only necessary during metadata initialization -->
-                <exclusion>
-                    <groupId>jakarta.activation</groupId>
-                    <artifactId>jakarta.activation-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/hibernate-orm/runtime/pom.xml
+++ b/extensions/hibernate-orm/runtime/pom.xml
@@ -59,20 +59,6 @@
         <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>jaxb-runtime</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.activation</groupId>
-                    <artifactId>jakarta.activation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.smallrye</groupId>
-                    <artifactId>jandex</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- ByteBuddy is marked as a "runtime" dependency of Hibernate ORM but we need it to compile the extension -->
         <dependency>
@@ -102,12 +88,6 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.xml.bind</groupId>
-                    <artifactId>jakarta.xml.bind-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/pom.xml
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/pom.xml
@@ -32,12 +32,6 @@
         <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-mapper-orm</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.activation</groupId>
-                    <artifactId>jakarta.activation-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
@@ -74,17 +74,6 @@
             <artifactId>quarkus-panache-common-deployment</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-jpamodelgen</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <!-- Workaround for https://hibernate.atlassian.net/browse/HHH-17362 -->
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -117,6 +106,13 @@
                             <goal>kapt</goal>
                         </goals>
                         <configuration>
+                            <annotationProcessorPaths>
+                                <annotationProcessorPath>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-jpamodelgen</artifactId>
+                                    <version>${hibernate-orm.version}</version>
+                                </annotationProcessorPath>
+                            </annotationProcessorPaths>
                             <annotationProcessors>
                                 <annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
                             </annotationProcessors>

--- a/extensions/panache/hibernate-orm-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/runtime/pom.xml
@@ -49,25 +49,12 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-jpamodelgen</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <!-- Workaround for https://hibernate.atlassian.net/browse/HHH-17362 -->
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Explicitly provide banned dependencies, in the correct version -->
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.eclipse.angus</groupId>
             <artifactId>angus-activation</artifactId>
@@ -80,6 +67,13 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <annotationProcessorPaths>
+                        <annotationProcessorPath>
+                            <groupId>org.hibernate.orm</groupId>
+                            <artifactId>hibernate-jpamodelgen</artifactId>
+                            <version>${hibernate-orm.version}</version>
+                        </annotationProcessorPath>
+                    </annotationProcessorPaths>
                     <annotationProcessors>
                         <annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
                     </annotationProcessors>

--- a/extensions/panache/hibernate-orm-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/runtime/pom.xml
@@ -48,18 +48,6 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <!-- Explicitly provide banned dependencies, in the correct version -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>angus-activation</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/pom.xml
@@ -75,13 +75,9 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Explicitly provide banned dependencies, in the correct version -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
+        <!-- Necessary runtime dependency of jpamodelgen,
+             which needs to be imported explicitly
+             otherwise it's not available during annotation processing -->
         <dependency>
             <groupId>org.eclipse.angus</groupId>
             <artifactId>angus-activation</artifactId>

--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/pom.xml
@@ -70,17 +70,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-jpamodelgen</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <!-- Workaround for https://hibernate.atlassian.net/browse/HHH-17362 -->
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-panache-common-deployment</artifactId>
             <scope>test</scope>
@@ -130,6 +119,13 @@
                             <goal>kapt</goal>
                         </goals>
                         <configuration>
+                            <annotationProcessorPaths>
+                                <annotationProcessorPath>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-jpamodelgen</artifactId>
+                                    <version>${hibernate-orm.version}</version>
+                                </annotationProcessorPath>
+                            </annotationProcessorPaths>
                             <annotationProcessors>
                                 <annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
                             </annotationProcessors>

--- a/extensions/panache/hibernate-reactive-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/runtime/pom.xml
@@ -52,18 +52,6 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <!-- Explicitly provide banned dependencies, in the correct version -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>angus-activation</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/panache/hibernate-reactive-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/runtime/pom.xml
@@ -53,25 +53,12 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-jpamodelgen</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <!-- Workaround for https://hibernate.atlassian.net/browse/HHH-17362 -->
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Explicitly provide banned dependencies, in the correct version -->
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.eclipse.angus</groupId>
             <artifactId>angus-activation</artifactId>
@@ -84,6 +71,13 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <annotationProcessorPaths>
+                        <annotationProcessorPath>
+                            <groupId>org.hibernate.orm</groupId>
+                            <artifactId>hibernate-jpamodelgen</artifactId>
+                            <version>${hibernate-orm.version}</version>
+                        </annotationProcessorPath>
+                    </annotationProcessorPaths>
                     <annotationProcessors>
                         <annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
                     </annotationProcessors>


### PR DESCRIPTION
The first item will likely require that we open an issue, because critically, it means Quarkus users can't rely on the BOM to apply, since the BOM doesn't manage Maven's `<annotationProcessorPaths>` and `hibernate-orm.version` doesn't get propagated to POMs using our BOM.

Not sure about changes in the second commit, but let's CI what CI has to say.

1. Properly apply annotation processors in Panache-Hibernate extensions

    Unfortunately, HHH-17362 doesn't fix the problem,
    and it's unlikely that it will ever be fixed.
    See https://hibernate.atlassian.net/browse/HHH-17362?focusedCommentId=113465
    
    We'll have to apply annotation processors the "right" way, as explained
    in https://github.com/hibernate/hibernate-orm/blob/6.3/migration-guide.adoc

2. Fix some wonky dependency exclusions in Hibernate ORM/Reactive/Search extensions
   1. It makes no sense to exclude a transitive dependency if its version
   is managed and we re-declare that dependency ourselves two lines
   below.
   2. jakarta.xml.bind-api and jakarta.activation-api are not banned at
   all, are actually transitive dependencies of hibernate-core and
   hibernate-jpamodelgen, and have their version managed in our BOM.
   So there's no need to exclude these transitive dependencies
   or to declare them when we don't use them directly.
   3. jakarta.activation-api is a dependency of jakarta.xml.bind-api,
   so there's no point excluding jakarta.activation-api if the same
   module is going to depend on jakarta.xml.bind-api.
   4. org.jboss:jandex (old artifact) is no longer a dependency of Hibernate ORM,
   so we don't need to exclude it.
   5. io.smallrye:jandex (new artifact) is never required as a runtime dependency
   of Hibernate ORM, so it should be excluded directly in the BOM.