### PR TITLE
Skip analysis of plugin executions with phases post quarkus:dev preparing for dev mode launch

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -588,6 +588,13 @@ public class DevMojo extends AbstractMojo {
                 continue;
             }
             for (PluginExecution e : p.getExecutions()) {
+                if (e.getPhase() != null && !PRE_DEV_MODE_PHASES.contains(e.getPhase())) {
+                    // skip executions with phases post quarkus:dev, such as install, deploy, site, etc
+                    if (getLog().isDebugEnabled()) {
+                        getLog().debug("Skipping " + e.getId() + " of " + p.getId());
+                    }
+                    continue;
+                }
                 String goalPrefix = null;
                 if (!e.getGoals().isEmpty()) {
                     goalPrefix = getMojoDescriptor(p, e.getGoals().get(0)).getPluginDescriptor().getGoalPrefix();


### PR DESCRIPTION
This change will skip analysis of plugin executions with phases post `quarkus:dev` that appear to be configured in a project.
As part of the plugin execution analysis we resolve plugin descriptors that may potentially require POM artifact resolutions of those plugins.
In case those POMs aren't available in locally and offline mode is enabled with `-o`, for example, dev mode may fail to start.

Here is a debug output with this change applied for a simple project
```
...
[DEBUG] Skipping default-test of org.apache.maven.plugins:maven-surefire-plugin:3.2.5
[DEBUG] Skipping default-clean of org.apache.maven.plugins:maven-clean-plugin:3.2.0
[DEBUG] Skipping default-jar of org.apache.maven.plugins:maven-jar-plugin:3.3.0
[DEBUG] Skipping default-install of org.apache.maven.plugins:maven-install-plugin:3.1.1
[DEBUG] Skipping default-deploy of org.apache.maven.plugins:maven-deploy-plugin:3.1.1
[DEBUG] Skipping default-site of org.apache.maven.plugins:maven-site-plugin:3.12.1
[DEBUG] Skipping default-deploy of org.apache.maven.plugins:maven-site-plugin:3.12.1
[INFO] Invoking resources:3.3.1:resources (default-resources) @ test-app
...
```