### PR TITLE
Bump actions/upload-artifact and download-artifact to v4

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           echo -n ${{ github.event.number }} > pull-request-number
       - name: Upload pull request number
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: pull-request-number-${{ github.event.number }}
           path: pull-request-number
@@ -194,7 +194,7 @@ jobs:
       - name: Tar .m2/repository/io/quarkus
         run: tar -czf m2-io-quarkus.tgz -C ~ .m2/repository/io/quarkus
       - name: Upload .m2/repository/io/quarkus
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: m2-io-quarkus
           path: m2-io-quarkus.tgz
@@ -209,7 +209,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: "build-reports-Initial JDK 17 Build"
@@ -356,7 +356,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           name: m2-io-quarkus
           path: .
@@ -383,7 +383,7 @@ jobs:
         if: failure()
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-reports-jvm${{matrix.java.name}}
@@ -398,7 +398,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: "build-reports-JVM Tests - JDK ${{matrix.java.name}}"
@@ -406,7 +406,7 @@ jobs:
             build-reports.zip
           retention-days: 7
       - name: Upload build.log (if build failed)
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: ${{ failure() || cancelled() }}
         with:
           name: "build-logs-JVM Tests - JDK ${{matrix.java.name}}"
@@ -458,7 +458,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           name: m2-io-quarkus
           path: .
@@ -485,7 +485,7 @@ jobs:
         if: failure()
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-reports-maven-java${{matrix.java.name}}
@@ -507,7 +507,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: "build-reports-Maven Tests - JDK ${{matrix.java.name}}"
@@ -555,7 +555,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           name: m2-io-quarkus
           path: .
@@ -592,7 +592,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: "build-reports-Gradle Tests - JDK ${{matrix.java.name}}"
@@ -642,7 +642,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           name: m2-io-quarkus
           path: .
@@ -668,7 +668,7 @@ jobs:
         if: failure()
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-reports-devtools-java${{matrix.java.name}}
@@ -683,7 +683,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: "build-reports-Devtools Tests - JDK ${{matrix.java.name}}"
@@ -733,7 +733,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           name: m2-io-quarkus
           path: .
@@ -759,7 +759,7 @@ jobs:
         if: failure()
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-reports-kubernetes-java${{matrix.java.name}}
@@ -774,7 +774,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: "build-reports-Kubernetes Tests - JDK ${{matrix.java.name}}"
@@ -811,7 +811,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           name: m2-io-quarkus
           path: .
@@ -843,7 +843,7 @@ jobs:
               'quarkus-quickstarts/target/build-report.json' \
               'quarkus-quickstarts/LICENSE' \
       - name: Upload build reports
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: "build-reports-Quickstarts Compilation - JDK ${{matrix.java.name}}"
@@ -876,7 +876,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           name: m2-io-quarkus
           path: .
@@ -915,7 +915,7 @@ jobs:
               'integration-tests/virtual-threads/target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: "build-reports-Virtual Thread Support Tests Native - ${{matrix.category}}"
@@ -955,7 +955,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           name: m2-io-quarkus
           path: .
@@ -980,7 +980,7 @@ jobs:
         if: failure()
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-reports-tcks
@@ -995,7 +995,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: "build-reports-MicroProfile TCKs Tests"
@@ -1063,7 +1063,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           name: m2-io-quarkus
           path: .
@@ -1090,7 +1090,7 @@ jobs:
         if: failure()
         run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-reports-native-${{matrix.category}}
@@ -1106,7 +1106,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: "build-reports-Native Tests - ${{matrix.category}}"
@@ -1120,7 +1120,7 @@ jobs:
     needs: [build-jdk17,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,quickstarts-tests,tcks-test,native-tests,virtual-thread-native-tests]
     if: always()
     steps:
-      - uses: actions/download-artifact@v4.1.4
+      - uses: actions/download-artifact@v4
         with:
           path: build-reports-artifacts
       - name: Set up JDK 17

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           echo -n ${{ github.event.number }} > pull-request-number
       - name: Upload pull request number
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: pull-request-number-${{ github.event.number }}
           path: pull-request-number
@@ -194,7 +194,7 @@ jobs:
       - name: Tar .m2/repository/io/quarkus
         run: tar -czf m2-io-quarkus.tgz -C ~ .m2/repository/io/quarkus
       - name: Upload .m2/repository/io/quarkus
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: m2-io-quarkus
           path: m2-io-quarkus.tgz
@@ -209,7 +209,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: always()
         with:
           name: "build-reports-Initial JDK 17 Build"
@@ -356,7 +356,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
           name: m2-io-quarkus
           path: .
@@ -383,7 +383,7 @@ jobs:
         if: failure()
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: failure()
         with:
           name: test-reports-jvm${{matrix.java.name}}
