### PR TITLE
Clarify that `quarkus.profile` cannot be set from a profile aware file

### DIFF
--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -397,7 +397,7 @@ Properties in the profile aware file have priority over profile aware properties
 
 [WARNING]
 ====
-Do not use Profile aware files to set `quarkus.profile` or `quarkus.test.profile`. This will not work because the
+Do not use profile aware files to set `quarkus.profile` or `quarkus.test.profile`. This will not work because the
 profile is required in advance to load the profile aware files.
 
 A profile aware file is only loaded if the unprofiled `application.properties` is also available in the same location

--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -397,6 +397,9 @@ Properties in the profile aware file have priority over profile aware properties
 
 [WARNING]
 ====
+Do not use Profile aware files to set `quarkus.profile` or `quarkus.test.profile`. This will not work because the
+profile is required in advance to load the profile aware files.
+
 A profile aware file is only loaded if the unprofiled `application.properties` is also available in the same location
 and the file extension matches between the files. This is required to keep a consistent loading order and pair all the
 resources together.


### PR DESCRIPTION
- Fixes #38424