### PR TITLE
[3.2] Upgrade to Hibernate Reactive 2.0.8

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -103,7 +103,7 @@
         <hibernate-orm.version>6.2.18.Final</hibernate-orm.version>
         <bytebuddy.version>1.14.7</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
-        <hibernate-reactive.version>2.0.6.Final</hibernate-reactive.version>
+        <hibernate-reactive.version>2.0.8.Final</hibernate-reactive.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <!-- When updating, align hibernate-search.version-for-documentation in docs/pom.xml -->
         <hibernate-search.version>6.2.2.Final</hibernate-search.version>


### PR DESCRIPTION
Mostly to be on a more recent version (tested against a version of ORM closer to the one we use) and for https://github.com/hibernate/hibernate-reactive/issues/1792

See https://github.com/hibernate/hibernate-reactive/compare/2.0.6...2.0.8

This follows up on #38105 where we refrained from upgrading to HR 2.0.7 because it had (erroneously) upgraded to Vert.x 4.5. That upgrade was reverted in HR 2.0.8 so we can now upgrade.

cc @gsmet 