### PR TITLE
Optionally run DNS lookup for OIDC server requests on worker thread

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -75,6 +75,13 @@ public class OidcCommonConfig {
     public Duration connectionTimeout = Duration.ofSeconds(10);
 
     /**
+     * Whether DNS lookup should be performed on the worker thread.
+     * Use this option when you can see logged warnings about blocked Vert.x event loop by HTTP requests to OIDC server.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean useBlockingDnsLookup;
+
+    /**
      * The maximum size of the connection pool used by the WebClient.
      */
     @ConfigItem

--- a/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
+++ b/extensions/oidc/deployment/src/test/resources/application-dev-mode.properties
@@ -11,3 +11,5 @@ quarkus.log.category."com.gargoylesoftware.htmlunit.javascript.host.css.CSSStyle
 quarkus.log.category."io.quarkus.oidc.runtime.TenantConfigContext".level=DEBUG
 quarkus.log.file.enable=true
 
+# use blocking DNS lookup so that we have it tested somewhere
+quarkus.oidc.use-blocking-dns-lookup=true

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -84,16 +84,22 @@ public class OidcProviderClient implements Closeable {
     }
 
     public Uni<JsonWebKeySet> getJsonWebKeySet(OidcRequestContextProperties contextProperties) {
-        return filter(OidcEndpoint.Type.JWKS, client.getAbs(metadata.getJsonWebKeySetUri()), null, contextProperties).send()
+        return OidcCommonUtils
+                .sendRequest(vertx,
+                        filter(OidcEndpoint.Type.JWKS, client.getAbs(metadata.getJsonWebKeySetUri()), null, contextProperties),
+                        oidcConfig.useBlockingDnsLookup)
                 .onItem()
                 .transform(resp -> getJsonWebKeySet(resp));
     }
 
     public Uni<UserInfo> getUserInfo(String token) {
         LOG.debugf("Get UserInfo on: %s auth: %s", metadata.getUserInfoUri(), OidcConstants.BEARER_SCHEME + " " + token);
-        return filter(OidcEndpoint.Type.USERINFO, client.getAbs(metadata.getUserInfoUri()), null, null)
-                .putHeader(AUTHORIZATION_HEADER, OidcConstants.BEARER_SCHEME + " " + token)
-                .send().onItem().transform(resp -> getUserInfo(resp));
+        return OidcCommonUtils
+                .sendRequest(vertx,
+                        filter(OidcEndpoint.Type.USERINFO, client.getAbs(metadata.getUserInfoUri()), null, null)
+                                .putHeader(AUTHORIZATION_HEADER, OidcConstants.BEARER_SCHEME + " " + token),
+                        oidcConfig.useBlockingDnsLookup)
+                .onItem().transform(resp -> getUserInfo(resp));
     }
 
     public Uni<TokenIntrospection> introspectToken(String token) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -470,8 +470,8 @@ public class OidcRecorder {
         WebClientOptions options = new WebClientOptions();
 
         OidcCommonUtils.setHttpClientOptions(oidcConfig, tlsConfig, options);
-
-        WebClient client = WebClient.create(new io.vertx.mutiny.core.Vertx(vertx), options);
+        var mutinyVertx = new io.vertx.mutiny.core.Vertx(vertx);
+        WebClient client = WebClient.create(mutinyVertx, options);
 
         Map<OidcEndpoint.Type, List<OidcRequestFilter>> oidcRequestFilters = OidcCommonUtils.getOidcRequestFilters();
 
@@ -481,7 +481,8 @@ public class OidcRecorder {
         } else {
             final long connectionDelayInMillisecs = OidcCommonUtils.getConnectionDelayInMillis(oidcConfig);
             metadataUni = OidcCommonUtils
-                    .discoverMetadata(client, oidcRequestFilters, authServerUriString, connectionDelayInMillisecs)
+                    .discoverMetadata(client, oidcRequestFilters, authServerUriString, connectionDelayInMillisecs, mutinyVertx,
+                            oidcConfig.useBlockingDnsLookup)
                     .onItem()
                     .transform(new Function<JsonObject, OidcConfigurationMetadata>() {
                         @Override


### PR DESCRIPTION
I can't really reproduce the issue and I don't think this option can be tested on localhost. Implementation can be improved by inspecting DNS lookup cache TTL and only running blocking lookup when we calculate that hostname is not in cache, but I want to keep it simple as I'm not convinced it's worth to have there something more complex.

- Fixes: #35993