### PR TITLE
Fix Build scan capture extension registration when using the Maven wrapper

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -143,6 +143,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Initial JDK 17 Build"
+          wrapper-init: true
       - name: Build
         env:
           CAPTURE_BUILD_SCAN: true
@@ -361,6 +362,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "JVM Tests - JDK ${{matrix.java.name}}"
+          wrapper-init: true
       - name: Build
         env:
           CAPTURE_BUILD_SCAN: true
@@ -467,6 +469,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Maven Tests - JDK ${{matrix.java.name}}"
+          wrapper-init: true
       - name: Build
         env:
           CAPTURE_BUILD_SCAN: true
@@ -563,6 +566,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Gradle Tests - JDK ${{matrix.java.name}}"
+          wrapper-init: true
       - name: Build
         env:
           CAPTURE_BUILD_SCAN: true
@@ -639,6 +643,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Devtools Tests - JDK ${{matrix.java.name}}"
+          wrapper-init: true
       - name: Build
         env:
           CAPTURE_BUILD_SCAN: true
@@ -724,6 +729,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Kubernetes Tests - JDK ${{matrix.java.name}}"
+          wrapper-init: true
       - name: Build
         env:
           CAPTURE_BUILD_SCAN: true
@@ -796,6 +802,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Quickstarts Compilation - JDK ${{matrix.java.name}}"
+          wrapper-init: true
       - name: Compile Quickstarts
         env:
           CAPTURE_BUILD_SCAN: true
@@ -859,6 +866,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Native Tests - Virtual Thread - ${{matrix.category}}"
+          wrapper-init: true
       - name: Build
         env:
           TEST_MODULES: ${{matrix.test-modules}}
@@ -920,6 +928,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "MicroProfile TCKs Tests"
+          wrapper-init: true
       - name: Verify
         env:
           CAPTURE_BUILD_SCAN: true
@@ -1020,6 +1029,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Native Tests - ${{matrix.category}}"
+          wrapper-init: true
       - name: Build
         env:
           TEST_MODULES: ${{matrix.test-modules}}


### PR DESCRIPTION
### Issue
No Develocity Build scans are being published because the Maven extension to capture unpublished Build Scans is not registered.

When using the Maven wrapper, a Maven extension can't be registered once at the beginning of the build by copying it to `$MAVEN_HOME/lib/ext` as the folder is created on the first `mvnw` invocation (and emptied if already present).

### Fix
Install the Maven extension in `./maven-build-scan-capture/lib/ext` (using a relative path makes this approach compatible with Windows OS) and register the Maven extension as a Maven CLI argument (`-Dmaven.ext.class.path`)