### PR TITLE
Add priority to OpenApiFilter to specify order of execution for multiple OASFilters

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyBuildTimeFilterPrio0.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyBuildTimeFilterPrio0.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.info.Info;
+import org.jboss.jandex.IndexView;
+
+import io.quarkus.smallrye.openapi.OpenApiFilter;
+
+/**
+ * Filter to add custom elements
+ */
+@OpenApiFilter(value = OpenApiFilter.RunStage.BUILD, priority = 0)
+public class MyBuildTimeFilterPrio0 implements OASFilter {
+
+    private IndexView view;
+
+    public MyBuildTimeFilterPrio0(IndexView aView) {
+        this.view = aView;
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI aOpenAPI) {
+        String currentDesc = Optional
+                .ofNullable(aOpenAPI.getInfo())
+                .map(Info::getDescription)
+                .orElse("");
+        aOpenAPI.setInfo(OASFactory.createInfo().description(currentDesc + "0"));
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyBuildTimeFilterPrio2.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyBuildTimeFilterPrio2.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.info.Info;
+import org.jboss.jandex.IndexView;
+
+import io.quarkus.smallrye.openapi.OpenApiFilter;
+
+/**
+ * Filter to add custom elements
+ */
+@OpenApiFilter(value = OpenApiFilter.RunStage.BUILD, priority = 2)
+public class MyBuildTimeFilterPrio2 implements OASFilter {
+
+    private IndexView view;
+
+    public MyBuildTimeFilterPrio2(IndexView aView) {
+        this.view = aView;
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI aOpenAPI) {
+        String currentDesc = Optional
+                .ofNullable(aOpenAPI.getInfo())
+                .map(Info::getDescription)
+                .orElse("");
+        aOpenAPI.setInfo(OASFactory.createInfo().description(currentDesc + "2"));
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyBuildTimeFilterPrioDefault.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyBuildTimeFilterPrioDefault.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.info.Info;
+import org.jboss.jandex.IndexView;
+
+import io.quarkus.smallrye.openapi.OpenApiFilter;
+
+/**
+ * Filter to add custom elements
+ */
+@OpenApiFilter(OpenApiFilter.RunStage.BUILD)
+public class MyBuildTimeFilterPrioDefault implements OASFilter {
+
+    private IndexView view;
+
+    public MyBuildTimeFilterPrioDefault(IndexView aView) {
+        this.view = aView;
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI aOpenAPI) {
+        String currentDesc = Optional
+                .ofNullable(aOpenAPI.getInfo())
+                .map(Info::getDescription)
+                .orElse("");
+        aOpenAPI.setInfo(OASFactory.createInfo().description(currentDesc + "1"));
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiFilterPriorityTest.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiFilterPriorityTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiFilterPriorityTest {
+    private static final String OPEN_API_PATH = "/q/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(OpenApiResource.class, ResourceBean.class,
+                            MyBuildTimeFilterPrioDefault.class, MyBuildTimeFilterPrio2.class, MyBuildTimeFilterPrio0.class));
+
+    @Test
+    public void shouldApplyFilterSortedByPriority() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("info.description", Matchers.equalTo("210"));
+
+    }
+
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/OpenApiFilter.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/OpenApiFilter.java
@@ -19,6 +19,13 @@ import java.lang.annotation.Target;
 public @interface OpenApiFilter {
     RunStage value() default RunStage.RUN; // When this filter should run, default Runtime
 
+    /**
+     * Filter with a higher priority will applied first
+     *
+     * @return
+     */
+    int priority() default 1;
+
     static enum RunStage {
         BUILD,
         RUN,


### PR DESCRIPTION
see https://github.com/quarkusio/quarkus/pull/36152#issuecomment-1866009465:

> Having multiple filters is Quarkus specific (the spec only allow one) so from a spec p.o.w a user needs to do everything in one filter. But because we allow many we can look at a way to order them for sure