### PR TITLE
Document datasource Dev Service reuse, add configuration to disable it, and enable reuse of Elasticsearch Dev Service containers

### DIFF
--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -61,6 +61,69 @@ ibmcom/db2:11.5.0.0a
 mcr.microsoft.com/mssql/server:2022-latest
 ----
 
+[[reuse]]
+== Reusing Dev Services
+
+[[reuse-within-execution]]
+=== General case
+
+Within a dev mode session or test suite execution,
+Quarkus will always reuse database Dev Services as long as their configuration
+(username, password, environment, port bindings, ...) did not change.
+
+When the configuration of any database Dev Services changes,
+Quarkus will always restart all database Dev Services.
+
+When a dev mode session or test suite execution ends,
+Quarkus will (by default) stop all database Dev Services.
+
+[[reuse-across-executions]]
+=== Reusing Dev Service containers across runs
+
+Assuming you rely on Dev Services based on containers (unlike H2 or Derby),
+if you want to keep Dev Service containers running *after a dev mode session or test suite execution*
+to reuse them in the next dev mode session or test suite execution,
+this is possible as well.
+Just enable https://java.testcontainers.org/features/reuse/[TestContainers reuse]
+by inserting this line in one of your
+https://java.testcontainers.org/features/configuration/[TestContainers configuration file]
+(generally `~/.testcontainers.properties` or `C:/Users/myuser/.testcontainers.properties`):
+
+[source,properties]
+----
+testcontainers.reuse.enable=true
+----
+
+[NOTE]
+====
+Even with container reuse enabled, containers will only be reused if their startup command did not change:
+same environment variables (username/password in particular), same port bindings, same volume mounts, ...
+====
+
+[WARNING]
+====
+Reusing containers implies reusing their internal state,
+including the database schema and the content of tables.
+
+If that's not what you want -- and if your tests write to the database, that's probably not what you want --
+consider xref:hibernate-orm.adoc#dev-mode[configuring Hibernate ORM appropriately],
+or using xref:flyway.adoc[Flyway] or xref:liquibase.adoc[Liquibase].
+====
+
+[WARNING]
+====
+With container reuse enabled, old containers (especially with obsolete configuration)
+might be left running indefinitely, even after starting a new Quarkus dev mode session or test suite execution.
+
+In that case, you will need to stop and remove these containers manually.
+====
+
+If you want to reuse containers for some Quarkus applications but not all of them,
+or some Dev Services but not all of them,
+you can disable this feature for a specific Dev Service by setting the configuration property
+xref:databases-dev-services.adoc#quarkus-datasource-config-group-dev-services-build-time-config_quarkus.datasource.devservices.reuse[`quarkus.datasource.devservices.reuse`/`quarkus.datasource."datasource-name".devservices.reuse`]
+to `false`.
+
 == Mapping volumes into Dev Services for Database
 
 Mapping volumes from the Docker host's filesystem to the containers is handy to provide files like scripts or configuration, but also to preserve database data and reuse it after an application restart.

--- a/docs/src/main/asciidoc/elasticsearch-dev-services.adoc
+++ b/docs/src/main/asciidoc/elasticsearch-dev-services.adoc
@@ -75,6 +75,71 @@ quarkus.elasticsearch.devservices.image-name=my-custom-image-with-no-clue-about-
 quarkus.elasticsearch.devservices.distribution=elasticsearch
 ----
 
