### PR TITLE
Bump JUnit Pioneer to 2.2.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -140,7 +140,7 @@
         <rest-assured.version>5.4.0</rest-assured.version>
         <hamcrest.version>2.2</hamcrest.version><!-- The version needs to be compatible with both REST Assured and Awaitility -->
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
-        <junit-pioneer.version>1.5.0</junit-pioneer.version>
+        <junit-pioneer.version>2.2.0</junit-pioneer.version>
         <infinispan.version>14.0.25.Final</infinispan.version>
         <infinispan.protostream.version>4.6.5.Final</infinispan.protostream.version>
         <caffeine.version>3.1.5</caffeine.version>


### PR DESCRIPTION
Hello,

I noticed that in the Quarkus BOM JUnit Pioneer was still in version 1.5.0 (released in November 2021) and was wondering if this could be bumped.

I was a bit unsure on how to test this, I ended up just forking and running the ci workflow https://github.com/gonmmarques/quarkus/actions/runs/8141924367 (it seems everything was ok, except the JVM tests which would take very long).

Let me know if this request makes sense, and if so how should I proceed. 

Thanks in advance.