### PR TITLE
Avoid integration-tests/kafka-sasl-elytron to modify test resources

### DIFF
--- a/integration-tests/kafka-sasl-elytron/src/main/resources/application.properties
+++ b/integration-tests/kafka-sasl-elytron/src/main/resources/application.properties
@@ -4,7 +4,7 @@ quarkus.log.category.\"org.apache.zookeeper\".level=WARN
 
 mp.messaging.connector.smallrye-kafka.security.protocol=SASL_PLAINTEXT
 mp.messaging.connector.smallrye-kafka.sasl.mechanism=GSSAPI
-mp.messaging.connector.smallrye-kafka.sasl.jaas.config=com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true debug=true serviceName="kafka" keyTab="src/test/resources/client.keytab" principal="client/localhost@EXAMPLE.COM";
+mp.messaging.connector.smallrye-kafka.sasl.jaas.config=com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true debug=true serviceName="kafka" keyTab="target/client.keytab" principal="client/localhost@EXAMPLE.COM";
 mp.messaging.connector.smallrye-kafka.sasl.kerberos.service.name=kafka
 mp.messaging.connector.smallrye-kafka.ssl.endpoint.identification.algorithm=https
 

--- a/integration-tests/kafka-sasl-elytron/src/test/java/io/quarkus/it/kafka/KafkaSaslTestResource.java
+++ b/integration-tests/kafka-sasl-elytron/src/test/java/io/quarkus/it/kafka/KafkaSaslTestResource.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jboss.logging.Logger;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.utility.MountableFile;
 
 import io.quarkus.it.kafka.containers.KerberosContainer;
@@ -39,9 +38,10 @@ public class KafkaSaslTestResource implements QuarkusTestResourceLifecycleManage
                         c -> String.format("SASL_PLAINTEXT://%s:%s", c.getHost(), c.getMappedPort(KAFKA_PORT)))
                 .withPort(KAFKA_PORT)
                 .withServerProperties(MountableFile.forClasspathResource("kafkaServer.properties"))
-                .withCopyFileToContainer(MountableFile.forClasspathResource("krb5KafkaBroker.conf"), "/etc/krb5.conf")
-                .withFileSystemBind("src/test/resources/kafkabroker.keytab", "/opt/kafka/config/kafkabroker.keytab",
-                        BindMode.READ_ONLY);
+                .withCopyFileToContainer(MountableFile.forClasspathResource("krb5KafkaBroker.conf"),
+                        "/etc/krb5.conf")
+                .withCopyFileToContainer(MountableFile.forHostPath("target/kafkabroker.keytab"),
+                        "/opt/kafka/config/kafkabroker.keytab");
         kafka.start();
         log.info(kafka.getLogs());
         properties.put("kafka.bootstrap.servers", kafka.getBootstrapServers());

--- a/integration-tests/kafka-sasl-elytron/src/test/java/io/quarkus/it/kafka/containers/KerberosContainer.java
+++ b/integration-tests/kafka-sasl-elytron/src/test/java/io/quarkus/it/kafka/containers/KerberosContainer.java
@@ -7,7 +7,6 @@ import java.io.InputStreamReader;
 import java.time.Duration;
 import java.util.stream.Collectors;
 
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -21,21 +20,23 @@ public class KerberosContainer extends GenericContainer<KerberosContainer> {
         withEnv("KRB5_KDC", "localhost");
         withEnv("KRB5_PASS", "mypass");
         withExposedPorts(749, 464, 88);
-        withFileSystemBind("src/test/resources/kafkabroker.keytab", "/tmp/keytab/kafkabroker.keytab", BindMode.READ_WRITE);
-        withFileSystemBind("src/test/resources/client.keytab", "/tmp/keytab/client.keytab", BindMode.READ_WRITE);
-        waitingFor(Wait.forLogMessage("Principal \"admin/admin@EXAMPLE.COM\" created.*", 1));
+        waitingFor(Wait.forListeningPorts(88));
         withNetwork(Network.SHARED);
         withNetworkAliases("kerberos");
     }
 
     public void createTestPrincipals() {
         try {
-            ExecResult lsResult = execInContainer("kadmin.local", "-q", "addprinc -randkey kafka/localhost@EXAMPLE.COM");
+            ExecResult lsResult = execInContainer("kadmin.local", "-q",
+                    "addprinc -randkey kafka/localhost@EXAMPLE.COM");
             lsResult = execInContainer("kadmin.local", "-q",
-                    "ktadd -norandkey -k /tmp/keytab/kafkabroker.keytab kafka/localhost@EXAMPLE.COM");
-            lsResult = execInContainer("kadmin.local", "-q", "addprinc -randkey client/localhost@EXAMPLE.COM");
+                    "ktadd -norandkey -k /kafkabroker.keytab kafka/localhost@EXAMPLE.COM");
             lsResult = execInContainer("kadmin.local", "-q",
-                    "ktadd -norandkey -k /tmp/keytab/client.keytab client/localhost@EXAMPLE.COM");
+                    "addprinc -randkey client/localhost@EXAMPLE.COM");
+            lsResult = execInContainer("kadmin.local", "-q",
+                    "ktadd -norandkey -k /client.keytab client/localhost@EXAMPLE.COM");
+            copyFileFromContainer("/kafkabroker.keytab", "target/kafkabroker.keytab");
+            copyFileFromContainer("/client.keytab", "target/client.keytab");
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Remove keytabs created in test-resources, the test now copies them to the target dir

Fixes #38002