### PR TITLE
[3.2] Only change the behavior for dots in anchors in Quarkus itself

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -434,6 +434,11 @@
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-AquarkusConfigDoc.replaceDotsInAnchors=true</arg>
+                        </compilerArgs>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/ExtensionAnnotationProcessor.java
@@ -39,6 +39,7 @@ import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Completion;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -77,11 +78,13 @@ import io.quarkus.annotation.processor.generate_doc.ConfigDocItemScanner;
 import io.quarkus.annotation.processor.generate_doc.ConfigDocWriter;
 import io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil;
 
+@SupportedOptions({ ExtensionAnnotationProcessor.REPLACE_DOTS_IN_ANCHORS })
 public class ExtensionAnnotationProcessor extends AbstractProcessor {
 
     private static final Pattern REMOVE_LEADING_SPACE = Pattern.compile("^ ", Pattern.MULTILINE);
 
-    private final ConfigDocWriter configDocWriter = new ConfigDocWriter();
+    public static final String REPLACE_DOTS_IN_ANCHORS = "quarkusConfigDoc.replaceDotsInAnchors";
+
     private final ConfigDocItemScanner configDocItemScanner = new ConfigDocItemScanner();
     private final Set<String> generatedAccessors = new ConcurrentHashMap<String, Boolean>().keySet(Boolean.TRUE);
     private final Set<String> generatedJavaDocs = new ConcurrentHashMap<String, Boolean>().keySet(Boolean.TRUE);
@@ -90,11 +93,6 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
     private final Map<String, Boolean> ANNOTATION_USAGE_TRACKER = new ConcurrentHashMap<>();
 
     public ExtensionAnnotationProcessor() {
-    }
-
-    @Override
-    public Set<String> getSupportedOptions() {
-        return Collections.emptySet();
     }
 
     @Override
@@ -259,6 +257,7 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
 
         try {
             if (generateDocs) {
+                ConfigDocWriter configDocWriter = new ConfigDocWriter(true, shouldReplaceDotsInAnchors());
                 final Set<ConfigDocGeneratedOutput> outputs = configDocItemScanner
                         .scanExtensionsConfigurationItems(javaDocProperties, isAnnotationUsed(ANNOTATION_CONFIG_MAPPING));
                 for (ConfigDocGeneratedOutput output : outputs) {
@@ -399,6 +398,10 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
                         + "' which is annotated with '@Record' does not contain a method parameter whose type is annotated with '@Recorder'.");
             }
         }
+    }
+
+    private boolean shouldReplaceDotsInAnchors() {
+        return "true".equals(processingEnv.getOptions().get(REPLACE_DOTS_IN_ANCHORS));
     }
 
     private Name getPackageName(TypeElement clazz) {

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocBuilder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocBuilder.java
@@ -28,6 +28,10 @@ class ConfigDocBuilder {
         summaryTableDocFormatter = new SummaryTableDocFormatter(showEnvVars);
     }
 
+    protected ConfigDocBuilder(boolean showEnvVars, boolean replaceDotsInAnchors) {
+        summaryTableDocFormatter = new SummaryTableDocFormatter(showEnvVars, replaceDotsInAnchors);
+    }
+
     /**
      * Add documentation in a summary table and descriptive format
      */

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocWriter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocWriter.java
@@ -9,6 +9,19 @@ import io.quarkus.annotation.processor.Constants;
 
 final public class ConfigDocWriter {
 
+    private final boolean showEnvVars;
+    private final boolean replaceDotsInAnchors;
+
+    public ConfigDocWriter() {
+        this.showEnvVars = true;
+        this.replaceDotsInAnchors = false;
+    }
+
+    public ConfigDocWriter(boolean showEnvVars, boolean replaceDotsInAnchors) {
+        this.showEnvVars = showEnvVars;
+        this.replaceDotsInAnchors = replaceDotsInAnchors;
+    }
+
     /**
      * Write all extension configuration in AsciiDoc format in `{root}/target/asciidoc/generated/config/` directory
      */
@@ -20,8 +33,9 @@ final public class ConfigDocWriter {
         }
 
         // Create single summary table
-        final var configDocBuilder = new ConfigDocBuilder().addSummaryTable(output.getAnchorPrefix(), output.isSearchable(),
-                output.getConfigDocItems(), output.getFileName(), true);
+        final var configDocBuilder = new ConfigDocBuilder(showEnvVars, replaceDotsInAnchors)
+                .addSummaryTable(output.getAnchorPrefix(), output.isSearchable(),
+                        output.getConfigDocItems(), output.getFileName(), true);
 
         generateDocumentation(output.getFileName(), configDocBuilder);
     }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocFormatter.java
@@ -6,7 +6,12 @@ import java.text.Normalizer;
 import java.util.List;
 
 interface DocFormatter {
+
     default String getAnchor(String string) {
+        return getAnchor(string, false);
+    }
+
+    default String getAnchor(String string, boolean replaceDotsInAnchors) {
         // remove accents
         string = Normalizer.normalize(string, Normalizer.Form.NFKC)
                 .replaceAll("[àáâãäåāąă]", "a")
@@ -53,8 +58,15 @@ interface DocFormatter {
 
         // Apostrophes.
         string = string.replaceAll("([a-z])'s([^a-z])", "$1s$2");
-        // Allow only letters, -, _
-        string = string.replaceAll("[^\\w-_]", "-").replaceAll("-{2,}", "-");
+
+        if (replaceDotsInAnchors) {
+            // Allow only letters, -, _
+            string = string.replaceAll("[^\\w-_]", "-").replaceAll("-{2,}", "-");
+        } else {
+            // Allow only letters, -, _, .
+            string = string.replaceAll("[^\\w-_\\.]", "-").replaceAll("-{2,}", "-");
+        }
+
         // Get rid of any - at the start and end.
         string = string.replaceAll("-+$", "").replaceAll("^-+", "");
 

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/MavenConfigDocBuilder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/MavenConfigDocBuilder.java
@@ -12,7 +12,7 @@ import io.quarkus.annotation.processor.Constants;
 public final class MavenConfigDocBuilder extends ConfigDocBuilder {
 
     public MavenConfigDocBuilder() {
-        super(false);
+        super(false, true);
     }
 
     private final JavaDocParser javaDocParser = new JavaDocParser();

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
@@ -19,16 +19,23 @@ final class SummaryTableDocFormatter implements DocFormatter {
     private static final String SECTION_TITLE = "[[%s]]link:#%s[%s]";
     private static final String TABLE_HEADER_FORMAT = "[%s, cols=\"80,.^10,.^10\"]\n|===";
     private static final String TABLE_SECTION_ROW_FORMAT = "\n\nh|%s\n%s\nh|Type\nh|Default";
+
     private final boolean showEnvVars;
+    private final boolean replaceDotsInAnchors;
 
     private String anchorPrefix = "";
 
-    public SummaryTableDocFormatter(boolean showEnvVars) {
+    public SummaryTableDocFormatter(boolean showEnvVars, boolean replaceDotsInAnchors) {
         this.showEnvVars = showEnvVars;
+        this.replaceDotsInAnchors = replaceDotsInAnchors;
+    }
+
+    public SummaryTableDocFormatter(boolean showEnvVars) {
+        this(showEnvVars, false);
     }
 
     public SummaryTableDocFormatter() {
-        this(true);
+        this(true, false);
     }
 
     /**
@@ -49,7 +56,7 @@ final class SummaryTableDocFormatter implements DocFormatter {
 
         // make sure that section-less configs get a legend
         if (configDocItems.isEmpty() || configDocItems.get(0).isConfigKey()) {
-            String anchor = anchorPrefix + getAnchor("configuration");
+            String anchor = anchorPrefix + getAnchor("configuration", replaceDotsInAnchors);
             writer.append(String.format(TABLE_SECTION_ROW_FORMAT,
                     String.format(SECTION_TITLE, anchor, anchor, "Configuration property"),
                     Constants.EMPTY));
@@ -111,8 +118,9 @@ final class SummaryTableDocFormatter implements DocFormatter {
         String required = configDocKey.isOptional() || !defaultValue.isEmpty() ? ""
                 : "required icon:exclamation-circle[title=Configuration property is required]";
         String key = configDocKey.getKey();
-        String configKeyAnchor = configDocKey.isPassThroughMap() ? getAnchor(key + Constants.DASH + configDocKey.getDocMapKey())
-                : getAnchor(key);
+        String configKeyAnchor = configDocKey.isPassThroughMap()
+                ? getAnchor(key + Constants.DASH + configDocKey.getDocMapKey(), replaceDotsInAnchors)
+                : getAnchor(key, replaceDotsInAnchors);
         String anchor = anchorPrefix + configKeyAnchor;
 
         StringBuilder keys = new StringBuilder();
@@ -141,7 +149,8 @@ final class SummaryTableDocFormatter implements DocFormatter {
     public void format(Writer writer, ConfigDocSection configDocSection) throws IOException {
         if (configDocSection.isShowSection()) {
             String anchor = anchorPrefix
-                    + getAnchor(configDocSection.getName() + Constants.DASH + configDocSection.getSectionDetailsTitle());
+                    + getAnchor(configDocSection.getName() + Constants.DASH + configDocSection.getSectionDetailsTitle(),
+                            replaceDotsInAnchors);
             String sectionTitle = String.format(SECTION_TITLE, anchor, anchor, configDocSection.getSectionDetailsTitle());
             final String sectionRow = String.format(TABLE_SECTION_ROW_FORMAT, sectionTitle,
                     configDocSection.isOptional() ? "This configuration section is optional" : Constants.EMPTY);

--- a/independent-projects/parent/pom.xml
+++ b/independent-projects/parent/pom.xml
@@ -201,7 +201,7 @@
                     <testSource>${maven.compiler.argument.testSource}</testSource>
                     <testTarget>${maven.compiler.argument.testTarget}</testTarget>
                     <parameters>true</parameters>
-                    <compilerArgs>
+                    <compilerArgs combine.children="append">
                         <arg>-Xlint:unchecked</arg>
                     </compilerArgs>
                 </configuration>


### PR DESCRIPTION
That was a lot harder than expected but this should make the dot replacement conditional so that it doesn't affect the external extensions.
This is for Quarkus 3.2 only. In current versions, the dots are always replaced.

@ppalaga IIRC, you agreed for the change affecting Camel Quarkus for Quarkus 3.7+ right?