### PR TITLE
Quartz - fix @Dependent job creation/destruction when there is a re-fire

### DIFF
--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/CdiAwareJob.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/CdiAwareJob.java
@@ -17,19 +17,20 @@ import org.quartz.spi.TriggerFiredBundle;
  */
 class CdiAwareJob implements Job {
 
-    private final Instance.Handle<? extends Job> jobInstanceHandle;
+    private final Instance<? extends Job> jobInstance;
 
-    public CdiAwareJob(Instance.Handle<? extends Job> jobInstanceHandle) {
-        this.jobInstanceHandle = jobInstanceHandle;
+    public CdiAwareJob(Instance<? extends Job> jobInstance) {
+        this.jobInstance = jobInstance;
     }
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
+        Instance.Handle<? extends Job> handle = jobInstance.getHandle();
         try {
-            jobInstanceHandle.get().execute(context);
+            handle.get().execute(context);
         } finally {
-            if (jobInstanceHandle.getBean().getScope().equals(Dependent.class)) {
-                jobInstanceHandle.destroy();
+            if (handle.getBean().getScope().equals(Dependent.class)) {
+                handle.destroy();
             }
         }
     }

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
@@ -1246,7 +1246,7 @@ public class QuartzSchedulerImpl implements QuartzScheduler {
             Instance<? extends Job> instance = jobs.select(jobClass);
             if (instance.isResolvable()) {
                 // This is a job backed by a CDI bean
-                return jobWithSpanWrapper(new CdiAwareJob(instance.getHandle()));
+                return jobWithSpanWrapper(new CdiAwareJob(instance));
             }
             // Instantiate a plain job class
             return jobWithSpanWrapper(super.newJob(bundle, Scheduler));


### PR DESCRIPTION
Fixes #38928 

`CdiAwareJob` now holds a reference to `Instance` instead of just its handle; this allows re-recreation of the dep. bean in case re-fire is requested.