### PR TITLE
Update OidcEndpoint annotation to support multiple values

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcEndpoint.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/OidcEndpoint.java
@@ -46,7 +46,7 @@ public @interface OidcEndpoint {
     }
 
     /**
-     * Identifies an OIDC tenant to which a given feature applies.
+     * Identifies one or more OIDC endpoints.
      */
-    Type value() default Type.ALL;
+    Type[] value() default Type.ALL;
 }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -504,8 +504,13 @@ public class OidcCommonUtils {
             for (OidcRequestFilter filter : container.listAll(OidcRequestFilter.class).stream().map(handle -> handle.get())
                     .collect(Collectors.toList())) {
                 OidcEndpoint endpoint = ClientProxy.unwrap(filter).getClass().getAnnotation(OidcEndpoint.class);
-                OidcEndpoint.Type type = endpoint != null ? endpoint.value() : OidcEndpoint.Type.ALL;
-                map.computeIfAbsent(type, k -> new ArrayList<OidcRequestFilter>()).add(filter);
+                if (endpoint != null) {
+                    for (OidcEndpoint.Type type : endpoint.value()) {
+                        map.computeIfAbsent(type, k -> new ArrayList<OidcRequestFilter>()).add(filter);
+                    }
+                } else {
+                    map.computeIfAbsent(OidcEndpoint.Type.ALL, k -> new ArrayList<OidcRequestFilter>()).add(filter);
+                }
             }
             return map;
         }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcDiscoveryJwksRequestCustomizer.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/OidcDiscoveryJwksRequestCustomizer.java
@@ -13,14 +13,21 @@ import io.vertx.mutiny.ext.web.client.HttpRequest;
 
 @ApplicationScoped
 @Unremovable
-@OidcEndpoint(value = Type.DISCOVERY)
-public class OidcDiscoveryRequestCustomizer implements OidcRequestFilter {
+@OidcEndpoint(value = { Type.DISCOVERY, Type.JWKS })
+public class OidcDiscoveryJwksRequestCustomizer implements OidcRequestFilter {
 
     @Override
     public void filter(HttpRequest<Buffer> request, Buffer buffer, OidcRequestContextProperties contextProps) {
-        if (!request.uri().endsWith(".well-known/openid-configuration")) {
+        if (!request.uri().endsWith(".well-known/openid-configuration")
+                && !isJwksRequest(request)) {
             throw new OIDCException("Filter is applied to the wrong endpoint: " + request.uri());
         }
-        request.putHeader("Discovery", "OK");
+        request.putHeader("Filter", "OK");
+    }
+
+    private boolean isJwksRequest(HttpRequest<Buffer> request) {
+        return request.uri().endsWith("/protocol/openid-connect/certs")
+                || request.uri().endsWith("/auth/azure/jwk")
+                || request.uri().endsWith("/single-key-without-kid-thumbprint");
     }
 }

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/WiremockTestResource.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/WiremockTestResource.java
@@ -25,7 +25,7 @@ public class WiremockTestResource {
 
         server.stubFor(
                 get(urlEqualTo("/auth/realms/quarkus2/.well-known/openid-configuration"))
-                        .withHeader("Discovery", equalTo("OK"))
+                        .withHeader("Filter", equalTo("OK"))
                         .willReturn(aResponse()
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\n" +
@@ -35,6 +35,7 @@ public class WiremockTestResource {
 
         server.stubFor(
                 get(urlEqualTo("/auth/realms/quarkus2/protocol/openid-connect/certs"))
+                        .withHeader("Filter", equalTo("OK"))
                         .willReturn(aResponse()
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\n" +


### PR DESCRIPTION
Fixes #38780

Initially I thought `OidcEndpoint` can be used to bind a single `OidcRequestFilter` and if the filter needs to deal with more than one OIDC endpoint then the request path will be checked manually. 

However, as #38780 shows it is not that great. `OidcEndpoint` already supports 6 unique OIDC endpoint values, which will rise to 8 once OIDC Dynamic Registration is in place, so if only a subset of those endpoints must be filtered (example, the Discovery and JWKS endpoint only as in the linked issue) then it can become problematic, one needs to be aware of the concrete endpoint addresses to avoid filtering requests to all of them, etc

So this simple PR only makes sure that `OidcEndpoint` can accept more than one endpoint type.

Sorry @gastaldi, please have a look when you can, please take your time, this PR is the last one for today 