### PR TITLE
JDK-8316304 in JDK 21 introduced a new field accessed through JNI

### DIFF
--- a/integration-tests/jpa-postgresql/src/test/resources/image-metrics/23.1/image-metrics.properties
+++ b/integration-tests/jpa-postgresql/src/test/resources/image-metrics/23.1/image-metrics.properties
@@ -17,5 +17,5 @@ analysis_results.types.jni=61
 analysis_results.types.jni.tolerance=1
 analysis_results.methods.jni=55
 analysis_results.methods.jni.tolerance=1
-analysis_results.fields.jni=59
-analysis_results.fields.jni.tolerance=1
+analysis_results.fields.jni=60
+analysis_results.fields.jni.tolerance=2


### PR DESCRIPTION
A new field `sun.nio.fs.UnixFileAttributes.st_birthtime_sec` is
introduced with https://bugs.openjdk.org/browse/JDK-8316304 and GraalVM
registers it for JNI access in 23.1

See
https://github.com/oracle/graal/commit/6b9b813291d5a640e91ffb897d5631b53f6da3d3

This PR increases the expected number of JNI fields to avoid test
failures with the anticipated 23.1 CPU release in January. It also
increases the threshold to ensure backwards compatibility.

cc @jerboaa 