### PR TITLE
Upgrade to testcontainers 1.19.6

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -207,8 +207,8 @@
         <avro.version>1.11.3</avro.version>
         <apicurio-registry.version>2.5.8.Final</apicurio-registry.version>
         <apicurio-common-rest-client.version>0.1.18.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
-        <testcontainers.version>1.19.4</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
-        <docker-java.version>3.3.4</docker-java.version> <!-- must be the version Testcontainers use -->
+        <testcontainers.version>1.19.6</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
+        <docker-java.version>3.3.5</docker-java.version> <!-- must be the version Testcontainers use -->
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
         <opensearch-testcontainers.version>2.0.0</opensearch-testcontainers.version>
         <com.dajudge.kindcontainer>1.4.4</com.dajudge.kindcontainer>


### PR DESCRIPTION
replaces https://github.com/quarkusio/quarkus/pull/38973