### PR TITLE
Avoid a warning for tests in interactive mode

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -278,7 +278,7 @@ public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
 
     private PluginManager pluginManager(OutputOptionMixin output, Optional<String> testDir, boolean interactiveMode) {
         PluginManagerSettings settings = PluginManagerSettings.defaultSettings()
-                .withInteractivetMode(interactiveMode); // Why not just getting it from output.isClieTest ? Cause args have not been parsed yet.
+                .withInteractiveMode(interactiveMode); // Why not just getting it from output.isCliTest ? Cause args have not been parsed yet.
         return PluginManager.create(settings, output, Optional.ofNullable(Paths.get(System.getProperty("user.home"))),
                 getProjectRoot(testDir), quarkusProject(testDir));
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsAdd.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsAdd.java
@@ -55,12 +55,12 @@ public class CliPluginsAdd extends CliPluginsBase implements Callable<Integer> {
             output.info(table.getContent());
             if (plugin.isInProjectCatalog() && existingPlugin.filter(p -> p.isInUserCatalog()).isPresent()) {
                 output.warn(
-                        "Plugin was added in the project scope, but another with the same name exists in the user scope!\nThe project scoped one will take precedence when invoked from within the project!");
+                        "Plugin was added in the project scope, but another with the same name exists in the user scope.\nThe project scoped one will take precedence when invoked from within the project.");
             }
 
             if (plugin.isInUserCatalog() && existingPlugin.filter(p -> p.isInProjectCatalog()).isPresent()) {
                 output.warn(
-                        "Plugin was added in the user scope, but another with the same name exists in the project scope!\nThe project scoped one will take precedence when invoked from within the project!");
+                        "Plugin was added in the user scope, but another with the same name exists in the project scope.\nThe project scoped one will take precedence when invoked from within the project.");
             }
 
             return CommandLine.ExitCode.OK;

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsList.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsList.java
@@ -89,7 +89,7 @@ public class CliPluginsList extends CliPluginsBase implements Callable<Integer> 
                 .collect(Collectors.toMap(p -> p.getName(), p -> p)));
 
         if (items.isEmpty()) {
-            output.info("No plugins " + (installable ? "installable" : "installed") + "!");
+            output.info("No plugins " + (installable ? "installable" : "installed") + ".");
         } else {
             PluginListTable table = new PluginListTable(
                     items.values().stream().filter(this::filter).collect(Collectors.toList()), showCommand);

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsRemove.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/CliPluginsRemove.java
@@ -49,15 +49,15 @@ public class CliPluginsRemove extends CliPluginsBase implements Callable<Integer
             if (pluginManager.getInstalledPlugins().containsKey(plugin.getName())) {
                 if (plugin.isInProjectCatalog()) {
                     output.warn(
-                            "The removed plugin was available both in user and project scopes. It was removed from the project but will remain available in the user scope!");
+                            "The removed plugin was available both in user and project scopes. It was removed from the project scope but will remain available in the user scope.");
                 } else {
                     output.warn(
-                            "The removed plugin was available both in user and project scopes. It was removed from the user but will remain available in the project scope!");
+                            "The removed plugin was available both in user and project scopes. It was removed from the user scope but will remain available in the project scope.");
                 }
             }
             return CommandLine.ExitCode.OK;
         }).orElseGet(() -> {
-            output.error("Plugin: " + name + " not found in catalog!");
+            output.error("Plugin: " + name + " not found in catalog.");
             return CommandLine.ExitCode.USAGE;
         });
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/JBangCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/JBangCommand.java
@@ -31,7 +31,7 @@ public class JBangCommand implements PluginCommand {
         if (jbang.ensureJBangIsInstalled()) {
             return PluginCommand.super.call();
         } else {
-            output.error("Unable to find JBang! Command execution aborted!");
+            output.error("Unable to find JBang. Command execution aborted as it requires JBang.");
             return ExitCode.SOFTWARE;
         }
     }

