### PR TITLE
ArC: consolidate handling of transitive interceptor bindings

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -638,12 +638,24 @@ public class BeanDeployment {
      * This returns a collection because in case of repeating interceptor bindings there can be multiple.
      * For most instances this will be a singleton instance (if given annotation is an interceptor binding) or
      * an empty list for cases where the annotation is not an interceptor binding.
+     * <p>
+     * In addition to repeating annotations, the result also includes transitive interceptor bindings.
      *
      * @param annotation annotation to be inspected
      * @return a collection of interceptor bindings or an empty collection
      */
     public Collection<AnnotationInstance> extractInterceptorBindings(AnnotationInstance annotation) {
-        return extractAnnotations(annotation, interceptorBindings, repeatingInterceptorBindingAnnotations);
+        Collection<AnnotationInstance> result = extractAnnotations(annotation, interceptorBindings,
+                repeatingInterceptorBindingAnnotations);
+        if (result.isEmpty()) {
+            return result;
+        }
+        Set<AnnotationInstance> transitive = transitiveInterceptorBindings.get(annotation.name());
+        if (transitive != null) {
+            result = new HashSet<>(result);
+            result.addAll(transitive);
+        }
+        return result;
     }
 
     private static Collection<AnnotationInstance> extractAnnotations(AnnotationInstance annotation,
@@ -665,10 +677,6 @@ public class BeanDeployment {
 
     ClassInfo getInterceptorBinding(DotName name) {
         return interceptorBindings.get(name);
-    }
-
-    Set<AnnotationInstance> getTransitiveInterceptorBindings(DotName name) {
-        return transitiveInterceptorBindings.get(name);
     }
 
     Map<DotName, Set<AnnotationInstance>> getTransitiveInterceptorBindings() {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorResolver.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorResolver.java
@@ -61,19 +61,6 @@ public final class InterceptorResolver {
         for (AnnotationInstance binding : bindings) {
             if (isInterceptorBinding(interceptorBinding, binding)) {
                 return true;
-            } else {
-                // could be transitive binding
-                Set<AnnotationInstance> transitiveInterceptorBindings = beanDeployment
-                        .getTransitiveInterceptorBindings(binding.name());
-                if (transitiveInterceptorBindings == null) {
-                    continue;
-                }
-                for (AnnotationInstance transitiveBindingInstance : transitiveInterceptorBindings) {
-                    if (isInterceptorBinding(interceptorBinding,
-                            transitiveBindingInstance)) {
-                        return true;
-                    }
-                }
             }
         }
         return false;
@@ -83,7 +70,6 @@ public final class InterceptorResolver {
         ClassInfo interceptorBindingClass = beanDeployment.getInterceptorBinding(interceptorBinding.name());
         if (candidate.name().equals(interceptorBinding.name())) {
             // Must have the same annotation member value for each member which is not annotated @Nonbinding
-            boolean matches = true;
             Set<String> nonBindingFields = beanDeployment.getInterceptorNonbindingMembers(interceptorBinding.name());
             for (AnnotationValue value : candidate.valuesWithDefaults(beanDeployment.getBeanArchiveIndex())) {
                 String annotationField = value.name();
@@ -91,13 +77,10 @@ public final class InterceptorResolver {
                         && !nonBindingFields.contains(annotationField)
                         && !value.equals(
                                 interceptorBinding.valueWithDefault(beanDeployment.getBeanArchiveIndex(), annotationField))) {
-                    matches = false;
-                    break;
+                    return false;
                 }
             }
-            if (matches) {
-                return true;
-            }
+            return true;
         }
         return false;
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/CounterInterceptor.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/CounterInterceptor.java
@@ -1,20 +1,29 @@
 package io.quarkus.arc.test.interceptors.bindings.transitive;
 
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.Set;
+
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
+
+import io.quarkus.arc.ArcInvocationContext;
 
 @Interceptor
 @Priority(1)
 @CounterBinding
 public class CounterInterceptor {
 
-    public static Integer timesInvoked = 0;
+    public static int timesInvoked = 0;
+
+    public static Set<Annotation> lastBindings = new HashSet<>();
 
     @AroundInvoke
     public Object aroundInvoke(InvocationContext context) throws Exception {
         timesInvoked++;
+        lastBindings = (Set<Annotation>) context.getContextData().get(ArcInvocationContext.KEY_INTERCEPTOR_BINDINGS);
         return context.proceed();
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/TransitiveCounterInterceptor.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/TransitiveCounterInterceptor.java
@@ -1,21 +1,30 @@
 package io.quarkus.arc.test.interceptors.bindings.transitive;
 
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.Set;
+
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
+
+import io.quarkus.arc.ArcInvocationContext;
 
 @Interceptor
 @Priority(2)
 @SomeAnnotation // this is transitive binding, it also brings in @CounterBinding
 public class TransitiveCounterInterceptor {
 
-    public static Integer timesInvoked = 0;
+    public static int timesInvoked = 0;
+
+    public static Set<Annotation> lastBindings = new HashSet<>();
 
     @AroundInvoke
     public Object aroundInvoke(InvocationContext context) throws Exception {
         // it should effectively interrupt all that CounterInterceptor does
         timesInvoked++;
+        lastBindings = (Set<Annotation>) context.getContextData().get(ArcInvocationContext.KEY_INTERCEPTOR_BINDINGS);
         return context.proceed();
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/with/transformer/MuchCoolerInterceptor.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/with/transformer/MuchCoolerInterceptor.java
@@ -1,20 +1,29 @@
 package io.quarkus.arc.test.interceptors.bindings.transitive.with.transformer;
 
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.Set;
+
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
+
+import io.quarkus.arc.ArcInvocationContext;
 
 @Interceptor
 @Priority(1)
 @MuchCoolerBinding
 public class MuchCoolerInterceptor {
 
-    public static Integer timesInvoked = 0;
+    public static int timesInvoked = 0;
+
+    public static Set<Annotation> lastBindings = new HashSet<>();
 
     @AroundInvoke
     public Object aroundInvoke(InvocationContext context) throws Exception {
         timesInvoked++;
+        lastBindings = (Set<Annotation>) context.getContextData().get(ArcInvocationContext.KEY_INTERCEPTOR_BINDINGS);
         return context.proceed();
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/with/transformer/PlainInterceptor.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/with/transformer/PlainInterceptor.java
@@ -1,9 +1,15 @@
 package io.quarkus.arc.test.interceptors.bindings.transitive.with.transformer;
 
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.Set;
+
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
+
+import io.quarkus.arc.ArcInvocationContext;
 
 @Interceptor
 @Priority(1)
@@ -11,11 +17,14 @@ import jakarta.interceptor.InvocationContext;
 // @MuchCoolerBinding is added programmatically
 public class PlainInterceptor {
 
-    public static Integer timesInvoked = 0;
+    public static int timesInvoked = 0;
+
+    public static Set<Annotation> lastBindings = new HashSet<>();
 
     @AroundInvoke
     public Object aroundInvoke(InvocationContext context) throws Exception {
         timesInvoked++;
+        lastBindings = (Set<Annotation>) context.getContextData().get(ArcInvocationContext.KEY_INTERCEPTOR_BINDINGS);
         return context.proceed();
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/with/transformer/TransitiveInterceptionWithTransformerApplicationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/bindings/transitive/with/transformer/TransitiveInterceptionWithTransformerApplicationTest.java
@@ -1,7 +1,13 @@
 package io.quarkus.arc.test.interceptors.bindings.transitive.with.transformer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
 import org.jboss.jandex.AnnotationTarget;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -21,14 +27,16 @@ public class TransitiveInterceptionWithTransformerApplicationTest {
 
     @Test
     public void testTransformersAreApplied() {
-        Assertions.assertTrue(Arc.container().instance(DummyBean.class).isAvailable());
+        assertTrue(Arc.container().instance(DummyBean.class).isAvailable());
         DummyBean bean = Arc.container().instance(DummyBean.class).get();
 
-        Assertions.assertTrue(PlainInterceptor.timesInvoked == 0);
-        Assertions.assertTrue(MuchCoolerInterceptor.timesInvoked == 0);
+        assertEquals(0, PlainInterceptor.timesInvoked);
+        assertEquals(0, MuchCoolerInterceptor.timesInvoked);
+        assertBindings(); // empty
         bean.ping();
-        Assertions.assertTrue(PlainInterceptor.timesInvoked == 1);
-        Assertions.assertTrue(MuchCoolerInterceptor.timesInvoked == 1);
+        assertEquals(1, PlainInterceptor.timesInvoked);
+        assertEquals(1, MuchCoolerInterceptor.timesInvoked);
+        assertBindings(PlainBinding.class, MuchCoolerBinding.class);
     }
 
     static class MyTransformer implements AnnotationsTransformer {
@@ -46,5 +54,19 @@ public class TransitiveInterceptionWithTransformerApplicationTest {
             }
         }
 
+    }
+
+    @SafeVarargs
+    static void assertBindings(Class<? extends Annotation>... bindings) {
+        assertBindings(PlainInterceptor.lastBindings, bindings);
+        assertBindings(MuchCoolerInterceptor.lastBindings, bindings);
+    }
+
+    private static void assertBindings(Set<Annotation> actualBindings, Class<? extends Annotation>[] expectedBindings) {
+        assertNotNull(actualBindings);
+        assertEquals(expectedBindings.length, actualBindings.size());
+        for (Class<? extends Annotation> expectedBinding : expectedBindings) {
+            assertTrue(actualBindings.stream().anyMatch(it -> it.annotationType() == expectedBinding));
+        }
     }
 }


### PR DESCRIPTION
Notably, this commit makes transitive interceptor bindings available at runtime from the `InvocationContext`.

Fixes #38264