### PR TITLE
Add config flag to disable jacoco

### DIFF
--- a/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
+++ b/test-framework/jacoco/deployment/src/main/java/io/quarkus/jacoco/deployment/JacocoProcessor.java
@@ -15,6 +15,7 @@ import org.codehaus.plexus.util.FileUtils;
 import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.workspace.SourceDir;
@@ -36,6 +37,8 @@ import io.quarkus.maven.dependency.ResolvedDependency;
 
 public class JacocoProcessor {
 
+    private static final Logger log = Logger.getLogger(JacocoProcessor.class);
+
     @BuildStep(onlyIf = IsTest.class)
     FeatureBuildItem feature() {
         return new FeatureBuildItem("jacoco");
@@ -51,6 +54,10 @@ public class JacocoProcessor {
             JacocoConfig config) throws Exception {
         if (launchModeBuildItem.isAuxiliaryApplication()) {
             //no code coverage for continuous testing, it does not really make sense
+            return;
+        }
+        if (!config.enabled) {
+            log.debug("quarkus-jacoco is disabled via config");
             return;
         }
 

--- a/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
+++ b/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
@@ -17,6 +17,13 @@ public class JacocoConfig {
     public static final String TARGET_JACOCO_REPORT = "target/" + JACOCO_REPORT;
 
     /**
+     * Whether or not the jacoco extension is enabled. Disabling it can come in handy when runnig tests in IDEs that do their
+     * own jacoco instrumentation, e.g. EclEmma in Eclipse.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean enabled;
+
+    /**
      * The jacoco data file.
      * The path can be relative (to the module) or absolute.
      */


### PR DESCRIPTION
Disabling jacoco seems to make sense in Eclipse when using EclEmma (that uses jacoco) to prevent a myriad of errors in the console like:
```
<looong trace omitted>
java.lang.IllegalStateException: Cannot process instrumented class com/company/config/RequestResponseFilters. Please supply original non-instrumented classes.
```

PS: Currently I'm keeping quarkus-jacoco away from the test classpath in Eclipse via some Maven profile acrobatics which I'd like to get rid of (especially because of the "unrecognized config option" warnings).