### PR TITLE
Optional support for the OIDC session cookie dir encryption

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -645,6 +645,33 @@ public class OidcTenantConfig extends OidcCommonConfig {
         @ConfigItem
         public Optional<String> encryptionSecret = Optional.empty();
 
+        /**
+         * Supported session cookie key encryption algorithms
+         */
+        public static enum EncryptionAlgorithm {
+            /**
+             * Content encryption key will be generated and encrypted using the A256GCMKW algorithm and the configured
+             * encryption secret.
+             * The generated content encryption key will be used to encrypt the session cookie content.
+             */
+            A256GCMKW,
+            /**
+             * The configured key encryption secret will be used as the content encryption key to encrypt the session cookie
+             * content.
+             * Using the direct encryption avoids a content encryption key generation step and
+             * will make the encrypted session cookie sequence slightly shorter.
+             * <p/>
+             * Avoid using the direct encryption if the encryption secret is less than 32 characters long.
+             */
+            DIR;
+        }
+
+        /**
+         * Session cookie key encryption algorithm
+         */
+        @ConfigItem(defaultValue = "A256GCMKW")
+        public EncryptionAlgorithm encryptionAlgorithm = EncryptionAlgorithm.A256GCMKW;
+
         public boolean isEncryptionRequired() {
             return encryptionRequired;
         }
@@ -675,6 +702,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setStrategy(Strategy strategy) {
             this.strategy = strategy;
+        }
+
+        public EncryptionAlgorithm getEncryptionAlgorithm() {
+            return encryptionAlgorithm;
+        }
+
+        public void setEncryptionAlgorithm(EncryptionAlgorithm encryptionAlgorithm) {
+            this.encryptionAlgorithm = encryptionAlgorithm;
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -947,9 +947,12 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                                             + " to have the ID, access and refresh tokens stored in separate cookies."
                                                             + " 2. Set 'quarkus.oidc.token-state-manager.strategy=id-refresh-tokens' if you do not need to use the access token"
                                                             + " as a source of roles or to request UserInfo or propagate it to the downstream services."
-                                                            + " 3. Decrease the session cookie's length by disabling its encryption with 'quarkus.oidc.token-state-manager.encryption-required=false'"
+                                                            + " 3. Decrease the encrypted session cookie's length by enabling a direct encryption algorithm"
+                                                            + " with 'quarkus.oidc.token-state-manager.encryption-algorithm=dir'."
+                                                            + " 4. Decrease the session cookie's length by disabling its encryption with 'quarkus.oidc.token-state-manager.encryption-required=false'"
                                                             + " but only if it is considered to be safe in your application's network."
-                                                            + " 4. Register a custom 'quarkus.oidc.TokenStateManager' CDI bean with the alternative priority set to 1.",
+                                                            + " 5. Use the 'quarkus-oidc-db-token-state-manager' extension or register a custom 'quarkus.oidc.TokenStateManager'"
+                                                            + " CDI bean with the alternative priority set to 1 and save the tokens on the server.",
                                                     configContext.oidcConfig.tenantId.get(),
                                                     OidcUtils.MAX_COOKIE_VALUE_LENGTH);
                                             for (int sessionIndex = 1,

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
@@ -8,6 +8,7 @@ import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.TokenStateManager;
 import io.quarkus.security.AuthenticationCompletionException;
 import io.quarkus.security.AuthenticationFailedException;
+import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.Cookie;
 import io.vertx.core.http.impl.ServerCookie;
@@ -146,7 +147,9 @@ public class DefaultTokenStateManager implements TokenStateManager {
         if (oidcConfig.tokenStateManager.encryptionRequired) {
             TenantConfigContext configContext = context.get(TenantConfigContext.class.getName());
             try {
-                return OidcUtils.encryptString(token, configContext.getTokenEncSecretKey());
+                KeyEncryptionAlgorithm encAlgorithm = KeyEncryptionAlgorithm
+                        .valueOf(oidcConfig.tokenStateManager.encryptionAlgorithm.name());
+                return OidcUtils.encryptString(token, configContext.getTokenEncSecretKey(), encAlgorithm);
             } catch (Exception ex) {
                 throw new AuthenticationFailedException(ex);
             }
@@ -158,7 +161,9 @@ public class DefaultTokenStateManager implements TokenStateManager {
         if (oidcConfig.tokenStateManager.encryptionRequired) {
             TenantConfigContext configContext = context.get(TenantConfigContext.class.getName());
             try {
-                return OidcUtils.decryptString(token, configContext.getTokenEncSecretKey());
+                KeyEncryptionAlgorithm encAlgorithm = KeyEncryptionAlgorithm
+                        .valueOf(oidcConfig.tokenStateManager.encryptionAlgorithm.name());
+                return OidcUtils.decryptString(token, configContext.getTokenEncSecretKey(), encAlgorithm);
             } catch (Exception ex) {
                 throw new AuthenticationFailedException(ex);
             }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -622,8 +622,12 @@ public final class OidcUtils {
     }
 
     public static String encryptString(String jweString, SecretKey key) throws Exception {
+        return encryptString(jweString, key, KeyEncryptionAlgorithm.A256GCMKW);
+    }
+
+    public static String encryptString(String jweString, SecretKey key, KeyEncryptionAlgorithm algorithm) throws Exception {
         JsonWebEncryption jwe = new JsonWebEncryption();
-        jwe.setAlgorithmHeaderValue(KeyEncryptionAlgorithm.A256GCMKW.getAlgorithm());
+        jwe.setAlgorithmHeaderValue(algorithm.getAlgorithm());
         jwe.setEncryptionMethodHeaderParameter(ContentEncryptionAlgorithm.A256GCM.getAlgorithm());
         jwe.setKey(key);
         jwe.setPlaintext(jweString);

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -35,6 +35,7 @@ quarkus.oidc.code-flow-encrypted-id-token-jwk.application-type=web-app
 quarkus.oidc.code-flow-encrypted-id-token-jwk.token-path=${keycloak.url}/realms/quarkus/encrypted-id-token
 quarkus.oidc.code-flow-encrypted-id-token-jwk.token.decryption-key-location=privateKeyEncryptedIdToken.jwk
 quarkus.oidc.code-flow-encrypted-id-token-jwk.token.audience=https://server.example.com
+quarkus.oidc.code-flow-encrypted-id-token-jwk.token-state-manager.encryption-algorithm=dir
 
 quarkus.oidc.code-flow-encrypted-id-token-pem.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-encrypted-id-token-pem.client-id=quarkus-web-app


### PR DESCRIPTION
Fixes #37785.

This PR adds an option to customize the way the session cookie is encrypted - it will continue using the current mode by default where a content encryption key (CEK) is generated (with more algorithms added as required - I'm not too keen to open it up completely to support all of them) - this mode is strongest but also produces a longer sequence and is a bit slower.

Direct `dir` encryption is a standard JWE option where the configured encryption key acts as CEK. 

FYI, difference in the cookie size, in the 2 updated tests is `2919` (dir) vs `3043` (CEK is generated and encoded) so it is about 120 bytes which might make a difference.