### PR TITLE
Updated MongoDB/Panache parser to latest ORM parser

### DIFF
--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/MongoParserVisitor.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/MongoParserVisitor.java
@@ -3,6 +3,13 @@ package io.quarkus.mongodb.panache.common.binder;
 import java.util.Map;
 
 import io.quarkus.panacheql.internal.HqlParser;
+import io.quarkus.panacheql.internal.HqlParser.ComparisonPredicateContext;
+import io.quarkus.panacheql.internal.HqlParser.GroupedExpressionContext;
+import io.quarkus.panacheql.internal.HqlParser.GroupedPredicateContext;
+import io.quarkus.panacheql.internal.HqlParser.NamedParameterContext;
+import io.quarkus.panacheql.internal.HqlParser.ParameterContext;
+import io.quarkus.panacheql.internal.HqlParser.PositionalParameterContext;
+import io.quarkus.panacheql.internal.HqlParser.StandardFunctionContext;
 import io.quarkus.panacheql.internal.HqlParserBaseVisitor;
 
 class MongoParserVisitor extends HqlParserBaseVisitor<String> {
@@ -38,18 +45,28 @@ class MongoParserVisitor extends HqlParserBaseVisitor<String> {
     }
 
     @Override
-    public String visitEqualityPredicate(HqlParser.EqualityPredicateContext ctx) {
-        return ctx.expression(0).accept(this) + ":" + ctx.expression(1).accept(this);
-    }
-
-    @Override
-    public String visitInequalityPredicate(HqlParser.InequalityPredicateContext ctx) {
-        return ctx.expression(0).accept(this) + ":{'$ne':" + ctx.expression(1).accept(this) + "}";
-    }
-
-    @Override
-    public String visitLessThanOrEqualPredicate(HqlParser.LessThanOrEqualPredicateContext ctx) {
-        return ctx.expression(0).accept(this) + ":{'$lte':" + ctx.expression(1).accept(this) + "}";
+    public String visitComparisonPredicate(ComparisonPredicateContext ctx) {
+        String lhs = ctx.expression(0).accept(this);
+        String rhs = ctx.expression(1).accept(this);
+        if (ctx.comparisonOperator().EQUAL() != null) {
+            return lhs + ":" + rhs;
+        }
+        if (ctx.comparisonOperator().NOT_EQUAL() != null) {
+            return lhs + ":{'$ne':" + rhs + "}";
+        }
+        if (ctx.comparisonOperator().GREATER() != null) {
+            return lhs + ":{'$gt':" + rhs + "}";
+        }
+        if (ctx.comparisonOperator().GREATER_EQUAL() != null) {
+            return lhs + ":{'$gte':" + rhs + "}";
+        }
+        if (ctx.comparisonOperator().LESS() != null) {
+            return lhs + ":{'$lt':" + rhs + "}";
+        }
+        if (ctx.comparisonOperator().LESS_EQUAL() != null) {
+            return lhs + ":{'$lte':" + rhs + "}";
+        }
+        return super.visitComparisonPredicate(ctx);
     }
 
     @Override
@@ -64,21 +81,6 @@ class MongoParserVisitor extends HqlParserBaseVisitor<String> {
     }
 
     @Override
-    public String visitGreaterThanPredicate(HqlParser.GreaterThanPredicateContext ctx) {
-        return ctx.expression(0).accept(this) + ":{'$gt':" + ctx.expression(1).accept(this) + "}";
-    }
-
-    @Override
-    public String visitLessThanPredicate(HqlParser.LessThanPredicateContext ctx) {
-        return ctx.expression(0).accept(this) + ":{'$lt':" + ctx.expression(1).accept(this) + "}";
-    }
-
-    @Override
-    public String visitGreaterThanOrEqualPredicate(HqlParser.GreaterThanOrEqualPredicateContext ctx) {
-        return ctx.expression(0).accept(this) + ":{'$gte':" + ctx.expression(1).accept(this) + "}";
-    }
-
-    @Override
     public String visitIsNullPredicate(HqlParser.IsNullPredicateContext ctx) {
         boolean exists = ctx.NOT() != null;
         return ctx.expression().accept(this) + ":{'$exists':" + exists + "}";
@@ -86,11 +88,40 @@ class MongoParserVisitor extends HqlParserBaseVisitor<String> {
 
     @Override
     public String visitLiteralExpression(HqlParser.LiteralExpressionContext ctx) {
-        return CommonQueryBinder.escape(ctx.getText());
+        String text = ctx.getText();
+        // FIXME: this only really supports text literals
+        if (ctx.literal().STRING_LITERAL() != null) {
+            text = text.substring(1, text.length() - 1);
+        }
+        return CommonQueryBinder.escape(text);
+    }
+
+    @Override
+    public String visitNamedParameter(NamedParameterContext ctx) {
+        return visitParameter(ctx);
+    }
+
+    @Override
+    public String visitPositionalParameter(PositionalParameterContext ctx) {
+        return visitParameter(ctx);
     }
 
     @Override
     public String visitParameterExpression(HqlParser.ParameterExpressionContext ctx) {
+        return visitParameter(ctx.parameter());
+    }
+
+    @Override
+    public String visitGroupedExpression(GroupedExpressionContext ctx) {
+        return ctx.expression().accept(this);
+    }
+
+    @Override
+    public String visitGroupedPredicate(GroupedPredicateContext ctx) {
+        return ctx.predicate().accept(this);
+    }
+
+    private String visitParameter(ParameterContext ctx) {
         // this will match parameters used by PanacheQL : '?1' for index based or ':key' for named one.
         if (parameterMaps.containsKey(ctx.getText())) {
             Object value = parameterMaps.get(ctx.getText());
@@ -102,9 +133,20 @@ class MongoParserVisitor extends HqlParserBaseVisitor<String> {
     }
 
     @Override
-    public String visitPathExpression(HqlParser.PathExpressionContext ctx) {
+    public String visitGeneralPathExpression(HqlParser.GeneralPathExpressionContext ctx) {
+        String identifier = unquote(ctx.getText());
         // this is the name of the field, we apply replacement and escape with '
-        return "'" + replacementMap.getOrDefault(ctx.getText(), ctx.getText()) + "'";
+        return "'" + replacementMap.getOrDefault(identifier, identifier) + "'";
+    }
+
+    /**
+     * Removes backticks for quoted identifiers
+     */
+    private String unquote(String text) {
+        if (text.startsWith("`") && text.endsWith("`") && text.length() >= 2) {
+            return text.substring(1, text.length() - 1);
+        }
+        return text;
     }
 
     @Override
@@ -114,5 +156,11 @@ class MongoParserVisitor extends HqlParserBaseVisitor<String> {
                 .append(ctx.inList().accept(this))
                 .append("]}");
         return sb.toString();
+    }
+
+    // Turn new date functions such as instant into regular fields, to not break existing queries
+    @Override
+    public String visitStandardFunction(StandardFunctionContext ctx) {
+        return "'" + ctx.getText() + "'";
     }
 }

--- a/extensions/panache/mongodb-panache-common/runtime/src/test/java/io/quarkus/mongodb/panache/common/runtime/MongoOperationsTest.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/test/java/io/quarkus/mongodb/panache/common/runtime/MongoOperationsTest.java
@@ -95,6 +95,14 @@ class MongoOperationsTest {
         //test field replacement
         query = operations.bindFilter(DemoObj.class, "property", new Object[] { "a value" });
         assertEquals("{'value':'a value'}", query);
+
+        // keywords (quoted)
+        query = operations.bindFilter(Object.class, "`instant` = ?1", new Object[] { "a value" });
+        assertEquals("{'instant':'a value'}", query);
+
+        // keywords (unquoted)
+        query = operations.bindFilter(Object.class, "instant = ?1", new Object[] { "a value" });
+        assertEquals("{'instant':'a value'}", query);
     }
 
     private Object toDate(LocalDateTime of) {
@@ -285,12 +293,12 @@ class MongoOperationsTest {
         assertEquals("{'field':{'$in':['f1', 'f2']},'isOk':true}", query);
 
         query = operations.bindFilter(DemoObj.class,
-                "field in ?1 and property = ?2 or property = ?3",
+                "field in ?1 and (property = ?2 or property = ?3)",
                 new Object[] { list, "jpg", "gif" });
         assertEquals("{'field':{'$in':['f1', 'f2']},'$or':[{'value':'jpg'},{'value':'gif'}]}", query);
 
         query = operations.bindFilter(DemoObj.class,
-                "field in ?1 and isOk = ?2 and property = ?3 or property = ?4",
+                "field in ?1 and isOk = ?2 and (property = ?3 or property = ?4)",
                 new Object[] { list, true, "jpg", "gif" });
         assertEquals("{'field':{'$in':['f1', 'f2']},'isOk':true,'$or':[{'value':'jpg'},{'value':'gif'}]}", query);
     }
@@ -361,12 +369,12 @@ class MongoOperationsTest {
         assertEquals("{'field':{'$in':['f1', 'f2']},'isOk':true}", query);
 
         query = operations.bindFilter(DemoObj.class,
-                "field in :fields and property = :p1 or property = :p2",
+                "field in :fields and (property = :p1 or property = :p2)",
                 Parameters.with("fields", list).and("p1", "jpg").and("p2", "gif").map());
         assertEquals("{'field':{'$in':['f1', 'f2']},'$or':[{'value':'jpg'},{'value':'gif'}]}", query);
 
         query = operations.bindFilter(DemoObj.class,
-                "field in :fields and isOk = :isOk and property = :p1 or property = :p2",
+                "field in :fields and isOk = :isOk and (property = :p1 or property = :p2)",
                 Parameters.with("fields", list)
                         .and("isOk", true)
                         .and("p1", "jpg")

--- a/extensions/panache/panacheql/src/main/antlr4/io/quarkus/panacheql/internal/HqlLexer.g4
+++ b/extensions/panache/panacheql/src/main/antlr4/io/quarkus/panacheql/internal/HqlLexer.g4
@@ -10,70 +10,95 @@ lexer grammar HqlLexer;
  */
 }
 
-WS : ( ' ' | '\t' | '\f' | EOL ) -> skip;
+WS : WS_CHAR+ -> skip;
 
 fragment
-EOL	: [\r\n]+;
+WS_CHAR : [ \f\t\r\n];
 
-INTEGER_LITERAL : INTEGER_NUMBER ;
-
-fragment
-INTEGER_NUMBER : ('0' | '1'..'9' '0'..'9'*) ;
-
-LONG_LITERAL : INTEGER_NUMBER ('l'|'L');
-
-BIG_INTEGER_LITERAL : INTEGER_NUMBER ('bi'|'BI') ;
-
-HEX_LITERAL : '0' ('x'|'X') HEX_DIGIT+ ('l'|'L')? ;
+COMMENT : '/*' (~'*' | '*' ~'/' )* '*/' -> skip;
 
 fragment
-HEX_DIGIT : ('0'..'9'|'a'..'f'|'A'..'F') ;
+DIGIT : [0-9];
 
-OCTAL_LITERAL : '0' ('0'..'7')+ ('l'|'L')? ;
+fragment
+HEX_DIGIT : [0-9a-fA-F];
 
-FLOAT_LITERAL : FLOATING_POINT_NUMBER ('f'|'F')? ;
+fragment
+EXPONENT : [eE] [+-]? DIGIT+;
+
+fragment
+LONG_SUFFIX : [lL];
+
+fragment
+FLOAT_SUFFIX : [fF];
+
+fragment
+DOUBLE_SUFFIX : [dD];
+
+fragment
+BIG_DECIMAL_SUFFIX : [bB] [dD];
+
+fragment
+BIG_INTEGER_SUFFIX : [bB] [iI];
+
+// Although this is not 100% correct because this accepts leading zeros,
+// we stick to this because temporal literals use this rule for simplicity.
+// Since we don't support octal literals, this shouldn't really be a big issue
+fragment
+INTEGER_NUMBER
+	: DIGIT+
+	;
 
 fragment
 FLOATING_POINT_NUMBER
-	: ('0'..'9')+ '.' ('0'..'9')* EXPONENT?
-	| '.' ('0'..'9')+ EXPONENT?
-    | ('0'..'9')+ EXPONENT
-    | ('0'..'9')+
+	: DIGIT+ '.' DIGIT* EXPONENT?
+	| '.' DIGIT+ EXPONENT?
+	| DIGIT+ EXPONENT
+	| DIGIT+
 	;
 
-DOUBLE_LITERAL : FLOATING_POINT_NUMBER ('d'|'D') ;
+INTEGER_LITERAL : INTEGER_NUMBER ('_' INTEGER_NUMBER)*;
 
-BIG_DECIMAL_LITERAL : FLOATING_POINT_NUMBER ('bd'|'BD') ;
+LONG_LITERAL : INTEGER_NUMBER  ('_' INTEGER_NUMBER)* LONG_SUFFIX;
 
-fragment
-EXPONENT : ('e'|'E') ('+'|'-')? ('0'..'9')+ ;
+FLOAT_LITERAL : FLOATING_POINT_NUMBER FLOAT_SUFFIX;
 
-CHARACTER_LITERAL
-	:	'\'' ( ESCAPE_SEQUENCE | ~('\''|'\\') ) '\'' {setText(getText().substring(1, getText().length()-1));}
-	;
+DOUBLE_LITERAL : FLOATING_POINT_NUMBER DOUBLE_SUFFIX?;
 
-STRING_LITERAL
-	:	'"' ( ESCAPE_SEQUENCE | ~('\\'|'"') )* '"' {setText(getText().substring(1, getText().length()-1));}
-	|	('\'' ( ESCAPE_SEQUENCE | ~('\\'|'\'') )* '\'')+ {setText(getText().substring(1, getText().length()-1).replace("''", "'"));}
-	;
+BIG_INTEGER_LITERAL : INTEGER_NUMBER BIG_INTEGER_SUFFIX;
+
+BIG_DECIMAL_LITERAL : FLOATING_POINT_NUMBER BIG_DECIMAL_SUFFIX;
+
+HEX_LITERAL : '0' [xX] HEX_DIGIT+ LONG_SUFFIX?;
+
+fragment SINGLE_QUOTE : '\'';
+fragment DOUBLE_QUOTE : '"';
+
+STRING_LITERAL : SINGLE_QUOTE ( SINGLE_QUOTE SINGLE_QUOTE | ~('\'') )* SINGLE_QUOTE;
+
+JAVA_STRING_LITERAL
+	: DOUBLE_QUOTE ( ESCAPE_SEQUENCE | ~('"') )* DOUBLE_QUOTE
+ 	| [jJ] SINGLE_QUOTE ( ESCAPE_SEQUENCE | ~('\'') )* SINGLE_QUOTE
+ 	| [jJ] DOUBLE_QUOTE ( ESCAPE_SEQUENCE | ~('\'') )* DOUBLE_QUOTE
+ 	;
+
+fragment BACKSLASH : '\\';
 
 fragment
 ESCAPE_SEQUENCE
-	:	'\\' ('b'|'t'|'n'|'f'|'r'|'\\"'|'\''|'\\')
-	|	UNICODE_ESCAPE
-	|	OCTAL_ESCAPE
-	;
-
-fragment
-OCTAL_ESCAPE
-	:	'\\' ('0'..'3') ('0'..'7') ('0'..'7')
-	|	'\\' ('0'..'7') ('0'..'7')
-	|	'\\' ('0'..'7')
+	: BACKSLASH [btnfr"']
+	| BACKSLASH UNICODE_ESCAPE
+	| BACKSLASH BACKSLASH
 	;
 
 fragment
 UNICODE_ESCAPE
-	:	'\\' 'u' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
+	: 'u' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
+	;
+
+BINARY_LITERAL
+	: [xX] SINGLE_QUOTE (HEX_DIGIT HEX_DIGIT)* SINGLE_QUOTE
+	| [xX] DOUBLE_QUOTE (HEX_DIGIT HEX_DIGIT)* DOUBLE_QUOTE
 	;
 
 // ESCAPE start tokens
@@ -100,7 +125,7 @@ PLUS : '+';
 MINUS :	'-';
 ASTERISK : '*';
 SLASH : '/';
-PERCENT	: '%';
+PERCENT_OP	: '%';
 AMPERSAND : '&';
 SEMICOLON :	';';
 COLON : ':';
@@ -109,123 +134,197 @@ DOUBLE_PIPE : '||';
 QUESTION_MARK :	'?';
 ARROW :	'->';
 
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Keywords
-ABS					: [aA] [bB] [sS];
-AS					: [aA] [sS];
+
+ID 				: [iI][dD];
+VERSION			: [vV] [eE] [rR] [sS] [iI] [oO] [nN];
+VERSIONED		: [vV] [eE] [rR] [sS] [iI] [oO] [nN] [eE] [dD];
+NATURALID		: [nN] [aA] [tT] [uU] [rR] [aA] [lL] [iI] [dD];
+FK				: [fF] [kK];
+
 ALL					: [aA] [lL] [lL];
 AND					: [aA] [nN] [dD];
 ANY					: [aA] [nN] [yY];
+AS					: [aA] [sS];
 ASC					: [aA] [sS] [cC];
 AVG					: [aA] [vV] [gG];
+BETWEEN	 			: [bB] [eE] [tT] [wW] [eE] [eE] [nN];
+BOTH				: [bB] [oO] [tT] [hH];
+BREADTH	 			: [bB] [rR] [eE] [aA] [dD] [tT] [hH];
 BY					: [bB] [yY];
-BETWEEN     		: [bB] [eE] [tT] [wW] [eE] [eE] [nN];
-BIT_LENGTH  		: [bB] [iI] [tT] [_] [lL] [eE] [nN] [gG] [tT] [hH];
-BOTH        		: [bB] [oO] [tT] [hH];
-CASE        		: [cC] [aA] [sS] [eE];
-CAST        		: [cC] [aA] [sS] [tT];
-CHARACTER_LENGTH	: [cC] [hH] [aA] [rR] [aA] [cC] [tT] [eE] [rR] '_' [lL] [eE] [nN] [gG] [tT] [hH];
-CLASS				: [cC] [lL] [aA] [sS] [sS];
-COALESCE			: [cC] [oO] [aA] [lL] [eE] [sS] [cC] [eE];
+CASE				: [cC] [aA] [sS] [eE];
+CAST				: [cC] [aA] [sS] [tT];
 COLLATE				: [cC] [oO] [lL] [lL] [aA] [tT] [eE];
-CONCAT				: [cC] [oO] [nN] [cC] [aA] [tT];
 COUNT				: [cC] [oO] [uU] [nN] [tT];
+CROSS				: [cC] [rR] [oO] [sS] [sS];
+CUBE				: [cC] [uU] [bB] [eE];
+CURRENT				: [cC] [uU] [rR] [rR] [eE] [nN] [tT];
 CURRENT_DATE		: [cC] [uU] [rR] [rR] [eE] [nN] [tT] '_' [dD] [aA] [tT] [eE];
+CURRENT_INSTANT		: [cC] [uU] [rR] [rR] [eE] [nN] [tT] '_' [iI] [nN] [sS] [tT] [aA] [nN] [tT]; //deprecated legacy
 CURRENT_TIME		: [cC] [uU] [rR] [rR] [eE] [nN] [tT] '_' [tT] [iI] [mM] [eE];
 CURRENT_TIMESTAMP	: [cC] [uU] [rR] [rR] [eE] [nN] [tT] '_' [tT] [iI] [mM] [eE] [sS] [tT] [aA] [mM] [pP];
-CROSS				: [cC] [rR] [oO] [sS] [sS];
+CYCLE				: [cC] [yY] [cC] [lL] [eE];
+DATE				: [dD] [aA] [tT] [eE];
+DATETIME			: [dD] [aA] [tT] [eE] [tT] [iI] [mM] [eE];
 DAY					: [dD] [aA] [yY];
+DEFAULT				: [dD] [eE] [fF] [aA] [uU] [lL] [tT];
 DELETE				: [dD] [eE] [lL] [eE] [tT] [eE];
+DEPTH	 			: [dD] [eE] [pP] [tT] [hH];
 DESC				: [dD] [eE] [sS] [cC];
 DISTINCT			: [dD] [iI] [sS] [tT] [iI] [nN] [cC] [tT];
+ELEMENT				: [eE] [lL] [eE] [mM] [eE] [nN] [tT];
 ELEMENTS			: [eE] [lL] [eE] [mM] [eE] [nN] [tT] [sS];
 ELSE				: [eE] [lL] [sS] [eE];
 EMPTY				: [eE] [mM] [pP] [tT] [yY];
 END					: [eE] [nN] [dD];
 ENTRY				: [eE] [nN] [tT] [rR] [yY];
+EPOCH				: [eE] [pP] [oO] [cC] [hH];
+ERROR				: [eE] [rR] [rR] [oO] [rR];
 ESCAPE				: [eE] [sS] [cC] [aA] [pP] [eE];
+EVERY				: [eE] [vV] [eE] [rR] [yY];
+EXCEPT				: [eE] [xX] [cC] [eE] [pP] [tT];
+EXCLUDE				: [eE] [xX] [cC] [lL] [uU] [dD] [eE];
 EXISTS				: [eE] [xX] [iI] [sS] [tT] [sS];
 EXTRACT				: [eE] [xX] [tT] [rR] [aA] [cC] [tT];
 FETCH				: [fF] [eE] [tT] [cC] [hH];
+FILTER				: [fF] [iI] [lL] [tT] [eE] [rR];
+FIRST				: [fF] [iI] [rR] [sS] [tT];
+FOLLOWING			: [fF] [oO] [lL] [lL] [oO] [wW] [iI] [nN] [gG];
+FOR					: [fF] [oO] [rR];
+FORMAT				: [fF] [oO] [rR] [mM] [aA] [tT];
 FROM				: [fF] [rR] [oO] [mM];
 FULL				: [fF] [uU] [lL] [lL];
 FUNCTION			: [fF] [uU] [nN] [cC] [tT] [iI] [oO] [nN];
 GROUP				: [gG] [rR] [oO] [uU] [pP];
+GROUPS				: [gG] [rR] [oO] [uU] [pP] [sS];
 HAVING				: [hH] [aA] [vV] [iI] [nN] [gG];
 HOUR				: [hH] [oO] [uU] [rR];
+IGNORE				: [iI] [gG] [nN] [oO] [rR] [eE];
+ILIKE				: [iI] [lL] [iI] [kK] [eE];
 IN					: [iI] [nN];
 INDEX				: [iI] [nN] [dD] [eE] [xX];
+INDICES				: [iI] [nN] [dD] [iI] [cC] [eE] [sS];
 INNER				: [iI] [nN] [nN] [eE] [rR];
 INSERT				: [iI] [nN] [sS] [eE] [rR] [tT];
+INSTANT				: [iI] [nN] [sS] [tT] [aA] [nN] [tT];
+INTERSECT			: [iI] [nN] [tT] [eE] [rR] [sS] [eE] [cC] [tT];
 INTO 				: [iI] [nN] [tT] [oO];
 IS					: [iI] [sS];
 JOIN				: [jJ] [oO] [iI] [nN];
 KEY					: [kK] [eE] [yY];
+KEYS				: [kK] [eE] [yY] [sS];
+LAST				: [lL] [aA] [sS] [tT];
+LATERAL				: [lL] [aA] [tT] [eE] [rR] [aA] [lL];
 LEADING				: [lL] [eE] [aA] [dD] [iI] [nN] [gG];
 LEFT				: [lL] [eE] [fF] [tT];
-LENGTH				: [lL] [eE] [nN] [gG] [tT] [hH];
-LIMIT				: [lL] [iI] [mM] [iI] [tT];
 LIKE				: [lL] [iI] [kK] [eE];
+LIMIT				: [lL] [iI] [mM] [iI] [tT];
 LIST				: [lL] [iI] [sS] [tT];
-LOCATE				: [lL] [oO] [cC] [aA] [tT] [eE];
-LOWER				: [lL] [oO] [wW] [eE] [rR];
+LISTAGG				: [lL] [iI] [sS] [tT] [aA] [gG] [gG];
+LOCAL				: [lL] [oO] [cC] [aA] [lL];
+LOCAL_DATE			: [lL] [oO] [cC] [aA] [lL] '_' [dD] [aA] [tT] [eE];
+LOCAL_DATETIME		: [lL] [oO] [cC] [aA] [lL] '_' [dD] [aA] [tT] [eE] [tT] [iI] [mM] [eE];
+LOCAL_TIME			: [lL] [oO] [cC] [aA] [lL] '_' [tT] [iI] [mM] [eE];
 MAP					: [mM] [aA] [pP];
+MATERIALIZED		: [mM] [aA] [tT] [eE] [rR] [iI] [aA] [lL] [iI] [zZ] [eE] [dD];
 MAX					: [mM] [aA] [xX];
 MAXELEMENT			: [mM] [aA] [xX] [eE] [lL] [eE] [mM] [eE] [nN] [tT];
 MAXINDEX			: [mM] [aA] [xX] [iI] [nN] [dD] [eE] [xX];
 MEMBER				: [mM] [eE] [mM] [bB] [eE] [rR];
+MICROSECOND			: [mM] [iI] [cC] [rR] [oO] [sS] [eE] [cC] [oO] [nN] [dD];
+MILLISECOND			: [mM] [iI] [lL] [lL] [iI] [sS] [eE] [cC] [oO] [nN] [dD];
 MIN					: [mM] [iI] [nN];
 MINELEMENT			: [mM] [iI] [nN] [eE] [lL] [eE] [mM] [eE] [nN] [tT];
 MININDEX			: [mM] [iI] [nN] [iI] [nN] [dD] [eE] [xX];
 MINUTE				: [mM] [iI] [nN] [uU] [tT] [eE];
-MOD					: [mM] [oO] [dD];
 MONTH				: [mM] [oO] [nN] [tT] [hH];
+NANOSECOND			: [nN] [aA] [nN] [oO] [sS] [eE] [cC] [oO] [nN] [dD];
 NEW					: [nN] [eE] [wW];
+NEXT				: [nN] [eE] [xX] [tT];
+NO					: [nN] [oO];
 NOT					: [nN] [oO] [tT];
-NULLIF				: [nN] [uU] [lL] [lL] [iI] [fF];
+NULLS				: [nN] [uU] [lL] [lL] [sS];
 OBJECT				: [oO] [bB] [jJ] [eE] [cC] [tT];
-OCTET_LENGTH		: [oO] [cC] [tT] [eE] [tT] '_' [lL] [eE] [nN] [gG] [tT] [hH];
 OF					: [oO] [fF];
 OFFSET				: [oO] [fF] [fF] [sS] [eE] [tT];
+OFFSET_DATETIME		: [oO] [fF] [fF] [sS] [eE] [tT] '_' [dD] [aA] [tT] [eE] [tT] [iI] [mM] [eE];
 ON					: [oO] [nN];
+ONLY				: [oO] [nN] [lL] [yY];
 OR					: [oO] [rR];
 ORDER				: [oO] [rR] [dD] [eE] [rR];
+OTHERS				: [oO] [tT] [hH] [eE] [rR] [sS];
 OUTER				: [oO] [uU] [tT] [eE] [rR];
+OVER				: [oO] [vV] [eE] [rR];
+OVERFLOW			: [oO] [vV] [eE] [rR] [fF] [lL] [oO] [wW];
+OVERLAY				: [oO] [vV] [eE] [rR] [lL] [aA] [yY];
+PAD					: [pP] [aA] [dD];
+PARTITION			: [pP] [aA] [rR] [tT] [iI] [tT] [iI] [oO] [nN];
+PERCENT				: [pP] [eE] [rR] [cC] [eE] [nN] [tT];
+PLACING				: [pP] [lL] [aA] [cC] [iI] [nN] [gG];
 POSITION			: [pP] [oO] [sS] [iI] [tT] [iI] [oO] [nN];
+PRECEDING			: [pP] [rR] [eE] [cC] [eE] [dD] [iI] [nN] [gG];
+QUARTER				: [qQ] [uU] [aA] [rR] [tT] [eE] [rR];
+RANGE				: [rR] [aA] [nN] [gG] [eE];
+RESPECT				: [rR] [eE] [sS] [pP] [eE] [cC] [tT];
 RIGHT				: [rR] [iI] [gG] [hH] [tT];
+ROLLUP				: [rR] [oO] [lL] [lL] [uU] [pP];
+ROW	    			: [rR] [oO] [wW];
+ROWS    			: [rR] [oO] [wW] [sS];
+SEARCH				: [sS] [eE] [aA] [rR] [cC] [hH];
 SECOND				: [sS] [eE] [cC] [oO] [nN] [dD];
 SELECT				: [sS] [eE] [lL] [eE] [cC] [tT];
 SET					: [sS] [eE] [tT];
 SIZE				: [sS] [iI] [zZ] [eE];
-SQRT				: [sS] [qQ] [rR] [tT];
-STR                 : [sS] [tT] [rR];
+SOME				: [sS] [oO] [mM] [eE];
 SUBSTRING			: [sS] [uU] [bB] [sS] [tT] [rR] [iI] [nN] [gG];
-SUBSTR				: [sS] [uU] [bB] [sS] [tT] [rR];
-SUM					: [sS] [uU] [mM];
+SUM					: [sS] [uM] [mM];
 THEN				: [tT] [hH] [eE] [nN];
+TIES				: [tT] [iI] [eE] [sS];
+TIME				: [tT] [iI] [mM] [eE];
+TIMESTAMP			: [tT] [iI] [mM] [eE] [sS] [tT] [aA] [mM] [pP];
 TIMEZONE_HOUR		: [tT] [iI] [mM] [eE] [zZ] [oO] [nN] [eE] '_' [hH] [oO] [uU] [rR];
 TIMEZONE_MINUTE		: [tT] [iI] [mM] [eE] [zZ] [oO] [nN] [eE] '_' [mM] [iI] [nN] [uU] [tT] [eE];
+TO					: [tT] [oO];
 TRAILING			: [tT] [rR] [aA] [iI] [lL] [iI] [nN] [gG];
 TREAT				: [tT] [rR] [eE] [aA] [tT];
 TRIM				: [tT] [rR] [iI] [mM];
+TRUNC				: [tT] [rR] [uU] [nN] [cC];
+TRUNCATE			: [tT] [rR] [uU] [nN] [cC] [aA] [tT] [eE];
 TYPE				: [tT] [yY] [pP] [eE];
+UNBOUNDED			: [uU] [nN] [bB] [oO] [uU] [nN] [dD] [eE] [dD];
+UNION				: [uU] [nN] [iI] [oO] [nN];
 UPDATE				: [uU] [pP] [dD] [aA] [tT] [eE];
-UPPER				: [uU] [pP] [pP] [eE] [rR];
+USING				: [uU] [sS] [iI] [nN] [gG];
 VALUE				: [vV] [aA] [lL] [uU] [eE];
+VALUES				: [vV] [aA] [lL] [uU] [eE] [sS];
+WEEK				: [wW] [eE] [eE] [kK];
 WHEN				: [wW] [hH] [eE] [nN];
 WHERE				: [wW] [hH] [eE] [rR] [eE];
 WITH				: [wW] [iI] [tT] [hH];
+WITHIN				: [wW] [iI] [tT] [hH] [iI] [nN];
+WITHOUT				: [wW] [iI] [tT] [hH] [oO] [uU] [tT];
 YEAR				: [yY] [eE] [aA] [rR];
+ZONED				: [zZ] [oO] [nN] [eE] [dD];
 
 // case-insensitive true, false and null recognition (split vote :)
 TRUE 	: [tT] [rR] [uU] [eE];
 FALSE 	: [fF] [aA] [lL] [sS] [eE];
 NULL 	: [nN] [uU] [lL] [lL];
 
+
+fragment
+LETTER : [a-zA-Z\u0080-\ufffe_$];
+
 // Identifiers
 IDENTIFIER
-	:	('a'..'z'|'A'..'Z'|'_'|'$'|'\u0080'..'\ufffe')('a'..'z'|'A'..'Z'|'_'|'$'|'0'..'9'|'\u0080'..'\ufffe')*
+	: LETTER (LETTER | DIGIT)*
 	;
 
+fragment
+BACKTICK : '`';
+
 QUOTED_IDENTIFIER
-	: '`' ( ESCAPE_SEQUENCE | ~('\\'|'`') )* '`'
+	: BACKTICK ( ESCAPE_SEQUENCE | '\\' BACKTICK | ~([`]) )* BACKTICK
 	;

--- a/extensions/panache/panacheql/src/main/antlr4/io/quarkus/panacheql/internal/HqlParser.g4
+++ b/extensions/panache/panacheql/src/main/antlr4/io/quarkus/panacheql/internal/HqlParser.g4
@@ -22,107 +22,249 @@ options {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Statements
 
+/**
+ * Toplevel rule, entrypoint to the whole grammar
+ */
 statement
-	: ( selectStatement | updateStatement | deleteStatement | insertStatement ) EOF
+	: (selectStatement | updateStatement | deleteStatement | insertStatement) EOF
 	;
 
+/**
+ * A 'select' query
+ */
 selectStatement
-	: querySpec
+	: queryExpression
 	;
 
+/**
+ * A 'select' query that occurs within another statement
+ */
+subquery
+	: queryExpression
+	;
+
+/**
+ * A declaration of a root entity, with an optional identification variable
+ */
+targetEntity
+	: entityName variable?
+	;
+
+/**
+ * A 'delete' statement
+ */
 deleteStatement
-	: DELETE FROM? entityName identificationVariableDef? whereClause?
+	: DELETE FROM? targetEntity whereClause?
 	;
 
+/**
+ * An 'update' statement
+ */
 updateStatement
-	: UPDATE FROM? entityName identificationVariableDef? setClause whereClause?
+	: UPDATE VERSIONED? targetEntity setClause whereClause?
 	;
 
+/**
+ * An 'set' list of assignments in an 'update' statement
+ */
 setClause
-	: SET assignment+
+	: SET assignment (COMMA assignment)*
 	;
 
+/**
+ * An assignment to an entity attribute in an 'update' statement
+ */
 assignment
-	: dotIdentifierSequence EQUAL expression
+	: simplePath EQUAL expressionOrPredicate
 	;
 
+/**
+ * An 'insert' statement
+ */
 insertStatement
-// todo (6.0 : VERSIONED
-	: INSERT insertSpec querySpec
+	: INSERT INTO? targetEntity targetFields (queryExpression | valuesList)
 	;
 
-insertSpec
-	: intoSpec targetFieldsSpec
+/**
+ * The list of target entity attributes in an 'insert' statement
+ */
+targetFields
+	: LEFT_PAREN simplePath (COMMA simplePath)* RIGHT_PAREN
 	;
 
-intoSpec
-	: INTO entityName
+/**
+ * A 'values' clause in an 'insert' statement, with one of more tuples of values to insert
+ */
+valuesList
+	: VALUES values (COMMA values)*
 	;
 
-targetFieldsSpec
-	:
-	LEFT_PAREN dotIdentifierSequence (COMMA dotIdentifierSequence)* RIGHT_PAREN
+/**
+ * A tuple of values to insert in an 'insert' statement
+ */
+values
+	: LEFT_PAREN expressionOrPredicate (COMMA expressionOrPredicate)* RIGHT_PAREN
 	;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // QUERY SPEC - general structure of root sqm or sub sqm
 
-querySpec
-	:	selectClause? fromClause whereClause? ( groupByClause havingClause? )? orderByClause? limitClause? offsetClause?
+withClause
+	: WITH cte (COMMA cte)*
+	;
+
+cte
+	: identifier AS (NOT? MATERIALIZED)? LEFT_PAREN queryExpression RIGHT_PAREN searchClause? cycleClause?
+	;
+
+cteAttributes
+	: identifier (COMMA identifier)*
+	;
+
+searchClause
+	: SEARCH (BREADTH|DEPTH) FIRST BY searchSpecifications SET identifier
+	;
+
+searchSpecifications
+	: searchSpecification (COMMA searchSpecification)*
+	;
+
+searchSpecification
+	: identifier sortDirection? nullsPrecedence?
+	;
+
+cycleClause
+	: CYCLE cteAttributes SET identifier (TO literal DEFAULT literal)? (USING identifier)?
+	;
+
+/**
+ * A toplevel query of subquery, which may be a union or intersection of subqueries
+ */
+queryExpression
+	: withClause? orderedQuery								# SimpleQueryGroup
+	| withClause? orderedQuery (setOperator orderedQuery)+	# SetQueryGroup
+	;
+
+/**
+ * A query with an optional 'order by' clause
+ */
+orderedQuery
+	: query queryOrder?										# QuerySpecExpression
+	| LEFT_PAREN queryExpression RIGHT_PAREN queryOrder?	# NestedQueryExpression
+	| queryOrder											# QueryOrderExpression
+	;
+
+/**
+ * An operator whose operands are whole queries
+ */
+setOperator
+	: UNION ALL?
+	| INTERSECT ALL?
+	| EXCEPT ALL?
+	;
+
+/**
+ * The 'order by' clause and optional subclauses for limiting and pagination
+ */
+queryOrder
+	: orderByClause limitClause? offsetClause? fetchClause?
+	;
+
+/**
+ * An unordered query, with just projection, restriction, and aggregation
+ *
+ * - The 'select' clause may come first, in which case 'from' is optional
+ * - The 'from' clause may come first, in which case 'select' is optional, and comes last
+ */
+query
+// TODO: add with clause
+	: selectClause fromClause? whereClause? (groupByClause havingClause?)?
+	| fromClause whereClause? (groupByClause havingClause?)? selectClause?
+	| whereClause
 	;
 
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // FROM clause
 
+/**
+ * The 'from' clause of a query
+ */
 fromClause
-	: FROM fromClauseSpace (COMMA fromClauseSpace)*
-	;
-
-fromClauseSpace
-	:	pathRoot ( crossJoin | jpaCollectionJoin | qualifiedJoin )*
-	;
-
-pathRoot
-	: entityName (identificationVariableDef)?
+	: FROM entityWithJoins (COMMA entityWithJoins)*
 	;
 
 /**
- * Rule for dotIdentifierSequence where we expect an entity-name.  The extra
- * "rule layer" allows the walker to specially handle such a case (to use a special
- * org.hibernate.query.hql.DotIdentifierConsumer, etc)
+ * The declaration of a root entity in 'from' clause, along with its joins
+ */
+entityWithJoins
+	: fromRoot (join | crossJoin | jpaCollectionJoin)*
+	;
+
+/**
+ * A root entity declaration in the 'from' clause, with optional identification variable
+ */
+fromRoot
+	: entityName variable?							# RootEntity
+	| LEFT_PAREN subquery RIGHT_PAREN variable?		# RootSubquery
+	;
+
+/**
+ * An entity name, for identifying the root entity
  */
 entityName
-	: dotIdentifierSequence
+	: identifier (DOT identifier)*
 	;
 
-identificationVariableDef
-	: (AS identifier)
-	| IDENTIFIER
+/**
+ * An identification variable (an entity alias)
+ */
+variable
+	: AS identifier
+	| nakedIdentifier
 	;
 
+/**
+ * A 'cross join' to a second root entity (a cartesian product)
+ */
 crossJoin
-	: CROSS JOIN pathRoot (identificationVariableDef)?
+	: CROSS JOIN entityName variable?
 	;
 
+/**
+ * Deprecated syntax dating back to EJB-QL prior to EJB 3, required by JPA, never documented in Hibernate
+ */
 jpaCollectionJoin
-	:	COMMA IN LEFT_PAREN path RIGHT_PAREN (identificationVariableDef)?
+	: COMMA IN LEFT_PAREN path RIGHT_PAREN variable?
 	;
 
-qualifiedJoin
-	: joinTypeQualifier JOIN FETCH? qualifiedJoinRhs (qualifiedJoinPredicate)?
+/**
+ * A 'join', with an optional 'on' or 'with' clause
+ */
+join
+	: joinType JOIN FETCH? joinTarget joinRestriction?
 	;
 
-joinTypeQualifier
+/**
+ * The inner or outer join type
+ */
+joinType
 	: INNER?
 	| (LEFT|RIGHT|FULL)? OUTER?
 	;
 
-qualifiedJoinRhs
-	: path (identificationVariableDef)?
+/**
+ * The joined path, with an optional identification variable
+ */
+joinTarget
+	: path variable?										#JoinPath
+	| LATERAL? LEFT_PAREN subquery RIGHT_PAREN variable?	#JoinSubquery
 	;
 
-qualifiedJoinPredicate
+/**
+ * An extra restriction added to the join condition
+ */
+joinRestriction
 	: (ON | WITH) predicate
 	;
 
@@ -131,472 +273,1064 @@ qualifiedJoinPredicate
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // SELECT clause
 
+/**
+ * The 'select' clause of a query
+ */
 selectClause
-	:	SELECT DISTINCT? selectionList
+	: SELECT DISTINCT? selectionList
 	;
 
+/**
+ * A projection list: a list of selected items
+ */
 selectionList
 	: selection (COMMA selection)*
 	;
 
+/**
+ * An element of a projection list: a selected item, with an optional alias
+ */
 selection
-	: selectExpression (resultIdentifier)?
+	: selectExpression variable?
 	;
 
+/**
+ * A selected item ocurring in the 'select' clause
+ */
 selectExpression
-	:	dynamicInstantiation
-	|	jpaSelectObjectSyntax
-	|	mapEntrySelection
-	|	expression
-	;
-
-resultIdentifier
-	: (AS identifier)
-	| IDENTIFIER
+	: instantiation
+	| mapEntrySelection
+	| jpaSelectObjectSyntax
+	| expressionOrPredicate
 	;
 
 
+/**
+ * The special function entry() which may only occur in the 'select' clause
+ */
 mapEntrySelection
 	: ENTRY LEFT_PAREN path RIGHT_PAREN
 	;
 
-dynamicInstantiation
-	: NEW dynamicInstantiationTarget LEFT_PAREN dynamicInstantiationArgs RIGHT_PAREN
+/**
+ * Instantiation using 'select new'
+ */
+instantiation
+	: NEW instantiationTarget LEFT_PAREN instantiationArguments RIGHT_PAREN
 	;
 
-dynamicInstantiationTarget
+/**
+ * The type to be instantiated with 'select new', 'list', 'map', or a fuly-qualified Java class name
+ */
+instantiationTarget
 	: LIST
 	| MAP
-	| dotIdentifierSequence
+	| simplePath
 	;
 
-dynamicInstantiationArgs
-	:	dynamicInstantiationArg ( COMMA dynamicInstantiationArg )*
+/**
+ * The arguments to a 'select new' instantiation
+ */
+instantiationArguments
+	: instantiationArgument (COMMA instantiationArgument)*
 	;
 
-dynamicInstantiationArg
-	:	dynamicInstantiationArgExpression (AS? identifier)?
+/**
+ * A single argument in a 'select new' instantiation, with an optional alias
+ */
+instantiationArgument
+	: instantiationArgumentExpression variable?
 	;
 
-dynamicInstantiationArgExpression
-	:	expression
-	|	dynamicInstantiation
+/**
+ * A single argument in a 'select new' instantiation: an expression, or a nested instantiation
+ */
+instantiationArgumentExpression
+	: expressionOrPredicate
+	| instantiation
 	;
 
+/**
+ * Deprecated syntax dating back to EJB-QL prior to EJB 3, required by JPA, never documented in Hibernate
+ */
 jpaSelectObjectSyntax
-	:	OBJECT LEFT_PAREN identifier RIGHT_PAREN
+	: OBJECT LEFT_PAREN identifier RIGHT_PAREN
 	;
-
 
 
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Path structures
 
-dotIdentifierSequence
-	: identifier dotIdentifierSequenceContinuation*
+/**
+ * A simple path expression
+ *
+ * - a reference to an identification variable (not case-sensitive),
+ * - followed by a list of period-separated identifiers (case-sensitive)
+ */
+simplePath
+	: identifier simplePathElement*
 	;
 
-dotIdentifierSequenceContinuation
+/**
+ * An element of a simple path expression: a period, and an identifier (case-sensitive)
+ */
+simplePathElement
 	: DOT identifier
 	;
 
-
 /**
+ * A much more complicated path expression involving operators and functions
+ *
  * A path which needs to be resolved semantically.  This recognizes
  * any path-like structure.  Generally, the path is semantically
  * interpreted by the consumer of the parse-tree.  However, there
  * are certain cases where we can syntactically recognize a navigable
- * path; see `syntacticNavigablePath` rule
+ * path; see 'syntacticNavigablePath' rule
  */
 path
-	: syntacticDomainPath (pathContinuation)?
+	: syntacticDomainPath pathContinuation?
 	| generalPathFragment
 	;
 
+/**
+ * A continuation of a path expression "broken" by an operator or function
+ */
 pathContinuation
-	: DOT dotIdentifierSequence (DOT pathContinuation)?
+	: DOT simplePath
 	;
 
 /**
+ * An operator or function that may occur within a path expression
+ *
  * Rule for cases where we syntactically know that the path is a
  * "domain path" because it is one of these special cases:
  *
  * 		* TREAT( path )
  * 		* ELEMENTS( path )
+ * 		* INDICES( path )
  *		* VALUE( path )
  * 		* KEY( path )
  * 		* path[ selector ]
  */
 syntacticDomainPath
 	: treatedNavigablePath
-	| collectionElementNavigablePath
+	| collectionValueNavigablePath
 	| mapKeyNavigablePath
-	| dotIdentifierSequence indexedPathAccessFragment
+	| simplePath indexedPathAccessFragment
 	;
 
 /**
- * The main path rule.  Recognition for all normal path structures including
+ * The main path rule
+ *
+ * Recognition for all normal path structures including
  * class, field and enum references as well as navigable paths.
  *
  * NOTE : this rule does *not* cover the special syntactic navigable path
  * cases: TREAT, KEY, ELEMENTS, VALUES
  */
 generalPathFragment
-	: dotIdentifierSequence (indexedPathAccessFragment)?
+	: simplePath indexedPathAccessFragment?
 	;
 
+/**
+ * In index operator that "breaks" a path expression
+ */
 indexedPathAccessFragment
 	: LEFT_BRACKET expression RIGHT_BRACKET (DOT generalPathFragment)?
 	;
 
+/**
+ * A 'treat()' function that "breaks" a path expression
+ */
 treatedNavigablePath
-	: TREAT LEFT_PAREN path AS dotIdentifierSequence RIGHT_PAREN (pathContinuation)?
+	: TREAT LEFT_PAREN path AS simplePath RIGHT_PAREN pathContinuation?
 	;
 
-collectionElementNavigablePath
-	: (VALUE | ELEMENTS) LEFT_PAREN path RIGHT_PAREN (pathContinuation)?
+/**
+ * A 'value()' function that "breaks" a path expression
+ */
+collectionValueNavigablePath
+	: elementValueQuantifier LEFT_PAREN path RIGHT_PAREN pathContinuation?
 	;
 
+/**
+ * A 'key()' or 'index()' function that "breaks" a path expression
+ */
 mapKeyNavigablePath
-	: KEY LEFT_PAREN path RIGHT_PAREN (pathContinuation)?
+	: indexKeyQuantifier LEFT_PAREN path RIGHT_PAREN pathContinuation?
 	;
 
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // GROUP BY clause
 
+/**
+ * The 'group by' clause of a query, controls aggregation
+ */
 groupByClause
-	:	GROUP BY groupingSpecification
+	: GROUP BY groupByExpression (COMMA groupByExpression)*
 	;
 
-groupingSpecification
-	:	groupingValue ( COMMA groupingValue )*
+/**
+ * A grouped item that occurs in the 'group by' clause
+ *
+ * a select item alias, an ordinal position of a select item, or an expression
+ */
+groupByExpression
+	: identifier
+	| INTEGER_LITERAL
+	| expression
 	;
-
-groupingValue
-	:	expression collationSpecification?
-	;
-
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //HAVING clause
 
+/**
+ * The 'having' clause of a query, a restriction on the grouped data
+ */
 havingClause
-	:	HAVING predicate
+	: HAVING predicate
 	;
 
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // ORDER BY clause
 
+/**
+ * The 'order by' clause of a query, controls sorting
+ */
 orderByClause
-// todo (6.0) : null precedence
 	: ORDER BY sortSpecification (COMMA sortSpecification)*
 	;
 
+/**
+ * Specialized rule for ordered Map and Set '@OrderBy' handling
+ */
+orderByFragment
+	: sortSpecification (COMMA sortSpecification)*
+	;
+
+/**
+ * A rule for sorting an item in the 'order by' clause
+ */
 sortSpecification
-	: expression collationSpecification? orderingSpecification?
+	: sortExpression sortDirection? nullsPrecedence?
 	;
 
-collationSpecification
-	:	COLLATE collateName
+/**
+ * A rule for sorting null values
+ */
+nullsPrecedence
+	: NULLS (FIRST | LAST)
 	;
 
-collateName
-	:	dotIdentifierSequence
+/**
+ * A sorted item that occurs in the 'order by' clause
+ *
+ * a select item alias, an ordinal position of a select item, or an expression
+ */
+sortExpression
+	: identifier
+	| INTEGER_LITERAL
+	| expression
 	;
 
-orderingSpecification
-	:	ASC
-	|	DESC
+/**
+ * The direction in which to sort
+ */
+sortDirection
+	: ASC
+	| DESC
 	;
+
+/**
+ * The special 'collate()' functions
+ */
+collateFunction
+	: COLLATE LEFT_PAREN expression AS collation RIGHT_PAREN
+	;
+
+/**
+ * The name of a database-defined collation
+ *
+ * Certain databases allow a period in a collation name
+ */
+collation
+	: simplePath
+	;
+
 
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // LIMIT/OFFSET clause
 
+/**
+ * A 'limit' on the number of query results
+ */
 limitClause
-	: LIMIT parameterOrNumberLiteral
+	: LIMIT parameterOrIntegerLiteral
 	;
 
+/**
+ * An 'offset' of the first query result to return
+ */
 offsetClause
-	: OFFSET parameterOrNumberLiteral
+	: OFFSET parameterOrIntegerLiteral
+	  (ROW | ROWS)?   // no semantics
 	;
 
+/**
+ * A much more complex syntax for limits
+ */
+fetchClause
+	: FETCH
+	  (FIRST | NEXT)  // no semantics
+      fetchCountOrPercent
+	  (ROW | ROWS)    // no semantics
+	  (ONLY | WITH TIES)
+	;
+
+fetchCountOrPercent
+    : parameterOrIntegerLiteral
+    | parameterOrNumberLiteral PERCENT
+    ;
+
+/**
+ * An parameterizable integer literal
+ */
+parameterOrIntegerLiteral
+	: parameter
+	| INTEGER_LITERAL
+	;
+
+/**
+ * An parameterizable numeric literal
+ */
 parameterOrNumberLiteral
 	: parameter
 	| INTEGER_LITERAL
+	| LONG_LITERAL
+	| FLOAT_LITERAL
+	| DOUBLE_LITERAL
 	;
 
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // WHERE clause & Predicates
 
+/**
+ * The 'were' clause of a query, update statement, or delete statement
+ */
 whereClause
-	:	WHERE predicate
+	: WHERE predicate
 	;
 
+/**
+ * A boolean-valued expression, usually used to express a restriction
+ */
 predicate
-	: LEFT_PAREN predicate RIGHT_PAREN						# GroupedPredicate
-	| predicate OR predicate								# OrPredicate
-	| predicate AND predicate								# AndPredicate
-	| NOT predicate											# NegatedPredicate
-	| expression IS (NOT)? NULL								# IsNullPredicate
-	| expression IS (NOT)? EMPTY							# IsEmptyPredicate
-	| expression EQUAL expression							# EqualityPredicate
-	| expression NOT_EQUAL expression						# InequalityPredicate
-	| expression GREATER expression							# GreaterThanPredicate
-	| expression GREATER_EQUAL expression					# GreaterThanOrEqualPredicate
-	| expression LESS expression							# LessThanPredicate
-	| expression LESS_EQUAL expression						# LessThanOrEqualPredicate
-	| expression (NOT)? IN inList							# InPredicate
-	| expression (NOT)? BETWEEN expression AND expression	# BetweenPredicate
-	| expression (NOT)? LIKE expression (likeEscape)?		# LikePredicate
-	| MEMBER OF path										# MemberOfPredicate
+	//highest to lowest precedence
+	: LEFT_PAREN predicate RIGHT_PAREN											# GroupedPredicate
+	| expression IS NOT? NULL													# IsNullPredicate
+	| expression IS NOT? EMPTY													# IsEmptyPredicate
+	| expression IS NOT? TRUE													# IsTruePredicate
+	| expression IS NOT? FALSE													# IsFalsePredicate
+	| expression IS NOT? DISTINCT FROM expression								# IsDistinctFromPredicate
+	| expression NOT? MEMBER OF? path											# MemberOfPredicate
+	| expression NOT? IN inList													# InPredicate
+	| expression NOT? BETWEEN expression AND expression							# BetweenPredicate
+	| expression NOT? (LIKE | ILIKE) expression likeEscape?						# LikePredicate
+	| expression comparisonOperator expression									# ComparisonPredicate
+	| EXISTS collectionQuantifier LEFT_PAREN simplePath RIGHT_PAREN				# ExistsCollectionPartPredicate
+	| EXISTS expression															# ExistsPredicate
+	| NOT predicate																# NegatedPredicate
+	| predicate AND predicate													# AndPredicate
+	| predicate OR predicate													# OrPredicate
+	| expression																# BooleanExpressionPredicate
 	;
 
+/**
+ * An operator which compares values for equality or order
+ */
+comparisonOperator
+	: EQUAL
+	| NOT_EQUAL
+	| GREATER
+	| GREATER_EQUAL
+	| LESS
+	| LESS_EQUAL
+	;
+
+/**
+ * Any right operand of the 'in' operator
+ *
+ * A list of values, a parameter (for a parameterized list of values), a subquery, or an 'elements()' or 'indices()' function
+ */
 inList
-	: ELEMENTS? LEFT_PAREN dotIdentifierSequence RIGHT_PAREN		# PersistentCollectionReferenceInList
-	| LEFT_PAREN expression (COMMA expression)*	RIGHT_PAREN			# ExplicitTupleInList
-	| expression													# SubQueryInList
+	: collectionQuantifier LEFT_PAREN simplePath RIGHT_PAREN						# PersistentCollectionReferenceInList
+	| LEFT_PAREN (expressionOrPredicate (COMMA expressionOrPredicate)*)? RIGHT_PAREN# ExplicitTupleInList
+	| LEFT_PAREN subquery RIGHT_PAREN												# SubqueryInList
+	| parameter 																	# ParamInList
 	;
 
+/**
+ * A single character used to escape the '_' and '%' wildcards in a 'like' pattern
+ */
 likeEscape
-	: ESCAPE expression
+	: ESCAPE (STRING_LITERAL | JAVA_STRING_LITERAL | parameter)
 	;
 
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Expression
 
+/**
+ * An expression, excluding boolean expressions
+ */
 expression
-	: expression DOUBLE_PIPE expression			# ConcatenationExpression
-	| expression PLUS expression				# AdditionExpression
-	| expression MINUS expression				# SubtractionExpression
-	| expression ASTERISK expression			# MultiplicationExpression
-	| expression SLASH expression				# DivisionExpression
-	| expression PERCENT expression				# ModuloExpression
-	// todo (6.0) : should these unary plus/minus rules only apply to literals?
-	//		if so, move the MINUS / PLUS recognition to the `literal` rule
-	//		specificcally for numeric literals
-	| MINUS expression							# UnaryMinusExpression
-	| PLUS expression							# UnaryPlusExpression
-	| caseStatement								# CaseExpression
-	| coalesce									# CoalesceExpression
-	| nullIf									# NullIfExpression
-	| literal									# LiteralExpression
-	| parameter									# ParameterExpression
-	| entityTypeReference						# EntityTypeExpression
-	| path										# PathExpression
-	| function									# FunctionExpression
-	| LEFT_PAREN querySpec RIGHT_PAREN		    # SubQueryExpression
+	//highest to lowest precedence
+	: LEFT_PAREN expression RIGHT_PAREN												# GroupedExpression
+	| LEFT_PAREN expressionOrPredicate (COMMA expressionOrPredicate)+ RIGHT_PAREN	# TupleExpression
+	| LEFT_PAREN subquery RIGHT_PAREN												# SubqueryExpression
+	| primaryExpression 															# BarePrimaryExpression
+	| signOperator numericLiteral													# UnaryNumericLiteralExpression
+	| signOperator expression														# UnaryExpression
+	| expression datetimeField  													# ToDurationExpression
+	| expression BY datetimeField													# FromDurationExpression
+	| expression multiplicativeOperator expression									# MultiplicationExpression
+	| expression additiveOperator expression										# AdditionExpression
+	| expression DOUBLE_PIPE expression												# ConcatenationExpression
 	;
 
+/**
+ * An expression not involving operators
+ */
+primaryExpression
+	: caseList											# CaseExpression
+	| literal											# LiteralExpression
+	| parameter											# ParameterExpression
+	| entityTypeReference								# EntityTypeExpression
+	| entityIdReference									# EntityIdExpression
+	| entityVersionReference							# EntityVersionExpression
+	| entityNaturalIdReference							# EntityNaturalIdExpression
+	| toOneFkReference									# ToOneFkExpression
+	| syntacticDomainPath pathContinuation?				# SyntacticPathExpression
+	| function											# FunctionExpression
+	| generalPathFragment								# GeneralPathExpression
+	;
+
+/**
+ * Any expression, including boolean expressions
+ */
+expressionOrPredicate
+	: expression
+	| predicate
+	;
+
+collectionQuantifier
+	: elementsValuesQuantifier
+	| indicesKeysQuantifier
+	;
+
+elementValueQuantifier
+	: ELEMENT
+	| VALUE
+	;
+
+indexKeyQuantifier
+	: INDEX
+	| KEY
+	;
+
+elementsValuesQuantifier
+	: ELEMENTS
+	| VALUES
+	;
+
+indicesKeysQuantifier
+	: INDICES
+	| KEYS
+	;
+
+/**
+ * A binary operator with the same precedence as *
+ */
+multiplicativeOperator
+	: SLASH
+	| PERCENT_OP
+	| ASTERISK
+	;
+
+/**
+ * A binary operator with the same precedence as +
+ */
+additiveOperator
+	: PLUS
+	| MINUS
+	;
+
+/**
+ * A unary prefix operator
+ */
+signOperator
+	: PLUS
+	| MINUS
+	;
+
+/**
+ * The special function 'type()'
+ */
 entityTypeReference
 	: TYPE LEFT_PAREN (path | parameter) RIGHT_PAREN
 	;
 
-caseStatement
-	: simpleCaseStatement
-	| searchedCaseStatement
+/**
+ * The special function 'id()'
+ */
+entityIdReference
+	: ID LEFT_PAREN path RIGHT_PAREN pathContinuation?
 	;
 
-simpleCaseStatement
-	: CASE expression (simpleCaseWhen)+ (caseOtherwise)? END
+/**
+ * The special function 'version()'
+ */
+entityVersionReference
+	: VERSION LEFT_PAREN path RIGHT_PAREN
 	;
 
+/**
+ * The special function 'naturalid()'
+ */
+entityNaturalIdReference
+	: NATURALID LEFT_PAREN path RIGHT_PAREN pathContinuation?
+	;
+
+/**
+ * The special function 'fk()'
+ */
+toOneFkReference
+	: FK LEFT_PAREN path RIGHT_PAREN
+	;
+
+/**
+ * A 'case' expression, which comes in two forms: "simple", and "searched"
+ */
+caseList
+	: simpleCaseList
+	| searchedCaseList
+	;
+
+/**
+ * A simple 'case' expression
+ */
+simpleCaseList
+	: CASE expressionOrPredicate simpleCaseWhen+ caseOtherwise? END
+	;
+
+/**
+ * The 'when' clause of a simple case
+ */
 simpleCaseWhen
-	: WHEN expression THEN expression
+	: WHEN expression THEN expressionOrPredicate
 	;
 
+/**
+ * The 'else' clause of a 'case' expression
+ */
 caseOtherwise
-	: ELSE expression
+	: ELSE expressionOrPredicate
 	;
 
-searchedCaseStatement
-	: CASE (searchedCaseWhen)+ (caseOtherwise)? END
+/**
+ * A searched 'case' expression
+ */
+searchedCaseList
+	: CASE searchedCaseWhen+ caseOtherwise? END
 	;
 
+/**
+ * The 'when' clause of a searched case
+ */
 searchedCaseWhen
-	: WHEN predicate THEN expression
+	: WHEN predicate THEN expressionOrPredicate
 	;
 
-coalesce
-	: COALESCE LEFT_PAREN expression (COMMA expression)+ RIGHT_PAREN
-	;
-
-nullIf
-	: NULLIF LEFT_PAREN expression COMMA expression RIGHT_PAREN
-	;
-
+/**
+ * A literal value
+ */
 literal
 	: STRING_LITERAL
-	| CHARACTER_LITERAL
-	| INTEGER_LITERAL
+	| JAVA_STRING_LITERAL
+	| NULL
+	| booleanLiteral
+	| numericLiteral
+	| binaryLiteral
+	| temporalLiteral
+	| generalizedLiteral
+	;
+
+/**
+ * A boolean literal value
+ */
+booleanLiteral
+	: TRUE
+	| FALSE
+	;
+
+/**
+ * A numeric literal value, including hexadecimal literals
+ */
+numericLiteral
+	: INTEGER_LITERAL
 	| LONG_LITERAL
 	| BIG_INTEGER_LITERAL
 	| FLOAT_LITERAL
 	| DOUBLE_LITERAL
 	| BIG_DECIMAL_LITERAL
 	| HEX_LITERAL
-	| OCTAL_LITERAL
-	| NULL
-	| TRUE
-	| FALSE
-	| timestampLiteral
+	;
+
+/**
+ * A binary literal value, as a SQL-style literal, or a braced list of byte literals
+ */
+binaryLiteral
+	: BINARY_LITERAL
+	| LEFT_BRACE HEX_LITERAL (COMMA HEX_LITERAL)* RIGHT_BRACE
+	;
+
+/**
+ * A literal date, time, or datetime, in HQL syntax, or as a JDBC-style "escape" syntax
+ */
+temporalLiteral
+	: dateTimeLiteral
 	| dateLiteral
 	| timeLiteral
+	| jdbcTimestampLiteral
+	| jdbcDateLiteral
+	| jdbcTimeLiteral
 	;
 
-// todo (6.0) : expand temporal literal support to Java 8 temporal types
-//		* Instant 			-> {instant '...'}
-//		* LocalDate 		-> {localDate '...'}
-//		* LocalDateTime 	-> {localDateTime '...'}
-//		* OffsetDateTime 	-> {offsetDateTime '...'}
-//		* OffsetTime 		-> {offsetTime '...'}
-//		* ZonedDateTime 	-> {localDate '...'}
-//		* ...
-//
-// Few things:
-//		1) the markers above are just initial thoughts.  They are obviously verbose.  Maybe acronyms or shortened forms would be better
-//		2) we may want to stay away from all of the timezone headaches by not supporting local, zoned and offset forms
-
-timestampLiteral
-	: TIMESTAMP_ESCAPE_START dateTimeLiteralText RIGHT_BRACE
+/**
+ * A literal datetime, in braces, or with the 'datetime' keyword
+ */
+dateTimeLiteral
+	: localDateTimeLiteral
+	| zonedDateTimeLiteral
+	| offsetDateTimeLiteral
 	;
 
+localDateTimeLiteral
+	: LEFT_BRACE localDateTime RIGHT_BRACE
+	| LOCAL? DATETIME localDateTime
+	;
+
+zonedDateTimeLiteral
+	: LEFT_BRACE zonedDateTime RIGHT_BRACE
+	| ZONED? DATETIME zonedDateTime
+	;
+
+offsetDateTimeLiteral
+	: LEFT_BRACE offsetDateTime RIGHT_BRACE
+	| OFFSET? DATETIME offsetDateTimeWithMinutes
+	;
+
+/**
+ * A literal date, in braces, or with the 'date' keyword
+ */
 dateLiteral
-	: DATE_ESCAPE_START dateTimeLiteralText RIGHT_BRACE
+	: LEFT_BRACE date RIGHT_BRACE
+	| LOCAL? DATE date
 	;
 
+/**
+ * A literal time, in braces, or with the 'time' keyword
+ */
 timeLiteral
-	: TIME_ESCAPE_START dateTimeLiteralText RIGHT_BRACE
+	: LEFT_BRACE time RIGHT_BRACE
+	| LOCAL? TIME time
 	;
 
-dateTimeLiteralText
-	: STRING_LITERAL | CHARACTER_LITERAL
+/**
+ * A literal datetime
+ */
+ dateTime
+ 	: localDateTime
+ 	| zonedDateTime
+ 	| offsetDateTime
+ 	;
+
+localDateTime
+	: date time
 	;
 
+zonedDateTime
+	: date time zoneId
+	;
+
+offsetDateTime
+	: date time offset
+	;
+
+offsetDateTimeWithMinutes
+	: date time offsetWithMinutes
+	;
+
+/**
+ * A literal date
+ */
+date
+	: year MINUS month MINUS day
+	;
+
+/**
+ * A literal time
+ */
+time
+	: hour COLON minute (COLON second)?
+	;
+
+/**
+ * A literal offset
+ */
+offset
+	: (PLUS | MINUS) hour (COLON minute)?
+	;
+
+offsetWithMinutes
+	: (PLUS | MINUS) hour COLON minute
+	;
+
+year: INTEGER_LITERAL;
+month: INTEGER_LITERAL;
+day: INTEGER_LITERAL;
+hour: INTEGER_LITERAL;
+minute: INTEGER_LITERAL;
+second: INTEGER_LITERAL | DOUBLE_LITERAL;
+zoneId
+	: IDENTIFIER (SLASH IDENTIFIER)?
+	| STRING_LITERAL;
+
+/**
+ * A JDBC-style timestamp escape, as required by JPQL
+ */
+jdbcTimestampLiteral
+	: TIMESTAMP_ESCAPE_START (dateTime | genericTemporalLiteralText) RIGHT_BRACE
+	;
+
+/**
+ * A JDBC-style date escape, as required by JPQL
+ */
+jdbcDateLiteral
+	: DATE_ESCAPE_START (date | genericTemporalLiteralText) RIGHT_BRACE
+	;
+
+/**
+ * A JDBC-style time escape, as required by JPQL
+ */
+jdbcTimeLiteral
+	: TIME_ESCAPE_START (time | genericTemporalLiteralText) RIGHT_BRACE
+	;
+
+genericTemporalLiteralText
+	: STRING_LITERAL
+	;
+
+/**
+ * A generic format for specifying literal values of arbitary types
+ */
+generalizedLiteral
+	: LEFT_BRACE generalizedLiteralType COLON generalizedLiteralText RIGHT_BRACE
+	;
+
+generalizedLiteralType : STRING_LITERAL;
+generalizedLiteralText : STRING_LITERAL;
+
+
+/**
+ * A query parameter: a named parameter, or an ordinal parameter
+ */
 parameter
 	: COLON identifier					# NamedParameter
 	| QUESTION_MARK INTEGER_LITERAL?	# PositionalParameter
 	;
 
+/**
+ * A function invocation that may occur in an arbitrary expression
+ */
 function
 	: standardFunction
 	| aggregateFunction
-	| jpaCollectionFunction
-	| hqlCollectionFunction
-	| jpaNonStandardFunction
-	| nonStandardFunction
+	| collectionSizeFunction
+	| collectionAggregateFunction
+	| collectionFunctionMisuse
+	| jpaNonstandardFunction
+	| genericFunction
 	;
 
-jpaNonStandardFunction
-	: FUNCTION LEFT_PAREN jpaNonStandardFunctionName (COMMA nonStandardFunctionArguments)? RIGHT_PAREN
+/**
+ * A syntax for calling user-defined or native database functions, required by JPQL
+ */
+jpaNonstandardFunction
+	: FUNCTION LEFT_PAREN jpaNonstandardFunctionName (COMMA genericFunctionArguments)? RIGHT_PAREN
 	;
 
-jpaNonStandardFunctionName
+/**
+ * The name of a user-defined or native database function, given as a quoted string
+ */
+jpaNonstandardFunctionName
 	: STRING_LITERAL
 	;
 
-nonStandardFunction
-	: nonStandardFunctionName LEFT_PAREN nonStandardFunctionArguments? RIGHT_PAREN
+/**
+ * Any function invocation that follows the regular syntax
+ *
+ * The function name, followed by a parenthesized list of comma-separated expressions
+ */
+genericFunction
+	: genericFunctionName LEFT_PAREN (genericFunctionArguments | ASTERISK)? RIGHT_PAREN
+	  nthSideClause? nullsClause? withinGroupClause? filterClause? overClause?
 	;
 
-nonStandardFunctionName
-	: dotIdentifierSequence
+/**
+ * The name of a generic function, which may contain periods and quoted identifiers
+ *
+ * Names of generic functions are resolved against the SqmFunctionRegistry
+ */
+genericFunctionName
+	: simplePath
 	;
 
-nonStandardFunctionArguments
-	: expression (COMMA expression)*
+/**
+ * The arguments of a generic function
+ */
+genericFunctionArguments
+	: (DISTINCT | datetimeField COMMA)? expressionOrPredicate (COMMA expressionOrPredicate)*
 	;
 
-jpaCollectionFunction
-	: SIZE LEFT_PAREN path RIGHT_PAREN					# CollectionSizeFunction
-	| INDEX LEFT_PAREN identifier RIGHT_PAREN			# CollectionIndexFunction
+/**
+ * The special 'size()' function defined by JPQL
+ */
+collectionSizeFunction
+	: SIZE LEFT_PAREN path RIGHT_PAREN
 	;
 
-hqlCollectionFunction
-	: MAXINDEX LEFT_PAREN path RIGHT_PAREN				# MaxIndexFunction
-	| MAXELEMENT LEFT_PAREN path RIGHT_PAREN			# MaxElementFunction
-	| MININDEX LEFT_PAREN path RIGHT_PAREN				# MinIndexFunction
-	| MINELEMENT LEFT_PAREN path RIGHT_PAREN			# MinElementFunction
+/**
+ * Special rule for 'max(elements())`, 'avg(keys())', 'sum(indices())`, etc., as defined by HQL
+ * Also the deprecated 'maxindex()', 'maxelement()', 'minindex()', 'minelement()' functions from old HQL
+ */
+collectionAggregateFunction
+	: (MAX|MIN|SUM|AVG) LEFT_PAREN elementsValuesQuantifier LEFT_PAREN path RIGHT_PAREN RIGHT_PAREN	# ElementAggregateFunction
+	| (MAX|MIN|SUM|AVG) LEFT_PAREN indicesKeysQuantifier LEFT_PAREN path RIGHT_PAREN RIGHT_PAREN	# IndexAggregateFunction
+	| (MAXELEMENT|MINELEMENT) LEFT_PAREN path RIGHT_PAREN											# ElementAggregateFunction
+	| (MAXINDEX|MININDEX) LEFT_PAREN path RIGHT_PAREN												# IndexAggregateFunction
 	;
 
+/**
+ * To accommodate the misuse of elements() and indices() in the select clause
+ *
+ * (At some stage in the history of HQL, someone mixed them up with value() and index(),
+ *  and so we have tests that insist they're interchangeable. Ugh.)
+ */
+collectionFunctionMisuse
+	: elementsValuesQuantifier LEFT_PAREN path RIGHT_PAREN
+	| indicesKeysQuantifier LEFT_PAREN path RIGHT_PAREN
+	;
+
+/**
+ * The special 'every()', 'all()', 'any()' and 'some()' functions defined by HQL
+ *
+ * May be applied to a subquery or collection reference, or may occur as an aggregate function in the 'select' clause
+ */
 aggregateFunction
-	: avgFunction
-	| sumFunction
-	| minFunction
-	| maxFunction
-	| countFunction
+	: everyFunction
+	| anyFunction
+	| listaggFunction
 	;
 
-avgFunction
-	: AVG LEFT_PAREN DISTINCT? expression RIGHT_PAREN
+/**
+ * The functions 'every()' and 'all()' are synonyms
+ */
+everyFunction
+	: everyAllQuantifier LEFT_PAREN predicate RIGHT_PAREN filterClause? overClause?
+	| everyAllQuantifier LEFT_PAREN subquery RIGHT_PAREN
+	| everyAllQuantifier collectionQuantifier LEFT_PAREN simplePath RIGHT_PAREN
 	;
 
-sumFunction
-	: SUM LEFT_PAREN DISTINCT? expression RIGHT_PAREN
+/**
+ * The functions 'any()' and 'some()' are synonyms
+ */
+anyFunction
+	: anySomeQuantifier LEFT_PAREN predicate RIGHT_PAREN filterClause? overClause?
+	| anySomeQuantifier LEFT_PAREN subquery RIGHT_PAREN
+	| anySomeQuantifier collectionQuantifier LEFT_PAREN simplePath RIGHT_PAREN
 	;
 
-minFunction
-	: MIN LEFT_PAREN DISTINCT? expression RIGHT_PAREN
+everyAllQuantifier
+    : EVERY
+    | ALL
+    ;
+
+anySomeQuantifier
+    : ANY
+    | SOME
+    ;
+
+/**
+ * The 'listagg()' ordered set-aggregate function
+ */
+listaggFunction
+	: LISTAGG LEFT_PAREN DISTINCT? expressionOrPredicate COMMA expressionOrPredicate onOverflowClause? RIGHT_PAREN
+	  withinGroupClause? filterClause? overClause?
 	;
 
-maxFunction
-	: MAX LEFT_PAREN DISTINCT? expression RIGHT_PAREN
+/**
+ * A 'on overflow' clause: what to do when the text data type used for 'listagg' overflows
+ */
+onOverflowClause
+	: ON OVERFLOW (ERROR | TRUNCATE expression? (WITH|WITHOUT) COUNT)
 	;
 
-countFunction
-	: COUNT LEFT_PAREN DISTINCT? (expression | ASTERISK) RIGHT_PAREN
+/**
+ * A 'within group' clause: defines the order in which the ordered set-aggregate function should work
+ */
+withinGroupClause
+	: WITHIN GROUP LEFT_PAREN orderByClause RIGHT_PAREN
 	;
 
+/**
+ * A 'filter' clause: a restriction applied to an aggregate function
+ */
+filterClause
+	: FILTER LEFT_PAREN whereClause RIGHT_PAREN
+	;
+
+/**
+ * A `nulls` clause: what should a value access window function do when encountering a `null`
+ */
+nullsClause
+	: RESPECT NULLS
+	| IGNORE NULLS
+	;
+
+/**
+ * A `nulls` clause: what should a value access window function do when encountering a `null`
+ */
+nthSideClause
+	: FROM FIRST
+	| FROM LAST
+	;
+
+/**
+ * A 'over' clause: the specification of a window within which the function should act
+ */
+overClause
+	: OVER LEFT_PAREN partitionClause? orderByClause? frameClause? RIGHT_PAREN
+	;
+
+/**
+ * A 'partition' clause: the specification the group within which a function should act in a window
+ */
+partitionClause
+	: PARTITION BY expression (COMMA expression)*
+	;
+
+/**
+ * A 'frame' clause: the specification the content of the window
+ */
+frameClause
+	: (RANGE|ROWS|GROUPS) frameStart frameExclusion?
+	| (RANGE|ROWS|GROUPS) BETWEEN frameStart AND frameEnd frameExclusion?
+	;
+
+/**
+ * The start of the window content
+ */
+frameStart
+	: CURRENT ROW
+	| UNBOUNDED PRECEDING
+	| expression PRECEDING
+	| expression FOLLOWING
+	;
+
+/**
+ * The end of the window content
+ */
+frameEnd
+	: CURRENT ROW
+	| UNBOUNDED FOLLOWING
+	| expression PRECEDING
+	| expression FOLLOWING
+	;
+
+/**
+ * A 'exclusion' clause: the specification what to exclude from the window content
+ */
+frameExclusion
+	: EXCLUDE CURRENT ROW
+	| EXCLUDE GROUP
+	| EXCLUDE TIES
+	| EXCLUDE NO OTHERS
+	;
+
+/**
+ * Any function with an irregular syntax for the argument list
+ *
+ * These are all inspired by the syntax of ANSI SQL
+ */
 standardFunction
-	:	castFunction
-	|	concatFunction
-	|	substringFunction
-	|	trimFunction
-	|	upperFunction
-	|	lowerFunction
-	|	lengthFunction
-	|	locateFunction
-	|	absFunction
-	|	sqrtFunction
-	|	modFunction
-	|   strFunction
-	|	currentDateFunction
-	|	currentTimeFunction
-	|	currentTimestampFunction
-	|	extractFunction
-	|	positionFunction
-	|	charLengthFunction
-	|	octetLengthFunction
-	|	bitLengthFunction
+	: castFunction
+	| extractFunction
+	| truncFunction
+	| formatFunction
+	| collateFunction
+	| substringFunction
+	| overlayFunction
+	| trimFunction
+	| padFunction
+	| positionFunction
+	| currentDateFunction
+	| currentTimeFunction
+	| currentTimestampFunction
+	| instantFunction
+	| localDateFunction
+	| localTimeFunction
+	| localDateTimeFunction
+	| offsetDateTimeFunction
+	| cube
+	| rollup
 	;
 
-
+/**
+ * The 'cast()' function for typecasting
+ */
 castFunction
 	: CAST LEFT_PAREN expression AS castTarget RIGHT_PAREN
 	;
 
+/**
+ * The target type for a typecast: a typename, together with length or precision/scale
+ */
 castTarget
-	// todo (6.0) : should allow either
-	// 		- named cast (IDENTIFIER)
-	//			- JavaTypeDescriptorRegistry (imported) key
-	//			- java.sql.Types field NAME (alias for its value as a coded cast)
-	//			- "pass through"
-	//		- coded cast (INTEGER_LITERAL)
-	//			- SqlTypeDescriptorRegistry key
-	: IDENTIFIER
+	: castTargetType (LEFT_PAREN INTEGER_LITERAL (COMMA INTEGER_LITERAL)? RIGHT_PAREN)?
 	;
 
-concatFunction
-	: CONCAT LEFT_PAREN expression (COMMA expression)+ RIGHT_PAREN
+/**
+ * The name of the target type in a typecast
+ *
+ * Like the 'entityName' rule, we have a specialized dotIdentifierSequence rule
+ */
+castTargetType
+	returns [String fullTargetName]
+	: (i=identifier { $fullTargetName = _localctx.i.getText(); }) (DOT c=identifier { $fullTargetName += ("." + _localctx.c.getText() ); })*
 	;
 
+/**
+ * The two formats for the 'substring() function: one defined by JPQL, the other by ANSI SQL
+ */
 substringFunction
-	: (SUBSTRING | SUBSTR) LEFT_PAREN expression COMMA substringFunctionStartArgument (COMMA substringFunctionLengthArgument)? RIGHT_PAREN
+	: SUBSTRING LEFT_PAREN expression COMMA substringFunctionStartArgument (COMMA substringFunctionLengthArgument)? RIGHT_PAREN
+	| SUBSTRING LEFT_PAREN expression FROM substringFunctionStartArgument (FOR substringFunctionLengthArgument)? RIGHT_PAREN
 	;
 
 substringFunctionStartArgument
@@ -607,6 +1341,9 @@ substringFunctionLengthArgument
 	: expression
 	;
 
+/**
+ * The ANSI SQL-style 'trim()' function
+ */
 trimFunction
 	: TRIM LEFT_PAREN trimSpecification? trimCharacter? FROM? expression RIGHT_PAREN
 	;
@@ -618,205 +1355,414 @@ trimSpecification
 	;
 
 trimCharacter
-	: CHARACTER_LITERAL | STRING_LITERAL
-	;
-
-upperFunction
-	: UPPER LEFT_PAREN expression RIGHT_PAREN
-	;
-
-lowerFunction
-	: LOWER LEFT_PAREN expression RIGHT_PAREN
-	;
-
-lengthFunction
-	: LENGTH LEFT_PAREN expression RIGHT_PAREN
-	;
-
-locateFunction
-	: LOCATE LEFT_PAREN locateFunctionSubstrArgument COMMA locateFunctionStringArgument (COMMA locateFunctionStartArgument)? RIGHT_PAREN
-	;
-
-locateFunctionSubstrArgument
-	: expression
-	;
-
-locateFunctionStringArgument
-	: expression
-	;
-
-locateFunctionStartArgument
-	: expression
-	;
-
-absFunction
-	:	ABS LEFT_PAREN expression RIGHT_PAREN
-	;
-
-sqrtFunction
-	:	SQRT LEFT_PAREN expression RIGHT_PAREN
-	;
-
-modFunction
-	:	MOD LEFT_PAREN modDividendArgument COMMA modDivisorArgument RIGHT_PAREN
-	;
-
-strFunction
-    :   STR LEFT_PAREN expression RIGHT_PAREN
-    ;
-
-modDividendArgument
-	: expression
-	;
-
-modDivisorArgument
-	: expression
-	;
-
-currentDateFunction
-	: CURRENT_DATE (LEFT_PAREN RIGHT_PAREN)?
-	;
-
-currentTimeFunction
-	: CURRENT_TIME (LEFT_PAREN RIGHT_PAREN)?
-	;
-
-currentTimestampFunction
-	: CURRENT_TIMESTAMP (LEFT_PAREN RIGHT_PAREN)?
-	;
-
-extractFunction
-	: EXTRACT LEFT_PAREN extractField FROM expression RIGHT_PAREN
-	;
-
-extractField
-	: datetimeField
-	| timeZoneField
-	;
-
-datetimeField
-	: nonSecondDatetimeField
-	| SECOND
-	;
-
-nonSecondDatetimeField
-	: YEAR
-	| MONTH
-	| DAY
-	| HOUR
-	| MINUTE
-	;
-
-timeZoneField
-	: TIMEZONE_HOUR
-	| TIMEZONE_MINUTE
-	;
-
-positionFunction
-	: POSITION LEFT_PAREN positionSubstrArgument IN positionStringArgument RIGHT_PAREN
-	;
-
-positionSubstrArgument
-	: expression
-	;
-
-positionStringArgument
-	: expression
-	;
-
-charLengthFunction
-	: CAST LEFT_PAREN expression RIGHT_PAREN
-	;
-
-octetLengthFunction
-	: OCTET_LENGTH LEFT_PAREN expression RIGHT_PAREN
-	;
-
-bitLengthFunction
-	: BIT_LENGTH LEFT_PAREN expression RIGHT_PAREN
+	: STRING_LITERAL
 	;
 
 /**
- * The `identifier` is used to provide "keyword as identifier" handling.
+ * A 'pad()' function inspired by 'trim()'
+ */
+padFunction
+	: PAD LEFT_PAREN expression WITH padLength padSpecification padCharacter? RIGHT_PAREN
+	;
+
+padSpecification
+	: LEADING
+	| TRAILING
+	;
+
+padCharacter
+	: STRING_LITERAL
+	;
+
+padLength
+	: expression
+	;
+
+/**
+ * The ANSI SQL-style 'overlay()' function
+ */
+overlayFunction
+	: OVERLAY LEFT_PAREN overlayFunctionStringArgument PLACING overlayFunctionReplacementArgument FROM overlayFunctionStartArgument (FOR overlayFunctionLengthArgument)? RIGHT_PAREN
+	;
+
+overlayFunctionStringArgument
+	: expression
+	;
+
+overlayFunctionReplacementArgument
+	: expression
+	;
+
+overlayFunctionStartArgument
+	: expression
+	;
+
+overlayFunctionLengthArgument
+	: expression
+	;
+
+/**
+ * The deprecated current_date function required by JPQL
+ */
+currentDateFunction
+	: CURRENT_DATE (LEFT_PAREN RIGHT_PAREN)?
+	| CURRENT DATE
+	;
+
+/**
+ * The deprecated current_time function required by JPQL
+ */
+currentTimeFunction
+	: CURRENT_TIME (LEFT_PAREN RIGHT_PAREN)?
+	| CURRENT TIME
+	;
+
+/**
+ * The deprecated current_timestamp function required by JPQL
+ */
+currentTimestampFunction
+	: CURRENT_TIMESTAMP (LEFT_PAREN RIGHT_PAREN)?
+	| CURRENT TIMESTAMP
+	;
+
+/**
+ * The instant function, and deprecated current_instant function
+ */
+instantFunction
+	: CURRENT_INSTANT (LEFT_PAREN RIGHT_PAREN)? //deprecated legacy syntax
+	| INSTANT
+	;
+
+/**
+ * The 'local datetime' function (or literal if you prefer)
+ */
+localDateTimeFunction
+	: LOCAL_DATETIME (LEFT_PAREN RIGHT_PAREN)?
+	| LOCAL DATETIME
+	;
+
+/**
+ * The 'offset datetime' function (or literal if you prefer)
+ */
+offsetDateTimeFunction
+	: OFFSET_DATETIME (LEFT_PAREN RIGHT_PAREN)?
+	| OFFSET DATETIME
+	;
+
+/**
+ * The 'local date' function (or literal if you prefer)
+ */
+localDateFunction
+	: LOCAL_DATE (LEFT_PAREN RIGHT_PAREN)?
+	| LOCAL DATE
+	;
+
+/**
+ * The 'local time' function (or literal if you prefer)
+ */
+localTimeFunction
+	: LOCAL_TIME (LEFT_PAREN RIGHT_PAREN)?
+	| LOCAL TIME
+	;
+
+/**
+ * The 'format()' function for formatting dates and times according to a pattern
+ */
+formatFunction
+	: FORMAT LEFT_PAREN expression AS format RIGHT_PAREN
+	;
+
+/**
+ * A format pattern, with a syntax inspired by by java.time.format.DateTimeFormatter
+ *
+ * see 'Dialect.appendDatetimeFormat()'
+ */
+format
+	: STRING_LITERAL
+	;
+
+/**
+ * The 'extract()' function for extracting fields of dates, times, and datetimes
+ */
+extractFunction
+	: EXTRACT LEFT_PAREN extractField FROM expression RIGHT_PAREN
+	| datetimeField LEFT_PAREN expression RIGHT_PAREN
+	;
+
+/**
+ * The 'trunc()' function for truncating both numeric and datetime values
+ */
+truncFunction
+	: (TRUNC | TRUNCATE) LEFT_PAREN expression (COMMA (datetimeField | expression))? RIGHT_PAREN
+	;
+
+/**
+ * A field that may be extracted from a date, time, or datetime
+ */
+extractField
+	: datetimeField
+	| dayField
+	| weekField
+	| timeZoneField
+	| dateOrTimeField
+	;
+
+datetimeField
+	: YEAR
+	| MONTH
+	| DAY
+	| WEEK
+	| QUARTER
+	| HOUR
+	| MINUTE
+	| SECOND
+	| NANOSECOND
+	| EPOCH
+	;
+
+dayField
+	: DAY OF MONTH
+	| DAY OF WEEK
+	| DAY OF YEAR
+	;
+
+weekField
+	: WEEK OF MONTH
+	| WEEK OF YEAR
+	;
+
+timeZoneField
+	: OFFSET (HOUR | MINUTE)?
+	| TIMEZONE_HOUR | TIMEZONE_MINUTE
+	;
+
+dateOrTimeField
+	: DATE
+	| TIME
+	;
+
+/**
+ * The ANSI SQL-style 'position()' function
+ */
+positionFunction
+	: POSITION LEFT_PAREN positionFunctionPatternArgument IN positionFunctionStringArgument RIGHT_PAREN
+	;
+
+positionFunctionPatternArgument
+	: expression
+	;
+
+positionFunctionStringArgument
+	: expression
+	;
+
+/**
+ * The 'cube()' function specific to the 'group by' clause
+ */
+cube
+	: CUBE LEFT_PAREN expressionOrPredicate (COMMA expressionOrPredicate)* RIGHT_PAREN
+	;
+
+/**
+ * The 'rollup()' function specific to the 'group by' clause
+ */
+rollup
+	: ROLLUP LEFT_PAREN expressionOrPredicate (COMMA expressionOrPredicate)* RIGHT_PAREN
+	;
+
+/**
+ * Support for "soft" keywords which may be used as identifiers
+ *
+ * The 'identifier' rule is used to provide "keyword as identifier" handling.
  *
  * The lexer hands us recognized keywords using their specific tokens.  This is important
  * for the recognition of sqm structure, especially in terms of performance!
  *
- * However we want to continue to allow users to use mopst keywords as identifiers (e.g., attribute names).
+ * However we want to continue to allow users to use most keywords as identifiers (e.g., attribute names).
  * This parser rule helps with that.  Here we expect that the caller already understands their
  * context enough to know that keywords-as-identifiers are allowed.
  */
-identifier
+ // All except the possible optional following keywords LEFT, RIGHT, INNER, FULL, OUTER
+ nakedIdentifier
 	: IDENTIFIER
-	| (ABS
-	| ALL
+	| QUOTED_IDENTIFIER
+	| (ALL
 	| AND
 	| ANY
 	| AS
 	| ASC
 	| AVG
-	| BY
 	| BETWEEN
-	| BIT_LENGTH
 	| BOTH
+	| BREADTH
+	| BY
+	| CASE
 	| CAST
-	| COALESCE
 	| COLLATE
-	| CONCAT
 	| COUNT
 	| CROSS
+	| CUBE
+	| CURRENT
+	| CURRENT_DATE
+	| CURRENT_INSTANT
+	| CURRENT_TIME
+	| CURRENT_TIMESTAMP
+	| CYCLE
+	| DATE
+	| DATETIME
 	| DAY
+	| DEFAULT
 	| DELETE
+	| DEPTH
 	| DESC
 	| DISTINCT
+	| ELEMENT
 	| ELEMENTS
+	| ELSE
+	| EMPTY
+	| END
 	| ENTRY
+	| EPOCH
+	| ERROR
+	| ESCAPE
+	| EVERY
+	| EXCEPT
+	| EXCLUDE
+	| EXISTS
+	| EXTRACT
+	| FETCH
+	| FILTER
+	| FIRST
+	| FOLLOWING
+	| FOR
+	| FORMAT
 	| FROM
-	| FULL
+//	| FULL
 	| FUNCTION
 	| GROUP
+	| GROUPS
+	| HAVING
 	| HOUR
+	| ID
+	| IGNORE
+	| ILIKE
 	| IN
 	| INDEX
-	| INNER
+	| INDICES
+//	| INNER
 	| INSERT
+	| INSTANT
+	| INTERSECT
+	| INTO
+	| IS
 	| JOIN
 	| KEY
+	| KEYS
+	| LAST
+	| LATERAL
 	| LEADING
-	| LEFT
-	| LENGTH
+//	| LEFT
 	| LIKE
+	| LIMIT
 	| LIST
-	| LOWER
+	| LISTAGG
+	| LOCAL
+	| LOCAL_DATE
+	| LOCAL_DATETIME
+	| LOCAL_TIME
 	| MAP
+	| MATERIALIZED
 	| MAX
-	| MIN
-	| MINUTE
+	| MAXELEMENT
+	| MAXINDEX
 	| MEMBER
+	| MICROSECOND
+	| MILLISECOND
+	| MIN
+	| MINELEMENT
+	| MININDEX
+	| MINUTE
 	| MONTH
+	| NANOSECOND
+	| NATURALID
+	| NEW
+	| NEXT
+	| NO
+	| NOT
+	| NULLS
 	| OBJECT
+	| OF
+	| OFFSET
+	| OFFSET_DATETIME
 	| ON
+	| ONLY
 	| OR
 	| ORDER
-	| OUTER
+	| OTHERS
+//	| OUTER
+	| OVER
+	| OVERFLOW
+	| OVERLAY
+	| PAD
+	| PARTITION
+	| PERCENT
+	| PLACING
 	| POSITION
-	| RIGHT
-	| SELECT
+	| PRECEDING
+	| QUARTER
+	| RANGE
+	| RESPECT
+//	| RIGHT
+	| ROLLUP
+	| ROW
+	| ROWS
+	| SEARCH
 	| SECOND
+	| SELECT
 	| SET
-	| SQRT
-	| STR
+	| SIZE
+	| SOME
 	| SUBSTRING
 	| SUM
+	| THEN
+	| TIES
+	| TIME
+	| TIMESTAMP
+	| TIMEZONE_HOUR
+	| TIMEZONE_MINUTE
+	| TO
 	| TRAILING
 	| TREAT
+	| TRIM
+	| TRUNC
+	| TRUNCATE
+	| TYPE
+	| UNBOUNDED
+	| UNION
 	| UPDATE
-	| UPPER
+	| USING
 	| VALUE
+	| VALUES
+	| VERSION
+	| VERSIONED
+	| WEEK
+	| WHEN
 	| WHERE
 	| WITH
-	| YEAR) {
-	    logUseOfReservedWordAsIdentifier(getCurrentToken());
+	| WITHIN
+	| WITHOUT
+	| YEAR
+	| ZONED) {
+		logUseOfReservedWordAsIdentifier( getCurrentToken() );
 	}
 	;
-
+identifier
+	: nakedIdentifier
+	| (FULL
+	| INNER
+	| LEFT
+	| OUTER
+	| RIGHT) {
+		logUseOfReservedWordAsIdentifier( getCurrentToken() );
+	}
+	;

--- a/extensions/panache/panacheql/src/test/java/io/quarkus/panacheql/LexerTest.java
+++ b/extensions/panache/panacheql/src/test/java/io/quarkus/panacheql/LexerTest.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.panacheql.internal.HqlLexer;
 import io.quarkus.panacheql.internal.HqlParser;
 import io.quarkus.panacheql.internal.HqlParser.AndPredicateContext;
-import io.quarkus.panacheql.internal.HqlParser.EqualityPredicateContext;
+import io.quarkus.panacheql.internal.HqlParser.ComparisonPredicateContext;
+import io.quarkus.panacheql.internal.HqlParser.GeneralPathExpressionContext;
 import io.quarkus.panacheql.internal.HqlParser.IsNullPredicateContext;
 import io.quarkus.panacheql.internal.HqlParser.LiteralExpressionContext;
-import io.quarkus.panacheql.internal.HqlParser.PathExpressionContext;
 import io.quarkus.panacheql.internal.HqlParser.PredicateContext;
 import io.quarkus.panacheql.internal.HqlParserBaseVisitor;
 
@@ -47,8 +47,11 @@ public class LexerTest {
             }
 
             @Override
-            public String visitEqualityPredicate(EqualityPredicateContext ctx) {
-                return ctx.expression(0).accept(this) + " == " + ctx.expression(1).accept(this);
+            public String visitComparisonPredicate(ComparisonPredicateContext ctx) {
+                if (ctx.comparisonOperator().EQUAL() != null) {
+                    return ctx.expression(0).accept(this) + " == " + ctx.expression(1).accept(this);
+                }
+                return super.visitComparisonPredicate(ctx);
             }
 
             @Override
@@ -57,7 +60,7 @@ public class LexerTest {
             }
 
             @Override
-            public String visitPathExpression(PathExpressionContext ctx) {
+            public String visitGeneralPathExpression(GeneralPathExpressionContext ctx) {
                 return ctx.getText();
             }
         };

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongoTestResources.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongoTestResources.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.mongodb.panache;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.mongodb.MongoReplicaSetTestResource;
+
+@QuarkusTestResource(MongoReplicaSetTestResource.class)
+public class MongoTestResources {
+
+}

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheMockingTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheMockingTest.java
@@ -16,13 +16,10 @@ import io.quarkus.it.mongodb.panache.person.PersonEntity;
 import io.quarkus.it.mongodb.panache.person.PersonRepository;
 import io.quarkus.mongodb.panache.PanacheMongoRepositoryBase;
 import io.quarkus.panache.mock.PanacheMock;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
-import io.quarkus.test.mongodb.MongoReplicaSetTestResource;
 
 @QuarkusTest
-@QuarkusTestResource(MongoReplicaSetTestResource.class)
 public class MongodbPanacheMockingTest {
 
     @Test

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -23,9 +23,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import io.quarkus.it.mongodb.panache.book.BookDetail;
 import io.quarkus.it.mongodb.panache.person.Person;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.mongodb.MongoReplicaSetTestResource;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.config.ObjectMapperConfig;
@@ -33,7 +31,6 @@ import io.restassured.parsing.Parser;
 import io.restassured.response.Response;
 
 @QuarkusTest
-@QuarkusTestResource(MongoReplicaSetTestResource.class)
 class MongodbPanacheResourceTest {
     private static final TypeRef<List<BookDTO>> LIST_OF_BOOK_TYPE_REF = new TypeRef<List<BookDTO>>() {
     };

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheMockingTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheMockingTest.java
@@ -14,14 +14,11 @@ import org.mockito.Mockito;
 import io.quarkus.it.mongodb.panache.reactive.person.MockableReactivePersonRepository;
 import io.quarkus.it.mongodb.panache.reactive.person.ReactivePersonEntity;
 import io.quarkus.panache.mock.PanacheMock;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
-import io.quarkus.test.mongodb.MongoReplicaSetTestResource;
 import io.smallrye.mutiny.Uni;
 
 @QuarkusTest
-@QuarkusTestResource(MongoReplicaSetTestResource.class)
 public class ReactiveMongodbPanacheMockingTest {
 
     private static final Duration timeout = Duration.ofSeconds(2);

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/reactive/ReactiveMongodbPanacheResourceTest.java
@@ -33,9 +33,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.quarkus.it.mongodb.panache.BookDTO;
 import io.quarkus.it.mongodb.panache.book.BookDetail;
 import io.quarkus.it.mongodb.panache.person.Person;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.mongodb.MongoReplicaSetTestResource;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.config.ObjectMapperConfig;
@@ -43,7 +41,6 @@ import io.restassured.parsing.Parser;
 import io.restassured.response.Response;
 
 @QuarkusTest
-@QuarkusTestResource(MongoReplicaSetTestResource.class)
 class ReactiveMongodbPanacheResourceTest {
     private static final TypeRef<List<BookDTO>> LIST_OF_BOOK_TYPE_REF = new TypeRef<List<BookDTO>>() {
     };

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/reactive/transaction/ReactiveMongodbPanacheTransactionTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/reactive/transaction/ReactiveMongodbPanacheTransactionTest.java
@@ -13,9 +13,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import io.quarkus.it.mongodb.panache.transaction.PersonDTO;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.mongodb.MongoReplicaSetTestResource;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.config.ObjectMapperConfig;
@@ -23,7 +21,6 @@ import io.restassured.parsing.Parser;
 import io.restassured.response.Response;
 
 @QuarkusTest
-@QuarkusTestResource(MongoReplicaSetTestResource.class)
 class ReactiveMongodbPanacheTransactionTest {
     private static final TypeRef<List<PersonDTO>> LIST_OF_PERSON_TYPE_REF = new TypeRef<List<PersonDTO>>() {
     };

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/record/MongodbPanacheRecordTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/record/MongodbPanacheRecordTest.java
@@ -6,13 +6,10 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.mongodb.MongoReplicaSetTestResource;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-@QuarkusTestResource(MongoReplicaSetTestResource.class)
 class MongodbPanacheRecordTest {
 
     private static final String ROOT_URL = "/persons/record";

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/transaction/MongodbPanacheTransactionTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/transaction/MongodbPanacheTransactionTest.java
@@ -12,9 +12,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.mongodb.MongoReplicaSetTestResource;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.config.ObjectMapperConfig;
@@ -22,7 +20,6 @@ import io.restassured.parsing.Parser;
 import io.restassured.response.Response;
 
 @QuarkusTest
-@QuarkusTestResource(MongoReplicaSetTestResource.class)
 class MongodbPanacheTransactionTest {
     private static final TypeRef<List<PersonDTO>> LIST_OF_PERSON_TYPE_REF = new TypeRef<List<PersonDTO>>() {
     };


### PR DESCRIPTION
This way, we keep it up to date, because the previous version was a pre-release of ORM 5-6.
This required some visitor changes, and in particular there's a precedence change between 'and/or' expresions who now require paren grouping.
Also, literals are not implemented correctly: only strings are supported but this was already the case: tests do not test other literals.

I could not run the tests locally, due to an outdated libssl requirement of flapdoodle. Hopefully CI will get it running.