### PR TITLE
ArC: introduce quarkus.arc.optimize-contexts=auto

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
@@ -224,13 +224,21 @@ public class ArcConfig {
     public ArcContextPropagationConfig contextPropagation;
 
     /**
-     * If set to {@code true}, the container should try to optimize the contexts for some of the scopes.
+     * If set to {@code true}, the container should try to optimize the contexts for some of the scopes. If set to {@code auto}
+     * then optimize the contexts if there's less than 1000 beans in the application. If set to {@code false} do not optimize
+     * the contexts.
      * <p>
      * Typically, some implementation parts of the context for {@link jakarta.enterprise.context.ApplicationScoped} could be
      * pregenerated during build.
      */
-    @ConfigItem(defaultValue = "true", generateDocumentation = false)
-    public boolean optimizeContexts;
+    @ConfigItem(defaultValue = "auto", generateDocumentation = false)
+    public OptimizeContexts optimizeContexts;
+
+    public enum OptimizeContexts {
+        TRUE,
+        FALSE,
+        AUTO
+    }
 
     public final boolean isRemoveUnusedBeansFieldValid() {
         return ALLOWED_REMOVE_UNUSED_BEANS_VALUES.contains(removeUnusedBeans.toLowerCase());

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/context/optimized/OptimizeContextsAutoTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/context/optimized/OptimizeContextsAutoTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.arc.test.context.optimized;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ServiceLoader;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.ComponentsProvider;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptimizeContextsAutoTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(SimpleBean.class))
+            .overrideConfigKey("quarkus.arc.optimize-contexts", "auto");
+
+    @Inject
+    SimpleBean bean;
+
+    @Test
+    public void testContexts() {
+        assertTrue(bean.ping());
+        for (ComponentsProvider componentsProvider : ServiceLoader.load(ComponentsProvider.class)) {
+            // We have less than 1000 beans
+            assertFalse(componentsProvider.getComponents().getContextInstances().isEmpty());
+        }
+    }
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/context/optimized/OptimizeContextsDisabledTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/context/optimized/OptimizeContextsDisabledTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.arc.test.context.optimized;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ServiceLoader;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.ComponentsProvider;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptimizeContextsDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(SimpleBean.class))
+            .overrideConfigKey("quarkus.arc.optimize-contexts", "false");
+
+    @Inject
+    SimpleBean bean;
+
+    @Test
+    public void testContexts() {
+        assertTrue(bean.ping());
+        for (ComponentsProvider componentsProvider : ServiceLoader.load(ComponentsProvider.class)) {
+            assertTrue(componentsProvider.getComponents().getContextInstances().isEmpty());
+        }
+    }
+
+}

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/context/optimized/SimpleBean.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/context/optimized/SimpleBean.java
@@ -1,0 +1,12 @@
+package io.quarkus.arc.test.context.optimized;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+class SimpleBean {
+
+    public boolean ping() {
+        return true;
+    }
+
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/ArcRecorder.java
@@ -42,12 +42,10 @@ public class ArcRecorder {
     public static volatile Map<String, Function<SyntheticCreationalContext<?>, ?>> syntheticBeanProviders;
 
     public ArcContainer initContainer(ShutdownContext shutdown, RuntimeValue<CurrentContextFactory> currentContextFactory,
-            boolean strictCompatibility, boolean optimizeContexts)
-            throws Exception {
+            boolean strictCompatibility) throws Exception {
         ArcInitConfig.Builder builder = ArcInitConfig.builder();
         builder.setCurrentContextFactory(currentContextFactory != null ? currentContextFactory.getValue() : null);
         builder.setStrictCompatibility(strictCompatibility);
-        builder.setOptimizeContexts(optimizeContexts);
         ArcContainer container = Arc.initialize(builder.build());
         shutdown.addShutdownTask(new Runnable() {
             @Override


### PR DESCRIPTION
- if "auto" is used then only optimize if there is less than 1000 beans in the app; removed beans are excluded
- use this as the default value