### PR TITLE
[3.2] -  Update to Vert.x 4.4.8

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -123,7 +123,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.2.1.Final</wildfly-elytron.version>
         <jboss-threads.version>3.5.0.Final</jboss-threads.version>
-        <vertx.version>4.4.6</vertx.version>
+        <vertx.version>4.4.8</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -63,7 +63,7 @@
         <version.surefire.plugin>3.0.0</version.surefire.plugin>
         <mutiny.version>2.3.1</mutiny.version>
         <smallrye-common.version>2.1.0</smallrye-common.version>
-        <vertx.version>4.4.6</vertx.version>
+        <vertx.version>4.4.8</vertx.version>
         <rest-assured.version>5.3.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.15.2</jackson-bom.version>


### PR DESCRIPTION
Fix CVE-2024-1300 io.vertx:vertx-core: memory leak when a TCP server is configured with TLS and SNI support