### PR TITLE
Refactor RESTEasy Classic default JAX-RS security to make endpoint detection more robust

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyBuiltinsProcessor.java
@@ -1,21 +1,11 @@
 package io.quarkus.resteasy.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
-import static io.quarkus.resteasy.deployment.RestPathAnnotationProcessor.getAllClassInterfaces;
-import static io.quarkus.resteasy.deployment.RestPathAnnotationProcessor.isRestEndpointMethod;
-import static io.quarkus.security.spi.SecurityTransformerUtils.hasSecurityAnnotation;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.DotName;
-import org.jboss.jandex.MethodInfo;
-import org.jboss.logging.Logger;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -25,7 +15,6 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
-import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.resteasy.runtime.AuthenticationCompletionExceptionMapper;
 import io.quarkus.resteasy.runtime.AuthenticationFailedExceptionMapper;
@@ -43,8 +32,7 @@ import io.quarkus.resteasy.runtime.vertx.JsonArrayReader;
 import io.quarkus.resteasy.runtime.vertx.JsonArrayWriter;
 import io.quarkus.resteasy.runtime.vertx.JsonObjectReader;
 import io.quarkus.resteasy.runtime.vertx.JsonObjectWriter;
-import io.quarkus.resteasy.server.common.deployment.ResteasyDeploymentBuildItem;
-import io.quarkus.security.spi.AdditionalSecuredMethodsBuildItem;
+import io.quarkus.security.spi.DefaultSecurityCheckBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.RouteDescriptionBuildItem;
@@ -54,92 +42,15 @@ import io.quarkus.vertx.http.runtime.devmode.RouteDescription;
 public class ResteasyBuiltinsProcessor {
 
     protected static final String META_INF_RESOURCES = "META-INF/resources";
-    private static final Logger LOG = Logger.getLogger(ResteasyBuiltinsProcessor.class);
 
     @BuildStep
-    void setUpDenyAllJaxRs(CombinedIndexBuildItem index,
-            JaxRsSecurityConfig config,
-            ResteasyDeploymentBuildItem resteasyDeployment,
-            BuildProducer<AdditionalSecuredMethodsBuildItem> additionalSecuredClasses) {
-        if (resteasyDeployment != null && (config.denyJaxRs || config.defaultRolesAllowed.isPresent())) {
-            final List<MethodInfo> methods = new ArrayList<>();
-
-            // add endpoints
-            List<String> resourceClasses = resteasyDeployment.getDeployment().getScannedResourceClasses();
-            for (String className : resourceClasses) {
-                ClassInfo classInfo = index.getIndex().getClassByName(DotName.createSimple(className));
-                if (classInfo == null)
-                    throw new IllegalStateException("Unable to find class info for " + className);
-                // add unannotated class endpoints as well as parent class unannotated endpoints
-                addAllUnannotatedEndpoints(index, classInfo, methods);
-
-                // interface endpoints implemented on resources are already in, now we need to resolve default interface
-                // methods as there, CDI interceptors won't work, therefore neither will our additional secured methods
-                Collection<ClassInfo> interfaces = getAllClassInterfaces(index, List.of(classInfo), new ArrayList<>());
-                if (!interfaces.isEmpty()) {
-                    final List<MethodInfo> interfaceEndpoints = new ArrayList<>();
-                    for (ClassInfo anInterface : interfaces) {
-                        addUnannotatedEndpoints(index, anInterface, interfaceEndpoints);
-                    }
-                    // look for implementors as implementors on resource classes are secured by CDI interceptors
-                    if (!interfaceEndpoints.isEmpty()) {
-                        interfaceBlock: for (MethodInfo interfaceEndpoint : interfaceEndpoints) {
-                            if (interfaceEndpoint.isDefault()) {
-                                for (MethodInfo endpoint : methods) {
-                                    boolean nameParamsMatch = endpoint.name().equals(interfaceEndpoint.name())
-                                            && (interfaceEndpoint.parameterTypes().equals(endpoint.parameterTypes()));
-                                    if (nameParamsMatch) {
-                                        // whether matched method is declared on class that implements interface endpoint
-                                        Predicate<DotName> isEndpointInterface = interfaceEndpoint.declaringClass()
-                                                .name()::equals;
-                                        if (endpoint.declaringClass().interfaceNames().stream().anyMatch(isEndpointInterface)) {
-                                            continue interfaceBlock;
-                                        }
-                                    }
-                                }
-                                String configProperty = config.denyJaxRs ? "quarkus.security.jaxrs.deny-unannotated-endpoints"
-                                        : "quarkus.security.jaxrs.default-roles-allowed";
-                                // this is logging only as I'm a bit worried about false positives and breaking things
-                                // for what is very much edge case
-                                LOG.warn("Default interface method '" + interfaceEndpoint
-                                        + "' cannot be secured with the '" + configProperty
-                                        + "' configuration property. Please implement this method for CDI "
-                                        + "interceptor binding to work");
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (!methods.isEmpty()) {
-                if (config.denyJaxRs) {
-                    additionalSecuredClasses.produce(new AdditionalSecuredMethodsBuildItem(methods));
-                } else {
-                    additionalSecuredClasses
-                            .produce(new AdditionalSecuredMethodsBuildItem(methods, config.defaultRolesAllowed));
-                }
-            }
-        }
-    }
-
-    private static void addAllUnannotatedEndpoints(CombinedIndexBuildItem index, ClassInfo classInfo,
-            List<MethodInfo> methods) {
-        if (classInfo == null) {
-            return;
-        }
-        addUnannotatedEndpoints(index, classInfo, methods);
-        if (classInfo.superClassType() != null && !classInfo.superClassType().name().equals(DotName.OBJECT_NAME)) {
-            addAllUnannotatedEndpoints(index, index.getIndex().getClassByName(classInfo.superClassType().name()), methods);
-        }
-    }
-
-    private static void addUnannotatedEndpoints(CombinedIndexBuildItem index, ClassInfo classInfo, List<MethodInfo> methods) {
-        if (!hasSecurityAnnotation(classInfo)) {
-            for (MethodInfo methodInfo : classInfo.methods()) {
-                if (isRestEndpointMethod(index, methodInfo) && !hasSecurityAnnotation(methodInfo)) {
-                    methods.add(methodInfo);
-                }
-            }
+    void setUpDenyAllJaxRs(JaxRsSecurityConfig securityConfig,
+            BuildProducer<DefaultSecurityCheckBuildItem> defaultSecurityCheckProducer) {
+        if (securityConfig.denyJaxRs) {
+            defaultSecurityCheckProducer.produce(DefaultSecurityCheckBuildItem.denyAll());
+        } else if (securityConfig.defaultRolesAllowed.isPresent()) {
+            defaultSecurityCheckProducer
+                    .produce(DefaultSecurityCheckBuildItem.rolesAllowed(securityConfig.defaultRolesAllowed.get()));
         }
     }
 

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/EagerSecurityFilter.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/EagerSecurityFilter.java
@@ -44,6 +44,7 @@ public class EagerSecurityFilter implements ContainerRequestFilter {
 
         }
     };
+    static final String SKIP_DEFAULT_CHECK = "io.quarkus.resteasy.runtime.EagerSecurityFilter#SKIP_DEFAULT_CHECK";
     private final Map<MethodDescription, Consumer<RoutingContext>> cache = new HashMap<>();
     private final EagerSecurityInterceptorStorage interceptorStorage;
     private final SecurityEventHelper<AuthorizationSuccessEvent, AuthorizationFailureEvent> eventHelper;
@@ -86,6 +87,11 @@ public class EagerSecurityFilter implements ContainerRequestFilter {
 
     private void applySecurityChecks(MethodDescription description) {
         SecurityCheck check = securityCheckStorage.getSecurityCheck(description);
+        if (check == null && securityCheckStorage.getDefaultSecurityCheck() != null
+                && routingContext.get(EagerSecurityFilter.class.getName()) == null
+                && routingContext.get(SKIP_DEFAULT_CHECK) == null) {
+            check = securityCheckStorage.getDefaultSecurityCheck();
+        }
         if (check != null) {
             if (check.isPermitAll()) {
                 fireEventOnAuthZSuccess(check, null);


### PR DESCRIPTION
This solution replaces build time detection of endpoints which proved to be an issue in past. I think it's more secure as annotation inheritance discord between CDI and JAX-RS is really complex.