### PR TITLE
WebSockets Next: test for filtering connected clients while broadcasting

### DIFF
--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/broadcast/BroadcastConnectionTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/broadcast/BroadcastConnectionTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.websockets.next.test.broadcast;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketClient;
+
+public class BroadcastConnectionTest {
+
+    @TestHTTPResource("lo-connection")
+    URI loConnectionUri;
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(LoConnection.class);
+            });
+
+    @Test
+    public void testBroadcast() throws Exception {
+        WebSocketClient client1 = null, client2 = null, client3 = null;
+        try {
+            List<String> messages = new CopyOnWriteArrayList<>();
+            Vertx vertx = Vertx.vertx();
+            client1 = connect(vertx, "C1", messages);
+            client2 = connect(vertx, "C2", messages);
+            client3 = connect(vertx, "C3", messages);
+            // All client are connected
+            assertEquals(3, messages.size());
+            for (String message : messages) {
+                assertTrue(message.equals("c1") || message.equals("c2") || message.equals("c3"));
+            }
+        } finally {
+            if (client1 != null) {
+                client1.close().toCompletionStage().toCompletableFuture().get();
+            }
+            if (client2 != null) {
+                client2.close().toCompletionStage().toCompletableFuture().get();
+            }
+            if (client3 != null) {
+                client3.close().toCompletionStage().toCompletableFuture().get();
+            }
+        }
+    }
+
+    WebSocketClient connect(Vertx vertx, String clientId, List<String> messages) throws InterruptedException {
+        WebSocketClient client = vertx.createWebSocketClient();
+        CountDownLatch connectedLatch = new CountDownLatch(1);
+        CountDownLatch messageLatch = new CountDownLatch(1);
+        client
+                .connect(loConnectionUri.getPort(), loConnectionUri.getHost(), loConnectionUri.getPath() + "/" + clientId)
+                .onComplete(r -> {
+                    if (r.succeeded()) {
+                        WebSocket ws = r.result();
+                        ws.textMessageHandler(msg -> {
+                            messages.add(msg);
+                            messageLatch.countDown();
+                        });
+                        connectedLatch.countDown();
+                    } else {
+                        throw new IllegalStateException(r.cause());
+                    }
+                });
+        assertTrue(connectedLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(messageLatch.await(5, TimeUnit.SECONDS));
+        return client;
+    }
+
+}

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/broadcast/BroadcastOnOpenTest.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/broadcast/BroadcastOnOpenTest.java
@@ -101,7 +101,7 @@ public class BroadcastOnOpenTest {
                         }
                     });
             assertTrue(c2ConnectedLatch.await(5, TimeUnit.SECONDS));
-            assertTrue(c2MessageLatch.await(5, TimeUnit.SECONDS));
+            assertTrue(c2MessageLatch.await(10, TimeUnit.SECONDS));
             // onOpen should be broadcasted to both clients
             assertEquals(2, messages.size());
             assertEquals("c2", messages.get(0));

--- a/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/broadcast/LoConnection.java
+++ b/extensions/websockets-next/server/deployment/src/test/java/io/quarkus/websockets/next/test/broadcast/LoConnection.java
@@ -1,0 +1,24 @@
+package io.quarkus.websockets.next.test.broadcast;
+
+import jakarta.inject.Inject;
+
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.websockets.next.WebSocketConnection;
+
+@WebSocket(path = "/lo-connection/{client}")
+public class LoConnection {
+
+    @Inject
+    WebSocketConnection connection;
+
+    @OnOpen
+    void open() {
+        // Send the message only to the current connection
+        // This does not make much sense but it's good enough to test the filter
+        connection.broadcast()
+                .filter(c -> connection.id().equals(c.id()))
+                .sendTextAndAwait(connection.pathParam("client").toLowerCase());
+    }
+
+}

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnection.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/WebSocketConnection.java
@@ -45,15 +45,6 @@ public interface WebSocketConnection extends Sender, BlockingSender {
     BroadcastSender broadcast();
 
     /**
-     * Sends messages to all open clients connected to the same WebSocket endpoint and matching the given filter predicate.
-     *
-     * @param filter
-     * @return the broadcast sender
-     * @see #getOpenConnections()
-     */
-    BroadcastSender broadcast(Predicate<WebSocketConnection> filter);
-
-    /**
      * The returned set also includes the connection this method is called upon.
      *
      * @return the set of open connections to the same endpoint
@@ -105,6 +96,14 @@ public interface WebSocketConnection extends Sender, BlockingSender {
      * @see WebSocketConnection#getOpenConnections()
      */
     interface BroadcastSender extends Sender, BlockingSender {
+
+        /**
+         *
+         * @param predicate
+         * @return a new sender that sends messages to all open clients connected to the same WebSocket endpoint and matching
+         *         the given filter predicate
+         */
+        BroadcastSender filter(Predicate<WebSocketConnection> predicate);
 
     }
 

--- a/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionImpl.java
+++ b/extensions/websockets-next/server/runtime/src/main/java/io/quarkus/websockets/next/runtime/WebSocketConnectionImpl.java
@@ -80,11 +80,6 @@ class WebSocketConnectionImpl implements WebSocketConnection {
     }
 
     @Override
-    public BroadcastSender broadcast(Predicate<WebSocketConnection> filter) {
-        return new BroadcastImpl(Objects.requireNonNull(filter));
-    }
-
-    @Override
     public Uni<Void> close() {
         return UniHelper.toUni(webSocket.close());
     }
@@ -207,6 +202,11 @@ class WebSocketConnectionImpl implements WebSocketConnection {
 
         BroadcastImpl(Predicate<WebSocketConnection> filter) {
             this.filter = filter;
+        }
+
+        @Override
+        public BroadcastSender filter(Predicate<WebSocketConnection> predicate) {
+            return new BroadcastImpl(Objects.requireNonNull(predicate));
         }
 
         @Override


### PR DESCRIPTION
- remove the WebSocketConnection#broadcast(filter) and add BroadcastSender#filter(predicate) instead so that the usage looks like connection.broadcast().filter(myPredicate).sendText("foo")
- wrap endpoint callback invocations with a try-catch-block to report the errors correctly
- also try to fix flaky BroadcastOnOpenTest#testLoMultiBidi()
- resolves #39157