### PR TITLE
Increase binary size baseline for postgresql IT with Mandrel 23.0

### DIFF
--- a/integration-tests/jpa-postgresql/src/test/resources/image-metrics/23.0/image-metrics.properties
+++ b/integration-tests/jpa-postgresql/src/test/resources/image-metrics/23.0/image-metrics.properties
@@ -1,5 +1,5 @@
 # Properties file used by ImageMetricsITCase
-image_details.total_bytes=79228920
+image_details.total_bytes=79712248
 image_details.total_bytes.tolerance=3
 analysis_results.types.reachable=19441
 analysis_results.types.reachable.tolerance=3


### PR DESCRIPTION
CPU updates seem to have a small effect on the binary size (~0.6%
increase).

The new baseline is based on a build with the mandrel builder image with
tag `23.0.3.0-Final-java17-2024-02-04`

Closes https://github.com/quarkusio/quarkus/issues/38563