### PR TITLE
Upgrade to Hibernate ORM 6.4.4.Final / bytebuddy 1.14.11

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -100,8 +100,8 @@
              bytebuddy.version (just below), hibernate-orm.version-for-documentation (in docs/pom.xml)
              and both hibernate-orm.version and antlr.version in build-parent/pom.xml
              WARNING again for diffs that don't provide enough context: when updating, see above -->
-        <hibernate-orm.version>6.4.3.Final</hibernate-orm.version>
-        <bytebuddy.version>1.14.7</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
+        <hibernate-orm.version>6.4.4.Final</hibernate-orm.version>
+        <bytebuddy.version>1.14.11</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-commons-annotations.version>6.0.6.Final</hibernate-commons-annotations.version> <!-- version controlled by Hibernate ORM -->
         <hibernate-reactive.version>2.2.2.Final</hibernate-reactive.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -75,7 +75,7 @@
              and unfortunately annotation processors are not covered by dependency management
              in kotlin-maven-plugin; see https://github.com/quarkusio/quarkus/issues/37477#issuecomment-1923662964
          -->
-        <hibernate-orm.version>6.4.3.Final</hibernate-orm.version>
+        <hibernate-orm.version>6.4.4.Final</hibernate-orm.version>
         <!-- Antlr 4 is used by the PanacheQL parser but also needs to match the requirements of Hibernate ORM 6.x-->
         <antlr.version>4.13.0</antlr.version>
 

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -46,7 +46,7 @@
         <!-- Versions -->
         <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
         <jandex.version>3.1.6</jandex.version>
-        <bytebuddy.version>1.14.7</bytebuddy.version>
+        <bytebuddy.version>1.14.11</bytebuddy.version>
         <junit5.version>5.10.2</junit5.version>
         <maven.version>3.9.6</maven.version>
         <assertj.version>3.25.3</assertj.version>


### PR DESCRIPTION
Tests for Hibernate Reactive's compatibility ~~are pending, but it's looking good so far: https://github.com/hibernate/hibernate-reactive/actions/runs/7830373800~~ => They passed

BTW @geoand, can't we use the Quarkus BOM for RestEasy reactive? I'm pretty sure I'll forget to sync the bytebuddy version one day...

Note the bytebuddy upgrade brings the ability to run against JDK 22 without `-Dnet.bytebuddy.experimental=true`.
