### PR TITLE
Add disabled workflow to deploy snapshots in Quarkiverse extensions

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/deploy-snapshots.tpl.qute.yml.disabled
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/deploy-snapshots.tpl.qute.yml.disabled
@@ -1,0 +1,40 @@
+# This workflow will build and deploy a snapshot of your artifact to Sonatype Snapshots repository
+name: Deploy Snapshots
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy-snapshot:
+    runs-on: ubuntu-latest
+    name: Deploy Snapshot artifacts
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: {java.version}
+          cache: 'maven'
+          server-id: 'ossrh'
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Deploy Snapshot
+        run: |
+          mvn -B clean deploy -DperformRelease=true -Drelease
+        env:
+            MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+            MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+            MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/dir-tree.snapshot
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateQuarkiverseExtension/dir-tree.snapshot
@@ -6,6 +6,7 @@ quarkus-my-quarkiverse-ext/.github/dependabot.yml
 quarkus-my-quarkiverse-ext/.github/project.yml
 quarkus-my-quarkiverse-ext/.github/workflows/
 quarkus-my-quarkiverse-ext/.github/workflows/build.yml
+quarkus-my-quarkiverse-ext/.github/workflows/deploy-snapshots.yml.disabled
 quarkus-my-quarkiverse-ext/.github/workflows/pre-release.yml
 quarkus-my-quarkiverse-ext/.github/workflows/quarkus-snapshot.yaml
 quarkus-my-quarkiverse-ext/.github/workflows/release.yml


### PR DESCRIPTION
This adds a workflow to publish snapshots to Sonatype when content is pushed to the `main` branch