### PR TITLE
[3.2] fix: use raw path and avoid double encoding, adapt tests accordingly

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/HelloClient.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/HelloClient.java
@@ -1,7 +1,11 @@
 package io.quarkus.rest.client.reactive.stork;
 
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
@@ -10,4 +14,13 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 public interface HelloClient {
     @GET
     String hello();
+
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Path("/")
+    String echo(String name);
+
+    @GET
+    @Path("/{name}")
+    public String helloWithPathParam(@PathParam("name") String name);
 }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/HelloResource.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/HelloResource.java
@@ -1,7 +1,13 @@
 package io.quarkus.rest.client.reactive.stork;
 
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Request;
 
 @Path("/hello")
 public class HelloResource {
@@ -11,5 +17,17 @@ public class HelloResource {
     @GET
     public String hello() {
         return HELLO_WORLD;
+    }
+
+    @GET
+    @Path("/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String invoke(@PathParam("name") String name) {
+        return "Hello, " + name;
+    }
+
+    @POST
+    public String echo(String name, @Context Request request) {
+        return "hello, " + name;
     }
 }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/PassThroughResource.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/PassThroughResource.java
@@ -4,6 +4,7 @@ import java.net.URI;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -20,6 +21,18 @@ public class PassThroughResource {
                 .baseUri(URI.create("stork://hello-service/hello"))
                 .build(HelloClient.class);
         return client.hello();
+    }
+
+    @Path("/v2/{name}")
+    @GET
+    public String invokeClientWithPathParamContainingSlash(@PathParam("name") String name) {
+        return client.helloWithPathParam(name + "/" + name);
+    }
+
+    @Path("/{name}")
+    @GET
+    public String invokeClientWithPathParam(@PathParam("name") String name) {
+        return client.helloWithPathParam(name);
     }
 
     @Path("/cdi")

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkDevModeTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkDevModeTest.java
@@ -67,4 +67,25 @@ public class StorkDevModeTest {
                 .body(equalTo(WIREMOCK_RESPONSE));
         // @formatter:on
     }
+
+    @Test
+    void shouldSayHelloNameWithSlash() {
+        when()
+                .get("/helper/v2/stork")
+                .then()
+                .statusCode(200)
+                // The response contains an encoded `/`
+                .body(equalTo("Hello, stork/stork"));
+
+    }
+
+    @Test
+    void shouldSayHelloNameWithBlank() {
+        when()
+                .get("/helper/smallrye stork")
+                .then()
+                .statusCode(200)
+                // The response contains an encoded blank espace
+                .body(equalTo("Hello, smallrye stork"));
+    }
 }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkResponseTimeLoadBalancerTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkResponseTimeLoadBalancerTest.java
@@ -16,8 +16,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
-import io.quarkus.rest.client.reactive.HelloClient2;
-import io.quarkus.rest.client.reactive.HelloResource;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class StorkResponseTimeLoadBalancerTest {
@@ -28,7 +26,7 @@ public class StorkResponseTimeLoadBalancerTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(HelloClient2.class, HelloResource.class))
+                    .addClasses(HelloClient.class, HelloResource.class))
             .withConfigurationResource("stork-stat-lb.properties");
 
     @BeforeAll
@@ -46,7 +44,7 @@ public class StorkResponseTimeLoadBalancerTest {
     }
 
     @RestClient
-    HelloClient2 client;
+    HelloClient client;
 
     @Test
     void shouldUseFasterService() {

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkWithPathIntegrationTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkWithPathIntegrationTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.rest.client.reactive.HelloClient2;
-import io.quarkus.rest.client.reactive.HelloResource;
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.stork.api.NoSuchServiceDefinitionException;
 
@@ -24,45 +22,57 @@ public class StorkWithPathIntegrationTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(HelloClient2.class, HelloResource.class))
+                    .addClasses(HelloClient.class, HelloResource.class))
             .withConfigurationResource("stork-application-with-path.properties");
 
     @RestClient
