### PR TITLE
Fix command line arguments being squashed

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
@@ -71,8 +71,14 @@ public interface BuildSystemRunner {
 
     default void paramsToQuarkusArgs(List<String> params, ArrayDeque<String> args) {
         if (!params.isEmpty()) {
-            args.add("-Dquarkus.args='" + String.join(" ", params) + "'");
+            args.add("-Dquarkus.args=" + String.join(" ", wrapWithDoubleQuotes(params)));
         }
+    }
+
+    default List<String> wrapWithDoubleQuotes(List<String> stringsToWrap) {
+        return stringsToWrap.stream()
+                .map("\"%s\""::formatted)
+                .toList();
     }
 
     default List<String> flattenMappedProperties(Map<String, String> props) {

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectGradleTest.java
@@ -348,8 +348,8 @@ public class CliProjectGradleTest {
         Assertions.assertFalse(result.stdout.contains("-Dsuspend"),
                 "gradle command should not specify '-Dsuspend'\n" + result);
 
-        Assertions.assertTrue(result.stdout.contains("-Dquarkus.args='arg1 arg2'"),
-                "gradle command should not specify -Dquarkus.args='arg1 arg2'\n" + result);
+        Assertions.assertTrue(result.stdout.contains("-Dquarkus.args=\"arg1\" \"arg2\""),
+                "gradle command should not specify -Dquarkus.args=\"arg1\" \"arg2\"\n" + result);
 
         // 4 TEST MODE: test --clean --debug --suspend --offline
         result = CliDriver.execute(project, "test", "-e", "--dry-run",
@@ -366,6 +366,13 @@ public class CliProjectGradleTest {
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("Run current project in test mode"), result.toString());
         Assertions.assertTrue(result.stdout.contains("--tests FooTest"), result.toString());
+
+        // 6 TEST MODE: Two word argument
+        result = CliDriver.execute(project, "dev", "-e", "--dry-run",
+                "--no-suspend", "--debug-host=0.0.0.0", "--debug-port=8008", "--debug-mode=connect", "--", "arg1 arg2");
+
+        Assertions.assertTrue(result.stdout.contains("-Dquarkus.args=\"arg1 arg2\""),
+                "mvn command should not specify -Dquarkus.args=\"arg1 arg2\"\n" + result);
     }
 
     @Test

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliProjectMavenTest.java
@@ -273,8 +273,8 @@ public class CliProjectMavenTest {
         Assertions.assertFalse(result.stdout.contains("-Dsuspend"),
                 "mvn command should not specify '-Dsuspend'\n" + result);
 
-        Assertions.assertTrue(result.stdout.contains("-Dquarkus.args='arg1 arg2'"),
-                "mvn command should not specify -Dquarkus.args='arg1 arg2'\n" + result);
+        Assertions.assertTrue(result.stdout.contains("-Dquarkus.args=\"arg1\" \"arg2\""),
+                "mvn command should not specify -Dquarkus.args=\"arg1\" \"arg2\"\n" + result);
 
         // 4 TEST MODE: test --clean --debug --suspend --offline
         result = CliDriver.execute(project, "test", "-e", "--dry-run",
@@ -291,6 +291,13 @@ public class CliProjectMavenTest {
                 "Expected OK return code. Result:\n" + result);
         Assertions.assertTrue(result.stdout.contains("Run current project in test mode"), result.toString());
         Assertions.assertTrue(result.stdout.contains("-Dtest=FooTest"), result.toString());
+
+        // 6 TEST MODE: Two word argument
+        result = CliDriver.execute(project, "dev", "-e", "--dry-run",
+                "--no-suspend", "--debug-host=0.0.0.0", "--debug-port=8008", "--debug-mode=connect", "--", "arg1 arg2");
+
+        Assertions.assertTrue(result.stdout.contains("-Dquarkus.args=\"arg1 arg2\""),
+                "mvn command should not specify -Dquarkus.args=\"arg1 arg2\"\n" + result);
     }
 
     @Test


### PR DESCRIPTION
It fixes #37921 - point first.
When Quarkus CLI was starting with individual parameters they later were treated as 1 String when the actual Application was set to start.