### PR TITLE
Fix documentation for profiles

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -262,10 +262,10 @@ public class TestConfig {
     public static class Profile {
 
         /**
-         * The profile (dev, test or prod) to use when testing using @QuarkusTest
+         * A comma separated list of profiles (dev, test, prod or custom profiles) to use when testing using @QuarkusTest
          */
         @ConfigItem(name = ConfigItem.PARENT, defaultValue = "test")
-        String profile;
+        List<String> profile;
 
         /**
          * The tags this profile is associated with.

--- a/core/runtime/src/main/java/io/quarkus/runtime/ConfigConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ConfigConfig.java
@@ -20,9 +20,9 @@ import io.smallrye.config.WithName;
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public interface ConfigConfig {
     /**
-     * Profile that will be active when Quarkus launches.
+     * A comma separated list of profiles that will be active when Quarkus launches.
      */
-    Optional<String> profile();
+    Optional<List<String>> profile();
 
     /**
      * Accepts a single configuration profile name. If a configuration property cannot be found in the current active


### PR DESCRIPTION
This corrects the documentation for the properties quarkus.profile and quarkus.test.profile.

Fixes #38345