### PR TITLE
Update the import.cypher script to use newer syntax

### DIFF
--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -846,8 +846,8 @@ we need the following cypher script which will import the data within the CSV fi
 
 [source,cypher]
 ----
-CREATE CONSTRAINT unique_vm_id ON (v:VM) ASSERT v.vmId IS UNIQUE;
-CREATE CONSTRAINT unique_method_id ON (m:Method) ASSERT m.methodId IS UNIQUE;
+CREATE CONSTRAINT unique_vm_id FOR (v:VM) REQUIRE v.vmId IS UNIQUE;
+CREATE CONSTRAINT unique_method_id FOR (m:Method) REQUIRE m.methodId IS UNIQUE;
 
 LOAD CSV WITH HEADERS FROM 'file:///reports/call_tree_vm.csv' AS row
 MERGE (v:VM {vmId: row.Id, name: row.Name})


### PR DESCRIPTION
Looks like the current script is using the 4.3 syntax (https://neo4j.com/docs/cypher-manual/4.3/constraints/syntax/)
While in the newer version (5) it got changed (https://neo4j.com/docs/cypher-manual/5/constraints/syntax/) and trying to run it results in:
```
Invalid constraint syntax, ON and ASSERT should not be used. Replace ON with FOR and ASSERT with REQUIRE. (line 1, column 1 (offset: 0))
"CREATE CONSTRAINT unique_vm_id ON (v:VM) ASSERT v.vmId IS UNIQUE
```

Note: neo4j container allows to start it without any auth using `--env=NEO4J_AUTH=none` (https://hub.docker.com/_/neo4j); it makes it simpler and requires less typing 😃, but I wasn't sure if that it was OK to make that change as well, so only a syntax update.