### PR TITLE
Optimise primitive clazz checks

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/Serialisers.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/Serialisers.java
@@ -4,7 +4,6 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -31,7 +30,6 @@ public abstract class Serialisers {
     public static final Annotation[] NO_ANNOTATION = new Annotation[0];
     public static final ReaderInterceptor[] NO_READER_INTERCEPTOR = new ReaderInterceptor[0];
     public static final WriterInterceptor[] NO_WRITER_INTERCEPTOR = new WriterInterceptor[0];
-    protected static final Map<Class<?>, Class<?>> primitivesToWrappers = new HashMap<>();
     // FIXME: spec says we should use generic type, but not sure how to pass that type from Jandex to reflection
     protected final QuarkusMultivaluedMap<Class<?>, ResourceWriter> writers = new QuarkusMultivaluedHashMap<>();
     protected final QuarkusMultivaluedMap<Class<?>, ResourceReader> readers = new QuarkusMultivaluedHashMap<>();
@@ -46,9 +44,7 @@ public abstract class Serialisers {
         List<MediaType> desired = MediaTypeHelper.getUngroupedMediaTypes(mediaType);
         List<MessageBodyReader<?>> ret = new ArrayList<>();
         Deque<Class<?>> toProcess = new LinkedList<>();
-        Class<?> klass = entityType;
-        if (primitivesToWrappers.containsKey(klass))
-            klass = primitivesToWrappers.get(klass);
+        Class<?> klass = lookupPrimitiveWrapper(entityType);
         QuarkusMultivaluedMap<Class<?>, ResourceReader> readers;
         if (configuration != null && !configuration.getResourceReaders().isEmpty()) {
             readers = new QuarkusMultivaluedHashMap<>();
@@ -124,9 +120,7 @@ public abstract class Serialisers {
         if (Response.class.isAssignableFrom(entityType)) {
             return Collections.emptyList();
         }
-        Class<?> klass = entityType;
-        if (primitivesToWrappers.containsKey(klass))
-            klass = primitivesToWrappers.get(klass);
+        Class<?> klass = primitiveWrapperOf(entityType);
         //first we check to make sure that the return type is build time selectable
         //this fails when there are eligible writers for a sub type of the entity type
         //e.g. if the entity type is Object and there are mappers for String then we
@@ -241,14 +235,17 @@ public abstract class Serialisers {
         return findWriters(configuration, entityType, resolvedMediaType, null);
     }
 
+    protected Class<?> lookupPrimitiveWrapper(Class<?> entityType) {
+        return entityType;
+    }
+
     public List<MessageBodyWriter<?>> findWriters(ConfigurationImpl configuration, Class<?> entityType,
             MediaType resolvedMediaType, RuntimeType runtimeType) {
         // FIXME: invocation is very different between client and server, where the server doesn't treat GenericEntity specially
         // it's probably missing from there, while the client handles it upstack
         List<MediaType> mt = Collections.singletonList(resolvedMediaType);
         Class<?> klass = entityType;
-        if (primitivesToWrappers.containsKey(klass))
-            klass = primitivesToWrappers.get(klass);
+        klass = primitiveWrapperOf(entityType);
         QuarkusMultivaluedMap<Class<?>, ResourceWriter> writers;
         if (configuration != null && !configuration.getResourceWriters().isEmpty()) {
             writers = new QuarkusMultivaluedHashMap<>();
@@ -261,6 +258,10 @@ public abstract class Serialisers {
         }
 
         return toMessageBodyWriters(findResourceWriters(writers, klass, mt, runtimeType));
+    }
+
+    private Class<?> primitiveWrapperOf(Class<?> entityType) {
+        return entityType;
     }
 
     public static class Builtin {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ServerSerialisers.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ServerSerialisers.java
@@ -86,17 +86,6 @@ public class ServerSerialisers extends Serialisers {
     private static final String LENGTH_LOWER = "length";
     private static final String CONTENT_TYPE = CONTENT + "-" + TYPE; // use this instead of the Vert.x constant because the TCK expects upper case
 
-    static {
-        primitivesToWrappers.put(boolean.class, Boolean.class);
-        primitivesToWrappers.put(char.class, Character.class);
-        primitivesToWrappers.put(byte.class, Byte.class);
-        primitivesToWrappers.put(short.class, Short.class);
-        primitivesToWrappers.put(int.class, Integer.class);
-        primitivesToWrappers.put(long.class, Long.class);
-        primitivesToWrappers.put(float.class, Float.class);
-        primitivesToWrappers.put(double.class, Double.class);
-    }
-
     public final static List<Serialisers.BuiltinReader> BUILTIN_READERS = List.of(
             new Serialisers.BuiltinReader(String.class, ServerStringMessageBodyHandler.class,
                     MediaType.WILDCARD),
@@ -188,6 +177,32 @@ public class ServerSerialisers extends Serialisers {
             return writers;
         }
     };
+
+    @Override
+    protected final Class<?> lookupPrimitiveWrapper(final Class<?> entityType) {
+        if (!entityType.isPrimitive()) {
+            return entityType;
+        }
+        if (entityType == boolean.class) {
+            return Boolean.class;
+        } else if (entityType == char.class) {
+            return Character.class;
+        } else if (entityType == byte.class) {
+            return Byte.class;
+        } else if (entityType == short.class) {
+            return Short.class;
+        } else if (entityType == int.class) {
+            return Integer.class;
+        } else if (entityType == long.class) {
+            return Long.class;
+        } else if (entityType == float.class) {
+            return Float.class;
+        } else if (entityType == double.class) {
+            return Double.class;
+        }
+        // this shouldn't really happen, but better be safe than sorry
+        return entityType;
+    }
 
     public static boolean invokeWriter(ResteasyReactiveRequestContext context, Object entity, MessageBodyWriter writer,
             ServerSerialisers serialisers)


### PR DESCRIPTION
I've run few microbenchmarks to be sure it is actually better performing than the original code, which has proved (in #37656) to be too costy.

I've used https://github.com/franz1981/java-puzzles/commit/aa09c3d08e155c40fbb467eadf31d54f00108b6d
with a fair distribution of class types, to save the JIT to optimize it somehow.

The results with `# VM version: JDK 21, Java HotSpot(TM) 64-Bit Server VM, 21+35-LTS-2513` are
```
Benchmark                                             (noPrimitives)   Mode  Cnt           Score          Error  Units
CheckPrimitiveWrappers.lookupPrimitiveWrapper                   true  thrpt   30  1468019504.269 ± 14740624.010  ops/s
CheckPrimitiveWrappers.lookupPrimitiveWrapper                  false  thrpt   30   916703637.882 ±  7936655.776  ops/s
CheckPrimitiveWrappers.lookupPrimitiveWrapperWithMap            true  thrpt   30   729446870.700 ±  1902697.898  ops/s
CheckPrimitiveWrappers.lookupPrimitiveWrapperWithMap           false  thrpt   30   507266225.423 ±  4544529.352  ops/s
```

- Closes #37656