### PR TITLE
Ignore annotation process warning when restarting dev mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
@@ -37,7 +37,7 @@ public class JavaCompilationProvider implements CompilationProvider {
     // -parameters is used to generate metadata for reflection on method parameters
     // this is useful when people using debuggers against their hot-reloaded app
     private static final Set<String> COMPILER_OPTIONS = Set.of("-g", "-parameters");
-    private static final Set<String> IGNORE_NAMESPACES = Set.of("org.osgi");
+    private static final Set<String> IGNORE_NAMESPACES = Set.of("org.osgi", "Annotation processing is enabled because");
 
     private static final String PROVIDER_KEY = "java";
 


### PR DESCRIPTION
It already appeared twice during the Maven build so we really don't need it to appear every time we restart dev mode.

Fixes #37532