### PR TITLE
Fix Build Scan conditional publication

### DIFF
--- a/.mvn/gradle-enterprise-custom-user-data.groovy
+++ b/.mvn/gradle-enterprise-custom-user-data.groovy
@@ -12,6 +12,17 @@ if(session?.getRequest()?.getBaseDirectory() != null) {
     if(!publish) {
         // do not publish a build scan for test builds
         log.debug("Disabling build scan publication for " + session.getRequest().getBaseDirectory())
+
+        // change storage location on CI to avoid Develocity scan dumps with disabled publication to be captured for republication
+        if (System.env.GITHUB_ACTIONS) {
+            try {
+                def storageLocationTmpDir = java.nio.file.Files.createTempDirectory(java.nio.file.Paths.get(System.env.RUNNER_TEMP), "buildScanTmp").toAbsolutePath()
+                log.debug('Update storage location to ' + storageLocationTmpDir)
+                gradleEnterprise.setStorageDirectory(storageLocationTmpDir)
+            } catch (IOException e) {
+                log.error('Temporary storage location directory cannot be created, the Build Scan will be published', e)
+            }
+        }
     }
 }
 buildScan.publishAlwaysIf(publish)


### PR DESCRIPTION
### Issue
The Develocity Build Scan publication is disabled for test builds (see [here](https://github.com/quarkusio/quarkus/blob/02471b809f0ce693b570af057d287127d43defa9/.mvn/gradle-enterprise-custom-user-data.groovy#L11)).
Disabling the publication does not prevent the scan dump from being created and later on [captured](https://github.com/quarkusio/quarkus/blob/02471b809f0ce693b570af057d287127d43defa9/.github/workflows/ci-actions-incremental.yml#L141) while running the Quarkus CI Github workflow.
Captured scan dumps are eventually published to [Develocity](https://ge.quarkus.io/) in a separate [workflow](https://github.com/quarkusio/quarkus/blob/main/.github/workflows/develocity-publish-build-scans.yml), which was not the intention.

### Fix
There is no way to prevent the scan dump from being created, the best option is to make sure the scan dump won't be captured by changing its storage location on CI.