### PR TITLE
Vertx: use NoopShutdownExecutorService and DevModeExecutorService

### DIFF
--- a/core/devmode-spi/src/main/java/io/quarkus/dev/spi/HotReplacementContext.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/spi/HotReplacementContext.java
@@ -68,4 +68,9 @@ public interface HotReplacementContext {
      * @return A set of changed files
      */
     Set<String> syncState(Map<String, String> fileHashes);
+
+    /**
+     * Adds a task that is run after the restart is performed.
+     */
+    void addPostRestartStep(Runnable runnable);
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ForwardingExecutorService.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ForwardingExecutorService.java
@@ -1,0 +1,87 @@
+package io.quarkus.runtime.util;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Forwards all method calls to the executor service returned from the {@link #delegate()} method. Only non-default methods
+ * declared on the {@link ExecutorService} interface are forwarded.
+ */
+public abstract class ForwardingExecutorService implements ExecutorService {
+
+    protected abstract ExecutorService delegate();
+
+    @Override
+    public void execute(Runnable command) {
+        delegate().execute(command);
+    }
+
+    @Override
+    public void shutdown() {
+        delegate().shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate().shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate().isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate().isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate().awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate().submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate().submit(task, result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate().submit(task);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate().invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        return delegate().invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return delegate().invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate().invokeAny(tasks, timeout, unit);
+    }
+
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/DevModeExecutorService.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/DevModeExecutorService.java
@@ -1,0 +1,44 @@
+package io.quarkus.vertx.core.runtime;
+
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.util.ForwardingExecutorService;
+
+/**
+ * This executor is only used in the dev mode as the Vertx worker thread pool.
+ * <p>
+ * The underlying executor can be shut down and then replaced with a new re-initialized executor.
+ */
+class DevModeExecutorService extends ForwardingExecutorService {
+
+    private static final Logger LOG = Logger.getLogger(DevModeExecutorService.class);
+
+    private final Supplier<ExecutorService> initializer;
+    private volatile ExecutorService executor;
+
+    DevModeExecutorService(Supplier<ExecutorService> initializer) {
+        this.initializer = initializer;
+        this.executor = initializer.get();
+    }
+
+    @Override
+    protected ExecutorService delegate() {
+        return executor;
+    }
+
+    /**
+     * Shutdown the underlying executor and then initialize a new one.
+     */
+    void reinit() {
+        ExecutorService oldExecutor = this.executor;
+        if (oldExecutor != null) {
+            oldExecutor.shutdownNow();
+        }
+        this.executor = initializer.get();
+        LOG.debug("Dev mode executor re-initialized");
+    }
+
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/NoopShutdownExecutorService.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/NoopShutdownExecutorService.java
@@ -1,0 +1,39 @@
+package io.quarkus.vertx.core.runtime;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.util.ForwardingExecutorService;
+
+/**
+ * This executor is only used in the prod mode as the Vertx worker thread pool.
+ */
+class NoopShutdownExecutorService extends ForwardingExecutorService {
+
+    private static final Logger LOG = Logger.getLogger(NoopShutdownExecutorService.class);
+
+    private final ExecutorService delegate;
+
+    NoopShutdownExecutorService(ExecutorService delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    protected ExecutorService delegate() {
+        return delegate;
+    }
+
+    @Override
+    public void shutdown() {
+        LOG.debug("shutdown() deliberately not delegated");
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        LOG.debug("shutdownNow() deliberately not delegated");
+        return List.of();
+    }
+
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusExecutorFactory.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/QuarkusExecutorFactory.java
@@ -3,6 +3,7 @@ package io.quarkus.vertx.core.runtime;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 import org.jboss.threads.EnhancedQueueExecutor;
@@ -15,6 +16,7 @@ import io.vertx.core.spi.ExecutorServiceFactory;
 
 public class QuarkusExecutorFactory implements ExecutorServiceFactory {
     static volatile ExecutorService sharedExecutor;
+    static volatile DevModeExecutorService devModeExecutor;
     private static final AtomicInteger executorCount = new AtomicInteger(0);
     private static final Logger log = Logger.getLogger(QuarkusExecutorFactory.class);
 
@@ -28,7 +30,14 @@ public class QuarkusExecutorFactory implements ExecutorServiceFactory {
 
     @Override
     public ExecutorService createExecutor(ThreadFactory threadFactory, Integer concurrency, Integer maxConcurrency) {
+        // The current Vertx impl creates two external executors during initialization
+        // The first one is used for the worker thread pool, the second one is used internally,
+        // and additional executors may be created on demand
+        // Unfortunately, there is no way to distinguish the particular executor types
+        // Therefore, we only consider the first one as the worker thread pool
+        // Note that in future versions of Vertx this may change!
         if (executorCount.incrementAndGet() == 1) {
+            // The first executor should be the worker thread pool
             if (launchMode != LaunchMode.DEVELOPMENT) {
                 if (sharedExecutor == null) {
                     log.warn("Shared executor not set. Unshared executor will be created for blocking work");
@@ -36,10 +45,34 @@ public class QuarkusExecutorFactory implements ExecutorServiceFactory {
                     sharedExecutor = internalCreateExecutor(threadFactory, concurrency, maxConcurrency);
                 }
                 return sharedExecutor;
+            } else {
+                // In dev mode we use a special executor for the worker pool
+                // where the underlying executor can be shut down and then replaced with a new re-initialized executor
+                // This is a workaround to solve the problem described in https://github.com/quarkusio/quarkus/issues/16833#issuecomment-1917042589
+                // The Vertx instance is reused between restarts but we must attempt to shut down this executor,
+                // for example to cancel/interrupt the scheduled methods
+                devModeExecutor = new DevModeExecutorService(new Supplier<ExecutorService>() {
+                    @Override
+                    public ExecutorService get() {
+                        return internalCreateExecutor(threadFactory, concurrency, maxConcurrency);
+                    }
+                });
+                return devModeExecutor;
             }
         }
-
         return internalCreateExecutor(threadFactory, concurrency, maxConcurrency);
+    }
+
+    /**
+     * In dev mode, shut down the underlying executor and then initialize a new one.
+     *
+     * @see DevModeExecutorService
+     */
+    public static void reinitializeDevModeExecutor() {
+        DevModeExecutorService executor = QuarkusExecutorFactory.devModeExecutor;
+        if (executor != null) {
+            executor.reinit();
+        }
     }
 
     private ExecutorService internalCreateExecutor(ThreadFactory threadFactory, Integer concurrency, Integer maxConcurrency) {

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -101,7 +101,7 @@ public class VertxCoreRecorder {
             LaunchMode launchMode, ShutdownContext shutdown, List<Consumer<VertxOptions>> customizers,
             ExecutorService executorProxy) {
         if (launchMode == LaunchMode.NORMAL) {
-            // In the prod mode we wrap the ExecutorService and the shutdown() and shutdownNow() are deliberately not delegated
+            // In prod mode, we wrap the ExecutorService and the shutdown() and shutdownNow() are deliberately not delegated
             // This is a workaround to solve the problem described in https://github.com/quarkusio/quarkus/issues/16833#issuecomment-1917042589
             // The Vertx instance is closed before io.quarkus.runtime.ExecutorRecorder.createShutdownTask() is used
             // And when it's closed the underlying worker thread pool (which is in the prod mode backed by the ExecutorBuildItem) is closed as well

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -100,7 +100,16 @@ public class VertxCoreRecorder {
     public Supplier<Vertx> configureVertx(VertxConfiguration config, ThreadPoolConfig threadPoolConfig,
             LaunchMode launchMode, ShutdownContext shutdown, List<Consumer<VertxOptions>> customizers,
             ExecutorService executorProxy) {
-        QuarkusExecutorFactory.sharedExecutor = executorProxy;
+        if (launchMode == LaunchMode.NORMAL) {
+            // In the prod mode we wrap the ExecutorService and the shutdown() and shutdownNow() are deliberately not delegated
+            // This is a workaround to solve the problem described in https://github.com/quarkusio/quarkus/issues/16833#issuecomment-1917042589
+            // The Vertx instance is closed before io.quarkus.runtime.ExecutorRecorder.createShutdownTask() is used
+            // And when it's closed the underlying worker thread pool (which is in the prod mode backed by the ExecutorBuildItem) is closed as well
+            // As a result the quarkus.thread-pool.shutdown-interrupt config property and logic defined in ExecutorRecorder.createShutdownTask() is completely ignored
+            QuarkusExecutorFactory.sharedExecutor = new NoopShutdownExecutorService(executorProxy);
+        } else {
+            QuarkusExecutorFactory.sharedExecutor = executorProxy;
+        }
         if (launchMode != LaunchMode.DEVELOPMENT) {
             vertx = new VertxSupplier(launchMode, config, customizers, threadPoolConfig, shutdown);
             // we need this to be part of the last shutdown tasks because closing it early (basically before Arc)

--- a/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/DelegatingExecutorService.java
+++ b/extensions/virtual-threads/runtime/src/main/java/io/quarkus/virtual/threads/DelegatingExecutorService.java
@@ -1,26 +1,24 @@
 package io.quarkus.virtual.threads;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+
+import io.quarkus.runtime.util.ForwardingExecutorService;
 
 /**
  * An implementation of {@code ExecutorService} that delegates to the real executor, while disallowing termination.
  */
-class DelegatingExecutorService implements ExecutorService {
+class DelegatingExecutorService extends ForwardingExecutorService {
     private final ExecutorService delegate;
 
     DelegatingExecutorService(final ExecutorService delegate) {
         this.delegate = delegate;
     }
 
-    public void execute(final Runnable command) {
-        delegate.execute(command);
+    @Override
+    protected ExecutorService delegate() {
+        return delegate;
     }
 
     public boolean isShutdown() {
@@ -43,43 +41,6 @@ class DelegatingExecutorService implements ExecutorService {
 
     public List<Runnable> shutdownNow() {
         throw new UnsupportedOperationException("shutdownNow not allowed on managed executor service");
-    }
-
-    @Override
-    public <T> Future<T> submit(Callable<T> task) {
-        return delegate.submit(task);
-    }
-
-    @Override
-    public <T> Future<T> submit(Runnable task, T result) {
-        return delegate.submit(task, result);
-    }
-
-    @Override
-    public Future<?> submit(Runnable task) {
-        return delegate.submit(task);
-    }
-
-    @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-        return delegate.invokeAll(tasks);
-    }
-
-    @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException {
-        return delegate.invokeAll(tasks, timeout, unit);
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        return delegate.invokeAny(tasks);
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        return delegate.invokeAny(tasks, timeout, unit);
     }
 
     public String toString() {


### PR DESCRIPTION
This PR attempts to fix two problems described in https://github.com/quarkusio/quarkus/issues/16833#issuecomment-1917042589. Both are related to the Vertx worker thread pool implementation.

### NoopShutdownExecutorService
In prod mode, we wrap the `ExecutorService` and the `shutdown()` and `shutdownNow()` methods are deliberately not delegated. This is a workaround to solve the problem described in https://github.com/quarkusio/quarkus/issues/16833#issuecomment-1917042589. The problem: the Vertx instance is closed before `io.quarkus.runtime.ExecutorRecorder.createShutdownTask()` is used and when it's closed the underlying worker thread pool (which is in the prod mode backed by the `ExecutorBuildItem`) is closed as well. As a result the `quarkus.thread-pool.shutdown-interrupt` config property and logic defined in `ExecutorRecorder.createShutdownTask()` is completely ignored.

### DevModeExecutorService
In dev mode we use a special executor for the worker pool where the underlying executor can be shut down and then replaced with a new re-initialized executor. This is a workaround to solve the problem described in https://github.com/quarkusio/quarkus/issues/16833#issuecomment-1917042589. The problem: the Vertx instance is reused between restarts but we must attempt to shut down this executor, for example to cancel/interrupt the scheduled methods.

Fixes https://github.com/quarkusio/quarkus/issues/16833