### PR TITLE
ArC: improve error message for unsatisfied dependency

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolverImpl.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolverImpl.java
@@ -131,6 +131,22 @@ class BeanResolverImpl implements BeanResolver {
         return resolved.isEmpty() ? Collections.emptyList() : resolved;
     }
 
+    List<BeanInfo> findUnrestrictedTypeMatching(TypeAndQualifiers typeAndQualifiers) {
+        List<BeanInfo> resolved = new ArrayList<>();
+        for (BeanInfo b : beanDeployment.getBeans()) {
+            if (!Beans.hasQualifiers(b, typeAndQualifiers.qualifiers)) {
+                continue;
+            }
+            for (Type type : b.getUnrestrictedTypes()) {
+                if (matches(typeAndQualifiers.type, type)) {
+                    resolved.add(b);
+                    break;
+                }
+            }
+        }
+        return resolved.isEmpty() ? Collections.emptyList() : resolved;
+    }
+
     Collection<BeanInfo> potentialBeans(Type type) {
         if ((type.kind() == CLASS || type.kind() == PARAMETERIZED_TYPE) && !type.name().equals(DotNames.OBJECT)) {
             return beanDeployment.getBeansByRawType(type.name());

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -36,7 +36,9 @@ import org.jboss.logging.Logger;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
 
+import io.quarkus.arc.processor.BeanDeployment.SkippedClass;
 import io.quarkus.arc.processor.InjectionPointInfo.TypeAndQualifiers;
+import io.quarkus.arc.processor.Types.TypeClosure;
 import io.quarkus.gizmo.ClassTransformer;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
@@ -78,7 +80,7 @@ public final class Beans {
         return null;
     }
 
-    static BeanInfo createProducerMethod(Set<Type> beanTypes, MethodInfo producerMethod, BeanInfo declaringBean,
+    static BeanInfo createProducerMethod(TypeClosure typeClosure, MethodInfo producerMethod, BeanInfo declaringBean,
             BeanDeployment beanDeployment,
             DisposerInfo disposer, InjectionPointModifier transformer) {
         Set<AnnotationInstance> qualifiers = new HashSet<>();
@@ -190,8 +192,9 @@ public final class Beans {
 
         List<Injection> injections = Injection.forBean(producerMethod, declaringBean, beanDeployment, transformer,
                 Injection.BeanType.PRODUCER_METHOD);
-        BeanInfo bean = new BeanInfo(producerMethod, beanDeployment, scope, beanTypes, qualifiers, injections, declaringBean,
-                disposer, isAlternative, stereotypes, name, isDefaultBean, null, priority);
+        BeanInfo bean = new BeanInfo(producerMethod, beanDeployment, scope, typeClosure.types(), qualifiers, injections,
+                declaringBean,
+                disposer, isAlternative, stereotypes, name, isDefaultBean, null, priority, typeClosure.unrestrictedTypes());
         for (Injection injection : injections) {
             injection.init(bean);
         }
@@ -202,7 +205,7 @@ public final class Beans {
             DisposerInfo disposer) {
         Set<AnnotationInstance> qualifiers = new HashSet<>();
         List<ScopeInfo> scopes = new ArrayList<>();
-        Set<Type> types = Types.getProducerFieldTypeClosure(producerField, beanDeployment);
+        TypeClosure typeClosure = Types.getProducerFieldTypeClosure(producerField, beanDeployment);
         Integer priority = null;
         boolean isAlternative = false;
         boolean isDefaultBean = false;
@@ -302,8 +305,10 @@ public final class Beans {
                     + "its scope must be @Dependent: " + producerField);
         }
 
-        BeanInfo bean = new BeanInfo(producerField, beanDeployment, scope, types, qualifiers, Collections.emptyList(),
-                declaringBean, disposer, isAlternative, stereotypes, name, isDefaultBean, null, priority);
+        BeanInfo bean = new BeanInfo(producerField, beanDeployment, scope, typeClosure.types(), qualifiers,
+                Collections.emptyList(),
+                declaringBean, disposer, isAlternative, stereotypes, name, isDefaultBean, null, priority,
+                typeClosure.unrestrictedTypes());
         return bean;
     }
 
@@ -460,21 +465,56 @@ public final class Beans {
         List<BeanInfo> resolved = deployment.beanResolver.resolve(injectionPoint.getTypeAndQualifiers());
         BeanInfo selected = null;
         if (resolved.isEmpty()) {
-            List<BeanInfo> typeMatching = deployment.beanResolver.findTypeMatching(injectionPoint.getRequiredType());
 
             StringBuilder message = new StringBuilder("Unsatisfied dependency for type ");
             addStandardErroneousDependencyMessage(target, injectionPoint, message);
+
+            List<BeanInfo> typeMatching = deployment.beanResolver.findTypeMatching(injectionPoint.getRequiredType());
             if (!typeMatching.isEmpty()) {
-                message.append("\n\tThe following beans match by type, but none have matching qualifiers:");
-                for (BeanInfo beanInfo : typeMatching) {
-                    message.append("\n\t\t- ");
-                    message.append("Bean [class=");
-                    message.append(beanInfo.getImplClazz());
-                    message.append(", qualifiers=");
-                    message.append(beanInfo.getQualifiers());
-                    message.append("]");
+                message.append("\n\tThe following beans match by type, but none has matching qualifiers:");
+                for (BeanInfo bean : typeMatching) {
+                    message.append("\n\t- ");
+                    message.append(bean);
                 }
+                message.append("\n\n");
             }
+
+            List<BeanInfo> unrestrictedTypeMatching = deployment.beanResolver
+                    .findUnrestrictedTypeMatching(injectionPoint.getTypeAndQualifiers());
+            if (!unrestrictedTypeMatching.isEmpty()) {
+                message.append("\n\tThe following beans match by type excluded by the @Typed annotation:");
+                for (BeanInfo bean : unrestrictedTypeMatching) {
+                    message.append("\n\t- ");
+                    message.append(bean);
+                }
+                message.append("\n\n");
+            }
+
+            List<SkippedClass> skippedClasses = deployment.findSkippedClassesMatching(injectionPoint.getRequiredType());
+            if (!skippedClasses.isEmpty()) {
+                message.append("\n\tThe following classes match by type, but have been skipped during discovery:");
+                for (SkippedClass skippedClass : skippedClasses) {
+                    message.append("\n\t- ");
+                    message.append(skippedClass.clazz().name());
+                    switch (skippedClass.reason()) {
+                        case EXCLUDED_TYPE:
+                            message.append(" was excluded in config");
+                            break;
+                        case VETOED:
+                            message.append(" was annotated with @Vetoed");
+                            break;
+                        case NO_BEAN_DEF_ANNOTATION:
+                            message.append(" has no bean defining annotation (scope, stereotype, etc.)");
+                            break;
+                        case NO_BEAN_CONSTRUCTOR:
+                            message.append(" does not declare a valid bean constructor");
+                        default:
+                            break;
+                    }
+                }
+                message.append("\n\n");
+            }
+
             errors.add(new UnsatisfiedResolutionException(message.toString()));
         } else if (resolved.size() > 1) {
             // Try to resolve the ambiguity
@@ -502,7 +542,7 @@ public final class Beans {
         if (injectionPoint.isSynthetic()) {
             message.append("\n\t- synthetic injection point");
         } else {
-            message.append("\n\t- java member: ");
+            message.append("\n\t- injection target: ");
             message.append(injectionPoint.getTargetInfo());
         }
         message.append("\n\t- declared on ");
@@ -1250,7 +1290,7 @@ public final class Beans {
         BeanInfo create() {
             Set<AnnotationInstance> qualifiers = new HashSet<>();
             List<ScopeInfo> scopes = new ArrayList<>();
-            Set<Type> types = Types.getClassBeanTypeClosure(beanClass, beanDeployment);
+            TypeClosure typeClosure = Types.getClassBeanTypeClosure(beanClass, beanDeployment);
 
             List<StereotypeInfo> stereotypes = new ArrayList<>();
             Collection<AnnotationInstance> annotations = beanDeployment.getAnnotations(beanClass);
@@ -1307,8 +1347,9 @@ public final class Beans {
 
             List<Injection> injections = Injection.forBean(beanClass, null, beanDeployment, transformer,
                     Injection.BeanType.MANAGED_BEAN);
-            BeanInfo bean = new BeanInfo(beanClass, beanDeployment, scope, types, qualifiers,
-                    injections, null, null, isAlternative, stereotypes, name, isDefaultBean, null, priority);
+            BeanInfo bean = new BeanInfo(beanClass, beanDeployment, scope, typeClosure.types(), qualifiers,
+                    injections, null, null, isAlternative, stereotypes, name, isDefaultBean, null, priority,
+                    typeClosure.unrestrictedTypes());
             for (Injection injection : injections) {
                 injection.init(bean);
             }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DecoratorInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DecoratorInfo.java
@@ -23,7 +23,7 @@ public class DecoratorInfo extends BeanInfo implements Comparable<DecoratorInfo>
             Set<Type> decoratedTypes, List<Injection> injections, int priority) {
         super(target, beanDeployment, BuiltinScope.DEPENDENT.getInfo(),
                 Sets.singletonHashSet(Type.create(target.asClass().name(), Kind.CLASS)), new HashSet<>(), injections,
-                null, null, false, Collections.emptyList(), null, false, null, priority);
+                null, null, false, Collections.emptyList(), null, false, null, priority, null);
         this.delegateInjectionPoint = delegateInjectionPoint;
         this.decoratedTypes = decoratedTypes;
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Decorators.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Decorators.java
@@ -19,6 +19,8 @@ import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
+import io.quarkus.arc.processor.Types.TypeClosure;
+
 final class Decorators {
 
     static final Logger LOGGER = Logger.getLogger(Decorators.class);
@@ -69,7 +71,8 @@ final class Decorators {
         }
 
         //  The set includes all bean types which are Java interfaces, except for java.io.Serializable
-        Set<Type> types = Types.getClassBeanTypeClosure(decoratorClass, beanDeployment);
+        TypeClosure typeClosure = Types.getClassBeanTypeClosure(decoratorClass, beanDeployment);
+        Set<Type> types = typeClosure.types();
         Set<Type> decoratedTypes = new HashSet<>();
         for (Type type : types) {
             if (type.name().equals(DotNames.SERIALIZABLE)) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorInfo.java
@@ -64,7 +64,8 @@ public class InterceptorInfo extends BeanInfo implements Comparable<InterceptorI
                             creatorClass.getName() + "#create() must not return null");
                     mc.returnValue(ret);
                 },
-                null, params, true, false, null, priority, creatorClass.getName() + (identifier != null ? identifier : ""));
+                null, params, true, false, null, priority, creatorClass.getName() + (identifier != null ? identifier : ""),
+                null);
         this.bindings = bindings;
         this.interceptionType = interceptionType;
         this.creatorClass = creatorClass;
@@ -78,7 +79,7 @@ public class InterceptorInfo extends BeanInfo implements Comparable<InterceptorI
             List<Injection> injections, int priority) {
         super(target, beanDeployment, BuiltinScope.DEPENDENT.getInfo(),
                 Sets.singletonHashSet(Type.create(target.asClass().name(), Kind.CLASS)), new HashSet<>(), injections,
-                null, null, false, Collections.emptyList(), null, false, null, priority);
+                null, null, false, Collections.emptyList(), null, false, null, priority, null);
         this.bindings = bindings;
         this.interceptionType = null;
         this.creatorClass = null;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
@@ -411,7 +411,7 @@ public final class Types {
         return elementType;
     }
 
-    static Set<Type> getProducerMethodTypeClosure(MethodInfo producerMethod, BeanDeployment beanDeployment) {
+    static TypeClosure getProducerMethodTypeClosure(MethodInfo producerMethod, BeanDeployment beanDeployment) {
         Set<Type> types;
         Set<Type> unrestrictedBeanTypes = new HashSet<>();
         Type returnType = producerMethod.returnType();
@@ -425,7 +425,7 @@ public final class Types {
             types = new HashSet<>();
             types.add(returnType);
             types.add(OBJECT_TYPE);
-            return types;
+            return new TypeClosure(types);
         } else {
             ClassInfo returnTypeClassInfo = getClassByName(beanDeployment.getBeanArchiveIndex(), returnType);
             if (returnTypeClassInfo == null) {
@@ -444,12 +444,11 @@ public final class Types {
                 throw new IllegalArgumentException("Unsupported return type");
             }
         }
-        return restrictBeanTypes(types, unrestrictedBeanTypes, beanDeployment.getAnnotations(producerMethod),
-                beanDeployment.getBeanArchiveIndex(),
-                producerMethod);
+        return new TypeClosure(restrictBeanTypes(types, unrestrictedBeanTypes, beanDeployment.getAnnotations(producerMethod),
+                beanDeployment.getBeanArchiveIndex(), producerMethod), unrestrictedBeanTypes);
     }
 
-    static Set<Type> getProducerFieldTypeClosure(FieldInfo producerField, BeanDeployment beanDeployment) {
+    static TypeClosure getProducerFieldTypeClosure(FieldInfo producerField, BeanDeployment beanDeployment) {
         Set<Type> types;
         Set<Type> unrestrictedBeanTypes = new HashSet<>();
         Type fieldType = producerField.type();
@@ -463,6 +462,7 @@ public final class Types {
             types = new HashSet<>();
             types.add(fieldType);
             types.add(OBJECT_TYPE);
+            return new TypeClosure(types);
         } else {
             ClassInfo fieldClassInfo = getClassByName(beanDeployment.getBeanArchiveIndex(), producerField.type());
             if (fieldClassInfo == null) {
@@ -480,12 +480,11 @@ public final class Types {
                 throw new IllegalArgumentException("Unsupported return type");
             }
         }
-        return restrictBeanTypes(types, unrestrictedBeanTypes, beanDeployment.getAnnotations(producerField),
-                beanDeployment.getBeanArchiveIndex(),
-                producerField);
+        return new TypeClosure(restrictBeanTypes(types, unrestrictedBeanTypes, beanDeployment.getAnnotations(producerField),
+                beanDeployment.getBeanArchiveIndex(), producerField), unrestrictedBeanTypes);
     }
 
-    static Set<Type> getClassBeanTypeClosure(ClassInfo classInfo, BeanDeployment beanDeployment) {
+    static TypeClosure getClassBeanTypeClosure(ClassInfo classInfo, BeanDeployment beanDeployment) {
         Set<Type> types;
         Set<Type> unrestrictedBeanTypes = new HashSet<>();
         List<TypeVariable> typeParameters = classInfo.typeParameters();
@@ -495,9 +494,28 @@ public final class Types {
             types = getTypeClosure(classInfo, null, buildResolvedMap(typeParameters, typeParameters,
                     Collections.emptyMap(), beanDeployment.getBeanArchiveIndex()), beanDeployment, null, unrestrictedBeanTypes);
         }
-        return restrictBeanTypes(types, unrestrictedBeanTypes, beanDeployment.getAnnotations(classInfo),
-                beanDeployment.getBeanArchiveIndex(),
-                classInfo);
+        return new TypeClosure(restrictBeanTypes(types, unrestrictedBeanTypes, beanDeployment.getAnnotations(classInfo),
+                beanDeployment.getBeanArchiveIndex(), classInfo), unrestrictedBeanTypes);
+    }
+
+    record TypeClosure(Set<Type> types, Set<Type> unrestrictedTypes) {
+
+        TypeClosure(Set<Type> types) {
+            this(types, types);
+        }
+    }
+
+    static Set<Type> getClassUnrestrictedTypeClosure(ClassInfo classInfo, BeanDeployment beanDeployment) {
+        Set<Type> types;
+        Set<Type> unrestrictedBeanTypes = new HashSet<>();
+        List<TypeVariable> typeParameters = classInfo.typeParameters();
+        if (typeParameters.isEmpty()) {
+            types = getTypeClosure(classInfo, null, Collections.emptyMap(), beanDeployment, null, unrestrictedBeanTypes);
+        } else {
+            types = getTypeClosure(classInfo, null, buildResolvedMap(typeParameters, typeParameters,
+                    Collections.emptyMap(), beanDeployment.getBeanArchiveIndex()), beanDeployment, null, unrestrictedBeanTypes);
+        }
+        return types;
     }
 
     static Map<String, Type> resolveDecoratedTypeParams(ClassInfo decoratedTypeClass, DecoratorInfo decorator) {

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/TypesTest.java
@@ -60,7 +60,7 @@ public class TypesTest {
         resolvedTypeVariables.clear();
         // Foo<T>, Object
         Set<Type> fooTypes = Types.getClassBeanTypeClosure(fooClass,
-                dummyDeployment);
+                dummyDeployment).types();
         assertEquals(2, fooTypes.size());
         for (Type t : fooTypes) {
             if (t.kind().equals(Kind.PARAMETERIZED_TYPE)) {
@@ -83,18 +83,20 @@ public class TypesTest {
         final String wildcardInTypeHierarchy = "eagleProducer";
         assertDoesNotThrow(
                 () -> verifyEagleTypes(
-                        Types.getProducerMethodTypeClosure(producerClass.method(wildcardInTypeHierarchy), dummyDeployment)));
+                        Types.getProducerMethodTypeClosure(producerClass.method(wildcardInTypeHierarchy), dummyDeployment)
+                                .types()));
         assertDoesNotThrow(
                 () -> verifyEagleTypes(
-                        Types.getProducerFieldTypeClosure(producerClass.field(wildcardInTypeHierarchy), dummyDeployment)));
+                        Types.getProducerFieldTypeClosure(producerClass.field(wildcardInTypeHierarchy), dummyDeployment)
+                                .types()));
         // now do the same for a non-producer scenario with Eagle class
         assertDoesNotThrow(
                 () -> verifyEagleTypes(Types.getClassBeanTypeClosure(index.getClassByName(DotName.createSimple(Eagle.class)),
-                        dummyDeployment)));
+                        dummyDeployment).types()));
 
         // raw type bean
         Set<Type> rawBeanTypes = Types.getClassBeanTypeClosure(index.getClassByName(DotName.createSimple(MyRawBean.class)),
-                dummyDeployment);
+                dummyDeployment).types();
         assertEquals(rawBeanTypes.size(), 5);
         assertContainsType(MyRawBean.class, rawBeanTypes);
         assertContainsType(MyBean.class, rawBeanTypes);

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/finalmethod/FinalMethodIllegalWhenNotInjectedTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/clientproxy/finalmethod/FinalMethodIllegalWhenNotInjectedTest.java
@@ -12,11 +12,11 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.test.ArcTestContainer;
 
 public class FinalMethodIllegalWhenNotInjectedTest {
+
     @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
             .beanClasses(Moo.class)
             .strictCompatibility(true)
-            .shouldFail()
             .build();
 
     @Test

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/unsatisfied/UnsatisfiedMatchByRestrictedTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/unsatisfied/UnsatisfiedMatchByRestrictedTypeTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.arc.test.injection.unsatisfied;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.Typed;
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class UnsatisfiedMatchByRestrictedTypeTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(FooService.class, Consumer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).rootCause().isInstanceOf(UnsatisfiedResolutionException.class)
+                .hasMessageContaining("The following beans match by type excluded by the @Typed annotation")
+                .hasMessageContaining(
+                        "io.quarkus.arc.test.injection.unsatisfied.UnsatisfiedMatchByRestrictedTypeTest$FooService");
+    }
+
+    @Singleton
+    static class Consumer {
+
+        @Inject
+        FooService foo;
+
+    }
+
+    @Typed(Comparable.class)
+    @Singleton
+    static class FooService implements Comparable<String> {
+
+        @Override
+        public int compareTo(String o) {
+            return 0;
+        }
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/unsatisfied/UnsatisfiedMatchByTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/unsatisfied/UnsatisfiedMatchByTypeTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.arc.test.injection.unsatisfied;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.MyQualifier;
+
+public class UnsatisfiedMatchByTypeTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(FooService.class, Consumer.class, MyQualifier.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).rootCause().isInstanceOf(UnsatisfiedResolutionException.class)
+                .hasMessageContaining("The following beans match by type, but none has matching qualifiers")
+                .hasMessageContaining("io.quarkus.arc.test.injection.unsatisfied.UnsatisfiedMatchByTypeTest$FooService");
+
+    }
+
+    @Singleton
+    static class Consumer {
+
+        @Inject
+        @MyQualifier
+        FooService foo;
+
+    }
+
+    @Singleton
+    static class FooService {
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/unsatisfied/UnsatisfiedMatchExcludedTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/unsatisfied/UnsatisfiedMatchExcludedTypeTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.arc.test.injection.unsatisfied;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.jandex.DotName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class UnsatisfiedMatchExcludedTypeTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(FooService.class, Consumer.class)
+            .excludeType(c -> c.name().equals(DotName.createSimple(FooService.class)))
+            .shouldFail()
+            .build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).rootCause().isInstanceOf(UnsatisfiedResolutionException.class)
+                .hasMessageContaining("The following classes match by type, but have been skipped during discovery")
+                .hasMessageContaining(
+                        "io.quarkus.arc.test.injection.unsatisfied.UnsatisfiedMatchExcludedTypeTest$FooService was excluded in config");
+
+    }
+
+    @Singleton
+    static class Consumer {
+
+        @Inject
+        FooService foo;
+
+    }
+
+    @Singleton
+    static class FooService {
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/unsatisfied/UnsatisfiedMatchNoBeanConstructorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/unsatisfied/UnsatisfiedMatchNoBeanConstructorTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.arc.test.injection.unsatisfied;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class UnsatisfiedMatchNoBeanConstructorTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(FooService.class, Consumer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).rootCause().isInstanceOf(UnsatisfiedResolutionException.class)
+                .hasMessageContaining("The following classes match by type, but have been skipped during discovery")
+                .hasMessageContaining(
+                        "io.quarkus.arc.test.injection.unsatisfied.UnsatisfiedMatchNoBeanConstructorTest$FooService does not declare a valid bean constructor");
+
+    }
+
+    @Singleton
+    static class Consumer {
+
+        @Inject
+        FooService foo;
+
+    }
+
+    static class FooService {
+
+        public FooService(boolean flag) {
+        }
+
+        public FooService(int score) {
+        }
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/unsatisfied/UnsatisfiedMatchNoBeanDefininAnnotationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/unsatisfied/UnsatisfiedMatchNoBeanDefininAnnotationTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.arc.test.injection.unsatisfied;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class UnsatisfiedMatchNoBeanDefininAnnotationTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(FooService.class, Consumer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).rootCause().isInstanceOf(UnsatisfiedResolutionException.class)
+                .hasMessageContaining("The following classes match by type, but have been skipped during discovery")
+                .hasMessageContaining(
+                        "io.quarkus.arc.test.injection.unsatisfied.UnsatisfiedMatchNoBeanDefininAnnotationTest$FooService has no bean defining annotation");
+
+    }
+
+    @Singleton
+    static class Consumer {
+
+        @Inject
+        FooService foo;
+
+    }
+
+    static class FooService {
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/unsatisfied/UnsatisfiedMatchVetoedTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/unsatisfied/UnsatisfiedMatchVetoedTypeTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.arc.test.injection.unsatisfied;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.enterprise.inject.Vetoed;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class UnsatisfiedMatchVetoedTypeTest {
+
+    @RegisterExtension
+    ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(FooService.class, Consumer.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void testExceptionThrown() {
+        Throwable error = container.getFailure();
+        assertThat(error).rootCause().isInstanceOf(UnsatisfiedResolutionException.class)
+                .hasMessageContaining("The following classes match by type, but have been skipped during discovery")
+                .hasMessageContaining(
+                        "io.quarkus.arc.test.injection.unsatisfied.UnsatisfiedMatchVetoedTypeTest$FooService was annotated with @Vetoed");
+
+    }
+
+    @Singleton
+    static class Consumer {
+
+        @Inject
+        FooService foo;
+
+    }
+
+    @Vetoed
+    @Singleton
+    static class FooService {
+
+    }
+
+}


### PR DESCRIPTION
- in particular, the message is improved when a user attempts to inject a bean class:
(a) that has no bean defining annotation.
(b) is vetoed
(c) is excluded in config
(d) does not declare a valid bean constructor
(e) has the matched type excluded by the Typed annotation


Fixes #33485