### PR TITLE
Scheduler: fix usage of some Quartz int config properties

### DIFF
--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
@@ -564,8 +564,9 @@ public class QuartzSchedulerImpl implements QuartzScheduler {
 
         props.put("org.quartz.scheduler.skipUpdateCheck", "true");
         props.put(StdSchedulerFactory.PROP_SCHED_INSTANCE_NAME, runtimeConfig.instanceName);
-        props.put(StdSchedulerFactory.PROP_SCHED_BATCH_TIME_WINDOW, runtimeConfig.batchTriggerAcquisitionFireAheadTimeWindow);
-        props.put(StdSchedulerFactory.PROP_SCHED_MAX_BATCH_SIZE, runtimeConfig.batchTriggerAcquisitionMaxCount);
+        props.put(StdSchedulerFactory.PROP_SCHED_BATCH_TIME_WINDOW,
+                "" + runtimeConfig.batchTriggerAcquisitionFireAheadTimeWindow);
+        props.put(StdSchedulerFactory.PROP_SCHED_MAX_BATCH_SIZE, "" + runtimeConfig.batchTriggerAcquisitionMaxCount);
         props.put(StdSchedulerFactory.PROP_SCHED_WRAP_JOB_IN_USER_TX, "false");
         props.put(StdSchedulerFactory.PROP_SCHED_SCHEDULER_THREADS_INHERIT_CONTEXT_CLASS_LOADER_OF_INITIALIZING_THREAD, "true");
         props.put(StdSchedulerFactory.PROP_THREAD_POOL_CLASS, "org.quartz.simpl.SimpleThreadPool");


### PR DESCRIPTION
- i.e. batchTriggerAcquisitionMaxCount and batchTriggerAcquisitionFireAheadTimeWindow
- fixes #38356