### PR TITLE
Add tests to the TLS certificate reload

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -3593,6 +3593,11 @@
                 <artifactId>hamcrest</artifactId>
                 <version>${hamcrest.version}</version>
             </dependency>
+            <dependency>
+                <groupId>me.escoffier.certs</groupId>
+                <artifactId>certificate-generator-junit5</artifactId>
+                <version>0.3.0</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.antlr</groupId>

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -239,8 +239,8 @@ Configure the `quarkus.http.ssl.certificate.reload-period` property to specify t
 
 [source, properties]
 ----
-quarkus.http.ssl.certificate.files=/mount/certs/cert.pem
-quarkus.http.ssl.certificate.key-files=/mount/certs/key.pem
+quarkus.http.ssl.certificate.files=/mount/certs/tls.crt
+quarkus.http.ssl.certificate.key-files=/mount/certs/tls.key
 quarkus.http.ssl.certificate.reload-period=1h
 ----
 

--- a/docs/src/main/asciidoc/management-interface-reference.adoc
+++ b/docs/src/main/asciidoc/management-interface-reference.adoc
@@ -58,6 +58,20 @@ quarkus.management.ssl.certificate.key-store-file=server-keystore.jks
 quarkus.management.ssl.certificate.key-store-password=secret
 ----
 
+Key store, trust store and certificate files can be reloaded periodically.
+Configure the `quarkus.management.ssl.certificate.reload-period` property to specify the interval at which the certificates should be reloaded:
+
+[source, properties]
+----
+quarkus.http.management.certificate.files=/mount/certs/tls.crt
+quarkus.http.management.certificate.key-files=/mount/certs/tls.key
+quarkus.http.management.certificate.reload-period=1h
+----
+
+The files are reloaded from the same location as they were initially loaded from.
+If there is no content change, the reloading is a no-op.
+It the reloading fails, the server will continue to use the previous certificates.
+
 IMPORTANT: Unlike the main HTTP server, the management interface does not handle _http_ and _https_ at the same time.
 If _https_ is configured, plain HTTP requests will be rejected.
 

--- a/extensions/vertx-http/deployment/pom.xml
+++ b/extensions/vertx-http/deployment/pom.xml
@@ -33,7 +33,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-spi</artifactId>
         </dependency>
-        
+
         <!-- Dev UI -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -64,7 +64,7 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
