### PR TITLE
Support using commas to add extensions with CLI

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsAdd.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsAdd.java
@@ -17,7 +17,7 @@ public class ProjectExtensionsAdd extends BaseBuildCommand implements Callable<I
     @CommandLine.Mixin
     RunModeOption runMode;
 
-    @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "extensions to add to this project")
+    @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "extensions to add to this project", split = ",")
     Set<String> extensions;
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsRemove.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsRemove.java
@@ -17,7 +17,7 @@ public class ProjectExtensionsRemove extends BaseBuildCommand implements Callabl
     @CommandLine.Mixin
     RunModeOption runMode;
 
-    @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "Extension(s) to remove from this project.")
+    @CommandLine.Parameters(arity = "1", paramLabel = "EXTENSION", description = "Extension(s) to remove from this project.", split = ",")
     Set<String> extensions;
 
     @Override

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliDriver.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliDriver.java
@@ -319,7 +319,7 @@ public class CliDriver {
     }
 
     public static Result invokeExtensionAddMultiple(Path projectRoot, Path file) throws Exception {
-        // add the qute extension
+        // add amazon-lambda-http and jackson extensions
         Result result = execute(projectRoot, "extension", "add", "amazon-lambda-http", "jackson", "-e", "-B", "--verbose");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
@@ -345,7 +345,7 @@ public class CliDriver {
     }
 
     public static Result invokeExtensionRemoveMultiple(Path projectRoot, Path file) throws Exception {
-        // add the qute extension
+        // remove amazon-lambda-http and jackson extensions
         Result result = execute(projectRoot, "extension", "remove", "amazon-lambda-http", "jackson", "-e", "-B", "--verbose");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
                 "Expected OK return code. Result:\n" + result);
@@ -366,6 +366,52 @@ public class CliDriver {
                 "quarkus-amazon-lambda-http should not be listed as a dependency. Result:\n" + content);
         Assertions.assertFalse(content.contains("quarkus-jackson"),
                 "quarkus-jackson should not be listed as a dependency. Result:\n" + content);
+
+        return result;
+    }
+
+    public static Result invokeExtensionAddMultipleCommas(Path projectRoot, Path file) throws Exception {
+        Result result = execute(projectRoot, "extension", "add",
+                "quarkus-resteasy-reactive-jsonb,quarkus-resteasy-reactive-jackson", "-e", "-B", "--verbose");
+        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+                "Expected OK return code. Result:\n" + result);
+
+        result = invokeValidateExtensionList(projectRoot);
+        Assertions.assertTrue(result.stdout.contains("quarkus-qute"),
+                "Expected quarkus-qute to be in the list of extensions. Result:\n" + result);
+        Assertions.assertTrue(result.stdout.contains("quarkus-resteasy-reactive-jsonb"),
+                "Expected quarkus-resteasy-reactive-jsonb to be in the list of extensions. Result:\n" + result);
+        Assertions.assertTrue(result.stdout.contains("quarkus-resteasy-reactive-jackson"),
+                "Expected quarkus-resteasy-reactive-jackson to be in the list of extensions. Result:\n" + result);
+
+        String content = CliDriver.readFileAsString(file);
+        Assertions.assertTrue(content.contains("quarkus-qute"),
+                "quarkus-qute should still be listed as a dependency. Result:\n" + content);
+        Assertions.assertTrue(content.contains("quarkus-resteasy-reactive-jsonb"),
+                "quarkus-resteasy-reactive-jsonb should be listed as a dependency. Result:\n" + content);
+        Assertions.assertTrue(content.contains("quarkus-resteasy-reactive-jackson"),
+                "quarkus-resteasy-reactive-jackson should be listed as a dependency. Result:\n" + content);
+
+        return result;
+    }
+
+    public static Result invokeExtensionRemoveMultipleCommas(Path projectRoot, Path file) throws Exception {
+        Result result = execute(projectRoot, "extension", "remove",
+                "quarkus-resteasy-reactive-jsonb,quarkus-resteasy-reactive-jackson", "-e", "-B", "--verbose");
+        Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
+                "Expected OK return code. Result:\n" + result);
+
+        result = invokeValidateExtensionList(projectRoot);
+        Assertions.assertFalse(result.stdout.contains("quarkus-resteasy-reactive-jsonb"),
+                "quarkus-resteasy-reactive-jsonb should not be in the list of extensions. Result:\n" + result);
+        Assertions.assertFalse(result.stdout.contains("quarkus-resteasy-reactive-jackson"),
+                "quarkus-resteasy-reactive-jackson should not be in the list of extensions. Result:\n" + result);
+
+        String content = CliDriver.readFileAsString(file);
+        Assertions.assertFalse(content.contains("quarkus-resteasy-reactive-jsonb"),
+                "quarkus-resteasy-reactive-jsonb should not be listed as a dependency. Result:\n" + content);
+        Assertions.assertFalse(content.contains("quarkus-resteasy-reactive-jackson"),
+                "quarkus-resteasy-reactive-jackson should not be listed as a dependency. Result:\n" + content);
 
         return result;
     }

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -145,8 +145,10 @@ public class CliProjectMavenTest {
         CliDriver.invokeExtensionAddRedundantQute(project);
         CliDriver.invokeExtensionListInstallable(project);
         CliDriver.invokeExtensionAddMultiple(project, pom);
+        CliDriver.invokeExtensionAddMultipleCommas(project, pom);
         CliDriver.invokeExtensionRemoveQute(project, pom);
         CliDriver.invokeExtensionRemoveMultiple(project, pom);
+        CliDriver.invokeExtensionRemoveMultipleCommas(project, pom);
 
         CliDriver.invokeExtensionListInstallableSearch(project);
         CliDriver.invokeExtensionListFormatting(project);

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -76,6 +76,62 @@
       ]
     },
     {
+      "name" : "RESTEasy Reactive Jackson",
+      "description" : "Jackson serialization support for RESTEasy Reactive. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it",
+      "metadata" : {
+        "codestart" : {
+          "name" : "resteasy-reactive",
+          "kind" : "core",
+          "languages" : [ "java", "kotlin", "scala" ],
+          "artifact" : "io.quarkus:quarkus-project-core-extension-codestarts::jar:999-FAKE"
+        },
+        "minimum-java-version" : "11",
+        "status" : "stable",
+        "config" : [ "quarkus.resteasy-reactive.", "quarkus.jackson." ],
+        "built-with-quarkus-core" : "999-FAKE",
+        "scm-url" : "https://github.com/quarkus-release/release",
+        "short-name" : "resteasy-reactive-jackson",
+        "capabilities" : {
+          "provides" : [ "io.quarkus.rest.jackson", "io.quarkus.resteasy.reactive.json.jackson" ]
+        },
+        "categories" : [ "web", "reactive" ],
+        "extension-dependencies" : [ "io.quarkus:quarkus-resteasy-reactive", "io.quarkus:quarkus-resteasy-reactive-common", "io.quarkus:quarkus-mutiny", "io.quarkus:quarkus-smallrye-context-propagation", "io.quarkus:quarkus-vertx", "io.quarkus:quarkus-netty", "io.quarkus:quarkus-vertx-http", "io.quarkus:quarkus-core", "io.quarkus:quarkus-jsonp", "io.quarkus:quarkus-virtual-threads", "io.quarkus:quarkus-arc", "io.quarkus:quarkus-resteasy-reactive-jackson-common", "io.quarkus:quarkus-jackson" ],
+        "keywords" : [ "rest-jackson", "quarkus-resteasy-reactive-json", "jaxrs-json", "rest", "jaxrs", "json", "jackson", "jakarta-rest" ]
+      },
+      "artifact" : "io.quarkus:quarkus-resteasy-reactive-jackson::jar:999-FAKE",
+      "origins": [
+        "io.quarkus:quarkus-fake-bom:999-FAKE:json:999-FAKE"
+      ]
+    },
+    {
+      "name" : "RESTEasy Reactive JSON-B",
+      "description" : "JSON-B serialization support for RESTEasy Reactive. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.",
+      "metadata" : {
+        "codestart" : {
+          "name" : "resteasy-reactive",
+          "kind" : "core",
+          "languages" : [ "java", "kotlin", "scala" ],
+          "artifact" : "io.quarkus:quarkus-project-core-extension-codestarts::jar:999-FAKE"
+        },
+        "minimum-java-version" : "11",
+        "status" : "stable",
+        "config" : [ "quarkus.resteasy-reactive." ],
+        "built-with-quarkus-core" : "999-FAKE",
+        "scm-url" : "https://github.com/quarkus-release/release",
+        "short-name" : "resteasy-reactive-jsonb",
+        "capabilities" : {
+          "provides" : [ "io.quarkus.rest.jsonb", "io.quarkus.resteasy.reactive.json.jsonb" ]
+        },
+        "categories" : [ "web", "reactive" ],
+        "extension-dependencies" : [ "io.quarkus:quarkus-resteasy-reactive", "io.quarkus:quarkus-resteasy-reactive-common", "io.quarkus:quarkus-mutiny", "io.quarkus:quarkus-smallrye-context-propagation", "io.quarkus:quarkus-vertx", "io.quarkus:quarkus-netty", "io.quarkus:quarkus-vertx-http", "io.quarkus:quarkus-core", "io.quarkus:quarkus-jsonp", "io.quarkus:quarkus-virtual-threads", "io.quarkus:quarkus-arc", "io.quarkus:quarkus-resteasy-reactive-jsonb-common", "io.quarkus:quarkus-jsonb" ],
+        "keywords" : [ "rest-jsonb", "resteasy-reactive-json", "jaxrs-json", "rest", "jaxrs", "json", "jsonb", "jakarta-rest" ]
+      },
+      "artifact" : "io.quarkus:quarkus-resteasy-reactive-jsonb::jar:999-FAKE",
+      "origins": [
+        "io.quarkus:quarkus-fake-bom:999-FAKE:json:999-FAKE"
+      ]
+    },
+    {
       "name": "YAML Configuration",
       "description": "Use YAML to configure your Quarkus application",
       "metadata": {


### PR DESCRIPTION
Actually, it was already supported when creating projects, just not when adding extensions.

Fixes #37564

Created as draft for now as I had to make some changes to the fake catalog and this might cause other tests to fail.