### PR TITLE
Netty PlatformDependent0.<init> uses `DirectByteBuffer` reflectively

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -94,6 +94,9 @@ class NettyProcessor {
                 .produce(ReflectiveClassBuildItem.builder("java.util.LinkedHashMap").build());
         reflectiveClass.produce(ReflectiveClassBuildItem.builder("sun.nio.ch.SelectorImpl").methods().fields().build());
 
+        // Setup reflective accesses happening in PlatformDependent0 static initializer
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder("java.nio.DirectByteBuffer").constructors().build());
+
         String maxOrder = calculateMaxOrder(config.allocatorMaxOrder, minMaxOrderBuildItems, false);
 
         NativeImageConfigBuildItem.Builder builder = NativeImageConfigBuildItem.builder()


### PR DESCRIPTION
Since we moved `io.netty.util.internal.PlatformDependent`'s and `io.netty.util.internal.PlatformDependent0`' initialization at runtime we need to register `java.nio.DirectByteBuffer`'s constructors for reflective access to avoid miss-configurations due to not being able to access the constructor in
https://github.com/netty/netty/blob/5db037beedca8aa5b6a486fa515cc6af013ced74/common/src/main/java/io/netty/util/internal/PlatformDependent0.java#L290-L292

More classes and methods might need to be registered as discussed in https://github.com/quarkusio/quarkus/issues/37626

Closes https://github.com/Karm/mandrel-integration-tests/issues/236

Note this is not a complete fix for https://github.com/quarkusio/quarkus/issues/37626, it only partially solves the problem and unblocks our (mandrel team) CI.