### PR TITLE
JDK-8316304 in JDK 21 introduced a new field accessed through JNI

### DIFF
--- a/integration-tests/main/src/test/resources/image-metrics/23.1/image-metrics.properties
+++ b/integration-tests/main/src/test/resources/image-metrics/23.1/image-metrics.properties
@@ -20,5 +20,5 @@ analysis_results.classes.jni=62
 analysis_results.classes.jni.tolerance=1
 analysis_results.methods.jni=55
 analysis_results.methods.jni.tolerance=1
-analysis_results.fields.jni=61
-analysis_results.fields.jni.tolerance=1
+analysis_results.fields.jni=62
+analysis_results.fields.jni.tolerance=2


### PR DESCRIPTION
Similar fix to `main` which was done in
https://github.com/quarkusio/quarkus/pull/37813 for jpa-postgresql and in https://github.com/quarkusio/quarkus/pull/37879 for jpa-postgresql-withxml.

Openning as draft till tests with mandrel 23.1 and JDK 21.0.1+12 build complete in https://github.com/graalvm/mandrel/actions/runs/7461888676

cc @jerboaa 