### PR TITLE
Keycloak docs fix wrong link and add small enhancement

### DIFF
--- a/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
@@ -20,7 +20,7 @@ To learn more about the Keycloak Admin Client, please refer to its https://www.k
 
 :prerequisites-docker:
 include::{includes}/prerequisites.adoc[]
-* https://www.keycloak.org/docs/latest/server_installation/index.html[Keycloak]
+* https://www.keycloak.org[Keycloak]
 
 == Creating the Project
 
@@ -124,8 +124,8 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.representations.idm.RoleRepresentation;
 
-import jakarta.annotations.PostConstruct;
-import jakarta.annotations.PreConstruct;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import java.util.List;

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -32,7 +32,7 @@ Please see https://www.keycloak.org/docs/latest/authorization_services/index.htm
 :prerequisites-docker:
 include::{includes}/prerequisites.adoc[]
 * https://stedolan.github.io/jq/[jq tool]
-* https://www.keycloak.org/docs/latest/server_installation/index.html[Keycloak]
+* https://www.keycloak.org[Keycloak]
 
 == Architecture
 
@@ -115,7 +115,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
-import org.jboss.resteasy.annotations.cache.NoCache;
+import org.jboss.resteasy.reactive.NoCache;
 
 import io.quarkus.security.identity.SecurityIdentity;
 
@@ -210,7 +210,7 @@ To start a Keycloak Server you can use Docker and just run the following command
 docker run --name keycloak -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -p 8543:8443 -v "$(pwd)"/config/keycloak-keystore.jks:/etc/keycloak-keystore.jks quay.io/keycloak/keycloak:{keycloak.version} start  --hostname-strict=false --https-key-store-file=/etc/keycloak-keystore.jks
 ----
 
-where `keycloak.version` should be set to `17.0.0` or higher.
+where `keycloak.version` should be set to `23.0.0` or higher and the `keycloak-keystore.jks` can be found in https://github.com/quarkusio/quarkus-quickstarts/blob/main/security-keycloak-authorization-quickstart/config/keycloak-keystore.jks[quarkus-quickstarts/security-keycloak-authorization-quickstart/config]
 
 You should be able to access your Keycloak Server at https://localhost:8543[localhost:8543].
 


### PR DESCRIPTION
Fix wrong link to Quarkus as the links return 404.

Fix wrong imports.

Add notes where to find the quarkus-realm.json and keycloak-keystore.jks with links to it.