### PR TITLE
Remove remnants of dev-v1

### DIFF
--- a/extensions/vertx-http/dev-console-spi/src/main/java/io/quarkus/devconsole/spi/DevConsoleRouteBuildItem.java
+++ b/extensions/vertx-http/dev-console-spi/src/main/java/io/quarkus/devconsole/spi/DevConsoleRouteBuildItem.java
@@ -14,7 +14,7 @@ import io.vertx.ext.web.RoutingContext;
 /**
  * A route for handling requests in the dev console.
  * <p>
- * Routes are registered under /q/dev-v1/{groupId}.{artifactId}/
+ * Routes are registered under /q/dev-ui/{groupId}.{artifactId}/
  * <p>
  * The route is registered:
  * <ul>

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/RemoteDevMojoIT.java
@@ -57,7 +57,6 @@ public class RemoteDevMojoIT extends RunAndCheckWithAgentMojoTestBase {
                 .until(() -> devModeClient.getHttpResponse("/app/hello").contains("carambar"));
 
         //also verify that the dev ui console is disabled
-        devModeClient.getHttpResponse("/q/dev-v1", 404, 10, TimeUnit.SECONDS);
         devModeClient.getHttpResponse("/q/dev-ui", 404, 10, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
The routes should be now registered under the `dev-ui`.

As we no longer don't have `dev-v1` the test will be always `404`.