### PR TITLE
Allow for multiple TestConfigProperty annotations on methods

### DIFF
--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/TestConfigProperty.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/TestConfigProperty.java
@@ -36,7 +36,7 @@ public @interface TestConfigProperty {
     String value();
 
     @Retention(RUNTIME)
-    @Target(TYPE)
+    @Target({ TYPE, METHOD })
     @interface TestConfigProperties {
 
         TestConfigProperty[] value();

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/beans/MultiPropComponent.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/beans/MultiPropComponent.java
@@ -1,0 +1,20 @@
+package io.quarkus.test.component.beans;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class MultiPropComponent {
+
+    @ConfigProperty(name = "foo")
+    String foo;
+
+    @ConfigProperty(name = "bar")
+    String bar;
+
+    public String getFooBar() {
+        return foo + bar;
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/MultipleConfigPropertiesDeclaredOnMethodTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/declarative/MultipleConfigPropertiesDeclaredOnMethodTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.test.component.declarative;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.component.QuarkusComponentTest;
+import io.quarkus.test.component.TestConfigProperty;
+import io.quarkus.test.component.beans.MultiPropComponent;
+
+@QuarkusComponentTest
+public class MultipleConfigPropertiesDeclaredOnMethodTest {
+
+    @Inject
+    MultiPropComponent component;
+
+    @TestConfigProperty(key = "foo", value = "BAR")
+    @TestConfigProperty(key = "bar", value = "BAZ")
+    @Test
+    public void testPing() {
+        assertEquals("BARBAZ", component.getFooBar());
+    }
+
+}


### PR DESCRIPTION
With this PR you can repeat the `@TestConfigProperty` annotation for Quarkus Component Test even on methods, not just classes. This allows for overriding multiple config values per test method..

- Fixes #38602

