### PR TITLE
Error when conflicting Deployment due to label selector version

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/Constants.java
@@ -33,6 +33,8 @@ public final class Constants {
     public static final String ROUTE = "Route";
     public static final String ROUTE_API_GROUP = "route.openshift.io/v1";
 
+    static final String VERSION_LABEL = "app.kubernetes.io/version";
+
     static final String OPENSHIFT_APP_RUNTIME = "app.openshift.io/runtime";
     static final String S2I = "s2i";
     static final String DEFAULT_S2I_IMAGE_NAME = "s2i-java"; //refers to the Dekorate default image.


### PR DESCRIPTION
Resolves: #39180

What the pull request does is that it checks if an existing Deployment is already installed with conflicting Deployment version and provides detailed error message with instructions on how the situation should be handled.

Also, it does the checking before applied resources (e.g. Service etc) that could leave the application in a non-working state.