### PR TITLE
Make possible to reuse code flow scope calculation and initialized OIDC WebClient

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -6,10 +6,8 @@ import static io.quarkus.oidc.runtime.OidcIdentityProvider.REFRESH_TOKEN_GRANT_R
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Base64.Encoder;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -64,7 +62,6 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     public static final String SESSION_MAX_AGE_PARAM = "session-max-age";
     static final String AMP = "&";
     static final String EQ = "=";
-    static final String COMMA = ",";
     static final String COOKIE_DELIM = "|";
     static final Pattern COOKIE_PATTERN = Pattern.compile("\\" + COOKIE_DELIM);
     static final String STATE_COOKIE_RESTORE_PATH = "restore-path";
@@ -602,23 +599,8 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                 .append(OidcCommonUtils.urlEncode(configContext.oidcConfig.clientId.get()));
 
                         // scope
-                        List<String> oidcConfigScopes = configContext.oidcConfig.getAuthentication().scopes.isPresent()
-                                ? configContext.oidcConfig.getAuthentication().scopes.get()
-                                : Collections.emptyList();
-                        List<String> scopes = new ArrayList<>(oidcConfigScopes.size() + 1);
-                        if (configContext.oidcConfig.getAuthentication().addOpenidScope.orElse(true)) {
-                            scopes.add(OidcConstants.OPENID_SCOPE);
-                        }
-                        scopes.addAll(oidcConfigScopes);
-                        // Extra scopes if any
-                        String extraScopeValue = configContext.oidcConfig.getAuthentication().getExtraParams()
-                                .get(OidcConstants.TOKEN_SCOPE);
-                        if (extraScopeValue != null) {
-                            String[] extraScopes = extraScopeValue.split(COMMA);
-                            scopes.addAll(List.of(extraScopes));
-                        }
                         codeFlowParams.append(AMP).append(OidcConstants.TOKEN_SCOPE).append(EQ)
-                                .append(OidcCommonUtils.urlEncode(String.join(" ", scopes)));
+                                .append(OidcUtils.encodeScopes(configContext.oidcConfig));
 
                         MultiMap requestQueryParams = null;
                         if (!configContext.oidcConfig.getAuthentication().forwardParams.isEmpty()) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -266,4 +266,8 @@ public class OidcProviderClient implements Closeable {
     public Vertx getVertx() {
         return vertx;
     }
+
+    public WebClient getWebClient() {
+        return client;
+    }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -163,6 +163,10 @@ public class TenantConfigContext {
         return provider != null ? provider.getMetadata() : null;
     }
 
+    public OidcProviderClient getOidcProviderClient() {
+        return provider != null ? provider.client : null;
+    }
+
     public SecretKey getStateEncryptionKey() {
         return stateSecretKey;
     }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -280,6 +280,27 @@ public class OidcUtilsTest {
         assertNull(perms[3].getActions());
     }
 
+    @Test
+    public void testEncodeScopesOpenidAdded() throws Exception {
+        OidcTenantConfig config = new OidcTenantConfig();
+        assertEquals("openid", OidcUtils.encodeScopes(config));
+    }
+
+    @Test
+    public void testEncodeScopesOpenidNotAdded() throws Exception {
+        OidcTenantConfig config = new OidcTenantConfig();
+        config.authentication.setAddOpenidScope(false);
+        assertEquals("", OidcUtils.encodeScopes(config));
+    }
+
+    @Test
+    public void testEncodeAllScopes() throws Exception {
+        OidcTenantConfig config = new OidcTenantConfig();
+        config.authentication.setScopes(List.of("a:1", "b:2"));
+        config.authentication.setExtraParams(Map.of("scope", "c,d"));
+        assertEquals("openid+a%3A1+b%3A2+c+d", OidcUtils.encodeScopes(config));
+    }
+
     public static JsonObject read(InputStream input) throws IOException {
         try (BufferedReader buffer = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
             return new JsonObject(buffer.lines().collect(Collectors.joining("\n")));


### PR DESCRIPTION
Two more simple updates to make some OIDC code reusable by OidcProxy:
* Instead of creating its own WebClient, it should get a correctly initialized one in OIDC (MTLS, proxy, connection timeout properties, etc)
* Move the CodeAuthenticationMechanism code for calculating OIDC scopes to a utility code that can be reused