### PR TITLE
Zero-Garbage ContextInstances::forEach

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -62,6 +63,9 @@ public final class MethodDescriptors {
             Map.class, String.class);
 
     public static final MethodDescriptor SUPPLIER_GET = MethodDescriptor.ofMethod(Supplier.class, "get", Object.class);
+
+    public static final MethodDescriptor CONSUMER_ACCEPT = MethodDescriptor.ofMethod(Consumer.class, "accept",
+            void.class, Object.class);
 
     public static final MethodDescriptor CREATIONAL_CTX_CHILD = MethodDescriptor.ofMethod(CreationalContextImpl.class, "child",
             CreationalContextImpl.class,

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractSharedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractSharedContext.java
@@ -1,9 +1,6 @@
 package io.quarkus.arc.impl;
 
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -87,7 +84,11 @@ abstract class AbstractSharedContext implements InjectableContext, InjectableCon
 
     @Override
     public synchronized void destroy() {
-        Set<ContextInstanceHandle<?>> values = instances.getAllPresent();
+        List<ContextInstanceHandle<?>> values = new LinkedList<>();
+        instances.forEach(values::add);
+        if (values.isEmpty()) {
+            return;
+        }
         // Destroy the producers first
         for (Iterator<ContextInstanceHandle<?>> iterator = values.iterator(); iterator.hasNext();) {
             ContextInstanceHandle<?> instanceHandle = iterator.next();

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ComputingCacheContextInstances.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ComputingCacheContextInstances.java
@@ -1,6 +1,7 @@
 package io.quarkus.arc.impl;
 
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import io.quarkus.arc.ContextInstanceHandle;
@@ -36,6 +37,11 @@ class ComputingCacheContextInstances implements ContextInstances {
     @Override
     public void clear() {
         instances.clear();
+    }
+
+    @Override
+    public void forEach(Consumer<? super ContextInstanceHandle<?>> handleConsumer) {
+        instances.getPresentValues().forEach(handleConsumer);
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ContextInstances.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ContextInstances.java
@@ -1,6 +1,7 @@
 package io.quarkus.arc.impl;
 
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import io.quarkus.arc.ContextInstanceHandle;
@@ -16,5 +17,7 @@ public interface ContextInstances {
     Set<ContextInstanceHandle<?>> getAllPresent();
 
     void clear();
+
+    void forEach(Consumer<? super ContextInstanceHandle<?>> handleConsumer);
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
@@ -210,7 +210,7 @@ class RequestContext implements ManagedContext {
             if (reqState.invalidate()) {
                 // Fire an event with qualifier @BeforeDestroyed(RequestScoped.class) if there are any observers for it
                 fireIfNotEmpty(beforeDestroyedNotifier);
-                reqState.contextInstances.getAllPresent().forEach(this::destroyContextElement);
+                reqState.contextInstances.forEach(this::destroyContextElement);
                 reqState.contextInstances.clear();
                 // Fire an event with qualifier @Destroyed(RequestScoped.class) if there are any observers for it
                 fireIfNotEmpty(destroyedNotifier);


### PR DESCRIPTION
This improvement is necessary due to https://github.com/quarkusio/quarkus/pull/36626, which has introduced a very good thing ie bytecode-generated context containers, but it's causing an `Set` allocation in the hot-path, which eventually lead to calling `System::identityHashCode` as well (which is not known to be super efficient nor fast).

The cost of `Arc` in plaintext Techempower for `org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.close` was at ~2.87% and has become 6.7%, which is ~ twice as costy as it was before the mentioned pr.

The flamegraphs shows clearly the problem, before:

![image](https://github.com/quarkusio/quarkus/assets/13125299/36c469fd-7956-426c-a683-26e47f8efb6a)

The problem was that, with a single ctx instance, the default capacity of `ConcurrentHashMap` was an overkill (16), and `forEach` and `clear` were forcing to iterate among *all* map's slots, including `null`-ones, twice.

https://github.com/quarkusio/quarkus/pull/36626 has introduced a big improvement on it, but:
![image](https://github.com/quarkusio/quarkus/assets/13125299/1cd31ef9-d74b-4fa9-8c65-8f06a670343d)

Shows that:
- an hash map (with default capacity) and an iterator are allocated in the hot path
- given that `HashSet`'s are backed by a map using the values as keys, this force the ctx instances to have their own equals/hashCode implementations ore they would rely on `System::identityHashCode` which is not great


This pr is "fixing" the "symptom" by providing an optimized `forEach` method given that `ContextInstances` is a container itself and I see no harm in this, but still:
1. do we really need the `getAllPresent` method? If is used elsewhere in the hotpath, is probably a good idea to fix there them as well IMO...
2. I have found `ApplicationContextInstancesTest`: I still need to write a new test for this additional API method, which use a ctx instances with more than 1 instance in
3. the existing generated implementation still cause `lock/unlock` to happen while reading the instances, which "could" still be an hot-path: I'm not fixing problems which I cannot observe, but calling volatile stores (twice, to enter/exit) in the hot path have some non-negligible performance impact, which could be improved as well. I don't plan to send the fix for it in this PR.     
