### PR TITLE
ArC: fix interception when some methods return void

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -341,7 +341,7 @@ public class SubclassGenerator extends AbstractGenerator {
                         applicationClassPredicate.test(bean.getBeanClass()),
                         funBytecode.getMethodParam(1),
                         funBytecode.getMethodParam(0));
-                funBytecode.returnValue(ret);
+                funBytecode.returnValue(ret != null ? ret : funBytecode.loadNull());
                 constructor.invokeInterfaceMethod(MethodDescriptors.LIST_ADD, methodsList, fun.getInstance());
             }
             constructor.writeInstanceField(field.getFieldDescriptor(), constructor.getThis(), methodsList);
@@ -461,9 +461,9 @@ public class SubclassGenerator extends AbstractGenerator {
                     MethodDescriptor virtualMethodDescriptor = MethodDescriptor.ofMethod(declaringClass,
                             originalMethodDescriptor.getName(),
                             decoratorMethodDescriptor.getReturnType(), decoratorMethodDescriptor.getParameterTypes());
-                    funcBytecode
-                            .returnValue(funcBytecode.invokeVirtualMethod(virtualMethodDescriptor, funDecoratorInstance,
-                                    superParamHandles));
+                    ResultHandle superResult = funcBytecode.invokeVirtualMethod(virtualMethodDescriptor, funDecoratorInstance,
+                            superParamHandles);
+                    funcBytecode.returnValue(superResult != null ? superResult : funcBytecode.loadNull());
                 } else {
                     ResultHandle superResult = funcBytecode.invokeVirtualMethod(forwardDescriptor, targetHandle,
                             superParamHandles);

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/VoidMethodDecoratorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/VoidMethodDecoratorTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.arc.test.decorators;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class VoidMethodDecoratorTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Performer.class, MainPerformer.class,
+            PerformerDecorator.class);
+
+    @Test
+    public void testDecoration() {
+        MainPerformer performer = Arc.container().instance(MainPerformer.class).get();
+
+        assertFalse(MainPerformer.DONE.get());
+        assertFalse(PerformerDecorator.DONE.get());
+
+        performer.doSomething();
+
+        assertTrue(MainPerformer.DONE.get());
+        assertTrue(PerformerDecorator.DONE.get());
+    }
+
+    interface Performer {
+        void doSomething();
+    }
+
+    @ApplicationScoped
+    static class MainPerformer implements Performer {
+        static final AtomicBoolean DONE = new AtomicBoolean();
+
+        @Override
+        public void doSomething() {
+            DONE.set(true);
+        }
+    }
+
+    @Dependent
+    @Priority(1)
+    @Decorator
+    static class PerformerDecorator implements Performer {
+        static final AtomicBoolean DONE = new AtomicBoolean();
+
+        @Inject
+        @Delegate
+        Performer delegate;
+
+        @Override
+        public void doSomething() {
+            DONE.set(true);
+            delegate.doSomething();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/interceptor/VoidMethodInterceptorAndDecoratorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/interceptor/VoidMethodInterceptorAndDecoratorTest.java
@@ -1,0 +1,101 @@
+package io.quarkus.arc.test.decorators.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class VoidMethodInterceptorAndDecoratorTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Performer.class, MainPerformer.class,
+            PerformerDecorator.class, MyInterceptorBinding.class, MyInterceptor.class);
+
+    @Test
+    public void testDecoration() {
+        MainPerformer performer = Arc.container().instance(MainPerformer.class).get();
+
+        assertFalse(MainPerformer.DONE.get());
+        assertFalse(PerformerDecorator.DONE.get());
+        assertFalse(MyInterceptor.INTERCEPTED.get());
+
+        performer.doSomething();
+
+        assertTrue(MainPerformer.DONE.get());
+        assertTrue(PerformerDecorator.DONE.get());
+        assertTrue(MyInterceptor.INTERCEPTED.get());
+    }
+
+    interface Performer {
+        void doSomething();
+    }
+
+    @ApplicationScoped
+    @MyInterceptorBinding
+    static class MainPerformer implements Performer {
+        static final AtomicBoolean DONE = new AtomicBoolean();
+
+        @Override
+        public void doSomething() {
+            DONE.set(true);
+        }
+    }
+
+    @Dependent
+    @Priority(1)
+    @Decorator
+    static class PerformerDecorator implements Performer {
+        static final AtomicBoolean DONE = new AtomicBoolean();
+
+        @Inject
+        @Delegate
+        Performer delegate;
+
+        @Override
+        public void doSomething() {
+            DONE.set(true);
+            delegate.doSomething();
+        }
+    }
+
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @InterceptorBinding
+    public @interface MyInterceptorBinding {
+    }
+
+    @MyInterceptorBinding
+    @Priority(1)
+    @Interceptor
+    static class MyInterceptor {
+        static final AtomicBoolean INTERCEPTED = new AtomicBoolean();
+
+        @AroundInvoke
+        Object log(InvocationContext ctx) throws Exception {
+            INTERCEPTED.set(true);
+            return ctx.proceed();
+        }
+    }
+}


### PR DESCRIPTION
This commit fixes 2 cases when invalid bytecode is generated:

- when a `void`-returning method is intercepted and also decorated
- when an interceptor declared on a target class returns `void`

Fixes #38236