### PR TITLE
Logging docs include build time config reference

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -841,4 +841,5 @@ NOTE: If applicable, MDC data is stored in a _duplicated context_, which is an i
 [[loggingConfigurationReference]]
 == Logging configuration reference
 
+include::{generated-dir}/config/quarkus-log-logging-log-build-time-config.adoc[opts=optional, leveloffset=+1]
 include::{generated-dir}/config/quarkus-log-logging-log-config.adoc[opts=optional, leveloffset=+1]


### PR DESCRIPTION
Resolves #37579 

Build time config for logging is present here: https://quarkus.io/guides/all-config but not here: https://quarkus.io/guides/logging

Oversight to not include build-time logging config on the logging page