### PR TITLE
Fix swallowed failures in Reactive SQL Client tests

### DIFF
--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/MSSQLPoolProducerTest.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/MSSQLPoolProducerTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.reactive.mssql.client;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -41,10 +40,8 @@ public class MSSQLPoolProducerTest {
         @Inject
         MSSQLPool mssqlClient;
 
-        public CompletionStage<Void> verify() {
-            CompletableFuture<Void> cf = new CompletableFuture<>();
-            mssqlClient.query("SELECT 1").execute(ar -> cf.complete(null));
-            return cf;
+        public CompletionStage<?> verify() {
+            return mssqlClient.query("SELECT 1").execute().toCompletionStage();
         }
     }
 
@@ -57,7 +54,6 @@ public class MSSQLPoolProducerTest {
         public CompletionStage<Void> verify() {
             return mssqlClient.query("SELECT 1").execute()
                     .onItem().ignore().andContinueWithNull()
-                    .onFailure().recoverWithItem((Void) null)
                     .subscribeAsCompletionStage();
         }
     }

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/application-default-datasource.properties
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/application-default-datasource.properties
@@ -1,2 +1,4 @@
 quarkus.datasource.db-kind=mssql
+quarkus.datasource.username=sa
+quarkus.datasource.password=yourStrong(!)Password
 quarkus.datasource.reactive.url=${reactive-mssql.url}

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MySQLPoolProducerTest.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/MySQLPoolProducerTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.reactive.mysql.client;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -40,10 +39,8 @@ public class MySQLPoolProducerTest {
         @Inject
         MySQLPool mysqlClient;
 
-        public CompletionStage<Void> verify() {
-            CompletableFuture<Void> cf = new CompletableFuture<>();
-            mysqlClient.query("SELECT 1").execute(ar -> cf.complete(null));
-            return cf;
+        public CompletionStage<?> verify() {
+            return mysqlClient.query("SELECT 1").execute().toCompletionStage();
         }
     }
 
@@ -56,7 +53,6 @@ public class MySQLPoolProducerTest {
         public CompletionStage<Void> verify() {
             return mysqlClient.query("SELECT 1").execute()
                     .onItem().ignore().andContinueWithNull()
-                    .onFailure().recoverWithItem((Void) null)
                     .subscribeAsCompletionStage();
         }
     }

--- a/extensions/reactive-mysql-client/deployment/src/test/resources/application-default-datasource.properties
+++ b/extensions/reactive-mysql-client/deployment/src/test/resources/application-default-datasource.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=mysql
+quarkus.datasource.username=hibernate_orm_test
+quarkus.datasource.password=hibernate_orm_test
+quarkus.datasource.reactive.url=${reactive-mysql.url}

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/OraclePoolProducerTest.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/OraclePoolProducerTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.reactive.oracle.client;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -41,10 +40,8 @@ public class OraclePoolProducerTest {
         @Inject
         OraclePool oracleClient;
 
-        public CompletionStage<Void> verify() {
-            CompletableFuture<Void> cf = new CompletableFuture<>();
-            oracleClient.query("SELECT 1 FROM DUAL").execute(ar -> cf.complete(null));
-            return cf;
+        public CompletionStage<?> verify() {
+            return oracleClient.query("SELECT 1 FROM DUAL").execute().toCompletionStage();
         }
     }
 
@@ -57,7 +54,6 @@ public class OraclePoolProducerTest {
         public CompletionStage<Void> verify() {
             return oracleClient.query("SELECT 1 FROM DUAL").execute()
                     .onItem().ignore().andContinueWithNull()
-                    .onFailure().recoverWithItem((Void) null)
                     .subscribeAsCompletionStage();
         }
     }

--- a/extensions/reactive-oracle-client/deployment/src/test/resources/application-default-datasource.properties
+++ b/extensions/reactive-oracle-client/deployment/src/test/resources/application-default-datasource.properties
@@ -1,2 +1,4 @@
 quarkus.datasource.db-kind=oracle
+quarkus.datasource.username=SYSTEM
+quarkus.datasource.password=hibernate_orm_test
 quarkus.datasource.reactive.url=${reactive-oracledb.url}

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/PgPoolProducerTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/PgPoolProducerTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.reactive.pg.client;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -41,10 +40,8 @@ public class PgPoolProducerTest {
         @Inject
         PgPool pgClient;
 
-        public CompletionStage<Void> verify() {
-            CompletableFuture<Void> cf = new CompletableFuture<>();
-            pgClient.query("SELECT 1").execute(ar -> cf.complete(null));
-            return cf;
+        public CompletionStage<?> verify() {
+            return pgClient.query("SELECT 1").execute().toCompletionStage();
         }
     }
 
@@ -57,7 +54,6 @@ public class PgPoolProducerTest {
         public CompletionStage<Void> verify() {
             return pgClient.query("SELECT 1").execute()
                     .onItem().ignore().andContinueWithNull()
-                    .onFailure().recoverWithItem(() -> null)
                     .subscribeAsCompletionStage();
         }
     }

--- a/extensions/reactive-pg-client/deployment/src/test/resources/application-default-datasource.properties
+++ b/extensions/reactive-pg-client/deployment/src/test/resources/application-default-datasource.properties
@@ -1,2 +1,4 @@
 quarkus.datasource.db-kind=postgresql
-quarkus.datasource.username=username-default
+quarkus.datasource.username=hibernate_orm_test
+quarkus.datasource.password=hibernate_orm_test
+quarkus.datasource.reactive.url=${reactive-postgres.url}


### PR DESCRIPTION
I have no idea why these tests swallow failures, but it doesn't seem necessary to test the CDI bean producer... 
I mean we're not even checking that failures occur, so I really don't know why we would trigger those failures.

I'd like to fix this in order to reuse `application-default-datasource.properties` in other tests for another PR. Currently it's not possible, since that file is incomplete: depending on the client, sometimes it's completely empty, sometimes it's lacking credentials, ...

Hey @tsegismont can you confirm I didn't overlook some important reason to have connections fail and ignore the failures here?