### PR TITLE
Make quarkus.rest-client.alpn work in programmatically created client

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -410,6 +410,12 @@ public class RestClientBuilderImpl implements RestClientBuilder {
             clientBuilder.http2(true);
         }
 
+        if (getConfiguration().hasProperty(QuarkusRestClientProperties.ALPN)) {
+            clientBuilder.alpn((Boolean) getConfiguration().getProperty(QuarkusRestClientProperties.ALPN));
+        } else if (restClientsConfig.alpn.isPresent()) {
+            clientBuilder.alpn(restClientsConfig.alpn.get());
+        }
+
         Boolean enableCompression = ConfigProvider.getConfig()
                 .getOptionalValue(ENABLE_COMPRESSION, Boolean.class).orElse(false);
         if (enableCompression) {


### PR DESCRIPTION
This is same thing as we do for http2

Fixes: #38499