### PR TITLE
Upgrade to Hibernate ORM 6.4.3.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -100,7 +100,7 @@
              bytebuddy.version (just below), hibernate-orm.version-for-documentation (in docs/pom.xml)
              and both hibernate-orm.version and antlr.version in build-parent/pom.xml
              WARNING again for diffs that don't provide enough context: when updating, see above -->
-        <hibernate-orm.version>6.4.2.Final</hibernate-orm.version>
+        <hibernate-orm.version>6.4.3.Final</hibernate-orm.version>
         <bytebuddy.version>1.14.7</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
         <hibernate-reactive.version>2.2.2.Final</hibernate-reactive.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -72,10 +72,10 @@
         <!-- MicroProfile TCK versions used to be defined here but have moved to the concrete tck modules -->
 
         <!-- Panache needs to run the hibernate-jpamodelgen annotation processor,
-             but version 6.3+ leads to issues in applications that use it too:
-             https://github.com/quarkusio/quarkus/issues/38378
-             As a workaround, we generate the static metamodel of Panache using an older version of jpamodelgen. -->
-        <hibernate-orm.jpamodelgen.for-panache.version>6.2.22.Final</hibernate-orm.jpamodelgen.for-panache.version>
+             and unfortunately annotation processors are not covered by dependency management
+             in kotlin-maven-plugin; see https://github.com/quarkusio/quarkus/issues/37477#issuecomment-1923662964
+         -->
+        <hibernate-orm.version>6.4.3.Final</hibernate-orm.version>
         <!-- Antlr 4 is used by the PanacheQL parser but also needs to match the requirements of Hibernate ORM 6.x-->
         <antlr.version>4.13.0</antlr.version>
 

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
@@ -110,7 +110,7 @@
                                 <annotationProcessorPath>
                                     <groupId>org.hibernate.orm</groupId>
                                     <artifactId>hibernate-jpamodelgen</artifactId>
-                                    <version>${hibernate-orm.jpamodelgen.for-panache.version}</version>
+                                    <version>${hibernate-orm.version}</version>
                                 </annotationProcessorPath>
                             </annotationProcessorPaths>
                             <annotationProcessors>

--- a/extensions/panache/hibernate-orm-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/runtime/pom.xml
@@ -59,7 +59,6 @@
                         <annotationProcessorPath>
                             <groupId>org.hibernate.orm</groupId>
                             <artifactId>hibernate-jpamodelgen</artifactId>
-                            <version>${hibernate-orm.jpamodelgen.for-panache.version}</version>
                         </annotationProcessorPath>
                     </annotationProcessorPaths>
                     <annotationProcessors>

--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/pom.xml
@@ -119,7 +119,7 @@
                                 <annotationProcessorPath>
                                     <groupId>org.hibernate.orm</groupId>
                                     <artifactId>hibernate-jpamodelgen</artifactId>
-                                    <version>${hibernate-orm.jpamodelgen.for-panache.version}</version>
+                                    <version>${hibernate-orm.version}</version>
                                 </annotationProcessorPath>
                             </annotationProcessorPaths>
                             <annotationProcessors>

--- a/extensions/panache/hibernate-reactive-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/runtime/pom.xml
@@ -63,7 +63,6 @@
                         <annotationProcessorPath>
                             <groupId>org.hibernate.orm</groupId>
                             <artifactId>hibernate-jpamodelgen</artifactId>
-                            <version>${hibernate-orm.jpamodelgen.for-panache.version}</version>
                         </annotationProcessorPath>
                     </annotationProcessorPaths>
                     <annotationProcessors>


### PR DESCRIPTION
Fixes #38451

No need to upgrade Reactive: https://hibernate.zulipchat.com/#narrow/stream/205413-hibernate-reactive-dev/topic/Reactive.20with.20ORM.206.2E4.2E3

Regarding upstream:

* See announcement: https://in.relation.to/2024/02/02/orm-643-final/
* See issues resolved: https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HHH%20AND%20fixVersion%20%3D%206.4.3