### PR TITLE
Reset CSRF cookie to minimize a risk of failures due to its expiry

### DIFF
--- a/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfReactiveConfig.java
+++ b/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfReactiveConfig.java
@@ -34,7 +34,7 @@ public class CsrfReactiveConfig {
     /**
      * CSRF cookie max age.
      */
-    @ConfigItem(defaultValue = "10M")
+    @ConfigItem(defaultValue = "2H")
     public Duration cookieMaxAge;
 
     /**


### PR DESCRIPTION
Fixes #36946.
Fixes #37928.

@FroMage FYI, it won't guarantee the failure won't ever happen, for example, the cookie age is 10 mins and the user just sits idle for 11 min and then returns, but with a reasonably large cookie age and with this PR recycling cookies, the chance of it happening will be very low. 
If you'd like please give this PR a try with Renarde or you can try snapshots later.
Andy, @ia3andy FYI
It is not urgent to review it, thanks

 