### PR TITLE
Bump Hibernate ORM to 6.4.1.Final and Hibernate Reactive to 2.2.1.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -100,7 +100,7 @@
              bytebuddy.version (just below), hibernate-orm.version-for-documentation (in docs/pom.xml)
              and both hibernate-orm.version and antlr.version in build-parent/pom.xml
              WARNING again for diffs that don't provide enough context: when updating, see above -->
-        <hibernate-orm.version>6.4.0.Final</hibernate-orm.version>
+        <hibernate-orm.version>6.4.1.Final</hibernate-orm.version>
         <bytebuddy.version>1.14.7</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
         <hibernate-reactive.version>2.2.0.Final</hibernate-reactive.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -103,7 +103,7 @@
         <hibernate-orm.version>6.4.1.Final</hibernate-orm.version>
         <bytebuddy.version>1.14.7</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
-        <hibernate-reactive.version>2.2.0.Final</hibernate-reactive.version>
+        <hibernate-reactive.version>2.2.1.Final</hibernate-reactive.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <!-- When updating, align hibernate-search.version-for-documentation in docs/pom.xml -->
         <hibernate-search.version>7.0.0.Final</hibernate-search.version>


### PR DESCRIPTION
Follows https://github.com/quarkusio/quarkus/pull/37936

@gsmet, I cannot existing PR directly (it might be because I don't have the right permissions, but I'm not sure). So, I've just sent a new one with an additional commit