### PR TITLE
Update to Brotli 1.14.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -145,7 +145,7 @@
         <infinispan.protostream.version>4.6.5.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>
         <netty.version>4.1.106.Final</netty.version>
-        <brotli4j.version>1.12.0</brotli4j.version>
+        <brotli4j.version>1.14.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.5.3.Final</jboss-logging.version>
         <mutiny.version>2.5.7</mutiny.version>


### PR DESCRIPTION
This is mainly to align with the version used by Netty.

We would backport it to 3.8 if everything goes smoothly (but not otherwise)