### PR TITLE
Fix Build Scan publication

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -143,6 +143,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Initial JDK 17 Build"
+          wrapper-init: true
       - name: Build
         env:
           CAPTURE_BUILD_SCAN: true
@@ -361,6 +362,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "JVM Tests - JDK ${{matrix.java.name}}"
+          wrapper-init: true
       - name: Build
         env:
           CAPTURE_BUILD_SCAN: true
@@ -467,6 +469,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Maven Tests - JDK ${{matrix.java.name}}"
+          wrapper-init: true
       - name: Build
         env:
           CAPTURE_BUILD_SCAN: true
@@ -563,6 +566,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Gradle Tests - JDK ${{matrix.java.name}}"
+          wrapper-init: true
       - name: Build
         env:
           CAPTURE_BUILD_SCAN: true
@@ -639,6 +643,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Devtools Tests - JDK ${{matrix.java.name}}"
+          wrapper-init: true
       - name: Build
         env:
           CAPTURE_BUILD_SCAN: true
@@ -724,6 +729,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Kubernetes Tests - JDK ${{matrix.java.name}}"
+          wrapper-init: true
       - name: Build
         env:
           CAPTURE_BUILD_SCAN: true
@@ -796,6 +802,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Quickstarts Compilation - JDK ${{matrix.java.name}}"
+          wrapper-init: true
       - name: Compile Quickstarts
         env:
           CAPTURE_BUILD_SCAN: true
@@ -859,6 +866,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Native Tests - Virtual Thread - ${{matrix.category}}"
+          wrapper-init: true
       - name: Build
         env:
           TEST_MODULES: ${{matrix.test-modules}}
@@ -920,6 +928,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "MicroProfile TCKs Tests"
+          wrapper-init: true
       - name: Verify
         env:
           CAPTURE_BUILD_SCAN: true
@@ -1020,6 +1029,7 @@ jobs:
         with:
           build-scan-capture-strategy: ON_DEMAND
           job-name: "Native Tests - ${{matrix.category}}"
+          wrapper-init: true
       - name: Build
         env:
           TEST_MODULES: ${{matrix.test-modules}}

--- a/.github/workflows/develocity-publish-build-scans.yml
+++ b/.github/workflows/develocity-publish-build-scans.yml
@@ -14,6 +14,7 @@ jobs:
     if: github.repository == 'quarkusio/quarkus' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'cancelled'
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       pull-requests: write
       checks: write
     steps:

--- a/.github/workflows/develocity-publish-build-scans.yml
+++ b/.github/workflows/develocity-publish-build-scans.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Output JSON file
         if: ${{ contains(fromJson(steps.extract-preapproved-developers.outputs.preapproved-developpers).preapproved-developers, github.event.workflow_run.actor.login) }}
         run: |
-          if [ -f build-metadata.json ]; then jq '.' build-metadata.json >> $GITHUB_STEP_SUMMARY; fi
+          if [ -f $HOME/build-metadata.json ]; then jq '.' $HOME/build-metadata.json >> $GITHUB_STEP_SUMMARY; fi


### PR DESCRIPTION
- Use `env.RUNNER_TEMP` to store Build Scan dumps copy
- Add permissions to delete an artifact to the publication workflow
- Fix `build-metadata.json` location