### PR TITLE
ArC: RequestContext - implement the activity check consistently

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableContext.java
@@ -11,13 +11,13 @@ import jakarta.enterprise.context.spi.CreationalContext;
 
 /**
  * A context implementing this interface makes it possible to capture and view its state via the {@link ContextState}.
- *
+ * <p>
  * It also allows users to destroy all contextual instances within this context.
  */
 public interface InjectableContext extends AlterableContext {
 
     /**
-     * Destroy all existing contextual instances.
+     * Destroys the current context and all existing contextual instances.
      */
     void destroy();
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
@@ -64,7 +64,7 @@ class RequestContext implements ManagedContext {
             throw Scopes.scopeDoesNotMatchException(this, bean);
         }
         RequestContextState ctxState = currentContext.get();
-        if (ctxState == null) {
+        if (!isActive(ctxState)) {
             // Context is not active!
             return null;
         }
@@ -102,7 +102,7 @@ class RequestContext implements ManagedContext {
             throw Scopes.scopeDoesNotMatchException(this, bean);
         }
         RequestContextState state = currentContext.get();
-        if (state == null) {
+        if (!isActive(state)) {
             throw notActive();
         }
         ContextInstanceHandle<T> instance = (ContextInstanceHandle<T>) state.contextInstances
@@ -112,14 +112,17 @@ class RequestContext implements ManagedContext {
 
     @Override
     public boolean isActive() {
-        RequestContextState requestContextState = currentContext.get();
-        return requestContextState == null ? false : requestContextState.isValid();
+        return isActive(currentContext.get());
+    }
+
+    private boolean isActive(RequestContextState state) {
+        return state == null ? false : state.isValid();
     }
 
     @Override
     public void destroy(Contextual<?> contextual) {
         RequestContextState state = currentContext.get();
-        if (state == null) {
+        if (!isActive(state)) {
             // Context is not active
             throw notActive();
         }
@@ -164,8 +167,7 @@ class RequestContext implements ManagedContext {
     @Override
     public ContextState getState() {
         RequestContextState state = currentContext.get();
-        if (state == null) {
-            // Thread local not set - context is not active!
+        if (!isActive(state)) {
             throw notActive();
         }
         return state;

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/optimized/RequestContextInstancesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/optimized/RequestContextInstancesTest.java
@@ -2,6 +2,7 @@ package io.quarkus.arc.test.contexts.request.optimized;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -14,6 +15,7 @@ import java.util.concurrent.TimeoutException;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 
@@ -58,7 +60,8 @@ public class RequestContextInstancesTest {
         InjectableContext appContext = container.getActiveContext(RequestScoped.class);
         // ContextInstances#removeEach()
         appContext.destroy();
-        assertNotEquals(id2, boom.ping());
+        // Request context was invalidated
+        assertThrows(ContextNotActiveException.class, () -> boom.ping());
 
         container.requestContext().terminate();
     }


### PR DESCRIPTION
- this is a follow-up of https://github.com/quarkusio/quarkus/pull/38107

In theory, this could break something because previously it was possible to call `RequestContext#destroy()` and then still use a client proxy to obtain a contextual reference. Which is obviously wrong but our API docs are not exactly clear in this area :shrug:.