--- a/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCommandFactory.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/plugin/PluginCommandFactory.java
@@ -41,7 +41,7 @@ public class PluginCommandFactory {
             case executable:
                 return plugin.getLocation().map(l -> new ShellCommand(plugin.getName(), Paths.get(l), output));
             default:
-                throw new IllegalStateException("Unknown plugin type!");
+                throw new IllegalStateException("Unknown plugin type");
         }
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/JBangCatalogService.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/JBangCatalogService.java
@@ -52,7 +52,7 @@ public class JBangCatalogService extends CatalogService<JBangCatalog> {
         if (!jbang.isAvailable() && !jbang.isInstallable()) {
             // When jbang is not available / installable just return an empty catalog.
             // We don't even return the parsed one as plugins won't be able to run without jbang anyway.
-            return new JBangCatalog();
+            return JBangCatalog.empty();
         }
 
         JBangCatalog localCatalog = super.readCatalog(path);
@@ -76,7 +76,7 @@ public class JBangCatalogService extends CatalogService<JBangCatalog> {
         if (!jbang.isAvailable() && !jbang.isInstallable()) {
             // When jbang is not available / installable just return an empty catalog.
             // We don't even return the parsed one as plugins won't be able to run without jbang anyway.
-            return new JBangCatalog();
+            return JBangCatalog.empty();
         }
 
         Map<String, JBangCatalog> catalogs = new HashMap<>();
@@ -146,7 +146,7 @@ public class JBangCatalogService extends CatalogService<JBangCatalog> {
 
         //If there are locally installed catalogs, then go through every single one of them
         //and collect the aliases.
-        //Unfortunaltely jbang can't return all alias in one go.
+        //Unfortunately jbang can't return all alias in one go.
         //This is because it currently omits `@catalog` suffix in some cases.
         if (!localCatalogs.isEmpty()) {
             Map<String, JBangAlias> aliases = new HashMap<>();

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/JBangSupport.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/JBangSupport.java
@@ -14,7 +14,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -22,11 +21,11 @@ import io.quarkus.devtools.exec.Executable;
 import io.quarkus.devtools.messagewriter.MessageWriter;
 import io.quarkus.devtools.utils.Prompt;
 import io.quarkus.fs.util.ZipUtils;
+import io.smallrye.common.os.OS;
 
 public class JBangSupport {
 
-    private static final boolean IS_OS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("windows");
-    private static final String JBANG_EXECUTABLE = IS_OS_WINDOWS ? "jbang.cmd" : "jbang";
+    private static final String JBANG_EXECUTABLE = OS.WINDOWS.isCurrent() ? "jbang.cmd" : "jbang";
 
     private static final Predicate<Path> EXISTS_AND_WRITABLE = p -> p != null && p.toFile().exists() && p.toFile().canWrite();
 
@@ -92,7 +91,7 @@ public class JBangSupport {
     }
 
     public File getExecutable() {
-        return getOptionalExecutable().orElseThrow(() -> new IllegalStateException("Unable to find and install jbang!"));
+        return getOptionalExecutable().orElseThrow(() -> new IllegalStateException("Unable to find or install JBang"));
     }
 
     public Path getWorkingDirectory() {
@@ -158,7 +157,7 @@ public class JBangSupport {
     public boolean promptForInstallation() {
         // We don't want to prompt users for input when running tests.
         if (interactiveMode
-                && Prompt.yesOrNo(true, "JBang is needed to list / run jbang plugins, would you like to install it now ?")) {
+                && Prompt.yesOrNo(true, "JBang is needed to list/run JBang plugins, would you like to install it now?")) {
             return true;
         }
         return false;
@@ -180,7 +179,7 @@ public class JBangSupport {
             return true;
         }
         if (!isInstallable()) {
-            output.warn("JBang is not installable!");
+            // this only happens for tests, do not output anything specific
             return false;
         }
         if (promptForInstallation()) {
@@ -188,7 +187,7 @@ public class JBangSupport {
                 installJBang();
                 return true;
             } catch (Exception e) {
-                output.warn("Failed to install jbang!");
+                output.warn("Failed to install JBang", e);
                 return false;
             }
         } else {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManager.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManager.java
@@ -17,7 +17,7 @@ public class PluginManager {
     private static PluginManager INSTANCE;
 
     private final MessageWriter output;
-    private final PluginMangerState state;
+    private final PluginManagerState state;
     private final PluginManagerSettings settings;
     private final PluginManagerUtil util;
 
@@ -41,7 +41,7 @@ public class PluginManager {
         this.settings = settings;
         this.output = output;
         this.util = PluginManagerUtil.getUtil(settings);
-        this.state = new PluginMangerState(settings, output, userHome, currentDir, quarkusProject);
+        this.state = new PluginManagerState(settings, output, userHome, currentDir, quarkusProject);
     }
 
     /**
@@ -159,7 +159,7 @@ public class PluginManager {
      */
     public Optional<Plugin> removePlugin(String name, boolean userCatalog) {
         PluginCatalogService pluginCatalogService = state.getPluginCatalogService();
-        Plugin plugin = state.getInstalledPluigns().get(name);
+        Plugin plugin = state.getInstalledPlugins().get(name);
         if (plugin == null) {
             return Optional.empty();
         } else if (userCatalog) {
@@ -333,7 +333,7 @@ public class PluginManager {
     }
 
     public Map<String, Plugin> getInstalledPlugins(boolean userCatalog) {
-        return userCatalog ? state.userPlugins() : state.getInstalledPluigns();
+        return userCatalog ? state.userPlugins() : state.getInstalledPlugins();
     }
 
     public Map<String, Plugin> getInstalledPlugins() {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManagerSettings.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManagerSettings.java
@@ -55,7 +55,7 @@ public class PluginManagerSettings {
                 toRelativePath);
     }
 
-    public PluginManagerSettings withInteractivetMode(boolean interactiveMode) {
+    public PluginManagerSettings withInteractiveMode(boolean interactiveMode) {
         return new PluginManagerSettings(interactiveMode, pluginPrefix, fallbackJBangCatalog, remoteJBangCatalogs,
                 toRelativePath);
     }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManagerState.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManagerState.java
@@ -17,11 +17,10 @@ import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.platform.catalog.processor.ExtensionProcessor;
 
-class PluginMangerState {
+class PluginManagerState {
 
-    PluginMangerState(PluginManagerSettings settings, MessageWriter output, Optional<Path> userHome, Optional<Path> currentDir,
+    PluginManagerState(PluginManagerSettings settings, MessageWriter output, Optional<Path> userHome, Optional<Path> currentDir,
             Supplier<QuarkusProject> quarkusProject) {
-        this.settings = settings;
         this.output = output;
         this.userHome = userHome;
         this.quarkusProject = quarkusProject;
@@ -35,7 +34,6 @@ class PluginMangerState {
         this.util = PluginManagerUtil.getUtil(settings);
     }
 
-    private final PluginManagerSettings settings;
     private final MessageWriter output;
     private final PluginManagerUtil util;
     private final Optional<Path> userHome;
@@ -73,7 +71,7 @@ class PluginMangerState {
         return allInstalledPlugins;
     }
 
-    public Map<String, Plugin> getInstalledPluigns() {
+    public Map<String, Plugin> getInstalledPlugins() {
         if (_installedPlugins == null) {
             _installedPlugins = installedPlugins();
         }
@@ -86,7 +84,7 @@ class PluginMangerState {
                 .collect(Collectors.toMap(p -> p.getName(), p -> p))).orElse(Collections.emptyMap());
     }
 
-    public Map<String, Plugin> getProjectPluigns() {
+    public Map<String, Plugin> getProjectPlugins() {
         if (_projectPlugins == null) {
             _projectPlugins = projectPlugins();
         }
@@ -99,7 +97,7 @@ class PluginMangerState {
                 .collect(Collectors.toMap(p -> p.getName(), p -> p))).orElse(Collections.emptyMap());
     }
 
-    public Map<String, Plugin> getUserPluigns() {
+    public Map<String, Plugin> getUserPlugins() {
         if (_userPlugins == null) {
             _userPlugins = userPlugins();
         }
@@ -228,7 +226,7 @@ class PluginMangerState {
 
     public PluginCatalog pluginCatalog(boolean userCatalog) {
         return (userCatalog ? getUserCatalog() : getProjectCatalog()).or(() -> getUserCatalog())
-                .orElseThrow(() -> new IllegalStateException("Unable to get project and user plugin catalogs!"));
+                .orElseThrow(() -> new IllegalStateException("Unable to get project and user plugin catalogs"));
     }
 
     public Optional<Path> getProjectRoot() {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManagerUtil.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/cli/plugin/PluginManagerUtil.java
@@ -72,9 +72,9 @@ public class PluginManagerUtil {
                 .or(() -> path.map(Path::getFileName).map(Path::toString)
                         .map(s -> s.replaceAll("\\.jar$", "").replaceAll("\\.java$", "")))
                 .map(n -> stripCliSuffix(n))
-                .map(n -> n.replaceAll("^" + prefix + "\\-cli\\-", prefix + "")) // stip cli prefix (after the quarkus bit)
-                .map(n -> n.replaceAll("^" + prefix + "\\-", "")) // stip quarkus prefix (after the quarkus bit)
-                .map(n -> n.replaceAll("@.*$", "")) // stip the @sufix
+                .map(n -> n.replaceAll("^" + prefix + "\\-cli\\-", prefix + "")) // strip cli prefix (after the quarkus bit)
+                .map(n -> n.replaceAll("^" + prefix + "\\-", "")) // strip quarkus prefix (after the quarkus bit)
+                .map(n -> n.replaceAll("@.*$", "")) // strip the @suffix
                 .orElseThrow(() -> new IllegalStateException("Could not determinate name for location."));
     }
 


### PR DESCRIPTION
The CliHelpTest#testCommandHelp has become extremely flaky lately because for one run, a warning saying JBang is not installable is there and for the other it's not. See https://ge.quarkus.io/s/gc7oirjtydrtg/tests/goal/io.quarkus:quarkus-cli:surefire:test@default-test/details/io.quarkus.cli.CliHelpTest/testCommandHelp?top-execution=1 for an example of the issue.

This is problematic and I really don't see the value of adding a warning about JBang that is specifically only displayed for tests.

Also fixed a bunch of typos and made the message more neutral (let's avoid using exclamation marks for messages and exceptions).