### PR TITLE
Only configure shared network for Elasticsearch/OpenSearch containers where necessary

### DIFF
--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -214,8 +214,8 @@ public class DevServicesElasticsearchProcessor {
         final Supplier<DevServicesResultBuildItem.RunningDevService> defaultElasticsearchSupplier = () -> {
 
             GenericContainer<?> container = resolvedDistribution.equals(Distribution.ELASTIC)
-                    ? createElasticsearchContainer(config, resolvedImageName)
-                    : createOpensearchContainer(config, resolvedImageName);
+                    ? createElasticsearchContainer(config, resolvedImageName, useSharedNetwork)
+                    : createOpensearchContainer(config, resolvedImageName, useSharedNetwork);
 
             if (config.serviceName != null) {
                 container.withLabel(DEV_SERVICE_LABEL, config.serviceName);
@@ -247,10 +247,12 @@ public class DevServicesElasticsearchProcessor {
     }
 
     private GenericContainer<?> createElasticsearchContainer(ElasticsearchDevServicesBuildTimeConfig config,
-            DockerImageName resolvedImageName) {
+            DockerImageName resolvedImageName, boolean useSharedNetwork) {
         ElasticsearchContainer container = new ElasticsearchContainer(
                 resolvedImageName.asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"));
-        ConfigureUtil.configureSharedNetwork(container, DEV_SERVICE_ELASTICSEARCH);
+        if (useSharedNetwork) {
+            ConfigureUtil.configureSharedNetwork(container, DEV_SERVICE_ELASTICSEARCH);
+        }
 
         // Disable security as else we would need to configure it correctly to avoid tons of WARNING in the log
         container.addEnv("xpack.security.enabled", "false");
@@ -264,10 +266,12 @@ public class DevServicesElasticsearchProcessor {
     }
 
     private GenericContainer<?> createOpensearchContainer(ElasticsearchDevServicesBuildTimeConfig config,
-            DockerImageName resolvedImageName) {
+            DockerImageName resolvedImageName, boolean useSharedNetwork) {
         OpensearchContainer container = new OpensearchContainer(
                 resolvedImageName.asCompatibleSubstituteFor("opensearchproject/opensearch"));
-        ConfigureUtil.configureSharedNetwork(container, DEV_SERVICE_OPENSEARCH);
+        if (useSharedNetwork) {
+            ConfigureUtil.configureSharedNetwork(container, DEV_SERVICE_OPENSEARCH);
+        }
 
         container.addEnv("bootstrap.memory_lock", "true");
         container.addEnv("plugins.index_state_management.enabled", "false");


### PR DESCRIPTION
Fixes #38706

When a shared network is configured, the configuration will change on each container start because of this:

https://github.com/quarkusio/quarkus/blob/cd90a560cfcf1bd1be4992bae9a1f68287e98623/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java#L46

This will result in the config hash being different on each start in testcontainers, and ultimately in testcontainers not reusing containers.

Fortunately, we're not supposed to configure share networks most of the time; it was wrong that we were. All database containers, for example, avoid this configuration using the same condition as we'll now be using for Elasticsearch/OpenSearch.

With these changes, I get this, and it's a delight:

```
2024-02-09 16:52:37,708 INFO  [tc.doc.io/.9.1] (build-13) Creating container for image: docker.io/elastic/elasticsearch:8.9.1
2024-02-09 16:52:37,770 INFO  [tc.doc.io/.9.1] (build-13) Reusing container with ID: 20656c74bf8ec5f88281d07d8ecc6643e1262f1bd90952d9c7353eb7a9d9821a and hash: 07fc5c4abe6432c92163095b5c1283d79f778e14
2024-02-09 16:52:37,771 INFO  [tc.doc.io/.9.1] (build-13) Reusing existing container (20656c74bf8ec5f88281d07d8ecc6643e1262f1bd90952d9c7353eb7a9d9821a) and not creating a new one
2024-02-09 16:52:37,919 INFO  [tc.doc.io/.9.1] (build-13) Container docker.io/elastic/elasticsearch:8.9.1 started in PT0.210882132S
```

Obviously this doesn't solve the problem when shared networks are required (e.g. when running the app as a container for `@QuarkusIntegrationTest`), but then this is a more general problem that probably affects all containers, not just Elasticsearch/OpenSearch.