### PR TITLE
Add commons-codec to Dev Services dependencies

### DIFF
--- a/extensions/devservices/common/pom.xml
+++ b/extensions/devservices/common/pom.xml
@@ -31,6 +31,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!--
+          This should be removed once we upgrade to commons-compress 1.26.1 (or similar).
+          See https://github.com/quarkusio/quarkus/issues/38990
+        -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit4-mock</artifactId>


### PR DESCRIPTION
Testcontainers uses commons-compress features that actually require commons-codec to be around and for now it's an optional dependency of commons-compress.
Adding it as an explicit dependency for now until the commons-compress project fixes it.

Fixes #38990