### PR TITLE
Do not use CSRF cookie as the next token value

### DIFF
--- a/integration-tests/csrf-reactive/src/main/java/io/quarkus/it/csrf/TestResource.java
+++ b/integration-tests/csrf-reactive/src/main/java/io/quarkus/it/csrf/TestResource.java
@@ -30,6 +30,12 @@ public class TestResource {
     Template csrfTokenForm;
 
     @Inject
+    Template csrfTokenFirstForm;
+
+    @Inject
+    Template csrfTokenSecondForm;
+
+    @Inject
     Template csrfTokenHeader;
 
     @Inject
@@ -47,6 +53,14 @@ public class TestResource {
     @Authenticated
     public TemplateInstance getCsrfTokenForm() {
         return csrfTokenForm.instance();
+    }
+
+    @GET
+    @Path("/csrfTokenFirstForm")
+    @Produces(MediaType.TEXT_HTML)
+    @Authenticated
+    public TemplateInstance getCsrfTokenFirstForm() {
+        return csrfTokenFirstForm.instance();
     }
 
     @GET
@@ -68,6 +82,22 @@ public class TestResource {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.TEXT_PLAIN)
     public String postCsrfTokenForm(@FormParam("name") String name, @HeaderParam("X-CSRF-TOKEN") String csrfHeader) {
+        return name + ":" + routingContext.get("csrf_token_verified", false) + ":tokenHeaderIsSet=" + (csrfHeader != null);
+    }
+
+    @POST
+    @Path("/csrfTokenFirstForm")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance postCsrfTokenFirstForm() {
+        return csrfTokenSecondForm.instance();
+    }
+
+    @POST
+    @Path("/csrfTokenSecondForm")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String postCsrfTokenSecondForm(@FormParam("name") String name, @HeaderParam("X-CSRF-TOKEN") String csrfHeader) {
         return name + ":" + routingContext.get("csrf_token_verified", false) + ":tokenHeaderIsSet=" + (csrfHeader != null);
     }
 

--- a/integration-tests/csrf-reactive/src/main/resources/application.properties
+++ b/integration-tests/csrf-reactive/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.csrf-reactive.cookie-name=csrftoken
-quarkus.csrf-reactive.create-token-path=/service/csrfTokenForm,/service/csrfTokenWithFormRead,/service/csrfTokenMultipart,/service/csrfTokenWithHeader
+quarkus.csrf-reactive.create-token-path=/service/csrfTokenForm,/service/csrfTokenFirstForm,/service/csrfTokenSecondForm,/service/csrfTokenWithFormRead,/service/csrfTokenMultipart,/service/csrfTokenWithHeader
 quarkus.csrf-reactive.token-signature-key=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 
 quarkus.http.auth.basic=true

--- a/integration-tests/csrf-reactive/src/main/resources/templates/csrfTokenFirstForm.html
+++ b/integration-tests/csrf-reactive/src/main/resources/templates/csrfTokenFirstForm.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>CSRF Token First Form Test</title> 
+</head>
+<body>
+    <h1>CSRF Test</h1>
+
+    <form action="/service/csrfTokenFirstForm" method="post">
+    	<input type="hidden" name="{inject:csrf.parameterName}" value="{inject:csrf.token}" />
+    	
+    	<p>Your Name: <input type="text" name="name" /></p>
+    	<p><input type="submit" name="submit"/></p>
+    </form>
+</body>
+</html>

--- a/integration-tests/csrf-reactive/src/main/resources/templates/csrfTokenSecondForm.html
+++ b/integration-tests/csrf-reactive/src/main/resources/templates/csrfTokenSecondForm.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>CSRF Token Second Form Test</title> 
+</head>
+<body>
+    <h1>CSRF Test</h1>
+
+    <form action="/service/csrfTokenSecondForm" method="post">
+    	<input type="hidden" name="{inject:csrf.parameterName}" value="{inject:csrf.token}" />
+    	
+    	<p>Your Name: <input type="text" name="name" /></p>
+    	<p><input type="submit" name="submit"/></p>
+    </form>
+</body>
+</html>

--- a/integration-tests/csrf-reactive/src/test/java/io/quarkus/it/csrf/CsrfReactiveTest.java
+++ b/integration-tests/csrf-reactive/src/test/java/io/quarkus/it/csrf/CsrfReactiveTest.java
@@ -62,6 +62,36 @@ public class CsrfReactiveTest {
     }
 
     @Test
+    public void testCsrfTokenTwoForms() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+            webClient.addRequestHeader("Authorization", basicAuth("alice", "alice"));
+            HtmlPage htmlPage = webClient.getPage("http://localhost:8081/service/csrfTokenFirstForm");
+
+            assertEquals("CSRF Token First Form Test", htmlPage.getTitleText());
+
+            HtmlForm loginForm = htmlPage.getForms().get(0);
+
+            loginForm.getInputByName("name").setValueAttribute("alice");
+
+            assertNotNull(webClient.getCookieManager().getCookie("csrftoken"));
+
+            htmlPage = loginForm.getInputByName("submit").click();
+
+            assertEquals("CSRF Token Second Form Test", htmlPage.getTitleText());
+
+            loginForm = htmlPage.getForms().get(0);
+
+            loginForm.getInputByName("name").setValueAttribute("alice");
+
+            TextPage textPage = loginForm.getInputByName("submit").click();
+            assertNotNull(webClient.getCookieManager().getCookie("csrftoken"));
+            assertEquals("alice:true:tokenHeaderIsSet=false", textPage.getContent());
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
     public void testCsrfTokenWithFormRead() throws Exception {
         try (final WebClient webClient = createWebClient()) {
 


### PR DESCRIPTION
Fixes #36848

CSRF filter works like this: it generates a CSRF token, sets it as a routing context property, https://github.com/quarkusio/quarkus/blob/main/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfRequestResponseReactiveFilter.java#L94

and then this provider helps to copy it into Qute templates which will have it saved as an internal form field, https://github.com/quarkusio/quarkus/blob/main/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfTokenParameterProvider.java#L39, or it can be returned as a header value (for example in case of HTMX). 
And a matching CSRF cookie is created.

Now lets imagine a Form containing a CSRF  token POSTs something and it will be accompanied by the CSRF cookie, and the filter will compare it and if values match then all is good.

However, if a response to this POST is another form (as demonstrated in the test, or in similar cases), what happens is that the csrf cookie value, not the crsf token value (contained in the form field or header) which is returned in the next form, because, as soon as the cookie is found, it is set as the next CSRF token value and which will be set in the next form as described above, due to:

https://github.com/quarkusio/quarkus/blob/main/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfRequestResponseReactiveFilter.java#L69.

It makes no difference when the CSRF token is not signed because both values are identical. When the CSRF token is signed, the cookie contains a signed copy of the token. 
So when the Form POST is done, the filter, in order to verify that the cookie and the token match, signs the token and compares it with the cookie. Now, this cookie, which is a signed copy of the token is making its way into the second form as the next token value - but now both the cookie and the token are identical - both are now SHA-256 hashes, and therefore, during the follow up submission, resigning the token and comparing it with the cookie produces a false result.

It took several hours to figure out how to reproduce it in a test, and the fix is straighforward: simply avoid using the existing CSRF cookie value as the next token value, instead, when the cookie and the token already exist, it is the same original token value which has to be used as the next token value once it has been verified.

FYI, the test will fail without the proposed fix, since the token signature is required in that test
