### PR TITLE
Prevent concurrently running Jacoco ReportCreators to avoid report corruption

### DIFF
--- a/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/ReportCreator.java
+++ b/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/ReportCreator.java
@@ -37,6 +37,16 @@ public class ReportCreator implements Runnable {
 
     @Override
     public void run() {
+        // Ugly workaround:
+        // Multiple ReportCreator shutdown hooks might run concurrently, possibly corrupting the report file(s) - e.g. when using @TestProfile.
+        // By locking on a class from the parent CL, all hooks are "serialized", one after another.
+        // In the long run there should only be as many hooks as there are different Jacoco configs...usually there will be only one config anyway!
+        synchronized (ExecFileLoader.class) {
+            doRun();
+        }
+    }
+
+    private void doRun() {
         File targetdir = new File(reportInfo.reportDir);
         targetdir.mkdirs();
         try {


### PR DESCRIPTION
Fixes #37496

The comment says it all...it's rather ugly.
I'm wondering whether we should at least resort to a Quarkus class instead of an external one, just like here: 
https://github.com/quarkusio/quarkus/pull/35308/files#diff-531e284b11c246b109c208d56573e6b12d5f3848019cd297715aa091676b613eR330

In the long run we should try to add only so many [ReportCreator hooks](https://github.com/quarkusio/quarkus/blob/3.6.1/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java#L118) as there are _distinct_ Jacoco configs.
Usually you only have one for all tests, regardless of test profiles and whatnot, but then again you can just override the jacoco properties in a profile or test resource manager.

PS: https://issues.apache.org/jira/browse/SUREFIRE-1879 makes it harder to understand the actual issue, because you don't see any "Generated Jacoco reports in ..." messages (two in case of the reproducer in #37496).

_Edit:_ Also fixes #37544