### PR TITLE
[3.2] Perform security checks on inherited endpoints before payload deserialization in the RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/DenyAllJaxRsTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/DenyAllJaxRsTest.java
@@ -92,6 +92,39 @@ public class DenyAllJaxRsTest {
     }
 
     @Test
+    public void shouldAllowAnnotatedParentEndpoint() {
+        // the endpoint has @RolesAllowed, therefore default JAX-RS security should not be applied
+        String path = "/unsecured/parent-annotated";
+        assertStatus(path, 200, 401);
+    }
+
+    @Test
+    public void shouldAllowAnnotatedEndpointOnInterface() {
+        // the endpoint has @RolesAllowed, therefore default JAX-RS security should not be applied
+        String path = "/unsecured/interface-annotated";
+        assertStatus(path, 200, 401);
+    }
+
+    @Test
+    public void shouldDenyUnannotatedOverriddenOnInterfaceImplementor() {
+        // @RolesAllowed on interface, however implementor overridden the endpoint method with @Path @GET
+        String path = "/unsecured/interface-overridden-declared-on-implementor";
+        assertStatus(path, 403, 401);
+    }
+
+    @Test
+    public void shouldAllowAnnotatedOverriddenEndpointDeclaredOnInterface() {
+        // @RolesAllowed on interface and implementor didn't declare endpoint declaring annotations @GET
+        String path = "/unsecured/interface-overridden-declared-on-interface";
+        assertStatus(path, 200, 401);
+        // check that response comes from the overridden method
+        given().auth().preemptive()
+                .basic("admin", "admin").get(path)
+                .then()
+                .body(Matchers.is("implementor-response"));
+    }
+
+    @Test
     public void shouldDenyUnannotatedOnInterface() {
         String path = "/unsecured/defaultSecurityInterface";
         assertStatus(path, 403, 401);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UnsecuredParentResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UnsecuredParentResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.resteasy.reactive.server.test.security;
 
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
@@ -9,6 +10,13 @@ public class UnsecuredParentResource {
     @GET
     public String defaultSecurityParent() {
         return "defaultSecurityParent";
+    }
+
+    @RolesAllowed({ "admin", "user" })
+    @GET
+    @Path("/parent-annotated")
+    public String parentAnnotated() {
+        return "parent-annotated";
     }
 
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UnsecuredResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UnsecuredResource.java
@@ -49,4 +49,16 @@ public class UnsecuredResource extends UnsecuredParentResource implements Unsecu
     public UnsecuredSubResource permitAllSub() {
         return new UnsecuredSubResource();
     }
+
+    @Override
+    public String interfaceOverriddenDeclaredOnInterface() {
+        return "implementor-response";
+    }
+
+    @GET
+    @Path("/interface-overridden-declared-on-implementor")
+    @Override
+    public String interfaceOverriddenDeclaredOnImplementor() {
+        return "implementor-response";
+    }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UnsecuredResourceInterface.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UnsecuredResourceInterface.java
@@ -1,5 +1,6 @@
 package io.quarkus.resteasy.reactive.server.test.security;
 
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
@@ -9,6 +10,29 @@ public interface UnsecuredResourceInterface {
     @GET
     default String defaultSecurityInterface() {
         return "defaultSecurityInterface";
+    }
+
+    @RolesAllowed({ "admin", "user" })
+    @GET
+    @Path("/interface-annotated")
+    default String interfaceAnnotated() {
+        return "interface-annotated";
+    }
+
+    @RolesAllowed({ "admin", "user" })
+    @GET
+    @Path("/interface-overridden-declared-on-interface")
+    default String interfaceOverriddenDeclaredOnInterface() {
+        // this interface is overridden without @GET and @Path
+        return "interface-overridden-declared-on-interface";
+    }
+
+    @RolesAllowed({ "admin", "user" })
+    @GET
+    @Path("/interface-overridden-declared-on-implementor")
+    default String interfaceOverriddenDeclaredOnImplementor() {
+        // this interface is overridden with @GET and @Path
+        return "interface-overridden-declared-on-implementor";
     }
 
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/EagerSecurityHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/EagerSecurityHandler.java
@@ -57,7 +57,7 @@ public class EagerSecurityHandler implements ServerRestHandler {
         }
         SecurityCheck check = this.check;
         ResteasyReactiveResourceInfo lazyMethod = requestContext.getTarget().getLazyMethod();
-        MethodDescription methodDescription = new MethodDescription(lazyMethod.getResourceClass().getName(),
+        MethodDescription methodDescription = new MethodDescription(lazyMethod.getActualDeclaringClassName(),
                 lazyMethod.getName(), MethodDescription.typesAsStrings(lazyMethod.getParameterTypes()));
         if (check == null) {
             SecurityCheckStorage storage = Arc.container().instance(SecurityCheckStorage.class).get();

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ServerEndpointIndexer.java
@@ -183,6 +183,7 @@ public class ServerEndpointIndexer
             }
         }
         serverResourceMethod.setHandlerChainCustomizers(methodCustomizers);
+        serverResourceMethod.setActualDeclaringClassName(methodInfo.declaringClass().name().toString());
         return serverResourceMethod;
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -189,7 +189,7 @@ public class RuntimeResourceDeployment {
 
         ResteasyReactiveResourceInfo lazyMethod = new ResteasyReactiveResourceInfo(method.getName(), resourceClass,
                 parameterDeclaredUnresolvedTypes, classAnnotationNames, method.getMethodAnnotationNames(),
-                !defaultBlocking && !method.isBlocking());
+                !defaultBlocking && !method.isBlocking(), method.getActualDeclaringClassName());
 
         RuntimeInterceptorDeployment.MethodInterceptorContext interceptorDeployment = runtimeInterceptorDeployment
                 .forMethod(method, lazyMethod);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerResourceMethod.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/model/ServerResourceMethod.java
@@ -18,6 +18,7 @@ public class ServerResourceMethod extends ResourceMethod {
 
     private List<HandlerChainCustomizer> handlerChainCustomizers = new ArrayList<>();
     private ParameterExtractor customerParameterExtractor;
+    private String actualDeclaringClassName;
 
     public ServerResourceMethod() {
     }
@@ -69,5 +70,13 @@ public class ServerResourceMethod extends ResourceMethod {
     public ServerResourceMethod setCustomerParameterExtractor(ParameterExtractor customerParameterExtractor) {
         this.customerParameterExtractor = customerParameterExtractor;
         return this;
+    }
+
+    public String getActualDeclaringClassName() {
+        return actualDeclaringClassName;
+    }
+
+    public void setActualDeclaringClassName(String actualDeclaringClassName) {
+        this.actualDeclaringClassName = actualDeclaringClassName;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ResteasyReactiveResourceInfo.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ResteasyReactiveResourceInfo.java
@@ -26,21 +26,33 @@ public class ResteasyReactiveResourceInfo implements ResourceInfo {
      * If it's non-blocking method within the runtime that won't always default to blocking
      */
     public final boolean isNonBlocking;
-
+    /**
+     * This class name will only differ from {@link this#declaringClass} name when the {@link this#method} was inherited.
+     */
+    private final String actualDeclaringClassName;
     private volatile Annotation[] classAnnotations;
     private volatile Method method;
     private volatile Annotation[] annotations;
     private volatile Type returnType;
     private volatile String methodId;
 
+    @Deprecated
     public ResteasyReactiveResourceInfo(String name, Class<?> declaringClass, Class[] parameterTypes,
             Set<String> classAnnotationNames, Set<String> methodAnnotationNames, boolean isNonBlocking) {
+        this(name, declaringClass, parameterTypes, classAnnotationNames, methodAnnotationNames, isNonBlocking,
+                declaringClass.getName());
+    }
+
+    public ResteasyReactiveResourceInfo(String name, Class<?> declaringClass, Class[] parameterTypes,
+            Set<String> classAnnotationNames, Set<String> methodAnnotationNames, boolean isNonBlocking,
+            String actualDeclaringClassName) {
         this.name = name;
         this.declaringClass = declaringClass;
         this.parameterTypes = parameterTypes;
         this.classAnnotationNames = classAnnotationNames;
         this.methodAnnotationNames = methodAnnotationNames;
         this.isNonBlocking = isNonBlocking;
+        this.actualDeclaringClassName = actualDeclaringClassName;
     }
 
     public String getName() {
@@ -118,5 +130,9 @@ public class ResteasyReactiveResourceInfo implements ResourceInfo {
             methodId = MethodId.get(name, declaringClass, parameterTypes);
         }
         return methodId;
+    }
+
+    public String getActualDeclaringClassName() {
+        return actualDeclaringClassName;
     }
 }


### PR DESCRIPTION
backports https://github.com/quarkusio/quarkus/pull/38832 with resolved conflicts (only difference is `lazyMethod.getActualDeclaringClassName()` moved to the `EagerSecurityHandler` to different place than in 3.8 branch).