### PR TITLE
Update ibmcom/db2 image version

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -95,7 +95,7 @@
         <!-- Database images for JDBC/Reactive/Hibernate tests and devservices -->
         <postgres.image>docker.io/postgres:14</postgres.image>
         <mariadb.image>docker.io/mariadb:10.11</mariadb.image>
-        <db2.image>docker.io/ibmcom/db2:11.5.7.0a</db2.image>
+        <db2.image>docker.io/ibmcom/db2:11.5.8.0</db2.image>
         <mssql.image>mcr.microsoft.com/mssql/server:2022-latest</mssql.image>
         <mysql.image>docker.io/mysql:8.0</mysql.image>
         <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>


### PR DESCRIPTION
Update image version of db2 image as used driver is now 11.5.8.0 https://github.com/quarkusio/quarkus/blob/main/bom/application/pom.xml#L138