### PR TITLE
Add missing brace in property expression

### DIFF
--- a/integration-tests/opentelemetry-reactive/src/main/resources/application.properties
+++ b/integration-tests/opentelemetry-reactive/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.rest-client.client.url=${test.url
+quarkus.rest-client.client.url=${test.url}
 
 quarkus.otel.bsp.schedule.delay=100
 quarkus.otel.bsp.export.timeout=5s


### PR DESCRIPTION
I noticed this while testing a properties parser that I wrote.