### PR TITLE
Make explicit that gradle build ignores quarkus.application.name

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config-client.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config-client.adoc
@@ -124,6 +124,12 @@ quarkus.spring-cloud-config.enabled=true
 quarkus.spring-cloud-config.url=http://localhost:8888
 ----
 
+[TIP]
+====
+If you are using Gradle, the Gradle setting `rootProject.name` has precedence over `quarkus.application.name`
+so be sure to set the Gradle property to the application name you want the Spring Cloud Config server to see. 
+====
+
 == Package and run the application
 
 Run the application with:


### PR DESCRIPTION
…le groject name when building with gradle

When following the guide i hit a problem that my expected property file wasnt being used, i am not a spring expert and so i assumed the issue was on the spring cloud config server side but in reality since quarkus 3 gradle settings about the project name override the quarkus.application.name setting discussed and explicitly set in the guide.