### PR TITLE
Store since JavaDoc tag in the configuration metadata, so that Quarkiverse projects can render it in their documentation if they like

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemFinder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocItemFinder.java
@@ -390,7 +390,8 @@ class ConfigDocItemFinder {
                 configDocKey.setConfigPhase(configPhase);
                 configDocKey.setDefaultValue(defaultValue);
                 configDocKey.setDocMapKey(configDocMapKey);
-                configDocKey.setConfigDoc(javaDocParser.parseConfigDescription(rawJavaDoc));
+                javaDocParser.parseConfigDescription(rawJavaDoc, configDocKey::setConfigDoc, configDocKey::setSince);
+                configDocKey.setEnvironmentVariable(DocGeneratorUtil.toEnvVarName(name));
                 configDocKey.setAcceptedValues(acceptedValues);
                 configDocKey.setJavaDocSiteLink(getJavaDocSiteLink(type));
                 ConfigDocItem configDocItem = new ConfigDocItem();
@@ -628,6 +629,8 @@ class ConfigDocItemFinder {
                 additionalKeys.addAll(additionalNames.stream().map(k -> k + configDocKey.getKey()).collect(toList()));
                 configDocKey.setAdditionalKeys(additionalKeys);
                 configDocKey.setKey(parentName + configDocKey.getKey());
+                configDocKey.setEnvironmentVariable(
+                        DocGeneratorUtil.toEnvVarName(parentName) + configDocKey.getEnvironmentVariable());
                 decoratedItems.add(configDocItem);
             } else {
                 ConfigDocSection section = configDocItem.getConfigDocSection();

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocKey.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocKey.java
@@ -27,6 +27,8 @@ final public class ConfigDocKey implements ConfigDocElement, Comparable<ConfigDo
     // if a key is "quarkus.kubernetes.part-of", then the value of this would be "kubernetes"
     private String topLevelGrouping;
     private boolean isEnum;
+    private String since;
+    private String environmentVariable;
 
     public ConfigDocKey() {
     }
@@ -130,7 +132,7 @@ final public class ConfigDocKey implements ConfigDocElement, Comparable<ConfigDo
         return withinAMap;
     }
 
-    String computeTypeSimpleName() {
+    public String computeTypeSimpleName() {
         String unwrappedType = DocGeneratorUtil.unbox(type);
 
         Matcher matcher = Constants.CLASS_NAME_PATTERN.matcher(unwrappedType);
@@ -191,6 +193,22 @@ final public class ConfigDocKey implements ConfigDocElement, Comparable<ConfigDo
 
     public void setEnum(boolean anEnum) {
         isEnum = anEnum;
+    }
+
+    public String getSince() {
+        return since;
+    }
+
+    public void setSince(String since) {
+        this.since = since;
+    }
+
+    public String getEnvironmentVariable() {
+        return environmentVariable;
+    }
+
+    public void setEnvironmentVariable(String environmentVariable) {
+        this.environmentVariable = environmentVariable;
     }
 
     @Override

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/MavenConfigDocBuilder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/MavenConfigDocBuilder.java
@@ -79,11 +79,8 @@ public final class MavenConfigDocBuilder extends ConfigDocBuilder {
             configDocKey.setAdditionalKeys(List.of(name));
             configDocKey.setConfigPhase(ConfigPhase.RUN_TIME);
             configDocKey.setDefaultValue(defaultValue == null ? Constants.EMPTY : defaultValue);
-            if (description != null && !description.isBlank()) {
-                configDocKey.setConfigDoc(javaDocParser.parseConfigDescription(description));
-            } else {
-                configDocKey.setConfigDoc(EMPTY);
-            }
+            javaDocParser.parseConfigDescription(description, configDocKey::setConfigDoc, configDocKey::setSince);
+            configDocKey.setEnvironmentVariable(DocGeneratorUtil.toEnvVarName(name));
             configDocKey.setOptional(!required);
             final ConfigDocItem configDocItem = new ConfigDocItem();
             configDocItem.setConfigDocKey(configDocKey);

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/JavaDocConfigDescriptionParserTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/JavaDocConfigDescriptionParserTest.java
@@ -3,6 +3,7 @@ package io.quarkus.annotation.processor.generate_doc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.asciidoctor.Asciidoctor.Factory;
 import org.junit.jupiter.api.BeforeEach;
@@ -250,6 +251,15 @@ public class JavaDocConfigDescriptionParserTest {
         // TODO
         // assertEquals("Example:\n\n```\nfoo\nbar\n```",
         // parser.parseConfigDescription("Example:\n\n<pre>{@code\nfoo\nbar\n}</pre>"));
+    }
+
+    @Test
+    public void since() {
+        AtomicReference<String> javadoc = new AtomicReference<>();
+        AtomicReference<String> since = new AtomicReference<>();
+        parser.parseConfigDescription("Javadoc text\n\n@since 1.2.3", javadoc::set, since::set);
+        assertEquals("Javadoc text", javadoc.get());
+        assertEquals("1.2.3", since.get());
     }
 
     @Test


### PR DESCRIPTION
https://github.com/quarkiverse/antora-ui-quarkiverse/issues/64