### PR TITLE
Add necessary Vertx dependency to quarkus-cache

### DIFF
--- a/extensions/cache/deployment/pom.xml
+++ b/extensions/cache/deployment/pom.xml
@@ -40,6 +40,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http-dev-ui-spi</artifactId>
         </dependency>
         <dependency>

--- a/extensions/cache/runtime/pom.xml
+++ b/extensions/cache/runtime/pom.xml
@@ -29,6 +29,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-cache-runtime-spi</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
This is now necessary because of #37077

- Fixes: #38157
