### PR TITLE
Reproduce #37934 Failed to find class com.fasterxml.jackson.databindext.CoreXMLSerializers when a POJO has field of type javax.xml.datatype.XMLGregorianCalendar

### DIFF
--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -125,8 +125,13 @@ public class JacksonProcessor {
                         "com.fasterxml.jackson.databind.deser.std.DateDeserializers$SqlDateDeserializer",
                         "com.fasterxml.jackson.databind.deser.std.DateDeserializers$TimestampDeserializer",
                         "com.fasterxml.jackson.annotation.SimpleObjectIdResolver").methods().build());
-        reflectiveClass.produce(ReflectiveClassBuildItem.builder("com.fasterxml.jackson.databind.ser.std.ClassSerializer")
-                .constructors().build());
+        reflectiveClass.produce(
+                ReflectiveClassBuildItem.builder(
+                        "com.fasterxml.jackson.databind.ser.std.ClassSerializer",
+                        "com.fasterxml.jackson.databind.ext.CoreXMLSerializers",
+                        "com.fasterxml.jackson.databind.ext.CoreXMLDeserializers")
+                        .constructors()
+                        .build());
 
         if (curateOutcomeBuildItem.getApplicationModel().getDependencies().stream().anyMatch(
                 x -> x.getGroupId().equals("com.fasterxml.jackson.module")

--- a/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/Greeting.java
+++ b/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/Greeting.java
@@ -3,16 +3,20 @@ package io.quarkus.it.resteasy.jackson;
 import java.sql.Date;
 import java.time.LocalDate;
 
+import javax.xml.datatype.XMLGregorianCalendar;
+
 public class Greeting {
 
     private final String message;
     private final LocalDate date;
     private final Date sqlDate;
+    private final XMLGregorianCalendar xmlGregorianCalendar;
 
-    public Greeting(String message, LocalDate date, Date sqlDate) {
+    public Greeting(String message, LocalDate date, Date sqlDate, XMLGregorianCalendar xmlGregorianCalendar) {
         this.message = message;
         this.date = date;
         this.sqlDate = sqlDate;
+        this.xmlGregorianCalendar = xmlGregorianCalendar;
     }
 
     public String getMessage() {
@@ -25,5 +29,9 @@ public class Greeting {
 
     public Date getSqlDate() {
         return sqlDate;
+    }
+
+    public XMLGregorianCalendar getXmlGregorianCalendar() {
+        return xmlGregorianCalendar;
     }
 }

--- a/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/GreetingResource.java
+++ b/integration-tests/resteasy-jackson/src/main/java/io/quarkus/it/resteasy/jackson/GreetingResource.java
@@ -1,9 +1,7 @@
 package io.quarkus.it.resteasy.jackson;
 
-import java.sql.Date;
-import java.time.LocalDate;
-
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
@@ -13,10 +11,9 @@ import org.jboss.resteasy.spi.ResteasyConfiguration;
 @Path("/greeting")
 public class GreetingResource {
 
-    @GET
-    public Greeting hello() {
-        LocalDate localDate = LocalDate.of(2019, 01, 01);
-        return new Greeting("hello", localDate, new Date(localDate.toEpochDay()));
+    @POST
+    public Greeting hello(Greeting body) {
+        return body;
     }
 
     @Path("config")

--- a/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/GreetingResourceTest.java
+++ b/integration-tests/resteasy-jackson/src/test/java/io/quarkus/it/resteasy/jackson/GreetingResourceTest.java
@@ -2,22 +2,44 @@ package io.quarkus.it.resteasy.jackson;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
 
 @QuarkusTest
 class GreetingResourceTest {
 
     @Test
-    void testEndpoint() {
+    void testEndpoint() throws DatatypeConfigurationException {
+
+        final LocalDate localDate = LocalDate.of(2019, 01, 01);
+        final Date sqlDate = new Date(localDate.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli());
+        final XMLGregorianCalendar xmlGregorianCalendar = DatatypeFactory.newInstance()
+                .newXMLGregorianCalendar("2019-01-01T00:00:00.000+00:00");
+        final Greeting greeting = new Greeting("hello", localDate, sqlDate, xmlGregorianCalendar);
+
         given()
-                .when().get("/greeting")
+                .contentType(ContentType.JSON)
+                .body(greeting)
+                .post("/greeting")
                 .then()
                 .statusCode(200)
-                .body(containsString("hello"))
-                .body(containsString("2019-01-01"));
+                .body("message", equalTo("hello"),
+                        "date", equalTo("2019-01-01"),
+                        "sqlDate", equalTo("2019-01-01"),
+                        "xmlGregorianCalendar", equalTo("2019-01-01T00:00:00.000+00:00"))
+                .extract().body().asString();
     }
 
     @Test


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/37934