### PR TITLE
ArC: clarify the description of quarkus.arc.context-propagation.enabled

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcContextPropagationConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcContextPropagationConfig.java
@@ -7,8 +7,14 @@ import io.quarkus.runtime.annotations.ConfigItem;
 public class ArcContextPropagationConfig {
 
     /**
-     * If set to true and SmallRye Context Propagation extension is present then enable the context propagation for CDI
+     * If set to true and the SmallRye Context Propagation extension is present then the CDI contexts will be propagated by
+     * means of the MicroProfile Context Propagation API. Specifically, a
+     * {@link org.eclipse.microprofile.context.spi.ThreadContextProvider} implementation is registered.
+     *
+     * On the other hand, if set to false then the MicroProfile Context Propagation API will never be used to propagate the CDI
      * contexts.
+     *
+     * Note that the CDI contexts may be propagated in a different way though. For example with the Vertx duplicated context.
      */
     @ConfigItem(defaultValue = "true")
     public boolean enabled;


### PR DESCRIPTION
- fixes #34123

Note that this PR merely clarifies the description. I don't think we should document this property in the MP CP docs - it's an interim solution anyway.