### PR TITLE
Fix Snappy note about native

### DIFF
--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -1952,10 +1952,8 @@ mp.messaging.outgoing.fruit-out.compression.type=snappy
 ----
 
 In JVM mode, it will work out of the box.
-However, to compile your application to a native executable, you need to:
-
-1. Uses GraalVM 21.+
-2. Add `quarkus.kafka.snappy.enabled=true` to your `application.properties`
+However, to compile your application to a native executable, you need to
+add `quarkus.kafka.snappy.enabled=true` to your `application.properties`.
 
 In native mode, Snappy is disabled by default as the use of Snappy requires embedding a native library and unpacking it when the application starts.
 


### PR DESCRIPTION
I went there to fix a typo (Uses -> Use) but in the end we don't support GraalVM 21 anymore so we can simplify all that.