### PR TITLE
Bump smallrye-open-api from 3.8.0 to 3.9.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -54,7 +54,7 @@
         <smallrye-config.version>3.5.2</smallrye-config.version>
         <smallrye-health.version>4.1.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>3.8.0</smallrye-open-api.version>
+        <smallrye-open-api.version>3.9.0</smallrye-open-api.version>
         <smallrye-graphql.version>2.7.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.2.6</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.4.0</smallrye-jwt.version>


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/38506