### PR TITLE
Fix guide URL in RESTEasy Client extension

### DIFF
--- a/extensions/resteasy-classic/resteasy-client-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-client-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,6 +9,7 @@ metadata:
   - "microprofile-rest-client"
   - "json"
   - "jackson"
+  guide: "https://quarkus.io/guides/resteasy-client"
   categories:
   - "web"
   - "serialization"

--- a/extensions/resteasy-classic/resteasy-client-jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-client-jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,6 +8,7 @@ metadata:
   - "web-client"
   - "microprofile-rest-client"
   - "jaxb"
+  guide: "https://quarkus.io/guides/resteasy-client"
   categories:
   - "web"
   - "serialization"

--- a/extensions/resteasy-classic/resteasy-client-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-client-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,6 +9,7 @@ metadata:
   - "microprofile-rest-client"
   - "json"
   - "jsonb"
+  guide: "https://quarkus.io/guides/resteasy-client"
   categories:
   - "web"
   - "serialization"

--- a/extensions/resteasy-classic/resteasy-client-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-client-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,6 +8,7 @@ metadata:
   - "web-client"
   - "microprofile-rest-client"
   - "mutiny"
+  guide: "https://quarkus.io/guides/resteasy-client"
   categories:
   - "web"
   - "reactive"

--- a/extensions/resteasy-classic/resteasy-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   - "rest-client"
   - "web-client"
   - "microprofile-rest-client"
-  guide: "https://quarkus.io/guides/rest-client"
+  guide: "https://quarkus.io/guides/resteasy-client"
   categories:
   - "web"
   codestart:


### PR DESCRIPTION
This is a consequence of renaming the extension in 3.7. I also added the guide to the subextensions.

@geoand a tiny thing I missed when I renamed the extensions and the guide.