### PR TITLE
Simplify Netty unsafe build item configuration for the shaded JCTools queues

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyProcessor.java
@@ -254,23 +254,8 @@ class NettyProcessor {
         return Arrays.asList(
                 new UnsafeAccessedFieldBuildItem("sun.nio.ch.SelectorImpl", "selectedKeys"),
                 new UnsafeAccessedFieldBuildItem("sun.nio.ch.SelectorImpl", "publicSelectedKeys"),
-
-                new UnsafeAccessedFieldBuildItem(
-                        "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField", "producerIndex"),
-                new UnsafeAccessedFieldBuildItem(
-                        "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField", "producerLimit"),
-                new UnsafeAccessedFieldBuildItem(
-                        "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField", "consumerIndex"),
-
-                new UnsafeAccessedFieldBuildItem(
-                        "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
-                        "producerIndex"),
-                new UnsafeAccessedFieldBuildItem(
-                        "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
-                        "producerLimit"),
-                new UnsafeAccessedFieldBuildItem(
-                        "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
-                        "consumerIndex"));
+                new UnsafeAccessedFieldBuildItem("io.netty.util.internal.shaded.org.jctools.util.UnsafeRefArrayAccess",
+                        "REF_ELEMENT_SHIFT"));
     }
 
     @BuildStep


### PR DESCRIPTION
GraalVM now seems to have good heuristics to spot the classic `Unsafe` usage patterns. 

I removed some `UnsafeAccessedFieldBuildItem` and added one for `UnsafeRefArrayAccess` as this class has a problematic static field (`REF_ELEMENT_SHIFT`).

For there record I found about this while working on https://github.com/smallrye/smallrye-mutiny/pull/1434