### PR TITLE
Fix Create the Maven project section in security-oidc-bearer-token-authentication-tutorial.adoc

### DIFF
--- a/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
+++ b/docs/src/main/asciidoc/security-oidc-bearer-token-authentication-tutorial.adoc
@@ -57,47 +57,33 @@ The solution is located in the `security-openid-connect-quickstart` link:{quicks
 You can either create a new Maven project with the `oidc` extension or you can add the extension to an existing Maven project.
 Complete one of the following commands:
 
-* To create a new Maven project, use the following command:
-+
-====
+To create a new Maven project, use the following command:
+
 :create-app-artifact-id: security-openid-connect-quickstart
 :create-app-extensions: oidc,resteasy-reactive-jackson
 include::{includes}/devtools/create-app.adoc[]
-====
-This command generates a Maven project, importing the `oidc` extension
-which is an implementation of OIDC for Quarkus.
 
-* If you already have your Quarkus project configured, you can add the `oidc` extension
-to your project by running the following command in your project base directory:
-+
-====
+If you already have your Quarkus project configured, you can add the `oidc` extension to your project by running the following command in your project base directory:
+
 :add-extension-extensions: oidc
 include::{includes}/devtools/extension-add.adoc[]
-====
-The following configuration gets added to your build file:
 
-* Using Maven (pom.xml):
-+
-====
+This will add the following to your build file:
+
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
 ----
 <dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-oidc</artifactId>
+   <groupId>io.quarkus</groupId>
+   <artifactId>quarkus-oidc</artifactId>
 </dependency>
 ----
-====
-+
-* Using Gradle (build.gradle):
-+
-====
---
+
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
 ----
 implementation("io.quarkus:quarkus-oidc")
 ----
---
-====
 
 == Write the application
 


### PR DESCRIPTION
Fixes #37973.

This PR fixes 2 issues mentioned in #37973:
* Extensions are now correctly shown when a new project is created
* Fixes the empty Gradle command when adding an extension to the existing project, and also makes it consistent with how it is shown in the OIDC code flow guide