### PR TITLE
Don't generate certificates for tests when build is skipped

### DIFF
--- a/integration-tests/rest-client-reactive/pom.xml
+++ b/integration-tests/rest-client-reactive/pom.xml
@@ -198,6 +198,7 @@
                             <goal>generate-truststore</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipTests}</skip>
                             <truststoreFormat>PKCS12</truststoreFormat>
                             <truststoreFile>${self-signed.trust-store}</truststoreFile>
                             <truststorePassword>${self-signed.trust-store-password}</truststorePassword>
@@ -215,6 +216,7 @@
                             <goal>generate-truststore</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipTests}</skip>
                             <truststoreFormat>PKCS12</truststoreFormat>
                             <truststoreFile>${wrong-host.trust-store}</truststoreFile>
                             <truststorePassword>${wrong-host.trust-store-password}</truststorePassword>

--- a/integration-tests/rest-client/pom.xml
+++ b/integration-tests/rest-client/pom.xml
@@ -155,6 +155,7 @@
                             <goal>generate-truststore</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipTests}</skip>
                             <truststoreFormat>PKCS12</truststoreFormat>
                             <truststoreFile>${self-signed.trust-store}</truststoreFile>
                             <truststorePassword>${self-signed.trust-store-password}</truststorePassword>
@@ -172,6 +173,7 @@
                             <goal>generate-truststore</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipTests}</skip>
                             <truststoreFormat>PKCS12</truststoreFormat>
                             <truststoreFile>${wrong-host.trust-store}</truststoreFile>
                             <truststorePassword>${wrong-host.trust-store-password}</truststorePassword>


### PR DESCRIPTION
This slightly speeds up the -Dquickly build