### PR TITLE
Enable retrying tests for Surefire

### DIFF
--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -854,6 +854,18 @@
                                 </gpgArguments>
                             </configuration>
                         </plugin>
+                        <plugin>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <artifactId>maven-failsafe-plugin</artifactId>
+                            <configuration>
+                                <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                            </configuration>
+                        </plugin>
                     </plugins>
                 </pluginManagement>
             </build>


### PR DESCRIPTION
Unfortunately, it doesn't seem that Failsafe can fail when there is a flaky test so for now only doing it for Surefire.

We will be able to generalize to Failsafe once we have the infrastructure to include the flaky tests in the reporting.

@jprinet it's what you had in mind, right?