### PR TITLE
Introduce env variable QUARKUS_NATIVE_IT_SKIP_VERIFY_IMAGE_METRICS

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/nativeimage/NativeBuildOutputExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/nativeimage/NativeBuildOutputExtension.java
@@ -47,6 +47,13 @@ public class NativeBuildOutputExtension implements BeforeAllCallback {
     }
 
     public void verifyImageMetrics(String propertiesFileName) {
+        /*
+         * Allow users to skip this kind of tests by setting env variable QUARKUS_NATIVE_IT_SKIP_VERIFY_IMAGE_METRICS to true
+         */
+        boolean skipVerifyImageMetrics = Boolean.parseBoolean(System.getenv("QUARKUS_NATIVE_IT_SKIP_VERIFY_IMAGE_METRICS"));
+        Assumptions.assumeFalse(skipVerifyImageMetrics,
+                "Environment variable QUARKUS_NATIVE_IT_SKIP_VERIFY_IMAGE_METRICS is set. Skipping image metrics verification.");
+
         Properties properties = getProperties(propertiesFileName);
 
         properties.forEach((key, value) -> {


### PR DESCRIPTION
Allow users to skip tests verifying native image build metrics (such as
binary size, classes registered for reflection, etc.)  by setting env
variable QUARKUS_NATIVE_IT_SKIP_VERIFY_IMAGE_METRICS to true.

Quarkus uses the "jvmci" version from the base-JDK used to build
GraalVM. When building GraalVM master with JDK 21, however, we are using
LabsJDK 21.0.1+12-jvmci-23.1-b26, so Quarkus thinks the GraalVM version
is 23.1 despite it acutally being 24.0. Since upstream GraalVM doesn't
plan on releasing GraalVM 24.0 based on JDK 21 it's not expected to get
a jvmci version bump in LabsJDK 21.

This patch allows us to keep testing GraalVM 24.0-dev with JDK 21 without
getting false negatives.
