### PR TITLE
Use smallrye-reactive-messaging-bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -472,6 +472,15 @@
                 <scope>import</scope>
             </dependency>
 
+            <!-- SmallRye Reactive Messaging BOM -->
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>smallrye-reactive-messaging-bom</artifactId>
+                <version>${smallrye-reactive-messaging.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- Quarkus core -->
 
             <dependency>
@@ -5265,31 +5274,6 @@
 
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-provider</artifactId>
-                <version>${smallrye-reactive-messaging.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-api</artifactId>
-                <version>${smallrye-reactive-messaging.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-health</artifactId>
-                <version>${smallrye-reactive-messaging.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-mqtt</artifactId>
-                <version>${smallrye-reactive-messaging.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-in-memory</artifactId>
-                <version>${smallrye-reactive-messaging.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-messaging-kafka</artifactId>
                 <version>${smallrye-reactive-messaging.version}</version>
                 <exclusions>
@@ -5318,11 +5302,6 @@
                         <artifactId>log4j</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-pulsar</artifactId>
-                <version>${smallrye-reactive-messaging.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.pulsar</groupId>
@@ -5365,11 +5344,6 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-kafka-api</artifactId>
-                <version>${smallrye-reactive-messaging.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-messaging-kafka-test-companion</artifactId>
                 <version>${smallrye-reactive-messaging.version}</version>
                 <exclusions>
@@ -5393,16 +5367,6 @@
                         <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-rabbitmq</artifactId>
-                <version>${smallrye-reactive-messaging.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-connector-attribute-processor</artifactId>
-                <version>${smallrye-reactive-messaging.version}</version>
             </dependency>
 
             <dependency>

--- a/integration-tests/virtual-threads/jms-virtual-threads/pom.xml
+++ b/integration-tests/virtual-threads/jms-virtual-threads/pom.xml
@@ -33,11 +33,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
         </dependency>
-        <!-- JMS connector not part of the Quarkus BOM -->
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-messaging-jms</artifactId>
-            <version>4.12.0</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This imports the smallrye-reactive-messaging-bom into the quarkus-bom. Some artifacts are still kept because they declare exclusions.

- Closes https://github.com/quarkusio/quarkus/pull/38112