### PR TITLE
Do not require IdentityProviders for HTTP Authentication mechanisms without credential types and fail if the required provider is missing

### DIFF
--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -72,6 +72,12 @@ public class CustomAwareJWTAuthMechanism implements HttpAuthenticationMechanism 
 }
 ----
 
+TIP: The `HttpAuthenticationMechanism` should transform incoming HTTP request with suitable authentication credentials
+into an `io.quarkus.security.identity.request.AuthenticationRequest` instance and delegate the authentication to the `io.quarkus.security.identity.IdentityProviderManager`.
+Leaving authentication to the `io.quarkus.security.identity.IdentityProvider`s gives you more options for credentials verifications,
+as well as convenient way to perform blocking tasks.
+Nevertheless, the `io.quarkus.security.identity.IdentityProvider` can be omitted and the `HttpAuthenticationMechanism` is free to authenticate request on its own in trivial use cases.
+
 [[dealing-with-more-than-one-http-auth-mechanisms]]
 == Dealing with more than one HttpAuthenticationMechanism
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/DisabledProactiveSecIdentityProviderTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/DisabledProactiveSecIdentityProviderTest.java
@@ -28,7 +28,6 @@ import io.vertx.ext.web.RoutingContext;
 public class DisabledProactiveSecIdentityProviderTest {
 
     private static final String APP_PROPS = "" +
-            "quarkus.http.auth.basic=true\n" +
             "quarkus.http.auth.proactive=false\n" +
             "quarkus.http.auth.policy.r1.roles-allowed=admin\n" +
             "quarkus.http.auth.permission.roles1.paths=/admin\n" +

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticationMechanism.java
@@ -3,6 +3,7 @@ package io.quarkus.vertx.http.runtime.security;
 import java.util.Set;
 import java.util.function.Function;
 
+import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AuthenticationRequest;
@@ -21,10 +22,17 @@ public interface HttpAuthenticationMechanism {
     Uni<ChallengeData> getChallenge(RoutingContext context);
 
     /**
-     * Returns the required credential types. If there are no identity managers installed that support the
-     * listed types then this mechanism will not be enabled.
+     * If this mechanism delegates authentication to the {@link IdentityProviderManager} using the
+     * {@link IdentityProviderManager#authenticate(AuthenticationRequest)} call, then the mechanism must provide
+     * supported {@link AuthenticationRequest} request types. It allows Quarkus to validate that one or more
+     * {@link IdentityProvider} providers with matching supported {@link IdentityProvider#getRequestType()} request
+     * types exist and fail otherwise.
+     *
+     * @return required credential types
      */
-    Set<Class<? extends AuthenticationRequest>> getCredentialTypes();
+    default Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+        return Set.of();
+    }
 
     default Uni<Boolean> sendChallenge(RoutingContext context) {
         return getChallenge(context).map(new ChallengeSender(context));


### PR DESCRIPTION
closes: #38508