### PR TITLE
Address increased build time RSS caused by certificate hot reload

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsPKCS12CertificateReloadTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/certReload/MainHttpServerTlsPKCS12CertificateReloadTest.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.security.cert.X509Certificate;
-import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.net.ssl.SSLHandshakeException;
 
@@ -82,7 +84,7 @@ public class MainHttpServerTlsPKCS12CertificateReloadTest {
     File certs;
 
     @Test
-    void test() throws IOException {
+    void test() throws IOException, ExecutionException, InterruptedException, TimeoutException {
         var options = new HttpClientOptions()
                 .setSsl(true)
                 .setDefaultPort(url.getPort())
@@ -102,7 +104,7 @@ public class MainHttpServerTlsPKCS12CertificateReloadTest {
                 new File(certs, "/tls.p12").toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
 
         // Trigger the reload
-        TlsCertificateReloader.reload().await().atMost(Duration.ofSeconds(10));
+        TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
 
         // The client truststore is not updated, thus it should fail.
         assertThatThrownBy(() -> vertx.createHttpClient(options)
@@ -126,7 +128,7 @@ public class MainHttpServerTlsPKCS12CertificateReloadTest {
         assertThat(response1).isNotEqualTo(response2); // Because cert duration are different.
 
         // Trigger another reload
-        TlsCertificateReloader.reload().await().atMost(Duration.ofSeconds(10));
+        TlsCertificateReloader.reload().toCompletableFuture().get(10, TimeUnit.SECONDS);
 
         var response3 = vertx.createHttpClient(options2)
                 .request(HttpMethod.GET, "/hello")

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloader.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsCertificateReloader.java
@@ -6,16 +6,17 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.jboss.logging.Logger;
 
 import io.quarkus.vertx.http.runtime.ServerSslConfig;
-import io.smallrye.mutiny.Uni;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -62,9 +63,9 @@ public class TlsCertificateReloader {
             return -1;
         }
 
-        Supplier<Uni<Boolean>> task = new Supplier<Uni<Boolean>>() {
+        Supplier<CompletionStage<Boolean>> task = new Supplier<CompletionStage<Boolean>>() {
             @Override
-            public Uni<Boolean> get() {
+            public CompletionStage<Boolean> get() {
 
                 Future<Boolean> future = vertx.executeBlocking(new Callable<SSLOptions>() {
                     @Override
@@ -101,15 +102,14 @@ public class TlsCertificateReloader {
                             }
                         });
 
-                return Uni.createFrom().completionStage(future.toCompletionStage());
+                return future.toCompletionStage();
             }
         };
 
-        long id = vertx.setPeriodic(configuration.certificate.reloadPeriod.get().toMillis(), new Handler<Long>() {
+        long id = vertx.setPeriodic(period, new Handler<Long>() {
             @Override
             public void handle(Long id) {
-                //noinspection ResultOfMethodCallIgnored
-                task.get().subscribeAsCompletionStage();
+                task.get();
             }
         });
 
@@ -133,9 +133,14 @@ public class TlsCertificateReloader {
      *
      * @return a Uni that is completed when all the reload tasks have been executed
      */
-    public static Uni<Void> reload() {
-        var unis = TASKS.stream().map(ReloadCertificateTask::action).map(Supplier::get).collect(Collectors.toList());
-        return Uni.join().all(unis).andFailFast().replaceWithVoid();
+    public static CompletionStage<Void> reload() {
+        @SuppressWarnings("rawtypes")
+        CompletableFuture[] futures = new CompletableFuture[TASKS.size()];
+        for (int i = 0; i < TASKS.size(); i++) {
+            futures[i] = TASKS.get(i).action().get().toCompletableFuture();
+        }
+
+        return CompletableFuture.allOf(futures);
     }
 
     private static SSLOptions reloadFileContent(SSLOptions ssl, ServerSslConfig configuration) throws IOException {
@@ -183,7 +188,45 @@ public class TlsCertificateReloader {
         return copy;
     }
 
-    record ReloadCertificateTask(long it, Supplier<Uni<Boolean>> action) {
+    static final class ReloadCertificateTask {
+        private final long it;
+        private final Supplier<CompletionStage<Boolean>> action;
+
+        ReloadCertificateTask(long it, Supplier<CompletionStage<Boolean>> action) {
+            this.it = it;
+            this.action = action;
+        }
+
+        public long it() {
+            return it;
+        }
+
+        public Supplier<CompletionStage<Boolean>> action() {
+            return action;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this)
+                return true;
+            if (obj == null || obj.getClass() != this.getClass())
+                return false;
+            var that = (ReloadCertificateTask) obj;
+            return this.it == that.it &&
+                    Objects.equals(this.action, that.action);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(it, action);
+        }
+
+        @Override
+        public String toString() {
+            return "ReloadCertificateTask[" +
+                    "it=" + it + ", " +
+                    "action=" + action + ']';
+        }
 
     }
 }


### PR DESCRIPTION
This PR resolves an issue where the build time RSS increased after implementing the certificate hot reload feature. While the exact cause wasn't pinpointed, several potential culprits were addressed. These include removing the usage of the Mutiny API (regrettably), converting a record class to a regular class, and modifying a Java Stream API usage that relied on method references.


Fix https://github.com/quarkusio/quarkus/issues/38919.