### PR TITLE
Add missing entry in BOM for Hibernate Search outbox-polling relocation

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -6256,6 +6256,16 @@
                 <artifactId>quarkus-rest-client-mutiny-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-hibernate-search-orm-coordination-outbox-polling</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-hibernate-search-orm-coordination-outbox-polling-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <!-- End of Relocations, please put new extensions above this list -->
 
         </dependencies>


### PR DESCRIPTION
Looks like I forgot about this when I added the relocation.