### PR TITLE
ArC: add covariant override of Instance.handlesStream() to InjectableInstance

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableInstance.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableInstance.java
@@ -2,6 +2,8 @@ package io.quarkus.arc;
 
 import java.lang.annotation.Annotation;
 import java.util.Iterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Instance;
@@ -14,9 +16,17 @@ import jakarta.enterprise.util.TypeLiteral;
  */
 public interface InjectableInstance<T> extends Instance<T> {
 
+    @Override
     InstanceHandle<T> getHandle();
 
+    @Override
     Iterable<InstanceHandle<T>> handles();
+
+    @Override
+    default Stream<InstanceHandle<T>> handlesStream() {
+        // copy of `Instance.handlesStream()` to avoid unchecked conversion
+        return StreamSupport.stream(handles().spliterator(), false);
+    }
 
     @Override
     InjectableInstance<T> select(Annotation... qualifiers);


### PR DESCRIPTION
In CDI 4.0, the `Instance` interface gained a few methods whose return types involve `Instance.Handle`. ArC's `InstanceHandle` extends `Instance.Handle` and `InjectableInstance` extends `Instance`, so it makes sense for `InjectableInstance` to have covariant overrides of these methods where the return type involves ArC's `InstanceHandle`
instead. Some methods used to be there even before CDI 4.0, so they always acted as covariant overrides. This commit adds the `@Override` annotation to them, plus it adds a covariant override of `handlesStream()`.

Inspired by the conversation in Zulip: https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/.E2.9C.94.20CDI.3A.20get.20.40Priority.20from.20bean.20defined.20in.20producer.20method