### PR TITLE
Fix quarkus.hibernate-search-orm.elasticsearch.version-check.enabled not appearing in docs

### DIFF
--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -462,7 +462,7 @@ public class HibernateSearchElasticsearchRecorder {
                 addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.THREAD_POOL_SIZE,
                         elasticsearchBackendConfig.threadPool().size());
                 addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.VERSION_CHECK_ENABLED,
-                        elasticsearchBackendConfig.versionCheck());
+                        elasticsearchBackendConfig.versionCheck().enabled());
                 addBackendConfig(propertyCollector, backendName, ElasticsearchBackendSettings.QUERY_SHARD_FAILURE_IGNORE,
                         elasticsearchBackendConfig.query().shardFailure().ignore());
 

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
@@ -154,15 +154,9 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
         ElasticsearchQueryConfig query();
 
         /**
-         * Whether Hibernate Search should check the version of the Elasticsearch cluster on startup.
-         *
-         * Set to `false` if the Elasticsearch cluster may not be available on startup.
-         *
-         * @asciidoclet
+         * Configuration for version checks on this backend.
          */
-        @WithName("version-check.enabled")
-        @WithDefault("true")
-        boolean versionCheck();
+        ElasticsearchVersionCheckConfig versionCheck();
 
         /**
          * The default configuration for the Elasticsearch indexes.
@@ -210,6 +204,19 @@ public interface HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
         public String getHibernateSearchString() {
             return hibernateSearchString;
         }
+    }
+
+    @ConfigGroup
+    interface ElasticsearchVersionCheckConfig {
+        /**
+         * Whether Hibernate Search should check the version of the Elasticsearch cluster on startup.
+         *
+         * Set to `false` if the Elasticsearch cluster may not be available on startup.
+         *
+         * @asciidoclet
+         */
+        @WithDefault("true")
+        boolean enabled();
     }
 
     @ConfigGroup


### PR DESCRIPTION
Looks like Smallrye config still has trouble with passing a name containing dots to `@WithName`.

Relates to #38430.