### PR TITLE
Query logging is being done in io.quarkus.mongodb.panache.common.runtime.MongoOperations

### DIFF
--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -746,7 +746,7 @@ This can be achieved by setting to DEBUG the following log category inside your 
 
 [source,properties]
 ----
-quarkus.log.category."io.quarkus.mongodb.panache.runtime".level=DEBUG
+quarkus.log.category."io.quarkus.mongodb.panache.common.runtime".level=DEBUG
 ----
 
 == The PojoCodecProvider: easy object to BSON document conversion.


### PR DESCRIPTION
Without this change, queries are not logged.