### PR TITLE
Save pathParamValues encoded and perform decoding when requested

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -226,18 +226,20 @@ public abstract class ResteasyReactiveRequestContext
         }
     }
 
-    public String getPathParam(int index) {
-        return doGetPathParam(index, pathParamValues);
+    public String getPathParam(int index, boolean encoded) {
+        return doGetPathParam(index, pathParamValues, encoded);
     }
 
-    private String doGetPathParam(int index, Object pathParamValues) {
+    private String doGetPathParam(int index, Object pathParamValues, boolean encoded) {
         if (pathParamValues instanceof String[]) {
-            return ((String[]) pathParamValues)[index];
+            String pathParam = ((String[]) pathParamValues)[index];
+            return encoded ? pathParam : Encode.decodePath(pathParam);
         }
         if (index > 1) {
             throw new IndexOutOfBoundsException();
         }
-        return (String) pathParamValues;
+        String pathParam = (String) pathParamValues;
+        return encoded ? pathParam : Encode.decodePath(pathParam);
     }
 
     public ResteasyReactiveRequestContext setPathParamValue(int index, String value) {
@@ -926,18 +928,11 @@ public abstract class ResteasyReactiveRequestContext
         Integer index = target.getPathParameterIndexes().get(name);
         String value;
         if (index != null) {
-            value = getPathParam(index);
-        } else {
-            // Check previous resources if the path is not defined in the current target
-            value = getResourceLocatorPathParam(name);
+            return getPathParam(index, encoded);
         }
 
-        // It's possible to inject a path param that's not defined, return null in this case
-        if (encoded && value != null) {
-            return Encode.encodeQueryParam(value);
-        }
-
-        return value;
+        // Check previous resources if the path is not defined in the current target
+        return getResourceLocatorPathParam(name, encoded);
     }
 
     @Override
@@ -996,8 +991,8 @@ public abstract class ResteasyReactiveRequestContext
 
     public abstract Runnable registerTimer(long millis, Runnable task);
 
-    public String getResourceLocatorPathParam(String name) {
-        return getResourceLocatorPathParam(name, (PreviousResource) getProperty(PreviousResource.PROPERTY_KEY));
+    public String getResourceLocatorPathParam(String name, boolean encoded) {
+        return getResourceLocatorPathParam(name, (PreviousResource) getProperty(PreviousResource.PROPERTY_KEY), encoded);
     }
 
     public FormData getFormData() {
@@ -1009,7 +1004,7 @@ public abstract class ResteasyReactiveRequestContext
         return this;
     }
 
-    private String getResourceLocatorPathParam(String name, PreviousResource previousResource) {
+    private String getResourceLocatorPathParam(String name, PreviousResource previousResource, boolean encoded) {
         if (previousResource == null) {
             return null;
         }
@@ -1020,13 +1015,13 @@ public abstract class ResteasyReactiveRequestContext
             for (URITemplate.TemplateComponent component : classPath.components) {
                 if (component.name != null) {
                     if (component.name.equals(name)) {
-                        return doGetPathParam(index, previousResource.locatorPathParamValues);
+                        return doGetPathParam(index, previousResource.locatorPathParamValues, encoded);
                     }
                     index++;
                 } else if (component.names != null) {
                     for (String nm : component.names) {
                         if (nm.equals(name)) {
-                            return doGetPathParam(index, previousResource.locatorPathParamValues);
+                            return doGetPathParam(index, previousResource.locatorPathParamValues, encoded);
                         }
                     }
                     index++;
@@ -1036,19 +1031,19 @@ public abstract class ResteasyReactiveRequestContext
         for (URITemplate.TemplateComponent component : previousResource.locatorTarget.getPath().components) {
             if (component.name != null) {
                 if (component.name.equals(name)) {
-                    return doGetPathParam(index, previousResource.locatorPathParamValues);
+                    return doGetPathParam(index, previousResource.locatorPathParamValues, encoded);
                 }
                 index++;
             } else if (component.names != null) {
                 for (String nm : component.names) {
                     if (nm.equals(name)) {
-                        return doGetPathParam(index, previousResource.locatorPathParamValues);
+                        return doGetPathParam(index, previousResource.locatorPathParamValues, encoded);
                     }
                 }
                 index++;
             }
         }
-        return getResourceLocatorPathParam(name, previousResource.prev);
+        return getResourceLocatorPathParam(name, previousResource.prev, encoded);
     }
 
     public abstract boolean resumeExternalProcessing();

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/LocatableResourcePathParamExtractor.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/LocatableResourcePathParamExtractor.java
@@ -12,7 +12,7 @@ public class LocatableResourcePathParamExtractor implements ParameterExtractor {
 
     @Override
     public Object extractParameter(ResteasyReactiveRequestContext context) {
-        return context.getResourceLocatorPathParam(name);
+        return context.getResourceLocatorPathParam(name, false);
     }
 
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/PathParamExtractor.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/PathParamExtractor.java
@@ -1,6 +1,8 @@
 package org.jboss.resteasy.reactive.server.core.parameters;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.jboss.resteasy.reactive.common.util.Encode;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
@@ -19,14 +21,14 @@ public class PathParamExtractor implements ParameterExtractor {
 
     @Override
     public Object extractParameter(ResteasyReactiveRequestContext context) {
-        String pathParam = context.getPathParam(index);
-        if (encoded) {
-            pathParam = Encode.encodeQueryParam(pathParam);
-        }
+        String pathParam = context.getPathParam(index, true);
         if (single) {
-            return pathParam;
+            return encoded ? pathParam : Encode.decodePath(pathParam);
         } else {
-            return List.of(pathParam.split("/"));
+            return encoded
+                    ? List.of(pathParam.split("/"))
+                    : Arrays.stream(pathParam.split("/")).map(Encode::decodePath)
+                            .collect(Collectors.toList());
         }
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/UriInfoImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/UriInfoImpl.java
@@ -152,7 +152,7 @@ public class UriInfoImpl implements UriInfo {
             RuntimeResource target = currentRequest.getTarget();
             if (target != null) { // a target can be null if this happens in a filter that runs before the target is set
                 for (Entry<String, Integer> pathParam : target.getPathParameterIndexes().entrySet()) {
-                    pathParams.add(pathParam.getKey(), currentRequest.getPathParam(pathParam.getValue()));
+                    pathParams.add(pathParam.getKey(), currentRequest.getPathParam(pathParam.getValue(), false));
                 }
             }
         }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 
-import org.jboss.resteasy.reactive.common.util.URIDecoder;
-
 public class RequestMapper<T> {
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
@@ -111,7 +109,7 @@ public class RequestMapper<T> {
                     while (matchPos < pathLength && path.charAt(matchPos) != '/') {
                         matchPos++;
                     }
-                    params[paramCount++] = URIDecoder.decodeURIComponent(path.substring(start, matchPos), false);
+                    params[paramCount++] = path.substring(start, matchPos);
                 }
             }
             if (!matched) {

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/RegexMatchTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/RegexMatchTest.java
@@ -41,6 +41,10 @@ public class RegexMatchTest {
                 .then()
                 .statusCode(200)
                 .body(equalTo("plain:abb/foo/alongpathtotriggerbug"));
+        RestAssured.get("/regex/first space/foo/second space")
+                .then()
+                .statusCode(200)
+                .body(equalTo("plain:first space/foo/second space"));
         RestAssured.get("/regex/abb/literal/ddc")
                 .then()
                 .statusCode(200)


### PR DESCRIPTION
Fixes #35960

As commented in original issue https://github.com/quarkusio/quarkus/issues/34586 the initial problem was that path params are first decoded (`%2F` chars are decoded int `/`) and then splitted by `/`. That should be done in the reverse order to maintain the correct paths. This PR saves the path params in the context encoded instead of decoded. Then they are decoded when needed. For example in the `PathParamExtractor` they are decoded after being splitted as required for triggering issue. Added a little test for the new issue #35960. I think all the CI is passing in my branch.

I have changed the signature of public methods `getPathParam` and `getResourceLocatorPathParam`, adding the `encoded` parameter. If you want to maintain the previous variant just let me know. I can add them without issues.

@geoand FYI.