### PR TITLE
Add quarkus version annotation to kubernetes resources

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
@@ -54,6 +54,7 @@ public final class Constants {
     static final String QUARKUS_ANNOTATIONS_COMMIT_ID = "app.quarkus.io/commit-id";
     static final String QUARKUS_ANNOTATIONS_VCS_URL = "app.quarkus.io/vcs-uri";
     static final String QUARKUS_ANNOTATIONS_BUILD_TIMESTAMP = "app.quarkus.io/build-timestamp";
+    static final String QUARKUS_ANNOTATIONS_QUARKUS_VERSION = "app.quarkus.io/quarkus-version";
 
     public static final String HTTP_PORT = "http";
     public static final int DEFAULT_HTTP_PORT = 8080;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
@@ -7,6 +7,7 @@ import static io.quarkus.kubernetes.deployment.Constants.HTTP_PORT;
 import static io.quarkus.kubernetes.deployment.Constants.KNATIVE;
 import static io.quarkus.kubernetes.deployment.Constants.QUARKUS_ANNOTATIONS_BUILD_TIMESTAMP;
 import static io.quarkus.kubernetes.deployment.Constants.QUARKUS_ANNOTATIONS_COMMIT_ID;
+import static io.quarkus.kubernetes.deployment.Constants.QUARKUS_ANNOTATIONS_QUARKUS_VERSION;
 import static io.quarkus.kubernetes.deployment.Constants.QUARKUS_ANNOTATIONS_VCS_URL;
 import static io.quarkus.kubernetes.deployment.Constants.SERVICE_ACCOUNT;
 
@@ -81,6 +82,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
+import io.quarkus.builder.Version;
 import io.quarkus.container.spi.ContainerImageInfoBuildItem;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
@@ -977,6 +979,8 @@ public class KubernetesCommonHelper {
             result.add(new DecoratorBuildItem(target, new RemoveAnnotationDecorator(Annotations.VCS_URL)));
             result.add(new DecoratorBuildItem(target, new RemoveAnnotationDecorator(Annotations.COMMIT_ID)));
 
+            result.add(new DecoratorBuildItem(target, new AddAnnotationDecorator(name,
+                    new Annotation(QUARKUS_ANNOTATIONS_QUARKUS_VERSION, Version.getVersion(), new String[0]))));
             //Add quarkus vcs annotations
             if (commitId != null && !config.isIdempotent()) {
                 result.add(new DecoratorBuildItem(target, new AddAnnotationDecorator(name,

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeTest.java
@@ -43,6 +43,7 @@ public class KnativeTest {
                 assertThat(s.getSpec()).satisfies(spec -> {
                     assertThat(s.getMetadata()).satisfies(m -> {
                         assertThat(m.getNamespace()).isNull();
+                        assertThat(m.getAnnotations().get("app.quarkus.io/quarkus-version")).isNotBlank();
                     });
 
                     assertThat(spec.getTemplate()).satisfies(template -> {

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithIdempotentTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithIdempotentTest.java
@@ -43,6 +43,7 @@ public class KubernetesWithIdempotentTest {
         assertThat(kubernetesList).allSatisfy(resource -> {
             assertThat(resource.getMetadata()).satisfies(m -> {
                 assertThat(m.getName()).isEqualTo(APP_NAME);
+                assertThat(m.getAnnotations().get("app.quarkus.io/quarkus-version")).isNotBlank();
                 assertThat(m.getAnnotations().get("app.quarkus.io/commit-id")).isNull();
                 assertThat(m.getAnnotations().get("app.quarkus.io/build-timestamp")).isNull();
             });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftV3Test.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftV3Test.java
@@ -47,6 +47,7 @@ public class OpenshiftV3Test {
                 assertThat(m.getLabels().get("app.kubernetes.io/name")).isEqualTo("openshift-v3");
                 assertThat(m.getLabels().get("app")).isEqualTo("openshift-v3");
                 assertThat(m.getNamespace()).isNull();
+                assertThat(m.getAnnotations().get("app.quarkus.io/quarkus-version")).isNotBlank();
             });
             AbstractObjectAssert<?, ?> specAssert = assertThat(h).extracting("spec");
             specAssert.extracting("selector").isInstanceOfSatisfying(Map.class, selectorsMap -> {

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftV4DeploymentConfigTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftV4DeploymentConfigTest.java
@@ -47,6 +47,7 @@ public class OpenshiftV4DeploymentConfigTest {
                 assertThat(m.getLabels().get("app.kubernetes.io/name")).isEqualTo("openshift-v4-deploymentconfig");
                 assertThat(m.getLabels().get("app")).isNull();
                 assertThat(m.getNamespace()).isNull();
+                assertThat(m.getAnnotations().get("app.quarkus.io/quarkus-version")).isNotBlank();
             });
             AbstractObjectAssert<?, ?> specAssert = assertThat(h).extracting("spec");
             specAssert.extracting("selector").isInstanceOfSatisfying(Map.class, selectorsMap -> {

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftV4Test.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftV4Test.java
@@ -47,6 +47,7 @@ public class OpenshiftV4Test {
                 assertThat(m.getLabels().get("app.kubernetes.io/name")).isEqualTo("openshift-v4");
                 assertThat(m.getLabels().get("app")).isNull();
                 assertThat(m.getNamespace()).isNull();
+                assertThat(m.getAnnotations().get("app.quarkus.io/quarkus-version")).isNotBlank();
             });
             AbstractObjectAssert<?, ?> specAssert = assertThat(h).extracting("spec");
             specAssert.extracting("selector.matchLabels").isInstanceOfSatisfying(Map.class, selectorsMap -> {


### PR DESCRIPTION
The pull request adds the Quarkus version as an annotation. This is extremely useful for all kinds of reasons.