### PR TITLE
Fix OIDC Security event fired before runtime config ready in Arc

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -18,6 +18,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 import org.jose4j.jwk.JsonWebKey;
 import org.jose4j.jwk.PublicJsonWebKey;
@@ -46,7 +47,6 @@ import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.TokenAuthenticationRequest;
-import io.quarkus.security.runtime.SecurityConfig;
 import io.quarkus.security.spi.runtime.BlockingSecurityExecutor;
 import io.quarkus.security.spi.runtime.MethodDescription;
 import io.quarkus.security.spi.runtime.SecurityEventHelper;
@@ -64,6 +64,7 @@ import io.vertx.mutiny.ext.web.client.WebClient;
 public class OidcRecorder {
 
     private static final Logger LOG = Logger.getLogger(OidcRecorder.class);
+    private static final String SECURITY_EVENTS_ENABLED_CONFIG_KEY = "quarkus.security.events.enabled";
 
     private static final Map<String, TenantConfigContext> dynamicTenantsConfig = new ConcurrentHashMap<>();
     private static final Set<String> tenantsExpectingServerAvailableEvents = ConcurrentHashMap.newKeySet();
@@ -559,7 +560,7 @@ public class OidcRecorder {
     }
 
     private static boolean fireOidcServerEvent(String authServerUrl, SecurityEvent.Type eventType) {
-        if (Arc.container().instance(SecurityConfig.class).get().events().enabled()) {
+        if (ConfigProvider.getConfig().getOptionalValue(SECURITY_EVENTS_ENABLED_CONFIG_KEY, boolean.class).orElse(true)) {
             SecurityEventHelper.fire(
                     Arc.container().beanManager().getEvent().select(SecurityEvent.class),
                     new SecurityEvent(eventType, Map.of(AUTH_SERVER_URL, authServerUrl)));


### PR DESCRIPTION
I have app here https://github.com/quarkus-qe/quarkus-test-suite/blob/main/security/oidc-client-mutual-tls/src/test/java/io/quarkus/ts/security/oidcclient/mtls/IncorrectKsFileTypeOidcMtlsIT.java which shows me that this code can be run before runtime config mappings are ready to be accessible from CDI as beans.

```
21:49:56,271 INFO  [app] Caused by: [CIRCULAR REFERENCE: io.smallrye.mutiny.CompositeException: Multiple exceptions caught:
21:49:56,271 INFO  [app] 	[Exception 0] java.lang.RuntimeException: OIDC Server is not available
21:49:56,271 INFO  [app] 	[Exception 1] java.lang.NullPointerException: Cannot invoke "io.quarkus.security.runtime.SecurityConfig.events()" because the return value of "io.quarkus.arc.InstanceHandle.get()" is null]
```
Following workaround fixed issue for me. I don't think we can or should delay execution of this code in any way. I'll suggest to use QE test as test coverage for this for now, because I'm busy ATM.