### PR TITLE
Detect .truststore and .keystore files as JKS

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsUtils.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/options/TlsUtils.java
@@ -114,23 +114,38 @@ public class TlsUtils {
         if (userType.isPresent()) {
             type = userType.get().toLowerCase();
         } else {
-            type = getTypeFromFileName("truststore", singleTrustStoreFile);
+            type = getTruststoreTypeFromFileName(singleTrustStoreFile);
         }
         return type;
     }
 
-    private static String getTypeFromFileName(String keystoreOrTruststore, Path path) {
+    private static String getKeystoreTypeFromFileName(Path path) {
         String name = path.getFileName().toString().toLowerCase();
         if (name.endsWith(".p12") || name.endsWith(".pkcs12") || name.endsWith(".pfx")) {
             return "pkcs12";
-        } else if (name.endsWith(".jks")) {
+        } else if (name.endsWith(".jks") || name.endsWith(".keystore")) {
             return "jks";
         } else if (name.endsWith(".key") || name.endsWith(".crt") || name.endsWith(".pem")) {
             return "pem";
         } else {
-            throw new IllegalArgumentException("Could not determine the " + keystoreOrTruststore
-                    + " type from the file name: " + path
-                    + ". Configure the `quarkus.http.ssl.certificate.[key-store|trust-store]-file-type` property.");
+            throw new IllegalArgumentException("Could not determine the keystore type from the file name: " + path
+                    + ". Configure the `quarkus.http.ssl.certificate.key-store-file-type` property.");
+
+        }
+
+    }
+
+    private static String getTruststoreTypeFromFileName(Path path) {
+        String name = path.getFileName().toString().toLowerCase();
+        if (name.endsWith(".p12") || name.endsWith(".pkcs12") || name.endsWith(".pfx")) {
+            return "pkcs12";
+        } else if (name.endsWith(".jks") || name.endsWith(".truststore")) {
+            return "jks";
+        } else if (name.endsWith(".ca") || name.endsWith(".crt") || name.endsWith(".pem")) {
+            return "pem";
+        } else {
+            throw new IllegalArgumentException("Could not determine the truststore type from the file name: " + path
+                    + ". Configure the `quarkus.http.ssl.certificate.trust-store-file-type` property.");
 
         }
 
@@ -154,7 +169,7 @@ public class TlsUtils {
         if (fileType.isPresent()) {
             type = fileType.get().toLowerCase();
         } else {
-            type = getTypeFromFileName("keystore", path);
+            type = getKeystoreTypeFromFileName(path);
         }
         return type;
     }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/TlsUtilsTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/options/TlsUtilsTest.java
@@ -17,7 +17,10 @@ class TlsUtilsTest {
             "server-keystore.jks, jKs, JKS",
             "server-keystore.jks, null, JKS",
             "server-keystore.jks, PKCS12, PKCS12",
-            "server.keystore, null, null", // Failure expected
+            "server.foo, null, null", // Failure expected
+            "server.truststore, null, null", // Failure expected
+            "server, null, null", // Failure expected
+            "server.keystore, null, JKS",
             "server-keystore.p12, PKCS12, PKCS12",
             "server-keystore.p12, pKCs12, PKCS12",
             "server-keystore.p12, null, PKCS12",
@@ -29,6 +32,7 @@ class TlsUtilsTest {
             "server.keystore.pem, null, PEM",
             "server.keystore.key, JKS, JKS",
             "server.keystore.pom, PeM, PEM",
+            "server.keystore.ca, null, null", // .ca is a truststore file
     })
     void testKeyStoreTypeDetection(String file, String userType, String expectedType) {
         Path path = new File("target/certs/" + file).toPath();
@@ -36,7 +40,7 @@ class TlsUtilsTest {
         if (expectedType.equals("null")) {
             String message = assertThrows(IllegalArgumentException.class, () -> TlsUtils.getKeyStoreType(path, type))
                     .getMessage();
-            assertTrue(message.contains("keystore"));
+            assertTrue(message.contains("keystore") && message.contains("key-store-file-type"));
         } else {
             assertEquals(expectedType.toLowerCase(), TlsUtils.getKeyStoreType(path, type));
         }
@@ -48,18 +52,22 @@ class TlsUtilsTest {
             "server-truststore.jks, jKs, JKS",
             "server-truststore.jks, null, JKS",
             "server-truststore.jks, PKCS12, PKCS12",
-            "server.truststore, null, null", // Failure expected
+            "server.foo, null, null", // Failure expected
+            "server.keystore, null, null", // Failure expected
+            "server, null, null", // Failure expected
+            "server.truststore, null, JKS",
             "server-truststore.p12, PKCS12, PKCS12",
             "server-truststore.p12, pKCs12, PKCS12",
             "server-truststore.p12, null, PKCS12",
             "server-truststore.pfx, null, PKCS12",
             "server-truststore.pkcs12, null, PKCS12",
             "server-truststore.pkcs12, JKS, JKS",
-            "server.truststore.key, null, PEM",
             "server.truststore.crt, null, PEM",
             "server.truststore.pem, null, PEM",
             "server.truststore.key, JKS, JKS",
             "server.truststore.pom, PeM, PEM",
+            "server.keystore.ca, null, PEM",
+            "server.keystore.key, null, null", // .key is a key file
     })
     void testTrustStoreTypeDetection(String file, String userType, String expectedType) {
         Path path = new File("target/certs/" + file).toPath();
@@ -67,7 +75,7 @@ class TlsUtilsTest {
         if (expectedType.equals("null")) {
             String message = assertThrows(IllegalArgumentException.class, () -> TlsUtils.getTruststoreType(path, type))
                     .getMessage();
-            assertTrue(message.contains("truststore"));
+            assertTrue(message.contains("truststore") && message.contains("trust-store-file-type"));
         } else {
             assertEquals(expectedType.toLowerCase(), TlsUtils.getTruststoreType(path, type));
         }


### PR DESCRIPTION
Despite the declining usage of JKS (Java KeyStore) format, many Java guides and articles, such as https://tomcat.apache.org/tomcat-9.0-doc/ssl-howto.html (updated in 2024), still reference it extensively. Traditionally, JKS files are identified by three common extensions: .jks, .keystore, and .truststore.

This commit addresses (reduces) the recent breaking change: JKS is no longer the default keystore/truststore format. It introduces the automatic association of files with extensions .keystore and .truststore to JKS format (in addition to .jks), which mitigates potential disruptions for users using these conventions.

@michalvavrik You recently reported this change. I decided to re-add the association of .keystore and .truststore as JKS. The reason is the abundance of resources using these conventions. 