@@ -398,7 +398,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: always()
         with:
           name: "build-reports-JVM Tests - JDK ${{matrix.java.name}}"
@@ -406,7 +406,7 @@ jobs:
             build-reports.zip
           retention-days: 7
       - name: Upload build.log (if build failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: ${{ failure() || cancelled() }}
         with:
           name: "build-logs-JVM Tests - JDK ${{matrix.java.name}}"
@@ -458,7 +458,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
           name: m2-io-quarkus
           path: .
@@ -485,7 +485,7 @@ jobs:
         if: failure()
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: failure()
         with:
           name: test-reports-maven-java${{matrix.java.name}}
@@ -507,7 +507,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: always()
         with:
           name: "build-reports-Maven Tests - JDK ${{matrix.java.name}}"
@@ -555,7 +555,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
           name: m2-io-quarkus
           path: .
@@ -592,7 +592,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: always()
         with:
           name: "build-reports-Gradle Tests - JDK ${{matrix.java.name}}"
@@ -642,7 +642,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
           name: m2-io-quarkus
           path: .
@@ -668,7 +668,7 @@ jobs:
         if: failure()
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: failure()
         with:
           name: test-reports-devtools-java${{matrix.java.name}}
@@ -683,7 +683,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: always()
         with:
           name: "build-reports-Devtools Tests - JDK ${{matrix.java.name}}"
@@ -733,7 +733,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
           name: m2-io-quarkus
           path: .
@@ -759,7 +759,7 @@ jobs:
         if: failure()
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: failure()
         with:
           name: test-reports-kubernetes-java${{matrix.java.name}}
@@ -774,7 +774,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: always()
         with:
           name: "build-reports-Kubernetes Tests - JDK ${{matrix.java.name}}"
@@ -811,7 +811,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
           name: m2-io-quarkus
           path: .
@@ -843,7 +843,7 @@ jobs:
               'quarkus-quickstarts/target/build-report.json' \
               'quarkus-quickstarts/LICENSE' \
       - name: Upload build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: always()
         with:
           name: "build-reports-Quickstarts Compilation - JDK ${{matrix.java.name}}"
@@ -876,7 +876,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
           name: m2-io-quarkus
           path: .
@@ -915,7 +915,7 @@ jobs:
               'integration-tests/virtual-threads/target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: always()
         with:
           name: "build-reports-Virtual Thread Support Tests Native - ${{matrix.category}}"
@@ -955,7 +955,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
           name: m2-io-quarkus
           path: .
@@ -980,7 +980,7 @@ jobs:
         if: failure()
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: failure()
         with:
           name: test-reports-tcks
@@ -995,7 +995,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: always()
         with:
           name: "build-reports-MicroProfile TCKs Tests"
@@ -1063,7 +1063,7 @@ jobs:
           # refresh cache every week to avoid unlimited growth
           key: ${{ needs.build-jdk17.outputs.m2-cache-key }}
       - name: Download .m2/repository/io/quarkus
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
           name: m2-io-quarkus
           path: .
@@ -1090,7 +1090,7 @@ jobs:
         if: failure()
         run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: failure()
         with:
           name: test-reports-native-${{matrix.category}}
@@ -1106,7 +1106,7 @@ jobs:
               'target/gradle-build-scan-url.txt' \
               LICENSE.txt
       - name: Upload build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: always()
         with:
           name: "build-reports-Native Tests - ${{matrix.category}}"
@@ -1120,7 +1120,7 @@ jobs:
     needs: [build-jdk17,jvm-tests,maven-tests,gradle-tests,devtools-tests,kubernetes-tests,quickstarts-tests,tcks-test,native-tests,virtual-thread-native-tests]
     if: always()
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4.1.4
         with:
           path: build-reports-artifacts
       - name: Set up JDK 17

--- a/.github/workflows/ci-istio.yml
+++ b/.github/workflows/ci-istio.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
       - name: Persist Maven repository
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: maven-repo
           path: maven-repo.tgz
@@ -49,7 +49,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven repository
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
           name: maven-repo
           path: .

--- a/.github/workflows/ci-istio.yml
+++ b/.github/workflows/ci-istio.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
       - name: Persist Maven repository
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: maven-repo
           path: maven-repo.tgz
@@ -49,7 +49,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven repository
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           name: maven-repo
           path: .

--- a/.github/workflows/ci-kubernetes.yml
+++ b/.github/workflows/ci-kubernetes.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
       - name: Persist Maven repository
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: maven-repo
           path: maven-repo.tgz
@@ -49,7 +49,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven repository
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
           name: maven-repo
           path: .
@@ -106,7 +106,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven repository
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
           name: maven-repo
           path: .
@@ -160,7 +160,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven repository
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
           name: maven-repo
           path: .

--- a/.github/workflows/ci-kubernetes.yml
+++ b/.github/workflows/ci-kubernetes.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
       - name: Persist Maven repository
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: maven-repo
           path: maven-repo.tgz
@@ -49,7 +49,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven repository
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           name: maven-repo
           path: .
@@ -106,7 +106,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven repository
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           name: maven-repo
           path: .
@@ -160,7 +160,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Download Maven repository
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           name: maven-repo
           path: .

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -70,7 +70,7 @@ jobs:
         run: echo ${{ github.event.number }} > pr-id.txt
 
       - name: Persist documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: documentation
           path: |

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -70,7 +70,7 @@ jobs:
         run: echo ${{ github.event.number }} > pr-id.txt
 
       - name: Persist documentation
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: |

--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -117,7 +117,7 @@ jobs:
         shell: bash
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-reports-linux-jvm${{ matrix.version }}

--- a/.github/workflows/jdk-early-access-build.yml
+++ b/.github/workflows/jdk-early-access-build.yml
@@ -117,7 +117,7 @@ jobs:
         shell: bash
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: failure()
         with:
           name: test-reports-linux-jvm${{ matrix.version }}

--- a/.github/workflows/owasp-check.yml
+++ b/.github/workflows/owasp-check.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Perform OWASP Dependency Check Report
       run: ./mvnw -Dowasp-report
 
-    - uses: actions/upload-artifact@v4.3.1
+    - uses: actions/upload-artifact@v4
       with:
         name: dependency-check-report
         path: target/dependency-check-report.html

--- a/.github/workflows/owasp-check.yml
+++ b/.github/workflows/owasp-check.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Perform OWASP Dependency Check Report
       run: ./mvnw -Dowasp-report
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4.3.1
       with:
         name: dependency-check-report
         path: target/dependency-check-report.html

--- a/.github/workflows/podman-build.yml
+++ b/.github/workflows/podman-build.yml
@@ -163,14 +163,14 @@ jobs:
         shell: bash
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-reports-jvm${{matrix.java.name}}
           path: 'test-reports.tgz'
           retention-days: 5
       - name: Upload build reports (if build failed)
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: ${{ failure() || cancelled() }}
         with:
           name: "build-reports-JVM Tests - JDK ${{matrix.java.name}}"
@@ -180,7 +180,7 @@ jobs:
             LICENSE.txt
           retention-days: 2
       - name: Upload gc.log
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: "GC log - JDK ${{matrix.java.name}}"
           path: |
@@ -188,7 +188,7 @@ jobs:
             !**/build/tmp/**
           retention-days: 5
       - name: Upload build.log (if build failed)
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: ${{ failure() || cancelled() }}
         with:
           name: "build-logs-JVM Tests - JDK ${{matrix.java.name}}"

--- a/.github/workflows/podman-build.yml
+++ b/.github/workflows/podman-build.yml
@@ -163,14 +163,14 @@ jobs:
         shell: bash
         run: find . -name '*-reports' -type d -o -name '*.log' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: failure()
         with:
           name: test-reports-jvm${{matrix.java.name}}
           path: 'test-reports.tgz'
           retention-days: 5
       - name: Upload build reports (if build failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: ${{ failure() || cancelled() }}
         with:
           name: "build-reports-JVM Tests - JDK ${{matrix.java.name}}"
@@ -180,7 +180,7 @@ jobs:
             LICENSE.txt
           retention-days: 2
       - name: Upload gc.log
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: "GC log - JDK ${{matrix.java.name}}"
           path: |
@@ -188,7 +188,7 @@ jobs:
             !**/build/tmp/**
           retention-days: 5
       - name: Upload build.log (if build failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         if: ${{ failure() || cancelled() }}
         with:
           name: "build-logs-JVM Tests - JDK ${{matrix.java.name}}"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,10 +15,9 @@ jobs:
         with:
           repository: quarkusio/quarkusio.github.io
       - name: Download PR Artifact
-        uses: dawidd6/action-download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
-          workflow: ${{ github.event.workflow_run.workflow_id }}
-          workflow_conclusion: success
+          run-id: ${{ github.event.workflow_run.workflow_id }}
           name: documentation
           path: documentation-temp
       - name: Store PR id as variable

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           repository: quarkusio/quarkusio.github.io
       - name: Download PR Artifact
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.workflow_id }}
           name: documentation


### PR DESCRIPTION
- Needed because NodeJS 16 images are deprecated
- Follow-up from https://github.com/quarkusio/quarkus/pull/37810
