### PR TITLE
Improve MongoDB tests on Java records

### DIFF
--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/record/PersonName.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/record/PersonName.java
@@ -2,6 +2,6 @@ package io.quarkus.it.mongodb.panache.record;
 
 import io.quarkus.mongodb.panache.common.ProjectionFor;
 
-@ProjectionFor(PersonWithRecord.class)
+@ProjectionFor(PersonRecord.class)
 public record PersonName(String firstName, String lastName) {
 }

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/record/PersonRecord.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/record/PersonRecord.java
@@ -1,0 +1,4 @@
+package io.quarkus.it.mongodb.panache.record;
+
+public record PersonRecord(String firstName, String lastName, Status status) {
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/record/PersonRecordRepository.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/record/PersonRecordRepository.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.mongodb.panache.record;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.mongodb.panache.PanacheMongoRepository;
+
+@ApplicationScoped
+public class PersonRecordRepository implements PanacheMongoRepository<PersonRecord> {
+}

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/record/PersonResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/record/PersonResource.java
@@ -1,24 +1,24 @@
 package io.quarkus.it.mongodb.panache.record;
 
-import java.net.URI;
 import java.util.List;
 
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.Response;
 
-@Path("/mongo/persons")
+@Path("/persons/record")
 public class PersonResource {
+    @Inject
+    PersonRecordRepository personRecordRepository;
+
     @GET
     public List<PersonName> getPersons() {
-        return PersonWithRecord.findAll().project(PersonName.class).list();
+        return personRecordRepository.findAll().project(PersonName.class).list();
     }
 
     @POST
-    public Response addPerson(PersonWithRecord person) {
-        person.persist();
-        String id = person.id.toString();
-        return Response.created(URI.create("/persons/entity/" + id)).build();
+    public void addPerson(PersonRecord person) {
+        personRecordRepository.persist(person);
     }
 }

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/record/PersonWithRecord.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/record/PersonWithRecord.java
@@ -1,9 +1,0 @@
-package io.quarkus.it.mongodb.panache.record;
-
-import io.quarkus.mongodb.panache.PanacheMongoEntity;
-
-public class PersonWithRecord extends PanacheMongoEntity {
-    public String firstname;
-    public String lastname;
-    public Status status = Status.ALIVE;
-}

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/record/MongodbPanacheRecordIT.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/record/MongodbPanacheRecordIT.java
@@ -1,40 +1,7 @@
 package io.quarkus.it.mongodb.panache.record;
 
-import static io.restassured.RestAssured.given;
-import static io.restassured.RestAssured.when;
-import static org.hamcrest.CoreMatchers.is;
-
-import org.junit.jupiter.api.Test;
-
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.restassured.http.ContentType;
 
 @QuarkusIntegrationTest
 class MongodbPanacheRecordIT extends MongodbPanacheRecordTest {
-
-    private static final String ROOT_URL = "/mongo/persons";
-
-    @Test
-    void testRecordInPanache() {
-        var person1 = new PersonWithRecord();
-        person1.firstname = "Loïc";
-        person1.lastname = "Mathieu";
-        person1.status = Status.ALIVE;
-        var person2 = new PersonWithRecord();
-        person1.firstname = "Zombie";
-        person2.lastname = "Zombie";
-        person2.status = Status.DEAD;
-
-        given().body(person1).contentType(ContentType.JSON)
-                .when().post(ROOT_URL)
-                .then().statusCode(201);
-        given().body(person2).contentType(ContentType.JSON)
-                .when().post(ROOT_URL)
-                .then().statusCode(201);
-
-        when().get(ROOT_URL)
-                .then()
-                .statusCode(200)
-                .body("size()", is(2));
-    }
 }

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/record/MongodbPanacheRecordTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/record/MongodbPanacheRecordTest.java
@@ -15,25 +15,19 @@ import io.restassured.http.ContentType;
 @QuarkusTestResource(MongoReplicaSetTestResource.class)
 class MongodbPanacheRecordTest {
 
-    private static final String ROOT_URL = "/mongo/persons";
+    private static final String ROOT_URL = "/persons/record";
 
     @Test
     void testRecordInPanache() {
-        var person1 = new PersonWithRecord();
-        person1.firstname = "Loïc";
-        person1.lastname = "Mathieu";
-        person1.status = Status.ALIVE;
-        var person2 = new PersonWithRecord();
-        person1.firstname = "Zombie";
-        person2.lastname = "Zombie";
-        person2.status = Status.DEAD;
+        var person1 = new PersonRecord("Loïc", "Mathieu", Status.ALIVE);
+        var person2 = new PersonRecord("Zombie", "Zombie", Status.DEAD);
 
         given().body(person1).contentType(ContentType.JSON)
                 .when().post(ROOT_URL)
-                .then().statusCode(201);
+                .then().statusCode(204);
         given().body(person2).contentType(ContentType.JSON)
                 .when().post(ROOT_URL)
-                .then().statusCode(201);
+                .then().statusCode(204);
 
         when().get(ROOT_URL)
                 .then()


### PR DESCRIPTION
Improve the test to use a record for both defining the BSON document and in projection.

I don't know if it's worth documenting it as it's the standard behavior but we do have an issue about it and it works as intended.