### PR TITLE
Revert "Escape column names with backticks in order by clause of hql query"

### DIFF
--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/JpaOperationsSortTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/JpaOperationsSortTest.java
@@ -2,11 +2,9 @@ package io.quarkus.hibernate.orm.panache.deployment.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.panache.common.Sort;
-import io.quarkus.panache.common.exception.PanacheQueryException;
 import io.quarkus.panache.hibernate.common.runtime.PanacheJpaUtil;
 
 public class JpaOperationsSortTest {
@@ -20,7 +18,7 @@ public class JpaOperationsSortTest {
     @Test
     public void testSortBy() {
         Sort sort = Sort.by("foo", "bar");
-        assertEquals(" ORDER BY `foo` , `bar`", PanacheJpaUtil.toOrderBy(sort));
+        assertEquals(" ORDER BY foo , bar", PanacheJpaUtil.toOrderBy(sort));
     }
 
     @Test
@@ -31,27 +29,14 @@ public class JpaOperationsSortTest {
 
     @Test
     public void testSortByNullsFirst() {
-        Sort sort = Sort.by("foo", Sort.Direction.Ascending, Sort.NullPrecedence.NULLS_FIRST);
-        assertEquals(" ORDER BY `foo` NULLS FIRST", PanacheJpaUtil.toOrderBy(sort));
+        Sort emptySort = Sort.by("foo", Sort.Direction.Ascending, Sort.NullPrecedence.NULLS_FIRST);
+        assertEquals(" ORDER BY foo NULLS FIRST", PanacheJpaUtil.toOrderBy(emptySort));
     }
 
     @Test
     public void testSortByNullsLast() {
-        Sort sort = Sort.by("foo", Sort.Direction.Descending, Sort.NullPrecedence.NULLS_LAST);
-        assertEquals(" ORDER BY `foo` DESC NULLS LAST", PanacheJpaUtil.toOrderBy(sort));
-    }
-
-    @Test
-    public void testSortByColumnWithBacktick() {
-        Sort sort = Sort.by("jeanne", "d`arc");
-        Assertions.assertThrowsExactly(PanacheQueryException.class, () -> PanacheJpaUtil.toOrderBy(sort),
-                "Sort column name cannot have backticks");
-    }
-
-    @Test
-    public void testSortByQuotedColumn() {
-        Sort sort = Sort.by("`foo`", "bar");
-        assertEquals(" ORDER BY `foo` , `bar`", PanacheJpaUtil.toOrderBy(sort));
+        Sort emptySort = Sort.by("foo", Sort.Direction.Descending, Sort.NullPrecedence.NULLS_LAST);
+        assertEquals(" ORDER BY foo DESC NULLS LAST", PanacheJpaUtil.toOrderBy(emptySort));
     }
 
 }

--- a/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
+++ b/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
@@ -175,7 +175,7 @@ public class PanacheJpaUtil {
             Sort.Column column = sort.getColumns().get(i);
             if (i > 0)
                 sb.append(" , ");
-            sb.append('`').append(unquoteColumnName(column)).append('`');
+            sb.append(column.getName());
             if (column.getDirection() != Sort.Direction.Ascending) {
                 sb.append(" DESC");
             }
@@ -190,21 +190,5 @@ public class PanacheJpaUtil {
 
         }
         return sb.toString();
-    }
-
-    private static String unquoteColumnName(Sort.Column column) {
-        String columnName = column.getName();
-        String unquotedColumnName;
-        //Note HQL uses backticks to escape/quote special words that are used as identifiers
-        if (columnName.charAt(0) == '`' && columnName.charAt(columnName.length() - 1) == '`') {
-            unquotedColumnName = columnName.substring(1, columnName.length() - 1);
-        } else {
-            unquotedColumnName = columnName;
-        }
-        // Note we're not dealing with columns but with entity attributes so no backticks expected in unquoted column name
-        if (unquotedColumnName.indexOf('`') >= 0) {
-            throw new PanacheQueryException("Sort column name cannot have backticks");
-        }
-        return unquotedColumnName;
     }
 }


### PR DESCRIPTION
Fixes #38521 
Reopens #1120 because it reverts #37282