### PR TITLE
Update activemq-artemis-broker container to 1.0.25

### DIFF
--- a/docs/src/main/asciidoc/amqp.adoc
+++ b/docs/src/main/asciidoc/amqp.adoc
@@ -372,7 +372,7 @@ version: '2'
 services:
 
   artemis:
-    image: quay.io/artemiscloud/activemq-artemis-broker:0.1.2
+    image: quay.io/artemiscloud/activemq-artemis-broker:1.0.25
     ports:
       - "8161:8161"
       - "61616:61616"

--- a/docs/src/main/asciidoc/jms.adoc
+++ b/docs/src/main/asciidoc/jms.adoc
@@ -83,7 +83,7 @@ You can follow the instructions from the https://activemq.apache.org/components/
 
 [source,bash]
 ----
-docker run -it --rm -p 8161:8161 -p 61616:61616 -p 5672:5672 -e AMQ_USER=quarkus -e AMQ_PASSWORD=quarkus quay.io/artemiscloud/activemq-artemis-broker:1.0.21
+docker run -it --rm -p 8161:8161 -p 61616:61616 -p 5672:5672 -e AMQ_USER=quarkus -e AMQ_PASSWORD=quarkus quay.io/artemiscloud/activemq-artemis-broker:1.0.25
 ----
 
 === The price producer

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesBuildTimeConfig.java
@@ -35,7 +35,7 @@ public class AmqpDevServicesBuildTimeConfig {
      * page</a>
      * to find the available versions.
      */
-    @ConfigItem(defaultValue = "quay.io/artemiscloud/activemq-artemis-broker:1.0.22")
+    @ConfigItem(defaultValue = "quay.io/artemiscloud/activemq-artemis-broker:1.0.25")
     public String imageName;
 
     /**

--- a/integration-tests/virtual-threads/jms-virtual-threads/src/main/resources/application.properties
+++ b/integration-tests/virtual-threads/jms-virtual-threads/src/main/resources/application.properties
@@ -5,4 +5,4 @@ mp.messaging.outgoing.prices-out.destination=prices
 smallrye.messaging.worker.<virtual-thread>.max-concurrency=5
 
 quarkus.artemis.devservices.enabled=true
-quarkus.artemis.devservices.image-name=quay.io/artemiscloud/activemq-artemis-broker:1.0.18
+quarkus.artemis.devservices.image-name=quay.io/artemiscloud/activemq-artemis-broker:1.0.25


### PR DESCRIPTION
And use the same version everywhere.
This might help with the CI issues.

This is to solve:
```
2024-02-07T02:52:22.6166402Z Caused by: org.testcontainers.containers.ContainerFetchException: Failed to get Docker client for quay.io/artemiscloud/activemq-artemis-broker:1.0.18
2024-02-07T02:52:22.6168342Z 	at org.testcontainers.images.RemoteDockerImage.resolve(RemoteDockerImage.java:125)
2024-02-07T02:52:22.6169747Z 	at org.testcontainers.images.RemoteDockerImage.resolve(RemoteDockerImage.java:28)
2024-02-07T02:52:22.6171088Z 	at org.testcontainers.utility.LazyFuture.getResolvedValue(LazyFuture.java:20)
2024-02-07T02:52:22.6172285Z 	at org.testcontainers.utility.LazyFuture.get(LazyFuture.java:41)
2024-02-07T02:52:22.6173689Z 	at org.testcontainers.containers.GenericContainer.getDockerImageName(GenericContainer.java:1365)
2024-02-07T02:52:22.6174784Z 	... 15 more
2024-02-07T02:52:22.6176528Z Caused by: com.github.dockerjava.api.exception.DockerClientException: Could not pull image: failed to register layer: write /usr/lib64/libc-2.28.so: no space left on device
2024-02-07T02:52:22.6179130Z 	at com.github.dockerjava.api.command.PullImageResultCallback.checkDockerClientPullSuccessful(PullImageResultCallback.java:97)
2024-02-07T02:52:22.6181331Z 	at com.github.dockerjava.api.command.PullImageResultCallback.throwFirstError(PullImageResultCallback.java:112)
2024-02-07T02:52:22.6183264Z 	at com.github.dockerjava.api.async.ResultCallbackTemplate.awaitCompletion(ResultCallbackTemplate.java:93)
2024-02-07T02:52:22.6185476Z 	at org.testcontainers.images.TimeLimitedLoggedPullImageResultCallback.awaitCompletion(TimeLimitedLoggedPullImageResultCallback.java:58)
2024-02-07T02:52:22.6187619Z 	at org.testcontainers.images.RemoteDockerImage.resolve(RemoteDockerImage.java:97)
2024-02-07T02:52:22.6188569Z 	... 19 more
```