### PR TITLE
Update docs as Quarkus no longer defautling keystore type to JKS

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -191,7 +191,7 @@ quarkus.http.ssl.certificate.key-store-file=/path/to/keystore
 ----
 
 As an optional hint, the type of keystore can be provided as one of the options listed.
-If the type is not provided, Quarkus will try to deduce it from the file extensions, defaulting to type JKS.
+If the type is not provided, Quarkus will try to deduce it from the file extensions.
 
 [source,properties]
 ----


### PR DESCRIPTION
As explained in https://github.com/quarkusio/quarkus/issues/39151 the keystore no longer defaulting to any type. Mention in migration guide https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.9#keystore-and-trust-store-default-format-chang.  So we should change it in docs as well. 

@cescoffier if you disagree and I understand it wrongly feel to close this.