### PR TITLE
Replace CONTENT_TYPE String with Vertx optimized one and make fast-path inlineable

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
@@ -24,6 +24,7 @@ import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.SecurityContext;
 
 import org.jboss.resteasy.reactive.server.core.Deployment;
@@ -167,6 +168,26 @@ public class ServletRequestContext extends ResteasyReactiveRequestContext
     @Override
     public boolean resumeExternalProcessing() {
         return false;
+    }
+
+    @Override
+    public String getRequestAccept() {
+        return getRequestHeader(HttpHeaders.ACCEPT);
+    }
+
+    @Override
+    public List<String> getAllRequestAccepts() {
+        return getAllRequestHeaders(HttpHeaders.ACCEPT);
+    }
+
+    @Override
+    public String getRequestContentType() {
+        return getRequestHeader(HttpHeaders.CONTENT_TYPE);
+    }
+
+    @Override
+    public List<String> getAllRequestContentTypes() {
+        return getAllRequestHeaders(HttpHeaders.CONTENT_TYPE);
     }
 
     @Override
@@ -400,6 +421,11 @@ public class ServletRequestContext extends ResteasyReactiveRequestContext
     public ServerHttpResponse setResponseHeader(CharSequence name, CharSequence value) {
         response.setHeader(name.toString(), value != null ? value.toString() : null);
         return this;
+    }
+
+    @Override
+    public ServerHttpResponse setResponseContentType(final boolean capitalLettersHeaderName, final CharSequence value) {
+        return setResponseHeader(capitalLettersHeaderName ? "Content-Type" : "content-type", value);
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -811,6 +811,57 @@ public abstract class ResteasyReactiveRequestContext
         return producesChecked;
     }
 
