### PR TITLE
[3.6] Upgrade to Hibernate ORM 6.2.18.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -97,7 +97,7 @@
         <classmate.version>1.5.1</classmate.version>
         <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below),
              as well as hibernate-orm.version-for-documentation in docs/pom.xml -->
-        <hibernate-orm.version>6.2.13.Final</hibernate-orm.version>
+        <hibernate-orm.version>6.2.18.Final</hibernate-orm.version>
         <bytebuddy.version>1.14.7</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
         <hibernate-reactive.version>2.0.6.Final</hibernate-reactive.version>


### PR DESCRIPTION
Let's try to get 6.2.18.Final for the Quarkus 3.6.5 I will release tomorrow.