### PR TITLE
Escape column names and paths in order by clause with backticks

### DIFF
--- a/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Sort.java
+++ b/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Sort.java
@@ -100,6 +100,7 @@ public class Sort {
     }
 
     private List<Column> columns = new ArrayList<>();
+    private boolean escapingEnabled = true;
 
     private Sort() {
     }
@@ -294,6 +295,16 @@ public class Sort {
     }
 
     /**
+     * Disables escaping of column names with a backticks during HQL Order By clause generation
+     *
+     * @return this instance, modified.
+     */
+    public Sort disableEscaping() {
+        escapingEnabled = false;
+        return this;
+    }
+
+    /**
      * Get the sort columns
      *
      * @return the sort columns
@@ -310,5 +321,9 @@ public class Sort {
      */
     public static Sort empty() {
         return by();
+    }
+
+    public boolean isEscapingEnabled() {
+        return escapingEnabled;
     }
 }

--- a/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
+++ b/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
@@ -175,7 +175,11 @@ public class PanacheJpaUtil {
             Sort.Column column = sort.getColumns().get(i);
             if (i > 0)
                 sb.append(" , ");
-            sb.append(column.getName());
+            if (sort.isEscapingEnabled()) {
+                sb.append(escapeColumnName(column.getName()));
+            } else {
+                sb.append(column.getName());
+            }
             if (column.getDirection() != Sort.Direction.Ascending) {
                 sb.append(" DESC");
             }
@@ -190,5 +194,31 @@ public class PanacheJpaUtil {
 
         }
         return sb.toString();
+    }
+
+    private static StringBuilder escapeColumnName(String columnName) {
+        StringBuilder sb = new StringBuilder();
+        String[] path = columnName.split("\\.");
+        for (int j = 0; j < path.length; j++) {
+            if (j > 0)
+                sb.append('.');
+            sb.append('`').append(unquoteColumnName(path[j])).append('`');
+        }
+        return sb;
+    }
+
+    private static String unquoteColumnName(String columnName) {
+        String unquotedColumnName;
+        //Note HQL uses backticks to escape/quote special words that are used as identifiers
+        if (columnName.charAt(0) == '`' && columnName.charAt(columnName.length() - 1) == '`') {
+            unquotedColumnName = columnName.substring(1, columnName.length() - 1);
+        } else {
+            unquotedColumnName = columnName;
+        }
+        // Note we're not dealing with columns but with entity attributes so no backticks expected in unquoted column name
+        if (unquotedColumnName.indexOf('`') >= 0) {
+            throw new PanacheQueryException("Sort column name cannot have backticks");
+        }
+        return unquotedColumnName;
     }
 }

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -1742,6 +1742,34 @@ public class TestEndpoint {
     }
 
     @GET
+    @Path("testSortByEmbedded")
+    @Transactional
+    public String testSortByEmbedded() {
+        Person.deleteAll();
+
+        Person stefPerson = new Person();
+        stefPerson.name = "Stef";
+        stefPerson.description = new PersonDescription();
+        stefPerson.description.size = 0;
+        stefPerson.persist();
+
+        Person josePerson = new Person();
+        josePerson.name = "Jose";
+        josePerson.description = new PersonDescription();
+        josePerson.description.size = 100;
+        josePerson.persist();
+
+        List<Person> persons = Person.findAll(Sort.by("description.size", Sort.Direction.Descending)).list();
+        assertEquals(josePerson.id, persons.get(0).id);
+        persons = Person.findAll(Sort.by("description.size", Sort.Direction.Ascending)).list();
+        assertEquals(josePerson.id, persons.get(persons.size() - 1).id);
+
+        Person.deleteAll();
+
+        return "OK";
+    }
+
+    @GET
     @Path("testEnhancement27184DeleteDetached")
     // NOT @Transactional
     public String testEnhancement27184DeleteDetached() {

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -91,6 +91,11 @@ public class PanacheFunctionalityTest {
     }
 
     @Test
+    public void testSortByEmbedded() {
+        RestAssured.when().get("/test/testSortByEmbedded").then().body(is("OK"));
+    }
+
+    @Test
     public void testJaxbAnnotationTransfer() {
         RestAssured.when()
                 .get("/test/testJaxbAnnotationTransfer")


### PR DESCRIPTION
This change includes previous escaping implementation as well as handles sorting by embedded columns which was the reason for the issue reopening. 
Sort.disableEscaping() method was introduced to give a simple workaround to the users who face any other future regression issues.
An integration test was added to replicate and cover #38521

- Closes #1120 