### PR TITLE
Fix smallrye ConfigValidationException not being handled properly at Quarkus startup

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -187,8 +187,9 @@ public class ApplicationLifecycleManager {
                         }
                         applicationLogger.warn("You can try to kill it with 'kill -9 <pid>'.");
                     }
-                } else if (rootCause instanceof ConfigurationException) {
+                } else if (ExceptionUtil.isAnyCauseInstanceOf(e, ConfigurationException.class)) {
                     System.err.println(rootCause.getMessage());
+                    e.printStackTrace();
                 } else if (rootCause instanceof PreventFurtherStepsException
                         && !StringUtil.isNullOrEmpty(rootCause.getMessage())) {
                     System.err.println(rootCause.getMessage());

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ExceptionUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ExceptionUtil.java
@@ -86,6 +86,17 @@ public class ExceptionUtil {
         return chain.isEmpty() ? null : chain.get(chain.size() - 1);
     }
 
+    public static <T> boolean isAnyCauseInstanceOf(Throwable exception, Class<T> classToCheck) {
+        Throwable curr = exception;
+        do {
+            if (classToCheck.isInstance(curr)) {
+                return true;
+            }
+            curr = curr.getCause();
+        } while (curr != null);
+        return false;
+    }
+
     /**
      * Creates and returns a new {@link Throwable} which has the following characteristics:
      * <ul>

--- a/core/runtime/src/test/java/io/quarkus/runtime/util/ExceptionUtilTest.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/util/ExceptionUtilTest.java
@@ -13,6 +13,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.runtime.configuration.ConfigurationException;
+
 /**
  *
  */
@@ -59,6 +61,11 @@ public class ExceptionUtilTest {
         assertEquals(NullPointerException.class, ExceptionUtil.getRootCause(new NullPointerException()).getClass());
     }
 
+    @Test
+    public void testIsAnyCauseInstanceOf() {
+        assertTrue(ExceptionUtil.isAnyCauseInstanceOf(generateConfigurationException(), ConfigurationException.class));
+    }
+
     private Throwable generateException() {
         try {
             try {
@@ -79,4 +86,26 @@ public class ExceptionUtilTest {
         }
         throw new RuntimeException("Should not reach here");
     }
+
+    private Throwable generateConfigurationException() {
+        try {
+            try {
+                Integer.parseInt("23.23232");
+            } catch (NumberFormatException nfe) {
+                throw new ConfigurationException("Incorrect param", nfe);
+            }
+        } catch (ConfigurationException ce) {
+            try {
+                throw new IOException("Request processing failed", ce);
+            } catch (IOException e) {
+                try {
+                    throw new IOError(e);
+                } catch (IOError ie) {
+                    return new RuntimeException("Unexpected exception", ie);
+                }
+            }
+        }
+        throw new RuntimeException("Should not reach here");
+    }
+
 }


### PR DESCRIPTION
It fixes #36376 
It was needed to wrap ```io.smallrye.config.ConfigValidationException``` exception with ```io.quarkus.runtime.configuration.ConfigurationException```
And then as it turned out every exception thrown by ```RuntimeConfigSetup#deploy``` method was automatically wrapped into RuntimeException which later ```ApplicationLifecycleManager``` could handle. Screenshot shows how it is now behaving.

![fixed](https://github.com/quarkusio/quarkus/assets/39798354/b58e641c-7635-4962-ae1d-8a1af4b9febd)
