### PR TITLE
DevUI: Show source editor when config file is empty

### DIFF
--- a/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration-editor.js
+++ b/extensions/vertx-http/dev-ui-resources/src/main/resources/dev-ui/qwc/qwc-configuration-editor.js
@@ -71,16 +71,14 @@ export class QwcConfigurationEditor extends LitElement {
             return html`<span>Error: ${this._error}</span>`;
         }
 
-        if(this._value){
-            return html`
-            ${this._renderToolbar()}
-            <qui-code-block id="code"
-                mode='${this._type}'
-                content='${this._value}'
-                value='${this._value}'
-                editable>
-            </qui-code-block>`;
-        }
+        return html`
+        ${this._renderToolbar()}
+        <qui-code-block id="code"
+            mode='${this._type}'
+            content='${this._value}'
+            value='${this._value}'
+            editable>
+        </qui-code-block>`;
     }
 
     _renderToolbar(){


### PR DESCRIPTION
The source editor would not render if the contents of the config file were empty. This PR fixes that