### PR TITLE
Expose pandaproxy port in Redpanda dev services

### DIFF
--- a/docs/src/main/asciidoc/kafka-dev-services.adoc
+++ b/docs/src/main/asciidoc/kafka-dev-services.adoc
@@ -14,7 +14,7 @@ If any Kafka-related extension is present (e.g. `quarkus-smallrye-reactive-messa
 So, you don't have to start a broker manually.
 The application is configured automatically.
 
-IMPORTANT: Because starting a Kafka broker can be long, Dev Services for Kafka uses https://vectorized.io/redpanda[Redpanda], a Kafka compatible broker which starts in ~1 second.
+IMPORTANT: Because starting a Kafka broker can be long, Dev Services for Kafka uses https://redpanda.com[Redpanda], a Kafka compatible broker which starts in ~1 second.
 
 == Enabling / Disabling Dev Services for Kafka
 
@@ -106,7 +106,7 @@ You can configure timeout for Kafka admin client calls used in topic creation us
 [[redpanda-transactions]]
 == Transactional and Idempotent producers support
 
-By default, the Red Panda broker is configured to enable transactions and idempotence features.
+By default, the Redpanda broker is configured to enable transactions and idempotence features.
 You can disable those using:
 
 [source, properties]

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -227,7 +227,7 @@ public class DevServicesKafkaProcessor {
         final Supplier<RunningDevService> defaultKafkaBrokerSupplier = () -> {
             switch (config.provider) {
                 case REDPANDA:
-                    RedPandaKafkaContainer redpanda = new RedPandaKafkaContainer(
+                    RedpandaKafkaContainer redpanda = new RedpandaKafkaContainer(
                             DockerImageName.parse(config.imageName).asCompatibleSubstituteFor("vectorized/redpanda"),
                             config.fixedExposedPort,
                             launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null,
@@ -321,7 +321,7 @@ public class DevServicesKafkaProcessor {
 
         private final KafkaDevServicesBuildTimeConfig.Provider provider;
 
-        private final RedPandaBuildTimeConfig redpanda;
+        private final RedpandaBuildTimeConfig redpanda;
 
         public KafkaDevServiceCfg(KafkaDevServicesBuildTimeConfig config) {
             this.devServicesEnabled = config.enabled.orElse(true);

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -33,7 +33,7 @@ public class KafkaDevServicesBuildTimeConfig {
      * Redpanda, Strimzi and kafka-native container providers are supported. Default is redpanda.
      * <p>
      * For Redpanda:
-     * See https://vectorized.io/docs/quick-start-docker/ and https://hub.docker.com/r/vectorized/redpanda
+     * See https://docs.redpanda.com/current/get-started/quick-start/ and https://hub.docker.com/r/vectorized/redpanda
      * <p>
      * For Strimzi:
      * See https://github.com/strimzi/test-container and https://quay.io/repository/strimzi-test-container/test-container
@@ -123,9 +123,9 @@ public class KafkaDevServicesBuildTimeConfig {
     public Map<String, String> containerEnv;
 
     /**
-     * Allows configuring the Red Panda broker.
+     * Allows configuring the Redpanda broker.
      */
     @ConfigItem
-    public RedPandaBuildTimeConfig redpanda;
+    public RedpandaBuildTimeConfig redpanda;
 
 }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedpandaBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedpandaBuildTimeConfig.java
@@ -1,22 +1,24 @@
 package io.quarkus.kafka.client.deployment;
 
+import java.util.Optional;
+
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
 /**
- * Allows configuring the Red Panda broker.
- * Notice that Red Panda is not a "genuine" Kafka, it's a 100% compatible implementation of the protocol.
+ * Allows configuring the Redpanda broker.
+ * Notice that Redpanda is not a "genuine" Kafka, it's a 100% compatible implementation of the protocol.
  *
- * Find more info about Red Panda on <a href="https://vectorized.io/redpanda/">https://vectorized.io/redpanda/</a>.
+ * Find more info about Redpanda on <a href="https://redpanda.com/">https://redpanda.com/</a>.
  */
 @ConfigGroup
-public class RedPandaBuildTimeConfig {
+public class RedpandaBuildTimeConfig {
 
     /**
      * Enables transaction support.
      * Also enables the producer idempotence.
      *
-     * Find more info about Red Panda transaction support on
+     * Find more info about Redpanda transaction support on
      * <a href="https://vectorized.io/blog/fast-transactions/">https://vectorized.io/blog/fast-transactions/</a>.
      *
      * Notice that
@@ -28,4 +30,12 @@ public class RedPandaBuildTimeConfig {
      */
     @ConfigItem(defaultValue = "true")
     public boolean transactionEnabled;
+
+    /**
+     * Port to access the Redpanda HTTP Proxy (<a href="https://docs.redpanda.com/current/develop/http-proxy/">pandaproxy</a>).
+     * <p>
+     * If not defined, the port will be chosen randomly.
+     */
+    @ConfigItem
+    public Optional<Integer> proxyPort;
 }

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedpandaKafkaContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedpandaKafkaContainer.java
@@ -15,20 +15,22 @@ import io.quarkus.devservices.common.ConfigureUtil;
 
 /**
  * Container configuring and starting the Redpanda broker.
- * See https://vectorized.io/docs/quick-start-docker/
+ * See <a href=
+ * "https://docs.redpanda.com/current/get-started/quick-start/">https://docs.redpanda.com/current/get-started/quick-start/</a>
  */
-final class RedPandaKafkaContainer extends GenericContainer<RedPandaKafkaContainer> {
+final class RedpandaKafkaContainer extends GenericContainer<RedpandaKafkaContainer> {
 
     private final Integer fixedExposedPort;
     private final boolean useSharedNetwork;
-    private final RedPandaBuildTimeConfig redpandaConfig;
+    private final RedpandaBuildTimeConfig redpandaConfig;
 
     private String hostName = null;
 
     private static final String STARTER_SCRIPT = "/var/lib/redpanda/redpanda.sh";
+    private static final int PANDAPROXY_PORT = 8082;
 
-    RedPandaKafkaContainer(DockerImageName dockerImageName, int fixedExposedPort, String serviceName,
-            boolean useSharedNetwork, RedPandaBuildTimeConfig redpandaConfig) {
+    RedpandaKafkaContainer(DockerImageName dockerImageName, int fixedExposedPort, String serviceName,
+            boolean useSharedNetwork, RedpandaBuildTimeConfig redpandaConfig) {
         super(dockerImageName);
         this.fixedExposedPort = fixedExposedPort;
         this.useSharedNetwork = useSharedNetwork;
@@ -100,6 +102,12 @@ final class RedPandaKafkaContainer extends GenericContainer<RedPandaKafkaContain
 
         if (fixedExposedPort != null) {
             addFixedExposedPort(fixedExposedPort, DevServicesKafkaProcessor.KAFKA_PORT);
+        }
+
+        if (redpandaConfig.proxyPort.isPresent()) {
+            addFixedExposedPort(redpandaConfig.proxyPort.get(), PANDAPROXY_PORT);
+        } else {
+            addExposedPort(PANDAPROXY_PORT);
         }
     }
 


### PR DESCRIPTION
Exposed the pandaproxy port 8082 to a random port by default, added configuration parameter to fix the port. Are there any tests for the kafka redpanda devservice? I could not find any.

I have also changed the naming from "Red Panda" to "Redpanda" as this seemed to be inconsistent. Let me know, if I should revert this change.

Also quick note for redpanda: The vectorized/redpanda image seems to be deprecated (https://hub.docker.com/r/vectorized/redpanda).

Resolves #37970 