### PR TITLE
Allow `RunAndCheckMojoTestBase` subclasses to override how much memory extension tests are allowed

### DIFF
--- a/test-framework/maven/src/main/java/io/quarkus/maven/it/RunAndCheckMojoTestBase.java
+++ b/test-framework/maven/src/main/java/io/quarkus/maven/it/RunAndCheckMojoTestBase.java
@@ -25,12 +25,21 @@ public class RunAndCheckMojoTestBase extends MojoTestBase {
     protected File testDir;
     protected DevModeClient devModeClient = new DevModeClient(getPort());
     private static final int DEFAULT_PORT = 8080;
+    private static final int DEFAULT_MEMORY_IN_MB = 128;
 
     /**
      * Default to port 8080, but allow subtests to override.
      */
     protected int getPort() {
         return DEFAULT_PORT;
+    }
+
+    /**
+     * Default to quite constrained memory, but allow subclasses to override, for hungrier tests.
+     */
+
+    protected int getAllowedHeapInMb() {
+        return DEFAULT_MEMORY_IN_MB;
     }
 
     @AfterEach
@@ -101,7 +110,7 @@ public class RunAndCheckMojoTestBase extends MojoTestBase {
         //running at once, if they add default to 75% of total mem we can easily run out
         //of physical memory as they will consume way more than what they need instead of
         //just running GC
-        args.add("-Djvm.args=-Xmx128m");
+        args.add("-Djvm.args=-Xmx" + getAllowedHeapInMb() + "m");
         running.execute(args, Map.of());
     }
 


### PR DESCRIPTION
See https://github.com/quarkiverse/quarkus-pact/pull/177 and https://github.com/quarkusio/quarkus/issues/38814 for context. From Quarkus 3.7, some extension tests need more memory to run. Rather than raising the memory allowance across the board, I've made the memory configurable so that we can give hungrier tests a bit more memory. Ideally, we'd also fix https://github.com/quarkusio/quarkus/issues/38814, but we saw a similar issue a while ago (https://github.com/quarkusio/quarkus/issues/32209), and I expect we might continue to see problems that will need working around.