### PR TITLE
Make it easier to get the default  OIDC metadata

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -9,6 +9,7 @@ import javax.crypto.spec.SecretKeySpec;
 import org.jboss.logging.Logger;
 
 import io.quarkus.oidc.OIDCException;
+import io.quarkus.oidc.OidcConfigurationMetadata;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.runtime.configuration.ConfigurationException;
@@ -156,6 +157,10 @@ public class TenantConfigContext {
 
     public OidcTenantConfig getOidcTenantConfig() {
         return oidcConfig;
+    }
+
+    public OidcConfigurationMetadata getOidcMetadata() {
+        return provider != null ? provider.getMetadata() : null;
     }
 
     public SecretKey getStateEncryptionKey() {


### PR DESCRIPTION
Minor update to make it easier to get the default metadata without having to inject it in the routes