### PR TITLE
Avoid dots in config doc ids as it's causing issues for downstream

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocFormatter.java
@@ -53,8 +53,8 @@ interface DocFormatter {
 
         // Apostrophes.
         string = string.replaceAll("([a-z])'s([^a-z])", "$1s$2");
-        // Allow only letters, -, _, .
-        string = string.replaceAll("[^\\w-_\\.]", "-").replaceAll("-{2,}", "-");
+        // Allow only letters, -, _
+        string = string.replaceAll("[^\\w-_]", "-").replaceAll("-{2,}", "-");
         // Get rid of any - at the start and end.
         string = string.replaceAll("-+$", "").replaceAll("^-+", "");
 

--- a/docs/src/main/asciidoc/build-analytics.adoc
+++ b/docs/src/main/asciidoc/build-analytics.adoc
@@ -166,19 +166,19 @@ mvn clean install -Dquarkus.analytics.disabled=true
 |===
 | Configuration property | Type | Default
 
-| [[build-analytics.quarkus.analytics.disabled]]`link:#build-analytics.quarkus.analytics.disabled[quarkus.analytics.disabled]`
+| [[build-analytics-quarkus-analytics-disabled]]`link:#build-analytics-quarkus-analytics-disabled[quarkus.analytics.disabled]`
 
 Values can be `true` or `false`.
 
 Setting this property to `true` will disable the collection of analytics data on that specific project regardless of any other configuration.
 | boolean
 | false
-| [[build-analytics.quarkus.analytics.uri.base]]`link:#build-analytics.quarkus.analytics.uri.base[quarkus.analytics.uri.base]`
+| [[build-analytics-quarkus-analytics-uri-base]]`link:#build-analytics.quarkus-analytics-uri-base[quarkus.analytics.uri.base]`
 
 Base URL of the analytics service. This is were all the data is sent to.
 | String
 | "https://api.segment.io/"
-| [[build-analytics.quarkus.analytics.timeout]]`link:#build-analytics.quarkus.analytics.timeout[quarkus.analytics.timeout]`
+| [[build-analytics-quarkus-analytics-timeout]]`link:#build-analytics-quarkus-analytics-timeout[quarkus.analytics.timeout]`
 
 Value in milliseconds for the timeout of the HTTP request to submit the analytics service.
 | int

--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -121,7 +121,7 @@ In that case, you will need to stop and remove these containers manually.
 If you want to reuse containers for some Quarkus applications but not all of them,
 or some Dev Services but not all of them,
 you can disable this feature for a specific Dev Service by setting the configuration property
-xref:databases-dev-services.adoc#quarkus-datasource-config-group-dev-services-build-time-config_quarkus.datasource.devservices.reuse[`quarkus.datasource.devservices.reuse`/`quarkus.datasource."datasource-name".devservices.reuse`]
+xref:databases-dev-services.adoc#quarkus-datasource-config-group-dev-services-build-time-config_quarkus-datasource-devservices-reuse[`quarkus.datasource.devservices.reuse`/`quarkus.datasource."datasource-name".devservices.reuse`]
 to `false`.
 
 == Mapping volumes into Dev Services for Database

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -238,7 +238,7 @@ You can provide the arguments that will be used by the Kubernetes Job via the pr
 
 Finally, the Kubernetes job will be launched every time it is installed in Kubernetes. You can know more about how to run Kubernetes jobs in this https://kubernetes.io/docs/concepts/workloads/controllers/job/#running-an-example-job[link].
 
-You can configure the rest of the Kubernetes Job configuration using the properties under `quarkus.kubernetes.job.xxx` (see xref:deploying-to-kubernetes.adoc#quarkus-kubernetes-kubernetes-config_quarkus.kubernetes.job.parallelism[link]).
+You can configure the rest of the Kubernetes Job configuration using the properties under `quarkus.kubernetes.job.xxx` (see xref:deploying-to-kubernetes.adoc#quarkus-kubernetes-kubernetes-config_quarkus-kubernetes-job-parallelism[link]).
 
 ==== Generating CronJob resources
 
@@ -253,7 +253,7 @@ quarkus.kubernetes.cron-job.schedule=0 * * * *
 
 IMPORTANT: CronJob resources require the https://en.wikipedia.org/wiki/Cron[Cron] expression to specify when to launch the job via the property `quarkus.kubernetes.cron-job.schedule`. If not provide, the build will fail.
 
-You can configure the rest of the Kubernetes CronJob configuration using the properties under `quarkus.kubernetes.cron-job.xxx` (see xref:deploying-to-kubernetes.adoc#quarkus-kubernetes-kubernetes-config_quarkus.kubernetes.cron-job.parallelism[link]).
+You can configure the rest of the Kubernetes CronJob configuration using the properties under `quarkus.kubernetes.cron-job.xxx` (see xref:deploying-to-kubernetes.adoc#quarkus-kubernetes-kubernetes-config_quarkus-kubernetes-cron-job-parallelism[link]).
 
 === Namespace
 

--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -417,7 +417,7 @@ You can provide the arguments that will be used by the Kubernetes Job via the pr
 
 Finally, the Kubernetes job will be launched every time that is installed in OpenShift. You can know more about how to run Kubernetes jobs in this https://kubernetes.io/docs/concepts/workloads/controllers/job/#running-an-example-job[link].
 
-You can configure the rest of the Kubernetes Job configuration using the properties under `quarkus.openshift.job.xxx` (see xref:deploying-to-openshift#quarkus-openshift-openshift-config_quarkus.openshift.job.parallelism[link]).
+You can configure the rest of the Kubernetes Job configuration using the properties under `quarkus.openshift.job.xxx` (see xref:deploying-to-openshift#quarkus-openshift-openshift-config_quarkus-openshift-job-parallelism[link]).
 
 ===== Generating CronJob resources
 
@@ -432,7 +432,7 @@ quarkus.openshift.cron-job.schedule=0 * * * *
 
 IMPORTANT: CronJob resources require the https://en.wikipedia.org/wiki/Cron[Cron] expression to specify when to launch the job via the property `quarkus.openshift.cron-job.schedule`. If not provide, the build will fail.
 
-You can configure the rest of the Kubernetes CronJob configuration using the properties under `quarkus.openshift.cron-job.xxx` (see xref:deploying-to-openshift.adoc#quarkus-openshift-openshift-config_quarkus.openshift.cron-job.parallelism[link]).
+You can configure the rest of the Kubernetes CronJob configuration using the properties under `quarkus.openshift.cron-job.xxx` (see xref:deploying-to-openshift.adoc#quarkus-openshift-openshift-config_quarkus-openshift-cron-job-parallelism[link]).
 
 ==== Validation
 

--- a/docs/src/main/asciidoc/elasticsearch-dev-services.adoc
+++ b/docs/src/main/asciidoc/elasticsearch-dev-services.adoc
@@ -123,7 +123,7 @@ including the Elasticsearch schema and the content of indexes.
 If that's not what you want -- and if your tests write to the indexes, that's probably not what you want --
 consider reinitializing your schema and data on application startup.
 If you use Hibernate Search,
-xref:hibernate-search-orm-elasticsearch.adoc#quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.schema-management.strategy[Hibernate Search's schema management]
+xref:hibernate-search-orm-elasticsearch.adoc#quarkus-hibernate-search-orm-elasticsearch_quarkus-hibernate-search-orm-schema-management-strategy[Hibernate Search's schema management]
 may help with that.
 ====
 
@@ -138,7 +138,7 @@ In that case, you will need to stop and remove these containers manually.
 If you want to reuse containers for some Quarkus applications but not all of them,
 or some Dev Services but not all of them,
 you can disable this feature for a specific Dev Service by setting the configuration property
-xref:elasticsearch-dev-services.adoc#quarkus-elasticsearch-devservices-elasticsearch-dev-services-build-time-config_quarkus.elasticsearch.devservices.reuse[`quarkus.elasticsearch.devservices.reuse`]
+xref:elasticsearch-dev-services.adoc#quarkus-elasticsearch-devservices-elasticsearch-dev-services-build-time-config_quarkus-elasticsearch-devservices-reuse[`quarkus.elasticsearch.devservices.reuse`]
 to `false`.
 
 == Current limitations

--- a/docs/src/main/asciidoc/getting-started-dev-services.adoc
+++ b/docs/src/main/asciidoc/getting-started-dev-services.adoc
@@ -238,7 +238,7 @@ Quarkus will automatically stop the container when your application stops.
 If you play with your code some more, you may notice that sometimes, after making an application change, http://localhost:8080/hello/names doesn't list any names.
 What's going on? By default, in dev mode, with a Dev Services database,
  Quarkus configures Hibernate ORM database generation to be `drop-and-create`.
- See the xref:hibernate-orm.adoc#quarkus-hibernate-orm_quarkus.hibernate-orm.database-database-related-configuration[Hibernate configuration reference] for more details.
+ See the xref:hibernate-orm.adoc#quarkus-hibernate-orm_quarkus-hibernate-orm-database-database-related-configuration[Hibernate configuration reference] for more details.
  If a code change triggers an application restart, the database tables
  will be dropped (deleted) and then re-created.
 

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -630,7 +630,7 @@ You can add mapping files following
 the https://jakarta.ee/specifications/persistence/3.0/jakarta-persistence-spec-3.0.html#a16944[`orm.xml` format (Jakarta Persistence)]
 or the http://hibernate.org/dtd/hibernate-mapping-3.0.dtd[`hbm.xml` format (specific to Hibernate ORM, deprecated)]:
 
-* in `application.properties` through the (build-time) link:#quarkus-hibernate-orm_quarkus.hibernate-orm.mapping-files[`quarkus.hibernate-orm.mapping-files`] property.
+* in `application.properties` through the (build-time) link:#quarkus-hibernate-orm_quarkus-hibernate-orm-mapping-files[`quarkus.hibernate-orm.mapping-files`] property.
 * in <<persistence-xml,`persistence.xml`>> through the `<mapping-file>` element.
 
 XML mapping files are parsed at build time.

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -659,7 +659,7 @@ which is why we provide Quarkus with this connection info in the `prod` profile 
 Because we rely on <<dev-services,Dev Services>>, the database and Elasticsearch schema
 will automatically be dropped and re-created on each application startup
 in tests and dev mode
-(unless link:#quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.schema-management.strategy[`quarkus.hibernate-search-orm.schema-management.strategy`] is set explicitly).
+(unless <<quarkus-hibernate-search-orm-elasticsearch_quarkus-hibernate-search-orm-schema-management-strategy,`quarkus.hibernate-search-orm.schema-management.strategy`>> is set explicitly).
 
 If for some reason you cannot use Dev Services,
 you will have to set the following properties to get similar behavior:
@@ -672,7 +672,7 @@ you will have to set the following properties to get similar behavior:
 %test.quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create
 ----
 
-See also link:#quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.schema-management.strategy[`quarkus.hibernate-search-orm.schema-management.strategy`].
+See also <<quarkus-hibernate-search-orm-elasticsearch_quarkus-hibernate-search-orm-schema-management-strategy,`quarkus.hibernate-search-orm.schema-management.strategy`>>.
 ====
 
 
@@ -898,10 +898,10 @@ this could cause a startup failure.
 To address this, you can configure Hibernate Search to not send any request on startup:
 
 * Disable Elasticsearch version checks on startup by setting the configuration property
-  link:#quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.elasticsearch.version-check.enabled[`quarkus.hibernate-search-orm.elasticsearch.version-check.enabled`]
+  <<quarkus-hibernate-search-orm-elasticsearch_quarkus-hibernate-search-orm-elasticsearch-version-check-enabled,`quarkus.hibernate-search-orm.elasticsearch.version-check.enabled`>>
   to `false`.
 * Disable schema management on startup by setting the configuration property
-  link:#quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.schema-management.strategy[`quarkus.hibernate-search-orm.schema-management.strategy`]
+  <<quarkus-hibernate-search-orm-elasticsearch_quarkus-hibernate-search-orm-schema-management-strategy,`quarkus.hibernate-search-orm.schema-management.strategy`>>
   to `none`.
 
 Of course, even with this configuration, Hibernate Search still won't be able to index anything or run search queries
@@ -948,7 +948,7 @@ To enable the `outbox-polling` coordination strategy, an additional extension is
 include::{includes}/devtools/extension-add.adoc[]
 
 Once the extension is there, you will need to explicitly select the `outbox-polling` strategy
-by setting link:#quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.coordination.strategy[`quarkus.hibernate-search-orm.coordination.strategy`]
+by setting <<quarkus-hibernate-search-orm-elasticsearch_quarkus-hibernate-search-orm-coordination-strategy,`quarkus.hibernate-search-orm.coordination.strategy`>>
 to `outbox-polling`.
 
 Finally, you will need to make sure that the Hibernate ORM entities added by Hibernate Search
@@ -965,16 +965,16 @@ link:{hibernate-search-docs-url}#coordination-outbox-polling-schema[manually alt
 The database schema Hibernate Search will expect for outbox-polling coordination
 may be customized through the following configuration properties:
 
-* link:#quarkus-hibernate-search-orm-outboxpolling_quarkus.hibernate-search-orm.coordination.entity-mapping.agent.catalog[`quarkus.hibernate-search-orm.coordination.entity-mapping.agent.catalog`]
-* link:#quarkus-hibernate-search-orm-outboxpolling_quarkus.hibernate-search-orm.coordination.entity-mapping.agent.schema[`quarkus.hibernate-search-orm.coordination.entity-mapping.agent.schema`]
-* link:#quarkus-hibernate-search-orm-outboxpolling_quarkus.hibernate-search-orm.coordination.entity-mapping.agent.table[`quarkus.hibernate-search-orm.coordination.entity-mapping.agent.table`]
-* link:#quarkus-hibernate-search-orm-outboxpolling_quarkus.hibernate-search-orm.coordination.entity-mapping.agent.uuid-gen-strategy[`quarkus.hibernate-search-orm.coordination.entity-mapping.agent.uuid-gen-strategy`]
-* link:#quarkus-hibernate-search-orm-outboxpolling_quarkus.hibernate-search-orm.coordination.entity-mapping.agent.uuid-type[`quarkus.hibernate-search-orm.coordination.entity-mapping.agent.uuid-type`]
-* link:#quarkus-hibernate-search-orm-outboxpolling_quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.catalog[`quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.catalog`]
-* link:#quarkus-hibernate-search-orm-outboxpolling_quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.schema[`quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.schema`]
-* link:#quarkus-hibernate-search-orm-outboxpolling_quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.table[`quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.table`]
-* link:#quarkus-hibernate-search-orm-outboxpolling_quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.uuid-gen-strategy[`quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.uuid-gen-strategy`]
-* link:#quarkus-hibernate-search-orm-outboxpolling_quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.uuid-type[`quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.uuid-type`]
+* <<quarkus-hibernate-search-orm-outboxpolling_quarkus-hibernate-search-orm-coordination-entity-mapping-agent-catalog,`quarkus.hibernate-search-orm.coordination.entity-mapping.agent.catalog`>>
+* <<quarkus-hibernate-search-orm-outboxpolling_quarkus-hibernate-search-orm-coordination-entity-mapping-agent-schema,`quarkus.hibernate-search-orm.coordination.entity-mapping.agent.schema`>>
+* <<quarkus-hibernate-search-orm-outboxpolling_quarkus-hibernate-search-orm-coordination-entity-mapping-agent-table,`quarkus.hibernate-search-orm.coordination.entity-mapping.agent.table`>>
+* <<quarkus-hibernate-search-orm-outboxpolling_quarkus-hibernate-search-orm-coordination-entity-mapping-agent-uuid-gen-strategy,`quarkus.hibernate-search-orm.coordination.entity-mapping.agent.uuid-gen-strategy`>>
+* <<quarkus-hibernate-search-orm-outboxpolling_quarkus-hibernate-search-orm-coordination-entity-mapping-agent-uuid-type,`quarkus.hibernate-search-orm.coordination.entity-mapping.agent.uuid-type`>>
+* <<quarkus-hibernate-search-orm-outboxpolling_quarkus-hibernate-search-orm-coordination-entity-mapping-outbox-event-catalog,`quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.catalog`>>
+* <<quarkus-hibernate-search-orm-outboxpolling_quarkus-hibernate-search-orm-coordination-entity-mapping-outbox-event-schema,`quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.schema`>>
+* <<quarkus-hibernate-search-orm-outboxpolling_quarkus-hibernate-search-orm-coordination-entity-mapping-outbox-event-table,`quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.table`>>
+* <<quarkus-hibernate-search-orm-outboxpolling_quarkus-hibernate-search-orm-coordination-entity-mapping-outbox-event-uuid-gen-strategy,`quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.uuid-gen-strategy`>>
+* <<quarkus-hibernate-search-orm-outboxpolling_quarkus-hibernate-search-orm-coordination-entity-mapping-outbox-event-uuid-type,`quarkus.hibernate-search-orm.coordination.entity-mapping.outbox-event.uuid-type`>>
 
 ====
 
@@ -992,7 +992,7 @@ However, there is one key difference: index updates are necessarily asynchronous
 they are guaranteed to happen _eventually_, but not immediately.
 
 This means in particular that the configuration property
-link:#quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy[`quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy`]
+<<quarkus-hibernate-search-orm-elasticsearch_quarkus-hibernate-search-orm-indexing-plan-synchronization-strategy,`quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy`>>
 cannot be set when using the `outbox-polling` coordination strategy:
 Hibernate Search will always behave as if this property was set to `write-sync` (the default).
 
@@ -1164,7 +1164,7 @@ For example `class:com.mycompany.MyClass`.
 * An arbitrary string referencing a built-in implementation.
 Available values are detailed in the documentation of each configuration property,
 such as `async`/`read-sync`/`write-sync`/`sync` for
-<<quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy,`quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy`>>.
+<<quarkus-hibernate-search-orm-elasticsearch_quarkus-hibernate-search-orm-indexing-plan-synchronization-strategy,`quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy`>>.
 
 Other formats are also accepted, but are only useful for advanced use cases.
 See link:{hibernate-search-docs-url}#configuration-bean-reference-parsing[this section of Hibernate Search's reference documentation]

--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -54,7 +54,7 @@ quarkus.kubernetes-client.trust-certs=false
 quarkus.kubernetes-client.namespace=default
 ----
 
-Note that the full list of properties is available in the link:#quarkus-kubernetes-client_quarkus.kubernetes-client.devservices-dev-services[Dev Services section of the configuration reference].
+Note that the full list of properties is available in the <<quarkus-kubernetes-client_quarkus-kubernetes-client-devservices-dev-services,Dev Services section of the configuration reference>>.
 
 In dev mode and when running tests, xref:kubernetes-dev-services.adoc[Dev Services for Kubernetes] automatically starts a Kubernetes API server.
 

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -434,7 +434,7 @@ quarkus.log.category."com.example".handlers=my-console-handler
 quarkus.log.category."com.example".use-parent-handlers=false
 ----
 
-For details about its configuration, see the xref:#quarkus-log-logging-log-config_quarkus.log.console-console-logging[console logging configuration] reference.
+For details about its configuration, see the xref:#quarkus-log-logging-log-config_quarkus-log-console-console-logging[console logging configuration] reference.
 
 
 === File log handler
@@ -468,7 +468,7 @@ quarkus.log.category."com.example".handlers=my-file-handler
 quarkus.log.category."com.example".use-parent-handlers=false
 ----
 
-For details about its configuration, see the xref:#quarkus-log-logging-log-config_quarkus.log.file-file-logging[file logging configuration] reference.
+For details about its configuration, see the xref:#quarkus-log-logging-log-config_quarkus-log-file-file-logging[file logging configuration] reference.
 
 
 === Syslog log handler
@@ -500,7 +500,7 @@ quarkus.log.category."com.example".handlers=my-syslog-handler
 quarkus.log.category."com.example".use-parent-handlers=false
 ----
 
-For details about its configuration, see the xref:#quarkus-log-logging-log-config_quarkus.log.syslog-syslog-logging[Syslog logging configuration] reference.
+For details about its configuration, see the xref:#quarkus-log-logging-log-config_quarkus-log-syslog-syslog-logging[Syslog logging configuration] reference.
 
 
 == Add a logging filter to your log handler

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -1641,7 +1641,7 @@ Given a default non-application endpoint root of `/q`, this will create an endpo
 Absolute paths also have an impact on nested endpoints. If the above called `nestedRoute("custom-endpoint", "/deep")`,
 the resulting endpoint will be found at `/deep`.
 
-Refer to the xref:all-config.adoc#quarkus-vertx-http_quarkus.http.non-application-root-path[Quarkus Vertx HTTP configuration reference]
+Refer to the xref:all-config.adoc#quarkus-vertx-http_quarkus-http-non-application-root-path[Quarkus Vertx HTTP configuration reference]
 for details on how the non-application root path is configured.
 
 === Extension Health Check


### PR DESCRIPTION
I think I went through all the links pointing to generated config doc...

/cc @quarkusio/documentation 
/cc @yrodiere you might want to check I didn't break anything in your doc, even if I tried to be thorough and use cross references to enable the checks