### PR TITLE
Avoid updating Quarkus in the Extension's Dependabot descriptor

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/dependabot.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      # don't update Quarkus as we want the extension to depend on the minimum working version, thus allowing for inclusion of the extension in tooling for older Quarkus versions
+      - dependency-name: io.quarkus:*


### PR DESCRIPTION
We encourage extension maintainers to keep their extensions to a minimum Quarkus version because it facilitates our tooling to determine the exact extension version when it's added or created to a project. 

This PR disables Dependabot updates for Quarkus in the Quarkiverse extensions. 