### PR TITLE
Fail early if OIDC client password grant is misconfigured

### DIFF
--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientPasswordGrantSecretIsMissingTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientPasswordGrantSecretIsMissingTestCase.java
@@ -1,0 +1,48 @@
+package io.quarkus.oidc.client;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OidcClientPasswordGrantSecretIsMissingTestCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(
+                            "quarkus.oidc-client.token-path=http://localhost:8180/oidc/tokens\n"
+                                    + "quarkus.oidc-client.client-id=quarkus\n"
+                                    + "quarkus.oidc-client.credentials.secret=secret\n"
+                                    + "quarkus.oidc-client.grant.type=password\n"
+                                    + "quarkus.oidc-client.grant-options.password.user=alice\n"),
+                            "application.properties"))
+            .assertException(t -> {
+                Throwable e = t;
+                ConfigurationException te = null;
+                while (e != null) {
+                    if (e instanceof ConfigurationException) {
+                        te = (ConfigurationException) e;
+                        break;
+                    }
+                    e = e.getCause();
+                }
+                assertNotNull(te);
+                assertTrue(
+                        te.getMessage()
+                                .contains("Username and password must be set when a password grant is used"),
+                        te.getMessage());
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail();
+    }
+
+}

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -170,10 +171,16 @@ public class OidcClientRecorder {
                                         // Without this block `password` will be listed first, before `username`
                                         // which is not a technical problem but might affect Wiremock tests or the endpoints
                                         // which expect a specific order.
-                                        tokenGrantParams.add(OidcConstants.PASSWORD_GRANT_USERNAME,
-                                                grantOptions.get(OidcConstants.PASSWORD_GRANT_USERNAME));
-                                        tokenGrantParams.add(OidcConstants.PASSWORD_GRANT_PASSWORD,
-                                                grantOptions.get(OidcConstants.PASSWORD_GRANT_PASSWORD));
+                                        final String userName = grantOptions.get(OidcConstants.PASSWORD_GRANT_USERNAME);
+                                        final String userPassword = grantOptions.get(OidcConstants.PASSWORD_GRANT_PASSWORD);
+                                        if (userName == null || userPassword == null) {
+                                            throw new ConfigurationException(
+                                                    "Username and password must be set when a password grant is used",
+                                                    Set.of("quarkus.oidc-client.grant.type",
+                                                            "quarkus.oidc-client.grant-options"));
+                                        }
+                                        tokenGrantParams.add(OidcConstants.PASSWORD_GRANT_USERNAME, userName);
+                                        tokenGrantParams.add(OidcConstants.PASSWORD_GRANT_PASSWORD, userPassword);
                                         for (Map.Entry<String, String> entry : grantOptions.entrySet()) {
                                             if (!OidcConstants.PASSWORD_GRANT_USERNAME.equals(entry.getKey())
                                                     && !OidcConstants.PASSWORD_GRANT_PASSWORD.equals(entry.getKey())) {


### PR DESCRIPTION
Fixes #38504

This PR includes a minor fix related to the misconfigured OIDC client password grant (#38504).