### PR TITLE
Collect classes dirs from all the modules in RuntimeUpdatesProcessor

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -187,12 +187,13 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
     }
 
     @Override
-    public Path getClassesDir() {
-        //TODO: fix all these
-        for (DevModeContext.ModuleInfo i : context.getAllModules()) {
-            return Paths.get(i.getMain().getClassesPath());
+    public List<Path> getClassesDir() {
+        final List<ModuleInfo> allModules = context.getAllModules();
+        final List<Path> paths = new ArrayList<>(allModules.size());
+        for (DevModeContext.ModuleInfo i : allModules) {
+            paths.add(Path.of(i.getMain().getClassesPath()));
         }
-        return null;
+        return paths;
     }
 
     @Override

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/spi/HotReplacementContext.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/spi/HotReplacementContext.java
@@ -8,7 +8,7 @@ import java.util.function.Consumer;
 
 public interface HotReplacementContext {
 
-    Path getClassesDir();
+    List<Path> getClassesDir();
 
     List<Path> getSourcesDir();
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/StaticResourcesHotReplacementSetup.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/StaticResourcesHotReplacementSetup.java
@@ -14,7 +14,9 @@ public class StaticResourcesHotReplacementSetup implements HotReplacementSetup {
     @Override
     public void setupHotDeployment(HotReplacementContext context) {
         List<Path> resources = new ArrayList<>();
-        addPathIfContainsStaticResources(resources, context.getClassesDir());
+        for (Path classesDir : context.getClassesDir()) {
+            addPathIfContainsStaticResources(resources, classesDir);
+        }
         for (Path resourceDir : context.getResourcesDir()) {
             addPathIfContainsStaticResources(resources, resourceDir);
         }


### PR DESCRIPTION
This change makes sure all the classes directories from all the modules are processed by the Vert.X HTTP `StaticResourcesHotReplacementSetup`.