-    HelloClient2 client;
+    HelloClient client;
 
     @Test
     void shouldDetermineUrlViaStork() {
         String greeting = RestClientBuilder.newBuilder().baseUri(URI.create("stork://hello-service"))
-                .build(HelloClient2.class)
+                .build(HelloClient.class)
                 .echo("black and white bird");
         assertThat(greeting).isEqualTo("hello, black and white bird");
+
+        greeting = RestClientBuilder.newBuilder().baseUri(URI.create("stork://hello-service"))
+                .build(HelloClient.class)
+                .helloWithPathParam("black and white bird");
+        assertThat(greeting).isEqualTo("Hello, black and white bird");
     }
 
     @Test
     void shouldDetermineUrlViaStorkWhenUsingTarget() throws URISyntaxException {
         String greeting = ClientBuilder.newClient().target("stork://hello-service").request().get(String.class);
-        assertThat(greeting).isEqualTo("Hello");
+        assertThat(greeting).isEqualTo("Hello, World!");
 
         greeting = ClientBuilder.newClient().target(new URI("stork://hello-service")).request().get(String.class);
-        assertThat(greeting).isEqualTo("Hello");
+        assertThat(greeting).isEqualTo("Hello, World!");
 
         greeting = ClientBuilder.newClient().target(UriBuilder.fromUri("stork://hello-service/")).request()
                 .get(String.class);
-        assertThat(greeting).isEqualTo("Hello");
+        assertThat(greeting).isEqualTo("Hello, World!");
+
+        greeting = ClientBuilder.newClient().target("stork://hello-service/").path("big bird").request()
+                .get(String.class);
+        assertThat(greeting).isEqualTo("Hello, big bird");
     }
 
     @Test
     void shouldDetermineUrlViaStorkCDI() {
         String greeting = client.echo("big bird");
         assertThat(greeting).isEqualTo("hello, big bird");
+
+        greeting = client.helloWithPathParam("big bird");
+        assertThat(greeting).isEqualTo("Hello, big bird");
     }
 
     @Test
     @Timeout(20)
     void shouldFailOnUnknownService() {
-        HelloClient2 client2 = RestClientBuilder.newBuilder()
+        HelloClient client = RestClientBuilder.newBuilder()
                 .baseUri(URI.create("stork://nonexistent-service"))
-                .build(HelloClient2.class);
-        assertThatThrownBy(() -> client2.echo("foo")).isInstanceOf(NoSuchServiceDefinitionException.class);
+                .build(HelloClient.class);
+        assertThatThrownBy(() -> client.echo("foo")).isInstanceOf(NoSuchServiceDefinitionException.class);
     }
 }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/StorkClientRequestFilter.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/StorkClientRequestFilter.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.ext.Provider;
 
 import org.jboss.logging.Logger;
@@ -62,7 +63,7 @@ public class StorkClientRequestFilter implements ResteasyReactiveClientRequestFi
                             }
                             // Service instance can also contain an optional path.
                             Optional<String> path = instance.getPath();
-                            String actualPath = uri.getPath();
+                            String actualPath = uri.getRawPath();
                             if (path.isPresent()) {
                                 var p = path.get();
                                 if (!p.startsWith("/")) {
@@ -79,11 +80,12 @@ public class StorkClientRequestFilter implements ResteasyReactiveClientRequestFi
                                     }
                                 }
                             }
-
+                            //To avoid the path double encoding we create uri with path=null and set the path after
                             URI newUri = new URI(scheme,
                                     uri.getUserInfo(), host, port,
-                                    actualPath, uri.getQuery(), uri.getFragment());
-                            requestContext.setUri(newUri);
+                                    null, uri.getQuery(), uri.getFragment());
+                            URI build = UriBuilder.fromUri(newUri).path(actualPath).build();
+                            requestContext.setUri(build);
                             if (measureTime && instance.gatherStatistics()) {
                                 requestContext.setCallStatsCollector(instance);
                             }

