### PR TITLE
Upgrade to Hibernate Search 7.1.0.CR1, bump Elasticsearch/OpenSearch version for tests/devservices to 8.12/2.11

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -106,7 +106,7 @@
         <hibernate-reactive.version>2.2.2.Final</hibernate-reactive.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <!-- When updating, align hibernate-search.version-for-documentation in docs/pom.xml -->
-        <hibernate-search.version>7.0.0.Final</hibernate-search.version>
+        <hibernate-search.version>7.1.0.CR1</hibernate-search.version>
         <narayana.version>7.0.0.Final</narayana.version>
         <agroal.version>2.1</agroal.version>
         <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -88,7 +88,7 @@
         <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
         <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
-        <opensearch-server.version>2.9.0</opensearch-server.version>
+        <opensearch-server.version>2.11.1</opensearch-server.version>
         <opensearch.image>docker.io/opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>
         <opensearch.protocol>http</opensearch.protocol>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -83,7 +83,7 @@
         <volume.access.modifier>:Z</volume.access.modifier>
 
         <!-- Defaults for integration tests -->
-        <elasticsearch-server.version>8.9.1</elasticsearch-server.version>
+        <elasticsearch-server.version>8.12.1</elasticsearch-server.version>
         <elasticsearch.image>docker.io/elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
         <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
         <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -759,7 +759,7 @@ as shown below.
 
 [source,properties]
 ----
