### PR TITLE
Scheduler: support skip predicate class with public no-args constructor

### DIFF
--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -255,7 +255,11 @@ NOTE: Note that only executions within the same application instance are conside
 === Conditional Execution
 
 You can define the logic to skip any execution of a scheduled method via `@Scheduled#skipExecutionIf()`.
-The specified bean class must implement `io.quarkus.scheduler.Scheduled.SkipPredicate` and the execution is skipped if the result of the `test()` method is `true`.
+The specified class must implement `io.quarkus.scheduler.Scheduled.SkipPredicate` and the execution is skipped if the result of the `test()` method is `true`.
+The class must either represent a CDI bean or declare a public no-args constructor. 
+In case of CDI, there must be exactly one bean that has the specified class in its set of bean types, otherwise the build fails. 
+Furthermore, the scope of the bean must be active during execution of the job. 
+If the scope is `@Dependent` then the bean instance belongs exclusively to the specific scheduled method and is destroyed when the application is shut down.
 
 [source,java]
 ----

--- a/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Scheduled.java
+++ b/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Scheduled.java
@@ -152,11 +152,12 @@ public @interface Scheduled {
     ConcurrentExecution concurrentExecution() default PROCEED;
 
     /**
-     * Specify the bean class that can be used to skip any execution of a scheduled method.
+     * Specify the predicate that can be used to skip an execution of a scheduled method.
      * <p>
-     * There must be exactly one bean that has the specified class in its set of bean types, otherwise the build
-     * fails. Furthermore, the scope of the bean must be active during execution. If the scope is {@link Dependent} then the
-     * bean instance belongs exclusively to the specific scheduled method and is destroyed when the application is shut down.
+     * The class must either represent a CDI bean or declare a public no-args constructor. In case of CDI, there must be exactly
+     * one bean that has the specified class in its set of bean types, otherwise the build fails. Furthermore, the scope of the
+     * bean must be active during execution of the job. If the scope is {@link Dependent} then the bean instance belongs
+     * exclusively to the specific scheduled method and is destroyed when the application is shut down.
      *
      * @return the bean class
      */

--- a/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Scheduler.java
+++ b/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Scheduler.java
@@ -150,6 +150,15 @@ public interface Scheduler {
         JobDefinition setSkipPredicate(SkipPredicate skipPredicate);
 
         /**
+         * {@link Scheduled#skipExecutionIf()}
+         *
+         * @param skipPredicateClass
+         * @return self
+         * @see Scheduled#skipExecutionIf()
+         */
+        JobDefinition setSkipPredicate(Class<? extends SkipPredicate> skipPredicateClass);
+
+        /**
          * {@link Scheduled#overdueGracePeriod()}
          *
          * @param period

--- a/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/AbstractJobDefinition.java
+++ b/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/AbstractJobDefinition.java
@@ -8,6 +8,7 @@ import io.quarkus.scheduler.Scheduled.ConcurrentExecution;
 import io.quarkus.scheduler.Scheduled.SkipPredicate;
 import io.quarkus.scheduler.ScheduledExecution;
 import io.quarkus.scheduler.Scheduler.JobDefinition;
+import io.quarkus.scheduler.common.runtime.util.SchedulerUtils;
 import io.smallrye.mutiny.Uni;
 
 public abstract class AbstractJobDefinition implements JobDefinition {
@@ -62,6 +63,11 @@ public abstract class AbstractJobDefinition implements JobDefinition {
         checkScheduled();
         this.skipPredicate = skipPredicate;
         return this;
+    }
+
+    @Override
+    public JobDefinition setSkipPredicate(Class<? extends SkipPredicate> skipPredicateClass) {
+        return setSkipPredicate(SchedulerUtils.instantiateBeanOrClass(skipPredicateClass));
     }
 
     @Override

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/ConditionalExecutionTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/ConditionalExecutionTest.java
@@ -24,8 +24,7 @@ public class ConditionalExecutionTest {
 
     @RegisterExtension
     static final QuarkusUnitTest test = new QuarkusUnitTest()
-            .withApplicationRoot((jar) -> jar
-                    .addClasses(Jobs.class));
+            .withApplicationRoot(root -> root.addClasses(Jobs.class, IsDisabled.class));
 
     @Test
     public void testExecution() {
@@ -79,14 +78,12 @@ public class ConditionalExecutionTest {
 
         void onSkip(@Observes SkippedExecution event) {
             if (event.triggerId.equals("foo")) {
-
                 SKIPPED_LATCH.countDown();
             }
         }
 
     }
 
-    @Singleton
     public static class OtherIsDisabled implements Scheduled.SkipPredicate {
 
         static final AtomicBoolean TESTED = new AtomicBoolean(false);

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SimpleScheduler.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SimpleScheduler.java
@@ -23,7 +23,6 @@ import jakarta.annotation.PreDestroy;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
-import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Singleton;
@@ -38,7 +37,6 @@ import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 
-import io.quarkus.arc.Arc;
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.scheduler.FailedExecution;
 import io.quarkus.scheduler.Scheduled;
@@ -382,7 +380,7 @@ public class SimpleScheduler implements Scheduler {
         if (predicateClass.equals(Scheduled.Never.class)) {
             return null;
         }
-        return Arc.container().select(predicateClass, Any.Literal.INSTANCE).get();
+        return SchedulerUtils.instantiateBeanOrClass(predicateClass);
     }
 
     static class ScheduledTask {


### PR DESCRIPTION
- it does not need to represent a CDI bean anymore
- add JobDefinition#skipPredicate() variant that accepts a class