### PR TITLE
Avoid Vert.x GraphQL deprecation warning

### DIFF
--- a/extensions/vertx-graphql/runtime/src/main/java/io/quarkus/vertx/graphql/runtime/VertxGraphqlRecorder.java
+++ b/extensions/vertx-graphql/runtime/src/main/java/io/quarkus/vertx/graphql/runtime/VertxGraphqlRecorder.java
@@ -1,9 +1,11 @@
 package io.quarkus.vertx.graphql.runtime;
 
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
@@ -12,12 +14,12 @@ import io.vertx.ext.web.handler.graphql.GraphiQLHandlerOptions;
 
 @Recorder
 public class VertxGraphqlRecorder {
-    public Handler<RoutingContext> handler() {
+    public Handler<RoutingContext> handler(Supplier<Vertx> vertx) {
 
         GraphiQLHandlerOptions options = new GraphiQLHandlerOptions();
         options.setEnabled(true);
 
-        Handler<RoutingContext> handler = GraphiQLHandler.create(options);
+        Handler<RoutingContext> handler = GraphiQLHandler.create(vertx.get(), options);
 
         return new Handler<RoutingContext>() {
             @Override


### PR DESCRIPTION
We, Quarkus QE team, test that Quarkus does not log unnecessary warnings or erros. After Vert.x bump we are getting following message logged `This instance of GraphiQLHandler has been created with a deprecated method, which will be removed in the next major version.`. I read `GraphiQLHandlerImpl` and I can't see a reason why we can't use Vert.x instance, but let see what CI and experts have to say to this.

P.S. I split `NativeImageResourceDirectoryBuildItem` producing from original method, for it is really hard to determine if there can't be a circular reference in some scenario (build item requiring another build item etc.). I'm not aware of such scenario though.