### PR TITLE
Qute: improvements and fixes of UserTagSectionHelper.Arguments

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1152,18 +1152,26 @@ In this case, just add `_isolated=false` or `_unisolated` argument to the call s
 
 ===== Arguments
 
-Named arguments can be accessed directly in a tag template.
-The first argument does not have to define a name but can be accessed using the `it` alias.
-Furthermore, arguments metadata are accessible in a tag using the `_args` alias.
+Named arguments can be accessed directly in the tag template.
+However, the first argument does not need to define a name and it can be accessed using the `it` alias.
+Furthermore, if an argument does not have a name defined and the value is a single identifier, such as `foo`, then the name is defaulted to the value identifier, e.g. `{#myTag foo /}` becomes `{#myTag foo=foo /}`.
+In other words, the argument value `foo` is resolved and can be accessed using `{foo}` in the tag template.
+
+NOTE: If an argument does not have a name and the value is a single word string literal , such as `"foo"`, then the name is defaulted and quotation marks are removed, e.g. `{#myTag "foo" /}` becomes `{#myTag foo="foo" /}`.
+
+`io.quarkus.qute.UserTagSectionHelper.Arguments` metadata are accessible in a tag using the `_args` alias.
 
 * `_args.size` - returns the actual number of arguments passed to a tag
-* `_args.empty` - returns `true` if no arguments are passed
-* `_args.get(String name)` - returns the argument value of the given name
+* `_args.empty`/`_args.isEmpty` - returns `true` if no arguments are passed
+* `_args.get(String name)` - returns the argument value of the given name or `null`
 * `_args.filter(String...)` - returns the arguments matching the given names
+* `_args.filterIdenticalKeyValue` - returns the arguments with the name equal to the value; typically `foo` from `{#test foo="foo" bar=true}` or `{#test "foo" bar=true /}`
 * `_args.skip(String...)` - returns only the arguments that do not match the given names
-* `_args.asHtmlAttributes` - renders the arguments as HTML attributes; e.g. `foo="true" bar="false"` (the arguments are sorted by name in alphabetical order)
+* `_args.skipIdenticalKeyValue` - returns only the arguments with the name not equal to the value; typically `bar` from `{#test foo="foo" bar=true /}`
+* `_args.skipIt` - returns all arguments except for the first unnamed argument; typically `bar` from `{#test foo bar=true /}`
+* `_args.asHtmlAttributes` - renders the arguments as HTML attributes; e.g. `foo="true" readonly="readonly"`; the arguments are sorted by name in alphabetical order and the `'`, `"`, `<`, `>`, `&` characters are escaped 
 
