### PR TITLE
Bring mvnw in line with the currently proposed Maven version 3.9.6

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.3/apache-maven-3.9.3-bin.zip
-distributionSha256Sum=80b3b63df0e40ca8cde902bb1a40e4488ede24b3f282bd7bd6fba8eb5a7e055c
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
+distributionSha256Sum=83aaf914c785c9faed661f223000a92d1de9553f5c82d3b4362e66d9c031625f
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar


### PR DESCRIPTION
Looks like this was forgotten in the last few update PRs, so e.g. CI is still running with 3.9.3.

Noticed via the warning at the beginning of the build:
> [WARNING] Maven Wrapper is configured with a different version (3.9.3) than the runtime version (3.9.6). This will negatively impact build consistency and build caching.

(I usually rely on sdkman)