### PR TITLE
Upgrade SmallRye OpenAPI to 3.10.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -54,7 +54,7 @@
         <smallrye-config.version>3.5.4</smallrye-config.version>
         <smallrye-health.version>4.1.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
-        <smallrye-open-api.version>3.9.0</smallrye-open-api.version>
+        <smallrye-open-api.version>3.10.0</smallrye-open-api.version>
         <smallrye-graphql.version>2.7.0</smallrye-graphql.version>
         <smallrye-fault-tolerance.version>6.2.6</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>4.4.0</smallrye-jwt.version>


### PR DESCRIPTION
See https://github.com/smallrye/smallrye-open-api/releases/tag/3.10.0

This also fix the custom branding issue in swagger UI (as discussed @ChMThiel)