### PR TITLE
Correct example generated yaml in extension metadata docs

### DIFF
--- a/docs/src/main/asciidoc/extension-metadata.adoc
+++ b/docs/src/main/asciidoc/extension-metadata.adoc
@@ -102,8 +102,7 @@ metadata:
 description: "A Jakarta REST implementation utilizing build time processing and Vert.x.\
   \ This extension is not compatible with the quarkus-resteasy extension, or any of\
   \ the extensions that depend on it." <4>
-scm:
-  url: "https://github.com/quarkusio/quarkus" <5>
+scm-url: "https://github.com/quarkusio/quarkus" <5>
 sponsor: A Sponsoring Organisation <6>
 ----
 
@@ -111,7 +110,7 @@ sponsor: A Sponsoring Organisation <6>
 <2> https://quarkus.io/guides/capabilities[Capabilities] this extension provides
 <3> Direct dependencies on other extensions
 <4> Description that can be displayed to users. In this case, the description was copied from the `pom.xml` of the extension module but it could also be provided in the template file.
-<5> The source code repository of this extension. Optional, and will often be set automatically. In GitHub Actions builds, it will be inferred from the CI environment. For other GitHub repositories, it can be controlled by setting a `GITHUB_REPOSITORY` environment variable.
+<5> The source code repository of this extension. Optional, and will often be set automatically using the `<scm>` information in the pom. In GitHub Actions builds, it will be inferred from the CI environment. For other GitHub repositories, it can be controlled by setting a `GITHUB_REPOSITORY` environment variable.
 <6> The sponsor(s) of this extension. Optional, and will sometimes be determined automatically from commit history.
 
 [[quarkus-extension-properties]]


### PR DESCRIPTION
I noticed while investigating https://github.com/quarkusio/extensions/issues/630 that the docs at https://quarkus.io/version/main/guides/extension-metadata#quarkus-extension-yaml are out of date. I think I did `scm:\nurl:` for the first iteration, and that caused problems, so I changed it to `scm-url` but didn't update the example in the docs. 

I also didn't mention the fact we read poms now, so I've added that too. 