### PR TITLE
Upgrade codeblock dev ui lib to 1.0.12

### DIFF
--- a/bom/dev-ui/pom.xml
+++ b/bom/dev-ui/pom.xml
@@ -28,7 +28,7 @@
         <vaadin-router.version>1.7.5</vaadin-router.version>
         <lit-state.version>1.7.0</lit-state.version>
         <echarts.version>5.4.3</echarts.version>
-        <codeblock.version>1.0.10</codeblock.version>
+        <codeblock.version>1.0.12</codeblock.version>
         <es-module-shims.version>1.8.2</es-module-shims.version>
         <path-to-regexp.version>2.4.0</path-to-regexp.version>
 


### PR DESCRIPTION
This is an important upgrade to fix an issue introduced by #38848. This is a roll-forward solution.

The code block is a composition jar, meaning it bundle all codemirror libs into one. This pr upgrade some of those libs that caused issues on Dev UI.