### PR TITLE
Bump dekorate to 4.1.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -164,7 +164,7 @@
         <kotlin.coroutine.version>1.7.3</kotlin.coroutine.version>
         <azure.toolkit-lib.version>0.27.0</azure.toolkit-lib.version>
         <kotlin-serialization.version>1.6.2</kotlin-serialization.version>
-        <dekorate.version>4.1.1</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
+        <dekorate.version>4.1.2</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>
         <jboss-logmanager.version>3.0.4.Final</jboss-logmanager.version>


### PR DESCRIPTION
This pull request bumps dekorate to 4.1.2 that makes `ServiceMonitor` resource `Namespaced`.

Resolves: #37855