### PR TITLE
Add SequencedCollection to BANNED_INTERFACE_TYPES

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
@@ -4,7 +4,6 @@ import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -78,13 +77,9 @@ public final class Types {
             DotNames.DOUBLE,
             DotNames.CHARACTER);
 
-    // we ban these interfaces because they are new to Java 12 and are used by java.lang.String which
-    // means that they cannot be included in bytecode if we want to have application built with Java 12+ but targeting Java 8 - 11
-    // actually run on those older versions
+    // we ban these interfaces because of mismatch between building JDK version and target JDK version
     // TODO:  add a extensible banning mechanism based on predicates if we find that this set needs to grow...
-    private static final Set<DotName> BANNED_INTERFACE_TYPES = new HashSet<>(
-            Arrays.asList(DotName.createSimple("java.lang.constant.ConstantDesc"),
-                    DotName.createSimple("java.lang.constant.Constable")));
+    private static final Set<DotName> BANNED_INTERFACE_TYPES = Collections.emptySet();
 
     private Types() {
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
@@ -79,7 +79,7 @@ public final class Types {
 
     // we ban these interfaces because of mismatch between building JDK version and target JDK version
     // TODO:  add a extensible banning mechanism based on predicates if we find that this set needs to grow...
-    private static final Set<DotName> BANNED_INTERFACE_TYPES = Collections.emptySet();
+    private static final Set<DotName> BANNED_INTERFACE_TYPES = Set.of(DotName.createSimple("java.util.SequencedCollection"));
 
     private Types() {
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/EnumBeanTypesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/EnumBeanTypesTest.java
@@ -27,7 +27,7 @@ public class EnumBeanTypesTest {
         InjectableBean<ExtendedBoolean> bean = Arc.container().instance(ExtendedBoolean.class).getBean();
         Set<Type> types = bean.getTypes();
 
-        assertEquals(5, types.size());
+        assertEquals(6, types.size());
         assertTrue(types.contains(Object.class));
         assertTrue(types.contains(Serializable.class));
         assertTrue(types.contains(ExtendedBoolean.class));


### PR DESCRIPTION
This is done because this type exists in Java 21
but not Java 17.

- Fixes: https://github.com/quarkusio/quarkus/issues/37768