### PR TITLE
Set the correct port properties for HTTPS

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PortSystemProperties.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/PortSystemProperties.java
@@ -11,28 +11,38 @@ public class PortSystemProperties {
 
     public void set(String subProperty, int actualPort, LaunchMode launchMode) {
         String portPropertyValue = String.valueOf(actualPort);
+        String portPropertyName = "quarkus." + subProperty + ".port";
+        String testPropName = "quarkus." + subProperty + ".test-port";
+
+        set(portPropertyName, testPropName, portPropertyValue, launchMode);
+        //if subProperty is "https", the correct properties are not quarkus.https.port and quarkus.https.test-port
+        //but quarkus.http.ssl-port and quarkus.http.test-ssl-port
+        //the incorrect properties are still set for backward compatibility with code that works around the incorrect
+        //names
+        if ("https".equals(subProperty)) {
+            set("quarkus.http.ssl-port", "quarkus.http.test-ssl-port", portPropertyValue, launchMode);
+        }
+    }
+
+    private void set(String portPropertyName, String testPropName, String portPropertyValue, LaunchMode launchMode) {
         //we always set the .port property, even if we are in test mode, so this will always
         //reflect the current port
-        String portPropertyName = "quarkus." + subProperty + ".port";
-        String prevPortPropertyValue = System.setProperty(portPropertyName, portPropertyValue);
-        if (!Objects.equals(prevPortPropertyValue, portPropertyValue)) {
-            portPropertiesToRestore.put(portPropertyName, prevPortPropertyValue);
-        }
+        set(portPropertyName, portPropertyValue);
         if (launchMode == LaunchMode.TEST) {
             //we also set the test-port property in a test
-            String testPropName = "quarkus." + subProperty + ".test-port";
-            String prevTestPropPrevValue = System.setProperty(testPropName, portPropertyValue);
-            if (!Objects.equals(prevTestPropPrevValue, portPropertyValue)) {
-                portPropertiesToRestore.put(testPropName, prevTestPropPrevValue);
-            }
+            set(testPropName, portPropertyValue);
         }
         if (launchMode.isDevOrTest()) {
             // set the profile property as well to make sure we don't have any inconsistencies
             portPropertyName = "%" + launchMode.getDefaultProfile() + "." + portPropertyName;
-            prevPortPropertyValue = System.setProperty(portPropertyName, portPropertyValue);
-            if (!Objects.equals(prevPortPropertyValue, portPropertyValue)) {
-                portPropertiesToRestore.put(portPropertyName, prevPortPropertyValue);
-            }
+            set(portPropertyName, portPropertyValue);
+        }
+    }
+
+    private void set(String propertyName, String propertyValue) {
+        String prevPropertyValue = System.setProperty(propertyName, propertyValue);
+        if (!Objects.equals(prevPropertyValue, propertyValue)) {
+            portPropertiesToRestore.put(propertyName, prevPropertyValue);
         }
     }
 

--- a/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/RandomTestPortTestCase.java
+++ b/integration-tests/vertx-http/src/test/java/io/quarkus/it/vertx/RandomTestPortTestCase.java
@@ -1,0 +1,86 @@
+package io.quarkus.it.vertx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.net.URL;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(RandomTestPortTestCase.TestPortProfile.class)
+public class RandomTestPortTestCase {
+
+    @ConfigProperty(name = "quarkus.http.port")
+    int httpPort;
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    int httpTestPort;
+
+    @TestHTTPResource(value = "/some-path")
+    URL httpTestUrl;
+
+    @ConfigProperty(name = "quarkus.http.ssl-port")
+    int httpsPort;
+
+    @ConfigProperty(name = "quarkus.http.test-ssl-port")
+    int httpsTestPort;
+
+    @TestHTTPResource(value = "/some-path", ssl = true)
+    URL httpsTestUrl;
+
+    @Test
+    public void testHttpTestPort() {
+        assertNotEquals(0, httpTestPort);
+        assertNotEquals(8080, httpTestPort);
+        assertNotEquals(8081, httpTestPort);
+
+        assertEquals(httpTestPort, httpPort);
+        assertEquals(httpTestPort, httpTestUrl.getPort());
+    }
+
+    @Test
+    public void testHttpsTestPort() {
+        assertNotEquals(0, httpsTestPort);
+        assertNotEquals(8443, httpsTestPort);
+        assertNotEquals(8444, httpsTestPort);
+
+        assertEquals(httpsTestPort, httpsPort);
+        assertEquals(httpsTestPort, httpsTestUrl.getPort());
+    }
+
+    @Test
+    public void testLegacyProperties() {
+        Config config = ConfigProvider.getConfig();
+
+        testLegacyProperty(config, "quarkus.http.ssl-port", "quarkus.https.port", httpsPort);
+        testLegacyProperty(config, "quarkus.http.test-ssl-port", "quarkus.https.test-port", httpsTestPort);
+        testLegacyProperty(config, "%test.quarkus.http.ssl-port", "%test.quarkus.https.port", httpsTestPort);
+    }
+
+    private void testLegacyProperty(Config config, String correctName, String legacyName, int expectedValue) {
+        Optional<Integer> portWithCorrectProperty = config.getOptionalValue(correctName, Integer.class);
+        Optional<Integer> portWithLegacyProperty = config.getOptionalValue(legacyName, Integer.class);
+
+        assertEquals(Optional.of(expectedValue), portWithCorrectProperty);
+        assertEquals(portWithCorrectProperty, portWithLegacyProperty);
+    }
+
+    public static class TestPortProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.http.test-port", "0", "quarkus.http.test-ssl-port", "0");
+        }
+    }
+}


### PR DESCRIPTION
Fixes [#37944](https://github.com/quarkusio/quarkus/issues/37944) while still keeping full backward compatibility for those that use the incorrect properties.