### PR TITLE
Adds Kotlin language tab for AWS-Lambda documentation

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -3120,7 +3120,7 @@
                             <skip>${skipDocs}</skip>
                             <backend>html5</backend>
                             <attributes>
-                                <source-highlighter>coderay</source-highlighter>
+                                <source-highlighter>rouge</source-highlighter>
                                 <!-- avoid content security policy violations -->
                                 <linkcss>true</linkcss>
                                 <copycss>true</copycss>
@@ -3252,7 +3252,7 @@
                                     <skip>${skipDocs}</skip>
                                     <backend>pdf</backend>
                                     <outputDirectory>${project.build.directory}/generated-docs-pdf</outputDirectory>
-                                    <sourceHighlighter>coderay</sourceHighlighter>
+                                    <sourceHighlighter>rouge</sourceHighlighter>
                                     <attributes>
                                         <pdf-stylesdir>${basedir}/src/main/resources/theme</pdf-stylesdir>
                                         <pdf-style>quarkus</pdf-style>

--- a/docs/src/main/asciidoc/aws-lambda.adoc
+++ b/docs/src/main/asciidoc/aws-lambda.adoc
@@ -87,7 +87,8 @@ with an environment variable too.
 
 If you look at the three generated handler classes in the project, you'll see that they are `@Named` differently.
 
-[source,java,subs=attributes+]
+[source,java,subs=attributes+,role="primary"]
+.Java
 ----
 @Named("test")
 public class TestLambda implements RequestHandler<InputObject, OutputObject> {
@@ -100,6 +101,19 @@ public class UnusedLambda implements RequestHandler<InputObject, OutputObject> {
 @Named("stream")
 public class StreamLambda implements RequestStreamHandler {
 }
+----
+
+[source,kotlin,subs=attributes+,role="secondary"]
+.Kotlin
+----
+@Named("test")
+class TestLambda : RequestHandler<InputObject, OutputObject> {}
+
+@Named("unused")
+class UnusedLambda : RequestHandler<InputObject, OutputObject> {}
+
+@Named("stream")
+class StreamLambda : RequestStreamHandler {}
 ----
 
 The CDI name of the handler class must match the value specified within the `quarkus.lambda.handler` property.
@@ -321,7 +335,8 @@ The default port for Rest Assured is automatically set to 8081 by Quarkus, so yo
 on this endpoint.
 
 
-[source,java]
+[source,java,role="primary"]
+.Java
 ----
 import org.junit.jupiter.api.Test;
 
@@ -347,6 +362,35 @@ public class LambdaHandlerTest {
                 .statusCode(200)
                 .body(containsString("Hello Stu"));
     }
+}
+----
+
+[source,kotlin,role="secondary"]
+.Kotlin
+----
+import org.junit.jupiter.api.Test
+
+import io.quarkus.test.junit.QuarkusTest
+
+import static io.restassured.RestAssured.given
+import static org.hamcrest.CoreMatchers.containsString
+
+
+@QuarkusTest
+class LambdaHandlerTest {
+
+    @Test
+    @Throws(Exception::class)
+    fun testSimpleLambdaSuccess() = given()
+        .contentType("application/json")
+        .accept("application/json")
+        .body(Person(name = "Stu"))
+        .`when`()
+        .post()
+        .then()
+        .statusCode(200)
+        .body(containsString("Hello Stu"))
+
 }
 ----
 

--- a/docs/src/main/asciidoc/aws-lambda.adoc
+++ b/docs/src/main/asciidoc/aws-lambda.adoc
@@ -87,7 +87,7 @@ with an environment variable too.
 
 If you look at the three generated handler classes in the project, you'll see that they are `@Named` differently.
 
-[source,java,subs=attributes+,role="primary"]
+[source,java,subs=attributes+,role="primary asciidoc-tabs-sync-java"]
 .Java
 ----
 @Named("test")
@@ -103,7 +103,7 @@ public class StreamLambda implements RequestStreamHandler {
 }
 ----
 
-[source,kotlin,subs=attributes+,role="secondary"]
+[source,kotlin,subs=attributes+,role="secondary asciidoc-tabs-sync-kotlin"]
 .Kotlin
 ----
 @Named("test")
@@ -335,7 +335,7 @@ The default port for Rest Assured is automatically set to 8081 by Quarkus, so yo
 on this endpoint.
 
 
-[source,java,role="primary"]
+[source,java,role="primary asciidoc-tabs-sync-java"]
 .Java
 ----
 import org.junit.jupiter.api.Test;
@@ -365,7 +365,7 @@ public class LambdaHandlerTest {
 }
 ----
 
-[source,kotlin,role="secondary"]
+[source,kotlin,role="secondary asciidoc-tabs-sync-kotlin"]
 .Kotlin
 ----
 import org.junit.jupiter.api.Test

--- a/docs/src/main/asciidoc/aws-lambda.adoc
+++ b/docs/src/main/asciidoc/aws-lambda.adoc
@@ -381,16 +381,17 @@ class LambdaHandlerTest {
 
     @Test
     @Throws(Exception::class)
-    fun testSimpleLambdaSuccess() = given()
-        .contentType("application/json")
-        .accept("application/json")
-        .body(Person(name = "Stu"))
-        .`when`()
-        .post()
-        .then()
-        .statusCode(200)
-        .body(containsString("Hello Stu"))
-
+    fun testSimpleLambdaSuccess() = {
+        given()
+            .contentType("application/json")
+            .accept("application/json")
+            .body(Person(name = "Stu"))
+            .`when`()
+            .post()
+            .then()
+            .statusCode(200)
+            .body(containsString("Hello Stu"))
+    }
 }
 ----
 


### PR DESCRIPTION
## Description

As Quarkus [aims to offer first class support for Kotlin](https://quarkus.io/guides/kotlin), it would be nice if the documentation was updated to offer code snippets for both Java and Kotlin.  


Quite often, in fact, the Kotlin approach to do something is not a 1 to 1 translation from Java. For example, a [Checked Template](https://quarkus.io/guides/qute#type-safe-templates) would look like this in Java
```java
@CheckedTemplate
public static class Templates {
    public static native TemplateInstance hello(String name); 
}
```
While in Kotlin it would require an extra annotation
```kotlin
@CheckedTemplate
object Templates {
    @JvmStatic
    external fun hello(name: String?): TemplateInstance
}
```

## Changes

The most "invasive" change of this PR is the move from `coderay` to `rouge` as source-highlighter, as the first doesn't support `Kotlin`'s syntax

## Preview

To offer this code snippets, I thought about reusing the "Asciidoctor Tabs" already used for `Cli | Maven | Gradle` in various pages. Here is how it would look like:
<img width="500" alt="image" src="https://github.com/quarkusio/quarkus/assets/47816664/6e68d999-df86-49e1-a843-49bd10316c2c">
<img width="400" alt="image" src="https://github.com/quarkusio/quarkus/assets/47816664/4582ebe2-903b-41f7-bfc8-bc735ff57995">

## Going forwards

If the idea is well liked by the team, I'll try to create more PRs to update more of the existing documentation so that it would easier than ever to pick Kotlin as a language for Quarkus!
 