### PR TITLE
Update SmallRye Config to 3.6.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -51,7 +51,7 @@
         <microprofile-lra.version>2.0</microprofile-lra.version>
         <microprofile-openapi.version>3.1.1</microprofile-openapi.version>
         <smallrye-common.version>2.3.0</smallrye-common.version>
-        <smallrye-config.version>3.5.4</smallrye-config.version>
+        <smallrye-config.version>3.6.0</smallrye-config.version>
         <smallrye-health.version>4.1.0</smallrye-health.version>
         <smallrye-metrics.version>4.0.0</smallrye-metrics.version>
         <smallrye-open-api.version>3.10.0</smallrye-open-api.version>

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientFallbackConfigSourceInterceptorTest.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientFallbackConfigSourceInterceptorTest.java
@@ -192,14 +192,13 @@ public class RestClientFallbackConfigSourceInterceptorTest {
         }
 
         @Override
-        public Iterator<String> iterateNames() {
-            return names.iterator();
+        public ConfigValue restart(String name) {
+            return proceed(name);
         }
 
         @Override
-        public Iterator<ConfigValue> iterateValues() {
-            return null;
+        public Iterator<String> iterateNames() {
+            return names.iterator();
         }
     }
-
 }


### PR DESCRIPTION
<summary>SmallRye Config Release notes:</summary>
<br>
<blockquote>
    <h2>3.6.0</h2>
    <ul> 
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1122">#1122 </a> Release 3.6.0
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1121">#1121 </a> Cleanup project
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1120">#1120 </a> Remove deprecated APIs
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1119">#1119 </a> Bump org.apache.maven.plugins:maven-shade-plugin from 3.5.1 to 3.5.2
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1118">#1118 </a> Bump io.fabric8:docker-maven-plugin from 0.43.4 to 0.44.0
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1117">#1117 </a> Properly read and validate Env configuration in Factories
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1116">#1116 </a> Bump dependency.version.openwebbeans from 4.0.1 to 4.0.2
        <li><a href="https://github.com/smallrye/smallrye-config/pull/1082">#1082 </a> Introduce restart method for interceptors
    </ul>
</blockquote>
