### PR TITLE
Support ManyToOne queries in Panache REST resource

### DIFF
--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/PanacheEntityResourceGetMethodTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/PanacheEntityResourceGetMethodTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.hibernate.orm.rest.data.panache.deployment.entity;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,22 @@ class PanacheEntityResourceGetMethodTest extends AbstractGetMethodTest {
                 .then().statusCode(200)
                 .and().body("id", is("full"))
                 .and().body("name", is("full collection"));
+    }
+
+    @Test
+    void shouldReturnItemsForFullCollection() {
+        given().accept("application/json")
+                .when().get("/items?collection.id=full")
+                .then().statusCode(200)
+                .body("$", hasSize(2));
+    }
+
+    @Test
+    void shouldReturnNoItemsForEmptyCollection() {
+        given().accept("application/json")
+                .when().get("/items?collection.id=empty")
+                .then().statusCode(200)
+                .body("$", hasSize(0));
     }
 
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
@@ -184,7 +184,11 @@ public class ListMethodImplementor extends StandardMethodImplementor {
         parameters.add(param("size", int.class, intType()));
         parameters.add(param("uriInfo", UriInfo.class));
         parameters.add(param("namedQuery", String.class));
-        parameters.addAll(compatibleFieldsForQuery);
+        for (SignatureMethodCreator.Parameter param : compatibleFieldsForQuery) {
+            parameters.add(param(
+                    param.getName().replace(".", "__"),
+                    param.getClazz()));
+        }
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(getMethodName(), classCreator,
                 isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
                 parameters.toArray(new SignatureMethodCreator.Parameter[0]));
@@ -271,7 +275,11 @@ public class ListMethodImplementor extends StandardMethodImplementor {
         List<SignatureMethodCreator.Parameter> parameters = new ArrayList<>();
         parameters.add(param("sort", List.class, parameterizedType(classType(List.class), classType(String.class))));
         parameters.add(param("namedQuery", String.class));
-        parameters.addAll(compatibleFieldsForQuery);
+        for (SignatureMethodCreator.Parameter param : compatibleFieldsForQuery) {
+            parameters.add(param(
+                    param.getName().replace(".", "__"),
+                    param.getClazz()));
+        }
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(getMethodName(), classCreator,
                 isNotReactivePanache() ? responseType() : uniType(resourceMetadata.getEntityType()),
                 parameters.toArray(new SignatureMethodCreator.Parameter[0]));
@@ -321,13 +329,14 @@ public class ListMethodImplementor extends StandardMethodImplementor {
         ResultHandle queryList = creator.newInstance(ofConstructor(ArrayList.class));
         for (Map.Entry<String, ResultHandle> field : fieldValues.entrySet()) {
             String fieldName = field.getKey();
+            String paramName = fieldName.replace(".", "__");
             ResultHandle fieldValueFromQuery = field.getValue();
             BytecodeCreator fieldValueFromQueryIsSet = creator.ifNotNull(fieldValueFromQuery).trueBranch();
             fieldValueFromQueryIsSet.invokeInterfaceMethod(ofMethod(List.class, "add", boolean.class, Object.class),
-                    queryList, fieldValueFromQueryIsSet.load(fieldName + "=:" + fieldName));
+                    queryList, fieldValueFromQueryIsSet.load(fieldName + "=:" + paramName));
             fieldValueFromQueryIsSet.invokeInterfaceMethod(
                     ofMethod(Map.class, "put", Object.class, Object.class, Object.class),
-                    dataParams, fieldValueFromQueryIsSet.load(fieldName), fieldValueFromQuery);
+                    dataParams, fieldValueFromQueryIsSet.load(paramName), fieldValueFromQuery);
         }
 
         /**

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/EntityTypeUtils.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/EntityTypeUtils.java
@@ -16,6 +16,10 @@ import io.quarkus.rest.data.panache.deployment.ResourceMethodListenerBuildItem;
 
 public final class EntityTypeUtils {
 
+    // https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.5
+    public static final int ACC_STATIC = 0x0008;
+    public static final int ACC_FINAL = 0x0010;
+
     private EntityTypeUtils() {
 
     }
@@ -25,7 +29,46 @@ public final class EntityTypeUtils {
         ClassInfo currentEntityClass = index.getClassByName(entityTypeName);
         while (currentEntityClass != null) {
             for (FieldInfo field : currentEntityClass.fields()) {
+                // skip static fields
+                if ((field.flags() & ACC_STATIC) != 0) {
+                    continue;
+                }
+                // skip final fields
+                if ((field.flags() & ACC_FINAL) != 0) {
+                    continue;
+                }
+                // skip fields with Transient annotation
+                if (field.hasAnnotation(DotName.createSimple("jakarta.persistence.Transient"))) {
+                    continue;
+                }
+
                 fields.put(field.name(), field.type());
+
+                // if the field is a ManyToOne relation, add the Id field of the relation to the fields map
+                if (field.type().kind() == Type.Kind.CLASS
+                        && field.hasAnnotation(DotName.createSimple("jakarta.persistence.ManyToOne"))) {
+                    // get the class info for the relation field
+                    ClassInfo currentRelationClass = index.getClassByName(field.type().name());
+                    while (currentRelationClass != null) {
+                        // get the field with Id annotation
+                        FieldInfo relationIdField = currentRelationClass.fields().stream().filter((relationField) -> {
+                            return relationField.hasAnnotation(DotName.createSimple("jakarta.persistence.Id"));
+                        }).findFirst().orElse(null);
+                        // if the field is not null, add it to the fields map
+                        if (relationIdField != null) {
+                            fields.put(field.name() + "." + relationIdField.name(), relationIdField.type());
+                        }
+
+                        // get the super class of the relation class
+                        if (currentRelationClass.superName() != null) {
+                            currentRelationClass = index.getClassByName(currentRelationClass.superName());
+                        } else {
+                            currentRelationClass = null;
+                        }
+                    }
+
+                }
+
             }
 
             if (currentEntityClass.superName() != null) {

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/SignatureMethodCreator.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/SignatureMethodCreator.java
@@ -72,6 +72,14 @@ public final class SignatureMethodCreator {
         public String getName() {
             return name;
         }
+
+        public Type getType() {
+            return type;
+        }
+
+        public Object getClazz() {
+            return clazz;
+        }
     }
 
     public static class ReturnType {


### PR DESCRIPTION
This small PR adds query parameters for ManyToOne relations, e.g. `/api/v1/product-variations?product=1`, where product is the parent Product for this ProductVariation:

 ```java
    @JsonIgnore
    @ManyToOne(fetch = FetchType.LAZY)
    @NotNull
    private Product product;
```

This should resolve #32150
