### PR TITLE
ConfigRecorder: fix value changed check with null build-time values

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
@@ -3,6 +3,7 @@ package io.quarkus.runtime.configuration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -42,7 +43,8 @@ public class ConfigRecorder {
         for (Map.Entry<String, ConfigValue> entry : buildTimeRuntimeValues.entrySet()) {
             ConfigValue currentValue = config.getConfigValue(entry.getKey());
             // Check for changes. Also, we only have a change if the source ordinal is higher
-            if (currentValue.getValue() != null && !entry.getValue().getValue().equals(currentValue.getValue())
+            // The config value can be null (for ex. if the property uses environment variables not available at build time)
+            if (currentValue.getValue() != null && !Objects.equals(entry.getValue().getValue(), currentValue.getValue())
                     && entry.getValue().getSourceOrdinal() < currentValue.getSourceOrdinal()) {
                 mismatches.add(
                         " - " + entry.getKey() + " is set to '" + currentValue.getValue()


### PR DESCRIPTION
This is a fix for a bug I encountered in production where the whole application would crash with a cryptic message:
![logs + stack trace](https://github.com/quarkusio/quarkus/assets/63104422/fb695ec5-ef66-4bb1-bed8-fe04c8fafa3d)

After remote debugging it, I found the problem to be the particular line I changed. The bug occurs when a build-time property is null as it tries to call `equals` on this value to check for runtime config changes.

One case in which this happens is when environment variables that aren't set are used in a config value. In particular, using, say, `$POSTGRES_USER` as a variable in `%prod.quarkus.datasource.url` causes the build-time value to evaluate to `null` with `rawValue` being the property without the variables substituted.
![values at exception time in the debugger](https://github.com/quarkusio/quarkus/assets/63104422/e44dc01f-4810-40ce-ad0c-3da0d757f60d)

This PR changes the logic to use [`Objects.equals`](https://docs.oracle.com/javase/8/docs/api/java/util/Objects.html#equals-java.lang.Object-java.lang.Object-) which is null safe. If the build-time value is `null`, it'll detect it as a change (as long as the runtime value isn't `null` too)

*Note for maintainers: the commit is unsigned as I recently changed my email and haven't updated my PGP key. Squash merge the PR to sign the commit with GitHub's key*