### PR TITLE
Allow setting the SettingsDecrypter when initializing a Maven artifact resolver

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
@@ -164,6 +164,7 @@ public class BootstrapMavenContext {
         this.remoteRepos = config.remoteRepos;
         this.remotePluginRepos = config.remotePluginRepos;
         this.remoteRepoManager = config.remoteRepoManager;
+        this.settingsDecrypter = config.settingsDecrypter;
         this.cliOptions = config.cliOptions;
         this.excludeSisuBeanPackages = config.getExcludeSisuBeanPackages();
         this.includeSisuBeanPackages = config.getIncludeSisuBeanPackages();
@@ -312,7 +313,7 @@ public class BootstrapMavenContext {
         return remotePluginRepos == null ? remotePluginRepos = resolveRemotePluginRepos() : remotePluginRepos;
     }
 
-    private SettingsDecrypter getSettingsDecrypter() {
+    public SettingsDecrypter getSettingsDecrypter() {
         if (settingsDecrypter == null) {
             initRepoSystemAndManager();
         }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContextConfig.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContextConfig.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.apache.maven.model.Model;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
@@ -28,6 +29,7 @@ public class BootstrapMavenContextConfig<T extends BootstrapMavenContextConfig<?
     protected List<RemoteRepository> remoteRepos;
     protected List<RemoteRepository> remotePluginRepos;
     protected RemoteRepositoryManager remoteRepoManager;
+    protected SettingsDecrypter settingsDecrypter;
     protected String alternatePomName;
     protected File userSettings;
     protected boolean artifactTransferLogging = true;
@@ -188,6 +190,18 @@ public class BootstrapMavenContextConfig<T extends BootstrapMavenContextConfig<?
     @SuppressWarnings("unchecked")
     public T setRemoteRepositoryManager(RemoteRepositoryManager remoteRepoManager) {
         this.remoteRepoManager = remoteRepoManager;
+        return (T) this;
+    }
+
+    /**
+     * Settings decryptor
+     *
+     * @param settingsDecrypter settings decrypter
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    public T setSettingsDecrypter(SettingsDecrypter settingsDecrypter) {
+        this.settingsDecrypter = settingsDecrypter;
         return (T) this;
     }
 


### PR DESCRIPTION
There is a use-case in the Quarkus platform generator project where this is necessary.