### PR TITLE
Revive Podman Test Build workflow

### DIFF
--- a/.github/workflows/podman-build.yml
+++ b/.github/workflows/podman-build.yml
@@ -74,6 +74,7 @@ jobs:
             | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
           sudo apt-get update -qq
           sudo apt-get -qq -y install podman
+          sudo bash -c "echo -e '[engine]\nservice_timeout=0' >> /etc/containers/containers.conf"
       # Runs a single command using the runners shell
       - name: Check podman
         run: docker version
@@ -89,7 +90,7 @@ jobs:
           key: q2maven-${{ steps.get-date.outputs.date }}
       - name: Initial build
         run: |
-          ./mvnw -T1C $COMMON_MAVEN_ARGS -DskipTests -DskipITs -Dinvoker.skip -Dno-format -Dtcks -Prelocations clean install
+          ./mvnw -T1C $COMMON_MAVEN_ARGS -DskipTests -DskipITs -DskipDocs -Dinvoker.skip -Dskip.gradle.tests -Djbang.skip -Dtruststore.skip -Dno-format -Dtcks -Prelocations clean install
       - name: Verify extension dependencies
         shell: bash
         run: ./update-extension-dependencies.sh $COMMON_MAVEN_ARGS
@@ -149,7 +150,7 @@ jobs:
       - name: Build
         shell: bash
         # Despite the pre-calculated run_jvm flag, GIB has to be re-run here to figure out the exact submodules to build.
-        run: ./mvnw $COMMON_MAVEN_ARGS install -Dsurefire.timeout=1200 -pl !integration-tests/gradle -pl !integration-tests/maven -pl !integration-tests/devtools -pl !docs $JVM_TEST_MAVEN_ARGS ${{ needs.build-jdk11.outputs.gib_args }}
+        run: ./mvnw $COMMON_MAVEN_ARGS install -Dsurefire.timeout=1200 -pl !integration-tests/gradle -pl !integration-tests/maven -pl !integration-tests/devmode -pl !integration-tests/devtools -Dno-test-kubernetes -pl !docs $JVM_TEST_MAVEN_ARGS ${{ steps.get-gib-args.outputs.gib_args }}
       - name: Delete Local Artifacts From Cache
         shell: bash
         run: rm -r ~/.m2/repository/io/quarkus


### PR DESCRIPTION
- Podman config service_timeout=0 for test containers compatibility

In my trial runs (ex. https://github.com/ozangunalp/quarkus/actions/runs/7913255728/job/21600534973)
I still see 3 test ITs failing:
- Quarkus - Integration Tests - Container Image - Invoker FAILURE [03:16 min]
- Quarkus - Integration Tests - Hibernate Reactive - MySQL FAILURE [ 23.601 s]
- Quarkus - Integration Tests - Hibernate Reactive - MySQL - With Agroal and Flyway FAILURE [ 23.719 s]

I tried updating the mysql image to 8.3 but did not resolve the issue.