### PR TITLE
OpenAPI: remove check that avoids running auto-security at build

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -428,8 +428,6 @@ public class SmallRyeOpenApiProcessor {
             LaunchModeBuildItem launchModeBuildItem,
             ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig) {
 
-        OASFilter autoRolesAllowedFilter = getAutoRolesAllowedFilter(apiFilteredIndexViewBuildItem, config);
-
         // Add a security scheme from config
         if (config.securityScheme.isPresent()) {
             addToOpenAPIDefinitionProducer
@@ -437,12 +435,11 @@ public class SmallRyeOpenApiProcessor {
                             new SecurityConfigFilter(config)));
         } else if (config.autoAddSecurity) {
             getAutoSecurityFilter(securityInformationBuildItems, config)
-                    // Only run the filter at build time if it will not be run at runtime
-                    .filter(securityFilter -> !autoSecurityRuntimeEnabled(securityFilter, () -> autoRolesAllowedFilter))
                     .map(AddToOpenAPIDefinitionBuildItem::new)
                     .ifPresent(addToOpenAPIDefinitionProducer::produce);
         }
 
+        OASFilter autoRolesAllowedFilter = getAutoRolesAllowedFilter(apiFilteredIndexViewBuildItem, config);
         // Add Auto roles allowed
         if (autoRolesAllowedFilter != null) {
             addToOpenAPIDefinitionProducer.produce(new AddToOpenAPIDefinitionBuildItem(autoRolesAllowedFilter));

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedWithScopesOIDCTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedWithScopesOIDCTestCase.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+class AutoSecurityRolesAllowedWithScopesOIDCTestCase extends AutoSecurityRolesAllowedWithScopesTestBase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ResourceBean.class, OpenApiResourceSecuredAtClassLevel.class,
+                            OpenApiResourceSecuredAtMethodLevel.class, OpenApiResourceSecuredAtMethodLevel2.class)
+                    .addAsResource(
+                            new StringAsset(
+                                    "quarkus.smallrye-openapi.security-scheme-name=MyScheme\n"
+                                            + "quarkus.smallrye-openapi.security-scheme-description=Authentication using MyScheme\n"
+                                            + "quarkus.devservices.enabled=false\n"
+                                            + "quarkus.oidc.auth-server-url=http://localhost:8081/auth/realms/OpenAPIOIDC"),
+                            "application.properties"))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-oidc", Version.getVersion())));
+
+    @Test
+    void testAutoSecurityRequirement() {
+        testAutoSecurityRequirement("openIdConnect");
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedWithScopesTestBase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedWithScopesTestBase.java
@@ -1,0 +1,61 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.hamcrest.Matcher;
+
+import io.restassured.RestAssured;
+
+abstract class AutoSecurityRolesAllowedWithScopesTestBase {
+
+    static Matcher<Iterable<Object>> schemeArray(String schemeName, Matcher<Iterable<?>> scopesMatcher) {
+        return allOf(
+                iterableWithSize(1),
+                hasItem(allOf(
+                        aMapWithSize(1),
+                        hasEntry(equalTo(schemeName), scopesMatcher))));
+    }
+
+    void testAutoSecurityRequirement(String schemeType) {
+        RestAssured.given()
+                .header("Accept", "application/json")
+                .when()
+                .get("/q/openapi")
+                .then()
+                .log().body()
+                .and()
+                .body("components.securitySchemes.MyScheme", allOf(
+                        hasEntry("type", schemeType),
+                        hasEntry("description", "Authentication using MyScheme")))
+                .and()
+                // OpenApiResourceSecuredAtMethodLevel
+                .body("paths.'/resource2/test-security/naked'.get.security", schemeArray("MyScheme", contains("admin")))
+                .body("paths.'/resource2/test-security/annotated'.get.security",
+                        schemeArray("JWTCompanyAuthentication", emptyIterable()))
+                .body("paths.'/resource2/test-security/methodLevel/1'.get.security", schemeArray("MyScheme", contains("user1")))
+                .body("paths.'/resource2/test-security/methodLevel/2'.get.security", schemeArray("MyScheme", contains("user2")))
+                .body("paths.'/resource2/test-security/methodLevel/public'.get.security", nullValue())
+                .body("paths.'/resource2/test-security/annotated/documented'.get.security",
+                        schemeArray("JWTCompanyAuthentication", emptyIterable()))
+                .body("paths.'/resource2/test-security/methodLevel/3'.get.security", schemeArray("MyScheme", contains("admin")))
+                .and()
+                // OpenApiResourceSecuredAtClassLevel
+                .body("paths.'/resource2/test-security/classLevel/1'.get.security", schemeArray("MyScheme", contains("user1")))
+                .body("paths.'/resource2/test-security/classLevel/2'.get.security", schemeArray("MyScheme", contains("user2")))
+                .body("paths.'/resource2/test-security/classLevel/3'.get.security", schemeArray("MyOwnName", emptyIterable()))
+                .body("paths.'/resource2/test-security/classLevel/4'.get.security", schemeArray("MyScheme", contains("admin")))
+                .and()
+                // OpenApiResourceSecuredAtMethodLevel2
+                .body("paths.'/resource3/test-security/annotated'.get.security",
+                        schemeArray("AtClassLevel", emptyIterable()));
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedWithScopesTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedWithScopesTestCase.java
@@ -1,24 +1,12 @@
 package io.quarkus.smallrye.openapi.test.jaxrs;
 
-import static org.hamcrest.Matchers.aMapWithSize;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.emptyIterable;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.iterableWithSize;
-import static org.hamcrest.Matchers.nullValue;
-
-import org.hamcrest.Matcher;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
-import io.restassured.RestAssured;
 
-class AutoSecurityRolesAllowedWithScopesTestCase {
+class AutoSecurityRolesAllowedWithScopesTestCase extends AutoSecurityRolesAllowedWithScopesTestBase {
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
@@ -27,52 +15,13 @@ class AutoSecurityRolesAllowedWithScopesTestCase {
                             OpenApiResourceSecuredAtMethodLevel.class, OpenApiResourceSecuredAtMethodLevel2.class)
                     .addAsResource(
                             new StringAsset("quarkus.smallrye-openapi.security-scheme=oauth2-implicit\n"
-                                    + "quarkus.smallrye-openapi.security-scheme-name=OAuth2\n"
-                                    + "quarkus.smallrye-openapi.security-scheme-description=OAuth2 Authentication"),
-
+                                    + "quarkus.smallrye-openapi.security-scheme-name=MyScheme\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-description=Authentication using MyScheme"),
                             "application.properties"));
-
-    static Matcher<Iterable<Object>> schemeArray(String schemeName, Matcher<Iterable<?>> scopesMatcher) {
-        return allOf(
-                iterableWithSize(1),
-                hasItem(allOf(
-                        aMapWithSize(1),
-                        hasEntry(equalTo(schemeName), scopesMatcher))));
-    }
 
     @Test
     void testAutoSecurityRequirement() {
-        RestAssured.given()
-                .header("Accept", "application/json")
-                .when()
-                .get("/q/openapi")
-                .then()
-                .log().body()
-                .and()
-                .body("components.securitySchemes.OAuth2", allOf(
-                        hasEntry("type", "oauth2"),
-                        hasEntry("description", "OAuth2 Authentication")))
-                .and()
-                // OpenApiResourceSecuredAtMethodLevel
-                .body("paths.'/resource2/test-security/naked'.get.security", schemeArray("OAuth2", contains("admin")))
-                .body("paths.'/resource2/test-security/annotated'.get.security",
-                        schemeArray("JWTCompanyAuthentication", emptyIterable()))
-                .body("paths.'/resource2/test-security/methodLevel/1'.get.security", schemeArray("OAuth2", contains("user1")))
-                .body("paths.'/resource2/test-security/methodLevel/2'.get.security", schemeArray("OAuth2", contains("user2")))
-                .body("paths.'/resource2/test-security/methodLevel/public'.get.security", nullValue())
-                .body("paths.'/resource2/test-security/annotated/documented'.get.security",
-                        schemeArray("JWTCompanyAuthentication", emptyIterable()))
-                .body("paths.'/resource2/test-security/methodLevel/3'.get.security", schemeArray("OAuth2", contains("admin")))
-                .and()
-                // OpenApiResourceSecuredAtClassLevel
-                .body("paths.'/resource2/test-security/classLevel/1'.get.security", schemeArray("OAuth2", contains("user1")))
-                .body("paths.'/resource2/test-security/classLevel/2'.get.security", schemeArray("OAuth2", contains("user2")))
-                .body("paths.'/resource2/test-security/classLevel/3'.get.security", schemeArray("MyOwnName", emptyIterable()))
-                .body("paths.'/resource2/test-security/classLevel/4'.get.security", schemeArray("OAuth2", contains("admin")))
-                .and()
-                // OpenApiResourceSecuredAtMethodLevel2
-                .body("paths.'/resource3/test-security/annotated'.get.security",
-                        schemeArray("AtClassLevel", emptyIterable()));
+        testAutoSecurityRequirement("oauth2");
     }
 
 }


### PR DESCRIPTION
Bug fix to remove check added in #38231 that skips running the auto-security filter at build time if it will run also at run time. Other filters (e.g. AutoRolesAllowedFilter) depend on the auto-security at build time, so it must always run if configured.

Fixes #38676