### PR TITLE
Build metrics: log warning when a build step exec time exceeds threshold

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/DebugConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/DebugConfig.java
@@ -45,4 +45,13 @@ public class DebugConfig {
      */
     @ConfigItem(defaultValue = "false")
     boolean dumpBuildMetrics;
+
+    /**
+     * When a build step execution exceeds the threshold a warning is logged.
+     */
+    @ConfigItem(defaultValue = DEFAULT_BUILD_STEP_EXECUTION_THRESHOLD)
+    long buildStepExecutionThreshold;
+
+    // The default value must be synced with QuarkusAugmentor
+    static final String DEFAULT_BUILD_STEP_EXECUTION_THRESHOLD = "5000";
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
@@ -174,6 +174,11 @@ public class QuarkusAugmentor {
                     buildResult.getMetrics().dumpTo(targetDir.resolve("build-metrics.json"));
                 }
             }
+
+            long threshold = Long.parseLong(System.getProperty("quarkus.debug.build-step-execution-threshold",
+                    DebugConfig.DEFAULT_BUILD_STEP_EXECUTION_THRESHOLD));
+            buildResult.getMetrics().checkDurations(threshold);
+
             return buildResult;
         } finally {
             try {


### PR DESCRIPTION
- the threshold is configurable with the quarkus.debug.build-step-execution-threshold system property

By default, the threshold is 5000ms.

For example, if you try to build the `cache-quickstart` with `mvn clean package -DskipTests -Dquarkus.debug.build-step-execution-threshold=60` then you will get something like:
```
[WARNING] [io.quarkus.builder.BuildMetrics] Execution time of the following build steps exceeded the threshold [60 ms]
	- [100 ms] io.quarkus.deployment.steps.ConfigGenerationBuildStep#generateConfigClass
	- [92 ms] io.quarkus.deployment.index.ApplicationArchiveBuildStep#build
	- [76 ms] io.quarkus.arc.deployment.ArcProcessor#registerBeans
	- [67 ms] io.quarkus.deployment.pkg.steps.JarResultBuildStep#buildRunnerJar
```