### PR TITLE
Extension logging-gelf: Adding missing GELF MDC Config

### DIFF
--- a/extensions/logging-gelf/runtime/src/main/java/io/quarkus/logging/gelf/GelfConfig.java
+++ b/extensions/logging-gelf/runtime/src/main/java/io/quarkus/logging/gelf/GelfConfig.java
@@ -101,6 +101,27 @@ public class GelfConfig {
     public boolean includeFullMdc;
 
     /**
+     * Send additional fields whose values are obtained from MDC. Name of the Fields are comma-separated. Example:
+     * mdcFields=Application,Version,SomeOtherFieldName
+     */
+    @ConfigItem()
+    public Optional<String> mdcFields;
+
+    /**
+     * Dynamic MDC Fields allows you to extract MDC values based on one or more regular expressions. Multiple regexes are
+     * comma-separated. The name of the MDC entry is used as GELF field name.
+     */
+    @ConfigItem
+    public Optional<String> dynamicMdcFields;
+
+    /**
+     * Pattern-based type specification for additional and MDC fields. Key-value pairs are comma-separated. Example:
+     * my_field.*=String,business\..*\.field=double
+     */
+    @ConfigItem
+    public Optional<String> dynamicMdcFieldTypes;
+
+    /**
      * Maximum message size (in bytes).
      * If the message size is exceeded, the appender will submit the message in multiple chunks.
      */

--- a/extensions/logging-gelf/runtime/src/main/java/io/quarkus/logging/gelf/GelfLogHandlerRecorder.java
+++ b/extensions/logging-gelf/runtime/src/main/java/io/quarkus/logging/gelf/GelfLogHandlerRecorder.java
@@ -39,6 +39,9 @@ public class GelfLogHandlerRecorder {
         handler.setFilterStackTrace(config.filterStackTrace);
         handler.setTimestampPattern(config.timestampPattern);
         handler.setIncludeFullMdc(config.includeFullMdc);
+        handler.setDynamicMdcFields(config.dynamicMdcFields.orElse(null));
+        handler.setMdcFields(config.mdcFields.orElse(null));
+        handler.setDynamicMdcFieldTypes(config.dynamicMdcFieldTypes.orElse(null));
         handler.setHost(config.host);
         handler.setPort(config.port);
         handler.setLevel(config.level);

--- a/integration-tests/logging-gelf/src/main/java/io/quarkus/logging/gelf/it/GelfLogHandlerResource.java
+++ b/integration-tests/logging-gelf/src/main/java/io/quarkus/logging/gelf/it/GelfLogHandlerResource.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
 import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
 
 /**
  * This endpoint allow to test central logging solution by generating a log event when
@@ -33,6 +34,8 @@ public class GelfLogHandlerResource {
 
     @GET
     public void log() {
+        MDC.put("field3", 99);
+        MDC.put("field4", 98);
         LOG.info("Some useful log message");
     }
 

--- a/integration-tests/logging-gelf/src/main/resources/application.properties
+++ b/integration-tests/logging-gelf/src/main/resources/application.properties
@@ -7,3 +7,5 @@ quarkus.log.handler.gelf.additional-field.field1.value=value
 quarkus.log.handler.gelf.additional-field.field1.type=String
 quarkus.log.handler.gelf.additional-field.field2.value=666
 quarkus.log.handler.gelf.additional-field.field2.type=long
+quarkus.log.handler.gelf.include-full-mdc=true
+quarkus.log.handler.gelf.dynamic-mdc-field-types=field3=String

--- a/integration-tests/logging-gelf/src/test/java/io/quarkus/logging/gelf/it/GelfLogHandlerTest.java
+++ b/integration-tests/logging-gelf/src/test/java/io/quarkus/logging/gelf/it/GelfLogHandlerTest.java
@@ -42,6 +42,8 @@ public class GelfLogHandlerTest {
                             assertEquals(200, response.statusCode());
                             assertNotNull(response.body().path("hits.hits[0]._source"));
                             assertEquals("Some useful log message", response.body().path("hits.hits[0]._source.message"));
+                            assertEquals(Integer.valueOf(98), response.body().path("hits.hits[0]._source.field4"));
+                            assertEquals("99", response.body().path("hits.hits[0]._source.field3"));
                         });
     }
 }


### PR DESCRIPTION
Adding additional [MDC Config ](https://logging.paluch.biz/examples/jbossas7.html):

- mdcFields
- dynamicMdcFields
- dynamicMdcFieldTypes

Example application.properties:
`quarkus.log.handler.gelf.dynamic-mdc-field-types=jobId=String`

Is there a reason why this config is not included in the quarkus `logging-gelf` extension?