### PR TITLE
Improve logging for IO utils and add thread info in build logs

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/MojoLogger.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/MojoLogger.java
@@ -91,7 +91,12 @@ public class MojoLogger implements LoggerProvider {
             void doActualLog(final Log log, final Level level, final String message, final Throwable thrown) {
                 final MessageBuilder buffer = MessageUtils.buffer();
                 // style options are limited unless we crack into jansi ourselves
-                buffer.strong("[").project(name).strong("]").a(" ").a(message);
+                if (Level.DEBUG.compareTo(level) <= 0) {
+                    buffer.strong("[").project(name).strong("]").a(" ").a("(").a(Thread.currentThread().getName()).a(")").a(" ")
+                            .a(message);
+                } else {
+                    buffer.strong("[").project(name).strong("]").a(" ").a(message);
+                }
                 if (thrown != null) {
                     switch (level) {
                         case FATAL:


### PR DESCRIPTION
This is the logging I added to figure out what was going on in #39210.

* Add additional logging on IO utils methods to detect potential issues with concurrent build steps.
* Print thread information for DEBUG or TRACE log messages in build logs.