### PR TITLE
Fix NPE when OIDC token must be verified with the chain with OIDC server returning no JWKs

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -194,7 +194,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
          * A parameter to specify the password of the truststore file if it is configured with {@link #trustStoreFile}.
          */
         @ConfigItem
-        public Optional<String> trustStorePassword;
+        public Optional<String> trustStorePassword = Optional.empty();
 
         /**
          * A parameter to specify the alias of the truststore certificate.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -87,8 +87,15 @@ public class OidcProvider implements Closeable {
         this.client = client;
         this.oidcConfig = oidcConfig;
         this.tokenCustomizer = tokenCustomizer;
-        this.asymmetricKeyResolver = jwks == null ? null
-                : new JsonWebKeyResolver(jwks, oidcConfig.token.forcedJwkRefreshInterval, oidcConfig.certificateChain);
+        if (jwks != null) {
+            this.asymmetricKeyResolver = new JsonWebKeyResolver(jwks, oidcConfig.token.forcedJwkRefreshInterval,
+                    oidcConfig.certificateChain);
+        } else if (oidcConfig != null && oidcConfig.certificateChain.trustStoreFile.isPresent()) {
+            this.asymmetricKeyResolver = new CertChainPublicKeyResolver(oidcConfig.certificateChain);
+        } else {
+            this.asymmetricKeyResolver = null;
+        }
+
         if (client != null && oidcConfig != null && !oidcConfig.jwks.resolveEarly) {
             this.keyResolverProvider = new DynamicVerificationKeyResolver(client, oidcConfig);
         } else {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/AzureAccessTokenCustomizer.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/AzureAccessTokenCustomizer.java
@@ -10,22 +10,22 @@ import jakarta.json.JsonObject;
 
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.TokenCustomizer;
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.runtime.OidcUtils;
 
 @Named("azure-access-token-customizer")
 @ApplicationScoped
 public class AzureAccessTokenCustomizer implements TokenCustomizer {
-    private static final String NONCE = "nonce";
 
     @Override
     public JsonObject customizeHeaders(JsonObject headers) {
         try {
-            String nonce = headers.getString(NONCE);
+            String nonce = headers.containsKey(OidcConstants.NONCE) ? headers.getString(OidcConstants.NONCE) : null;
             if (nonce != null) {
                 byte[] nonceSha256 = OidcUtils.getSha256Digest(nonce.getBytes(StandardCharsets.UTF_8));
                 byte[] newNonceBytes = Base64.getUrlEncoder().withoutPadding().encode(nonceSha256);
                 return Json.createObjectBuilder(headers)
-                        .add(NONCE, new String(newNonceBytes, StandardCharsets.UTF_8)).build();
+                        .add(OidcConstants.NONCE, new String(newNonceBytes, StandardCharsets.UTF_8)).build();
             }
             return null;
         } catch (Exception ex) {

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
@@ -42,7 +42,7 @@ public class AdminResource {
     @Authenticated
     @Produces(MediaType.APPLICATION_JSON)
     public String adminAzure() {
-        return "Issuer:" + ((JsonWebToken) identity.getPrincipal()).getIssuer();
+        return "Name:" + identity.getPrincipal().getName() + ",Issuer:" + ((JsonWebToken) identity.getPrincipal()).getIssuer();
     }
 
     @Path("bearer-no-introspection")

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowTokenIntrospectionResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowTokenIntrospectionResource.java
@@ -4,6 +4,8 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
 import io.quarkus.oidc.TokenIntrospection;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -20,6 +22,10 @@ public class CodeFlowTokenIntrospectionResource {
 
     @GET
     public String access() {
-        return identity.getPrincipal().getName() + ":" + tokenIntrospection.getUsername();
+        if (identity.getPrincipal() instanceof JsonWebToken) {
+            return identity.getPrincipal().getName();
+        } else {
+            return identity.getPrincipal().getName() + ":" + tokenIntrospection.getUsername();
+        }
     }
 }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
@@ -16,12 +16,15 @@ import io.quarkus.security.identity.SecurityIdentity;
 @Authenticated
 public class CodeFlowUserInfoResource {
 
+    // UserInfo stubs are available for code flow JWT and binary access tokens and bearer JWT tokens
     @Inject
     UserInfo userInfo;
 
+    // Custom test augmentor changes Principal to use UserInfo which has a preferred `alice` name
     @Inject
     SecurityIdentity identity;
 
+    // current access token
     @Inject
     JsonWebToken accessToken;
 

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -88,6 +88,7 @@ quarkus.oidc.bearer-user-info-github-service.client-id=quarkus-web-app
 quarkus.oidc.bearer-user-info-github-service.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.provider=github
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.application-type=hybrid
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.authorization-path=/
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.token-path=access_token_refreshed
@@ -101,6 +102,9 @@ quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.authentication.verify-
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.client-id=quarkus-web-app
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.credentials.client-secret.value=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.credentials.client-secret.method=query
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.certificate-chain.trust-store-file=truststore.p12
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.certificate-chain.trust-store-password=storepassword
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.certificate-chain.trust-store-cert-alias=fullchain
 
 
 quarkus.oidc.code-flow-token-introspection.provider=github
@@ -150,6 +154,9 @@ quarkus.oidc.bearer-azure.jwks-path=${keycloak.url}/azure/jwk
 quarkus.oidc.bearer-azure.jwks.resolve-early=false
 quarkus.oidc.bearer-azure.token.lifespan-grace=2147483647
 quarkus.oidc.bearer-azure.token.customizer-name=azure-access-token-customizer
+quarkus.oidc.bearer-azure.certificate-chain.trust-store-file=truststore.p12
+quarkus.oidc.bearer-azure.certificate-chain.trust-store-password=storepassword
+quarkus.oidc.bearer-azure.certificate-chain.trust-store-cert-alias=fullchain
 
 quarkus.oidc.bearer-role-claim-path.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.bearer-role-claim-path.client-id=quarkus-app

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -8,6 +8,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.notContaining;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -23,6 +24,7 @@ import java.util.Set;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -271,6 +273,16 @@ public class CodeFlowAuthorizationTest {
 
             webClient.getCookieManager().clearCookies();
         }
+
+        // Now send a bearer access token with the inline chain
+        String bearerAccessToken = TestUtils.createTokenWithInlinedCertChain("alice-certificate");
+
+        RestAssured.given().auth().oauth2(bearerAccessToken)
+                .when().get("/code-flow-user-info-github-cached-in-idtoken")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("alice:alice:alice-certificate, cache size: 0"));
+
         clearCache();
     }
 
@@ -296,6 +308,7 @@ public class CodeFlowAuthorizationTest {
 
             webClient.getCookieManager().clearCookies();
         }
+
         clearCache();
     }
 

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/TestUtils.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/TestUtils.java
@@ -1,0 +1,51 @@
+package io.quarkus.it.keycloak;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import io.quarkus.oidc.runtime.OidcUtils;
+import io.smallrye.jwt.build.Jwt;
+import io.smallrye.jwt.util.KeyUtils;
+import io.smallrye.jwt.util.ResourceUtils;
+import io.vertx.core.json.JsonObject;
+
+public class TestUtils {
+
+    public static String createTokenWithInlinedCertChain(String preferredUserName) throws Exception {
+        X509Certificate rootCert = KeyUtils.getCertificate(ResourceUtils.readResource("/ca.cert.pem"));
+        X509Certificate intermediateCert = KeyUtils.getCertificate(ResourceUtils.readResource("/intermediate.cert.pem"));
+        X509Certificate subjectCert = KeyUtils.getCertificate(ResourceUtils.readResource("/www.quarkustest.com.cert.pem"));
+        PrivateKey subjectPrivateKey = KeyUtils.readPrivateKey("/www.quarkustest.com.key.pem");
+
+        String bearerAccessToken = getAccessTokenWithCertChain(
+                List.of(subjectCert, intermediateCert, rootCert),
+                subjectPrivateKey,
+                preferredUserName);
+
+        assertX5cOnlyIsPresent(bearerAccessToken);
+        return bearerAccessToken;
+    }
+
+    public static String getAccessTokenWithCertChain(List<X509Certificate> chain,
+            PrivateKey privateKey, String preferredUserName) throws Exception {
+        return Jwt.preferredUserName(preferredUserName)
+                .groups("admin")
+                .issuer("https://server.example.com")
+                .audience("https://service.example.com")
+                .jws().chain(chain)
+                .sign(privateKey);
+    }
+
+    public static void assertX5cOnlyIsPresent(String token) {
+        JsonObject headers = OidcUtils.decodeJwtHeaders(token);
+        assertTrue(headers.containsKey("x5c"));
+        assertFalse(headers.containsKey("kid"));
+        assertFalse(headers.containsKey("x5t"));
+        assertFalse(headers.containsKey("x5t#S256"));
+    }
+
+}


### PR DESCRIPTION
Fixes #38901.

The token which contains the inlined cert chain can be verified independently but the cert chain verification can also be used as a fallback when JWK are null at the moment the OIDC provider code is setup. 
It can happen in 2 cases, when OAuth2 providers like GitHub are used and when the JWK acquisition is delayed with OIDC compliant providers.
So this PR updates the code covering these 2 cases to avoid NPE, adds tests for both cases,  fixes NPE along the way in the Azure token customizer which showed during the test. Minor update to OidcIdenttyProvider is only about making it clearer which way should be followed when the token must be verified

