### PR TITLE
Update reference metrics for Mandrel/GraalVM 23.0

### DIFF
--- a/integration-tests/jpa-postgresql-withxml/src/test/resources/image-metrics/23.0/image-metrics.properties
+++ b/integration-tests/jpa-postgresql-withxml/src/test/resources/image-metrics/23.0/image-metrics.properties
@@ -1,15 +1,15 @@
 # Properties file used by ImageMetricsITCase
-image_details.total_bytes=86417288
+image_details.total_bytes=88215776
 image_details.total_bytes.tolerance=3
-analysis_results.types.reachable=20067
+analysis_results.types.reachable=20414
 analysis_results.types.reachable.tolerance=3
-analysis_results.methods.reachable=99493
+analysis_results.methods.reachable=100917
 analysis_results.methods.reachable.tolerance=3
-analysis_results.fields.reachable=29845
+analysis_results.fields.reachable=29906
 analysis_results.fields.reachable.tolerance=3
-analysis_results.types.reflection=6394
+analysis_results.types.reflection=6530
 analysis_results.types.reflection.tolerance=3
-analysis_results.methods.reflection=4580
+analysis_results.methods.reflection=4664
 analysis_results.methods.reflection.tolerance=3
 analysis_results.fields.reflection=143
 analysis_results.fields.reflection.tolerance=3

--- a/integration-tests/jpa-postgresql/src/test/resources/image-metrics/23.0/image-metrics.properties
+++ b/integration-tests/jpa-postgresql/src/test/resources/image-metrics/23.0/image-metrics.properties
@@ -1,15 +1,15 @@
 # Properties file used by ImageMetricsITCase
-image_details.total_bytes=78626464
+image_details.total_bytes=79228920
 image_details.total_bytes.tolerance=3
-analysis_results.types.reachable=19172
+analysis_results.types.reachable=19441
 analysis_results.types.reachable.tolerance=3
-analysis_results.methods.reachable=95204
+analysis_results.methods.reachable=96417
 analysis_results.methods.reachable.tolerance=3
-analysis_results.fields.reachable=27139
+analysis_results.fields.reachable=27131
 analysis_results.fields.reachable.tolerance=3
-analysis_results.types.reflection=5939
+analysis_results.types.reflection=6060
 analysis_results.types.reflection.tolerance=3
-analysis_results.methods.reflection=4401
+analysis_results.methods.reflection=4484
 analysis_results.methods.reflection.tolerance=3
 analysis_results.fields.reflection=170
 analysis_results.fields.reflection.tolerance=3

--- a/integration-tests/main/src/test/resources/image-metrics/23.0/image-metrics.properties
+++ b/integration-tests/main/src/test/resources/image-metrics/23.0/image-metrics.properties
@@ -1,15 +1,15 @@
 # Properties file used by ImageMetricsITCase
-image_details.total_bytes=139447360
+image_details.total_bytes=138255480
 image_details.total_bytes.tolerance=3
-analysis_results.types.reachable=30117
+analysis_results.types.reachable=29952
 analysis_results.types.reachable.tolerance=3
-analysis_results.methods.reachable=150060
+analysis_results.methods.reachable=149162
 analysis_results.methods.reachable.tolerance=3
-analysis_results.fields.reachable=44502
+analysis_results.fields.reachable=44103
 analysis_results.fields.reachable.tolerance=3
-analysis_results.types.reflection=8989
+analysis_results.types.reflection=8927
 analysis_results.types.reflection.tolerance=3
-analysis_results.methods.reflection=7393
+analysis_results.methods.reflection=7136
 analysis_results.methods.reflection.tolerance=3
 analysis_results.fields.reflection=438
 analysis_results.fields.reflection.tolerance=3


### PR DESCRIPTION
Reference metrics where set using an older Mandrel 23.0 image, update
them using the latest Mandrel-23.0-based upstream builder image.

Closes https://github.com/quarkusio/quarkus/issues/37882
