### PR TITLE
[3.6] Update to Vertx 4.4.8

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -118,7 +118,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.2.2.Final</wildfly-elytron.version>
         <jboss-threads.version>3.5.1.Final</jboss-threads.version>
-        <vertx.version>4.4.6</vertx.version>
+        <vertx.version>4.4.8</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -64,7 +64,7 @@
         <version.surefire.plugin>3.1.2</version.surefire.plugin>
         <mutiny.version>2.5.1</mutiny.version>
         <smallrye-common.version>2.1.2</smallrye-common.version>
-        <vertx.version>4.4.6</vertx.version>
+        <vertx.version>4.4.8</vertx.version>
         <rest-assured.version>5.3.2</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.15.3</jackson-bom.version>


### PR DESCRIPTION
Fix [CVE-2024-1300](https://bugzilla.redhat.com/show_bug.cgi?id=2263139) io.vertx:vertx-core: memory leak when a TCP server is configured with TLS and SNI support