### PR TITLE
Add smallrye metrics capability

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -94,9 +94,10 @@ public interface Capability {
     String KUBERNETES_CLIENT = QUARKUS_PREFIX + ".kubernetes.client";
 
     /**
-     * @deprecated
+     * @deprecated Use more precise capability {@link Capability#SMALLRYE_METRICS}
      * @see io.quarkus.deployment.metrics.MetricsCapabilityBuildItem
      */
+    @Deprecated
     String METRICS = QUARKUS_PREFIX + ".metrics";
     String CONTAINER_IMAGE_JIB = QUARKUS_PREFIX + ".container.image.jib";
     String CONTAINER_IMAGE_DOCKER = QUARKUS_PREFIX + ".container.image.docker";
@@ -117,6 +118,7 @@ public interface Capability {
 
     String SCHEDULER = QUARKUS_PREFIX + ".scheduler";
 
+    String SMALLRYE_METRICS = QUARKUS_PREFIX + ".smallrye.metrics";
     String SMALLRYE_HEALTH = QUARKUS_PREFIX + ".smallrye.health";
     String SMALLRYE_OPENAPI = QUARKUS_PREFIX + ".smallrye.openapi";
     String SMALLRYE_GRAPHQL = QUARKUS_PREFIX + ".smallrye.graphql";

--- a/extensions/smallrye-metrics/runtime/pom.xml
+++ b/extensions/smallrye-metrics/runtime/pom.xml
@@ -58,6 +58,7 @@
                 <configuration>
                     <capabilities>
                         <provides>io.quarkus.metrics</provides>
+                        <provides>io.quarkus.smallrye.metrics</provides>
                     </capabilities>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The Capability got marked as `@Deprecated` in favor of  `io.quarkus.deployment.metrics.MetricsCapabilityBuildItem`

This is not correct as it does serve a different purpose.
A capability describes if a functionality is available at all.
E.g:
I want to add a bean that configures micro meter only if the extension is added. Therefor I need to check for a capability as I might not have a `MetricsCapabilityBuildItem` producer at all.

### Solution
`MetricsCapabilityBuildItem` got introduced for more precise distinction of the used metrics library. Therefor this should also be reflected in the capabilities