### PR TITLE
Use Vert.x pool with Jackson

### DIFF
--- a/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/io/quarkus/jackson/deployment/JacksonProcessor.java
@@ -68,6 +68,7 @@ import io.quarkus.jackson.runtime.JacksonSupport;
 import io.quarkus.jackson.runtime.JacksonSupportRecorder;
 import io.quarkus.jackson.runtime.MixinsRecorder;
 import io.quarkus.jackson.runtime.ObjectMapperProducer;
+import io.quarkus.jackson.runtime.VertxHybridPoolObjectMapperCustomizer;
 import io.quarkus.jackson.spi.ClassPathJacksonModuleBuildItem;
 import io.quarkus.jackson.spi.JacksonModuleBuildItem;
 
@@ -108,9 +109,11 @@ public class JacksonProcessor {
     List<IgnoreJsonDeserializeClassBuildItem> ignoreJsonDeserializeClassBuildItems;
 
     @BuildStep
-    void unremovable(Capabilities capabilities, BuildProducer<UnremovableBeanBuildItem> producer) {
+    void unremovable(Capabilities capabilities, BuildProducer<UnremovableBeanBuildItem> producer,
+            BuildProducer<AdditionalBeanBuildItem> additionalProducer) {
         if (capabilities.isPresent(Capability.VERTX_CORE)) {
             producer.produce(UnremovableBeanBuildItem.beanTypes(ObjectMapper.class));
+            additionalProducer.produce(AdditionalBeanBuildItem.unremovableOf(VertxHybridPoolObjectMapperCustomizer.class));
         }
     }
 

--- a/extensions/jackson/runtime/pom.xml
+++ b/extensions/jackson/runtime/pom.xml
@@ -33,6 +33,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/VertxHybridPoolObjectMapperCustomizer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/VertxHybridPoolObjectMapperCustomizer.java
@@ -1,0 +1,17 @@
+package io.quarkus.jackson.runtime;
+
+import com.fasterxml.jackson.core.util.JsonRecyclerPools;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+import io.vertx.core.json.jackson.HybridJacksonPool;
+
+public class VertxHybridPoolObjectMapperCustomizer implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        if (objectMapper.getFactory()._getRecyclerPool() == JsonRecyclerPools.defaultPool()) {
+            objectMapper.getFactory().setRecyclerPool(HybridJacksonPool.getInstance());
+        }
+    }
+}


### PR DESCRIPTION
This pull request is not intended to be merged as it is, but it's only a draft to demonstrate that it is possible to integrate in Quakus that Jackson pool implemented in vert.x with this pull request https://github.com/eclipse-vertx/vert.x/pull/4920