### PR TITLE
Display current args at edit prompt

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/console/AeshConsole.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/AeshConsole.java
@@ -496,7 +496,13 @@ public class AeshConsole extends QuarkusConsole {
         setPromptMessage("");
         connection.setAttributes(attributes);
         doingReadline = true;
+    }
 
+    @Override
+    public void doReadLineWithPrompt(String initialPrompt) {
+        setPromptMessage(initialPrompt);
+        connection.setAttributes(attributes);
+        doingReadline = true;
     }
 
     void rebalance() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleStateManager.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleStateManager.java
@@ -70,7 +70,13 @@ public class ConsoleStateManager {
                     Holder command = commands.get(key);
                     if (command != null) {
                         if (command.consoleCommand.getReadLineHandler() != null) {
-                            QuarkusConsole.INSTANCE.doReadLine();
+                            if (key == 'e') {
+                                QuarkusConsole.INSTANCE.doReadLineWithPrompt("Current args: "
+                                        + String.join(" ", RuntimeUpdatesProcessor.INSTANCE.getCommandLineArgs())
+                                        + ">");
+                            } else {
+                                QuarkusConsole.INSTANCE.doReadLine();
+                            }
                             readLineBuilder = new StringBuilder();
                             readLineConsumer = command.consoleCommand.getReadLineHandler();
                         } else {

--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleStateManager.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleStateManager.java
@@ -71,8 +71,9 @@ public class ConsoleStateManager {
                     if (command != null) {
                         if (command.consoleCommand.getReadLineHandler() != null) {
                             if (key == 'e') {
-                                QuarkusConsole.INSTANCE.doReadLineWithPrompt("Current args: "
+                                QuarkusConsole.INSTANCE.doReadLineWithPrompt("Enter new arguments (was \""
                                         + String.join(" ", RuntimeUpdatesProcessor.INSTANCE.getCommandLineArgs())
+                                        + "\"):\n"
                                         + ">");
                             } else {
                                 QuarkusConsole.INSTANCE.doReadLine();

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/BasicConsole.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/BasicConsole.java
@@ -101,6 +101,13 @@ public class BasicConsole extends QuarkusConsole {
         output.accept(">");
     }
 
+    @Override
+    public void doReadLineWithPrompt(String prompt) {
+        setPromptMessage(prompt);
+        readingLine = true;
+        output.accept(">");
+    }
+
     public StatusLine registerStatusLine(int priority) {
         return new StatusLine() {
 

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/QuarkusConsole.java
@@ -141,6 +141,8 @@ public abstract class QuarkusConsole {
 
     public abstract void doReadLine();
 
+    public abstract void doReadLineWithPrompt(String prompt);
+
     public abstract StatusLine registerStatusLine(int priority);
 
     public abstract void setPromptMessage(String message);


### PR DESCRIPTION
It fixes #37921 - point 3.
At the edit prompt it shows now current command line arguments, as shown in the screenshot below.
![edit-demo](https://github.com/quarkusio/quarkus/assets/39798354/544f0113-8727-4b59-9ecd-276f201dd4e8)
