### PR TITLE
Propagate Vert.x context on all ExecutorService methods for VirtualThreadExecutor

### DIFF
--- a/extensions/virtual-threads/runtime/src/test/java/io/quarkus/virtual/threads/VirtualThreadExecutorSupplierTest.java
+++ b/extensions/virtual-threads/runtime/src/test/java/io/quarkus/virtual/threads/VirtualThreadExecutorSupplierTest.java
@@ -5,16 +5,33 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
 
 class VirtualThreadExecutorSupplierTest {
+
+    @BeforeEach
+    void configRecorder() {
+        VirtualThreadsRecorder.config = new VirtualThreadsConfig();
+        VirtualThreadsRecorder.config.enabled = true;
+        VirtualThreadsRecorder.config.namePrefix = Optional.empty();
+    }
 
     @Test
     @EnabledForJreRange(min = JRE.JAVA_20, disabledReason = "Virtual Threads are a preview feature starting from Java 20")
@@ -42,6 +59,74 @@ class VirtualThreadExecutorSupplierTest {
         }).runSubscriptionOn(executor)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
         assertSubscriber.awaitItem(Duration.ofSeconds(1)).assertCompleted();
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_20, disabledReason = "Virtual Threads are a preview feature starting from Java 20")
+    void executePropagatesVertxContext() throws ExecutionException, InterruptedException {
+        ExecutorService executorService = VirtualThreadsRecorder.getCurrent();
+        Vertx vertx = Vertx.vertx();
+        CompletableFuture<Context> future = new CompletableFuture<>();
+        vertx.executeBlocking(() -> {
+            executorService.execute(() -> {
+                assertThatItRunsOnVirtualThread();
+                future.complete(Vertx.currentContext());
+            });
+            return null;
+        }).toCompletionStage().toCompletableFuture().get();
+        assertThat(future.get()).isNotNull();
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_20, disabledReason = "Virtual Threads are a preview feature starting from Java 20")
+    void executePropagatesVertxContextMutiny() {
+        ExecutorService executorService = VirtualThreadsRecorder.getCurrent();
+        Vertx vertx = Vertx.vertx();
+        var assertSubscriber = Uni.createFrom().voidItem()
+                .runSubscriptionOn(command -> vertx.executeBlocking(() -> {
+                    command.run();
+                    return null;
+                }))
+                .emitOn(executorService)
+                .map(x -> {
+                    assertThatItRunsOnVirtualThread();
+                    return Vertx.currentContext();
+                })
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+        assertThat(assertSubscriber.awaitItem().assertCompleted().getItem()).isNotNull();
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_20, disabledReason = "Virtual Threads are a preview feature starting from Java 20")
+    void submitPropagatesVertxContext() throws ExecutionException, InterruptedException {
+        ExecutorService executorService = VirtualThreadsRecorder.getCurrent();
+        Vertx vertx = Vertx.vertx();
+        CompletableFuture<Context> future = new CompletableFuture<>();
+        vertx.executeBlocking(() -> {
+            executorService.submit(() -> {
+                assertThatItRunsOnVirtualThread();
+                future.complete(Vertx.currentContext());
+            });
+            return null;
+        }).toCompletionStage().toCompletableFuture().get();
+        assertThat(future.get()).isNotNull();
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_20, disabledReason = "Virtual Threads are a preview feature starting from Java 20")
+    void invokeAllPropagatesVertxContext() throws ExecutionException, InterruptedException {
+        ExecutorService executorService = VirtualThreadsRecorder.getCurrent();
+        Vertx vertx = Vertx.vertx();
+        List<Future<Context>> futures = vertx.executeBlocking(() -> {
+            return executorService.invokeAll(List.of((Callable<Context>) () -> {
+                assertThatItRunsOnVirtualThread();
+                return Vertx.currentContext();
+            }, (Callable<Context>) () -> {
+                assertThatItRunsOnVirtualThread();
+                return Vertx.currentContext();
+            }));
+        }).toCompletionStage().toCompletableFuture().get();
+        assertThat(futures).allSatisfy(contextFuture -> assertThat(contextFuture.get()).isNotNull());
     }
 
     public static void assertThatItRunsOnVirtualThread() {

--- a/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/FilteredResource.java
+++ b/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/FilteredResource.java
@@ -1,5 +1,9 @@
 package io.quarkus.virtual.rr;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -7,7 +11,9 @@ import jakarta.ws.rs.core.Response;
 
 import org.jboss.logmanager.MDC;
 
+import io.quarkus.arc.Arc;
 import io.quarkus.test.vertx.VirtualThreadsAssertions;
+import io.quarkus.virtual.threads.VirtualThreads;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 import io.vertx.core.Vertx;
 
@@ -17,13 +23,28 @@ public class FilteredResource {
     @Inject
     Counter counter;
 
+    @Inject
+    @VirtualThreads
+    ExecutorService vt;
+
     @GET
     @RunOnVirtualThread
-    public Response filtered() {
+    public Response filtered() throws ExecutionException, InterruptedException {
         VirtualThreadsAssertions.assertEverything();
 
         // Request scope
         assert counter.increment() == 2;
+
+        // Request scope propagated
+        assert vt.submit(() -> counter.increment()).get() == 3;
+
+        // Request scope active
+        assert Arc.container().requestContext().isActive();
+        assert vt.submit(() -> Arc.container().requestContext().isActive()).get();
+
+        CompletableFuture<Boolean> requestContextActive = new CompletableFuture<>();
+        vt.execute(() -> requestContextActive.complete(Arc.container().requestContext().isActive()));
+        assert requestContextActive.get();
 
         // DC
         assert Vertx.currentContext().getLocal("filter").equals("test");

--- a/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/Filters.java
+++ b/integration-tests/virtual-threads/resteasy-reactive-virtual-threads/src/main/java/io/quarkus/virtual/rr/Filters.java
@@ -27,7 +27,7 @@ public class Filters {
         if (responseContext.getHeaders().get("X-filter") != null) {
             VirtualThreadsAssertions.assertEverything();
             // the request filter, the method, and here.
-            assert CDI.current().select(Counter.class).get().increment() == 3;
+            assert CDI.current().select(Counter.class).get().increment() == 4;
             assert Vertx.currentContext().getLocal("test").equals("test test");
             assert MDC.get("mdc").equals("test test");
         }


### PR DESCRIPTION
Previous propagation only decorated execute method.

- Fixes #38815