### PR TITLE
Bump to DB2 11.5.9.0

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -95,7 +95,7 @@
         <!-- Database images for JDBC/Reactive/Hibernate tests and devservices -->
         <postgres.image>docker.io/postgres:14</postgres.image>
         <mariadb.image>docker.io/mariadb:10.11</mariadb.image>
-        <db2.image>docker.io/ibmcom/db2:11.5.8.0</db2.image>
+        <db2.image>icr.io/db2_community/db2:11.5.9.0</db2.image>
         <mssql.image>mcr.microsoft.com/mssql/server:2022-latest</mssql.image>
         <mysql.image>docker.io/mysql:8.0</mysql.image>
         <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -82,7 +82,7 @@ public class DB2DevServicesProcessor {
 
         public QuarkusDb2Container(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork) {
             super(DockerImageName.parse(imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("db2")))
-                    .asCompatibleSubstituteFor(DockerImageName.parse("ibmcom/db2")));
+                    .asCompatibleSubstituteFor(DockerImageName.parse("icr.io/db2_community/db2")));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
         }


### PR DESCRIPTION
According to https://hub.docker.com/r/ibmcom/db2, DB2 images will be published in `icr.io/db2_community/db2` and the original location will be sunset