### PR TITLE
Make ClientLogger beans unremovable

### DIFF
--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -1681,7 +1681,14 @@ quarkus.rest-client.logging.body-limit=50
 quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG
 ----
 
-TIP: REST Client Reactive uses a default `ClientLogger` implementation. You can change it by providing a custom `ClientLogger` instance through CDI or when programmatically creating your client.
+[TIP]
+====
+REST Client Reactive uses a default `ClientLogger` implementation, which can be swapped out for a custom implementation.
+
+When setting up the client programmatically using the `QuarkusRestClientBuilder`, the `ClientLogger` is set via the `clientLogger` method.
+
+For declarative clients using `@RegisterRestClient`, simply providing a CDI bean that implements `ClientLogger` is enough for that logger to be used by said clients.
+====
 
 == Mocking the client for tests
 If you use a client injected with the `@RestClient` annotation, you can easily mock it for tests.

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/RestClientReactiveProcessor.java
@@ -60,6 +60,7 @@ import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.client.api.ClientLogger;
 import org.jboss.resteasy.reactive.client.interceptors.ClientGZIPDecodingInterceptor;
 import org.jboss.resteasy.reactive.client.spi.MissingMessageBodyReaderErrorMessageContextualizer;
 import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
@@ -179,8 +180,8 @@ class RestClientReactiveProcessor {
     }
 
     @BuildStep
-    UnremovableBeanBuildItem makeConfigUnremovable() {
-        return UnremovableBeanBuildItem.beanTypes(RestClientsConfig.class);
+    UnremovableBeanBuildItem unremovableBeans() {
+        return UnremovableBeanBuildItem.beanTypes(RestClientsConfig.class, ClientLogger.class);
     }
 
     @BuildStep

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/MyClientLogger.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/MyClientLogger.java
@@ -12,7 +12,7 @@ import io.vertx.core.http.HttpClientResponse;
 
 @ApplicationScoped
 public class MyClientLogger implements ClientLogger {
-    public final AtomicBoolean used = new AtomicBoolean(false);
+    private final AtomicBoolean used = new AtomicBoolean(false);
 
     @Override
     public void setBodySize(int bodySize) {


### PR DESCRIPTION
There is no reason why users should be forced to annotate their `ClientLogger` beans with `@Unremovable`

- Closes: https://github.com/quarkusio/quarkus/issues/38658