--- a/integration-tests/rest-client-reactive-stork/src/main/java/io/quarkus/it/rest/client/reactive/stork/Client.java
+++ b/integration-tests/rest-client-reactive-stork/src/main/java/io/quarkus/it/rest/client/reactive/stork/Client.java
@@ -2,6 +2,9 @@ package io.quarkus.it.rest.client.reactive.stork;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
@@ -11,4 +14,9 @@ public interface Client {
     @GET
     @Consumes(MediaType.TEXT_PLAIN)
     String echo(String name);
+
+    @GET
+    @Path("/v2/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    String invoke(@PathParam("name") String name);
 }

--- a/integration-tests/rest-client-reactive-stork/src/main/java/io/quarkus/it/rest/client/reactive/stork/ClientCallingResource.java
+++ b/integration-tests/rest-client-reactive-stork/src/main/java/io/quarkus/it/rest/client/reactive/stork/ClientCallingResource.java
@@ -3,6 +3,9 @@ package io.quarkus.it.rest.client.reactive.stork;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -16,5 +19,12 @@ public class ClientCallingResource {
     @GET
     public String passThrough() {
         return client.echo("World!");
+    }
+
+    @GET
+    @Path("/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String invoke(@PathParam("name") String name) {
+        return client.invoke(name + "/" + name);
     }
 }

--- a/integration-tests/rest-client-reactive-stork/src/test/java/io/quarkus/it/rest/reactive/stork/FastWiremockServer.java
+++ b/integration-tests/rest-client-reactive-stork/src/test/java/io/quarkus/it/rest/reactive/stork/FastWiremockServer.java
@@ -25,6 +25,8 @@ public class FastWiremockServer extends WiremockBase {
     protected Map<String, String> initWireMock(WireMockServer server) {
         server.stubFor(WireMock.get("/hello")
                 .willReturn(aResponse().withBody(FAST_RESPONSE).withStatus(200)));
+        server.stubFor(WireMock.get("/hello/v2/quarkus%2Fquarkus")
+                .willReturn(aResponse().withBody(FAST_RESPONSE).withStatus(200)));
         return Map.of("fast-service", "localhost:8443");
     }
 }

--- a/integration-tests/rest-client-reactive-stork/src/test/java/io/quarkus/it/rest/reactive/stork/RestClientReactiveStorkTest.java
+++ b/integration-tests/rest-client-reactive-stork/src/test/java/io/quarkus/it/rest/reactive/stork/RestClientReactiveStorkTest.java
@@ -54,4 +54,17 @@ public class RestClientReactiveStorkTest {
         // after hitting the slow endpoint, we should only use the fast one:
         assertThat(responses).containsOnly(FAST_RESPONSE, FAST_RESPONSE, FAST_RESPONSE);
     }
+
+    @Test
+    void shouldUseV2Service() {
+        Set<String> responses = new HashSet<>();
+
+        for (int i = 0; i < 2; i++) {
+            Response response = when().get("/client/quarkus");
+            response.then().statusCode(200);
+        }
+
+        responses.clear();
+
+    }
 }

--- a/integration-tests/rest-client-reactive-stork/src/test/java/io/quarkus/it/rest/reactive/stork/SlowWiremockServer.java
+++ b/integration-tests/rest-client-reactive-stork/src/test/java/io/quarkus/it/rest/reactive/stork/SlowWiremockServer.java
@@ -26,6 +26,9 @@ public class SlowWiremockServer extends WiremockBase {
         server.stubFor(WireMock.get("/hello")
                 .willReturn(aResponse().withFixedDelay(1000)
                         .withBody(SLOW_RESPONSE).withStatus(200)));
+        server.stubFor(WireMock.get("/hello/v2/quarkus%2Fquarkus")
+                .willReturn(aResponse().withFixedDelay(1000)
+                        .withBody(SLOW_RESPONSE).withStatus(200)));
         return Map.of("slow-service", "localhost:8444");
     }
 }


### PR DESCRIPTION
3.2 backport of "fix: use raw path and avoid double encoding, adapt tests accordingly"

Related to #37713