### PR TITLE
Redis Client: add support for new configuration options

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/VertxRedisClientFactory.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/VertxRedisClientFactory.java
@@ -75,9 +75,11 @@ public class VertxRedisClientFactory {
         options.setMaxWaitingHandlers(config.maxWaitingHandlers());
 
         options.setProtocolNegotiation(config.protocolNegotiation());
+        config.preferredProtocolVersion().ifPresent(options::setPreferredProtocolVersion);
         options.setPassword(config.password().orElse(null));
         config.poolCleanerInterval().ifPresent(d -> options.setPoolCleanerInterval((int) d.toMillis()));
         options.setPoolRecycleTimeout((int) config.poolRecycleTimeout().toMillis());
+        options.setHashSlotCacheTTL(config.hashSlotCacheTtl().toMillis());
 
         config.role().ifPresent(options::setRole);
         options.setType(config.clientType());

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/RedisClientConfig.java
@@ -9,6 +9,7 @@ import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
+import io.vertx.redis.client.ProtocolVersion;
 import io.vertx.redis.client.RedisClientType;
 import io.vertx.redis.client.RedisReplicas;
 import io.vertx.redis.client.RedisRole;
@@ -138,6 +139,24 @@ public interface RedisClientConfig {
     boolean protocolNegotiation();
 
     /**
+     * The preferred protocol version to be used during protocol negotiation. When not set,
+     * defaults to RESP 3. When protocol negotiation is disabled, this setting has no effect.
+     */
+    @ConfigDocDefault("resp3")
+    Optional<ProtocolVersion> preferredProtocolVersion();
+
+    /**
+     * The TTL of the hash slot cache. A hash slot cache is used by the clustered Redis client
+     * to prevent constantly sending {@code CLUSTER SLOTS} commands to the first statically
+     * configured cluster node.
+     * <p>
+     * This setting is only meaningful in case of a clustered Redis client and has no effect
+     * otherwise.
+     */
+    @WithDefault("1s")
+    Duration hashSlotCacheTtl();
+
+    /**
      * TCP config.
      */
     @ConfigDocSection
@@ -168,6 +187,8 @@ public interface RedisClientConfig {
                 ", reconnectAttempts=" + reconnectAttempts() +
                 ", reconnectInterval=" + reconnectInterval() +
                 ", protocolNegotiation=" + protocolNegotiation() +
+                ", preferredProtocolVersion=" + preferredProtocolVersion() +
+                ", hashSlotCacheTtl=" + hashSlotCacheTtl() +
                 ", tcp=" + tcp() +
                 ", tls=" + tls() +
                 '}';


### PR DESCRIPTION
The Vert.x Redis Client recently gained 2 new configuration options, the preferred protocol version for protocol negotiation and a hash slot cache TTL. This commit exposes these config options through Quarkus configuration mechanism.