### PR TITLE
Update to Vert.x 4.5.4 and Netty 4.1.107

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -121,7 +121,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>2.3.1.Final</wildfly-elytron.version>
         <jboss-threads.version>3.5.1.Final</jboss-threads.version>
-        <vertx.version>4.5.3</vertx.version>
+        <vertx.version>4.5.4</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -144,7 +144,7 @@
         <infinispan.version>14.0.25.Final</infinispan.version>
         <infinispan.protostream.version>4.6.5.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>
-        <netty.version>4.1.106.Final</netty.version>
+        <netty.version>4.1.107.Final</netty.version>
         <brotli4j.version>1.14.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.5.3.Final</jboss-logging.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -62,7 +62,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.1</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>3.10.0</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>4.17.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>4.18.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.5.0</smallrye-stork.version>
         <jakarta.activation.version>2.1.2</jakarta.activation.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -34,7 +34,7 @@
         <opentelemetry.version>1.32.0</opentelemetry.version>
         <opentelemetry-alpha.version>1.32.0-alpha</opentelemetry-alpha.version>
         <opentelemetry-semconv.version>1.21.0-alpha</opentelemetry-semconv.version> <!-- keep in sync with opentelemetry-java-instrumentation in the alpha bom-->
-        <quarkus-http.version>5.1.0.Final</quarkus-http.version>
+        <quarkus-http.version>5.2.0.Final</quarkus-http.version>
         <micrometer.version>1.12.3</micrometer.version><!-- keep in sync with hdrhistogram -->
         <hdrhistogram.version>2.1.12</hdrhistogram.version><!-- keep in sync with micrometer -->
         <google-auth.version>0.22.0</google-auth.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -61,7 +61,7 @@
         <smallrye-context-propagation.version>2.1.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>3.0.1</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>3.9.0</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>3.10.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>4.17.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>2.5.0</smallrye-stork.version>
         <jakarta.activation.version>2.1.2</jakarta.activation.version>

