### PR TITLE
Fix entity-manager retrieval in spring-data-jpa

### DIFF
--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/AdditionalJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/AdditionalJpaOperations.java
@@ -32,7 +32,7 @@ public class AdditionalJpaOperations {
     public static PanacheQuery<?> find(AbstractJpaOperations<?> jpaOperations, Class<?> entityClass, String query,
             String countQuery, Sort sort, Map<String, Object> params) {
         String findQuery = createFindQuery(entityClass, query, jpaOperations.paramCount(params));
-        EntityManager em = jpaOperations.getEntityManager();
+        EntityManager em = jpaOperations.getEntityManager(entityClass);
         Query jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
         JpaOperations.bindParameters(jpaQuery, params);
         return new CustomCountPanacheQuery(em, jpaQuery, countQuery, params);
@@ -47,14 +47,14 @@ public class AdditionalJpaOperations {
     public static PanacheQuery<?> find(AbstractJpaOperations<?> jpaOperations, Class<?> entityClass, String query,
             String countQuery, Sort sort, Object... params) {
         String findQuery = createFindQuery(entityClass, query, jpaOperations.paramCount(params));
-        EntityManager em = jpaOperations.getEntityManager();
+        EntityManager em = jpaOperations.getEntityManager(entityClass);
         Query jpaQuery = em.createQuery(sort != null ? findQuery + toOrderBy(sort) : findQuery);
         JpaOperations.bindParameters(jpaQuery, params);
         return new CustomCountPanacheQuery(em, jpaQuery, countQuery, params);
     }
 
     public static long deleteAllWithCascade(AbstractJpaOperations<?> jpaOperations, Class<?> entityClass) {
-        EntityManager em = jpaOperations.getEntityManager();
+        EntityManager em = jpaOperations.getEntityManager(entityClass);
         //detecting the case where there are cascade-delete associations, and do the bulk delete query otherwise.
         if (deleteOnCascadeDetected(jpaOperations, entityClass)) {
             int count = 0;
@@ -77,7 +77,7 @@ public class AdditionalJpaOperations {
      * @return true if cascading delete is needed. False otherwise
      */
     private static boolean deleteOnCascadeDetected(AbstractJpaOperations<?> jpaOperations, Class<?> entityClass) {
-        EntityManager em = jpaOperations.getEntityManager();
+        EntityManager em = jpaOperations.getEntityManager(entityClass);
         Metamodel metamodel = em.getMetamodel();
         EntityType<?> entity1 = metamodel.entity(entityClass);
         Set<Attribute<?, ?>> declaredAttributes = ((EntityTypeImpl) entity1).getDeclaredAttributes();
@@ -96,7 +96,7 @@ public class AdditionalJpaOperations {
 
     public static <PanacheQueryType> long deleteWithCascade(AbstractJpaOperations<PanacheQueryType> jpaOperations,
             Class<?> entityClass, String query, Object... params) {
-        EntityManager em = jpaOperations.getEntityManager();
+        EntityManager em = jpaOperations.getEntityManager(entityClass);
         if (deleteOnCascadeDetected(jpaOperations, entityClass)) {
             int count = 0;
             List<?> objects = jpaOperations.list(jpaOperations.find(entityClass, query, params));
@@ -112,7 +112,7 @@ public class AdditionalJpaOperations {
     public static <PanacheQueryType> long deleteWithCascade(AbstractJpaOperations<PanacheQueryType> jpaOperations,
             Class<?> entityClass, String query,
             Map<String, Object> params) {
-        EntityManager em = jpaOperations.getEntityManager();
+        EntityManager em = jpaOperations.getEntityManager(entityClass);
         if (deleteOnCascadeDetected(jpaOperations, entityClass)) {
             int count = 0;
             List<?> objects = jpaOperations.list(jpaOperations.find(entityClass, query, params));

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/MultiplePersistenceUnitConfigTest.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/MultiplePersistenceUnitConfigTest.java
@@ -1,9 +1,20 @@
 package io.quarkus.spring.data.deployment.multiple_pu;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Supplier;
+
+import jakarta.inject.Inject;
+
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.spring.data.deployment.multiple_pu.first.FirstEntity;
 import io.quarkus.spring.data.deployment.multiple_pu.first.FirstEntityRepository;
 import io.quarkus.spring.data.deployment.multiple_pu.second.SecondEntity;
@@ -21,6 +32,17 @@ public class MultiplePersistenceUnitConfigTest {
                             PanacheTestResource.class)
                     .addAsResource("application-multiple-persistence-units.properties", "application.properties"));
 
+    @Inject
+    private FirstEntityRepository repository1;
+    @Inject
+    private SecondEntityRepository repository2;
+
+    @BeforeEach
+    void beforeEach() {
+        repository1.deleteAll();
+        repository2.deleteAll();
+    }
+
     @Test
     public void panacheOperations() {
         /**
@@ -34,5 +56,65 @@ public class MultiplePersistenceUnitConfigTest {
          */
         RestAssured.when().get("/persistence-unit/second/name-1").then().body(Matchers.is("1"));
         RestAssured.when().get("/persistence-unit/second/name-2").then().body(Matchers.is("2"));
+    }
+
+    @Test
+    public void entityLifecycle() {
+        var detached = repository2.save(new SecondEntity());
+        assertThat(detached.id).isNotNull();
+        assertThat(inTx(repository2::count)).isEqualTo(1);
+
+        detached.name = "name";
+        repository2.save(detached);
+        assertThat(inTx(repository2::count)).isEqualTo(1);
+
+        inTx(() -> {
+            var lazyRef = repository2.getOne(detached.id);
+            assertThat(lazyRef.name).isEqualTo(detached.name);
+            return null;
+        });
+
+        repository2.deleteByName("otherThan" + detached.name);
+        assertThat(inTx(() -> repository2.findById(detached.id))).isPresent();
+
+        repository2.deleteByName(detached.name);
+        assertThat(inTx(() -> repository2.findById(detached.id))).isEmpty();
+    }
+
+    @Test
+    void pagedQueries() {
+        var newEntity = new SecondEntity();
+        newEntity.name = "name";
+        var detached = repository2.save(newEntity);
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
+
+        var page = inTx(() -> repository2.findByName(detached.name, pageable));
+        assertThat(page.getContent()).extracting(e -> e.id).containsExactly(detached.id);
+
+        var pageIndexParam = inTx(() -> repository2.findByNameQueryIndexed(detached.name, pageable));
+        assertThat(pageIndexParam.getContent()).extracting(e -> e.id).containsExactly(detached.id);
+
+        var pageNamedParam = inTx(() -> repository2.findByNameQueryNamed(detached.name, pageable));
+        assertThat(pageNamedParam.getContent()).extracting(e -> e.id).containsExactly(detached.id);
+    }
+
+    @Test
+    void cascading() {
+        var newParent = new SecondEntity();
+        newParent.name = "parent";
+        var newChild = new SecondEntity();
+        newChild.name = "child";
+        newParent.child = newChild;
+        var detachedParent = repository2.save(newParent);
+
+        assertThat(inTx(repository2::count)).isEqualTo(2);
+
+        repository2.deleteByName(detachedParent.name);
+        assertThat(inTx(repository2::count)).isZero();
+    }
+
+    private <T> T inTx(Supplier<T> action) {
+        return QuarkusTransaction.requiringNew().call(action::get);
     }
 }

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/second/SecondEntity.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/second/SecondEntity.java
@@ -1,8 +1,6 @@
 package io.quarkus.spring.data.deployment.multiple_pu.second;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 
 @Entity
 public class SecondEntity {
@@ -12,4 +10,7 @@ public class SecondEntity {
     public Long id;
 
     public String name;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    public SecondEntity child;
 }

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/second/SecondEntityRepository.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/multiple_pu/second/SecondEntityRepository.java
@@ -1,5 +1,11 @@
 package io.quarkus.spring.data.deployment.multiple_pu.second;
 
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -8,4 +14,21 @@ public interface SecondEntityRepository extends org.springframework.data.reposit
     SecondEntity save(SecondEntity entity);
 
     long count();
+
+    Optional<SecondEntity> findById(Long id);
+
+    SecondEntity getOne(Long id);
+
+    void deleteAll();
+
+    void deleteByName(String name);
+
+    Page<SecondEntity> findByName(String name, Pageable pageable);
+
+    @Query(value = "SELECT se FROM SecondEntity se WHERE name=?1", countQuery = "SELECT COUNT(*) FROM SecondEntity se WHERE name=?1")
+    Page<SecondEntity> findByNameQueryIndexed(String name, Pageable pageable);
+
+    @Query(value = "SELECT se FROM SecondEntity se WHERE name=:name", countQuery = "SELECT COUNT(*) FROM SecondEntity se WHERE name=:name")
+    Page<SecondEntity> findByNameQueryNamed(@Param("name") String name, Pageable pageable);
+
 }

--- a/extensions/spring-data-jpa/runtime/src/main/java/io/quarkus/spring/data/runtime/RepositorySupport.java
+++ b/extensions/spring-data-jpa/runtime/src/main/java/io/quarkus/spring/data/runtime/RepositorySupport.java
@@ -42,7 +42,7 @@ public final class RepositorySupport {
     }
 
     public static Object getOne(AbstractJpaOperations<PanacheQuery<?>> operations, Class<?> entityClass, Object id) {
-        return operations.getEntityManager().getReference(entityClass, id);
+        return operations.getEntityManager(entityClass).getReference(entityClass, id);
     }
 
     public static void clear(Class<?> clazz) {


### PR DESCRIPTION
Resolves some problems with `quarkus-spring-data-repositories` when using multiple persistence-units for the following operations:
* save a detached entity (merge)
* getOne
* paginated queries
* deleteAll


Fixes: https://github.com/quarkusio/quarkus/issues/38319