### PR TITLE
Don't fail testCallBackContextIsNotFailed on aborted tests

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestCallbacksITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestCallbacksITCase.java
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.opentest4j.TestAbortedException;
 
+import io.quarkus.test.common.TestStatus;
 import io.quarkus.test.junit.QuarkusIntegrationTestExtension;
 
 /**
@@ -58,7 +60,10 @@ public class QuarkusTestCallbacksITCase {
     @Test
     @Order(4)
     public void testCallbackContextIsNotFailed() {
-        assertFalse(TestContextCheckerBeforeEachCallback.CONTEXT.getTestStatus().isTestFailed());
+        TestStatus testStatus = TestContextCheckerBeforeEachCallback.CONTEXT.getTestStatus();
+        // Ignore The test should not be marked as failed, unless it was aborted.
+        assertFalse(testStatus.isTestFailed() && !(testStatus.getTestErrorCause() instanceof TestAbortedException),
+                testStatus.getTestErrorCause().toString());
         // To force the exception in the before each handler.
         throwsCustomException = true;
     }


### PR DESCRIPTION
As seen in https://github.com/quarkusio/quarkus/issues/37809 `testCallBackContextIsNotFailed` fails when other tests get aborted due to a failing assumption, e.g. in https://github.com/quarkusio/quarkus/blob/21f055a531ec2828c5224e304fc0b4cc8f3707fb/test-framework/junit5/src/main/java/io/quarkus/test/junit/nativeimage/NativeBuildOutputExtension.java#L54

This happens because test failures are recorded in the test's extension context through `io.quarkus.test.junit.AbstractQuarkusTestWithContextExtension` and are then seen by `io.quarkus.it.main.QuarkusTestCallbacksITCase#testCallbackContextIsNotFailed` which checks to see the test status of the context in https://github.com/quarkusio/quarkus/blob/1ed54f025198d4ef728b38fe7fe6f880518b1592/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestCallbacksITCase.java#L61

This is a naive fix that doesn't treat `TestAbortedException`s as failures for the said test.