### PR TITLE
Arc - Decide whether req. context is active based on validity of its ContextState

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/router/ReqContextActivationTerminationTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/router/ReqContextActivationTerminationTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.vertx.http.router;
+
+import static org.hamcrest.Matchers.is;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.ext.web.Router;
+
+/**
+ * Test is located here so that {@code VertxCurrentContextFactory} is used within req. context implementation.
+ * See also https://github.com/quarkusio/quarkus/issues/37741
+ */
+public class ReqContextActivationTerminationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(BeanWithObserver.class));
+
+    @Test
+    public void testRoute() {
+        RestAssured.when().get("/boom").then().statusCode(200).body(is("ok"));
+    }
+
+    @Singleton
+    public static class BeanWithObserver {
+
+        private static int counter;
+
+        void observeRouter(@Observes StartupEvent startup, Router router) {
+            router.get("/boom").handler(ctx -> {
+                // context starts as inactive; we perform manual activation/termination and assert
+                Assertions.assertEquals(false, Arc.container().requestContext().isActive());
+                Arc.container().requestContext().activate();
+                Assertions.assertEquals(true, Arc.container().requestContext().isActive());
+                Arc.container().requestContext().terminate();
+                Assertions.assertEquals(false, Arc.container().requestContext().isActive());
+                ctx.response().setStatusCode(200).end("ok");
+            });
+        }
+
+    }
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
@@ -112,7 +112,8 @@ class RequestContext implements ManagedContext {
 
     @Override
     public boolean isActive() {
-        return currentContext.get() != null;
+        RequestContextState requestContextState = currentContext.get();
+        return requestContextState == null ? false : requestContextState.isValid();
     }
 
     @Override


### PR DESCRIPTION
Fixes #37741

@michalvavrik Can you give this a spin please? I did test it with your first reproducer (the `code-with-quarkus` with added observer) but not much else yet.

I am still trying to understand why we never clear the context state from duplicated context but I didn't get any closer to an explanation yet. It could just be an optimization :shrug: 

I'll try to some simple test as well but I first wanted to see what CI thinks about it as I only ran tests from few modules locally.