### PR TITLE
Fixed deprecation warnings caused by QuarkusPlugin

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -136,6 +136,7 @@ public class QuarkusPlugin implements Plugin<Project> {
         final QuarkusPluginExtension quarkusExt = project.getExtensions().create(EXTENSION_NAME, QuarkusPluginExtension.class,
                 project);
 
+        createSourceSets(project);
         createConfigurations(project);
         registerTasks(project, quarkusExt);
     }
@@ -323,7 +324,7 @@ public class QuarkusPlugin implements Plugin<Project> {
                     quarkusGenerateCodeDev.configure(task -> task.setSourcesDirectories(getSourcesParents(mainSourceSet)));
                     quarkusGenerateCodeTests.configure(task -> task.setSourcesDirectories(getSourcesParents(testSourceSet)));
 
-                    SourceSet intTestSourceSet = sourceSets.create(INTEGRATION_TEST_SOURCE_SET_NAME);
+                    SourceSet intTestSourceSet = sourceSets.getByName(INTEGRATION_TEST_SOURCE_SET_NAME);
                     intTestSourceSet.setCompileClasspath(
                             intTestSourceSet.getCompileClasspath()
                                     .plus(mainSourceSet.getOutput())
@@ -345,7 +346,7 @@ public class QuarkusPlugin implements Plugin<Project> {
                         intTestTask.setTestClassesDirs(intTestSourceOutputClasses);
                     });
 
-                    SourceSet nativeTestSourceSet = sourceSets.create(NATIVE_TEST_SOURCE_SET_NAME);
+                    SourceSet nativeTestSourceSet = sourceSets.getByName(NATIVE_TEST_SOURCE_SET_NAME);
                     nativeTestSourceSet.setCompileClasspath(
                             nativeTestSourceSet.getCompileClasspath()
                                     .plus(mainSourceSet.getOutput())
@@ -391,8 +392,8 @@ public class QuarkusPlugin implements Plugin<Project> {
                     // quarkusBuild is expected to run after the project has passed the tests
                     quarkusBuildCacheableAppParts.configure(task -> task.shouldRunAfter(tasks.withType(Test.class)));
 
-                    SourceSet generatedSourceSet = sourceSets.create(QuarkusGenerateCode.QUARKUS_GENERATED_SOURCES);
-                    SourceSet generatedTestSourceSet = sourceSets.create(QuarkusGenerateCode.QUARKUS_TEST_GENERATED_SOURCES);
+                    SourceSet generatedSourceSet = sourceSets.getByName(QuarkusGenerateCode.QUARKUS_GENERATED_SOURCES);
+                    SourceSet generatedTestSourceSet = sourceSets.getByName(QuarkusGenerateCode.QUARKUS_TEST_GENERATED_SOURCES);
 
                     // Register the quarkus-generated-code
                     for (String provider : QuarkusGenerateCode.CODE_GENERATION_PROVIDER) {
@@ -423,14 +424,22 @@ public class QuarkusPlugin implements Plugin<Project> {
         task.getGeneratedOutputDirectory().set(generatedSources.getJava().getClassesDirectory().get().getAsFile());
     }
 
+    private void createSourceSets(Project project) {
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        sourceSets.create(INTEGRATION_TEST_SOURCE_SET_NAME);
+        sourceSets.create(NATIVE_TEST_SOURCE_SET_NAME);
+        sourceSets.create(QuarkusGenerateCode.QUARKUS_GENERATED_SOURCES);
+        sourceSets.create(QuarkusGenerateCode.QUARKUS_TEST_GENERATED_SOURCES);
+    }
+
     private void createConfigurations(Project project) {
 
         final ConfigurationContainer configContainer = project.getConfigurations();
 
         // Custom configuration to be used for the dependencies of the testNative task
-        configContainer.maybeCreate(NATIVE_TEST_IMPLEMENTATION_CONFIGURATION_NAME)
+        configContainer.getByName(NATIVE_TEST_IMPLEMENTATION_CONFIGURATION_NAME)
                 .extendsFrom(configContainer.findByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME));
-        configContainer.maybeCreate(NATIVE_TEST_RUNTIME_ONLY_CONFIGURATION_NAME)
+        configContainer.getByName(NATIVE_TEST_RUNTIME_ONLY_CONFIGURATION_NAME)
                 .extendsFrom(configContainer.findByName(JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME));
 
         // create a custom configuration to be used for the dependencies of the quarkusIntTest task


### PR DESCRIPTION
Fixed deprecation warnings for Gradle 9 caused by QuarkusPlugin. Made sure the sourceSets are created before accessing their configurations. 

Explanation:

Creating configurations that a sourceSet creates is deprecated, resulting in [this deprecation warning](https://ge.solutions-team.gradle.com/s/6bnyzxjnkl2xg/deprecations?expanded=WyI0Il0&expanded-stacktrace=WyI2Il0&focused-stack-frame=0-0-24). Doing it this way will also cause problems when configuration permitted usages are misaligned, resulting in a second [deprecation warning](https://ge.solutions-team.gradle.com/s/6bnyzxjnkl2xg/deprecations?expanded=WyI0Il0&expanded-stacktrace=WyI2Il0#32).

With the fix applied, custom sourcesets (and their configurations) are created first, then the configurations are configured, after which sourcesets are configured as part of `registerTasks` method, which also removes the [deprecation warnings](https://ge.solutions-team.gradle.com/s/cwarw47lscflo/deprecations).