### PR TITLE
Document that JDK 17+ is Quarkus prerequisity

### DIFF
--- a/docs/src/main/asciidoc/_includes/prerequisites.adoc
+++ b/docs/src/main/asciidoc/_includes/prerequisites.adoc
@@ -8,7 +8,7 @@ ifndef::prerequisites-time[]
 endif::[]
 * An IDE
 ifdef::prerequisites-ide[{prerequisites-ide}]
-* JDK 11+ installed with `JAVA_HOME` configured appropriately
+* JDK 17+ installed with `JAVA_HOME` configured appropriately
 ifndef::prerequisites-no-maven[]
 * Apache Maven {maven-version}
 endif::[]

--- a/docs/src/main/asciidoc/ansible.adoc
+++ b/docs/src/main/asciidoc/ansible.adoc
@@ -167,7 +167,7 @@ By default, the Ansible collection for Quarkus will install and use the OpenJDK 
 [source,bash]
 ----
 $ ansible-playbook -i inventory ...
-    -e quarkus_java_package_version: java-11-openjdk
+    -e quarkus_java_package_version: java-17-openjdk
 ----
 ====
 

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -147,7 +147,7 @@ You can use Homebrew to install (and update) the Quarkus CLI.
 Make sure you have a JDK installed before installing the Quarkus CLI.
 We haven't added an explicit dependency as we wanted to make sure you could use your preferred JDK version.
 
-You can install a JDK with `brew install openjdk` for the latest Java version, `brew install openjdk@17` for Java 17, or `brew install openjdk@11` for Java 11.
+You can install a JDK with `brew install openjdk` for the latest Java version, `brew install openjdk@17` for Java 17, or `brew install openjdk@21` for Java 21.
 ====
 
 To install the Quarkus CLI using Homebrew, run the following command:
@@ -190,7 +190,7 @@ You can use Chocolatey to install (and update) the Quarkus CLI.
 ====
 Make sure you have a JDK installed before installing the Quarkus CLI.
 
-You can install a JDK with `choco install ojdkbuild17` for Java 17 or `choco install ojdkbuild11` for Java 11.
+You can install a JDK with `choco install temurin17` for Java 17 or `choco install temurin21` for Java 21.
 ====
 
 To install the Quarkus CLI using Chocolatey, run the following command:
@@ -226,7 +226,7 @@ You can use Scoop to install (and update) the Quarkus CLI.
 [NOTE]
 ====
 Make sure you have a JDK installed before installing the Quarkus CLI.
-You can install a JDK with `scoop install openjdk17` for Java 17 or `scoop install openjdk11` for Java 11.
+You can install a JDK with `scoop install openjdk17` for Java 17 or `scoop install openjdk21` for Java 21.
 ====
 To install the Quarkus CLI using Scoop, run the following command:
 [source,shell]

--- a/docs/src/main/asciidoc/deploying-to-heroku.adoc
+++ b/docs/src/main/asciidoc/deploying-to-heroku.adoc
@@ -92,11 +92,11 @@ Two additional files are needed in your application's root directory:
 * `system.properties` to configure the Java version
 * `Procfile` to configure how Heroku starts your application
 
-Quarkus needs JDK 11, so we specify that first:
+Quarkus needs JDK 17, so we specify that first:
 
 [source,bash]
 ----
-echo "java.runtime.version=11" >> system.properties
+echo "java.runtime.version=17" >> system.properties
 git add system.properties
 git commit -am "Configure the Java version for Heroku."
 ----

--- a/docs/src/main/asciidoc/funqy-gcp-functions.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions.adoc
@@ -147,7 +147,7 @@ You will have a single JAR inside the `target/deployment` repository that contai
 Then you will be able to use `gcloud` to deploy your function to Google Cloud.
 The `gcloud` command will be different depending on which event triggers your function.
 
-NOTE: We will use the Java 17 runtime but you can switch to the Java 11 runtime by using `--runtime=java11` instead of `--runtime=java17` on the deploy commands.
+NOTE: We will use the Java 17 runtime but you can switch to the Java 21 runtime by using `--runtime=java21` instead of `--runtime=java17` on the deploy commands.
 
 [WARNING]
 ====

--- a/docs/src/main/asciidoc/gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/gcp-functions-http.adoc
@@ -162,7 +162,7 @@ The result of the previous command is a single JAR file inside the `target/deplo
 
 Then you will be able to use `gcloud` to deploy your function to Google Cloud.
 
-NOTE: We will use the Java 17 runtime but you can switch to the Java 11 runtime by using `--runtime=java11` instead of `--runtime=java17` on the deploy commands.
+NOTE: We will use the Java 17 runtime but you can switch to the Java 21 runtime by using `--runtime=java21` instead of `--runtime=java17` on the deploy commands.
 
 [source,bash]
 ----

--- a/docs/src/main/asciidoc/gcp-functions.adoc
+++ b/docs/src/main/asciidoc/gcp-functions.adoc
@@ -242,7 +242,7 @@ The result of the previous command is a single JAR file inside the `target/deplo
 Then you will be able to use `gcloud` to deploy your function to Google Cloud.
 The `gcloud` command will be different depending on which event triggers your function.
 
-NOTE: We will use the Java 17 runtime but you can switch to the Java 11 runtime by using `--runtime=java11` instead of `--runtime=java17` on the deploy commands.
+NOTE: We will use the Java 17 runtime but you can switch to the Java 21 runtime by using `--runtime=java21` instead of `--runtime=java17` on the deploy commands.
 
 [WARNING]
 ====

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -539,7 +539,7 @@ You can find instructions on how to quickly set up this application in this guid
 
 This debugging guide has the following requirements:
 
-* JDK 11 installed with `JAVA_HOME` configured appropriately
+* JDK 17 installed with `JAVA_HOME` configured appropriately
 * Apache Maven {maven-version}
 * A working container runtime (Docker, podman)
 
@@ -589,13 +589,6 @@ quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:{
 quarkus.container-image.build=true
 quarkus.container-image.group=test
 ----
-
-[IMPORTANT]
-====
-Starting with 22.3, Mandrel does not provide a `-java11` version anymore.
-Note, however,  that this doesn't mean that you may no longer produce native executables with Mandrel for Java 11 projects.
-You can still compile your Java 11 projects using OpenJDK 11 and produce native executables from the resulting Java 11 bytecode using the `-java17` Mandrel builder images.
-====
 
 === First Debugging Steps
 


### PR DESCRIPTION
I read https://quarkus.io/version/main/guides/security-openid-connect-multitenancy (it's the main branch) and prerequisities still say that JDK 11+ is required. This PR updates it and few other 11 references.

Context for changes:

- ojdkbuild17 chocolatey package is deprecated in favor of temurin https://community.chocolatey.org/packages/ojdkbuild#discussion
  - 21 https://community.chocolatey.org/packages/Temurin21
  - 17 https://community.chocolatey.org/packages/Temurin17
- gcp supports 21 https://cloud.google.com/functions/docs/concepts/java-runtime
- scoop has openjdk21 package https://scoop.sh/#/apps?q=openjdk21
- ansible has java-17-openjdk package https://ansible.readthedocs.io/projects/rulebook/en/stable/installation.html
