### PR TITLE
Apply polish to REST Client read timeout handling

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/timeout/RegisterReadTimeoutTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/timeout/RegisterReadTimeoutTest.java
@@ -15,7 +15,6 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -28,11 +27,10 @@ public class RegisterReadTimeoutTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withApplicationRoot((jar) -> jar
-                    .addClasses(Client.class, Resource.class)
-                    .addAsResource(new StringAsset(
-                            "client/mp-rest/readTimeout=1000\nclient/mp-rest/url=http://${quarkus.http.host}:${quarkus.http.test-port}"),
-                            "application.properties"));
+            .withApplicationRoot((jar) -> jar.addClasses(Client.class, Resource.class))
+            .overrideRuntimeConfigKey("quarkus.rest-client.client.read-timeout", "1000")
+            .overrideRuntimeConfigKey("quarkus.rest-client.client.url",
+                    "http://${quarkus.http.host}:${quarkus.http.test-port}");
 
     @Test
     void shouldTimeoutIfReadTimeoutSetShort() {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/InvocationBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/InvocationBuilderImpl.java
@@ -1,7 +1,5 @@
 package org.jboss.resteasy.reactive.client.impl;
 
-import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.READ_TIMEOUT;
-
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Locale;
@@ -33,8 +31,6 @@ import io.vertx.core.http.HttpClient;
 
 public class InvocationBuilderImpl implements Invocation.Builder {
 
-    private static final long DEFAULT_READ_TIMEOUT = 30_000L;
-
     final URI uri;
     final HttpClient httpClient;
     final WebTargetImpl target;
@@ -44,7 +40,6 @@ public class InvocationBuilderImpl implements Invocation.Builder {
     final ClientImpl restClient;
     final HandlerChain handlerChain;
     final ThreadSetupAction requestContext;
-    final long readTimeoutMs;
 
     public InvocationBuilderImpl(URI uri, ClientImpl restClient, HttpClient httpClient,
             WebTargetImpl target,
@@ -57,12 +52,6 @@ public class InvocationBuilderImpl implements Invocation.Builder {
         this.configuration = configuration;
         this.handlerChain = handlerChain;
         this.requestContext = requestContext;
-        Object readTimeoutMs = configuration.getProperty(READ_TIMEOUT);
-        if (readTimeoutMs == null) {
-            this.readTimeoutMs = DEFAULT_READ_TIMEOUT;
-        } else {
-            this.readTimeoutMs = (long) readTimeoutMs;
-        }
     }
 
     @Override


### PR DESCRIPTION
These changes essentially make it a little easier to follow how the REST Client handles the read timeout configuratiojn