### PR TITLE
Avoid executing OpenAPI build filters twice on build

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -1117,7 +1117,7 @@ public class SmallRyeOpenApiProcessor {
 
     private OpenApiDocument loadDocument(OpenAPI staticModel, OpenAPI annotationModel,
             List<AddToOpenAPIDefinitionBuildItem> openAPIBuildItems, IndexView index) {
-        OpenApiDocument document = prepareOpenApiDocument(staticModel, annotationModel, openAPIBuildItems, index);
+        OpenApiDocument document = prepareOpenApiDocument(staticModel, annotationModel, openAPIBuildItems, index, true);
 
         Config c = ConfigProvider.getConfig();
         String title = c.getOptionalValue("quarkus.application.name", String.class).orElse("Generated");
@@ -1146,7 +1146,7 @@ public class SmallRyeOpenApiProcessor {
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = new OpenApiConfigImpl(config);
 
-        OpenApiDocument document = prepareOpenApiDocument(loadedModel, null, Collections.emptyList(), index);
+        OpenApiDocument document = prepareOpenApiDocument(loadedModel, null, Collections.emptyList(), index, false);
 
         if (includeRuntimeFilters) {
             List<String> userDefinedRuntimeFilters = getUserDefinedRuntimeFilters(openApiConfig, index);
@@ -1186,7 +1186,8 @@ public class SmallRyeOpenApiProcessor {
     private OpenApiDocument prepareOpenApiDocument(OpenAPI staticModel,
             OpenAPI annotationModel,
             List<AddToOpenAPIDefinitionBuildItem> openAPIBuildItems,
-            IndexView index) {
+            IndexView index,
+            boolean executeBuildFilters) {
         Config config = ConfigProvider.getConfig();
         OpenApiConfig openApiConfig = new OpenApiConfigImpl(config);
 
@@ -1203,10 +1204,12 @@ public class SmallRyeOpenApiProcessor {
             OASFilter otherExtensionFilter = openAPIBuildItem.getOASFilter();
             document.filter(otherExtensionFilter);
         }
-        // Add user defined Build time filters
-        List<String> userDefinedFilters = getUserDefinedBuildtimeFilters(index);
-        for (String filter : userDefinedFilters) {
-            document.filter(filter(filter, index));
+        // Add user defined Build time filters if necessary
+        if (executeBuildFilters) {
+            List<String> userDefinedFilters = getUserDefinedBuildtimeFilters(index);
+            for (String filter : userDefinedFilters) {
+                document.filter(filter(filter, index));
+            }
         }
         return document;
     }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/CounterBuildtimeFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/CounterBuildtimeFilter.java
@@ -1,0 +1,25 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+
+import io.quarkus.smallrye.openapi.OpenApiFilter;
+
+@OpenApiFilter(OpenApiFilter.RunStage.BUILD)
+public class CounterBuildtimeFilter implements OASFilter {
+
+    private static final AtomicInteger TIMES = new AtomicInteger();
+
+    public CounterBuildtimeFilter() {
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI aOpenAPI) {
+        int times = TIMES.incrementAndGet();
+        aOpenAPI.info(
+                OASFactory.createInfo().description("CounterBuildtimeFilter was called " + times + " time(s)"));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiAnnotatedCounterBuildtimeFilterTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiAnnotatedCounterBuildtimeFilterTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class OpenApiAnnotatedCounterBuildtimeFilterTestCase {
+    private static final String OPEN_API_PATH = "/q/openapi";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(OpenApiResource.class, ResourceBean.class, CounterBuildtimeFilter.class));
+
+    @Test
+    public void testOpenApiFilterResource() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("info.description", Matchers.startsWith("CounterBuildtimeFilter was called 1 time(s)"));
+
+    }
+
+}


### PR DESCRIPTION
Fixes #37901 