### PR TITLE
Order Map entries when serializing registry artifacts

### DIFF
--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigMapperHelper.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigMapperHelper.java
@@ -36,10 +36,11 @@ public class RegistriesConfigMapperHelper {
     }
 
     public static ObjectMapper initMapper(ObjectMapper mapper) {
-        mapper.addMixIn(ArtifactCoords.class, JsonArtifactCoordsMixin.class);
-        mapper.enable(SerializationFeature.INDENT_OUTPUT);
-        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.addMixIn(ArtifactCoords.class, JsonArtifactCoordsMixin.class)
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         return mapper;
     }
 


### PR DESCRIPTION
This should result in a deterministic way when comparing serialized Map entries

- Based on https://github.com/quarkusio/quarkus/pull/37413
