### PR TITLE
Check the code flow access token after ID token

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractJsonObjectResponse.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/AbstractJsonObjectResponse.java
@@ -58,7 +58,7 @@ public class AbstractJsonObjectResponse {
     }
 
     public boolean contains(String propertyName) {
-        return json.containsKey(propertyName) && !json.isNull(propertyName);
+        return json != null && json.containsKey(propertyName) && !json.isNull(propertyName);
     }
 
     public Set<String> getPropertyNames() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -83,6 +83,7 @@ public final class OidcUtils {
     public static final Integer MAX_COOKIE_VALUE_LENGTH = 4096;
     public static final String POST_LOGOUT_COOKIE_NAME = "q_post_logout";
     static final String UNDERSCORE = "_";
+    static final String CODE_ACCESS_TOKEN_RESULT = "code_flow_access_token_result";
     static final String COMMA = ",";
     static final Uni<Void> VOID_UNI = Uni.createFrom().voidItem();
     static final BlockingTaskRunner<Void> deleteTokensRequestContext = new BlockingTaskRunner<Void>();
@@ -350,6 +351,10 @@ public final class OidcUtils {
         setSecurityIdentityConfigMetadata(builder, resolvedContext);
         setBlockingApiAttribute(builder, vertxContext);
         setTenantIdAttribute(builder, config);
+        TokenVerificationResult codeFlowAccessTokenResult = (TokenVerificationResult) requestData.get(CODE_ACCESS_TOKEN_RESULT);
+        if (codeFlowAccessTokenResult != null) {
+            builder.addAttribute(CODE_ACCESS_TOKEN_RESULT, codeFlowAccessTokenResult);
+        }
         return builder.build();
     }
 

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowTokenIntrospectionResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowTokenIntrospectionResource.java
@@ -4,6 +4,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
+import io.quarkus.oidc.TokenIntrospection;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 
@@ -14,8 +15,11 @@ public class CodeFlowTokenIntrospectionResource {
     @Inject
     SecurityIdentity identity;
 
+    @Inject
+    TokenIntrospection tokenIntrospection;
+
     @GET
     public String access() {
-        return identity.getPrincipal().getName();
+        return identity.getPrincipal().getName() + ":" + tokenIntrospection.getUsername();
     }
 }

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -287,12 +287,12 @@ public class CodeFlowAuthorizationTest {
 
             TextPage textPage = form.getInputByValue("login").click();
 
-            assertEquals("alice", textPage.getContent());
+            assertEquals("alice:alice", textPage.getContent());
 
             // refresh
             Thread.sleep(3000);
             textPage = webClient.getPage("http://localhost:8081/code-flow-token-introspection");
-            assertEquals("admin", textPage.getContent());
+            assertEquals("admin:admin", textPage.getContent());
 
             webClient.getCookieManager().clearCookies();
         }


### PR DESCRIPTION
 PR is simple but since it moves a Uni block around it appears the changes are quite involved, let me clarify which problems it solves.

When the authorization code flow is used, at least 2 tokens, ID and (code flow) access tokens are acquired from the OIDC provider. ID token is always verified, while the access token is optionally verified. If both the ID and access token must be verified then the current order of the verification is wrong: ID token must be verified first, the code flow access token next  but currently it is the other way around - the access token first  and ID token next.
So far it has not been problem, since if at least one of the tokens fails the verification, the request fails.

But if both the ID and access token have expired then there is a problem: the remote token introspection will return an `active` status set to `false` for the expired access token and the request fails, however, with the ID token verification going ahead first, if it has expired, the token refresh will happen with both ID and access tokens recycled.

So this PR simply fixes the order, the primary code flow token, ID token, is checked first, and only if it is valid, the code flow is checked next. This changing of the order has the most impact at the code level, but this is all it is, instead of runinng a code flow access token uni first, it is run after the primary token uni is run.
 
The other related issue is that the code  flow access introspection results are actually very hard to access right now, if it is in JWT format then `JsonWebToken` injection works, but no luck for the binary access tokens.
So the 2nd thing this PR does it fixes the way `TokenIntrospection` is injected. If both ID token and code flow token must be introspected (quite an unrealistic case IMHO since ID token is typically verified as JWT with the keys), the users will do `@IdToken TokenIntrospection idTokenIntrospection; TokenIntrospection accessTokenIntrospection;`, exactly the same as 
it is done when both of these tokens are in JWT format. I only had to continue supporting `TokenIntrospection` for ID token with the `@IdToken` qualifier if only the ID token must be introspected since it is the way it already works now...

As far as tests are concerned, I've found it hard to prove at the test level that if the ID token verification fails the code flow verification does not go ahead, I just can't see how it can be done without creating something very flaky were we emulate the case with both ID and access tokens expiring, and the introspection response is incomplete for the access token and it all still works in the end...

But I've update the test to confirm that the injected TokenInrospection now correctly represents the refreshed code flow access token. FYI the test refresh at [this point](https://github.com/quarkusio/quarkus/blob/main/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java#L292) is supported by [this stub](https://github.com/quarkusio/quarkus/blob/main/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java#L440) - so the test first check that `alice` is returned, and then `admin` - both from the internal ID token verification and the code flow access token - `admin` can only be returned if the refresh ha worked 

- Fixes #38777.
- Fixes #38763.