### PR TITLE
JDK-8316304 in JDK 21 introduced a new field accessed through JNI

### DIFF
--- a/integration-tests/jpa-postgresql-withxml/src/test/resources/image-metrics/23.1/image-metrics.properties
+++ b/integration-tests/jpa-postgresql-withxml/src/test/resources/image-metrics/23.1/image-metrics.properties
@@ -17,5 +17,5 @@ analysis_results.types.jni=61
 analysis_results.types.jni.tolerance=1
 analysis_results.methods.jni=55
 analysis_results.methods.jni.tolerance=1
-analysis_results.fields.jni=59
-analysis_results.fields.jni.tolerance=1
+analysis_results.fields.jni=60
+analysis_results.fields.jni.tolerance=2


### PR DESCRIPTION
Similar fix to jpa-postgresql-withxml which was done in #37813 for jpa-postgresql

We recently saw a failure with JDK 21.0.2 EA on 23.1 here:
https://github.com/graalvm/mandrel/actions/runs/7280179502/job/19838880389?pr=651#step:12:737

Failure looks like this:
```
 Error:  Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 5.331 s <<< FAILURE! -- in io.quarkus.it.jpa.postgresql.ImageMetricsITCase
Error:  io.quarkus.it.jpa.postgresql.ImageMetricsITCase.verifyImageMetrics -- Time elapsed: 0.252 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Expected analysis_results.fields.jni to be within range [59 +- 1%] but was 60 ==> expected: <true> but was: <false>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
	at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:36)
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:214)
	at io.quarkus.test.junit.nativeimage.NativeBuildOutputExtension.assertValueWithinRange(NativeBuildOutputExtension.java:90)
	at io.quarkus.test.junit.nativeimage.NativeBuildOutputExtension.lambda$verifyImageMetrics$0(NativeBuildOutputExtension.java:66)
	at java.base/java.util.concurrent.ConcurrentHashMap.forEach(ConcurrentHashMap.java:1603)
	at java.base/java.util.Properties.forEach(Properties.java:1422)
	at io.quarkus.test.junit.nativeimage.NativeBuildOutputExtension.verifyImageMetrics(NativeBuildOutputExtension.java:59)
	at io.quarkus.test.junit.nativeimage.NativeBuildOutputExtension.verifyImageMetrics(NativeBuildOutputExtension.java:46)
	at io.quarkus.it.jpa.postgresql.ImageMetricsITCase.verifyImageMetrics(ImageMetricsITCase.java:15)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

This patch should fix it. /cc @zakkak 