+
+[[reuse]]
+== Reusing Dev Services
+
+[[reuse-within-execution]]
+=== General case
+
+Within a dev mode session or test suite execution,
+Quarkus will always reuse Elasticsearch Dev Services as long as their configuration
+(username, password, environment, port bindings, ...) did not change.
+
+When the configuration of Elasticsearch Dev Services changes,
+Quarkus will always restart the corresponding containers.
+
+When a dev mode session or test suite execution ends,
+Quarkus will (by default) stop Elasticsearch Dev Services.
+
+[[reuse-across-executions]]
+=== Reusing Dev Service containers across runs
+
+If you want to keep Dev Service containers running *after a dev mode session or test suite execution*
+to reuse them in the next dev mode session or test suite execution,
+this is possible as well.
+Just enable https://java.testcontainers.org/features/reuse/[TestContainers reuse]
+by inserting this line in one of your
+https://java.testcontainers.org/features/configuration/[TestContainers configuration file]
+(generally `~/.testcontainers.properties` or `C:/Users/myuser/.testcontainers.properties`):
+
+[source,properties]
+----
+testcontainers.reuse.enable=true
+----
+
+[NOTE]
+====
+Even with container reuse enabled, containers will only be reused if their startup command did not change:
+same environment variables (username/password in particular), same port bindings, ...
+====
+
+[WARNING]
+====
+Reusing containers implies reusing their internal state,
+including the Elasticsearch schema and the content of indexes.
+
+If that's not what you want -- and if your tests write to the indexes, that's probably not what you want --
+consider reinitializing your schema and data on application startup.
+If you use Hibernate Search,
+xref:hibernate-search-orm-elasticsearch.adoc#quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.schema-management.strategy[Hibernate Search's schema management]
+may help with that.
+====
+
+[WARNING]
+====
+With container reuse enabled, old containers (especially with obsolete configuration)
+might be left running indefinitely, even after starting a new Quarkus dev mode session or test suite execution.
+
+In that case, you will need to stop and remove these containers manually.
+====
+
+If you want to reuse containers for some Quarkus applications but not all of them,
+or some Dev Services but not all of them,
+you can disable this feature for a specific Dev Service by setting the configuration property
+xref:elasticsearch-dev-services.adoc#quarkus-elasticsearch-devservices-elasticsearch-dev-services-build-time-config_quarkus.elasticsearch.devservices.reuse[`quarkus.elasticsearch.devservices.reuse`]
+to `false`.
+
 == Current limitations
 
 Currently, only the default backend for Hibernate Search Elasticsearch is supported, because Dev Services for Elasticsearch can only start one Elasticsearch container.

--- a/docs/src/main/asciidoc/elasticsearch-dev-services.adoc
+++ b/docs/src/main/asciidoc/elasticsearch-dev-services.adoc
@@ -53,7 +53,8 @@ Note that the Elasticsearch hosts property is automatically configured with the 
 
 Dev Services for Elasticsearch support distributions based on both Elasticsearch and OpenSearch images.
 
