### PR TITLE
Docs: fix wrong link in Security JDBC guide

### DIFF
--- a/docs/src/main/asciidoc/security-jdbc.adoc
+++ b/docs/src/main/asciidoc/security-jdbc.adoc
@@ -184,7 +184,8 @@ INSERT INTO test_user (id, username, password, role) VALUES (2, 'user','user', '
 [NOTE]
 ====
 It is probably useless, but we kindly remind you that you must not store clear-text passwords in production environment ;-).
-The `elytron-security-jdbc` offers a built-in bcrypt password mapper. You can see the section `Define the user entity` for more details at xref:security-getting-started-tutorial.adoc#define-the-user-entity.
+The `elytron-security-jdbc` offers a built-in bcrypt password mapper.
+Please refer to the xref:security-getting-started-tutorial.adoc#define-the-user-entity[Define the user entity] section of the Getting Started with Security using Basic authentication and Jakarta Persistence tutorial for practical example.
 ====
 
 We can now configure the Elytron JDBC Realm.


### PR DESCRIPTION
Here https://quarkus.io/version/main/guides/security-jdbc I can see the link is in fact plain text because xref has no title. This is result of my clumsy suggestion in #37771.