-        
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -109,6 +109,12 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>me.escoffier.certs</groupId>
+            <artifactId>certificate-generator-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsCertificateReloadTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsCertificateReloadTest.java
@@ -1,0 +1,160 @@
+package io.quarkus.vertx.http.certReload;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.UUID;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.runtime.options.TlsCertificateReloader;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.ext.web.Router;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certificates", certificates = {
+        @Certificate(name = "reload-A", formats = Format.PEM),
+        @Certificate(name = "reload-B", formats = Format.PEM, duration = 365),
+})
+@DisabledOnOs(OS.WINDOWS)
+public class MainHttpServerTlsCertificateReloadTest {
+
+    @TestHTTPResource(value = "/hello", ssl = true)
+    URL url;
+
+    public static final File temp = new File("target/test-certificates-" + UUID.randomUUID());
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class))
+            .overrideConfigKey("quarkus.http.ssl.insecure-requests", "redirect")
+            .overrideConfigKey("quarkus.http.ssl.certificate.reload-period", "30s")
+            .overrideConfigKey("quarkus.http.ssl.certificate.files", temp.getAbsolutePath() + "/tls.crt")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-files", temp.getAbsolutePath() + "/tls.key")
+            .overrideConfigKey("loc", temp.getAbsolutePath())
+            .setBeforeAllCustomizer(() -> {
+                try {
+                    // Prepare a random directory to store the certificates.
+                    temp.mkdirs();
+                    Files.copy(new File("target/certificates/reload-A.crt").toPath(),
+                            new File(temp, "/tls.crt").toPath());
+                    Files.copy(new File("target/certificates/reload-A.key").toPath(),
+                            new File(temp, "/tls.key").toPath());
+                    Files.copy(new File("target/certificates/reload-A-ca.crt").toPath(),
+                            new File(temp, "/ca.crt").toPath());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .setAfterAllCustomizer(() -> {
+                try {
+                    Files.deleteIfExists(new File(temp, "/tls.crt").toPath());
+                    Files.deleteIfExists(new File(temp, "/tls.key").toPath());
+                    Files.deleteIfExists(new File(temp, "/ca.crt").toPath());
+                    Files.deleteIfExists(temp.toPath());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @ConfigProperty(name = "loc")
+    File certs;
+
+    @Test
+    void test() throws IOException {
+        var options = new HttpClientOptions()
+                .setSsl(true)
+                .setDefaultPort(url.getPort())
+                .setDefaultHost(url.getHost())
+                .setTrustOptions(new PemTrustOptions().addCertPath("target/certificates/reload-A-ca.crt"));
+
+        String response1 = vertx.createHttpClient(options)
+                .request(HttpMethod.GET, "/hello")
+                .flatMap(HttpClientRequest::send)
+                .flatMap(HttpClientResponse::body)
+                .map(Buffer::toString)
+                .toCompletionStage().toCompletableFuture().join();
+
+        // Update certs
+        Files.copy(new File("target/certificates/reload-B.crt").toPath(),
+                new File(certs, "/tls.crt").toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(new File("target/certificates/reload-B.key").toPath(),
+                new File(certs, "/tls.key").toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+
+        // Trigger the reload
+        TlsCertificateReloader.reload().await().atMost(Duration.ofSeconds(10));
+
+        // The client truststore is not updated, thus it should fail.
+        assertThatThrownBy(() -> vertx.createHttpClient(options)
+                .request(HttpMethod.GET, "/hello")
+                .flatMap(HttpClientRequest::send)
+                .flatMap(HttpClientResponse::body)
+                .map(Buffer::toString)
+                .toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+
+        var options2 = new HttpClientOptions(options)
+                .setTrustOptions(new PemTrustOptions().addCertPath("target/certificates/reload-B-ca.crt"));
+
+        var response2 = vertx.createHttpClient(options2)
+                .request(HttpMethod.GET, "/hello")
+                .flatMap(HttpClientRequest::send)
+                .flatMap(HttpClientResponse::body)
+                .map(Buffer::toString)
+                .toCompletionStage().toCompletableFuture().join();
+
+        assertThat(response1).isNotEqualTo(response2); // Because cert duration are different.
+
+        // Trigger another reload
+        TlsCertificateReloader.reload().await().atMost(Duration.ofSeconds(10));
+
+        var response3 = vertx.createHttpClient(options2)
+                .request(HttpMethod.GET, "/hello")
+                .flatMap(HttpClientRequest::send)
+                .flatMap(HttpClientResponse::body)
+                .map(Buffer::toString)
+                .toCompletionStage().toCompletableFuture().join();
+
+        assertThat(response2).isEqualTo(response3);
+    }
+
+    public static class MyBean {
+
+        public void onStart(@Observes Router router) {
+            router.get("/hello").handler(rc -> {
+                var exp = ((X509Certificate) rc.request().connection().sslSession().getLocalCertificates()[0]).getNotAfter()
+                        .toInstant().toEpochMilli();
+                rc.response().end("Hello " + exp);
+            });
+        }
+
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsPKCS12CertificateReloadTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsPKCS12CertificateReloadTest.java
@@ -1,0 +1,153 @@
+package io.quarkus.vertx.http.certReload;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.UUID;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.vertx.http.runtime.options.TlsCertificateReloader;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.net.PfxOptions;
+import io.vertx.ext.web.Router;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certificates", certificates = {
+        @Certificate(name = "reload-A", formats = Format.PKCS12, password = "password"),
+        @Certificate(name = "reload-B", formats = Format.PKCS12, password = "password", duration = 365),
+})
+@DisabledOnOs(OS.WINDOWS)
+public class MainHttpServerTlsPKCS12CertificateReloadTest {
+
+    @TestHTTPResource(value = "/hello", ssl = true)
+    URL url;
+
+    public static final File temp = new File("target/test-certificates-" + UUID.randomUUID());
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(MyBean.class))
+            .overrideConfigKey("quarkus.http.ssl.insecure-requests", "redirect")
+            .overrideConfigKey("quarkus.http.ssl.certificate.reload-period", "30s")
+            .overrideConfigKey("quarkus.http.ssl.certificate.key-store-file", temp.getAbsolutePath() + "/tls.p12")
+            .overrideConfigKey("loc", temp.getAbsolutePath())
+            .setBeforeAllCustomizer(() -> {
+                try {
+                    // Prepare a random directory to store the certificates.
+                    temp.mkdirs();
+                    Files.copy(new File("target/certificates/reload-A-keystore.p12").toPath(),
+                            new File(temp, "/tls.p12").toPath());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .setAfterAllCustomizer(() -> {
+                try {
+                    Files.deleteIfExists(new File(temp, "/tls.p12").toPath());
+                    Files.deleteIfExists(temp.toPath());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+    @Inject
+    Vertx vertx;
+
+    @ConfigProperty(name = "loc")
+    File certs;
+
+    @Test
+    void test() throws IOException {
+        var options = new HttpClientOptions()
+                .setSsl(true)
+                .setDefaultPort(url.getPort())
+                .setDefaultHost(url.getHost())
+                .setTrustOptions(
+                        new PfxOptions().setPath("target/certificates/reload-A-truststore.p12").setPassword("password"));
+
+        String response1 = vertx.createHttpClient(options)
+                .request(HttpMethod.GET, "/hello")
+                .flatMap(HttpClientRequest::send)
+                .flatMap(HttpClientResponse::body)
+                .map(Buffer::toString)
+                .toCompletionStage().toCompletableFuture().join();
+
+        // Update certs
+        Files.copy(new File("target/certificates/reload-B-keystore.p12").toPath(),
+                new File(certs, "/tls.p12").toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+
+        // Trigger the reload
+        TlsCertificateReloader.reload().await().atMost(Duration.ofSeconds(10));
+
+        // The client truststore is not updated, thus it should fail.
+        assertThatThrownBy(() -> vertx.createHttpClient(options)
+                .request(HttpMethod.GET, "/hello")
+                .flatMap(HttpClientRequest::send)
+                .flatMap(HttpClientResponse::body)
+                .map(Buffer::toString)
+                .toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+
+        var options2 = new HttpClientOptions(options)
+                .setTrustOptions(
+                        new PfxOptions().setPath("target/certificates/reload-B-truststore.p12").setPassword("password"));
+
+        var response2 = vertx.createHttpClient(options2)
+                .request(HttpMethod.GET, "/hello")
+                .flatMap(HttpClientRequest::send)
+                .flatMap(HttpClientResponse::body)
+                .map(Buffer::toString)
+                .toCompletionStage().toCompletableFuture().join();
+
+        assertThat(response1).isNotEqualTo(response2); // Because cert duration are different.
+
+        // Trigger another reload
+        TlsCertificateReloader.reload().await().atMost(Duration.ofSeconds(10));
+
+        var response3 = vertx.createHttpClient(options2)
+                .request(HttpMethod.GET, "/hello")
+                .flatMap(HttpClientRequest::send)
+                .flatMap(HttpClientResponse::body)
+                .map(Buffer::toString)
+                .toCompletionStage().toCompletableFuture().join();
+
+        assertThat(response2).isEqualTo(response3);
+    }
+
+    public static class MyBean {
+
+        public void onStart(@Observes Router router) {
+            router.get("/hello").handler(rc -> {
+                var exp = ((X509Certificate) rc.request().connection().sslSession().getLocalCertificates()[0]).getNotAfter()
+                        .toInstant().toEpochMilli();
+                rc.response().end("Hello " + exp);
+            });
+        }
+
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/ManagementHttpServerTlsCertificateReloadTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/ManagementHttpServerTlsCertificateReloadTest.java
@@ -1,0 +1,174 @@
+package io.quarkus.vertx.http.certReload;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.quarkus.vertx.http.runtime.options.TlsCertificateReloader;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.ext.web.RoutingContext;
+import me.escoffier.certs.Format;
+import me.escoffier.certs.junit5.Certificate;
+import me.escoffier.certs.junit5.Certificates;
+
+@Certificates(baseDir = "target/certificates", certificates = {
+        @Certificate(name = "reload-C", formats = Format.PEM),
+        @Certificate(name = "reload-D", formats = Format.PEM, duration = 365),
+})
+@DisabledOnOs(OS.WINDOWS)
+public class ManagementHttpServerTlsCertificateReloadTest {
+
+    public static final File temp = new File("target/test-certificates-" + UUID.randomUUID());
+
+    private static final String APP_PROPS = """
+            quarkus.management.enabled=true
+            quarkus.management.ssl.certificate.reload-period=30s
+            quarkus.management.ssl.certificate.files=%s
+            quarkus.management.ssl.certificate.key-files=%s
+
+            loc=%s
+            """.formatted(temp.getAbsolutePath() + "/tls.crt", temp.getAbsolutePath() + "/tls.key", temp.getAbsolutePath());
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties"))
+            .setBeforeAllCustomizer(() -> {
+                try {
+                    // Prepare a random directory to store the certificates.
+                    temp.mkdirs();
+                    Files.copy(new File("target/certificates/reload-C.crt").toPath(),
+                            new File(temp, "/tls.crt").toPath());
+                    Files.copy(new File("target/certificates/reload-C.key").toPath(),
+                            new File(temp, "/tls.key").toPath());
+                    Files.copy(new File("target/certificates/reload-C-ca.crt").toPath(),
+                            new File(temp, "/ca.crt").toPath());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .addBuildChainCustomizer(buildCustomizer())
+            .setAfterAllCustomizer(() -> {
+                try {
+                    Files.deleteIfExists(new File(temp, "/tls.crt").toPath());
+                    Files.deleteIfExists(new File(temp, "/tls.key").toPath());
+                    Files.deleteIfExists(new File(temp, "/ca.crt").toPath());
+                    Files.deleteIfExists(temp.toPath());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        NonApplicationRootPathBuildItem buildItem = context.consume(NonApplicationRootPathBuildItem.class);
+                        context.produce(buildItem.routeBuilder()
+                                .management()
+                                .route("/hello")
+                                .handler(new MyHandler())
+                                .build());
+                    }
+                }).produces(RouteBuildItem.class)
+                        .consumes(NonApplicationRootPathBuildItem.class)
+                        .build();
+            }
+        };
+    }
+
+    @Inject
+    Vertx vertx;
+
+    @ConfigProperty(name = "loc")
+    File certs;
+
+    @Test
+    void test() throws IOException {
+        var options = new HttpClientOptions()
+                .setSsl(true)
+                .setDefaultPort(9001) // Management interface test port
+                .setDefaultHost("localhost")
+                .setTrustOptions(new PemTrustOptions().addCertPath(new File(certs, "/ca.crt").getAbsolutePath()));
+
+        String response1 = vertx.createHttpClient(options)
+                .request(HttpMethod.GET, "/q/hello")
+                .flatMap(HttpClientRequest::send)
+                .flatMap(HttpClientResponse::body)
+                .map(Buffer::toString)
+                .toCompletionStage().toCompletableFuture().join();
+
+        // Update certs
+        Files.copy(new File("target/certificates/reload-D.crt").toPath(),
+                new File(certs, "/tls.crt").toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(new File("target/certificates/reload-D.key").toPath(),
+                new File(certs, "/tls.key").toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+
+        // Trigger the reload
+        TlsCertificateReloader.reload().await().atMost(Duration.ofSeconds(10));
+
+        // The client truststore is not updated, thus it should fail.
+        assertThatThrownBy(() -> vertx.createHttpClient(options)
+                .request(HttpMethod.GET, "/hello")
+                .flatMap(HttpClientRequest::send)
+                .flatMap(HttpClientResponse::body)
+                .map(Buffer::toString)
+                .toCompletionStage().toCompletableFuture().join()).hasCauseInstanceOf(SSLHandshakeException.class);
+
+        var options2 = new HttpClientOptions(options)
+                .setTrustOptions(new PemTrustOptions().addCertPath("target/certificates/reload-D-ca.crt"));
+
+        var response2 = vertx.createHttpClient(options2)
+                .request(HttpMethod.GET, "/hello")
+                .flatMap(HttpClientRequest::send)
+                .flatMap(HttpClientResponse::body)
+                .map(Buffer::toString)
+                .toCompletionStage().toCompletableFuture().join();
+
+        assertThat(response1).isNotEqualTo(response2); // Because cert duration are different.
+    }
+
+    public static class MyHandler implements Handler<RoutingContext> {
+        @Override
+        public void handle(RoutingContext rc) {
+            var exp = ((X509Certificate) rc.request().connection().sslSession().getLocalCertificates()[0]).getNotAfter()
+                    .toInstant().toEpochMilli();
+            rc.response().end("Hello Management " + exp);
+        }
+    }
+
+}


### PR DESCRIPTION
This PR uses the new certificate generator utility.

Once in, we will be able to remove all the hand-crafted certificates.