### PR TITLE
Replace {project-name} attribute in document title for downstream

### DIFF
--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 [id="datasources"]
-= Configure data sources in Quarkus
+= Configure data sources in {project-name}
 include::_attributes.adoc[]
 :diataxis-type: reference
 :categories: data,getting-started,reactive

--- a/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/AssembleDownstreamDocumentation.java
@@ -50,6 +50,9 @@ public class AssembleDownstreamDocumentation {
     private static final String SOURCE_BLOCK_PREFIX = "[source";
     private static final String SOURCE_BLOCK_DELIMITER = "--";
 
+    private static final String PROJECT_NAME_ATTRIBUTE = "{project-name}";
+    private static final String RED_HAT_BUILD_OF_QUARKUS = "Red Hat build of Quarkus";
+
     private static final String QUARKUS_IO_GUIDES_ATTRIBUTE = "{quarkusio-guides}";
 
     private static final Map<Pattern, String> TABS_REPLACEMENTS = Map.of(
@@ -301,10 +304,17 @@ public class AssembleDownstreamDocumentation {
         boolean findDelimiter = false;
         String currentSourceBlockDelimiter = "----";
         int lineNumber = 0;
+        boolean documentTitleFound = false;
 
         for (String line : guideLines) {
             lineNumber++;
 
+            if (!documentTitleFound && line.startsWith("= ")) {
+                // this is the document title
+                rewrittenGuide.append(line.replace(PROJECT_NAME_ATTRIBUTE, RED_HAT_BUILD_OF_QUARKUS) + "\n");
+                documentTitleFound = true;
+                continue;
+            }
             if (inSourceBlock) {
                 if (findDelimiter) {
                     rewrittenGuide.append(line + "\n");


### PR DESCRIPTION
The downstream tool does not handle attributes in project title so we need to replace the attribute ourselves.

The attribute is only replaced in the document title, the rest of the document uses standard attributes.

I pushed an example in datasource.adoc.

/cc @quarkusio/documentation 