### PR TITLE
Make registration of OAuthBearerValidatorCallbackHandler conditional

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -415,6 +415,9 @@ public class KafkaProcessor {
         reflectiveClassCondition.produce(new ReflectiveClassConditionBuildItem(
                 "org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerValidatorCallbackHandler",
                 "org.jose4j.keys.resolvers.VerificationKeyResolver"));
+        reflectiveClassCondition.produce(new ReflectiveClassConditionBuildItem(
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler",
+                "org.jose4j.keys.resolvers.VerificationKeyResolver"));
     }
 
     private void registerJDKLoginModules(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {


### PR DESCRIPTION
`org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler`
depends on the optional
`org.jose4j.keys.resolvers.VerificationKeyResolver` so it should only be
registered when the latter is present, similarly to
`org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerValidatorCallbackHandler`

Closes https://github.com/quarkusio/quarkus/issues/38851

CI run with Mandrel 24.1-dev: https://github.com/graalvm/mandrel/actions/runs/7957837530