### PR TITLE
Typo in gradle example

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -24,7 +24,7 @@ To scaffold a Gradle project you can either use the xref:cli-tooling.adoc[Quarku
 [source, bash]
 ----
 quarkus create app my-groupId:my-artifactId \
-    --extension=resteasy-reactive,resteasy-reactive-jackson \
+    --extensions=resteasy-reactive,resteasy-reactive-jackson \
     --gradle
 ----
 


### PR DESCRIPTION
There is a typo in the example code for creating a new project using Gradle.