### PR TITLE
Make sure we can do a GET with a CSRF token cookie and still obtain the token

### DIFF
--- a/integration-tests/csrf-reactive/src/main/java/io/quarkus/it/csrf/TestResource.java
+++ b/integration-tests/csrf-reactive/src/main/java/io/quarkus/it/csrf/TestResource.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.resteasy.reactive.RestForm;
 
+import io.quarkus.csrf.reactive.runtime.CsrfTokenParameterProvider;
 import io.quarkus.csrf.reactive.runtime.CsrfTokenUtils;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
@@ -46,6 +47,9 @@ public class TestResource {
 
     @Inject
     RoutingContext routingContext;
+
+    @Inject
+    CsrfTokenParameterProvider parameterProvider;
 
     @GET
     @Path("/csrfTokenForm")
@@ -151,6 +155,13 @@ public class TestResource {
     @Produces(MediaType.TEXT_PLAIN)
     public String getSimpleGet() {
         return "hello";
+    }
+
+    @GET
+    @Path("/token")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getToken() {
+        return this.parameterProvider.getToken();
     }
 
     public static class MultiPart {

--- a/integration-tests/csrf-reactive/src/main/resources/application.properties
+++ b/integration-tests/csrf-reactive/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.csrf-reactive.cookie-name=csrftoken
-quarkus.csrf-reactive.create-token-path=/service/csrfTokenForm,/service/csrfTokenFirstForm,/service/csrfTokenSecondForm,/service/csrfTokenWithFormRead,/service/csrfTokenMultipart,/service/csrfTokenWithHeader
+quarkus.csrf-reactive.create-token-path=/service/csrfTokenForm,/service/csrfTokenFirstForm,/service/csrfTokenSecondForm,/service/csrfTokenWithFormRead,/service/csrfTokenMultipart,/service/csrfTokenWithHeader,/service/token
 quarkus.csrf-reactive.token-signature-key=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 
 quarkus.http.auth.basic=true

--- a/integration-tests/csrf-reactive/src/test/java/io/quarkus/it/csrf/CsrfReactiveTest.java
+++ b/integration-tests/csrf-reactive/src/test/java/io/quarkus/it/csrf/CsrfReactiveTest.java
@@ -349,6 +349,31 @@ public class CsrfReactiveTest {
         }
     }
 
+    @Test
+    public void testGetWithCsrfToken() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            assertNull(webClient.getCookieManager().getCookie("csrftoken"));
+
+            TextPage htmlPage = webClient.getPage("http://localhost:8081/service/token");
+
+            assertNotNull(webClient.getCookieManager().getCookie("csrftoken"));
+
+            // Can't check that it matches the cookie because it's signed
+            assertNotNull(htmlPage.getContent());
+
+            // get it again
+            htmlPage = webClient.getPage("http://localhost:8081/service/token");
+
+            assertNotNull(webClient.getCookieManager().getCookie("csrftoken"));
+
+            // Can't check that it matches the cookie because it's signed
+            assertNotNull(htmlPage.getContent());
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
     private WebClient createWebClient() {
         WebClient webClient = new WebClient();
         webClient.setCssErrorHandler(new SilentCssErrorHandler());


### PR DESCRIPTION
This is only a test to make sure we never regress on such a common use-case. This was already fixed in #37725