### PR TITLE
Option to warn about failures when loading workspace modules, instead of throwing errors

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/BootstrapConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/BootstrapConfig.java
@@ -25,6 +25,13 @@ public class BootstrapConfig {
     Boolean workspaceDiscovery;
 
     /**
+     * If set to true, workspace loader will log warnings for modules that could not be loaded for some reason
+     * instead of throwing errors.
+     */
+    @ConfigItem(defaultValue = "false")
+    boolean warnOnFailingWorkspaceModules;
+
+    /**
      * By default, the bootstrap mechanism will create a shared cache of open JARs for
      * Quarkus classloaders to reduce the total number of opened ZIP FileSystems in dev and test modes.
      * Setting system property {@code quarkus.bootstrap.disable-jar-cache} to {@code true} will make

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
@@ -96,6 +96,7 @@ public class BootstrapMavenContext {
     private static final String SETTINGS_SECURITY = "settings.security";
 
     private static final String EFFECTIVE_MODEL_BUILDER_PROP = "quarkus.bootstrap.effective-model-builder";
+    private static final String WARN_ON_FAILING_WS_MODULES_PROP = "quarkus.bootstrap.warn-on-failing-workspace-modules";
 
     private static final String MAVEN_RESOLVER_TRANSPORT_KEY = "maven.resolver.transport";
     private static final String MAVEN_RESOLVER_TRANSPORT_DEFAULT = "default";
@@ -112,6 +113,11 @@ public class BootstrapMavenContext {
     private File userSettings;
     private File globalSettings;
     private Boolean offline;
+
+    // Typically, this property will not be enabled in Quarkus application development use-cases
+    // It was introduced to support use-cases of using the bootstrap resolver API beyond Quarkus application development
+    private Boolean warnOnFailingWorkspaceModules;
+
     private LocalWorkspace workspace;
     private LocalProject currentProject;
     private Settings settings;
@@ -152,6 +158,7 @@ public class BootstrapMavenContext {
         this.artifactTransferLogging = config.artifactTransferLogging;
         this.localRepo = config.localRepo;
         this.offline = config.offline;
+        this.warnOnFailingWorkspaceModules = config.warnOnFailedWorkspaceModules;
         this.repoSystem = config.repoSystem;
         this.repoSession = config.repoSession;
         this.remoteRepos = config.remoteRepos;
@@ -271,6 +278,12 @@ public class BootstrapMavenContext {
         return offline == null
                 ? offline = (getCliOptions().hasOption(BootstrapMavenOptions.OFFLINE) || getEffectiveSettings().isOffline())
                 : offline;
+    }
+
+    public boolean isWarnOnFailingWorkspaceModules() {
+        return warnOnFailingWorkspaceModules == null
+                ? warnOnFailingWorkspaceModules = Boolean.getBoolean(WARN_ON_FAILING_WS_MODULES_PROP)
+                : warnOnFailingWorkspaceModules;
     }
 
     public RepositorySystem getRepositorySystem() throws BootstrapMavenException {

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContextConfig.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContextConfig.java
@@ -39,6 +39,7 @@ public class BootstrapMavenContextConfig<T extends BootstrapMavenContextConfig<?
     protected Function<Path, Model> modelProvider;
     protected List<String> excludeSisuBeanPackages;
     protected List<String> includeSisuBeanPackages;
+    protected Boolean warnOnFailedWorkspaceModules;
 
     public T excludeSisuBeanPackage(String packageName) {
         if (excludeSisuBeanPackages == null) {
@@ -317,6 +318,18 @@ public class BootstrapMavenContextConfig<T extends BootstrapMavenContextConfig<?
     @SuppressWarnings("unchecked")
     public T setProjectModelProvider(Function<Path, Model> modelProvider) {
         this.modelProvider = modelProvider;
+        return (T) this;
+    }
+
+    /**
+     * Whether to warn about failures loading workspace modules instead of throwing errors
+     *
+     * @param warnOnFailedWorkspaceModules whether to warn about failures loading workspace modules instead of throwing errors
+     * @return this config instance
+     */
+    @SuppressWarnings("unchecked")
+    public T setWarnOnFailedWorkspaceModules(boolean warnOnFailedWorkspaceModules) {
+        this.warnOnFailedWorkspaceModules = warnOnFailedWorkspaceModules;
         return (T) this;
     }
 

--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/workspace/test/LocalWorkspaceDiscoveryTest.java
@@ -667,6 +667,26 @@ public class LocalWorkspaceDiscoveryTest {
         assertEquals(parentDir.resolve("custom-target").resolve("test-classes"), parent.getTestClassesDir());
     }
 
+    @Test
+    public void warnOnFailingWorkspaceModules() throws Exception {
+        final URL moduleUrl = Thread.currentThread().getContextClassLoader()
+                .getResource("invalid-module");
+        assertNotNull(moduleUrl);
+        final Path moduleDir = Path.of(moduleUrl.toURI());
+        assertNotNull(moduleUrl);
+
+        final LocalWorkspace ws = new BootstrapMavenContext(BootstrapMavenContext.config()
+                .setOffline(true)
+                .setEffectiveModelBuilder(true)
+                .setWarnOnFailedWorkspaceModules(true)
+                .setCurrentProject(moduleDir.toString()))
+                .getWorkspace();
+
+        assertNotNull(ws.getProject("io.playground", "asm"));
+        assertNotNull(ws.getProject("io.playground", "module"));
+        assertEquals(2, ws.getProjects().size());
+    }
+
     private void testMavenCiFriendlyVersion(String placeholder, String testResourceDirName, String expectedResolvedVersion,
             boolean resolvesFromWorkspace) throws Exception {
         final URL module1Url = Thread.currentThread().getContextClassLoader()

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/invalid-module/invalid-module/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/invalid-module/invalid-module/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.playground</groupId>
+    <artifactId>asm</artifactId>
+    <version>2.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>invalid-module</artifactId>
+</project>
+

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/invalid-module/module/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/invalid-module/module/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.playground</groupId>
+    <artifactId>asm</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>module</artifactId>
+</project>
+

--- a/independent-projects/bootstrap/maven-resolver/src/test/resources/invalid-module/pom.xml
+++ b/independent-projects/bootstrap/maven-resolver/src/test/resources/invalid-module/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.playground</groupId>
+  <artifactId>asm</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>module</module>
+    <module>invalid-module</module>
+  </modules>
+</project>
+


### PR DESCRIPTION
This option is added to support use-cases beyond Quarkus application development.