### PR TITLE
Fix wrong volume host path being used on Windows

### DIFF
--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Volumes.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Volumes.java
@@ -18,19 +18,12 @@ public final class Volumes {
     public static void addVolumes(GenericContainer<?> container, Map<String, String> volumes) {
         for (Map.Entry<String, String> volume : volumes.entrySet()) {
             String hostLocation = volume.getKey();
-            BindMode bindMode = BindMode.READ_WRITE;
             if (volume.getKey().startsWith(CLASSPATH)) {
-                URL url = Thread.currentThread().getContextClassLoader()
-                        .getResource(hostLocation.replaceFirst(CLASSPATH, EMPTY));
-                if (url == null) {
-                    throw new IllegalStateException("Classpath resource at '" + hostLocation + "' not found!");
-                }
-
-                hostLocation = url.getPath();
-                bindMode = BindMode.READ_ONLY;
+                container.withClasspathResourceMapping(hostLocation.replaceFirst(CLASSPATH, EMPTY), volume.getValue(),
+                        BindMode.READ_ONLY);
+            } else {
+                container.withFileSystemBind(hostLocation, volume.getValue(), BindMode.READ_WRITE);
             }
-
-            container.withFileSystemBind(hostLocation, volume.getValue(), bindMode);
         }
     }
 }

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Volumes.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/Volumes.java
@@ -1,6 +1,5 @@
 package io.quarkus.devservices.common;
 
-import java.net.URL;
 import java.util.Map;
 
 import org.testcontainers.containers.BindMode;


### PR DESCRIPTION
This PR fixes wrong host path used on Windows when mapping classpath volumes into Dev Services for Database.

Previously the code used URL.getPath() which returned `/C:/quarkus-app`, and that caused Docker to fail because of the column after the drive letter.
Now it uses GenericContainer's `withClasspathResourceMapping` which automatically uses the correct path - `C:\quarkus-app`.

- Fixes #39123