### PR TITLE
ArC: improve description of injection points that are parameters

### DIFF
--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/inject/InjectionFailedTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/inject/InjectionFailedTest.java
@@ -37,7 +37,7 @@ public class InjectionFailedTest {
                     assertTrue(s.getMessage().contains(
                             "No template found for path [foo] defined at io.quarkus.qute.deployment.inject.InjectionFailedTest#foo")
                             || s.getMessage().contains(
-                                    "No template found for path [alpha] defined at io.quarkus.qute.deployment.inject.InjectionFailedTest$Client()"),
+                                    "No template found for path [alpha] defined at parameter 'alpha' of io.quarkus.qute.deployment.inject.InjectionFailedTest$Client constructor"),
                             s.getMessage());
                 }
             });

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
@@ -292,11 +292,11 @@ public class InjectionPointInfo {
                 }
                 String method = target.asMethod().name();
                 if (method.equals(Methods.INIT)) {
-                    method = "";
+                    method = " constructor";
                 } else {
-                    method = "#" + method;
+                    method = "#" + method + "()";
                 }
-                return target.asMethod().declaringClass().name() + method + "()" + ":" + param;
+                return "parameter '" + param + "' of " + target.asMethod().declaringClass().name() + method;
             default:
                 return target.toString();
         }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/illegal/TypeVariableInitializerInjectionPointTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/illegal/TypeVariableInitializerInjectionPointTest.java
@@ -24,7 +24,7 @@ public class TypeVariableInitializerInjectionPointTest {
         assertNotNull(failure);
         assertTrue(failure instanceof DefinitionException);
         assertEquals(
-                "Type variable is not a legal injection point type: io.quarkus.arc.test.injection.illegal.TypeVariableInitializerInjectionPointTest$Head#setIt():it",
+                "Type variable is not a legal injection point type: parameter 'it' of io.quarkus.arc.test.injection.illegal.TypeVariableInitializerInjectionPointTest$Head#setIt()",
                 failure.getMessage());
     }
 


### PR DESCRIPTION
The improvement is twofold:

- it highlights that the injection point is a parameter by putting the parameter name at the beginning instead of the end;
- it uses the word "constructor" explicitly in case the parameter belongs to a constructor.

Resolves #37923