### PR TITLE
Testing: fix @MockitoConfig(convertScopes=true) with auto-producers

### DIFF
--- a/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/SuffixServiceSingletonProducer.java
+++ b/integration-tests/injectmock/src/main/java/io/quarkus/it/mockbean/SuffixServiceSingletonProducer.java
@@ -1,11 +1,10 @@
 package io.quarkus.it.mockbean;
 
-import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
 
 public class SuffixServiceSingletonProducer {
 
-    @Produces
+    //@Produces // intentionally commented out to test that auto-producers work with `@InjectMock`
     @Singleton
     public SuffixServiceSingleton dummyService() {
         return new SuffixServiceSingleton();

--- a/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/UnusedServiceTest.java
+++ b/integration-tests/injectmock/src/test/java/io/quarkus/it/mockbean/UnusedServiceTest.java
@@ -21,7 +21,7 @@ public class UnusedServiceTest {
     }
 
     @Test
-    public void testNonInjectedUnusedBeanIsNotRemoved() {
+    public void testNonInjectedUnusedBeanIsRemoved() {
         Assertions.assertFalse(Arc.container().instance(OtherUnusedService.class).isAvailable());
     }
 }


### PR DESCRIPTION
The annotation transformer in `SingletonToApplicationScopedTestBuildChainCustomizerProducer` has to:

- look for the `@Produces` annotation in ArC's `AnnotationStore`, not in Jandex;
- run _after_ the annotation transformer in `AutoProducerMethodsProcessor`.

This is enough to recognize an auto-producer (producer without `@Produces`).

- Fixes #38817