### PR TITLE
Upgrade to Hibernate Search 7.0.0.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -106,7 +106,7 @@
         <hibernate-reactive.version>2.2.0.Final</hibernate-reactive.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <!-- When updating, align hibernate-search.version-for-documentation in docs/pom.xml -->
-        <hibernate-search.version>7.0.0.CR2</hibernate-search.version>
+        <hibernate-search.version>7.0.0.Final</hibernate-search.version>
         <narayana.version>7.0.0.Final</narayana.version>
         <agroal.version>2.1</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>


### PR DESCRIPTION
No relevant changes for Quarkus since 7.0.0.CR2: https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HSEARCH%20AND%20fixVersion%20in%20(7.0.0.Final)%20ORDER%20BY%20updated

Still, better use the Final if it's there :)