### PR TITLE
Upgrade to Hibernate ORM 6.4.2.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -100,7 +100,7 @@
              bytebuddy.version (just below), hibernate-orm.version-for-documentation (in docs/pom.xml)
              and both hibernate-orm.version and antlr.version in build-parent/pom.xml
              WARNING again for diffs that don't provide enough context: when updating, see above -->
-        <hibernate-orm.version>6.4.1.Final</hibernate-orm.version>
+        <hibernate-orm.version>6.4.2.Final</hibernate-orm.version>
         <bytebuddy.version>1.14.7</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
         <hibernate-reactive.version>2.2.1.Final</hibernate-reactive.version>


### PR DESCRIPTION
Fixes #36633 
Fixes #36441


Apparently we don't need to do anything else:

* None of the transitive deps changed
* The version of HR we currently depend on is already compatible without any change: https://github.com/hibernate/hibernate-reactive/pull/1837

Now, let's see if CI is happy.