### PR TITLE
Increase JNI metrics values to account for (upcoming) 17.0.11+1 changes

### DIFF
--- a/integration-tests/jpa-postgresql-withxml/src/test/resources/image-metrics/23.0/image-metrics.properties
+++ b/integration-tests/jpa-postgresql-withxml/src/test/resources/image-metrics/23.0/image-metrics.properties
@@ -17,5 +17,5 @@ analysis_results.types.jni=63
 analysis_results.types.jni.tolerance=1
 analysis_results.methods.jni=55
 analysis_results.methods.jni.tolerance=1
-analysis_results.fields.jni=68
-analysis_results.fields.jni.tolerance=1
+analysis_results.fields.jni=70
+analysis_results.fields.jni.tolerance=3

--- a/integration-tests/jpa-postgresql/src/test/resources/image-metrics/23.0/image-metrics.properties
+++ b/integration-tests/jpa-postgresql/src/test/resources/image-metrics/23.0/image-metrics.properties
@@ -17,5 +17,5 @@ analysis_results.types.jni=63
 analysis_results.types.jni.tolerance=1
 analysis_results.methods.jni=55
 analysis_results.methods.jni.tolerance=1
-analysis_results.fields.jni=68
-analysis_results.fields.jni.tolerance=1
+analysis_results.fields.jni=70
+analysis_results.fields.jni.tolerance=3


### PR DESCRIPTION
Mandrel `23.0.4` will be JDK `17.0.11` based (April CPU). JDK-8316304 got backported to JDK 17.0.11+1, therefore adding two fields accessed by JNI. The tolerance should be large enough for it to work with a JDK 17.0.10-based build too (`70*0.97 = 67.9`).

See the test failure for example here:
https://github.com/graalvm/mandrel/actions/runs/8068592571/job/22043086080?pr=683#step:12:497

/cc @zakkak 