### PR TITLE
Update kindcontainer to 1.4.5

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -210,7 +210,7 @@
         <docker-java.version>3.3.5</docker-java.version> <!-- must be the version Testcontainers use -->
         <!-- Check the compatibility matrix (https://github.com/opensearch-project/opensearch-testcontainers) before upgrading: -->
         <opensearch-testcontainers.version>2.0.0</opensearch-testcontainers.version>
-        <com.dajudge.kindcontainer>1.4.4</com.dajudge.kindcontainer>
+        <com.dajudge.kindcontainer>1.4.5</com.dajudge.kindcontainer>
         <aesh.version>2.7</aesh.version>
         <aesh-readline.version>2.4</aesh-readline.version>
         <jansi.version>2.4.0</jansi.version> <!-- Keep in sync with aesh-readline and dekorate -->


### PR DESCRIPTION
Bumping kindcontainer if possible, CI tests seem to be all ok https://github.com/gonmmarques/quarkus/actions/runs/8154887937


I noticed also that it seems the dependabot is not opening PR for this dependency, should it be added?