### PR TITLE
Revert "Unlist quarkus-resteasy-qute and quarkus-resteasy-reactive-qute"

### DIFF
--- a/extensions/resteasy-classic/resteasy-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -2,7 +2,6 @@
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 name: "RESTEasy Classic Qute"
 metadata:
-  unlisted: true
   keywords:
   - "templating"
   - "templates"

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,7 +1,6 @@
 name: "RESTEasy Reactive Qute"
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
-  unlisted: true
   keywords:
     - "templating"
     - "templates"


### PR DESCRIPTION
This reverts commit 5e8e7e6db2b9707b33a401a450acc0fa75712b3f.

This has been done too fast:
- we haven't documented it at all
- there are still references to these extensions in our documentation (https://quarkus.io/guides/qute-reference#resteasy_integration) and people can't find the extensions anymore (see https://github.com/quarkusio/quarkus/issues/37478)

We need to finalize the documentation before actually unlisting these extensions.
I would advise to target 3.7 for that.

Fixes https://github.com/quarkusio/quarkus/issues/37478