### PR TITLE
Docs: dont use deprecated RoutingContext cookies methods in OIDC multitenancy guide example

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -822,10 +822,10 @@ public class CustomTenantResolver implements TenantResolver {
         List<String> tenantIdQuery = context.queryParam("tenantId");
         if (!tenantIdQuery.isEmpty()) {
             String tenantId = tenantIdQuery.get(0);
-            context.addCookie(Cookie.cookie("tenant", tenantId));
+            context.response().addCookie(Cookie.cookie("tenant", tenantId));
             return tenantId;
-        } else if (context.cookieMap().containsKey("tenant")) {
-            return context.getCookie("tenant").getValue();
+        } else if (!context.request().cookies("tenant").isEmpty()) {
+            return context.request().getCookie("tenant").getValue();
         }
 
         return null;


### PR DESCRIPTION
Methods used in this example are deprecated. I checked with relevant quickstart and this part of code is not present there, therefore no update needed on QS side.