### PR TITLE
Scheduler: Quartz - support JobDefinition API if DB type store is used

### DIFF
--- a/docs/src/main/asciidoc/scheduler-reference.adoc
+++ b/docs/src/main/asciidoc/scheduler-reference.adoc
@@ -404,7 +404,7 @@ class MyJobs {
 
 NOTE: By default, the scheduler is not started unless a `@Scheduled` business method is found. You may need to force the start of the scheduler for "pure" programmatic scheduling via `quarkus.scheduler.start-mode=forced`.
 
-NOTE: If the xref:quartz.adoc[Quartz extension] is present then only the RAM store type is supported, i.e. `quarkus.quartz.store-type=ram` must be set. The Quartz API can be also used to schedule a job programmatically.
+NOTE: If the xref:quartz.adoc[Quartz extension] is present and the DB store type is used then it's not possible to pass a task instance to the job definition and a task class must be used instead. The Quartz API can be also used to schedule a job programmatically.
 
 == Scheduled Methods and Testing
 

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/programmatic/ProgrammaticJobsTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/programmatic/ProgrammaticJobsTest.java
@@ -8,17 +8,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.arc.Unremovable;
 import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.ScheduledExecution;
 import io.quarkus.scheduler.Scheduler;
 import io.quarkus.scheduler.Scheduler.JobDefinition;
+import io.quarkus.scheduler.Trigger;
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.common.vertx.VertxContext;
 import io.smallrye.mutiny.Uni;
@@ -38,10 +45,24 @@ public class ProgrammaticJobsTest {
     MyService myService;
 
     static final CountDownLatch SYNC_LATCH = new CountDownLatch(1);
+    static final CountDownLatch SYNC_CLASS_LATCH = new CountDownLatch(1);
     static final CountDownLatch ASYNC_LATCH = new CountDownLatch(1);
+    static final AtomicInteger SKIPPED_EXECUTIONS = new AtomicInteger();
+    static final CountDownLatch ASYNC_CLASS_LATCH = new CountDownLatch(1);
 
     @Test
     public void testJobs() throws InterruptedException {
+        scheduler.newJob("alwaysSkip1")
+                .setInterval("1s")
+                .setSkipPredicate(ex -> true)
+                .setTask(ex -> SKIPPED_EXECUTIONS.incrementAndGet())
+                .schedule();
+        scheduler.newJob("alwaysSkip2")
+                .setInterval("1s")
+                .setTask(ex -> SKIPPED_EXECUTIONS.incrementAndGet())
+                .setSkipPredicate(AlwaysSkipPredicate.class)
+                .schedule();
+
         Scheduler.JobDefinition job1 = scheduler.newJob("foo")
                 .setInterval("1s")
                 .setTask(ec -> {
@@ -58,7 +79,8 @@ public class ProgrammaticJobsTest {
         job2.setTask(ec -> {
         });
 
-        job1.schedule();
+        Trigger trigger1 = job1.schedule();
+        assertNotNull(trigger1);
         assertTrue(ProgrammaticJobsTest.SYNC_LATCH.await(5, TimeUnit.SECONDS));
 
         assertEquals("Cannot modify a job that was already scheduled",
@@ -79,6 +101,10 @@ public class ProgrammaticJobsTest {
         assertNull(scheduler.unscheduleJob("nonexisting"));
 
         assertNotNull(scheduler.unscheduleJob("foo"));
+        assertNotNull(scheduler.unscheduleJob("alwaysSkip1"));
+        assertNotNull(scheduler.unscheduleJob("alwaysSkip2"));
+        assertEquals(0, SKIPPED_EXECUTIONS.get());
+        // Jobs#dummy()
         assertEquals(1, scheduler.getScheduledJobs().size());
     }
 
@@ -97,10 +123,31 @@ public class ProgrammaticJobsTest {
                 assertThrows(IllegalStateException.class, () -> asyncJob.setTask(ec -> {
                 })).getMessage());
 
-        asyncJob.schedule();
+        Trigger trigger = asyncJob.schedule();
+        assertNotNull(trigger);
 
         assertTrue(ProgrammaticJobsTest.ASYNC_LATCH.await(5, TimeUnit.SECONDS));
         assertNotNull(scheduler.unscheduleJob("fooAsync"));
+    }
+
+    @Test
+    public void testClassJobs() throws InterruptedException {
+        scheduler.newJob("fooClass")
+                .setInterval("1s")
+                .setTask(JobClassTask.class)
+                .schedule();
+        assertTrue(ProgrammaticJobsTest.SYNC_CLASS_LATCH.await(5, TimeUnit.SECONDS));
+        assertNotNull(scheduler.unscheduleJob("fooClass"));
+    }
+
+    @Test
+    public void testClassAsyncJobs() throws InterruptedException {
+        scheduler.newJob("fooAsyncClass")
+                .setInterval("1s")
+                .setAsyncTask(JobClassAsyncTask.class)
+                .schedule();
+        assertTrue(ProgrammaticJobsTest.ASYNC_CLASS_LATCH.await(5, TimeUnit.SECONDS));
+        assertNotNull(scheduler.unscheduleJob("fooAsyncClass"));
     }
 
     static class Jobs {
@@ -115,6 +162,47 @@ public class ProgrammaticJobsTest {
 
         void countDown(CountDownLatch latch) {
             latch.countDown();
+        }
+
+    }
+
+    public static class AlwaysSkipPredicate implements Scheduled.SkipPredicate {
+
+        @Override
+        public boolean test(ScheduledExecution execution) {
+            return true;
+
+        }
+    }
+
+    @Unremovable
+    @Singleton
+    public static class JobClassTask implements Consumer<ScheduledExecution> {
+
+        @Inject
+        MyService myService;
+
+        @Override
+        public void accept(ScheduledExecution se) {
+            assertTrue(Arc.container().requestContext().isActive());
+            myService.countDown(SYNC_CLASS_LATCH);
+        }
+
+    }
+
+    @Unremovable
+    @Singleton
+    public static class JobClassAsyncTask implements Function<ScheduledExecution, Uni<Void>> {
+
+        @Inject
+        MyService myService;
+
+        @Override
+        public Uni<Void> apply(ScheduledExecution se) {
+            assertTrue(Context.isOnEventLoopThread() && VertxContext.isOnDuplicatedContext());
+            assertTrue(Arc.container().requestContext().isActive());
+            myService.countDown(ASYNC_CLASS_LATCH);
+            return Uni.createFrom().voidItem();
         }
 
     }

--- a/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Scheduler.java
+++ b/extensions/scheduler/api/src/main/java/io/quarkus/scheduler/Scheduler.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import jakarta.enterprise.context.Dependent;
+
 import io.quarkus.scheduler.Scheduled.ConcurrentExecution;
 import io.quarkus.scheduler.Scheduled.SkipPredicate;
 import io.smallrye.mutiny.Uni;
@@ -185,13 +187,52 @@ public interface Scheduler {
         }
 
         /**
+         * The class must either represent a CDI bean or declare a public no-args constructor.
+         * <p>
+         * In case of CDI, there must be exactly one bean that has the specified class in its set of bean types. The scope of
+         * the bean must be active during execution of the job. If the scope is {@link Dependent} then the bean instance belongs
+         * exclusively to the specific job definition and is destroyed when the application is shut down. If the bean is not a
+         * dependency of any other bean it has to be marked as unremovable; for example annotated with
+         * {@link io.quarkus.arc.Unremovable}.
+         * <p>
+         * In case of a class with public no-args constructor, the constructor must be registered for reflection when an
+         * application is compiled to a native executable; for example annotate the class with
+         * {@link io.quarkus.runtime.annotations.RegisterForReflection}.
+         *
+         * @param taskClass
+         * @return self
+         */
+        default JobDefinition setTask(Class<? extends Consumer<ScheduledExecution>> taskClass) {
+            return setTask(taskClass, false);
+        }
+
+        /**
          * Configures the task to schedule.
          *
          * @param task the task, must not be {@code null}
          * @param runOnVirtualThread whether the task must be run on a virtual thread if the JVM allows it.
-         * @return self the current job definition
+         * @return self
          */
         JobDefinition setTask(Consumer<ScheduledExecution> task, boolean runOnVirtualThread);
+
+        /**
+         * The class must either represent a CDI bean or declare a public no-args constructor.
+         * <p>
+         * In case of CDI, there must be exactly one bean that has the specified class in its set of bean types. The scope of
+         * the bean must be active during execution of the job. If the scope is {@link Dependent} then the bean instance belongs
+         * exclusively to the specific job definition and is destroyed when the application is shut down. If the bean is not a
+         * dependency of any other bean it has to be marked as unremovable; for example annotated with
+         * {@link io.quarkus.arc.Unremovable}.
+         * <p>
+         * In case of a class with public no-args constructor, the constructor must be registered for reflection when an
+         * application is compiled to a native executable; for example annotate the class with
+         * {@link io.quarkus.runtime.annotations.RegisterForReflection}.
+         *
+         * @param consumerClass
+         * @param runOnVirtualThread
+         * @return self
+         */
+        JobDefinition setTask(Class<? extends Consumer<ScheduledExecution>> consumerClass, boolean runOnVirtualThread);
 
         /**
          *
@@ -199,6 +240,24 @@ public interface Scheduler {
          * @return self
          */
         JobDefinition setAsyncTask(Function<ScheduledExecution, Uni<Void>> asyncTask);
+
+        /**
+         * The class must either represent a CDI bean or declare a public no-args constructor.
+         * <p>
+         * In case of CDI, there must be exactly one bean that has the specified class in its set of bean types. The scope of
+         * the bean must be active during execution of the job. If the scope is {@link Dependent} then the bean instance belongs
+         * exclusively to the specific job definition and is destroyed when the application is shut down. If the bean is not a
+         * dependency of any other bean it has to be marked as unremovable; for example annotated with
+         * {@link io.quarkus.arc.Unremovable}.
+         * <p>
+         * In case of a class with public no-args constructor, the constructor must be registered for reflection when an
+         * application is compiled to a native executable; for example annotate the class with
+         * {@link io.quarkus.runtime.annotations.RegisterForReflection}.
+         *
+         * @param asyncTaskClass
+         * @return self
+         */
+        JobDefinition setAsyncTask(Class<? extends Function<ScheduledExecution, Uni<Void>>> asyncTaskClass);
 
         /**
          * Attempts to schedule the job.

--- a/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/AbstractJobDefinition.java
+++ b/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/AbstractJobDefinition.java
@@ -20,8 +20,11 @@ public abstract class AbstractJobDefinition implements JobDefinition {
     protected String overdueGracePeriod = "";
     protected ConcurrentExecution concurrentExecution = ConcurrentExecution.PROCEED;
     protected SkipPredicate skipPredicate = null;
+    protected Class<? extends SkipPredicate> skipPredicateClass;
     protected Consumer<ScheduledExecution> task;
+    protected Class<? extends Consumer<ScheduledExecution>> taskClass;
     protected Function<ScheduledExecution, Uni<Void>> asyncTask;
+    protected Class<? extends Function<ScheduledExecution, Uni<Void>>> asyncTaskClass;
     protected boolean scheduled = false;
     protected String timeZone = Scheduled.DEFAULT_TIMEZONE;
     protected boolean runOnVirtualThread;
@@ -67,6 +70,7 @@ public abstract class AbstractJobDefinition implements JobDefinition {
 
     @Override
     public JobDefinition setSkipPredicate(Class<? extends SkipPredicate> skipPredicateClass) {
+        this.skipPredicateClass = skipPredicateClass;
         return setSkipPredicate(SchedulerUtils.instantiateBeanOrClass(skipPredicateClass));
     }
 
@@ -96,6 +100,12 @@ public abstract class AbstractJobDefinition implements JobDefinition {
     }
 
     @Override
+    public JobDefinition setTask(Class<? extends Consumer<ScheduledExecution>> taskClass, boolean runOnVirtualThread) {
+        this.taskClass = taskClass;
+        return setTask(SchedulerUtils.instantiateBeanOrClass(taskClass), runOnVirtualThread);
+    }
+
+    @Override
     public JobDefinition setAsyncTask(Function<ScheduledExecution, Uni<Void>> asyncTask) {
         checkScheduled();
         if (task != null) {
@@ -103,6 +113,12 @@ public abstract class AbstractJobDefinition implements JobDefinition {
         }
         this.asyncTask = asyncTask;
         return this;
+    }
+
+    @Override
+    public JobDefinition setAsyncTask(Class<? extends Function<ScheduledExecution, Uni<Void>>> asyncTaskClass) {
+        this.asyncTaskClass = asyncTaskClass;
+        return setAsyncTask(SchedulerUtils.instantiateBeanOrClass(asyncTaskClass));
     }
 
     protected void checkScheduled() {

--- a/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/SyntheticScheduled.java
+++ b/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/SyntheticScheduled.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 import jakarta.enterprise.util.AnnotationLiteral;
 
 import io.quarkus.scheduler.Scheduled;
+import io.vertx.core.json.JsonObject;
 
 public final class SyntheticScheduled extends AnnotationLiteral<Scheduled> implements Scheduled {
 
@@ -85,6 +86,37 @@ public final class SyntheticScheduled extends AnnotationLiteral<Scheduled> imple
     @Override
     public String timeZone() {
         return timeZone;
+    }
+
+    public String toJson() {
+        if (skipPredicate != null) {
+            throw new IllegalStateException("A skipPredicate instance may not be serialized");
+        }
+        JsonObject json = new JsonObject();
+        json.put("identity", identity);
+        json.put("cron", cron);
+        json.put("every", every);
+        json.put("delay", delay);
+        json.put("delayUnit", delayUnit.toString());
+        json.put("delayed", delayed);
+        json.put("overdueGracePeriod", overdueGracePeriod);
+        json.put("concurrentExecution", concurrentExecution.toString());
+        json.put("timeZone", timeZone);
+        return json.encode();
+    }
+
+    public static SyntheticScheduled fromJson(String json) {
+        JsonObject jsonObj = new JsonObject(json);
+        return new SyntheticScheduled(jsonObj.getString("identity"), jsonObj.getString("cron"), jsonObj.getString("every"),
+                jsonObj.getLong("delay"), TimeUnit.valueOf(jsonObj.getString("delayUnit")), jsonObj.getString("delayed"),
+                jsonObj.getString("overdueGracePeriod"), ConcurrentExecution.valueOf(jsonObj.getString("concurrentExecution")),
+                null, jsonObj.getString("timeZone"));
+    }
+
+    @Override
+    public String toString() {
+        return "SyntheticScheduled [" + (identity != null ? "identity=" + identity + ", " : "")
+                + (cron != null ? "cron=" + cron + ", " : "") + (every != null ? "every=" + every : "") + "]";
     }
 
 }

--- a/extensions/scheduler/common/src/test/java/io/quarkus/scheduler/common/runtime/util/SyntheticScheduledTest.java
+++ b/extensions/scheduler/common/src/test/java/io/quarkus/scheduler/common/runtime/util/SyntheticScheduledTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.scheduler.common.runtime.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.Scheduled.ConcurrentExecution;
+import io.quarkus.scheduler.common.runtime.SyntheticScheduled;
+
+public class SyntheticScheduledTest {
+
+    @Test
+    public void testJson() {
+        SyntheticScheduled s1 = new SyntheticScheduled("foo", "", "2s", 0, TimeUnit.SECONDS, "1s", "15m",
+                ConcurrentExecution.PROCEED, null, Scheduled.DEFAULT_TIMEZONE);
+        SyntheticScheduled s2 = SyntheticScheduled.fromJson(s1.toJson());
+        assertEquals(s1.identity(), s2.identity());
+        assertEquals(s1.concurrentExecution(), s2.concurrentExecution());
+        assertEquals(s1.cron(), s2.cron());
+        assertEquals(s1.every(), s2.every());
+        assertEquals(s1.delay(), s2.delay());
+        assertEquals(s1.delayUnit(), s2.delayUnit());
+        assertEquals(s1.delayed(), s2.delayed());
+        assertEquals(s1.overdueGracePeriod(), s2.overdueGracePeriod());
+        assertEquals(s1.timeZone(), s2.timeZone());
+    }
+
+}

--- a/integration-tests/quartz/src/main/java/io/quarkus/it/quartz/ProgrammaticJobResource.java
+++ b/integration-tests/quartz/src/main/java/io/quarkus/it/quartz/ProgrammaticJobResource.java
@@ -1,0 +1,123 @@
+package io.quarkus.it.quartz;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.quartz.SchedulerException;
+import org.quartz.TriggerKey;
+
+import io.quarkus.quartz.QuartzScheduler;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.quarkus.scheduler.ScheduledExecution;
+import io.quarkus.scheduler.Scheduler;
+import io.quarkus.scheduler.Scheduler.JobDefinition;
+import io.quarkus.scheduler.Trigger;
+import io.smallrye.mutiny.Uni;
+
+@Path("/scheduler/programmatic")
+public class ProgrammaticJobResource {
+
+    static final AtomicInteger SYNC_COUNTER = new AtomicInteger();
+    static final AtomicInteger ASYNC_COUNTER = new AtomicInteger();
+
+    @Inject
+    QuartzScheduler scheduler;
+
+    @POST
+    @Path("register")
+    public void register() {
+        JobDefinition syncJob = scheduler.newJob("sync").setInterval("1s");
+        try {
+            syncJob.setTask(se -> {
+            });
+            throw new AssertionError();
+        } catch (IllegalStateException expected) {
+        }
+        try {
+            syncJob.setTask(se -> {
+            }, true);
+            throw new AssertionError();
+        } catch (IllegalStateException expected) {
+        }
+        try {
+            syncJob.setSkipPredicate(se -> true);
+            throw new AssertionError();
+        } catch (IllegalStateException expected) {
+        }
+        syncJob.setTask(SyncJob.class).schedule();
+
+        JobDefinition asyncJob = scheduler.newJob("async").setInterval("1s");
+        try {
+            asyncJob.setAsyncTask(se -> null);
+            throw new AssertionError();
+        } catch (IllegalStateException expected) {
+        }
+        asyncJob.setAsyncTask(AsyncJob.class).schedule();
+    }
+
+    @GET
+    @Path("sync")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Integer getSyncCount() throws SchedulerException {
+        // Assert that triggers are available
+        Trigger trigger = scheduler.getScheduledJob("sync");
+        if (trigger == null) {
+            throw new IllegalStateException();
+        }
+        org.quartz.Trigger quartzTrigger = scheduler.getScheduler()
+                .getTrigger(new TriggerKey("sync", Scheduler.class.getName()));
+        if (quartzTrigger == null) {
+            throw new IllegalStateException();
+        }
+        // Return the number of executions
+        return SYNC_COUNTER.get();
+    }
+
+    @GET
+    @Path("async")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Integer getAsyncCount() throws SchedulerException {
+        // Assert that triggers are available
+        Trigger trigger = scheduler.getScheduledJob("async");
+        if (trigger == null) {
+            throw new IllegalStateException();
+        }
+        org.quartz.Trigger quartzTrigger = scheduler.getScheduler()
+                .getTrigger(new TriggerKey("async", Scheduler.class.getName()));
+        if (quartzTrigger == null) {
+            throw new IllegalStateException();
+        }
+        // Return the number of executions
+        return ASYNC_COUNTER.get();
+    }
+
+    @RegisterForReflection
+    public static class SyncJob implements Consumer<ScheduledExecution> {
+
+        @Override
+        public void accept(ScheduledExecution t) {
+            SYNC_COUNTER.incrementAndGet();
+        }
+
+    }
+
+    @RegisterForReflection
+    public static class AsyncJob implements Function<ScheduledExecution, Uni<Void>> {
+
+        @Override
+        public Uni<Void> apply(ScheduledExecution t) {
+            ASYNC_COUNTER.incrementAndGet();
+            return Uni.createFrom().voidItem();
+        }
+
+    }
+
+}

--- a/integration-tests/quartz/src/test/java/io/quarkus/it/quartz/QuartzTestCase.java
+++ b/integration-tests/quartz/src/test/java/io/quarkus/it/quartz/QuartzTestCase.java
@@ -36,6 +36,13 @@ public class QuartzTestCase {
         assertExpectedBodyString("/scheduler/instance-id", "myInstanceId");
     }
 
+    @Test
+    public void testProgrammaticJobs() {
+        given().when().post("/scheduler/programmatic/register").then().statusCode(204);
+        assertCounter("/scheduler/programmatic/sync", 1, Duration.ofSeconds(3));
+        assertCounter("/scheduler/programmatic/async", 1, Duration.ofSeconds(3));
+    }
+
     private void assertEmptyValueForDisabledMethod(String path) {
         assertExpectedBodyString(path, "");
     }


### PR DESCRIPTION
- resolves #37805

TODO:

- [ ] ~~tests that jobs registered programmatically survive app restart if a DB store type is used~~ unfortunately, I have no idea how to write an automated test for this; @machi1990 @gsmet @gastaldi do you have some idea?
- [x] docs