### PR TITLE
Migrate from config classes to `@ConfigMapping` OIDC token propagation, OIDC GraphQL client and OIDC client filters

### DIFF
--- a/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
+++ b/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
@@ -47,7 +47,7 @@ public class OidcClientFilterBuildStep {
         final Set<String> namedFilterClientClasses = namedOidcClientFilterBuildItem.namedFilterClientClasses;
 
         // register default request filter provider against the rest of the clients (client != namedFilterClientClasses)
-        if (config.registerFilter) {
+        if (config.registerFilter()) {
             if (namedFilterClientClasses.isEmpty()) {
                 // register default request filter as global rest client provider
                 jaxrsProviders.produce(new ResteasyJaxrsProviderBuildItem(OidcClientRequestFilter.class.getName()));
@@ -101,7 +101,7 @@ public class OidcClientFilterBuildStep {
             final String clientName = OidcClientFilterDeploymentHelper.getClientName(instance);
             // do not create & register named filter for the OidcClient registered through configuration property
             // as default request filter got it covered
-            if (clientName != null && !clientName.equals(config.clientName.orElse(null))) {
+            if (clientName != null && !clientName.equals(config.clientName().orElse(null))) {
 
                 // create named filter class for named OidcClient
                 // we generate exactly one custom filter for each named client specified through annotation

--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/OidcClientRequestFilter.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/OidcClientRequestFilter.java
@@ -20,6 +20,6 @@ public class OidcClientRequestFilter extends AbstractOidcClientRequestFilter {
     OidcClientFilterConfig oidcClientFilterConfig;
 
     protected Optional<String> clientId() {
-        return oidcClientFilterConfig.clientName;
+        return oidcClientFilterConfig.clientName();
     }
 }

--- a/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/OidcClientFilterConfig.java
+++ b/extensions/oidc-client-filter/runtime/src/main/java/io/quarkus/oidc/client/filter/runtime/OidcClientFilterConfig.java
@@ -2,23 +2,24 @@ package io.quarkus.oidc.client.filter.runtime;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
-@ConfigRoot(name = "resteasy-client-oidc-filter", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class OidcClientFilterConfig {
+@ConfigMapping(prefix = "quarkus.resteasy-client-oidc-filter")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface OidcClientFilterConfig {
     /**
      * Enable OidcClientRequestFilter for all the injected MP RestClient implementations.
      * If this property is disabled then OidcClientRequestFilter has to be registered as an MP RestClient provider.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean registerFilter;
+    @WithDefault("false")
+    boolean registerFilter();
 
     /**
      * Name of the configured OidcClient used by the OidcClientRequestFilter. You can override this configuration for
      * individual MP RestClient with the `io.quarkus.oidc.client.filter.OidcClientFilter` annotation.
      */
-    @ConfigItem
-    public Optional<String> clientName;
+    Optional<String> clientName();
 }

--- a/extensions/oidc-client-graphql/deployment/src/main/java/io/quarkus/oidc/client/graphql/OidcGraphQLClientIntegrationProcessor.java
+++ b/extensions/oidc-client-graphql/deployment/src/main/java/io/quarkus/oidc/client/graphql/OidcGraphQLClientIntegrationProcessor.java
@@ -54,6 +54,6 @@ public class OidcGraphQLClientIntegrationProcessor {
                 }
             }
         }
-        recorder.enhanceGraphQLClientConfigurationWithOidc(configKeysToOidcClients, config.clientName.orElse(null));
+        recorder.enhanceGraphQLClientConfigurationWithOidc(configKeysToOidcClients, config.clientName().orElse(null));
     }
 }

--- a/extensions/oidc-client-graphql/runtime/src/main/java/io/quarkus/oidc/client/graphql/runtime/OidcClientGraphQLConfig.java
+++ b/extensions/oidc-client-graphql/runtime/src/main/java/io/quarkus/oidc/client/graphql/runtime/OidcClientGraphQLConfig.java
@@ -2,17 +2,17 @@ package io.quarkus.oidc.client.graphql.runtime;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
 
-@ConfigRoot(name = "oidc-client-graphql", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class OidcClientGraphQLConfig {
+@ConfigMapping(prefix = "quarkus.oidc-client-graphql")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface OidcClientGraphQLConfig {
 
     /**
      * Name of the configured OidcClient used by GraphQL clients. You can override this configuration
      * for typesafe clients with the `io.quarkus.oidc.client.filter.OidcClientFilter` annotation.
      */
-    @ConfigItem
-    public Optional<String> clientName;
+    Optional<String> clientName();
 }

--- a/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
@@ -47,7 +47,7 @@ public class OidcClientReactiveFilterBuildStep {
             // get client name from annotation @OidcClientFilter("clientName")
             final String clientName = OidcClientFilterDeploymentHelper.getClientName(instance);
             final AnnotationValue valueAttr;
-            if (clientName != null && !clientName.equals(oidcClientReactiveFilterConfig.clientName.orElse(null))) {
+            if (clientName != null && !clientName.equals(oidcClientReactiveFilterConfig.clientName().orElse(null))) {
                 // create and use custom filter for named OidcClient
                 // we generate exactly one custom filter for each named client specified through annotation
                 valueAttr = createClassValue(helper.getOrCreateFilter(clientName));

--- a/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestReactiveFilter.java
+++ b/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestReactiveFilter.java
@@ -17,6 +17,6 @@ public class OidcClientRequestReactiveFilter extends AbstractOidcClientRequestRe
 
     @Override
     protected Optional<String> clientId() {
-        return config.clientName;
+        return config.clientName();
     }
 }

--- a/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/OidcClientReactiveFilterConfig.java
+++ b/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/runtime/OidcClientReactiveFilterConfig.java
@@ -2,17 +2,17 @@ package io.quarkus.oidc.client.reactive.filter.runtime;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
 
-@ConfigRoot(name = "rest-client-oidc-filter", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class OidcClientReactiveFilterConfig {
+@ConfigMapping(prefix = "quarkus.rest-client-oidc-filter")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface OidcClientReactiveFilterConfig {
 
     /**
      * Name of the configured OidcClient used by the OidcClientRequestReactiveFilter. You can override this configuration
      * for individual MP RestClients with the `io.quarkus.oidc.client.filter.OidcClientFilter` annotation.
      */
-    @ConfigItem
-    public Optional<String> clientName;
+    Optional<String> clientName();
 }

--- a/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveBuildStep.java
+++ b/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveBuildStep.java
@@ -86,7 +86,7 @@ public class OidcTokenPropagationReactiveBuildStep {
         OidcTokenPropagationReactiveBuildTimeConfig config;
 
         public boolean getAsBoolean() {
-            return config.enabled;
+            return config.enabled();
         }
     }
 
@@ -94,7 +94,7 @@ public class OidcTokenPropagationReactiveBuildStep {
         OidcTokenPropagationReactiveBuildTimeConfig config;
 
         public boolean getAsBoolean() {
-            return config.enabledDuringAuthentication;
+            return config.enabledDuringAuthentication();
         }
     }
 }

--- a/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveBuildTimeConfig.java
+++ b/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveBuildTimeConfig.java
@@ -1,18 +1,20 @@
 package io.quarkus.oidc.token.propagation.reactive;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 /**
  * Build time configuration for OIDC Token Propagation Reactive.
  */
-@ConfigRoot(name = "rest-client-oidc-token-propagation")
-public class OidcTokenPropagationReactiveBuildTimeConfig {
+@ConfigMapping(prefix = "quarkus.rest-client-oidc-token-propagation")
+@ConfigRoot
+public interface OidcTokenPropagationReactiveBuildTimeConfig {
     /**
      * If the OIDC Token Reactive Propagation is enabled.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enabled;
+    @WithDefault("true")
+    boolean enabled();
 
     /**
      * Whether the token propagation is enabled during the `SecurityIdentity` augmentation.
@@ -25,6 +27,6 @@ public class OidcTokenPropagationReactiveBuildTimeConfig {
      *
      * @asciidoclet
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean enabledDuringAuthentication;
+    @WithDefault("false")
+    boolean enabledDuringAuthentication();
 }

--- a/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveConfig.java
+++ b/extensions/oidc-token-propagation-reactive/runtime/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveConfig.java
@@ -2,25 +2,26 @@ package io.quarkus.oidc.token.propagation.reactive;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
-@ConfigRoot(name = "rest-client-oidc-token-propagation", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class OidcTokenPropagationReactiveConfig {
+@ConfigMapping(prefix = "quarkus.rest-client-oidc-token-propagation")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface OidcTokenPropagationReactiveConfig {
     /**
      * Exchange the current token with OpenId Connect Provider for a new token using either
      * "urn:ietf:params:oauth:grant-type:token-exchange" or "urn:ietf:params:oauth:grant-type:jwt-bearer" token grant
      * before propagating it.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean exchangeToken;
+    @WithDefault("false")
+    boolean exchangeToken();
 
     /**
      * Name of the configured OidcClient.
      *
      * Note this property is only used if the `exchangeToken` property is enabled.
      */
-    @ConfigItem
-    public Optional<String> clientName;
+    Optional<String> clientName();
 }

--- a/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
+++ b/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
@@ -53,8 +53,8 @@ public class OidcTokenPropagationBuildStep {
         reflectiveClass
                 .produce(ReflectiveClassBuildItem.builder(JsonWebTokenRequestFilter.class).methods().fields().build());
 
-        if (config.registerFilter) {
-            Class<?> filterClass = config.jsonWebToken ? JsonWebTokenRequestFilter.class : AccessTokenRequestFilter.class;
+        if (config.registerFilter()) {
+            Class<?> filterClass = config.jsonWebToken() ? JsonWebTokenRequestFilter.class : AccessTokenRequestFilter.class;
             jaxrsProviders.produce(new ResteasyJaxrsProviderBuildItem(filterClass.getName()));
         } else {
             restAnnotationProvider.produce(new RestClientAnnotationProviderBuildItem(JWT_ACCESS_TOKEN_CREDENTIAL,

--- a/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/runtime/OidcTokenPropagationConfig.java
+++ b/extensions/oidc-token-propagation/runtime/src/main/java/io/quarkus/oidc/token/propagation/runtime/OidcTokenPropagationConfig.java
@@ -2,12 +2,14 @@ package io.quarkus.oidc.token.propagation.runtime;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
-@ConfigRoot(name = "resteasy-client-oidc-token-propagation", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public class OidcTokenPropagationConfig {
+@ConfigMapping(prefix = "quarkus.resteasy-client-oidc-token-propagation")
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public interface OidcTokenPropagationConfig {
     /**
      * Enable either AccessTokenRequestFilter or JsonWebTokenRequestFilter for all the injected MP RestClient implementations.
      *
@@ -20,8 +22,8 @@ public class OidcTokenPropagationConfig {
      * implementations, both filters can be registered as MP RestClient providers with the specific MP RestClient
      * implementations.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean registerFilter;
+    @WithDefault("false")
+    boolean registerFilter();
 
     /**
      * Enable JsonWebTokenRequestFilter instead of AccessTokenRequestFilter for all the injected MP RestClient implementations.
@@ -29,8 +31,8 @@ public class OidcTokenPropagationConfig {
      *
      * Note this property is ignored unless the 'registerFilter' property is enabled.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean jsonWebToken;
+    @WithDefault("false")
+    boolean jsonWebToken();
 
     /**
      * Secure the injected and possibly modified JsonWebToken.
@@ -38,8 +40,8 @@ public class OidcTokenPropagationConfig {
      *
      * Note this property is injected into JsonWebTokenRequestFilter.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean secureJsonWebToken;
+    @WithDefault("false")
+    boolean secureJsonWebToken();
 
     /**
      * Exchange the current token with OpenId Connect Provider for a new token using either
@@ -48,14 +50,13 @@ public class OidcTokenPropagationConfig {
      *
      * Note this property is injected into AccessTokenRequestFilter.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean exchangeToken;
+    @WithDefault("false")
+    boolean exchangeToken();
 
     /**
      * Name of the configured OidcClient.
      *
      * Note this property is injected into AccessTokenRequestFilter and is only used if the `exchangeToken` property is enabled.
      */
-    @ConfigItem
-    public Optional<String> clientName;
+    Optional<String> clientName();
 }


### PR DESCRIPTION
Small part of https://github.com/quarkusio/quarkus/issues/39185 effort. I'll follow with other small PRs.

According to Maven central, there are no known usages (like in Quarkiverse):

- https://mvnrepository.com/artifact/io.quarkus/quarkus-oidc-token-propagation/usages
- https://mvnrepository.com/artifact/io.quarkus/quarkus-oidc-token-propagation-reactive/usages
- https://mvnrepository.com/artifact/io.quarkus/quarkus-oidc-client-graphql/usages
- Https://Mvnrepository.Com/Artifact/Io.Quarkus/Quarkus-Oidc-Client-Reactive-Filter/Usages

Quarkus OIDC Client Filter is used by https://mvnrepository.com/artifact/io.quarkus/quarkus-oidc-client-filter/usages:
- https://github.com/quarkiverse/quarkus-openapi-generator (cloned, checked, no config class usage)
- FoundationDB API Client (I've looked for this project for 20 minutes, I have no idea whether project exists or where are it's source codes, can't find anything about it)
- https://github.com/kiegroup/kogito-runtimes/tree/main/quarkus/integration-tests/integration-tests-quarkus-openapi-client (cloned, checked, no config class usage)
- https://github.com/kiegroup/kogito-runtimes/tree/main/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test  (cloned, checked, no config class usage)

Please feel free to squashing commits during merging, I wasn't sure whether it's good idea to have them as one commit, but they are tiny changes.