### PR TITLE
Docs: security-jdbc guide linking user entity section where is used built-in bcrypt password mapper

### DIFF
--- a/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-getting-started-tutorial.adoc
@@ -228,7 +228,7 @@ public class UserResource {
 }
 ----
 ====
-
+[[define-the-user-entity]]
 === Define the user entity
 
 * You can now describe how you want security information to be stored in the model by adding annotations to the `user` entity, as outlined in the following code snippet:

--- a/docs/src/main/asciidoc/security-jdbc.adoc
+++ b/docs/src/main/asciidoc/security-jdbc.adoc
@@ -184,7 +184,7 @@ INSERT INTO test_user (id, username, password, role) VALUES (2, 'user','user', '
 [NOTE]
 ====
 It is probably useless, but we kindly remind you that you must not store clear-text passwords in production environment ;-).
-The `elytron-security-jdbc` offers a built-in bcrypt password mapper.
+The `elytron-security-jdbc` offers a built-in bcrypt password mapper. You can see the section `Define the user entity` for more details at xref:security-getting-started-tutorial.adoc#define-the-user-entity.
 ====
 
 We can now configure the Elytron JDBC Realm.


### PR DESCRIPTION
As I describe in point 1 from https://github.com/quarkusio/quarkus/issues/37682 : 
In the "Configuring the Application" section, from https://quarkus.io/version/main/guides/security-jdbc, there is a clear-text password used in the INSERTS command SQL script. A note reminds us not to store clear-text passwords in production environments. Additionally, it is mentioned that the elytron-security-jdbc offers a built-in bcrypt password mapper. 
However, it would be great to show how to implement this or link to another source demonstrating the process.