### PR TITLE
ArC: deprecate ArcInitConfig.Builder.setOptimizeContexts()

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Arc.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Arc.java
@@ -35,8 +35,7 @@ public final class Arc {
                 container = INSTANCE.get();
                 if (container == null) {
                     // Set the container instance first because Arc.container() can be used within ArcContainerImpl.init()
-                    container = new ArcContainerImpl(config.getCurrentContextFactory(),
-                            config.isStrictCompatibility(), config.isOptimizeContexts());
+                    container = new ArcContainerImpl(config.getCurrentContextFactory(), config.isStrictCompatibility());
                     INSTANCE.set(container);
                     container.init();
                 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcInitConfig.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcInitConfig.java
@@ -39,6 +39,12 @@ public final class ArcInitConfig {
         return currentContextFactory;
     }
 
+    /**
+     *
+     * @return {@code true} if optimized contexts should be used, {@code false} otherwise
+     * @deprecated This method was never used and will be removed at some point after Quarkus 3.10
+     */
+    @Deprecated(since = "3.7", forRemoval = true)
     public boolean isOptimizeContexts() {
         return optimizeContexts;
     }
@@ -65,6 +71,14 @@ public final class ArcInitConfig {
             return this;
         }
 
+        /**
+         * The value was actually never used.
+         *
+         * @param value
+         * @return this
+         * @deprecated This value was never used; this method will be removed at some point after Quarkus 3.10
+         */
+        @Deprecated(since = "3.7", forRemoval = true)
         public Builder setOptimizeContexts(boolean value) {
             optimizeContexts = value;
             return this;

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -104,7 +104,7 @@ public class ArcContainerImpl implements ArcContainer {
 
     private final boolean strictMode;
 
-    public ArcContainerImpl(CurrentContextFactory currentContextFactory, boolean strictMode, boolean optimizeContexts) {
+    public ArcContainerImpl(CurrentContextFactory currentContextFactory, boolean strictMode) {
         this.strictMode = strictMode;
         id = String.valueOf(ID_GENERATOR.incrementAndGet());
         running = new AtomicBoolean(true);


### PR DESCRIPTION
- this value was actually never used