-When using Hibernate Search, Dev Services will default to Elasticsearch or OpenSearch based on Hibernate Search configuration.
+When using xref:hibernate-search-orm-elasticsearch.adoc[Hibernate Search],
+Dev Services will default to Elasticsearch or OpenSearch based on Hibernate Search configuration.
 
 Otherwise, Dev Services will default to Elasticsearch. To use OpenSearch, configure the distribution explicitly:
 [source,properties,subs="attributes"]

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
@@ -17,6 +17,7 @@ public class DevServicesDatasourceContainerConfig {
     private final Optional<String> password;
     private final Optional<String> initScriptPath;
     private final Map<String, String> volumes;
+    private final boolean reuse;
 
     public DevServicesDatasourceContainerConfig(Optional<String> imageName,
             Map<String, String> containerEnv,
@@ -28,7 +29,8 @@ public class DevServicesDatasourceContainerConfig {
             Optional<String> username,
             Optional<String> password,
             Optional<String> initScriptPath,
-            Map<String, String> volumes) {
+            Map<String, String> volumes,
+            boolean reuse) {
         this.imageName = imageName;
         this.containerEnv = containerEnv;
         this.containerProperties = containerProperties;
@@ -40,6 +42,7 @@ public class DevServicesDatasourceContainerConfig {
         this.password = password;
         this.initScriptPath = initScriptPath;
         this.volumes = volumes;
+        this.reuse = reuse;
     }
 
     public Optional<String> getImageName() {
@@ -84,5 +87,9 @@ public class DevServicesDatasourceContainerConfig {
 
     public Map<String, String> getVolumes() {
         return volumes;
+    }
+
+    public boolean isReuse() {
+        return reuse;
     }
 }

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -276,7 +276,8 @@ public class DevServicesDatasourceProcessor {
                     dataSourceBuildTimeConfig.devservices().username(),
                     dataSourceBuildTimeConfig.devservices().password(),
                     dataSourceBuildTimeConfig.devservices().initScriptPath(),
-                    dataSourceBuildTimeConfig.devservices().volumes());
+                    dataSourceBuildTimeConfig.devservices().volumes(),
+                    dataSourceBuildTimeConfig.devservices().reuse());
 
             DevServicesDatasourceProvider.RunningDevServicesDatasource datasource = devDbProvider
                     .startDatabase(

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
 
 @ConfigGroup
 public interface DevServicesBuildTimeConfig {
@@ -93,4 +94,30 @@ public interface DevServicesBuildTimeConfig {
      * This has no effect if the provider is not a container-based database, such as H2 or Derby.
      */
     Map<String, String> volumes();
+
+    /**
+     * Whether to keep Dev Service containers running *after a dev mode session or test suite execution*
+     * to reuse them in the next dev mode session or test suite execution.
+     *
+     * Within a dev mode session or test suite execution,
+     * Quarkus will always reuse Dev Services as long as their configuration
+     * (username, password, environment, port bindings, ...) did not change.
+     * This feature is specifically about keeping containers running
+     * **when Quarkus is not running** to reuse them across runs.
+     *
+     * WARNING: This feature needs to be enabled explicitly in `testcontainers.properties`,
+     * may require changes to how you configure data initialization in dev mode and tests,
+     * and may leave containers running indefinitely, forcing you to stop and remove them manually.
+     * See xref:databases-dev-services.adoc#reuse[this section of the documentation] for more information.
+     *
+     * This configuration property is set to `true` by default,
+     * so it is mostly useful to *disable* reuse,
+     * if you enabled it in `testcontainers.properties`
+     * but only want to use it for some of your Quarkus applications or datasources.
+     *
+     * @asciidoclet
+     */
+    @WithDefault("true")
+    boolean reuse();
+
 }

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerShutdownCloseable.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerShutdownCloseable.java
@@ -9,10 +9,11 @@ import org.testcontainers.utility.TestcontainersConfiguration;
 
 /**
  * Helper to define the stop strategy for containers created by DevServices.
- * In particular we don't want to actually stop the containers when they
+ * <p>
+ * In particular, we don't want to actually stop the containers when they
  * have been flagged for reuse, and when the Testcontainers configuration
  * has been explicitly set to allow container reuse.
- * To enable reuse, ass {@literal testcontainers.reuse.enable=true} in your
+ * To enable reuse, add {@literal testcontainers.reuse.enable=true} in your
  * {@literal .testcontainers.properties} file, to be stored in your home.
  *
  * @see <a href="https://www.testcontainers.org/features/configuration/">Testcontainers Configuration</a>.
@@ -21,14 +22,14 @@ public final class ContainerShutdownCloseable implements Closeable {
 
     private static final Logger LOG = Logger.getLogger(ContainerShutdownCloseable.class);
 
-    private final GenericContainer container;
+    private final GenericContainer<?> container;
     private final String friendlyServiceName;
 
     /**
      * @param container the container to be eventually closed
      * @param friendlyServiceName for logging purposes
      */
-    public ContainerShutdownCloseable(GenericContainer container, String friendlyServiceName) {
+    public ContainerShutdownCloseable(GenericContainer<?> container, String friendlyServiceName) {
         Objects.requireNonNull(container);
         Objects.requireNonNull(friendlyServiceName);
         this.container = container;

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -51,7 +51,7 @@ public class DB2DevServicesProcessor {
                 container.withUsername(effectiveUsername)
                         .withPassword(effectivePassword)
                         .withDatabaseName(effectiveDbName)
-                        .withReuse(true);
+                        .withReuse(containerConfig.isReuse());
                 Labels.addDataSourceLabel(container, datasourceName);
                 Volumes.addVolumes(container, containerConfig.getVolumes());
 

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -55,7 +55,7 @@ public class MariaDBDevServicesProcessor {
                 container.withUsername(effectiveUsername)
                         .withPassword(effectivePassword)
                         .withDatabaseName(effectiveDbName)
-                        .withReuse(true);
+                        .withReuse(containerConfig.isReuse());
                 Labels.addDataSourceLabel(container, datasourceName);
                 Volumes.addVolumes(container, containerConfig.getVolumes());
 

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -51,7 +51,7 @@ public class MSSQLDevServicesProcessor {
 
                 // Defining the database name and the username is not supported by this container yet
                 container.withPassword(effectivePassword)
-                        .withReuse(true);
+                        .withReuse(containerConfig.isReuse());
                 Labels.addDataSourceLabel(container, datasourceName);
                 Volumes.addVolumes(container, containerConfig.getVolumes());
 

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -54,7 +54,7 @@ public class MySQLDevServicesProcessor {
                 container.withUsername(effectiveUsername)
                         .withPassword(effectivePassword)
                         .withDatabaseName(effectiveDbName)
-                        .withReuse(true);
+                        .withReuse(containerConfig.isReuse());
                 Labels.addDataSourceLabel(container, datasourceName);
                 Volumes.addVolumes(container, containerConfig.getVolumes());
 

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -58,7 +58,7 @@ public class OracleDevServicesProcessor {
                 container.withUsername(effectiveUsername)
                         .withPassword(effectivePassword)
                         .withDatabaseName(effectiveDbName)
-                        .withReuse(true);
+                        .withReuse(containerConfig.isReuse());
                 Labels.addDataSourceLabel(container, datasourceName);
                 Volumes.addVolumes(container, containerConfig.getVolumes());
 

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -61,7 +61,7 @@ public class PostgresqlDevServicesProcessor {
                 container.withUsername(effectiveUsername)
                         .withPassword(effectivePassword)
                         .withDatabaseName(effectiveDbName)
-                        .withReuse(true);
+                        .withReuse(containerConfig.isReuse());
                 Labels.addDataSourceLabel(container, datasourceName);
                 Volumes.addVolumes(container, containerConfig.getVolumes());
 

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -34,6 +34,7 @@ import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerAddress;
 import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.devservices.common.ContainerShutdownCloseable;
 import io.quarkus.elasticsearch.restclient.common.deployment.ElasticsearchDevServicesBuildTimeConfig.Distribution;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
@@ -226,10 +227,12 @@ public class DevServicesElasticsearchProcessor {
 
             container.withEnv(config.containerEnv);
 
+            container.withReuse(config.reuse);
+
             container.start();
             return new DevServicesResultBuildItem.RunningDevService(Feature.ELASTICSEARCH_REST_CLIENT_COMMON.getName(),
                     container.getContainerId(),
-                    container::close,
+                    new ContainerShutdownCloseable(container, "Elasticsearch"),
                     buildPropertiesMap(buildItemConfig,
                             container.getHost() + ":" + container.getMappedPort(ELASTICSEARCH_PORT)));
         };

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchDevServicesBuildTimeConfig.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchDevServicesBuildTimeConfig.java
@@ -98,6 +98,31 @@ public class ElasticsearchDevServicesBuildTimeConfig {
     @ConfigItem
     public Map<String, String> containerEnv;
 
+    /**
+     * Whether to keep Dev Service containers running *after a dev mode session or test suite execution*
+     * to reuse them in the next dev mode session or test suite execution.
+     *
+     * Within a dev mode session or test suite execution,
+     * Quarkus will always reuse Dev Services as long as their configuration
+     * (username, password, environment, port bindings, ...) did not change.
+     * This feature is specifically about keeping containers running
+     * **when Quarkus is not running** to reuse them across runs.
+     *
+     * WARNING: This feature needs to be enabled explicitly in `testcontainers.properties`,
+     * may require changes to how you configure data initialization in dev mode and tests,
+     * and may leave containers running indefinitely, forcing you to stop and remove them manually.
+     * See xref:elasticsearch-dev-services.adoc#reuse[this section of the documentation] for more information.
+     *
+     * This configuration property is set to `true` by default,
+     * so it is mostly useful to *disable* reuse,
+     * if you enabled it in `testcontainers.properties`
+     * but only want to use it for some of your Quarkus applications.
+     *
+     * @asciidoclet
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean reuse;
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -112,12 +137,13 @@ public class ElasticsearchDevServicesBuildTimeConfig {
                 && Objects.equals(imageName, that.imageName)
                 && Objects.equals(javaOpts, that.javaOpts)
                 && Objects.equals(serviceName, that.serviceName)
-                && Objects.equals(containerEnv, that.containerEnv);
+                && Objects.equals(containerEnv, that.containerEnv)
+                && Objects.equals(reuse, that.reuse);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enabled, port, distribution, imageName, javaOpts, shared, serviceName, containerEnv);
+        return Objects.hash(enabled, port, distribution, imageName, javaOpts, shared, serviceName, containerEnv, reuse);
     }
 
     public enum Distribution {


### PR DESCRIPTION
Initially my objective was simply to enable reuse on Elasticsearch Dev Services, because it can be a major pain to lose your indexes between two executions of `quarkus dev` if indexing take a long time; you can try that with https://github.com/quarkusio/search.quarkus.io/pull/104, container reuse is really helpful there.

But then I saw the feature was completely undocumented for datasources, and there was no way to disable it on a per-application or per-datasource basis... So I fixed that.