+    public List<String> getAccept(boolean single) {
+        if (httpHeaders == null) {
+            if (single) {
+                var accept = serverRequest().getRequestAccept();
+                if (accept == null) {
+                    return null;
+                }
+                return List.of(accept);
+            }
+            // empty collections must not be turned to null
+            return serverRequest().getAllRequestAccepts();
+        } else {
+            if (single) {
+                return List.of(httpHeaders.getMutableHeaders().getFirst(HttpHeaders.ACCEPT));
+            }
+            // empty collections must not be turned to null
+            List<String> list = httpHeaders.getMutableHeaders().get(HttpHeaders.ACCEPT);
+            if (list == null) {
+                return Collections.emptyList();
+            } else {
+                return list;
+            }
+        }
+    }
+
+    // same as getAccept but for ContentType
+    public List<String> getContentType(boolean single) {
+        if (httpHeaders == null) {
+            if (single) {
+                var contentType = serverRequest().getRequestContentType();
+                if (contentType == null) {
+                    return null;
+                }
+                return List.of(contentType);
+            }
+            // empty collections must not be turned to null
+            return serverRequest().getAllRequestContentTypes();
+        } else {
+            if (single) {
+                return List.of(httpHeaders.getMutableHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+            }
+            // empty collections must not be turned to null
+            List<String> list = httpHeaders.getMutableHeaders().get(HttpHeaders.CONTENT_TYPE);
+            if (list == null) {
+                return Collections.emptyList();
+            } else {
+                return list;
+            }
+        }
+    }
+
     @Override
     public Object getHeader(String name, boolean single) {
         if (httpHeaders == null) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ClassRoutingHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ClassRoutingHandler.java
@@ -13,7 +13,6 @@ import jakarta.ws.rs.NotAcceptableException;
 import jakarta.ws.rs.NotAllowedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.NotSupportedException;
-import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -106,12 +105,12 @@ public class ClassRoutingHandler implements ServerRestHandler {
 
         // according to the spec we need to return HTTP 415 when content-type header doesn't match what is specified in @Consumes
         if (!target.value.getConsumes().isEmpty()) {
-            String contentType = (String) requestContext.getHeader(HttpHeaders.CONTENT_TYPE, true);
-            if (contentType != null) {
+            var contentTypes = requestContext.getContentType(true);
+            if (contentTypes != null) {
                 try {
                     if (MediaTypeHelper.getFirstMatch(
                             target.value.getConsumes(),
-                            Collections.singletonList(MediaType.valueOf(contentType))) == null) {
+                            Collections.singletonList(MediaType.valueOf(contentTypes.get(0)))) == null) {
                         throw new NotSupportedException("The content-type header value did not match the value in @Consumes");
                     }
                 } catch (IllegalArgumentException e) {
@@ -123,7 +122,7 @@ public class ClassRoutingHandler implements ServerRestHandler {
         if (target.value.getProduces() != null) {
             // there could potentially be multiple Accept headers and we need to response with 406
             // if none match the method's @Produces
-            List<String> accepts = (List<String>) requestContext.getHeader(HttpHeaders.ACCEPT, false);
+            List<String> accepts = requestContext.getAccept(false);
             if (!accepts.isEmpty()) {
                 boolean hasAtLeastOneMatch = false;
                 for (int i = 0; i < accepts.size(); i++) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerHttpRequest.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerHttpRequest.java
@@ -10,6 +10,14 @@ import org.jboss.resteasy.reactive.server.core.multipart.FormData;
 
 public interface ServerHttpRequest {
 
+    String getRequestAccept();
+
+    List<String> getAllRequestAccepts();
+
+    String getRequestContentType();
+
+    List<String> getAllRequestContentTypes();
+
     String getRequestHeader(CharSequence name);
 
     Iterable<Map.Entry<String, String>> getAllRequestHeaders();

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerHttpResponse.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerHttpResponse.java
@@ -23,6 +23,8 @@ public interface ServerHttpResponse extends StreamingResponse<ServerHttpResponse
 
     ServerHttpResponse setResponseHeader(CharSequence name, CharSequence value);
 
+    ServerHttpResponse setResponseContentType(boolean capitalLettersHeaderName, CharSequence value);
+
     ServerHttpResponse setResponseHeader(CharSequence name, Iterable<CharSequence> values);
 
     Iterable<Map.Entry<String, String>> getAllResponseHeaders();

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -45,6 +45,8 @@ import io.vertx.ext.web.RoutingContext;
 public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequestContext
         implements ServerHttpRequest, ServerHttpResponse, Handler<Void> {
 
+    private static final CharSequence CAPITAL_CONTENT_TYPE = io.vertx.core.http.HttpHeaders
+            .createOptimized(HttpHeaders.CONTENT_TYPE);
     public static final String CONTINUE = "100-continue";
     protected final RoutingContext context;
     protected final HttpServerRequest request;
@@ -142,6 +144,26 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
     public boolean resumeExternalProcessing() {
         context.next();
         return true;
+    }
+
+    @Override
+    public String getRequestAccept() {
+        return request.headers().get(io.vertx.core.http.HttpHeaders.ACCEPT);
+    }
+
+    @Override
+    public List<String> getAllRequestAccepts() {
+        return request.headers().getAll(io.vertx.core.http.HttpHeaders.ACCEPT);
+    }
+
+    @Override
+    public String getRequestContentType() {
+        return request.headers().get(io.vertx.core.http.HttpHeaders.CONTENT_TYPE);
+    }
+
+    @Override
+    public List<String> getAllRequestContentTypes() {
+        return request.headers().getAll(io.vertx.core.http.HttpHeaders.CONTENT_TYPE);
     }
 
     @Override
@@ -386,6 +408,13 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
     @Override
     public ServerHttpResponse setResponseHeader(CharSequence name, Iterable<CharSequence> values) {
         response.headers().set(name, values);
+        return this;
+    }
+
+    @Override
+    public ServerHttpResponse setResponseContentType(boolean capitalLettersHeaderName, CharSequence value) {
+        response.headers().set(capitalLettersHeaderName ? CAPITAL_CONTENT_TYPE : io.vertx.core.http.HttpHeaders.CONTENT_TYPE,
+                value);
         return this;
     }
 


### PR DESCRIPTION
The original method was not inlineable due to its bytecode size being > `FreqInlineSize` (which is 325 bytes).
Splitting it into fast/slow path make it inlineable.
Furthermore I'm replacing the `String` upper-case header name to allow vertx headers to reuse its precomputed hashcode.

@geoand is it safe to assume that it's always a Vertx HTTP response?

I see a comment stating that we have to use it upper-case, is it still valid?
Considering that the map is case-insensitive, I don't understand why...