### PR TITLE
Fix generation of Scheduler startmode enum tooltip

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemFinder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemFinder.java
@@ -15,6 +15,7 @@ import static io.quarkus.annotation.processor.Constants.DOT;
 import static io.quarkus.annotation.processor.Constants.EMPTY;
 import static io.quarkus.annotation.processor.Constants.HYPHENATED_ELEMENT_NAME;
 import static io.quarkus.annotation.processor.Constants.LIST_OF_CONFIG_ITEMS_TYPE_REF;
+import static io.quarkus.annotation.processor.Constants.NEW_LINE;
 import static io.quarkus.annotation.processor.Constants.NO_DEFAULT;
 import static io.quarkus.annotation.processor.Constants.OBJECT_MAPPER;
 import static io.quarkus.annotation.processor.Constants.PARENT;
@@ -496,7 +497,7 @@ class ConfigDocItemFinder {
                     // Show enum constant description as a Tooltip
                     String javaDoc = enumJavaDocParser.parseConfigDescription(rawJavaDoc);
                     acceptedValues.add(String.format(Constants.TOOLTIP, enumValue,
-                            javaDoc.replace("<p>", Constants.EMPTY).replace("</p>", Constants.EMPTY)));
+                            javaDoc.replace("<p>", EMPTY).replace("</p>", EMPTY).replace(NEW_LINE, " ")));
                 } else {
                     acceptedValues.add(Constants.CODE_DELIMITER
                             + enumValue + Constants.CODE_DELIMITER);


### PR DESCRIPTION
fixes: #37818

I tested generation of Scheduler runtime config reference with / without this and this PR fixes the issue.