### PR TITLE
Remove checks that Elasticsearch dev service distribution/version matches Hibernate Search configuration

### DIFF
--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -181,29 +181,6 @@ public class DevServicesElasticsearchProcessor {
 
         Distribution resolvedDistribution = resolveDistribution(config, buildItemConfig);
         DockerImageName resolvedImageName = resolveImageName(config, resolvedDistribution);
-        // Hibernate Search Elasticsearch have a version configuration property, we need to check that it is coherent
-        // with the image we are about to launch
-        if (buildItemConfig.version != null) {
-            String containerTag = resolvedImageName.getVersionPart();
-            if (!containerTag.startsWith(buildItemConfig.version)) {
-                throw new BuildException(
-                        "Dev Services for Elasticsearch detected a version mismatch."
-                                + " Consuming extensions are configured to use version " + config.imageName
-                                + " but Dev Services are configured to use version " + buildItemConfig.version +
-                                ". Either configure the same version or disable Dev Services for Elasticsearch.",
-                        Collections.emptyList());
-            }
-        }
-
-        if (buildItemConfig.distribution != null
-                && !buildItemConfig.distribution.equals(resolvedDistribution)) {
-            throw new BuildException(
-                    "Dev Services for Elasticsearch detected a distribution mismatch."
-                            + " Consuming extensions are configured to use distribution " + config.distribution
-                            + " but Dev Services are configured to use distribution " + buildItemConfig.distribution +
-                            ". Either configure the same distribution or disable Dev Services for Elasticsearch.",
-                    Collections.emptyList());
-        }
 
         final Optional<ContainerAddress> maybeContainerAddress = elasticsearchContainerLocator.locateContainer(
                 config.serviceName,


### PR DESCRIPTION
Because:

1. The distribution/version must be set explicitly in Hibernate Search.
2. If dev services are not configured explicitly, we default to using the distribution extracted from Hibernate Search, so the distribution check in particular cannot fail.
3. Hibernate Search will check the distribution/version on startup anway.
4. If users disable Hibernate Search startup checks, they obviously know what they are doing.
5. This check is very annoying when you explicitly set the dev service image to something like opensearch-custom:latest.

See also https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Elasticsearch.20dev.20service.20checking.20Hibernate.20Search.20config