### PR TITLE
Update links to java docs from java 11 to java 17

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
@@ -108,7 +108,7 @@ final public class Constants {
             ".About the Duration format\n" +
             "====\n" +
             "To write duration values, use the standard `java.time.Duration` format.\n" +
-            "See the link:https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)[Duration#parse() Java API documentation] for more information.\n"
+            "See the link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)[Duration#parse() Java API documentation] for more information.\n"
             +
             "\n" +
             "You can also use a simplified format, starting with a number:\n" +

--- a/docs/src/main/asciidoc/_includes/duration-format-note.adoc
+++ b/docs/src/main/asciidoc/_includes/duration-format-note.adoc
@@ -1,7 +1,7 @@
 [NOTE]
 ====
 To write duration values, use the standard `java.time.Duration` format.
-See the link:https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)[Duration#parse() javadoc] for more information.
+See the link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)[Duration#parse() javadoc] for more information.
 
 You can also use a simplified format, starting with a number:
 

--- a/docs/src/main/asciidoc/config-extending-support.adoc
+++ b/docs/src/main/asciidoc/config-extending-support.adoc
@@ -25,7 +25,7 @@ image::config-sources.png[align=center,width=90%]
 
 A custom `ConfigSource` requires an implementation of `org.eclipse.microprofile.config.spi.ConfigSource` or
 `org.eclipse.microprofile.config.spi.ConfigSourceProvider`. Each implementation requires registration via
-the https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html[ServiceLoader] mechanism, either in
+the https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html[ServiceLoader] mechanism, either in
 `META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource` or
 `META-INF/services/org.eclipse.microprofile.config.spi.ConfigSourceProvider` files.
 
@@ -175,7 +175,7 @@ link:https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/as
 is the factory ability to provide a context with access to the available configuration.
 
 Each implementation of `io.smallrye.config.ConfigSourceFactory` requires registration via
-the https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html[ServiceLoader]
+the https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html[ServiceLoader]
 mechanism in the `META-INF/services/io.smallrye.config.ConfigSourceFactory` file.
 
 === Example
@@ -248,7 +248,7 @@ It is possible to create a custom `Converter` type as specified by
 link:https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/converters.asciidoc#adding-custom-converters[MicroProfile Config].
 
 A custom `Converter` requires an implementation of `org.eclipse.microprofile.config.spi.Converter<T>`. Each implementation
-requires registration via the https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html[ServiceLoader]
+requires registration via the https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html[ServiceLoader]
 mechanism in the `META-INF/services/org.eclipse.microprofile.config.spi.Converter` file. Consider:
 
 [source,java]
@@ -344,7 +344,7 @@ xref:config-reference.adoc#property-expressions[Property Expressions],
 or just logging to find out where the config value was loaded from.
 
 An interceptor requires an implementation of `io.smallrye.config.ConfigSourceInterceptor`. Each implementation
-requires registration via the https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html[ServiceLoader]
+requires registration via the https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html[ServiceLoader]
 mechanism in the `META-INF/services/io.smallrye.config.ConfigSourceInterceptor` file.
 
 The `io.smallrye.config.ConfigSourceInterceptor` is able to intercept the resolution of a configuration name with the
@@ -356,7 +356,7 @@ origin and ordinal.
 NOTE: The interceptor chain is applied before any conversion is performed on the configuration value.
 
 Interceptors may also be created with an implementation of `io.smallrye.config.ConfigSourceInterceptorFactory`. Each
-implementation requires registration via the https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html[ServiceLoader]
+implementation requires registration via the https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html[ServiceLoader]
 mechanism in the `META-INF/services/io.smallrye.config.ConfigSourceInterceptorFactory` file.
 
 The `ConfigSourceInterceptorFactory` may initialize an interceptor with access to the current chain

--- a/docs/src/main/asciidoc/context-propagation.adoc
+++ b/docs/src/main/asciidoc/context-propagation.adoc
@@ -9,7 +9,7 @@ include::_attributes.adoc[]
 :summary: Learn more about how you can pass contextual information with SmallRye Context Propagation.
 :topics: context-propagation
 
-Traditional blocking code uses link:https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/ThreadLocal.html[`ThreadLocal`]
+Traditional blocking code uses link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/ThreadLocal.html[`ThreadLocal`]
  variables to store contextual objects in order to avoid
 passing them as parameters everywhere. Many Quarkus extensions require those contextual objects to operate
 properly: xref:rest-json.adoc[RESTEasy Reactive], xref:cdi-reference.adoc[ArC] and xref:transaction.adoc[Transaction]
@@ -115,7 +115,7 @@ The 3 items are persisted using the same transaction and this transaction is com
 
 == Usage example for `CompletionStage`
 
-If you are using link:https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletionStage.html[`CompletionStage`]
+If you are using link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/CompletionStage.html[`CompletionStage`]
 you need manual context propagation. You can do that by injecting a `ThreadContext`
 or `ManagedExecutor` that will propagate every context. For example, here we use the xref:vertx.adoc[Vert.x Web Client]
 to get the list of Star Wars people, then store them in the database using

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -17,7 +17,7 @@ Quarkus supports the JBoss Logging API and multiple other logging APIs, seamless
 You can use any of the <<logging-apis,following APIs>>:
 
 * link:https://github.com/jboss-logging/jboss-logging[JBoss Logging]
-* link:https://docs.oracle.com/en/java/javase/11/docs/api/java.logging/java/util/logging/package-summary.html[JDK `java.util.logging` (JUL)]
+* link:https://docs.oracle.com/en/java/javase/17/docs/api/java.logging/java/util/logging/package-summary.html[JDK `java.util.logging` (JUL)]
 * link:https://www.slf4j.org/[SLF4J]
 * link:https://commons.apache.org/proper/commons-logging/[Apache Commons Logging]
 * link:https://logging.apache.org/log4j/2.x/[Apache Log4j 2]
@@ -505,7 +505,7 @@ For details about its configuration, see the xref:#quarkus-log-logging-log-confi
 
 == Add a logging filter to your log handler
 
-Log handlers, such as the console log handler, can be linked with a link:https://docs.oracle.com/en/java/javase/11/docs/api/java.logging/java/util/logging/Filter.html[filter] that determines whether a log record should be logged.
+Log handlers, such as the console log handler, can be linked with a link:https://docs.oracle.com/en/java/javase/17/docs/api/java.logging/java/util/logging/Filter.html[filter] that determines whether a log record should be logged.
 
 To register a logging filter:
 

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -11,7 +11,7 @@ include::_attributes.adoc[]
 :summary: Discover how to develop highly scalable reactive REST services with Jakarta REST and RESTEasy Reactive.
 :jaxrsapi: https://javadoc.io/doc/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0/jakarta.ws.rs
 :jaxrsspec: https://jakarta.ee/specifications/restful-ws/3.1/jakarta-restful-ws-spec-3.1.html
-:jdkapi: https://docs.oracle.com/en/java/javase/11/docs/api/java.base
+:jdkapi: https://docs.oracle.com/en/java/javase/17/docs/api/java.base
 :mutinyapi: https://javadoc.io/doc/io.smallrye.reactive/mutiny/2.1.0/io.smallrye.mutiny
 :httpspec: https://tools.ietf.org/html/rfc7231
 :jsonpapi: https://javadoc.io/doc/jakarta.json/jakarta.json-api/2.1.2/jakarta.json

--- a/integration-tests/awt/src/main/java/io/quarkus/awt/it/ImageResource.java
+++ b/integration-tests/awt/src/main/java/io/quarkus/awt/it/ImageResource.java
@@ -272,7 +272,7 @@ public class ImageResource {
      */
     public static void writePNG(ImageWriter writer, IIOMetadata iioMetadata, ImageWriteParam params, String[] desc,
             BufferedImage img) throws IOException {
-        // https://docs.oracle.com/en/java/javase/11/docs/api/java.desktop/javax/imageio/metadata/doc-files/png_metadata.html
+        // https://docs.oracle.com/en/java/javase/17/docs/api/java.desktop/javax/imageio/metadata/doc-files/png_metadata.html
         // Metadata is mutable, we can just add to the tree:
         final IIOMetadataNode textEntry = new IIOMetadataNode("tEXtEntry");
         textEntry.setAttribute("keyword", "ImageDescription");
@@ -319,7 +319,7 @@ public class ImageResource {
      */
     public static void writeGIF(ImageWriter writer, IIOMetadata iioMetadata, ImageWriteParam params, String[] desc,
             BufferedImage img) throws IOException {
-        // https://docs.oracle.com/en/java/javase/11/docs/api/java.desktop/javax/imageio/metadata/doc-files/gif_metadata.html
+        // https://docs.oracle.com/en/java/javase/17/docs/api/java.desktop/javax/imageio/metadata/doc-files/gif_metadata.html
         final IIOMetadataNode root = (IIOMetadataNode) iioMetadata.getAsTree("javax_imageio_gif_image_1.0");
         final IIOMetadataNode commentsNode = new IIOMetadataNode("CommentExtensions");
         root.appendChild(commentsNode);


### PR DESCRIPTION
As Quarkus move from java 11+ to java 17+ the links for java docs should be updated as well. These should be all 
occurrences containing `javase/11` keyword. Tested it and all new links works.