### PR TITLE
Polish datasource config structure to get better generated documentation

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -180,7 +180,7 @@ public class DataSources {
         }
 
         DataSourceJdbcRuntimeConfig dataSourceJdbcRuntimeConfig = dataSourcesJdbcRuntimeConfig
-                .getDataSourceJdbcRuntimeConfig(dataSourceName);
+                .dataSources().get(dataSourceName).jdbc();
         if (!dataSourceJdbcRuntimeConfig.url().isPresent()) {
             //this is not an error situation, because we want to allow the situation where a JDBC extension
             //is installed but has not been configured

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourcesJdbcBuildTimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourcesJdbcBuildTimeConfig.java
@@ -4,7 +4,6 @@ import java.util.Map;
 
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -20,7 +19,6 @@ public interface DataSourcesJdbcBuildTimeConfig {
     /**
      * Datasources.
      */
-    @ConfigDocSection
     @ConfigDocMapKey("datasource-name")
     @WithParentName
     @WithDefaults

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourcesJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourcesJdbcRuntimeConfig.java
@@ -4,33 +4,29 @@ import java.util.Map;
 
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefaults;
 import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
 
 @ConfigMapping(prefix = "quarkus.datasource")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public interface DataSourcesJdbcRuntimeConfig {
 
     /**
-     * The default datasource.
-     */
-    DataSourceJdbcRuntimeConfig jdbc();
-
-    /**
-     * Additional named datasources.
+     * Datasources.
      */
     @ConfigDocMapKey("datasource-name")
     @WithParentName
     @WithDefaults
-    Map<String, DataSourceJdbcOuterNamedRuntimeConfig> namedDataSources();
+    @WithUnnamedKey(DataSourceUtil.DEFAULT_DATASOURCE_NAME)
+    Map<String, DataSourceJdbcOuterNamedRuntimeConfig> dataSources();
 
     @ConfigGroup
-    public interface DataSourceJdbcOuterNamedRuntimeConfig {
+    interface DataSourceJdbcOuterNamedRuntimeConfig {
 
         /**
          * The JDBC runtime configuration.
@@ -38,11 +34,4 @@ public interface DataSourcesJdbcRuntimeConfig {
         DataSourceJdbcRuntimeConfig jdbc();
     }
 
-    default DataSourceJdbcRuntimeConfig getDataSourceJdbcRuntimeConfig(String dataSourceName) {
-        if (DataSourceUtil.isDefault(dataSourceName)) {
-            return jdbc();
-        }
-
-        return namedDataSources().get(dataSourceName).jdbc();
-    }
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourcesJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourcesJdbcRuntimeConfig.java
@@ -24,7 +24,6 @@ public interface DataSourcesJdbcRuntimeConfig {
     /**
      * Additional named datasources.
      */
-    @ConfigDocSection
     @ConfigDocMapKey("datasource-name")
     @WithParentName
     @WithDefaults

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourcesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourcesBuildTimeConfig.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -22,7 +21,6 @@ public interface DataSourcesBuildTimeConfig {
     /**
      * Datasources.
      */
-    @ConfigDocSection
     @ConfigDocMapKey("datasource-name")
     @WithParentName
     @WithDefaults

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourcesRuntimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DataSourcesRuntimeConfig.java
@@ -4,7 +4,6 @@ import java.util.Map;
 
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -19,7 +18,6 @@ public interface DataSourcesRuntimeConfig {
     /**
      * Datasources.
      */
-    @ConfigDocSection
     @ConfigDocMapKey("datasource-name")
     @WithParentName
     @WithDefaults


### PR DESCRIPTION
In particular, this gets rid of unnecessary headings such as "Datasources" (that's important when you know that section nesting is not really handled):

![Screenshot from 2024-02-12 13-24-13](https://github.com/quarkusio/quarkus/assets/412878/f1b02556-d364-4154-8e49-6adfcd28f11d)

And it makes sure that merging of config properties for the default/named datasources (see above) is handled consistently, which is not always the case right now:

![Screenshot from 2024-02-12 13-24-18](https://github.com/quarkusio/quarkus/assets/412878/d3eed909-4262-4e78-8aba-fd9604b108e2)

