### PR TITLE
Remove the base URI for docker.io images

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -82,22 +82,22 @@
 
         <!-- Defaults for integration tests -->
         <elasticsearch-server.version>8.9.1</elasticsearch-server.version>
-        <elasticsearch.image>docker.io/elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
-        <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
-        <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>
+        <elasticsearch.image>elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
+        <logstash.image>elastic/logstash:${elasticsearch-server.version}</logstash.image>
+        <kibana.image>elastic/kibana:${elasticsearch-server.version}</kibana.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
         <opensearch-server.version>2.9.0</opensearch-server.version>
-        <opensearch.image>docker.io/opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>
+        <opensearch.image>opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>
         <opensearch.protocol>http</opensearch.protocol>
 
         <!-- Database images for JDBC/Reactive/Hibernate tests and devservices -->
-        <postgres.image>docker.io/postgres:14</postgres.image>
-        <mariadb.image>docker.io/mariadb:10.11</mariadb.image>
-        <db2.image>docker.io/ibmcom/db2:11.5.7.0a</db2.image>
+        <postgres.image>postgres:14</postgres.image>
+        <mariadb.image>mariadb:10.11</mariadb.image>
+        <db2.image>ibmcom/db2:11.5.7.0a</db2.image>
         <mssql.image>mcr.microsoft.com/mssql/server:2022-latest</mssql.image>
-        <mysql.image>docker.io/mysql:8.0</mysql.image>
-        <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
-        <mongo.image>docker.io/mongo:4.4</mongo.image>
+        <mysql.image>mysql:8.0</mysql.image>
+        <oracle.image>gvenzl/oracle-free:23-slim-faststart</oracle.image>
+        <mongo.image>mongo:4.4</mongo.image>
 
         <!-- Align various dependencies that are not really part of the bom-->
         <junit4.version>4.13.2</junit4.version>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -36,7 +36,7 @@
         <quickstarts-base-url>https://github.com/quarkusio/quarkus-quickstarts</quickstarts-base-url>
         <generated-dir>${project.basedir}/../target/asciidoc/generated</generated-dir>
         <code-examples-dir>${generated-dir}/examples</code-examples-dir>
-        <vale.image>docker.io/jdkato/vale:v2.15.5</vale.image>
+        <vale.image>jdkato/vale:v2.15.5</vale.image>
 
         <!-- Keep these in sync with the full versions in bom/application/pom.xml -->
         <hibernate-orm.version-for-documentation>6.4</hibernate-orm.version-for-documentation>

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -47,7 +47,7 @@ public class KafkaDevServicesBuildTimeConfig {
     public Provider provider = Provider.REDPANDA;
 
     public enum Provider {
-        REDPANDA("docker.io/vectorized/redpanda:v22.3.4"),
+        REDPANDA("vectorized/redpanda:v22.3.4"),
         STRIMZI("quay.io/strimzi-test-container/test-container:latest-kafka-3.2.1"),
         KAFKA_NATIVE("quay.io/ogunalp/kafka-native:latest");
 

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/deployment/client/DevServicesRedisProcessor.java
@@ -42,7 +42,7 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 @BuildSteps(onlyIfNot = IsNormal.class, onlyIf = { GlobalDevServicesConfig.Enabled.class })
 public class DevServicesRedisProcessor {
     private static final Logger log = Logger.getLogger(DevServicesRedisProcessor.class);
-    private static final String REDIS_IMAGE = "docker.io/redis:7";
+    private static final String REDIS_IMAGE = "redis:7";
     private static final int REDIS_EXPOSED_PORT = 6379;
     private static final String REDIS_SCHEME = "redis://";
 

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest.java
@@ -26,7 +26,7 @@ public class HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest {
             return Map.of(
                     "quarkus.elasticsearch.devservices.enabled", "true",
                     // This needs to be different from the default image, or the test makes no sense.
-                    "quarkus.elasticsearch.devservices.image-name", "docker.io/opensearchproject/opensearch:2.8.0",
+                    "quarkus.elasticsearch.devservices.image-name", "opensearchproject/opensearch:2.8.0",
                     // This needs to match the version used just above,
                     // so that Hibernate Search itself will assert that we're using a custom version.
                     "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.8");


### PR DESCRIPTION
This feature allow users to use a mirror registry
to bypass the docker hub rate limit.

fix #37912 
