### PR TITLE
Fix JAXB unmarshalling error when compiling to native

### DIFF
--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
@@ -70,6 +70,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarningBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
@@ -186,6 +187,7 @@ public class JaxbProcessor {
             BuildProducer<NativeImageProxyDefinitionBuildItem> proxyDefinitions,
             CombinedIndexBuildItem combinedIndexBuildItem,
             List<JaxbFileRootBuildItem> fileRoots,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchies,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<NativeImageResourceBuildItem> resource,
             BuildProducer<NativeImageResourceBundleBuildItem> resourceBundle,
@@ -202,10 +204,11 @@ public class JaxbProcessor {
         for (DotName jaxbRootAnnotation : JAXB_ROOT_ANNOTATIONS) {
             for (AnnotationInstance jaxbRootAnnotationInstance : index
                     .getAnnotations(jaxbRootAnnotation)) {
-                if (jaxbRootAnnotationInstance.target().kind() == Kind.CLASS) {
-                    String className = jaxbRootAnnotationInstance.target().asClass().name().toString();
-                    reflectiveClass.produce(ReflectiveClassBuildItem.builder(className).methods().fields().build());
-                    classesToBeBound.add(className);
+                if (jaxbRootAnnotationInstance.target().kind() == Kind.CLASS
+                        && !JAXB_ANNOTATIONS.contains(jaxbRootAnnotationInstance.target().asClass().getClass())) {
+                    DotName targetClass = jaxbRootAnnotationInstance.target().asClass().name();
+                    addReflectiveHierarchyClass(targetClass, reflectiveHierarchies, index);
+                    classesToBeBound.add(targetClass.toString());
                     jaxbRootAnnotationsDetected = true;
                 }
             }
@@ -410,6 +413,17 @@ public class JaxbProcessor {
         } catch (IOException e) {
             throw new IOError(e);
         }
+    }
+
+    private void addReflectiveHierarchyClass(DotName className,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchy,
+            IndexView index) {
+        Type jandexType = Type.create(className, Type.Kind.CLASS);
+        reflectiveHierarchy.produce(new ReflectiveHierarchyBuildItem.Builder()
+                .type(jandexType)
+                .index(index)
+                .source(getClass().getSimpleName() + " > " + jandexType.name().toString())
+                .build());
     }
 
     private void addReflectiveClass(BuildProducer<ReflectiveClassBuildItem> reflectiveClass, boolean methods, boolean fields,

--- a/integration-tests/jaxb/src/main/java/io/quarkus/it/jaxb/BookIBANField.java
+++ b/integration-tests/jaxb/src/main/java/io/quarkus/it/jaxb/BookIBANField.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.jaxb;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlTransient
+public abstract class BookIBANField {
+    @XmlElement
+    private String IBAN;
+
+    public BookIBANField() {
+    }
+
+    public void setIBAN(String IBAN) {
+        this.IBAN = IBAN;
+    }
+
+    public String getIBAN() {
+        return IBAN;
+    }
+}

--- a/integration-tests/jaxb/src/main/java/io/quarkus/it/jaxb/BookWithParent.java
+++ b/integration-tests/jaxb/src/main/java/io/quarkus/it/jaxb/BookWithParent.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.jaxb;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlRootElement
+@XmlType(propOrder = { "IBAN", "title" })
+public class BookWithParent extends BookIBANField {
+    @XmlElement
+    private String title;
+
+    public BookWithParent() {
+    }
+
+    public BookWithParent(String title) {
+        this.title = title;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+}

--- a/integration-tests/jaxb/src/main/java/io/quarkus/it/jaxb/JaxbResource.java
+++ b/integration-tests/jaxb/src/main/java/io/quarkus/it/jaxb/JaxbResource.java
@@ -65,4 +65,19 @@ public class JaxbResource {
         return response;
     }
 
+    //Test for Jaxb with parent class field
+    @Path("/bookwithparent")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getBookWithParent(@QueryParam("name") String name, @QueryParam("iban") String iban) throws JAXBException {
+        BookWithParent bookWithParent = new BookWithParent();
+        bookWithParent.setTitle(name);
+        bookWithParent.setIBAN(iban);
+        JAXBContext context = JAXBContext.newInstance(bookWithParent.getClass());
+        Marshaller marshaller = context.createMarshaller();
+        StringWriter sw = new StringWriter();
+        marshaller.marshal(bookWithParent, sw);
+        return sw.toString();
+    }
+
 }

--- a/integration-tests/jaxb/src/test/java/io/quarkus/it/jaxb/JaxbIT.java
+++ b/integration-tests/jaxb/src/test/java/io/quarkus/it/jaxb/JaxbIT.java
@@ -1,8 +1,24 @@
 package io.quarkus.it.jaxb;
 
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
 public class JaxbIT extends JaxbTest {
-
+    //We have to test native executable of Jaxb
+    @Test
+    public void bookWithParent() {
+        given().when()
+                .param("name", "Foundation")
+                .param("iban", "4242")
+                .get("/jaxb/bookwithparent")
+                .then()
+                .statusCode(200)
+                .body(is(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><bookWithParent><IBAN>4242</IBAN><title>Foundation</title></bookWithParent>"));
+    }
 }


### PR DESCRIPTION
Fix #36479

The root cause was that not all classes annotated with Jaxb annotations were marked for reflection when using native compilation, in case there we have fields that are declared in parent classes. The fix made was to replace the ReflectiveClassBuildItem from JaxbProcessor with ReflectiveHierarchyBuildItem in order to mark inherited fields for native compilation.

There is a warning throw stating that some classes are not indexed via Jandex. If anyone know how to fix this don't hesitate to tell me ! I have added the jandex maven plugins as documented in the Quarkus doc but it changes nothing. For instance : 
```logs
[WARNING] [io.quarkus.deployment.steps.ReflectiveHierarchyStep] Unable to properly register the hierarchy of the following classes for reflection as they are not in the Jandex index:
        - com.sun.istack.FinalArrayList (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - com.sun.org.apache.xerces.internal.impl.dv.xs.SchemaDVFactoryImpl (source: JaxbProcessor > com.sun.org.apache.xerces.internal.impl.dv.xs.SchemaDVFactoryImpl)
        - com.sun.org.apache.xpath.internal.functions.FuncNot (source: JaxbProcessor > com.sun.org.apache.xpath.internal.functions.FuncNot)
        - com.sun.xml.internal.stream.XMLInputFactoryImpl (source: JaxbProcessor > com.sun.xml.internal.stream.XMLInputFactoryImpl)
        - com.sun.xml.internal.stream.XMLOutputFactoryImpl (source: JaxbProcessor > com.sun.xml.internal.stream.XMLOutputFactoryImpl)
        - jakarta.activation.MimeType (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - javax.xml.namespace.QName (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.annotation.AnnotationReader (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.annotation.Locatable (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.Adapter (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.BuiltinLeafInfo (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.ClassInfo (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.Element (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.ElementInfo (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.ElementPropertyInfo (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.EnumLeafInfo (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.ErrorHandler (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.ID (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.NonElement (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.PropertyInfo (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.PropertyKind (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.TypeInfo (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.TypeInfoSet (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.core.WildcardMode (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.model.nav.Navigator (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.runtime.IllegalAnnotationException (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.runtime.Location (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
        - org.glassfish.jaxb.core.v2.runtime.RuntimeUtil$ToStringAdapter (source: JaxbProcessor > org.glassfish.jaxb.core.v2.runtime.RuntimeUtil$ToStringAdapter)
        - org.xml.sax.Locator (source: JaxbProcessor > jakarta.xml.bind.annotation.XmlAccessorType)
Consider adding them to the index either by creating a Jandex index for your dependency via the Maven plugin, an empty META-INF/beans.xml or quarkus.index-dependency properties.
```