### PR TITLE
Remove duplicate runtime init io.netty.buffer.PooledByteBufAllocator

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -163,8 +163,7 @@ class NettyProcessor {
         }
 
         builder.addRuntimeReinitializedClass("io.netty.util.internal.PlatformDependent")
-                .addRuntimeReinitializedClass("io.netty.util.internal.PlatformDependent0")
-                .addRuntimeReinitializedClass("io.netty.buffer.PooledByteBufAllocator");
+                .addRuntimeReinitializedClass("io.netty.util.internal.PlatformDependent0");
 
         if (QuarkusClassLoader.isClassPresentAtRuntime("io.netty.buffer.UnpooledByteBufAllocator")) {
             builder.addRuntimeReinitializedClass("io.netty.buffer.UnpooledByteBufAllocator")


### PR DESCRIPTION
`io.netty.buffer.PooledByteBufAllocator` is already registered for runtime initialization earlier in NettyProcessor.java

Follow up to https://github.com/quarkusio/quarkus/pull/37633

Also fixes the following warning when using Mandrel and GraalVM 23.0:

```
com.oracle.svm.core.util.UserError$UserException: Incompatible change of initialization policy for io.netty.buffer.PooledByteBufAllocator: trying to change RUN_TIME from 'META-INF/native-image/io.netty/netty-buffer/native-image.properties' in 'file:///home/zakkak/code/mandrel-integration-tests/apps/jfr-native-image-performance/target/jfr-plaintext-native-image-source-jar/lib/io.netty.netty-buffer-4.1.100.Final.jar' with 'io.netty.buffer.PooledByteBufAllocator' and from feature io.quarkus.runner.Feature.beforeAnalysis with 'PooledByteBufAllocator.class' to RERUN Quarkus
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.UserError.abort(UserError.java:73)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationConfiguration.insertRec(ClassInitializationConfiguration.java:103)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationConfiguration.insertRec(ClassInitializationConfiguration.java:117)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationConfiguration.insertRec(ClassInitializationConfiguration.java:117)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationConfiguration.insertRec(ClassInitializationConfiguration.java:117)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationConfiguration.insertRec(ClassInitializationConfiguration.java:117)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationConfiguration.insert(ClassInitializationConfiguration.java:64)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ProvenSafeClassInitializationSupport.rerunInitialization(ProvenSafeClassInitializationSupport.java:162)
	at io.quarkus.runner.Feature.runtimeReinitializedClasses(Unknown Source)
	at io.quarkus.runner.Feature.beforeAnalysis(Unknown Source)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.lambda$runPointsToAnalysis$9(NativeImageGenerator.java:757)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.FeatureHandler.forEachFeature(FeatureHandler.java:89)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:757)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:582)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:539)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:408)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:612)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.start(NativeImageGeneratorRunner.java:134)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:94)
```

CI run with Mandrel 24.0-dev: https://github.com/graalvm/mandrel/actions/runs/7191882995
Failures are due to 

1. pg-using tests due to
https://github.com/quarkusio/quarkus/issues/37208 (JDK 22 compatibility issue)
2. quarkus-integration-test-jpa-postgresql fails the XML factory checking test. Issue:
https://github.com/quarkusio/quarkus/issues/37498