### PR TITLE
Netty requires more classes to be runtime initialized

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -162,8 +162,28 @@ class NettyProcessor {
             log.debug("Not registering Netty native kqueue classes as they were not found");
         }
 
-        builder.addRuntimeReinitializedClass("io.netty.util.internal.PlatformDependent");
-        builder.addRuntimeReinitializedClass("io.netty.util.internal.PlatformDependent0");
+        builder.addRuntimeReinitializedClass("io.netty.util.internal.PlatformDependent")
+                .addRuntimeReinitializedClass("io.netty.util.internal.PlatformDependent0")
+                .addRuntimeReinitializedClass("io.netty.buffer.PooledByteBufAllocator");
+
+        if (QuarkusClassLoader.isClassPresentAtRuntime("io.netty.buffer.UnpooledByteBufAllocator")) {
+            builder.addRuntimeReinitializedClass("io.netty.buffer.UnpooledByteBufAllocator")
+                    .addRuntimeReinitializedClass("io.netty.buffer.Unpooled")
+                    .addRuntimeReinitializedClass("io.vertx.core.http.impl.Http1xServerResponse")
+                    .addRuntimeReinitializedClass("io.netty.handler.codec.http.HttpObjectAggregator")
+                    .addRuntimeReinitializedClass("io.netty.handler.codec.ReplayingDecoderByteBuf")
+                    .addRuntimeReinitializedClass("io.vertx.core.parsetools.impl.RecordParserImpl");
+
+            if (QuarkusClassLoader.isClassPresentAtRuntime("io.vertx.ext.web.client.impl.MultipartFormUpload")) {
+                builder.addRuntimeReinitializedClass("io.vertx.ext.web.client.impl.MultipartFormUpload");
+            }
+
+            if (QuarkusClassLoader
+                    .isClassPresentAtRuntime("org.jboss.resteasy.reactive.client.impl.multipart.QuarkusMultipartFormUpload")) {
+                builder.addRuntimeReinitializedClass(
+                        "org.jboss.resteasy.reactive.client.impl.multipart.QuarkusMultipartFormUpload");
+            }
+        }
 
         return builder //TODO: make configurable
                 .build();


### PR DESCRIPTION
In https://github.com/quarkusio/quarkus/pull/37347 we moved
`PlatformDependent` and `PlatformDependent0` classes to
run-time-initialization as they are platform-dependent and thus need to
be initialized on the target platform. It looks like there are more
classes like these that need to be runtime initialized as they
transitively rely on platform dependent values.

Closes https://github.com/Karm/mandrel-integration-tests/issues/236

Supersedes https://github.com/quarkusio/quarkus/pull/37628

CI run with latest Mandrel 24.0-dev https://github.com/graalvm/mandrel/actions/runs/7147836492