### PR TITLE
Fix Keycloak Admin Client Reactive Jackson reader provider priority so that the client can work when the JSONB REST client extension is present

### DIFF
--- a/extensions/keycloak-admin-client-reactive/runtime/src/main/java/io/quarkus/keycloak/admin/client/reactive/runtime/ResteasyReactiveClientProvider.java
+++ b/extensions/keycloak-admin-client-reactive/runtime/src/main/java/io/quarkus/keycloak/admin/client/reactive/runtime/ResteasyReactiveClientProvider.java
@@ -28,7 +28,8 @@ import io.quarkus.rest.client.reactive.jackson.runtime.serialisers.ClientJackson
 public class ResteasyReactiveClientProvider implements ResteasyClientProvider {
 
     private static final List<String> HANDLED_MEDIA_TYPES = List.of(MediaType.APPLICATION_JSON);
-    private static final int PROVIDER_PRIORITY = Priorities.USER + 100; // ensures that it will be used first
+    private static final int WRITER_PROVIDER_PRIORITY = Priorities.USER + 100; // ensures that it will be used first
+    private static final int READER_PROVIDER_PRIORITY = Priorities.USER - 100; // ensures that it will be used first
 
     private final boolean tlsTrustAll;
 
@@ -77,9 +78,9 @@ public class ResteasyReactiveClientProvider implements ResteasyClientProvider {
                 clientBuilder = clientBuilder
                         .registerMessageBodyReader(new JacksonBasicMessageBodyReader(newObjectMapper), Object.class,
                                 HANDLED_MEDIA_TYPES, true,
-                                PROVIDER_PRIORITY)
+                                READER_PROVIDER_PRIORITY)
                         .registerMessageBodyWriter(new ClientJacksonMessageBodyWriter(newObjectMapper), Object.class,
-                                HANDLED_MEDIA_TYPES, true, PROVIDER_PRIORITY);
+                                HANDLED_MEDIA_TYPES, true, WRITER_PROVIDER_PRIORITY);
             }
             InstanceHandle<ClientLogger> clientLogger = arcContainer.instance(ClientLogger.class);
             if (clientLogger.isAvailable()) {


### PR DESCRIPTION
fixes: #38833

- Readers with lower priority comes first https://github.com/quarkusio/quarkus/blob/427e73fa9b9b95b61a7d2cf62a2e5cc8131ff8a1/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceReader.java#L111
- Writers with higher priority comes first https://github.com/quarkusio/quarkus/blob/427e73fa9b9b95b61a7d2cf62a2e5cc8131ff8a1/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceWriter.java#L129