### PR TITLE
Remove the driver property in the documentation for Cloud SQL

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
+++ b/docs/src/main/asciidoc/deploying-to-google-cloud.adoc
@@ -251,7 +251,6 @@ Finally, you need to configure your datasource specifically to use the socket fa
 ----
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.jdbc.url=jdbc:postgresql:///mydatabase <1>
-quarkus.datasource.jdbc.driver=org.postgresql.Driver
 quarkus.datasource.username=quarkus
 quarkus.datasource.password=quarkus
 quarkus.datasource.jdbc.additional-jdbc-properties.cloudSqlInstance=project-id:gcp-region:instance <2>


### PR DESCRIPTION
This property is not necessary, so better to remove it.