### PR TITLE
Update Vert.x to version 4.5.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -121,7 +121,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.2.3.Final</wildfly-elytron.version>
         <jboss-threads.version>3.5.1.Final</jboss-threads.version>
-        <vertx.version>4.5.2</vertx.version>
+        <vertx.version>4.5.3</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -61,7 +61,7 @@
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
         <mutiny.version>2.5.6</mutiny.version>
         <smallrye-common.version>2.1.2</smallrye-common.version>
-        <vertx.version>4.5.1</vertx.version>
+        <vertx.version>4.5.3</vertx.version>
         <rest-assured.version>5.4.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.16.1</jackson-bom.version>


### PR DESCRIPTION
The only breaking changes detected are related to the vertx-mutiny-http-proxy module, which is not used in Quarkus.

Full release notes are here: https://github.com/vert-x3/wiki/wiki/4.5.3-Release-Notes.

**Important:**
 - Fix [CVE-2024-1300](https://bugzilla.redhat.com/show_bug.cgi?id=2263139) io.vertx:vertx-core: memory leak when a TCP server is configured with TLS and SNI support
 - Fix the classloading issue for NVMPN and WebJars in dev mode (https://github.com/quarkusio/quarkus/issues/38576)
