### PR TITLE
Hibernate DDL created twice

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-persistence-units.js
+++ b/extensions/hibernate-orm/deployment/src/main/resources/dev-ui/hibernate-orm-persistence-units.js
@@ -88,6 +88,21 @@ export class HibernateOrmPersistenceUnitsComponent extends LitElement {
                         <vaadin-horizontal-layout
                                 theme="spacing"
                                 style="align-items: center;">
+                            <span>Update Script</span>
+                            <vaadin-button @click="${(e) => this._copyToClipboard(e, 'Update Script')}"
+                                    theme="small">
+                                <vaadin-icon icon="font-awesome-solid:clipboard"></vaadin-icon>
+                                Copy
+                            </vaadin-button>
+                        </vaadin-horizontal-layout>
+                    </vaadin-details-summary>
+                    <pre class="ddl-script">${pu.updateDDL}</pre>
+                </vaadin-details>
+                <vaadin-details>
+                    <vaadin-details-summary slot="summary" theme="filled">
+                        <vaadin-horizontal-layout
+                                theme="spacing"
+                                style="align-items: center;">
                             <span>Drop Script</span>
                             <vaadin-button @click="${(e) => this._copyToClipboard(e, 'Drop Script')}"
                                     theme="small">

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevInfo.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dev/HibernateOrmDevInfo.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 
 import org.hibernate.LockOptions;
 import org.hibernate.boot.query.NamedHqlQueryDefinition;
@@ -44,18 +45,24 @@ public class HibernateOrmDevInfo {
         private final List<Entity> managedEntities;
         private final List<Query> namedQueries;
         private final List<Query> namedNativeQueries;
-        private final String createDDL;
-        private final String dropDDL;
+        private String createDDL;
+        private String dropDDL;
+        private String updateDDL;
+        private final Supplier<String> createDDLSupplier;
+        private final Supplier<String> dropDDLSupplier;
+        private final Supplier<String> updateDDLSupplier;
 
         public PersistenceUnit(String name, List<Entity> managedEntities,
                 List<Query> namedQueries,
-                List<Query> namedNativeQueries, String createDDL, String dropDDL) {
+                List<Query> namedNativeQueries, Supplier<String> createDDL, Supplier<String> dropDDL,
+                Supplier<String> updateDDLSupplier) {
             this.name = name;
             this.managedEntities = managedEntities;
             this.namedQueries = namedQueries;
             this.namedNativeQueries = namedNativeQueries;
-            this.createDDL = createDDL;
-            this.dropDDL = dropDDL;
+            this.createDDLSupplier = createDDL;
+            this.dropDDLSupplier = dropDDL;
+            this.updateDDLSupplier = updateDDLSupplier;
         }
 
         public String getName() {
@@ -81,12 +88,25 @@ public class HibernateOrmDevInfo {
             return allQueries;
         }
 
-        public String getCreateDDL() {
+        public synchronized String getCreateDDL() {
+            if (createDDL == null) {
+                createDDL = createDDLSupplier.get();
+            }
             return createDDL;
         }
 
-        public String getDropDDL() {
+        public synchronized String getDropDDL() {
+            if (dropDDL == null) {
+                dropDDL = dropDDLSupplier.get();
+            }
             return dropDDL;
+        }
+
+        public synchronized String getUpdateDDL() {
+            if (updateDDL == null) {
+                updateDDL = updateDDLSupplier.get();
+            }
+            return updateDDL;
         }
 
     }


### PR DESCRIPTION
In dev mode the hibernate DDL is eagerly created just in case is might be needed in the dev UI. This fixes that, and also adds the ability to view the update script which can be really useful to create flyway migrations.

Fixes #38357