### PR TITLE
ArC: use a separate lock for each bean in generated ContextInstances

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractInstanceHandle.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractInstanceHandle.java
@@ -7,16 +7,12 @@ import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.spi.CreationalContext;
 
-import org.jboss.logging.Logger;
-
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.InstanceHandle;
 
 abstract class AbstractInstanceHandle<T> implements InstanceHandle<T> {
-
-    private static final Logger LOGGER = Logger.getLogger(AbstractInstanceHandle.class.getName());
 
     @SuppressWarnings("rawtypes")
     private static final AtomicIntegerFieldUpdater<AbstractInstanceHandle> DESTROYED_UPDATER = AtomicIntegerFieldUpdater

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractSharedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractSharedContext.java
@@ -84,23 +84,24 @@ abstract class AbstractSharedContext implements InjectableContext, InjectableCon
 
     @Override
     public synchronized void destroy() {
-        List<ContextInstanceHandle<?>> values = new LinkedList<>();
-        instances.forEach(values::add);
+        // Note that shared contexts are usually only destroyed when the app stops
+        // I.e. we don't need to use the optimized ContextInstances methods here
+        Set<ContextInstanceHandle<?>> values = instances.getAllPresent();
         if (values.isEmpty()) {
             return;
         }
         // Destroy the producers first
-        for (Iterator<ContextInstanceHandle<?>> iterator = values.iterator(); iterator.hasNext();) {
-            ContextInstanceHandle<?> instanceHandle = iterator.next();
+        for (Iterator<ContextInstanceHandle<?>> it = values.iterator(); it.hasNext();) {
+            ContextInstanceHandle<?> instanceHandle = it.next();
             if (instanceHandle.getBean().getDeclaringBean() != null) {
                 instanceHandle.destroy();
-                iterator.remove();
+                it.remove();
             }
         }
         for (ContextInstanceHandle<?> instanceHandle : values) {
             instanceHandle.destroy();
         }
-        instances.clear();
+        instances.removeEach(null);
     }
 
     @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ComputingCacheContextInstances.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ComputingCacheContextInstances.java
@@ -35,13 +35,11 @@ class ComputingCacheContextInstances implements ContextInstances {
     }
 
     @Override
-    public void clear() {
+    public void removeEach(Consumer<? super ContextInstanceHandle<?>> action) {
+        if (action != null) {
+            instances.getPresentValues().forEach(action);
+        }
         instances.clear();
-    }
-
-    @Override
-    public void forEach(Consumer<? super ContextInstanceHandle<?>> handleConsumer) {
-        instances.getPresentValues().forEach(handleConsumer);
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ContextInstanceHandleImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ContextInstanceHandleImpl.java
@@ -2,6 +2,8 @@ package io.quarkus.arc.impl;
 
 import jakarta.enterprise.context.spi.CreationalContext;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.arc.ContextInstanceHandle;
 import io.quarkus.arc.InjectableBean;
 
@@ -12,13 +14,19 @@ import io.quarkus.arc.InjectableBean;
  */
 public class ContextInstanceHandleImpl<T> extends EagerInstanceHandle<T> implements ContextInstanceHandle<T> {
 
+    private static final Logger LOG = Logger.getLogger(ContextInstanceHandleImpl.class);
+
     public ContextInstanceHandleImpl(InjectableBean<T> bean, T instance, CreationalContext<T> creationalContext) {
         super(bean, instance, creationalContext);
     }
 
     @Override
     public void destroy() {
-        destroyInternal();
+        try {
+            destroyInternal();
+        } catch (Exception e) {
+            LOG.error("Unable to destroy instance" + get(), e);
+        }
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ContextInstances.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ContextInstances.java
@@ -8,16 +8,39 @@ import io.quarkus.arc.ContextInstanceHandle;
 
 public interface ContextInstances {
 
+    /**
+     *
+     * @param id
+     * @param supplier
+     * @return the instance handle
+     */
     ContextInstanceHandle<?> computeIfAbsent(String id, Supplier<ContextInstanceHandle<?>> supplier);
 
+    /**
+     *
+     * @param id
+     * @return the instance handle if present, {@code null} otherwise
+     */
     ContextInstanceHandle<?> getIfPresent(String id);
 
+    /**
+     *
+     * @param id
+     * @return the removed instance handle, or {@code null}
+     */
     ContextInstanceHandle<?> remove(String id);
 
+    /**
+     *
+     * @return all instance handles
+     */
     Set<ContextInstanceHandle<?>> getAllPresent();
 
-    void clear();
-
-    void forEach(Consumer<? super ContextInstanceHandle<?>> handleConsumer);
+    /**
+     * Removes all instance handles and performs the given action (if present) for each handle.
+     *
+     * @param action
+     */
+    void removeEach(Consumer<? super ContextInstanceHandle<?>> action);
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
@@ -210,8 +210,7 @@ class RequestContext implements ManagedContext {
             if (reqState.invalidate()) {
                 // Fire an event with qualifier @BeforeDestroyed(RequestScoped.class) if there are any observers for it
                 fireIfNotEmpty(beforeDestroyedNotifier);
-                reqState.contextInstances.forEach(this::destroyContextElement);
-                reqState.contextInstances.clear();
+                reqState.contextInstances.removeEach(ContextInstanceHandle::destroy);
                 // Fire an event with qualifier @Destroyed(RequestScoped.class) if there are any observers for it
                 fireIfNotEmpty(destroyedNotifier);
             }
@@ -227,14 +226,6 @@ class RequestContext implements ManagedContext {
                 .map(se -> "\n\t" + se.toString())
                 .collect(Collectors.joining());
         LOG.tracef("Destroy %s%s\n\t...", state != null ? Integer.toHexString(state.hashCode()) : "", stack);
-    }
-
-    private void destroyContextElement(ContextInstanceHandle<?> contextInstanceHandle) {
-        try {
-            contextInstanceHandle.destroy();
-        } catch (Exception e) {
-            throw new IllegalStateException("Unable to destroy instance" + contextInstanceHandle.get(), e);
-        }
     }
 
     private void fireIfNotEmpty(Notifier<Object> notifier) {


### PR DESCRIPTION
- fixes #37958

I'd like to stress that I would still recommend users to avoid things like calling external services in the `@PostConstruct`/`@PreDestroy` callbacks. Very often it's not clear when exactly a bean will be instantiated and since the API is blocking an undesired behavior may occur.

CC @franz1981 - I've replaced the `forEach()` method with `removeEach()` which is more useful for the request context destruction. It would be great if you could run some perf benchmarks so that we can be sure that this PR does not cause any significant perf regression. Although I expect a perf drop because we must use a separate lock for each bean...