### PR TITLE
QuarkusComponentTest: support parameterized test methods

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1666,10 +1666,13 @@ The fields annotated with `@Inject` and `@InjectMock` are injected after a test 
 Finally, the CDI request context is activated and terminated per each test method.
 
 === Injection
+
 Test class fields annotated with `@jakarta.inject.Inject` and `@io.quarkus.test.InjectMock` are injected after a test instance is created.
 Dependent beans injected into these fields are correctly destroyed before a test instance is destroyed.
 Parameters of a test method for which a matching bean exists are resolved unless annotated with `@io.quarkus.test.component.SkipInject`.
 Dependent beans injected into the test method arguments are correctly destroyed after the test method completes.
+
+NOTE: Arguments of a `@ParameterizedTest` method that are provided by an `ArgumentsProvider`, for example with `@org.junit.jupiter.params.provider.ValueArgumentsProvider`, must be annotated with `@SkipInject`. 
 
 === Auto Mocking Unsatisfied Dependencies
 

--- a/test-framework/junit5-component/pom.xml
+++ b/test-framework/junit5-component/pom.xml
@@ -74,6 +74,11 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestConfiguration.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestConfiguration.java
@@ -18,7 +18,6 @@ import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 
 import org.jboss.logging.Logger;
-import org.junit.jupiter.api.Test;
 
 import io.quarkus.arc.InjectableInstance;
 import io.quarkus.arc.processor.AnnotationsTransformer;
@@ -98,7 +97,7 @@ class QuarkusComponentTestConfiguration {
             // - not annotated with @InjectMock
             // - not annotated with @SkipInject
             for (Method method : current.getDeclaredMethods()) {
-                if (method.isAnnotationPresent(Test.class)) {
+                if (QuarkusComponentTestExtension.isTestMethod(method)) {
                     for (Parameter param : method.getParameters()) {
                         if (QuarkusComponentTestExtension.BUILTIN_PARAMETER.test(param)
                                 || param.isAnnotationPresent(InjectMock.class)

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
@@ -64,6 +64,7 @@ import org.jboss.jandex.Indexer;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
 import org.jboss.logging.Logger;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -1031,7 +1032,9 @@ public class QuarkusComponentTestExtension
     }
 
     static boolean isTestMethod(Executable method) {
-        return method.isAnnotationPresent(Test.class) || method.isAnnotationPresent(ParameterizedTest.class);
+        return method.isAnnotationPresent(Test.class)
+                || method.isAnnotationPresent(ParameterizedTest.class)
+                || method.isAnnotationPresent(RepeatedTest.class);
     }
 
     private List<Field> findFields(Class<?> testClass, List<Class<? extends Annotation>> annotations) {

--- a/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
+++ b/test-framework/junit5-component/src/main/java/io/quarkus/test/component/QuarkusComponentTestExtension.java
@@ -5,6 +5,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -79,6 +80,7 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
 
 import io.quarkus.arc.All;
 import io.quarkus.arc.Arc;
@@ -269,7 +271,7 @@ public class QuarkusComponentTestExtension
         // Target is empty for constructor or static method
         parameterContext.getTarget().isPresent()
                 // Only test methods are supported
-                && parameterContext.getDeclaringExecutable().isAnnotationPresent(Test.class)
+                && isTestMethod(parameterContext.getDeclaringExecutable())
                 // A method/param annotated with @SkipInject is never supported
                 && !parameterContext.isAnnotated(SkipInject.class)
                 && !parameterContext.getDeclaringExecutable().isAnnotationPresent(SkipInject.class)
@@ -999,7 +1001,7 @@ public class QuarkusComponentTestExtension
     }
 
     private List<Parameter> findInjectParams(Class<?> testClass) {
-        List<Method> testMethods = findMethods(testClass, m -> m.isAnnotationPresent(Test.class));
+        List<Method> testMethods = findMethods(testClass, QuarkusComponentTestExtension::isTestMethod);
         List<Parameter> ret = new ArrayList<>();
         for (Method method : testMethods) {
             for (Parameter param : method.getParameters()) {
@@ -1015,7 +1017,7 @@ public class QuarkusComponentTestExtension
     }
 
     private List<Parameter> findInjectMockParams(Class<?> testClass) {
-        List<Method> testMethods = findMethods(testClass, m -> m.isAnnotationPresent(Test.class));
+        List<Method> testMethods = findMethods(testClass, QuarkusComponentTestExtension::isTestMethod);
         List<Parameter> ret = new ArrayList<>();
         for (Method method : testMethods) {
             for (Parameter param : method.getParameters()) {
@@ -1026,6 +1028,10 @@ public class QuarkusComponentTestExtension
             }
         }
         return ret;
+    }
+
+    static boolean isTestMethod(Executable method) {
+        return method.isAnnotationPresent(Test.class) || method.isAnnotationPresent(ParameterizedTest.class);
     }
 
     private List<Field> findFields(Class<?> testClass, List<Class<? extends Annotation>> annotations) {

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/paraminject/ParameterInjectionParameterizedTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/paraminject/ParameterInjectionParameterizedTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.test.component.paraminject;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.Dependent;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.test.component.QuarkusComponentTest;
+import io.quarkus.test.component.SkipInject;
+
+@QuarkusComponentTest
+public class ParameterInjectionParameterizedTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = { "alpha", "bravo", "delta" })
+    public void testParamsInjection(@SkipInject String param, Converter converter) {
+        Assertions.assertThat(converter.convert(param)).isIn("ALPHA", "BRAVO", "DELTA");
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        assertEquals(3, Converter.DESTROYED.get());
+    }
+
+    @Dependent
+    public static class Converter {
+
+        static final AtomicInteger DESTROYED = new AtomicInteger();
+
+        String convert(String param) {
+            return param.toUpperCase();
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.incrementAndGet();
+        }
+    }
+
+}

--- a/test-framework/junit5-component/src/test/java/io/quarkus/test/component/paraminject/ParameterInjectionRepeatedTest.java
+++ b/test-framework/junit5-component/src/test/java/io/quarkus/test/component/paraminject/ParameterInjectionRepeatedTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.test.component.paraminject;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.Dependent;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.RepetitionInfo;
+
+import io.quarkus.test.component.QuarkusComponentTest;
+
+@QuarkusComponentTest
+public class ParameterInjectionRepeatedTest {
+    @RepeatedTest(10)
+    public void testParamsInjection(
+            // component under test
+            Converter converter,
+            // ignored automatically, no need for `@SkipInject`
+            RepetitionInfo info) {
+        assertEquals(10, info.getTotalRepetitions());
+        assertEquals("FOOBAR", converter.convert("fooBar"));
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        assertEquals(10, Converter.DESTROYED.get());
+    }
+
+    @Dependent
+    public static class Converter {
+        static final AtomicInteger DESTROYED = new AtomicInteger();
+
+        String convert(String param) {
+            return param.toUpperCase();
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.incrementAndGet();
+        }
+    }
+}


### PR DESCRIPTION
- arguments of a parameterized test method that are provided by an ArgumentsProvider must be annotated with SkipInject