### PR TITLE
Fix panache JPA not work with new lines after keyword

### DIFF
--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonPanacheQueryImpl.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/CommonPanacheQueryImpl.java
@@ -78,7 +78,7 @@ public class CommonPanacheQueryImpl<Entity> {
             selectQuery = NamedQueryUtil.getNamedQuery(query.substring(1));
         }
 
-        String lowerCasedTrimmedQuery = selectQuery.trim().toLowerCase();
+        String lowerCasedTrimmedQuery = selectQuery.trim().replace('\n', ' ').replace('\r', ' ').toLowerCase();
         if (lowerCasedTrimmedQuery.startsWith("select new ")) {
             throw new PanacheQueryException("Unable to perform a projection on a 'select new' query: " + query);
         }
@@ -89,7 +89,7 @@ public class CommonPanacheQueryImpl<Entity> {
         // New query: SELECT new org.acme.ProjectionClass(e.field1, e.field2) from EntityClass e
         if (lowerCasedTrimmedQuery.startsWith("select ")) {
             int endSelect = lowerCasedTrimmedQuery.indexOf(" from ");
-            String trimmedQuery = selectQuery.trim();
+            String trimmedQuery = selectQuery.trim().replace('\n', ' ').replace('\r', ' ');
             // 7 is the length of "select "
             String selectClause = trimmedQuery.substring(7, endSelect).trim();
             String from = trimmedQuery.substring(endSelect);

--- a/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
+++ b/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
@@ -90,7 +90,7 @@ public class PanacheJpaUtil {
         if (query == null)
             return "SELECT COUNT(*) FROM " + getEntityName(entityClass);
 
-        String trimmed = query.trim();
+        String trimmed = query.replace('\n', ' ').replace('\r', ' ').trim();
         if (trimmed.isEmpty())
             return "SELECT COUNT(*) FROM " + getEntityName(entityClass);
 
@@ -113,7 +113,7 @@ public class PanacheJpaUtil {
             throw new PanacheQueryException("Query string cannot be null");
         }
 
-        String trimmed = query.trim();
+        String trimmed = query.replace('\n', ' ').replace('\r', ' ').trim();
         if (trimmed.isEmpty()) {
             throw new PanacheQueryException("Query string cannot be empty");
         }
@@ -142,7 +142,7 @@ public class PanacheJpaUtil {
         if (query == null)
             return "DELETE FROM " + getEntityName(entityClass);
 
-        String trimmed = query.trim();
+        String trimmed = query.replace('\n', ' ').replace('\r', ' ').trim();
         if (trimmed.isEmpty())
             return "DELETE FROM " + getEntityName(entityClass);
 

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -1718,4 +1718,29 @@ public class TestEndpoint {
 
         return "OK";
     }
+
+    @GET
+    @Path("testStripNewLine")
+    @Transactional
+    public String testNewLineStrip() {
+
+        Person person = new Person();
+        person.name = "Jakub";
+        person.persist();
+
+        List<Person> persons = Person.find("\nFROM\n Person2  \nWHERE\n name = ?1", "Jakub").list();
+        Assertions.assertEquals(1, persons.size());
+        Assertions.assertEquals(person, persons.get(0));
+
+        long count = Person.count("\nFROM\n Person2 \nWHERE\n name = ?1", "Jakub");
+        Assertions.assertEquals(1, count);
+
+        int updateCount = Person.update("\nUPDATE\n Person2 set name = 'Jacob' \nWHERE\n name = ?1", "Jakub");
+        Assertions.assertEquals(1, updateCount);
+
+        long deleteCount = Person.delete("\nDELETE\n Person2 \nWHERE\n name = ?1", "Jacob");
+        Assertions.assertEquals(1, deleteCount);
+
+        return "OK";
+    }
 }

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -238,4 +238,9 @@ public class PanacheFunctionalityTest {
     public void testEnhancement27184DeleteDetached() {
         RestAssured.when().get("/test/testEnhancement27184DeleteDetached").then().body(is("OK"));
     }
+
+    @Test
+    public void testNewLineStrip() {
+        RestAssured.when().get("/test/testStripNewLine").then().body(is("OK"));
+    }
 }

--- a/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/TestEndpoint.java
+++ b/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/TestEndpoint.java
@@ -1597,7 +1597,9 @@ public class TestEndpoint {
                 }).flatMap(person -> {
                     Assertions.assertEquals("2", person.name);
 
-                    return Person.find("select uniqueName, name\nfrom\n io.quarkus.it.panache.Person\nwhere\n name = ?1", "2")
+                    return Person
+                            .find("select uniqueName, name\nfrom\n io.quarkus.it.panache.reactive.Person\nwhere\n name = ?1",
+                                    "2")
                             .project(PersonName.class)
                             .<PersonName> firstResult();
                 }).flatMap(person -> {

--- a/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
@@ -156,6 +156,11 @@ public class PanacheFunctionalityTest {
 
     @Test
     public void testSortByNullPrecedence() {
+        RestAssured.when().get("/test/testStripNewLine").then().body(is("OK"));
+    }
+
+    @Test
+    public void testNewLineStrip() {
         RestAssured.when().get("/test/testSortByNullPrecedence").then().body(is("OK"));
     }
 


### PR DESCRIPTION
Hi this PR fixing the problem when using query with new line after keyword. As it's looking for keywords with space after them (example `"from "`) but when we have query containing new line after the keyword it failing to resolve query.

This was partially fixed with https://github.com/quarkusio/quarkus/pull/31419 but this PR take care only for `createFindQuery` method and not others methods.

Second part about https://github.com/quarkusio/quarkus/issues/31117 which should be fixed but I try our test and it was not fixed. The fix was only for non-reactive panache part of `CommonPanacheQueryImpl`, but reactive counter part was stay same. So this adding the same fix on same places as https://github.com/quarkusio/quarkus/pull/29851 and after changed by https://github.com/quarkusio/quarkus/pull/29986