-quarkus.hibernate-search-orm.elasticsearch.version=opensearch:1.2
+quarkus.hibernate-search-orm.elasticsearch.version=opensearch:2.11
 ----
 
 All other configuration options and APIs are exactly the same as with Elasticsearch.

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -259,7 +259,7 @@ public class DevServicesElasticsearchProcessor {
         // Disable disk-based shard allocation thresholds:
         // in a single-node setup they just don't make sense,
         // and lead to problems on large disks with little space left.
-        // See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
+        // See https://www.elastic.co/guide/en/elasticsearch/reference/8.12/modules-cluster.html#disk-based-shard-allocation
         container.addEnv("cluster.routing.allocation.disk.threshold_enabled", "false");
         container.addEnv("ES_JAVA_OPTS", config.javaOpts);
         return container;

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/resources/application-start-offline.properties
@@ -3,7 +3,7 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 
-quarkus.hibernate-search-orm.elasticsearch.version=8.9
+quarkus.hibernate-search-orm.elasticsearch.version=8.12
 # Simulate an offline Elasticsearch instance by pointing to a non-existing cluster
 quarkus.hibernate-search-orm.elasticsearch.hosts=localhost:14800
 quarkus.hibernate-search-orm.schema-management.strategy=none

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateSearchActiveFalseAndNamedPuActiveTrueTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateSearchActiveFalseAndNamedPuActiveTrueTest.java
@@ -19,11 +19,11 @@ public class DevUIHibernateSearchActiveFalseAndNamedPuActiveTrueTest extends Abs
                             + "quarkus.hibernate-orm.datasource=<default>\n"
                             + "quarkus.hibernate-orm.packages=io.quarkus.test.devui\n"
                             + "quarkus.hibernate-search-orm.active=false\n"
-                            + "quarkus.hibernate-search-orm.elasticsearch.version=8.9\n"
+                            + "quarkus.hibernate-search-orm.elasticsearch.version=8.12\n"
                             // ... but it's (implicitly) active for a named PU
                             + "quarkus.hibernate-orm.\"namedpu\".datasource=nameddatasource\n"
                             + "quarkus.hibernate-orm.\"namedpu\".packages=io.quarkus.test.devui.namedpu\n"
-                            + "quarkus.hibernate-search-orm.\"namedpu\".elasticsearch.version=8.9\n"
+                            + "quarkus.hibernate-search-orm.\"namedpu\".elasticsearch.version=8.12\n"
                             // Start Hibernate Search offline for the named PU,
                             // because we don't have dev services except for the default PU
                             + "quarkus.hibernate-search-orm.\"namedpu\".schema-management.strategy=none\n"

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateSearchActiveFalseTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateSearchActiveFalseTest.java
@@ -14,7 +14,7 @@ public class DevUIHibernateSearchActiveFalseTest extends AbstractDevUIHibernateS
                             + "quarkus.datasource.jdbc.url=jdbc:h2:mem:test\n"
                             // Hibernate Search is inactive: the dev console should be empty.
                             + "quarkus.hibernate-search-orm.active=false\n"
-                            + "quarkus.hibernate-search-orm.elasticsearch.version=8.9\n"),
+                            + "quarkus.hibernate-search-orm.elasticsearch.version=8.12\n"),
                     "application.properties")
                     .addClasses(MyIndexedEntity.class));
 

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateSearchSmokeTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devui/DevUIHibernateSearchSmokeTest.java
@@ -12,7 +12,7 @@ public class DevUIHibernateSearchSmokeTest extends AbstractDevUIHibernateSearchT
             .withApplicationRoot((jar) -> jar.addAsResource(
                     new StringAsset("quarkus.datasource.db-kind=h2\n"
                             + "quarkus.datasource.jdbc.url=jdbc:h2:mem:test\n"
-                            + "quarkus.hibernate-search-orm.elasticsearch.version=8.9\n"
+                            + "quarkus.hibernate-search-orm.elasticsearch.version=8.12\n"
                             // Start offline, we don't have an Elasticsearch cluster here
                             + "quarkus.hibernate-search-orm.schema-management.strategy=none\n"
                             + "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled=false\n"),

--- a/integration-tests/elasticsearch-java-client/pom.xml
+++ b/integration-tests/elasticsearch-java-client/pom.xml
@@ -170,7 +170,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.12/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/elasticsearch-rest-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-client/pom.xml
@@ -170,7 +170,7 @@
                       <!-- Disable disk-based shard allocation thresholds:
                            in a single-node setup they just don't make sense,
                            and lead to problems on large disks with little space left.
-                           See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
+                           See https://www.elastic.co/guide/en/elasticsearch/reference/8.12/modules-cluster.html#disk-based-shard-allocation
                        -->
                       <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                       <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-outbox-polling/pom.xml
@@ -211,7 +211,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.12/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
@@ -227,7 +227,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.12/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
@@ -189,7 +189,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.12/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/mapping/MappingTestResource.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/mapping/MappingTestResource.java
@@ -44,7 +44,7 @@ public class MappingTestResource {
         // since the property overrides this mapper from the extension:
         assertThatThrownBy(() -> assertSearch(searchSession, MappingTestingSearchExtensionEntity.class))
                 .isInstanceOf(SearchException.class)
-                .hasMessageContainingAll("No matching indexed entity types for types",
+                .hasMessageContainingAll("No matching indexed entity types for classes",
                         MappingTestingSearchExtensionEntity.class.getName());
         return "OK";
     }
@@ -58,15 +58,15 @@ public class MappingTestResource {
 
         assertThatThrownBy(() -> assertSearch(searchSession, MappingTestingApplicationBeanEntity.class))
                 .isInstanceOf(SearchException.class)
-                .hasMessageContainingAll("No matching indexed entity types for types",
+                .hasMessageContainingAll("No matching indexed entity types for classes",
                         MappingTestingApplicationBeanEntity.class.getName());
         assertThatThrownBy(() -> assertSearch(searchSession, MappingTestingDependentBeanEntity.class))
                 .isInstanceOf(SearchException.class)
-                .hasMessageContainingAll("No matching indexed entity types for types",
+                .hasMessageContainingAll("No matching indexed entity types for classes",
                         MappingTestingDependentBeanEntity.class.getName());
         assertThatThrownBy(() -> assertSearch(searchSession, MappingTestingClassEntity.class))
                 .isInstanceOf(SearchException.class)
-                .hasMessageContainingAll("No matching indexed entity types for types",
+                .hasMessageContainingAll("No matching indexed entity types for classes",
                         MappingTestingClassEntity.class.getName());
 
         assertSearch(searchSession, MappingTestingSearchExtensionEntity.class);

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
@@ -38,7 +38,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.9"));
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.12"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to Elasticsearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.9");
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "8.12");
         }
 
         @Override

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest.java
@@ -26,10 +26,10 @@ public class HibernateSearchOpenSearchDevServicesConfiguredExplicitlyTest {
             return Map.of(
                     "quarkus.elasticsearch.devservices.enabled", "true",
                     // This needs to be different from the default image, or the test makes no sense.
-                    "quarkus.elasticsearch.devservices.image-name", "docker.io/opensearchproject/opensearch:2.8.0",
+                    "quarkus.elasticsearch.devservices.image-name", "docker.io/opensearchproject/opensearch:2.10.0",
                     // This needs to match the version used just above,
                     // so that Hibernate Search itself will assert that we're using a custom version.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.8");
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.10");
         }
 
         @Override

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest.java
@@ -38,7 +38,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledExplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.9"));
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.11"));
             return config;
         }
 

--- a/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-opensearch/src/test/java/io/quarkus/it/hibernate/search/orm/opensearch/devservices/HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest.java
@@ -37,7 +37,7 @@ public class HibernateSearchOpenSearchDevServicesDisabledImplicitlyTest {
                     // But here it doesn't matter as we won't send a request to OpenSearch anyway,
                     // so we're free to put anything.
                     // Just make sure to set something consistent with what we have in application.properties.
-                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.9");
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "opensearch:2.11");
         }
 
         @Override

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -162,7 +162,7 @@
                                             <!-- Disable disk-based shard allocation thresholds:
                                                  in a single-node setup they just don't make sense,
                                                  and lead to problems on large disks with little space left.
-                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/modules-cluster.html#disk-based-shard-allocation
+                                                 See https://www.elastic.co/guide/en/elasticsearch/reference/8.12/modules-cluster.html#disk-based-shard-allocation
                                              -->
                                             <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <!-- Disable some features that are not needed in our tests and just slow down startup -->


### PR DESCRIPTION
Announcement for Hibernate Search: https://in.relation.to/2024/02/12/hibernate-search-7-1-0-CR1/

Most important is the addition of [vector search](https://docs.jboss.org/hibernate/search/7.1/reference/en-US/html_single/#search-dsl-predicate-knn), though proper integration (e.g. with Langchain4j) will require follow-up PRs; this is just the version bump.
Also interesting are the [changes to the Standalone Pojo Mapper](https://in.relation.to/2024/02/12/hibernate-search-7-1-0-CR1/#standalon-pojo-mapper-simpler-entity-registration), though it's not available on Quarkus yet; I'm working on that separately (#26182).

This version of Hibernate Search is still targeting Hibernate ORM 6.4, which we currently use in Quarkus.

I guarantee a 7.1.0.Final before the release of Quarkus 3.9.0.CR1 in March; TBH it will likely happen in the next two weeks, tops.

I added the version bumps for Elasticsearch/OpenSearch in devservices mostly because it made sense: vector search is better in Elsaticsearch 8.12 / OpenSearch 2.11. They are not strictly necessary though.

We will need an entry in the migration guide to cover:

* Potential changes to the schema when using outbox-polling coordination (preview in Quarkus): https://docs.jboss.org/hibernate/search/7.1/migration/html_single/#outboxpolling
* The version bumps for the Elasticsearch/OpenSearch devservices