### PR TITLE
Add build-metadata-file-path as extra input to report action

### DIFF
--- a/.github/workflows/develocity-publish-build-scans.yml
+++ b/.github/workflows/develocity-publish-build-scans.yml
@@ -30,6 +30,7 @@ jobs:
         if: ${{ contains(fromJson(steps.extract-preapproved-developers.outputs.preapproved-developpers).preapproved-developers, github.event.workflow_run.actor.login) }}
         uses: gradle/github-actions/maven-build-scan-setup@v0.2
       - name: Publish Maven Build Scans
+        id: publish
         if: ${{ contains(fromJson(steps.extract-preapproved-developers.outputs.preapproved-developpers).preapproved-developers, github.event.workflow_run.actor.login) }}
         uses: gradle/github-actions/maven-build-scan-publish@v0.2
         with:
@@ -44,7 +45,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           action: inject-build-scans
           workflow-run-id: ${{ github.event.workflow_run.id }}
+          build-metadata-file-path: ${{ steps.publish.outputs.build-metadata-file-path }}
       - name: Output JSON file
         if: ${{ contains(fromJson(steps.extract-preapproved-developers.outputs.preapproved-developpers).preapproved-developers, github.event.workflow_run.actor.login) }}
         run: |
-          if [ -f $HOME/build-metadata.json ]; then jq '.' $HOME/build-metadata.json >> $GITHUB_STEP_SUMMARY; fi
+          if [ -f "${{ steps.publish.outputs.build-metadata-file-path }}" ]; then jq '.' ${{ steps.publish.outputs.build-metadata-file-path }} >> $GITHUB_STEP_SUMMARY; fi
+


### PR DESCRIPTION
### Issue
`build-metadata.json` is not found in the reporting action follow-up to its relocation

### Fix
Make the file path an output of the publish action and add it as input to the reporting action

### Requires
https://github.com/quarkusio/action-helpers/pull/32