### PR TITLE
Scheduler: JobDefinition API is only supported if RAM store type is used

### DIFF
--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -400,7 +400,7 @@ class MyJobs {
 
 NOTE: By default, the scheduler is not started unless a `@Scheduled` business method is found. You may need to force the start of the scheduler for "pure" programmatic scheduling via `quarkus.scheduler.start-mode=forced`.
 
-NOTE: If the xref:quartz.adoc[Quartz extension] is present then the Quartz API can be also used to schedule a job programmatically.
+NOTE: If the xref:quartz.adoc[Quartz extension] is present then only the RAM store type is supported, i.e. `quarkus.quartz.store-type=ram` must be set. The Quartz API can be also used to schedule a job programmatically.
 
 == Scheduled Methods and Testing
 

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
@@ -127,6 +127,7 @@ public class QuartzSchedulerImpl implements QuartzScheduler {
     private final QuartzRuntimeConfig runtimeConfig;
     private final SchedulerConfig schedulerConfig;
     private final Instance<JobInstrumenter> jobInstrumenter;
+    private final StoreType storeType;
 
     public QuartzSchedulerImpl(SchedulerContext context, QuartzSupport quartzSupport,
             SchedulerRuntimeConfig schedulerRuntimeConfig,
@@ -150,6 +151,7 @@ public class QuartzSchedulerImpl implements QuartzScheduler {
         this.defaultOverdueGracePeriod = schedulerRuntimeConfig.overdueGracePeriod;
         this.schedulerConfig = schedulerConfig;
         this.jobInstrumenter = jobInstrumenter;
+        this.storeType = quartzSupport.getBuildTimeConfig().storeType;
 
         StartMode startMode = initStartMode(schedulerRuntimeConfig, runtimeConfig);
 
@@ -437,6 +439,9 @@ public class QuartzSchedulerImpl implements QuartzScheduler {
 
     @Override
     public JobDefinition newJob(String identity) {
+        if (storeType.isDbStore()) {
+            throw new IllegalStateException("The current store type does not support programmatic scheduling: " + storeType);
+        }
         Objects.requireNonNull(identity);
         if (scheduledTasks.containsKey(identity)) {
             throw new IllegalStateException("A job with this identity is already scheduled: " + identity);


### PR DESCRIPTION
- Quartz DB store types are not supported yet
- related to #37805