### PR TITLE
Set quarkus-oidc-token-propagation-reactive status to stable

### DIFF
--- a/extensions/oidc-token-propagation-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/oidc-token-propagation-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,6 +11,6 @@ metadata:
   guide: "https://quarkus.io/guides/security-openid-connect-client"
   categories:
   - "security"
-  status: "preview"
+  status: "stable"
   config:
   - "quarkus.oidc-token-propagation-reactive."


### PR DESCRIPTION
I've noticed in Dev UI `quarkus-oidc-token-propagation-reactive` still has a `preview` status, it has been stable for a while now