### PR TITLE
Kafka Streams fire event after created and before scheduling the start

### DIFF
--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsRuntimeConfig.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsRuntimeConfig.java
@@ -16,7 +16,7 @@ public class KafkaStreamsRuntimeConfig {
     /**
      * Default Kafka bootstrap server.
      */
-    public static final String DEFAULT_KAFKA_BROKER = "localhost:9012";
+    public static final String DEFAULT_KAFKA_BROKER = "localhost:9092";
 
     /**
      * A unique identifier for this Kafka Streams application.
@@ -27,7 +27,7 @@ public class KafkaStreamsRuntimeConfig {
 
     /**
      * A comma-separated list of host:port pairs identifying the Kafka bootstrap server(s).
-     * If not set, fallback to {@code kafka.bootstrap.servers}, and if not set either use {@code localhost:9012}.
+     * If not set, fallback to {@code kafka.bootstrap.servers}, and if not set either use {@code localhost:9092}.
      */
     @ConfigItem(defaultValue = DEFAULT_KAFKA_BROKER)
     public List<InetSocketAddress> bootstrapServers;

--- a/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsEventCounter.java
+++ b/integration-tests/kafka-streams/src/main/java/io/quarkus/it/kafka/streams/KafkaStreamsEventCounter.java
@@ -6,13 +6,16 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsConfig;
 
 @ApplicationScoped
 public class KafkaStreamsEventCounter {
 
     LongAdder eventCount = new LongAdder();
 
-    void onKafkaStreamsEvent(@Observes KafkaStreams kafkaStreams) {
+    void onKafkaStreamsEvent(@Observes KafkaStreams kafkaStreams, StreamsConfig streamsConfig) {
+        assert kafkaStreams.state() == KafkaStreams.State.CREATED;
+        assert streamsConfig != null;
         eventCount.increment();
     }
 


### PR DESCRIPTION
Schedules the KafkaStreams#start at StartupEvent instead of PostConstruct.
Removes Startup annotation from producer methods.

Fixes #36341 and #36774

Corrects Kafka streams default Kafka broker to localhost:9092 instead of 9012.

Switching StartupEvent I haven't noticed any change in registered classes for native compilation 