### PR TITLE
Remove misleading note from jacoco.enabled

### DIFF
--- a/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
+++ b/test-framework/jacoco/runtime/src/main/java/io/quarkus/jacoco/runtime/JacocoConfig.java
@@ -17,8 +17,7 @@ public class JacocoConfig {
     public static final String TARGET_JACOCO_REPORT = "target/" + JACOCO_REPORT;
 
     /**
-     * Whether or not the jacoco extension is enabled. Disabling it can come in handy when runnig tests in IDEs that do their
-     * own jacoco instrumentation, e.g. EclEmma in Eclipse.
+     * Whether or not the jacoco extension is enabled.
      */
     @ConfigItem(defaultValue = "true")
     public boolean enabled;


### PR DESCRIPTION
I've added this flag just recently (#38868) but turned out my problem was instead an incomplete jacoco config in Eclipse (`*QuarkusClassLoader` exclusion was missing).
So the correct way in Eclipse/EclEmma is to leave quarkus-jacoco _enabled_, but configure it properly to reflect what's documented at https://quarkus.io/guides/tests-with-coverage.

The flag itself might still be useful though.