-`_args` is also iterable: `{#each _args}{it.key}={it.value}{/each}`.
+`_args` is also iterable of `java.util.Map.Entry`: `{#each _args}{it.key}={it.value}{/each}`.
 
 For example, we can call the user tag defined below with `{#test 'Martin' readonly=true /}`.
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/LiteralSupport.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/LiteralSupport.java
@@ -23,8 +23,7 @@ class LiteralSupport {
         if (literal == null || literal.isEmpty()) {
             return value;
         }
-        char firstChar = literal.charAt(0);
-        if (isStringLiteralSeparator(firstChar) && literal.charAt(literal.length() - 1) == firstChar) {
+        if (isStringLiteral(literal)) {
             value = literal.substring(1, literal.length() - 1);
         } else if (literal.equals("true")) {
             value = Boolean.TRUE;
@@ -33,6 +32,7 @@ class LiteralSupport {
         } else if (literal.equals("null")) {
             value = null;
         } else {
+            char firstChar = literal.charAt(0);
             if (Character.isDigit(firstChar) || firstChar == '-' || firstChar == '+') {
                 if (INTEGER_LITERAL_PATTERN.matcher(literal).matches()) {
                     try {
@@ -75,6 +75,14 @@ class LiteralSupport {
      */
     static boolean isStringLiteralSeparator(char character) {
         return character == '"' || character == '\'';
+    }
+
+    static boolean isStringLiteral(String value) {
+        if (value == null || value.isEmpty()) {
+            return false;
+        }
+        char firstChar = value.charAt(0);
+        return isStringLiteralSeparator(firstChar) && value.charAt(value.length() - 1) == firstChar;
     }
 
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
@@ -159,9 +159,12 @@ public interface SectionHelperFactory<T extends SectionHelper> {
         String getLabel();
 
         /**
-         * Undeclared params with default values are included.
+         * An unmodifiable ordered map of parsed parameters.
+         * <p>
+         * Note that the order does not necessary reflect the original positions of the parameters but the parsing order.
          *
          * @return the map of parameters
+         * @see SectionHelperFactory#getParameters()
          */
         Map<String, String> getParameters();
 
@@ -172,6 +175,14 @@ public interface SectionHelperFactory<T extends SectionHelper> {
         default boolean hasParameter(String name) {
             return getParameters().containsKey(name);
         }
+
+        /**
+         *
+         * @param position
+         * @return the parameter for the specified position, or {@code null} if no such parameter exists
+         * @see SectionBlock#getParameter(int)
+         */
+        String getParameter(int position);
 
         /**
          * Parse and register an expression for the specified parameter.
@@ -197,6 +208,7 @@ public interface SectionHelperFactory<T extends SectionHelper> {
         /**
          *
          * @return the parameters of the main block
+         * @see SectionBlock#parameters
          */
         default public Map<String, String> getParameters() {
             return getBlocks().get(0).parameters;
@@ -217,6 +229,15 @@ public interface SectionHelperFactory<T extends SectionHelper> {
          */
         default public String getParameter(String name) {
             return getParameters().get(name);
+        }
+
+        /**
+         *
+         * @return the parameter for the specified position
+         * @see SectionBlock#getParameter(int)
+         */
+        default public String getParameter(int position) {
+            return getBlocks().get(0).getParameter(position);
         }
 
         /**

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/UserTagSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/UserTagSectionHelper.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public class UserTagSectionHelper extends IncludeSectionHelper implements SectionHelper {
@@ -15,14 +17,16 @@ public class UserTagSectionHelper extends IncludeSectionHelper implements Sectio
     private static final String NESTED_CONTENT = "nested-content";
 
     protected final boolean isNestedContentNeeded;
-
     private final HtmlEscaper htmlEscaper;
+    private final String itKey;
 
     UserTagSectionHelper(Supplier<Template> templateSupplier, Map<String, SectionBlock> extendingBlocks,
-            Map<String, Expression> parameters, boolean isIsolated, boolean isNestedContentNeeded, HtmlEscaper htmlEscaper) {
+            Map<String, Expression> parameters, boolean isIsolated, boolean isNestedContentNeeded, HtmlEscaper htmlEscaper,
+            String itKey) {
         super(templateSupplier, extendingBlocks, parameters, isIsolated);
         this.isNestedContentNeeded = isNestedContentNeeded;
         this.htmlEscaper = htmlEscaper;
+        this.itKey = itKey;
     }
 
     @Override
@@ -32,7 +36,7 @@ public class UserTagSectionHelper extends IncludeSectionHelper implements Sectio
 
     @Override
     protected void addAdditionalEvaluatedParams(SectionResolutionContext context, Map<String, Object> evaluatedParams) {
-        evaluatedParams.put(Factory.ARGS, new Arguments(evaluatedParams, htmlEscaper));
+        evaluatedParams.put(Factory.ARGS, new Arguments(evaluatedParams));
         if (isNestedContentNeeded) {
             // If needed then add the {nested-content} to the evaluated params
             Expression nestedContent = ((TemplateImpl) template.get()).findExpression(this::isNestedContent);
@@ -90,15 +94,17 @@ public class UserTagSectionHelper extends IncludeSectionHelper implements Sectio
         }
 
         @Override
-        protected boolean ignoreParameterInit(String key, String value) {
+        protected boolean ignoreParameterInit(Supplier<String> firstParamSupplier, String key, String value) {
             // {#myTag _isolated=true /}
-            return super.ignoreParameterInit(key, value) || (key.equals(ISOLATED)
-                    // {#myTag _isolated /}
-                    || value.equals(ISOLATED)
-                    // {#myTag _unisolated /}
-                    || value.equals(UNISOLATED)
-                    // IT with default value, e.g. {#myTag foo=bar /}
-                    || (key.equals(IT) && value.equals(IT)));
+            return super.ignoreParameterInit(firstParamSupplier, key, value)
+                    || (key.equals(ISOLATED)
+                            // {#myTag _isolated /}
+                            || value.equals(ISOLATED)
+                            // {#myTag _unisolated /}
+                            || value.equals(UNISOLATED)
+                            // IT with default value or not the first agrument
+                            // e.g. it=it in {#myTag foo=bar /} or baz in {#myTag foo=bar baz /}
+                            || (key.equals(IT) && (!firstParamSupplier.get().equals(value) || value.equals(IT))));
         }
 
         @Override
@@ -110,43 +116,60 @@ public class UserTagSectionHelper extends IncludeSectionHelper implements Sectio
         protected UserTagSectionHelper newHelper(Supplier<Template> template, Map<String, Expression> params,
                 Map<String, SectionBlock> extendingBlocks, Boolean isolatedValue, SectionInitContext context) {
             boolean isNestedContentNeeded = !context.getBlock(SectionHelperFactory.MAIN_BLOCK_NAME).isEmpty();
+            // Use the filtered map of paramas and not the original map from the SectionInitContext
+            Expression itKeyExpr = params.getOrDefault(IT, null);
+
             return new UserTagSectionHelper(template, extendingBlocks, params,
                     isolatedValue != null ? isolatedValue
                             : Boolean.parseBoolean(context.getParameterOrDefault(ISOLATED, ISOLATED_DEFAULT_VALUE)),
-                    isNestedContentNeeded, htmlEscaper);
+                    isNestedContentNeeded, htmlEscaper,
+                    itKeyExpr != null ? stripQuotationMarks(itKeyExpr.toOriginalString()) : null);
         }
 
         @Override
-        protected void handleParamInit(String key, String value, SectionInitContext context, Map<String, Expression> params) {
+        protected void handleParam(String key, String value, Supplier<String> firstParamSupplier,
+                BiConsumer<String, String> paramConsumer) {
             if (key.equals(IT)) {
                 if (value.equals(IT)) {
                     return;
                 } else if (isSinglePart(value)) {
-                    // Also register the param with a defaulted key
-                    params.put(value, context.getExpression(key));
+                    // Also register the param expression with the defaulted key
+                    // {#include "foo" /} => {#include foo="foo" /}
+                    String defaultedKey = stripQuotationMarks(value);
+                    paramConsumer.accept(defaultedKey, value);
                 }
             }
-            super.handleParamInit(key, value, context, params);
+            super.handleParam(key, value, firstParamSupplier, paramConsumer);
         }
 
     }
 
-    public static class Arguments implements Iterable<Entry<String, Object>> {
+    private static String stripQuotationMarks(String value) {
+        if (LiteralSupport.isStringLiteral(value)) {
+            // {#include "foo" /} => {#include foo="foo" /}
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    public class Arguments implements Iterable<Entry<String, Object>> {
 
         private final List<Entry<String, Object>> args;
-        private final HtmlEscaper htmlEscaper;
 
-        Arguments(Map<String, Object> map, HtmlEscaper htmlEscaper) {
+        Arguments(Map<String, Object> map) {
             this.args = new ArrayList<>(Objects.requireNonNull(map).size());
-            map.entrySet().forEach(args::add);
-            // sort by key
+            for (Entry<String, Object> e : map.entrySet()) {
+                // Always skip the first unnamed parameter
+                if (!e.getKey().equals(UserTagSectionHelper.Factory.IT)) {
+                    args.add(e);
+                }
+            }
+            // Sort by key
             this.args.sort(Comparator.comparing(Entry::getKey));
-            this.htmlEscaper = htmlEscaper;
         }
 
         private Arguments(List<Entry<String, Object>> args, HtmlEscaper htmlEscaper) {
             this.args = args;
-            this.htmlEscaper = htmlEscaper;
         }
 
         public boolean isEmpty() {
@@ -173,27 +196,30 @@ public class UserTagSectionHelper extends IncludeSectionHelper implements Sectio
 
         public Arguments skip(String... keys) {
             Set<String> keySet = Set.of(keys);
-            List<Entry<String, Object>> newArgs = new ArrayList<>(args.size());
-            for (Entry<String, Object> e : args) {
-                if (!keySet.contains(e.getKey())) {
-                    newArgs.add(e);
-                }
-            }
-            return new Arguments(newArgs, htmlEscaper);
+            return doFilter(e -> !keySet.contains(e.getKey()));
+        }
+
+        public Arguments skipIdenticalKeyValue() {
+            return doFilter(e -> !e.getKey().equals(e.getValue()));
+        }
+
+        /**
+         * Skip the first argument if it does not define a name.
+         */
+        public Arguments skipIt() {
+            return doFilter(e -> !e.getKey().equals(itKey));
         }
 
         public Arguments filter(String... keys) {
             Set<String> keySet = Set.of(keys);
-            List<Entry<String, Object>> newArgs = new ArrayList<>(args.size());
-            for (Entry<String, Object> e : args) {
-                if (keySet.contains(e.getKey())) {
-                    newArgs.add(e);
-                }
-            }
-            return new Arguments(newArgs, htmlEscaper);
+            return doFilter(e -> keySet.contains(e.getKey()));
         }
 
-        // foo="1" bar="true"
+        public Arguments filterIdenticalKeyValue() {
+            return doFilter(e -> e.getKey().equals(e.getValue()));
+        }
+
+        // foo="1" bar="true" readonly="readonly"
         public RawString asHtmlAttributes() {
             StringBuilder builder = new StringBuilder();
             for (Iterator<Entry<String, Object>> it = args.iterator(); it.hasNext();) {
@@ -207,6 +233,16 @@ public class UserTagSectionHelper extends IncludeSectionHelper implements Sectio
                 }
             }
             return new RawString(builder.toString());
+        }
+
+        private Arguments doFilter(Predicate<Entry<String, Object>> predicate) {
+            List<Entry<String, Object>> newArgs = new ArrayList<>(args.size());
+            for (Entry<String, Object> e : args) {
+                if (predicate.test(e)) {
+                    newArgs.add(e);
+                }
+            }
+            return new Arguments(newArgs, htmlEscaper);
         }
 
     }


### PR DESCRIPTION
- always skip the artificial "it" arg
- strip quotes from the defaulted key for a single word string literal value-only argument; {#tag "foo"} becomes {#tag foo="foo"}
- add Arguments#skipIdenticalKeyValue(),  Arguments#filterIdenticalKeyValue() and Arguments#skipIt()
- resolves https://github.com/quarkusio/quarkus/issues/38280