### PR TITLE
Allow Java 11 as LTS for older streams and other platforms

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/JavaVersion.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/JavaVersion.java
@@ -62,7 +62,7 @@ public final class JavaVersion {
     }
 
     // ordering is important here, so let's keep them ordered
-    public static final SortedSet<Integer> JAVA_VERSIONS_LTS = new TreeSet<>(List.of(17, 21));
+    public static final SortedSet<Integer> JAVA_VERSIONS_LTS = new TreeSet<>(List.of(11, 17, 21));
     public static final int DEFAULT_JAVA_VERSION = 17;
     // we want to maximize the compatibility of extensions with the Quarkus ecosystem so let's stick to 17 by default
     public static final String DEFAULT_JAVA_VERSION_FOR_EXTENSION = "17";

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/JavaVersionTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/JavaVersionTest.java
@@ -31,7 +31,8 @@ class JavaVersionTest {
 
     @Test
     void shouldProperlyUseMinJavaVersion() {
-        assertThat(getCompatibleLTSVersions(new JavaVersion("17"))).isEqualTo(JAVA_VERSIONS_LTS);
+        assertThat(getCompatibleLTSVersions(new JavaVersion("11"))).isEqualTo(JAVA_VERSIONS_LTS);
+        assertThat(getCompatibleLTSVersions(new JavaVersion("17"))).containsExactly(17, 21);
         assertThat(getCompatibleLTSVersions(new JavaVersion("21"))).containsExactly(21);
         assertThat(getCompatibleLTSVersions(new JavaVersion("100"))).isEmpty();
         assertThat(getCompatibleLTSVersions(JavaVersion.NA)).isEqualTo(JAVA_VERSIONS_LTS);
@@ -46,7 +47,7 @@ class JavaVersionTest {
     @Test
     public void testDetermineBestLtsVersion() {
         assertEquals(17, determineBestJavaLtsVersion(8));
-        assertEquals(17, determineBestJavaLtsVersion(11));
+        assertEquals(11, determineBestJavaLtsVersion(11));
         assertEquals(17, determineBestJavaLtsVersion(17));
         assertEquals(17, determineBestJavaLtsVersion(18));
         assertEquals(21, determineBestJavaLtsVersion(21));


### PR DESCRIPTION
Fixes #38732