### PR TITLE
Fix terminology: Replace configuration key with configuration property

### DIFF
--- a/docs/src/main/asciidoc/amqp.adoc
+++ b/docs/src/main/asciidoc/amqp.adoc
@@ -257,7 +257,7 @@ Open the `src/main/resources/application.properties` file and add:
 mp.messaging.incoming.requests.address=quote-requests
 ----
 
-The configuration keys are structured as follows:
+The configuration properties are structured as follows:
 
 `mp.messaging.[outgoing|incoming].{channel-name}.property=value`
 

--- a/docs/src/main/asciidoc/config-yaml.adoc
+++ b/docs/src/main/asciidoc/config-yaml.adoc
@@ -192,9 +192,9 @@ The file must be present in the root of the working directory relative to the {p
 
 The values from this file override any values from the regular `application.yaml` file if it exists.
 
-== Configuration key conflicts
+== Configuration property conflicts
 
-The MicroProfile Config specification defines configuration keys as an arbitrary `.`-delimited string.
+The MicroProfile Config specification defines configuration properties as an arbitrary `.`-delimited string.
 However, structured formats such as YAML only support a subset of the possible configuration namespace.
 For example, consider the two configuration properties `quarkus.http.cors` and `quarkus.http.cors.methods`.
 One property is the prefix of another, so it might not be immediately evident how to specify both keys in your YAML configuration.
@@ -210,7 +210,7 @@ quarkus:
       methods: GET,PUT,POST
 ----
 
-YAML `null` keys are not included in the assembly of the configuration property name, allowing them to be used at any level for disambiguating configuration keys.
+YAML `null` keys are not included in the assembly of the configuration property name, allowing them to be used at any level for disambiguating configuration properties.
 
 Although Quarkus primarily uses `.properties` file extension for configuration, the snakeyaml library, which is used for parsing YAML in Quarkus, can also parse JSON structures. This means you can use YAML files with JSON content inside.
 

--- a/docs/src/main/asciidoc/context-propagation.adoc
+++ b/docs/src/main/asciidoc/context-propagation.adoc
@@ -174,7 +174,7 @@ The following configuration properties allow you to specify the default sets of 
 
 [cols="1,1,1"]
 |===
-|Configuration Key|Description|Default Value
+|Configuration property|Description|Default Value
 
 |`mp.context.ThreadContext.propagated`
 |The comma-separated set of propagated contexts

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -351,7 +351,7 @@ The Hibernate ORM extension supports defining xref:hibernate-orm.adoc#multiple-p
 For each persistence unit, point to the datasource of your choice.
 ====
 
-Defining multiple datasources works like defining a single datasource, with one important change - you have to specify a name (configuration key) for each datasource.
+Defining multiple datasources works like defining a single datasource, with one important change - you have to specify a name (configuration property) for each datasource.
 
 The following example provides three different datasources:
 
@@ -379,7 +379,7 @@ quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
 quarkus.datasource.inventory.jdbc.max-size=12
 ----
 
-Notice there is an extra section in the configuration key.
+Notice there is an extra section in the configuration property.
 The syntax is as follows: `quarkus.datasource.[optional name.][datasource property]`.
 
 NOTE: Even when only one database extension is installed, named databases need to specify at least one build-time property so that Quarkus can detect them.

--- a/docs/src/main/asciidoc/kafka-reactive-getting-started.adoc
+++ b/docs/src/main/asciidoc/kafka-reactive-getting-started.adoc
@@ -255,7 +255,7 @@ mp.messaging.incoming.requests.auto.offset.reset=earliest
 ----
 
 Note that in this case we have one incoming and one outgoing connector configuration, each one distinctly named.
-The configuration keys are structured as follows:
+The configuration properties are structured as follows:
 
 `mp.messaging.[outgoing|incoming].{channel-name}.property=value`
 

--- a/docs/src/main/asciidoc/mailer-reference.adoc
+++ b/docs/src/main/asciidoc/mailer-reference.adoc
@@ -322,7 +322,7 @@ Three API flavors are exposed:
 
 Check the xref:vertx.adoc[Using Vert.x guide] for further details about these different APIs and how to select the most suitable for you.
 
-The retrieved `MailClient` is configured using the configuration key presented above.
+The retrieved `MailClient` is configured using the configuration property presented above.
 You can also create your own instance, and pass your own configuration.
 
 

--- a/docs/src/main/asciidoc/pulsar-getting-started.adoc
+++ b/docs/src/main/asciidoc/pulsar-getting-started.adoc
@@ -255,7 +255,7 @@ mp.messaging.incoming.requests.subscriptionInitialPosition=Earliest
 ----
 
 Note that in this case we have one incoming and one outgoing connector configuration, each one distinctly named.
-The configuration keys are structured as follows:
+The configuration properties are structured as follows:
 
 `mp.messaging.[outgoing|incoming].{channel-name}.property=value`
 

--- a/docs/src/main/asciidoc/rabbitmq.adoc
+++ b/docs/src/main/asciidoc/rabbitmq.adoc
@@ -295,7 +295,7 @@ mp.messaging.outgoing.quotes.exchange.name=quotes
 ----
 
 Note that in this case we have one incoming and one outgoing connector configuration, each one distinctly named.
-The configuration keys are structured as follows:
+The configuration properties are structured as follows:
 
 `mp.messaging.[outgoing|incoming].{channel-name}.property=value`
 


### PR DESCRIPTION
Purpose: Use the correct term, configuration property, consistently.