### PR TITLE
Ignore `ValidationSchema` that results in registering all models

### DIFF
--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubeSchema;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.ValidationSchema;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
@@ -67,6 +68,7 @@ public class KubernetesClientProcessor {
     private static final DotName RESOURCE_EVENT_HANDLER = DotName
             .createSimple(io.fabric8.kubernetes.client.informers.ResourceEventHandler.class.getName());
     private static final DotName KUBERNETES_RESOURCE = DotName.createSimple(KubernetesResource.class.getName());
+    private static final DotName VALIDATION_SCHEMA = DotName.createSimple(ValidationSchema.class.getName());
     private static final DotName KUBERNETES_RESOURCE_LIST = DotName
             .createSimple(KubernetesResourceList.class.getName());
     private static final DotName KUBE_SCHEMA = DotName.createSimple(KubeSchema.class.getName());
@@ -189,6 +191,7 @@ public class KubernetesClientProcessor {
         ignoredJsonDeserializationClasses.produce(new IgnoreJsonDeserializeClassBuildItem(KUBE_SCHEMA));
         ignoredJsonDeserializationClasses.produce(new IgnoreJsonDeserializeClassBuildItem(KUBERNETES_RESOURCE_LIST));
         ignoredJsonDeserializationClasses.produce(new IgnoreJsonDeserializeClassBuildItem(KUBERNETES_RESOURCE));
+        ignoredJsonDeserializationClasses.produce(new IgnoreJsonDeserializeClassBuildItem(VALIDATION_SCHEMA));
 
         final String[] deserializerClasses = fullIndex
                 .getAllKnownSubclasses(DotName.createSimple("com.fasterxml.jackson.databind.JsonDeserializer"))


### PR DESCRIPTION
`ValidationSchema` is annotated with `@JsonDeserialize` which leads in its entire type hierarchy being registered for reflective access along with the corresponding methods. This essentially ends up registering all models as [in kubernetes-client 6.9.0 ValidationSchema was augmented to implement `Editable<ValidationSchemaBuilder>`](https://github.com/fabric8io/kubernetes-client/commit/a3efaa3d773de02f42ca16255d66155b8bc97118#diff-2332025261852c63b455fe0a06e0aac236d3d608351f53ba9dc950eecd9e2581), which increases the reachable types in comparison to previous versions.

Ignoring registrations for `ValidationSchema` aligns with what we already do for `KubeSchema` and after discussing it with @manusa and @iocanel it seems like the right thing to do.

@manusa went a step further and opened an [upstream PR](https://github.com/fabric8io/kubernetes-client/pull/5759) to remove the `@JsonDeserialize` (along with other annotations) from the _problematic_ classes, potentially making this PR obsolete in the future. However, for the time being this seems to significantly the number of types and methods registered for reflection saving quite some space and build time.

The safest approach is probably to wait for https://github.com/fabric8io/kubernetes-client/pull/5759 to be approved before merging this, as it will then be clear that there is no need to handle this annotations in native mode as they are obsolete and will be removed in a future version.

The numbers reported below are based on builds of https://github.com/marcnuri-demo/quarkus-kubernetes-client-models/tree/c4123613e94646018d2d4e6ade36267dde056d8a with:

```
mvn -Dnative verify -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17
```

### Before this PR

```
[2/8] Performing analysis...  [*****]                                                                   (24.5s @ 4.25GB)
  21,686 (92.53%) of 23,436 types reachable
  43,114 (76.84%) of 56,112 fields reachable
 203,787 (80.56%) of 252,951 methods reachable
  12,568 types, 23,620 fields, and 112,658 methods registered for reflection
      63 types,    68 fields, and    55 methods registered for JNI access
       4 native libraries: dl, pthread, rt, z
...
[8/8] Creating image...       [***]                                                                      (6.9s @ 4.76GB)
  78.78MB (52.68%) for code area:   174,296 compilation units
  70.37MB (47.06%) for image heap:  651,043 objects and 10 resources
 404.81kB ( 0.26%) for other data
 149.54MB in total
------------------------------------------------------------------------------------------------------------------------
Top 10 origins of code area:                                Top 10 object types in image heap:
  14.27MB io.fabric8.openshift-model-6.10.0.jar               16.53MB byte[] for code metadata
  12.87MB java.base                                            9.47MB byte[] for java.lang.String
   9.10MB io.fabric8.kubernetes-model-core-6.10.0.jar          8.98MB byte[] for reflection metadata
   8.79MB svm.jar (Native Image)                               8.14MB java.lang.Class
   2.90MB i.f.k.10.0.jar                                       5.84MB java.lang.String
   2.80MB io.fabric8.kubernetes-model-gatewayapi-6.10.0.jar    5.14MB c.oracle.svm.core.reflect.SubstrateMethodAccessor
   2.43MB io.fabric8.kubernetes-model-flowcontrol-6.10.0.jar   4.77MB byte[] for general heap data
   1.95MB c.f.jackson.core.jackson-databind-2.16.1.jar         1.82MB com.oracle.svm.core.hub.DynamicHubCompanion
   1.72MB i.f.kubernetes-model-apiextensions-6.10.0.jar        1.29MB java.lang.Object[]
   1.71MB io.fabric8.kubernetes-model-autoscaling-6.10.0.jar   1.20MB java.lang.String[]
  18.90MB for 116 more packages                                6.53MB for 3331 more object types
```

### After this PR

```
[2/8] Performing analysis...  [*****]                                                                   (14.2s @ 4.96GB)
  17,892 (76.63%) of 23,348 types reachable
  34,707 (72.77%) of 47,692 fields reachable
 138,893 (61.40%) of 226,221 methods reachable
   8,328 types,   173 fields, and 39,628 methods registered for reflection
      63 types,    68 fields, and    55 methods registered for JNI access
       4 native libraries: dl, pthread, rt, z
...
[8/8] Creating image...       [**]                                                                       (4.5s @ 5.79GB)
  52.73MB (54.21%) for code area:   100,164 compilation units
  44.14MB (45.38%) for image heap:  463,734 objects and 10 resources
 402.77kB ( 0.40%) for other data
  97.27MB in total
------------------------------------------------------------------------------------------------------------------------
Top 10 origins of code area:                                Top 10 object types in image heap:
  12.86MB java.base                                           10.91MB byte[] for code metadata
   6.71MB io.fabric8.openshift-model-6.10.0.jar                5.47MB byte[] for java.lang.String
   5.46MB svm.jar (Native Image)                               4.61MB java.lang.Class
   4.30MB io.fabric8.kubernetes-model-core-6.10.0.jar          4.29MB java.lang.String
   1.95MB c.f.jackson.core.jackson-databind-2.16.1.jar         3.76MB byte[] for general heap data
   1.44MB i.f.k.10.0.jar                                       3.42MB byte[] for reflection metadata
   1.31MB io.fabric8.kubernetes-model-gatewayapi-6.10.0.jar    1.59MB c.oracle.svm.core.reflect.SubstrateMethodAccessor
   1.24MB io.fabric8.kubernetes-model-flowcontrol-6.10.0.jar   1.50MB com.oracle.svm.core.hub.DynamicHubCompanion
   1.18MB modified-io.vertx.vertx-core-4.5.3.jar             880.38kB java.lang.String[]
 997.95kB q.0.0-SNAPSHOT-runner.jar                          679.41kB java.lang.Object[]
  14.54MB for 116 more packages                                6.06MB for 3318 more object types
```

Fixes https://github.com/quarkusio/quarkus/issues/38683 (at least partially since there seems to be space for further improvement)

Related Zulip discussion https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/kubernetes.2Fopenshift.20client.20native.20image.20issue