### PR TITLE
Introduce option to create uncompressed jars

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/PackageConfig.java
@@ -104,6 +104,13 @@ public class PackageConfig {
     public String type;
 
     /**
+     * Whether the created jar will be compressed. This setting is not used when building a native image
+     */
+    @ConfigItem
+    @ConfigDocDefault("false")
+    public Optional<Boolean> compressJar;
+
+    /**
      * Manifest configuration of the runner jar.
      */
     @ConfigItem

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -329,7 +329,7 @@ public class JarResultBuildStep {
             MainClassBuildItem mainClassBuildItem,
             ClassLoadingConfig classLoadingConfig,
             Path runnerJar) throws Exception {
-        try (FileSystem runnerZipFs = ZipUtils.newZip(runnerJar)) {
+        try (FileSystem runnerZipFs = createNewZip(runnerJar, packageConfig)) {
 
             log.info("Building uber jar: " + runnerJar);
 
@@ -530,7 +530,7 @@ public class JarResultBuildStep {
         Files.deleteIfExists(runnerJar);
         IoUtils.createOrEmptyDir(libDir);
 
-        try (FileSystem runnerZipFs = ZipUtils.newZip(runnerJar)) {
+        try (FileSystem runnerZipFs = createNewZip(runnerJar, packageConfig)) {
 
             log.info("Building thin jar: " + runnerJar);
 
@@ -629,7 +629,7 @@ public class JarResultBuildStep {
         if (!transformedClasses.getTransformedClassesByJar().isEmpty()) {
             Path transformedZip = quarkus.resolve(TRANSFORMED_BYTECODE_JAR);
             fastJarJarsBuilder.setTransformed(transformedZip);
-            try (FileSystem out = ZipUtils.newZip(transformedZip)) {
+            try (FileSystem out = createNewZip(transformedZip, packageConfig)) {
                 for (Set<TransformedClassesBuildItem.TransformedClass> transformedSet : transformedClasses
                         .getTransformedClassesByJar().values()) {
                     for (TransformedClassesBuildItem.TransformedClass transformed : transformedSet) {
@@ -650,7 +650,7 @@ public class JarResultBuildStep {
         //now generated classes and resources
         Path generatedZip = quarkus.resolve(GENERATED_BYTECODE_JAR);
         fastJarJarsBuilder.setGenerated(generatedZip);
-        try (FileSystem out = ZipUtils.newZip(generatedZip)) {
+        try (FileSystem out = createNewZip(generatedZip, packageConfig)) {
             for (GeneratedClassBuildItem i : generatedClasses) {
                 String fileName = i.getName().replace('.', '/') + ".class";
                 Path target = out.getPath(fileName);
@@ -683,7 +683,7 @@ public class JarResultBuildStep {
         if (!rebuild) {
             Predicate<String> ignoredEntriesPredicate = getThinJarIgnoredEntriesPredicate(packageConfig);
 
-            try (FileSystem runnerZipFs = ZipUtils.newZip(runnerJar)) {
+            try (FileSystem runnerZipFs = createNewZip(runnerJar, packageConfig)) {
                 copyFiles(applicationArchivesBuildItem.getRootArchive(), runnerZipFs, null, ignoredEntriesPredicate);
             }
         }
@@ -695,7 +695,7 @@ public class JarResultBuildStep {
             if (!rebuild) {
                 copyDependency(parentFirstKeys, outputTargetBuildItem, copiedArtifacts, mainLib, baseLib,
                         fastJarJarsBuilder::addDep, true,
-                        classPath, appDep, transformedClasses, removed);
+                        classPath, appDep, transformedClasses, removed, packageConfig);
             } else if (includeAppDep(appDep, outputTargetBuildItem.getIncludedOptionalDependencies(), removed)) {
                 appDep.getResolvedPaths().forEach(fastJarJarsBuilder::addDep);
             }
@@ -768,7 +768,7 @@ public class JarResultBuildStep {
             }
         }
         if (!rebuild) {
-            try (FileSystem runnerZipFs = ZipUtils.newZip(initJar)) {
+            try (FileSystem runnerZipFs = createNewZip(initJar, packageConfig)) {
                 ResolvedDependency appArtifact = curateOutcomeBuildItem.getApplicationModel().getAppArtifact();
                 generateManifest(runnerZipFs, classPath.toString(), packageConfig, appArtifact,
                         QuarkusEntryPoint.class.getName(),
@@ -783,7 +783,7 @@ public class JarResultBuildStep {
                     copyDependency(parentFirstKeys, outputTargetBuildItem, copiedArtifacts, deploymentLib, baseLib, (p) -> {
                     },
                             false, classPath,
-                            appDep, new TransformedClassesBuildItem(Map.of()), removed); //we don't care about transformation here, so just pass in an empty item
+                            appDep, new TransformedClassesBuildItem(Map.of()), removed, packageConfig); //we don't care about transformation here, so just pass in an empty item
                 }
                 Map<ArtifactKey, List<String>> relativePaths = new HashMap<>();
                 for (Map.Entry<ArtifactKey, List<Path>> e : copiedArtifacts.entrySet()) {
@@ -884,7 +884,8 @@ public class JarResultBuildStep {
     private void copyDependency(Set<ArtifactKey> parentFirstArtifacts, OutputTargetBuildItem outputTargetBuildItem,
             Map<ArtifactKey, List<Path>> runtimeArtifacts, Path libDir, Path baseLib, Consumer<Path> targetPathConsumer,
             boolean allowParentFirst, StringBuilder classPath, ResolvedDependency appDep,
-            TransformedClassesBuildItem transformedClasses, Set<ArtifactKey> removedDeps)
+            TransformedClassesBuildItem transformedClasses, Set<ArtifactKey> removedDeps,
+            PackageConfig packageConfig)
             throws IOException {
 
         // Exclude files that are not jars (typically, we can have XML files here, see https://github.com/quarkusio/quarkus/issues/2852)
@@ -912,7 +913,7 @@ public class JarResultBuildStep {
                 // This case can happen when we are building a jar from inside the Quarkus repository
                 // and Quarkus Bootstrap's localProjectDiscovery has been set to true. In such a case
                 // the non-jar dependencies are the Quarkus dependencies picked up on the file system
-                packageClasses(resolvedDep, targetPath);
+                packageClasses(resolvedDep, targetPath, packageConfig);
             } else {
                 Set<TransformedClassesBuildItem.TransformedClass> transformedFromThisArchive = transformedClasses
                         .getTransformedClassesByJar().get(resolvedDep);
@@ -934,8 +935,8 @@ public class JarResultBuildStep {
         }
     }
 
-    private void packageClasses(Path resolvedDep, final Path targetPath) throws IOException {
-        try (FileSystem runnerZipFs = ZipUtils.newZip(targetPath)) {
+    private void packageClasses(Path resolvedDep, final Path targetPath, PackageConfig packageConfig) throws IOException {
+        try (FileSystem runnerZipFs = createNewZip(targetPath, packageConfig)) {
             Files.walkFileTree(resolvedDep, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
                     new SimpleFileVisitor<Path>() {
                         @Override
@@ -1647,6 +1648,14 @@ public class JarResultBuildStep {
                 return true;
             }
         }
+    }
+
+    private static FileSystem createNewZip(Path runnerJar, PackageConfig config) throws IOException {
+        boolean useUncompressedJar = config.compressJar.map(o -> !o).orElse(false);
+        if (useUncompressedJar) {
+            return ZipUtils.newZip(runnerJar, Map.of("compressionMethod", "STORED"));
+        }
+        return ZipUtils.newZip(runnerJar);
     }
 
 }

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -76,7 +76,7 @@
         <smallrye-common.version>2.1.2</smallrye-common.version>
         <smallrye-beanbag.version>1.3.2</smallrye-beanbag.version>
         <gradle-tooling.version>8.5</gradle-tooling.version>
-        <quarkus-fs-util.version>0.0.9</quarkus-fs-util.version>
+        <quarkus-fs-util.version>0.0.10</quarkus-fs-util.version>
         <org-crac.version>0.1.3</org-crac.version>
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>


### PR DESCRIPTION
This is done by setting `quarkus.package.compress-jar` to `false`.
This is a niche setting, but it can lead to slightly
reduced boot time when using `uber-jar` packaging

- Closes: #38128