### PR TITLE
Fix GraalVM version checker in order to accept other implementations

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -31,9 +31,9 @@ public final class GraalVM {
 
         private static final String VENDOR_VERS = "(?<VENDOR>.*)";
         private static final String JDK_DEBUG = "[^\\)]*"; // zero or more of >anything not a ')'<
-        private static final String RUNTIME_NAME = "(?<RUNTIME>(?:OpenJDK|GraalVM) Runtime Environment) ";
+        private static final String RUNTIME_NAME = "(?<RUNTIME>(?:.*) Runtime Environment) ";
         private static final String BUILD_INFO = "(?<BUILDINFO>.*)";
-        private static final String VM_NAME = "(?<VM>(?:OpenJDK 64-Bit Server|Substrate) VM) ";
+        private static final String VM_NAME = "(?<VM>(?:.*) VM) ";
 
         private static final String FIRST_LINE_PATTERN = "native-image " + VSTR_FORMAT + " .*$";
         private static final String SECOND_LINE_PATTERN = RUNTIME_NAME

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -63,6 +63,16 @@ public class GraalVMTest {
                         + "GraalVM Runtime Environment GraalVM CE (build 20+34-jvmci-23.0-b10)\n"
                         + "Substrate VM GraalVM CE (build 20+34, serial gc)").split("\\n"))));
 
+        // Should also work for other unknown implementations of GraalVM
+        assertVersion(new Version("GraalVM 23.0", "23.0", GRAALVM), GRAALVM,
+                Version.of(Stream.of(("native-image 20 2023-07-30\n"
+                        + "Foo Runtime Environment whatever (build 20+34-jvmci-23.0-b7)\n"
+                        + "Foo VM whatever (build 20+34, serial gc)").split("\\n"))));
+        assertVersion(new Version("GraalVM 23.0", "23.0", GRAALVM), GRAALVM,
+                Version.of(Stream.of(("native-image 20 2023-07-30\n"
+                        + "Another Runtime Environment whatever (build 20+34-jvmci-23.0-b7)\n"
+                        + "Another VM whatever (build 20+34, serial gc)").split("\\n"))));
+
         // Older version parsing
         assertVersion(new Version("GraalVM 20.1", "20.1", GRAALVM), GRAALVM,
                 Version.of(Stream.of("GraalVM Version 20.1.0 (Java Version 11.0.7)")));

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -141,6 +141,19 @@ public class GraalVMTest {
     }
 
     @Test
+    public void testGraalVMEE22DevVersionParser() {
+        Version graalVMEE22Dev = Version.of(Stream.of(("native-image 22 2024-03-19\n"
+                + "Java(TM) SE Runtime Environment Oracle GraalVM 22-dev+25.1 (build 22+25-jvmci-b01)\n"
+                + "Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 22-dev+25.1 (build 22+25-jvmci-b01, mixed mode, sharing)")
+                .split("\\n")));
+        assertThat(graalVMEE22Dev.distribution.name()).isEqualTo("GRAALVM");
+        assertThat(graalVMEE22Dev.getVersionAsString()).isEqualTo("24.0-dev");
+        assertThat(graalVMEE22Dev.javaVersion.toString()).isEqualTo("22+25-jvmci-b01");
+        assertThat(graalVMEE22Dev.javaVersion.feature()).isEqualTo(22);
+        assertThat(graalVMEE22Dev.javaVersion.update()).isEqualTo(0);
+    }
+
+    @Test
     public void testGraalVMVersionsOlderThan() {
         assertOlderThan("GraalVM Version 19.3.6 CE", "GraalVM Version 20.2.0 (Java Version 11.0.9)");
         assertOlderThan("GraalVM Version 20.0.0 (Java Version 11.0.7)", "GraalVM Version 20.1.0 (Java Version 11.0.8)");


### PR DESCRIPTION
As communicated in [https://github.com/quarkusio/quarkus/issues/36972](https://github.com/quarkusio/quarkus/issues/36972)

When building a Native Image using GraalVM, Quarkus parses the version of native-image. The check fails for custom Runtimes different of OpenJDK/GraalVM and VM names different to OpenJDK 64-Bit Server and Substrate.

I propose the following modifications in order to make the parser less strict.

