### PR TITLE
Reorg of persistence related maintainers

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -112,7 +112,7 @@ triage:
         matches("hibernate", title) && matches("reactive", title)
         && !matches("hibernate.validator", title)
         && !matches("hibernate.search", titleBody)
-      notify: [DavideD, gavinking, Sanne]
+      notify: [DavideD, gavinking]
       directories:
         - extensions/hibernate-reactive
     - id: hibernate-orm
@@ -122,7 +122,7 @@ triage:
         && !matches("hibernate.validator", title)
         && !matches("hibernate.search", titleBody)
         && !matches("hibernate.reactive", titleBody)
-      notify: [gsmet, Sanne, yrodiere]
+      notify: [gsmet, yrodiere]
       notifyInPullRequest: true
       directories:
         # No trailing slashes: we also match sibling directories starting with these names
@@ -709,7 +709,7 @@ triage:
     - id: agroal
       labels: [area/agroal]
       title: "agroal"
-      notify: [barreiro, Sanne, yrodiere]
+      notify: [barreiro, yrodiere]
       directories:
         - extensions/agroal/
     - id: continuous-testing

--- a/MAINTAINERS.adoc
+++ b/MAINTAINERS.adoc
@@ -50,7 +50,7 @@ If you think some information is outdated, either provide a pull request or emai
 |https://github.com/geoand[Georgios Andrianakis]
 
 |Elasticsearch REST Client Common
-|https://github.com/gsmet[Guillaume Smet], https://github.com/loicmathieu[Loïc Mathieu]
+|https://github.com/gsmet[Guillaume Smet], https://github.com/yrodiere[Yoann Rodière], https://github.com/loicmathieu[Loïc Mathieu]
 
 |Elasticsearch REST Client
 |https://github.com/loicmathieu[Loïc Mathieu], https://github.com/gsmet[Guillaume Smet]
@@ -83,7 +83,7 @@ If you think some information is outdated, either provide a pull request or emai
 |https://github.com/cescoffier[Clément Escoffier], https://github.com/alesj[Aleš Justin]
 
 |Hibernate ORM
-|https://github.com/Sanne[Sanne Grinovero], https://github.com/gsmet[Guillaume Smet]
+|https://github.com/yrodiere[Yoann Rodière], https://github.com/gsmet[Guillaume Smet]
 
 |Hibernate ORM with Panache
 |https://github.com/FroMage[Stéphane Épardaud]
@@ -92,7 +92,7 @@ If you think some information is outdated, either provide a pull request or emai
 |https://github.com/evanchooly[Justin Lee]
 
 |Hibernate Search
-|https://github.com/gsmet[Guillaume Smet]
+|https://github.com/yrodiere[Yoann Rodière], https://github.com/gsmet[Guillaume Smet]
 
 |Hibernate Validator
 |https://github.com/gsmet[Guillaume Smet]
@@ -116,7 +116,7 @@ If you think some information is outdated, either provide a pull request or emai
 |https://github.com/Sanne[Sanne Grinovero], https://github.com/gsmet[Guillaume Smet]
 
 |JDBC - MySQL
-|https://github.com/machi1990[Manyanda Chitimbo], https://github.com/Sanne[Sanne Grinovero], https://github.com/gsmet[Guillaume Smet]
+|https://github.com/machi1990[Manyanda Chitimbo], https://github.com/gsmet[Guillaume Smet]
 
 |JDBC - PostgreSQL
 |https://github.com/Sanne[Sanne Grinovero], https://github.com/gsmet[Guillaume Smet]


### PR DESCRIPTION
I was just going to remove myself from being too thinly spread out, but while doing so I also noticed that the "maintainers" file seems a bit out of date.

For example for Agroal, in the "maintainers" file it's listing Luis and @gsmet - but the github-bot file is listing Luis and @yrodiere (and not @gsmet).

I've amended in those cases in which I'm certain, but I suppose others might want to polish it further...  e.g. perhaps add @marko-bekhta to some Hibernate Search related areas?

It would seem that for some JDBC drivers I'm the only maintainer; that could be a problem.