### PR TITLE
Introduce `quarkus-snapshot` profile

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/pom.tpl.qute.xml
@@ -123,4 +123,19 @@
         </pluginManagement>
     </build>
 {/if}
+    <profiles>
+        <!-- Activate this profile to build against the Quarkus Snapshot artifacts -->
+        <profile>
+            <id>quarkus-snapshot</id>
+            <activation>
+                <property>
+                    <name>quarkus-snapshot</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+                <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
@@ -206,6 +206,19 @@
                 <skipITs>false</skipITs>
             </properties>
         </profile>
+        <!-- Activate this profile to build against the Quarkus Snapshot artifacts -->
+        <profile>
+            <id>quarkus-snapshot</id>
+            <activation>
+                <property>
+                    <name>quarkus-snapshot</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+                <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+            </properties>
+        </profile>
     </profiles>
     {/if}
 </project>


### PR DESCRIPTION
There are cases where it would be interesting to build/run an application using the latest Quarkus SNAPSHOT. This introduces a Maven profile changing the properties in the pom.xml to use the `io.quarkus:quarkus-bom:999-SNAPSHOT` artifact by doing:

```bash
mvn clean package -Dquarkus-snapshot
```

