### PR TITLE
Use UpdateDependencyVersionOperation first to update Quarkus version

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/update/rewrite/QuarkusUpdates.java
@@ -39,7 +39,12 @@ public final class QuarkusUpdates {
         }
         switch (request.buildTool) {
             case MAVEN:
-                recipe.addOperation(new UpdatePropertyOperation("quarkus.platform.version", request.targetVersion))
+                recipe.addOperation(
+                        new UpdateDependencyVersionOperation("io.quarkus.platform", "quarkus-bom", request.targetVersion))
+                        .addOperation(new UpdateDependencyVersionOperation("io.quarkus", "quarkus-bom", request.targetVersion))
+                        .addOperation(new UpdateDependencyVersionOperation("io.quarkus", "quarkus-universe-bom",
+                                request.targetVersion))
+                        .addOperation(new UpdatePropertyOperation("quarkus.platform.version", request.targetVersion))
                         .addOperation(new UpdatePropertyOperation("quarkus.version", request.targetVersion))
                         .addOperation(new UpdatePropertyOperation("quarkus-plugin.version", request.targetVersion));
                 if (request.kotlinVersion != null) {


### PR DESCRIPTION
It is important to try that first as that recipe updates the OpenRewrite model, and thus the BOM, for the following recipes. This is important for the recipe syncing the Hibernate ORM modelgen annotation processor with the version coming from the BOM as we want to sync it with the updated version.