### PR TITLE
Allow custom OIDC client filters to force a new token acquisition

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
@@ -21,6 +21,10 @@ public class TokensHelper {
     }
 
     public Uni<Tokens> getTokens(OidcClient oidcClient) {
+        return getTokens(oidcClient, false);
+    }
+
+    public Uni<Tokens> getTokens(OidcClient oidcClient, boolean forceNewTokens) {
         TokenRequestState currentState = null;
         TokenRequestState newState = null;
         //if the tokens are expired we refresh them in an async manner
@@ -39,9 +43,9 @@ public class TokensHelper {
                 return currentState.tokenUni;
             } else {
                 Tokens tokens = currentState.tokens;
-                if (tokens.isAccessTokenExpired() || tokens.isAccessTokenWithinRefreshInterval()) {
+                if (forceNewTokens || tokens.isAccessTokenExpired() || tokens.isAccessTokenWithinRefreshInterval()) {
                     newState = new TokenRequestState(
-                            prepareUni((tokens.getRefreshToken() != null && !tokens.isRefreshTokenExpired())
+                            prepareUni((!forceNewTokens && tokens.getRefreshToken() != null && !tokens.isRefreshTokenExpired())
                                     ? oidcClient.refreshTokens(tokens.getRefreshToken())
                                     : oidcClient.getTokens()));
                     if (tokenRequestStateUpdater.compareAndSet(this, currentState, newState)) {


### PR DESCRIPTION
This simple PR is based on  the @lordvlad's input and initial implementation. It adds an option for custom filters to force a new token acquisition, even if the current access token is still valid, when the access token propagation fails even if the access token has not yet expired.

I have only added a new method overload to avoid (a rather unlikely) breaking of some client code using the TokenHelpers directly and a log message to inform that the current tokens will be discarded if the custom filter has requested it.

I've looked at the `integration-tests/oidc-client-reactive` test which checks the file logs to confirm that the tokens have been refreshed and I thought it would be quite tricky to try to update it with another log check to verify that the second token refresh happened because the custom filter may have requested it, with having to order tests, and deal with some likely flakiness, not sure it is necessary given the simplicity of this update.

@lordvlad, can you check this PR please ?
@gastaldi can you please review, I'll try to figure out how to test it if you prefer, would not be a problem, @lordvlad has a workaround, so the PR is not urgent to merge