### PR TITLE
[3.6] - Update to Vert.x 4.4.7

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -118,7 +118,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.2.2.Final</wildfly-elytron.version>
         <jboss-threads.version>3.5.1.Final</jboss-threads.version>
-        <vertx.version>4.4.6</vertx.version>
+        <vertx.version>4.4.7</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>


### PR DESCRIPTION
- Contains the fix for https://access.redhat.com/security/cve/cve-2024-1023.

Full release notes: https://github.com/vert-x3/wiki/wiki/4.4.7-Release-Notes