### PR TITLE
Remove unnecessary content type checks

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -135,6 +135,7 @@ public abstract class ResteasyReactiveRequestContext
     private OutputStream outputStream;
     private OutputStream underlyingOutputStream;
     private FormData formData;
+    private boolean producesChecked;
 
     public ResteasyReactiveRequestContext(Deployment deployment,
             ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain) {
@@ -794,6 +795,14 @@ public abstract class ResteasyReactiveRequestContext
                 this.remaining = newPath.substring(getPathWithoutPrefix().length() - this.remaining.length());
             }
         }
+    }
+
+    public void setProducesChecked(boolean checked) {
+        producesChecked = checked;
+    }
+
+    public boolean isProducesChecked() {
+        return producesChecked;
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ClassRoutingHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ClassRoutingHandler.java
@@ -141,6 +141,8 @@ public class ClassRoutingHandler implements ServerRestHandler {
                     throw new NotAcceptableException(INVALID_ACCEPT_HEADER_MESSAGE);
                 }
             }
+
+            requestContext.setProducesChecked(true);
         }
 
         requestContext.restart(target.value);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/FixedProducesHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/FixedProducesHandler.java
@@ -36,7 +36,7 @@ public class FixedProducesHandler implements ServerRestHandler {
     @Override
     public void handle(ResteasyReactiveRequestContext requestContext) throws Exception {
         List<String> acceptValues = (List<String>) requestContext.getHeader(HttpHeaders.ACCEPT, false);
-        if (acceptValues.isEmpty()) {
+        if (acceptValues.isEmpty() || requestContext.isProducesChecked()) {
             requestContext.setResponseContentType(mediaType);
             requestContext.setEntityWriter(writer);
         } else {


### PR DESCRIPTION
These checks have potentially already
been performed in `ClassRoutingHandler`

Closes: #37637