### PR TITLE
Enhance RestMulti, configurable demand + distinct objects

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -1005,6 +1005,124 @@ public class Endpoint {
 }
 ----
 
+=== Concurrent stream element processing
+
+By default, `RestMulti` ensures serial/sequential order of the items/elements produced by the wrapped
+`Multi` by using a value of 1 for the demand signaled to the publishers. To enable concurrent
+processing/generation of multiple items, use `withDemand(long demand)`.
+
+Using a demand higher than 1 is useful when multiple items shall be returned and the production of each
+item takes some time, i.e. when parallel/concurrent production improves the service response time. Be
+aware the concurrent processing also requires more resources and puts a higher load on services or
+resources that are needed to produce the items. Also consider using `Multi.capDemandsTo(long)` and
+`Multi.capDemandsUsing(LongFunction)`.
+
+The example below produces 5 (JSON) strings, but the _order_ of the strings in the returned JSON array
+is not guaranteed. The below example also works for JSON objects and not just simple types.
+
+[source,java]
+----
+package org.acme.rest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.smallrye.mutiny.Multi;
+import org.jboss.resteasy.reactive.RestMulti;
+
+@Path("message-stream")
+public class Endpoint {
+    @GET
+    public Multi<String> streamMessages() {
+        Multi<String> sourceMulti = Multi
+            .createBy()
+            .merging()
+            .streams(
+                Multi.createFrom().items(
+                    "message-1",
+                    "message-2",
+                    "message-3",
+                    "message-4",
+                    "message-5"
+                )
+            );
+
+        return RestMulti
+            .fromMultiData(sourceMulti)
+            .withDemand(5)
+            .build();
+    }
+}
+----
+
+Example response, the order is non-deterministic.
+
+[source,text]
+----
+"message-3"
+"message-5"
+"message-4"
+"message-1"
+"message-2"
+----
+
+=== Returning multiple JSON objects
+
+By default, `RestMulti` returns items/elements produced by the wrapped `Multi` as a JSON array, if the
+media-type is `application/json`. To return separate JSON objects that are not wrapped in a JSON array,
+use `encodeAsArray(false)` (`encodeAsArray(true)` is the default). Note that streaming multiple
+objects this way requires a slightly different parsing on the client side, but objects can be parsed and
+consumed as they appear without having to deserialize a possibly huge result at once.
+
+The example below produces 5 (JSON) strings, that are not wrapped in an array, like this:
+
+[source,text]
+----
+"message-1"
+"message-2"
+"message-3"
+"message-4"
+"message-5"
+----
+
+[source,java]
+----
+package org.acme.rest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.smallrye.mutiny.Multi;
+import org.jboss.resteasy.reactive.RestMulti;
+
+@Path("message-stream")
+public class Endpoint {
+    @GET
+    public Multi<String> streamMessages() {
+        Multi<String> sourceMulti = Multi
+            .createBy()
+            .merging()
+            .streams(
+                Multi.createFrom().items(
+                    "message-1",
+                    "message-2",
+                    "message-3",
+                    "message-4",
+                    "message-5"
+                )
+            );
+
+        return RestMulti
+            .fromMultiData(sourceMulti)
+            .encodeAsJsonArray(false)
+            .build();
+    }
+}
+----
+
+
 === Server-Sent Event (SSE) support
 
 If you want to stream JSON objects in your response, you can use

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/streams/Demands.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/streams/Demands.java
@@ -1,0 +1,15 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.streams;
+
+import java.util.List;
+
+public class Demands {
+    public List<Long> demands;
+
+    public Demands(List<Long> demands) {
+        this.demands = demands;
+    }
+
+    // for Jsonb
+    public Demands() {
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/PublisherResponseHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/PublisherResponseHandler.java
@@ -10,9 +10,6 @@ import java.util.Map;
 import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
 
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.sse.OutboundSseEvent;
@@ -51,8 +48,9 @@ public class PublisherResponseHandler implements ServerRestHandler {
 
     private static class SseMultiSubscriber extends AbstractMultiSubscriber {
 
-        SseMultiSubscriber(ResteasyReactiveRequestContext requestContext, List<StreamingResponseCustomizer> staticCustomizers) {
-            super(requestContext, staticCustomizers);
+        SseMultiSubscriber(ResteasyReactiveRequestContext requestContext, List<StreamingResponseCustomizer> staticCustomizers,
+                long demand) {
+            super(requestContext, staticCustomizers, demand);
         }
 
         @Override
@@ -63,67 +61,43 @@ public class PublisherResponseHandler implements ServerRestHandler {
             } else {
                 event = new OutboundSseEventImpl.BuilderImpl().data(item).build();
             }
-            SseUtil.send(requestContext, event, staticCustomizers).whenComplete(new BiConsumer<Object, Throwable>() {
-                @Override
-                public void accept(Object v, Throwable t) {
-                    if (t != null) {
-                        // need to cancel because the exception didn't come from the Multi
-                        subscription.cancel();
-                        handleException(requestContext, t);
-                    } else {
-                        // send in the next item
-                        subscription.request(1);
-                    }
+            SseUtil.send(requestContext, event, staticCustomizers).whenComplete((v, t) -> {
+                if (t != null) {
+                    // need to cancel because the exception didn't come from the Multi
+                    subscription.cancel();
+                    handleException(requestContext, t);
+                } else {
+                    // send in the next item
+                    subscription.request(demand);
                 }
             });
         }
     }
 
-    private static class ChunkedStreamingMultiSubscriber extends StreamingMultiSubscriber {
+    @SuppressWarnings("rawtypes")
+    private static class StreamingMultiSubscriber extends AbstractMultiSubscriber {
 
         private static final String LINE_SEPARATOR = "\n";
 
-        private boolean isFirstItem = true;
-
-        ChunkedStreamingMultiSubscriber(ResteasyReactiveRequestContext requestContext,
-                List<StreamingResponseCustomizer> staticCustomizers, Publisher publisher, boolean json) {
-            super(requestContext, staticCustomizers, publisher, json);
-        }
-
-        @Override
-        protected String messagePrefix() {
-            // When message is chunked, we don't need to add prefixes at first
-            return null;
-        }
-
-        @Override
-        protected String messageSuffix() {
-            return LINE_SEPARATOR;
-        }
-
-        @Override
-        protected String onCompleteText() {
-            // When message is chunked, we don't need to add text at the end of the messages
-            return null;
-        }
-    }
-
-    private static class StreamingMultiSubscriber extends AbstractMultiSubscriber {
+        private final Publisher publisher;
+        private final boolean json;
+        private final boolean encodeAsJsonArray;
 
         // Huge hack to stream valid json
-        private boolean json;
-        private String nextJsonPrefix;
-        private boolean hadItem;
-
-        private final Publisher publisher;
+        private volatile String nextJsonPrefix;
+        private volatile boolean hadItem;
 
         StreamingMultiSubscriber(ResteasyReactiveRequestContext requestContext,
                 List<StreamingResponseCustomizer> staticCustomizers, Publisher publisher,
-                boolean json) {
-            super(requestContext, staticCustomizers);
+                boolean json, long demand, boolean encodeAsJsonArray) {
+            super(requestContext, staticCustomizers, demand);
             this.publisher = publisher;
             this.json = json;
-            this.nextJsonPrefix = "[";
+            // encodeAsJsonArray == true means JSON array "encoding"
+            // encodeAsJsonArray == false mean no prefix, no suffix and LF as message separator,
+            //     also used for/same as chunked-streaming
+            this.encodeAsJsonArray = encodeAsJsonArray;
+            this.nextJsonPrefix = encodeAsJsonArray ? "[" : null;
             this.hadItem = false;
         }
 
@@ -132,33 +106,29 @@ public class PublisherResponseHandler implements ServerRestHandler {
             List<StreamingResponseCustomizer> customizers = determineCustomizers(!hadItem);
             hadItem = true;
             StreamingUtil.send(requestContext, customizers, item, messagePrefix(), messageSuffix())
-                    .handle(new BiFunction<Object, Throwable, Object>() {
-                        @Override
-                        public Object apply(Object v, Throwable t) {
-                            if (t != null) {
-                                // need to cancel because the exception didn't come from the Multi
-                                try {
-                                    subscription.cancel();
-                                } catch (Throwable t2) {
-                                    t2.printStackTrace();
-                                }
-                                handleException(requestContext, t);
-                            } else {
-                                // next item will need this prefix if json
-                                nextJsonPrefix = ",";
-                                // send in the next item
-                                subscription.request(1);
+                    .handle((v, t) -> {
+                        if (t != null) {
+                            // need to cancel because the exception didn't come from the Multi
+                            try {
+                                subscription.cancel();
+                            } catch (Throwable t2) {
+                                t2.printStackTrace();
                             }
-                            return null;
+                            handleException(requestContext, t);
+                        } else {
+                            // next item will need this prefix if json
+                            nextJsonPrefix = encodeAsJsonArray ? "," : null;
+                            // send in the next item
+                            subscription.request(demand);
                         }
+                        return null;
                     });
         }
 
         private List<StreamingResponseCustomizer> determineCustomizers(boolean isFirst) {
             // we only need to obtain the customizers from the Publisher if it's the first time we are sending data and the Publisher has customizable data
             // at this point no matter the type of RestMulti we can safely obtain the headers and status
-            if (isFirst && (publisher instanceof RestMulti)) {
-                RestMulti<?> restMulti = (RestMulti<?>) publisher;
+            if (isFirst && (publisher instanceof RestMulti<?> restMulti)) {
                 Map<String, List<String>> headers = restMulti.getHeaders();
                 Integer status = restMulti.getStatus();
                 if (headers.isEmpty() && (status == null)) {
@@ -201,6 +171,10 @@ public class PublisherResponseHandler implements ServerRestHandler {
         }
 
         protected String onCompleteText() {
+            if (!encodeAsJsonArray) {
+                return null;
+            }
+
             String postfix;
             // check if we never sent the open prefix
             if (!hadItem) {
@@ -218,20 +192,23 @@ public class PublisherResponseHandler implements ServerRestHandler {
         }
 
         protected String messageSuffix() {
-            return null;
+            return !encodeAsJsonArray ? LINE_SEPARATOR : null;
         }
     }
 
     static abstract class AbstractMultiSubscriber implements Subscriber<Object> {
-        protected Subscription subscription;
-        protected ResteasyReactiveRequestContext requestContext;
-        protected List<StreamingResponseCustomizer> staticCustomizers;
-        private boolean weClosed = false;
+        protected final ResteasyReactiveRequestContext requestContext;
+        protected final List<StreamingResponseCustomizer> staticCustomizers;
+        protected final long demand;
+
+        protected volatile Subscription subscription;
+        private volatile boolean weClosed = false;
 
         AbstractMultiSubscriber(ResteasyReactiveRequestContext requestContext,
-                List<StreamingResponseCustomizer> staticCustomizers) {
+                List<StreamingResponseCustomizer> staticCustomizers, long demand) {
             this.requestContext = requestContext;
             this.staticCustomizers = staticCustomizers;
+            this.demand = demand;
             // let's make sure we never restart by accident, also make sure we're not marked as completed
             requestContext.restart(AWOL, true);
             requestContext.serverResponse().addCloseHandler(() -> {
@@ -245,7 +222,7 @@ public class PublisherResponseHandler implements ServerRestHandler {
         public void onSubscribe(Subscription s) {
             this.subscription = s;
             // initially ask for one item
-            s.request(1);
+            s.request(demand);
         }
 
         @Override
@@ -279,13 +256,8 @@ public class PublisherResponseHandler implements ServerRestHandler {
     private static final Logger log = Logger.getLogger(PublisherResponseHandler.class);
 
     private static final ServerRestHandler[] AWOL = new ServerRestHandler[] {
-            new ServerRestHandler() {
-
-                @Override
-                public void handle(ResteasyReactiveRequestContext requestContext)
-                        throws Exception {
-                    throw new IllegalStateException("FAILURE: should never be restarted");
-                }
+            requestContext -> {
+                throw new IllegalStateException("FAILURE: should never be restarted");
             }
     };
 
@@ -296,8 +268,7 @@ public class PublisherResponseHandler implements ServerRestHandler {
         if (requestContextResult instanceof org.reactivestreams.Publisher) {
             requestContextResult = AdaptersToFlow.publisher((org.reactivestreams.Publisher<?>) requestContextResult);
         }
-        if (requestContextResult instanceof Publisher) {
-            Publisher<?> result = (Publisher<?>) requestContextResult;
+        if (requestContextResult instanceof Publisher<?> result) {
             // FIXME: if we make a pretend Response and go through the normal route, we will get
             // media type negotiation and fixed entity writer set up, perhaps it's better than
             // cancelling the normal route?
@@ -310,7 +281,6 @@ public class PublisherResponseHandler implements ServerRestHandler {
                     throw new IllegalStateException(
                             "Negotiation or dynamic media type resolution for Multi is only supported when using 'org.jboss.resteasy.reactive.RestMulti'");
                 }
-
             }
             MediaType[] mediaTypes = produces.getSortedOriginalMediaTypes();
             if (mediaTypes.length != 1) {
@@ -343,24 +313,43 @@ public class PublisherResponseHandler implements ServerRestHandler {
     }
 
     private void handleChunkedStreaming(ResteasyReactiveRequestContext requestContext, Publisher<?> result, boolean json) {
-        result.subscribe(new ChunkedStreamingMultiSubscriber(requestContext, streamingResponseCustomizers, result, json));
+        long demand = 1L;
+        if (result instanceof RestMulti.SyncRestMulti) {
+            RestMulti.SyncRestMulti rest = (RestMulti.SyncRestMulti) result;
+            demand = rest.getDemand();
+        }
+        result.subscribe(
+                new StreamingMultiSubscriber(requestContext, streamingResponseCustomizers, result, json, demand, false));
     }
 
     private void handleStreaming(ResteasyReactiveRequestContext requestContext, Publisher<?> result, boolean json) {
-        result.subscribe(new StreamingMultiSubscriber(requestContext, streamingResponseCustomizers, result, json));
+        long demand = 1L;
+        boolean encodeAsJsonArray = true;
+        if (result instanceof RestMulti.SyncRestMulti) {
+            RestMulti.SyncRestMulti rest = (RestMulti.SyncRestMulti) result;
+            demand = rest.getDemand();
+            encodeAsJsonArray = rest.encodeAsJsonArray();
+        }
+        result.subscribe(new StreamingMultiSubscriber(requestContext, streamingResponseCustomizers, result, json, demand,
+                encodeAsJsonArray));
     }
 
     private void handleSse(ResteasyReactiveRequestContext requestContext, Publisher<?> result) {
+        long demand;
+        if (result instanceof RestMulti.SyncRestMulti) {
+            RestMulti.SyncRestMulti rest = (RestMulti.SyncRestMulti) result;
+            demand = rest.getDemand();
+        } else {
+            demand = 1L;
+        }
+
         SseUtil.setHeaders(requestContext, requestContext.serverResponse(), streamingResponseCustomizers);
         requestContext.suspend();
-        requestContext.serverResponse().write(EMPTY_BUFFER, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable throwable) {
-                if (throwable == null) {
-                    result.subscribe(new SseMultiSubscriber(requestContext, streamingResponseCustomizers));
-                } else {
-                    requestContext.resume(throwable);
-                }
+        requestContext.serverResponse().write(EMPTY_BUFFER, throwable -> {
+            if (throwable == null) {
+                result.subscribe(new SseMultiSubscriber(requestContext, streamingResponseCustomizers, demand));
+            } else {
+                requestContext.resume(throwable);
             }
         });
     }


### PR DESCRIPTION
Adds two enhancements:

1. Produce multiple JSON objects, not just an array
2. Make requested demand configurable

## Produce multiple JSON objects

Currently, `PublisherResponseHandler.StreamingMultiSubscriber` produces a JSON array, where each emitted item is encoded as a JSON array element. For some use cases it is easier to consume a bunch of "bare" JSON objects - i.e. just write the individual JSON objects, possibly separated by a newline. As an option, of course.

Proposal to add:
```java
RestMulti.fromMultiData(multi).encodeAsArray(false)...
```

With `encodeAsArray(false)`, the produced JSON would look like this:
```json
{"some": "value"}
{"some": "value"}
{"some": "value"}
```

`encodeAsArray(true)` or omitting it would use the current behavior and produce something like this:
```json
[
{"some": "value"},
{"some": "value"},
{"some": "value"}
]
```

## Configure request-demand

All implementations of `PublisherResponseHandler.AbstractMultiSubscriber` work with a hard-coded request-demand of `1`, which means that every emitted item is "produced"/"computed" serially / one-after-the-other. If the computation of individual items takes somewhat longer, possibly waiting for remote resources to reply, it makes sense to use a higher demand to produce multiple items concurrently.

For example, if each item takes maybe 250 ms (requesting data from a remote source) to be produced, and 100 items are produced, it currently takes 25 seconds. With a higher concurrency it would take a fraction of that time. I.e. if the use case is known to be not CPU but (async) I/O bound, it _might_ be legit/feasible to use a high demand.

Proposal to add:
```
RestMulti.fromMultiData(multi).withDemand( (long) 123 )...
```

Which would pass `123` as the demand for all call sites to `Subscription.request` in implementations of `PublisherResponseHandler.AbstractMultiSubscriber`.