### PR TITLE
Make the Forwarded Parser syntax parsing case-insensitive

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedForwarderProxyTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/proxy/TrustedForwarderProxyTest.java
@@ -30,4 +30,20 @@ public class TrustedForwarderProxyTest {
                 .then()
                 .body(Matchers.equalTo("http|somehost2|backend2:5555|/path|http://somehost2/path"));
     }
+
+    /**
+     * As described on <a href=
+     * "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded">https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded</a>,
+     * the syntax should be case-insensitive.
+     * <p>
+     * Kong, for example, uses `Proto` instead of `proto` and `For` instead of `for`.
+     */
+    @Test
+    public void testHeadersAreUsedWhenUsingCasedCharacters() {
+        RestAssured.given()
+                .header("Forwarded", "Proto=http;For=backend2:5555;Host=somehost2")
+                .get("/path")
+                .then()
+                .body(Matchers.equalTo("http|somehost2|backend2:5555|/path|http://somehost2/path"));
+    }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedParser.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/ForwardedParser.java
@@ -42,9 +42,9 @@ class ForwardedParser {
     private static final AsciiString X_FORWARDED_PORT = AsciiString.cached("X-Forwarded-Port");
     private static final AsciiString X_FORWARDED_FOR = AsciiString.cached("X-Forwarded-For");
 
-    private static final Pattern FORWARDED_HOST_PATTERN = Pattern.compile("host=\"?([^;,\"]+)\"?");
-    private static final Pattern FORWARDED_PROTO_PATTERN = Pattern.compile("proto=\"?([^;,\"]+)\"?");
-    private static final Pattern FORWARDED_FOR_PATTERN = Pattern.compile("for=\"?([^;,\"]+)\"?");
+    private static final Pattern FORWARDED_HOST_PATTERN = Pattern.compile("host=\"?([^;,\"]+)\"?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern FORWARDED_PROTO_PATTERN = Pattern.compile("proto=\"?([^;,\"]+)\"?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern FORWARDED_FOR_PATTERN = Pattern.compile("for=\"?([^;,\"]+)\"?", Pattern.CASE_INSENSITIVE);
 
     private final static int PORT_MIN_VALID_VALUE = 0;
     private final static int PORT_MAX_VALID_VALUE = 65535;


### PR DESCRIPTION
As described on https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded, the forwarded header syntax parsing should be case-insensitive. It's not a real spec, but Kong is using `Proto` instead of `proto` and `For` instead of `for`.
