### PR TITLE
Introduce BuildInfo.quarkusVersion

### DIFF
--- a/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
+++ b/extensions/info/deployment/src/main/java/io/quarkus/info/deployment/InfoProcessor.java
@@ -28,6 +28,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.builder.Version;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -221,10 +222,12 @@ public class InfoProcessor {
         buildData.put("version", version);
         String time = ISO_OFFSET_DATE_TIME.format(OffsetDateTime.now());
         buildData.put("time", time); // TODO: what is the proper notion of build time?
+        String quarkusVersion = Version.getVersion();
+        buildData.put("quarkusVersion", quarkusVersion);
         Map<String, Object> data = finalBuildData(buildData, config.build());
         valuesProducer.produce(new InfoBuildTimeValuesBuildItem("build", data));
         beanProducer.produce(SyntheticBeanBuildItem.configure(BuildInfo.class)
-                .supplier(recorder.buildInfoSupplier(group, artifact, version, time))
+                .supplier(recorder.buildInfoSupplier(group, artifact, version, time, quarkusVersion))
                 .scope(Singleton.class)
                 .setRuntimeInit()
                 .done());

--- a/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/EnabledInfoTest.java
+++ b/extensions/info/deployment/src/test/java/io/quarkus/info/deployment/EnabledInfoTest.java
@@ -46,6 +46,7 @@ public class EnabledInfoTest {
                 .body("java.version", is(notNullValue()))
                 .body("build", is(notNullValue()))
                 .body("build.time", is(notNullValue()))
+                .body("build.quarkusVersion", is(notNullValue()))
                 .body("git", is(notNullValue()))
                 .body("git.branch", is(notNullValue()))
                 .body("git.build", is(nullValue()));
@@ -55,6 +56,7 @@ public class EnabledInfoTest {
         assertNotNull(buildInfo.artifact());
         assertNotNull(buildInfo.version());
         assertNotNull(buildInfo.time());
+        assertNotNull(buildInfo.quarkusVersion());
 
         assertNotNull(gitInfo);
         assertNotNull(gitInfo.branch());

--- a/extensions/info/runtime/src/main/java/io/quarkus/info/BuildInfo.java
+++ b/extensions/info/runtime/src/main/java/io/quarkus/info/BuildInfo.java
@@ -11,4 +11,6 @@ public interface BuildInfo {
     String version();
 
     OffsetDateTime time();
+
+    String quarkusVersion();
 }

--- a/extensions/info/runtime/src/main/java/io/quarkus/info/runtime/InfoRecorder.java
+++ b/extensions/info/runtime/src/main/java/io/quarkus/info/runtime/InfoRecorder.java
@@ -52,7 +52,8 @@ public class InfoRecorder {
         };
     }
 
-    public Supplier<BuildInfo> buildInfoSupplier(String group, String artifact, String version, String time) {
+    public Supplier<BuildInfo> buildInfoSupplier(String group, String artifact, String version, String time,
+            String quarkusVersion) {
         return new Supplier<BuildInfo>() {
             @Override
             public BuildInfo get() {
@@ -75,6 +76,11 @@ public class InfoRecorder {
                     @Override
                     public OffsetDateTime time() {
                         return OffsetDateTime.parse(time, ISO_OFFSET_DATE_TIME);
+                    }
+
+                    @Override
+                    public String quarkusVersion() {
+                        return quarkusVersion;
                     }
                 };
             }


### PR DESCRIPTION
Please, review and let me know, if this implementation follows all the guidelines (I might missed something). The quarkus builds locally and passes [Quarkus CI action in the forked repo](https://github.com/zemiak/quarkus/actions/runs/7210792277).

I also created a hello world example using locally built Quarkus (999-SNAPSHOT) and it seems to report the right version (999-SNAPSHOT). If needed, I can publish it to Github as well.

Thank you!

- Closes: #37380