### PR TITLE
Avoid calling getModifiers to remove DOMSerializer leak

### DIFF
--- a/extensions/jackson/runtime/pom.xml
+++ b/extensions/jackson/runtime/pom.xml
@@ -33,6 +33,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/graal/JacksonSubstitutions.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/graal/JacksonSubstitutions.java
@@ -1,0 +1,30 @@
+package io.quarkus.jackson.runtime.graal;
+
+import java.lang.reflect.Constructor;
+
+import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "com.fasterxml.jackson.databind.util.ClassUtil")
+final class Target_com_fasterxml_jackson_databind_util_ClassUtil {
+    @Substitute
+    public static <T> Constructor<T> findConstructor(Class<T> cls, boolean forceAccess) {
+        try {
+            Constructor<T> ctor = cls.getDeclaredConstructor();
+            if (forceAccess) {
+                ClassUtil.checkAndFixAccess(ctor, forceAccess);
+            }
+            return ctor;
+        } catch (NoSuchMethodException e) {
+            ;
+        } catch (Exception e) {
+            ClassUtil.unwrapAndThrowAsIAE(e,
+                    "Failed to find default constructor of class " + cls.getName() + ", problem: " + e.getMessage());
+        }
+        return null;
+    }
+}
+
+class JacksonSubstitutions {
+}


### PR DESCRIPTION
A workaround to avoid #37498.

Avoiding to call `Constructor.getModifiers` removes leaking `DOMSerializer` as entry point and therefore does not bring in XML baggage. 

See https://github.com/oracle/graal/issues/8019 for details and updates on if/how upstream will fix this.