--- a/docs/src/main/asciidoc/amqp-reference.adoc
+++ b/docs/src/main/asciidoc/amqp-reference.adoc
@@ -448,7 +448,7 @@ public AmqpClientOptions getNamedOptions() {
         .setPemKeyCertOptions(keycert)
         .setPemTrustOptions(trust)
         .addEnabledSaslMechanism("EXTERNAL")
-        .setHostnameVerificationAlgorithm("")
+        .setHostnameVerificationAlgorithm("") // Disables the hostname verification. Defaults is "HTTPS"
         .setConnectTimeout(30000)
         .setReconnectInterval(5000)
         .setContainerId("my-container");

--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -225,6 +225,8 @@ To use TLS, you need to:
 1. Set the `quarkus.redis.tls.enabled=true` property
 2. Make sure that your URL starts with `rediss://` (with two `s`)
 
+IMPORTANT: The default hostname verifier is set to `NONE`, meaning it does not verify the host name. You can change this behavior by setting the `quarkus.redis.tls.hostname-verification-algorithm` property, to `HTTPS` for example.
+
 === Configure the authentication
 
 The Redis password can be set in the `redis://` URL or with the `quarkus.redis.password` property.

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
@@ -111,9 +111,11 @@ public interface DataSourceReactiveRuntimeConfig {
 
     /**
      * The hostname verification algorithm to use in case the server's identity should be checked.
-     * Should be HTTPS, LDAPS or an empty string.
+     * Should be {@code HTTPS}, {@code LDAPS} or {@code NONE}.
+     * {@code NONE} is the default value and disables the verification.
      */
-    Optional<String> hostnameVerificationAlgorithm();
+    @WithDefault("NONE")
+    String hostnameVerificationAlgorithm();
 
     /**
      * The maximum time a connection remains unused in the pool before it is closed.

--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
@@ -217,9 +217,11 @@ public class DB2PoolRecorder {
 
         connectOptions.setReconnectInterval(dataSourceReactiveRuntimeConfig.reconnectInterval().toMillis());
 
-        if (dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm().isPresent()) {
-            connectOptions.setHostnameVerificationAlgorithm(
-                    dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm().get());
+        var algo = dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm();
+        if ("NONE".equalsIgnoreCase(algo)) {
+            connectOptions.setHostnameVerificationAlgorithm("");
+        } else {
+            connectOptions.setHostnameVerificationAlgorithm(algo);
         }
 
         dataSourceReactiveRuntimeConfig.additionalProperties().forEach(connectOptions::addProperty);

--- a/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
+++ b/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
@@ -220,9 +220,11 @@ public class MSSQLPoolRecorder {
         configureJksKeyCertOptions(mssqlConnectOptions, dataSourceReactiveRuntimeConfig.keyCertificateJks());
         configurePfxKeyCertOptions(mssqlConnectOptions, dataSourceReactiveRuntimeConfig.keyCertificatePfx());
 
-        if (dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm().isPresent()) {
-            mssqlConnectOptions.setHostnameVerificationAlgorithm(
-                    dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm().get());
+        var algo = dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm();
+        if ("NONE".equalsIgnoreCase(algo)) {
+            mssqlConnectOptions.setHostnameVerificationAlgorithm("");
+        } else {
+            mssqlConnectOptions.setHostnameVerificationAlgorithm(algo);
         }
 
         dataSourceReactiveRuntimeConfig.additionalProperties().forEach(mssqlConnectOptions::addProperty);

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
@@ -215,8 +215,8 @@ public class MySQLPoolRecorder {
                 mysqlConnectOptions.setSslMode(sslMode);
 
                 // If sslMode is verify-identity, we also need a hostname verification algorithm
-                if (sslMode == SslMode.VERIFY_IDENTITY && (!dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm()
-                        .isPresent() || "".equals(dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm().get()))) {
+                var algo = dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm();
+                if ("NONE".equalsIgnoreCase(algo) && sslMode == SslMode.VERIFY_IDENTITY) {
                     throw new IllegalArgumentException(
                             "quarkus.datasource.reactive.hostname-verification-algorithm must be specified under verify-identity sslmode");
                 }
@@ -236,8 +236,12 @@ public class MySQLPoolRecorder {
 
             mysqlConnectOptions.setReconnectInterval(dataSourceReactiveRuntimeConfig.reconnectInterval().toMillis());
 
-            dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm().ifPresent(
-                    mysqlConnectOptions::setHostnameVerificationAlgorithm);
+            var algo = dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm();
+            if ("NONE".equalsIgnoreCase(algo)) {
+                mysqlConnectOptions.setHostnameVerificationAlgorithm("");
+            } else {
+                mysqlConnectOptions.setHostnameVerificationAlgorithm(algo);
+            }
 
             dataSourceReactiveMySQLConfig.authenticationPlugin().ifPresent(mysqlConnectOptions::setAuthenticationPlugin);
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/VertxRedisClientFactory.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/VertxRedisClientFactory.java
@@ -116,7 +116,14 @@ public class VertxRedisClientFactory {
         tcp.alpn().ifPresent(net::setUseAlpn);
         tcp.applicationLayerProtocols().ifPresent(net::setApplicationLayerProtocols);
         tcp.connectionTimeout().ifPresent(d -> net.setConnectTimeout((int) d.toMillis()));
-        tls.hostnameVerificationAlgorithm().ifPresent(net::setHostnameVerificationAlgorithm);
+
+        String verificationAlgorithm = tls.hostnameVerificationAlgorithm();
+        if ("NONE".equalsIgnoreCase(verificationAlgorithm)) {
+            net.setHostnameVerificationAlgorithm("");
+        } else {
+            net.setHostnameVerificationAlgorithm(verificationAlgorithm);
+        }
+
         tcp.idleTimeout().ifPresent(d -> net.setIdleTimeout((int) d.toSeconds()));
 
         tcp.keepAlive().ifPresent(b -> net.setTcpKeepAlive(true));
@@ -162,8 +169,6 @@ public class VertxRedisClientFactory {
         tcp.fastOpen().ifPresent(net::setTcpFastOpen);
         tcp.quickAck().ifPresent(net::setTcpQuickAck);
         tcp.writeIdleTimeout().ifPresent(d -> net.setWriteIdleTimeout((int) d.toSeconds()));
-
-        tls.hostnameVerificationAlgorithm().ifPresent(net::setHostnameVerificationAlgorithm);
 
         return net;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/TlsConfig.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/config/TlsConfig.java
@@ -1,7 +1,5 @@
 package io.quarkus.redis.runtime.client.config;
 
-import java.util.Optional;
-
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.vertx.core.runtime.config.JksConfiguration;
 import io.quarkus.vertx.core.runtime.config.PemKeyCertConfiguration;
@@ -68,8 +66,12 @@ public interface TlsConfig {
 
     /**
      * The hostname verification algorithm to use in case the server's identity should be checked.
-     * Should be HTTPS, LDAPS or an empty string.
+     * Should be {@code HTTPS}, {@code LDAPS} or an {@code NONE} (default).
+     * <p>
+     * If set to {@code NONE}, it does not verify the hostname.
+     * <p>
      */
-    Optional<String> hostnameVerificationAlgorithm();
+    @WithDefault("NONE")
+    String hostnameVerificationAlgorithm();
 
 }

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -61,7 +61,7 @@
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
         <mutiny.version>2.5.7</mutiny.version>
         <smallrye-common.version>2.3.0</smallrye-common.version>
-        <vertx.version>4.5.3</vertx.version>
+        <vertx.version>4.5.4</vertx.version>
         <rest-assured.version>5.4.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.16.1</jackson-bom.version>


### PR DESCRIPTION
This update significantly changes extensions utilizing a (Vert.x) TCP **clients**. With Vert.x version 4.5.4, establishing TLS connections now mandates the use of hostname verification algorithms. This requirement impacts various components, including Reactive SQL clients, Redis, RabbitMQ, and MQTT, among others.

Previously, the verification algorithm defaulted to `""` (aka `NONE`), if not explicitly specified by the protocol. This setting skipped the verification process. However, with the new version, explicit configuration is necessary. So, each extension has been adjusted to allow the user to configure the hostname verification easily. To avoid breaking applications, the default is still skipping the verification. 

It's important to understand that this is only for TCP-based protocols that do not mandate hostname verification. HTTP, for example, is untouched by this. 


Supersedes: https://github.com/quarkusio/quarkus/pull/39114