### PR TITLE
Save FixedProducesHandler lookup

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/FixedProducesHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/FixedProducesHandler.java
@@ -35,8 +35,9 @@ public class FixedProducesHandler implements ServerRestHandler {
 
     @Override
     public void handle(ResteasyReactiveRequestContext requestContext) throws Exception {
-        List<String> acceptValues = (List<String>) requestContext.getHeader(HttpHeaders.ACCEPT, false);
-        if (acceptValues.isEmpty() || requestContext.isProducesChecked()) {
+        List<String> acceptValues;
+        if (requestContext.isProducesChecked() ||
+                (acceptValues = (List<String>) requestContext.getHeader(HttpHeaders.ACCEPT, false)).isEmpty()) {
             requestContext.setResponseContentType(mediaType);
             requestContext.setEntityWriter(writer);
         } else {


### PR DESCRIPTION
9d9cb794218b61b1213dae3c43176c0cb6d99250 has improved a lot `FixedProducesHandler`, but it can be pushed further by avoiding the costy header's `Accept` lookup, in the happy path.

Similarly, `ClassRoutingHandler`s map's lookup, can be optimized by using the single-value `Map::of(key, value)` which is backed just by a wrapper around the key/value pair and doesn't requires performing any hashing on the key, saving chasing the actual position of the entry in the `HashMap`s node.
It shouldn't have any adverse effects in case single and multi-value `Map` are observed in the maps usages, because OpenJDK can perform bimorphic-inlining in `invokeinterface` cases ie the total number of `Map` implementors are just `HashMap` and the singleton map hidden in `Map::of`.

The performance of plaintext Techempower has moved further from 4.3 -> 4.4 M requests/sec