### PR TITLE
Using optimized Vertx HTTP header names

### DIFF
--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/RouteHandlers.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/RouteHandlers.java
@@ -1,5 +1,7 @@
 package io.quarkus.vertx.web.runtime;
 
+import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
+
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
@@ -9,20 +11,20 @@ public final class RouteHandlers {
     private RouteHandlers() {
     }
 
-    static final String CONTENT_TYPE = "content-type";
-
     public static void setContentType(RoutingContext context, String defaultContentType) {
         HttpServerResponse response = context.response();
         context.addHeadersEndHandler(new Handler<Void>() {
             @Override
             public void handle(Void aVoid) {
+                var headers = response.headers();
                 //use a listener to set the content type if it has not been set
-                if (response.headers().get(CONTENT_TYPE) == null) {
+                if (!headers.contains(CONTENT_TYPE)) {
                     String acceptableContentType = context.getAcceptableContentType();
+                    // we can use add because we know already there's no content type
                     if (acceptableContentType != null) {
-                        response.putHeader(CONTENT_TYPE, acceptableContentType);
+                        headers.add(CONTENT_TYPE, acceptableContentType);
                     } else if (defaultContentType != null) {
-                        response.putHeader(CONTENT_TYPE, defaultContentType);
+                        headers.add(CONTENT_TYPE, defaultContentType);
                     }
                 }
             }

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/ValidationSupport.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/ValidationSupport.java
@@ -10,6 +10,7 @@ import jakarta.validation.Path.Node;
 import jakarta.validation.Validator;
 
 import io.quarkus.arc.ArcContainer;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -70,7 +71,7 @@ public class ValidationSupport {
     public static void handleViolationException(ConstraintViolationException ex, RoutingContext rc, boolean forceJsonEncoding) {
         String accept = rc.request().getHeader(ACCEPT_HEADER);
         if (forceJsonEncoding || accept != null && accept.contains(APPLICATION_JSON)) {
-            rc.response().putHeader(RouteHandlers.CONTENT_TYPE, APPLICATION_JSON);
+            rc.response().putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
             JsonObject json = generateJsonResponse(ex.getConstraintViolations(), false);
             rc.response().setStatusCode(json.getInteger(PROBLEM_STATUS));
             rc.response().end(json.encode());


### PR DESCRIPTION
Another low hanging fruit: vertx AsciiStrings constant in Httpheaders have constant and cached case-insensitive hashcodes, which make them faster under pretty much any circumstances.

The benefit is to drop to ~0 the ~2.87% cost reported in plaintext with reactive routes at

![image](https://github.com/quarkusio/quarkus/assets/13125299/6b34f738-a907-49a0-8bf1-072816bfd5bc)

Moving to `contains` bring another additional benefit: a reduced allocation pressure, because Vertx multimap's `get` force allocating a `String` out of `AsciiString`'s value (which is the `AsciiString::toString` calls in the flamegrah).

The header matching cost of `HeadersMultiMap::get0` instead (in `AsciiString::contentEqualsIgnoreCase`) depends by NOT using a const `AsciiString` header values.

Not a big, but ~3% less overall is sensible, especially because, looking a finer picture of encoding and sending back the response in the same test, it's relevant for `11.20%` of the cost, on par of encoding the content in the buffer to be sent back (which is a small content, but still...).

![image](https://github.com/quarkusio/quarkus/assets/13125299/b0f09c18-b0cb-4809-b90f-c00ef19c24f1)
