### PR TITLE
Make mutiny version of pool use the already configured vertx pool

### DIFF
--- a/extensions/reactive-db2-client/deployment/src/main/java/io/quarkus/reactive/db2/client/deployment/ReactiveDB2ClientProcessor.java
+++ b/extensions/reactive-db2-client/deployment/src/main/java/io/quarkus/reactive/db2/client/deployment/ReactiveDB2ClientProcessor.java
@@ -65,11 +65,15 @@ import io.vertx.sqlclient.Pool;
 
 class ReactiveDB2ClientProcessor {
 
-    private static final ParameterizedType POOL_INJECTION_TYPE = ParameterizedType.create(DotName.createSimple(Instance.class),
+    private static final ParameterizedType POOL_CREATOR_INJECTION_TYPE = ParameterizedType.create(
+            DotName.createSimple(Instance.class),
             new Type[] { ClassType.create(DotName.createSimple(DB2PoolCreator.class.getName())) }, null);
     private static final AnnotationInstance[] EMPTY_ANNOTATIONS = new AnnotationInstance[0];
 
     private static final DotName REACTIVE_DATASOURCE = DotName.createSimple(ReactiveDataSource.class);
+
+    private static final DotName VERTX_DB2_POOL = DotName.createSimple(DB2Pool.class);
+    private static final Type VERTX_DB2_POOL_TYPE = Type.create(VERTX_DB2_POOL, Type.Kind.CLASS);
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
@@ -208,7 +212,7 @@ class ReactiveDB2ClientProcessor {
                 .defaultBean()
                 .addType(Pool.class)
                 .scope(ApplicationScoped.class)
-                .addInjectionPoint(POOL_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
+                .addInjectionPoint(POOL_CREATOR_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
                 .addInjectionPoint(ClassType.create(DataSourceSupport.class))
                 .createWith(poolFunction)
                 .unremovable()
@@ -223,9 +227,9 @@ class ReactiveDB2ClientProcessor {
                 .defaultBean()
                 .addType(io.vertx.mutiny.sqlclient.Pool.class)
                 .scope(ApplicationScoped.class)
-                .addInjectionPoint(POOL_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
+                .addInjectionPoint(VERTX_DB2_POOL_TYPE, injectionPointAnnotations(dataSourceName))
                 .addInjectionPoint(ClassType.create(DataSourceSupport.class))
-                .createWith(recorder.mutinyDB2Pool(poolFunction))
+                .createWith(recorder.mutinyDB2Pool(dataSourceName))
                 .unremovable()
                 .setRuntimeInit();
 

--- a/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
+++ b/extensions/reactive-db2-client/runtime/src/main/java/io/quarkus/reactive/db2/client/runtime/DB2PoolRecorder.java
@@ -10,11 +10,13 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemTrustOpt
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxKeyCertOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOptions;
 
+import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
@@ -47,7 +49,7 @@ import io.vertx.sqlclient.impl.Utils;
 public class DB2PoolRecorder {
 
     private static final Logger log = Logger.getLogger(DB2PoolRecorder.class);
-    private static final TypeLiteral<Instance<DB2PoolCreator>> TYPE_LITERAL = new TypeLiteral<>() {
+    private static final TypeLiteral<Instance<DB2PoolCreator>> POOL_CREATOR_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     public Function<SyntheticCreationalContext<DB2Pool>, DB2Pool> configureDB2Pool(RuntimeValue<Vertx> vertx,
@@ -75,14 +77,28 @@ public class DB2PoolRecorder {
     }
 
     public Function<SyntheticCreationalContext<io.vertx.mutiny.db2client.DB2Pool>, io.vertx.mutiny.db2client.DB2Pool> mutinyDB2Pool(
-            Function<SyntheticCreationalContext<DB2Pool>, DB2Pool> function) {
+            String dataSourceName) {
         return new Function<>() {
             @SuppressWarnings("unchecked")
             @Override
             public io.vertx.mutiny.db2client.DB2Pool apply(SyntheticCreationalContext context) {
-                return io.vertx.mutiny.db2client.DB2Pool.newInstance(function.apply(context));
+                DataSourceSupport datasourceSupport = (DataSourceSupport) context.getInjectedReference(DataSourceSupport.class);
+                if (datasourceSupport.getInactiveNames().contains(dataSourceName)) {
+                    throw DataSourceUtil.dataSourceInactive(dataSourceName);
+                }
+                DB2Pool db2Pool = (DB2Pool) context.getInjectedReference(DB2Pool.class,
+                        getReactiveDataSourceQualifier(dataSourceName));
+                return io.vertx.mutiny.db2client.DB2Pool.newInstance(db2Pool);
             }
         };
+    }
+
+    private static Annotation getReactiveDataSourceQualifier(String dataSourceName) {
+        if (DataSourceUtil.isDefault(dataSourceName)) {
+            return Default.Literal.INSTANCE;
+        }
+
+        return new ReactiveDataSource.ReactiveDataSourceLiteral(dataSourceName);
     }
 
     private DB2Pool initialize(VertxInternal vertx,
@@ -240,9 +256,9 @@ public class DB2PoolRecorder {
             SyntheticCreationalContext<DB2Pool> context) {
         Instance<DB2PoolCreator> instance;
         if (DataSourceUtil.isDefault(dataSourceName)) {
-            instance = context.getInjectedReference(TYPE_LITERAL);
+            instance = context.getInjectedReference(POOL_CREATOR_TYPE_LITERAL);
         } else {
-            instance = context.getInjectedReference(TYPE_LITERAL,
+            instance = context.getInjectedReference(POOL_CREATOR_TYPE_LITERAL,
                     new ReactiveDataSource.ReactiveDataSourceLiteral(dataSourceName));
         }
         if (instance.isResolvable()) {

--- a/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/ReactiveMSSQLClientProcessor.java
+++ b/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/ReactiveMSSQLClientProcessor.java
@@ -65,10 +65,13 @@ import io.vertx.sqlclient.Pool;
 
 class ReactiveMSSQLClientProcessor {
 
-    private static final ParameterizedType POOL_INJECTION_TYPE = ParameterizedType.create(DotName.createSimple(Instance.class),
+    private static final ParameterizedType POOL_CREATOR_INJECTION_TYPE = ParameterizedType.create(
+            DotName.createSimple(Instance.class),
             new Type[] { ClassType.create(DotName.createSimple(MSSQLPoolCreator.class.getName())) }, null);
     private static final AnnotationInstance[] EMPTY_ANNOTATIONS = new AnnotationInstance[0];
     private static final DotName REACTIVE_DATASOURCE = DotName.createSimple(ReactiveDataSource.class);
+    private static final DotName VERTX_MSSQL_POOL = DotName.createSimple(MSSQLPool.class);
+    private static final Type VERTX_MSSQL_POOL_TYPE = Type.create(VERTX_MSSQL_POOL, Type.Kind.CLASS);
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
@@ -207,7 +210,7 @@ class ReactiveMSSQLClientProcessor {
                 .defaultBean()
                 .addType(Pool.class)
                 .scope(ApplicationScoped.class)
-                .addInjectionPoint(POOL_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
+                .addInjectionPoint(POOL_CREATOR_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
                 .addInjectionPoint(ClassType.create(DataSourceSupport.class))
                 .createWith(poolFunction)
                 .unremovable()
@@ -222,9 +225,9 @@ class ReactiveMSSQLClientProcessor {
                 .defaultBean()
                 .addType(io.vertx.mutiny.sqlclient.Pool.class)
                 .scope(ApplicationScoped.class)
-                .addInjectionPoint(POOL_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
+                .addInjectionPoint(VERTX_MSSQL_POOL_TYPE, injectionPointAnnotations(dataSourceName))
                 .addInjectionPoint(ClassType.create(DataSourceSupport.class))
-                .createWith(recorder.mutinyMSSQLPool(poolFunction))
+                .createWith(recorder.mutinyMSSQLPool(dataSourceName))
                 .unremovable()
                 .setRuntimeInit();
 

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/SamePoolInstanceTest.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/SamePoolInstanceTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.reactive.mssql.client;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SamePoolInstanceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.devservices.enabled", "false");
+
+    @Inject
+    io.vertx.mutiny.mssqlclient.MSSQLPool mutinyPool;
+    @Inject
+    io.vertx.mssqlclient.MSSQLPool pool;
+
+    @Test
+    public void test() {
+        Assertions.assertThat(ClientProxy.unwrap(pool)).isSameAs(ClientProxy.unwrap(mutinyPool.getDelegate()));
+    }
+}

--- a/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
+++ b/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
@@ -10,11 +10,13 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemTrustOpt
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxKeyCertOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOptions;
 
+import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
@@ -46,7 +48,7 @@ import io.vertx.sqlclient.impl.Utils;
 @Recorder
 public class MSSQLPoolRecorder {
 
-    private static final TypeLiteral<Instance<MSSQLPoolCreator>> TYPE_LITERAL = new TypeLiteral<>() {
+    private static final TypeLiteral<Instance<MSSQLPoolCreator>> POOL_CREATOR_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     private static final Logger log = Logger.getLogger(MSSQLPoolRecorder.class);
@@ -80,14 +82,29 @@ public class MSSQLPoolRecorder {
     }
 
     public Function<SyntheticCreationalContext<io.vertx.mutiny.mssqlclient.MSSQLPool>, io.vertx.mutiny.mssqlclient.MSSQLPool> mutinyMSSQLPool(
-            Function<SyntheticCreationalContext<MSSQLPool>, MSSQLPool> function) {
+            String dataSourceName) {
         return new Function<SyntheticCreationalContext<io.vertx.mutiny.mssqlclient.MSSQLPool>, io.vertx.mutiny.mssqlclient.MSSQLPool>() {
             @Override
             @SuppressWarnings("unchecked")
             public io.vertx.mutiny.mssqlclient.MSSQLPool apply(SyntheticCreationalContext context) {
-                return io.vertx.mutiny.mssqlclient.MSSQLPool.newInstance(function.apply(context));
+                DataSourceSupport datasourceSupport = (DataSourceSupport) context.getInjectedReference(DataSourceSupport.class);
+                if (datasourceSupport.getInactiveNames().contains(dataSourceName)) {
+                    throw DataSourceUtil.dataSourceInactive(dataSourceName);
+                }
+
+                return io.vertx.mutiny.mssqlclient.MSSQLPool.newInstance(
+                        (MSSQLPool) context.getInjectedReference(MSSQLPool.class,
+                                getReactiveDataSourceQualifier(dataSourceName)));
             }
         };
+    }
+
+    private static Annotation getReactiveDataSourceQualifier(String dataSourceName) {
+        if (DataSourceUtil.isDefault(dataSourceName)) {
+            return Default.Literal.INSTANCE;
+        }
+
+        return new ReactiveDataSource.ReactiveDataSourceLiteral(dataSourceName);
     }
 
     private MSSQLPool initialize(VertxInternal vertx,
@@ -243,9 +260,9 @@ public class MSSQLPoolRecorder {
             SyntheticCreationalContext<MSSQLPool> context) {
         Instance<MSSQLPoolCreator> instance;
         if (DataSourceUtil.isDefault(dataSourceName)) {
-            instance = context.getInjectedReference(TYPE_LITERAL);
+            instance = context.getInjectedReference(POOL_CREATOR_TYPE_LITERAL);
         } else {
-            instance = context.getInjectedReference(TYPE_LITERAL,
+            instance = context.getInjectedReference(POOL_CREATOR_TYPE_LITERAL,
                     new ReactiveDataSource.ReactiveDataSourceLiteral(dataSourceName));
         }
         if (instance.isResolvable()) {

--- a/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
+++ b/extensions/reactive-mysql-client/deployment/src/main/java/io/quarkus/reactive/mysql/client/deployment/ReactiveMySQLClientProcessor.java
@@ -65,10 +65,13 @@ import io.vertx.sqlclient.Pool;
 
 class ReactiveMySQLClientProcessor {
 
-    private static final ParameterizedType POOL_INJECTION_TYPE = ParameterizedType.create(DotName.createSimple(Instance.class),
+    private static final ParameterizedType POOL_CREATOR_INJECTION_TYPE = ParameterizedType.create(
+            DotName.createSimple(Instance.class),
             new Type[] { ClassType.create(DotName.createSimple(MySQLPoolCreator.class.getName())) }, null);
     private static final AnnotationInstance[] EMPTY_ANNOTATIONS = new AnnotationInstance[0];
     private static final DotName REACTIVE_DATASOURCE = DotName.createSimple(ReactiveDataSource.class);
+    private static final DotName VERTX_MYSQL_POOL = DotName.createSimple(MySQLPool.class);
+    private static final Type VERTX_MYSQL_POOL_TYPE = Type.create(VERTX_MYSQL_POOL, Type.Kind.CLASS);
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
@@ -208,7 +211,7 @@ class ReactiveMySQLClientProcessor {
                 .defaultBean()
                 .addType(Pool.class)
                 .scope(ApplicationScoped.class)
-                .addInjectionPoint(POOL_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
+                .addInjectionPoint(POOL_CREATOR_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
                 .addInjectionPoint(ClassType.create(DataSourceSupport.class))
                 .createWith(poolFunction)
                 .unremovable()
@@ -223,9 +226,9 @@ class ReactiveMySQLClientProcessor {
                 .defaultBean()
                 .addType(io.vertx.mutiny.sqlclient.Pool.class)
                 .scope(ApplicationScoped.class)
-                .addInjectionPoint(POOL_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
+                .addInjectionPoint(VERTX_MYSQL_POOL_TYPE, injectionPointAnnotations(dataSourceName))
                 .addInjectionPoint(ClassType.create(DataSourceSupport.class))
-                .createWith(recorder.mutinyMySQLPool(poolFunction))
+                .createWith(recorder.mutinyMySQLPool(dataSourceName))
                 .unremovable()
                 .setRuntimeInit();
 

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/SamePoolInstanceTest.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/SamePoolInstanceTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.reactive.mysql.client;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SamePoolInstanceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest();
+
+    @Inject
+    io.vertx.mutiny.mysqlclient.MySQLPool mutinyPool;
+    @Inject
+    io.vertx.mysqlclient.MySQLPool pool;
+
+    @Test
+    public void test() {
+        Assertions.assertThat(ClientProxy.unwrap(pool)).isSameAs(ClientProxy.unwrap(mutinyPool.getDelegate()));
+    }
+}

--- a/extensions/reactive-oracle-client/deployment/src/main/java/io/quarkus/reactive/oracle/client/deployment/ReactiveOracleClientProcessor.java
+++ b/extensions/reactive-oracle-client/deployment/src/main/java/io/quarkus/reactive/oracle/client/deployment/ReactiveOracleClientProcessor.java
@@ -65,10 +65,13 @@ import io.vertx.sqlclient.Pool;
 
 class ReactiveOracleClientProcessor {
 
-    private static final ParameterizedType POOL_INJECTION_TYPE = ParameterizedType.create(DotName.createSimple(Instance.class),
+    private static final ParameterizedType POOL_CREATOR_INJECTION_TYPE = ParameterizedType.create(
+            DotName.createSimple(Instance.class),
             new Type[] { ClassType.create(DotName.createSimple(OraclePoolCreator.class.getName())) }, null);
     private static final AnnotationInstance[] EMPTY_ANNOTATIONS = new AnnotationInstance[0];
     private static final DotName REACTIVE_DATASOURCE = DotName.createSimple(ReactiveDataSource.class);
+    private static final DotName VERTX_ORACLE_POOL = DotName.createSimple(OraclePool.class);
+    private static final Type VERTX_ORACLE_POOL_TYPE = Type.create(VERTX_ORACLE_POOL, Type.Kind.CLASS);
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
@@ -209,7 +212,7 @@ class ReactiveOracleClientProcessor {
                 .defaultBean()
                 .addType(Pool.class)
                 .scope(ApplicationScoped.class)
-                .addInjectionPoint(POOL_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
+                .addInjectionPoint(POOL_CREATOR_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
                 .addInjectionPoint(ClassType.create(DataSourceSupport.class))
                 .createWith(poolFunction)
                 .unremovable()
@@ -224,9 +227,9 @@ class ReactiveOracleClientProcessor {
                 .defaultBean()
                 .addType(io.vertx.mutiny.sqlclient.Pool.class)
                 .scope(ApplicationScoped.class)
-                .addInjectionPoint(POOL_INJECTION_TYPE, injectionPointAnnotations(dataSourceName))
+                .addInjectionPoint(VERTX_ORACLE_POOL_TYPE, injectionPointAnnotations(dataSourceName))
                 .addInjectionPoint(ClassType.create(DataSourceSupport.class))
-                .createWith(recorder.mutinyOraclePool(poolFunction))
+                .createWith(recorder.mutinyOraclePool(dataSourceName))
                 .unremovable()
                 .setRuntimeInit();
 

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/SamePoolInstanceTest.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/SamePoolInstanceTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.reactive.oracle.client;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SamePoolInstanceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest();
+
+    @Inject
+    io.vertx.mutiny.oracleclient.OraclePool mutinyPool;
+    @Inject
+    io.vertx.oracleclient.OraclePool pool;
+
+    @Test
+    public void test() {
+        Assertions.assertThat(ClientProxy.unwrap(pool)).isSameAs(ClientProxy.unwrap(mutinyPool.getDelegate()));
+    }
+}

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/SamePoolInstanceTest.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/SamePoolInstanceTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.reactive.pg.client;
+
+import static org.assertj.core.api.Assertions.*;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SamePoolInstanceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest();
+
+    @Inject
+    io.vertx.mutiny.pgclient.PgPool mutinyPool;
+    @Inject
+    io.vertx.pgclient.PgPool pool;
+
+    @Test
+    public void test() {
+        assertThat(ClientProxy.unwrap(pool)).isSameAs(ClientProxy.unwrap(mutinyPool.getDelegate()));
+    }
+}

--- a/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
+++ b/extensions/reactive-pg-client/runtime/src/main/java/io/quarkus/reactive/pg/client/runtime/PgPoolRecorder.java
@@ -10,12 +10,14 @@ import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemTrustOpt
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxKeyCertOptions;
 import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOptions;
 
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
@@ -46,7 +48,7 @@ import io.vertx.sqlclient.impl.Utils;
 @Recorder
 public class PgPoolRecorder {
 
-    private static final TypeLiteral<Instance<PgPoolCreator>> TYPE_LITERAL = new TypeLiteral<>() {
+    private static final TypeLiteral<Instance<PgPoolCreator>> PG_POOL_CREATOR_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     public Function<SyntheticCreationalContext<PgPool>, PgPool> configurePgPool(RuntimeValue<Vertx> vertx,
@@ -74,14 +76,28 @@ public class PgPoolRecorder {
     }
 
     public Function<SyntheticCreationalContext<io.vertx.mutiny.pgclient.PgPool>, io.vertx.mutiny.pgclient.PgPool> mutinyPgPool(
-            Function<SyntheticCreationalContext<PgPool>, PgPool> function) {
+            String dataSourceName) {
         return new Function<>() {
             @SuppressWarnings("unchecked")
             @Override
             public io.vertx.mutiny.pgclient.PgPool apply(SyntheticCreationalContext context) {
-                return io.vertx.mutiny.pgclient.PgPool.newInstance(function.apply(context));
+                DataSourceSupport datasourceSupport = (DataSourceSupport) context.getInjectedReference(DataSourceSupport.class);
+                if (datasourceSupport.getInactiveNames().contains(dataSourceName)) {
+                    throw DataSourceUtil.dataSourceInactive(dataSourceName);
+                }
+
+                return io.vertx.mutiny.pgclient.PgPool.newInstance(
+                        (PgPool) context.getInjectedReference(PgPool.class, getReactiveDataSourceQualifier(dataSourceName)));
             }
         };
+    }
+
+    private static Annotation getReactiveDataSourceQualifier(String dataSourceName) {
+        if (DataSourceUtil.isDefault(dataSourceName)) {
+            return Default.Literal.INSTANCE;
+        }
+
+        return new ReactiveDataSource.ReactiveDataSourceLiteral(dataSourceName);
     }
 
     private PgPool initialize(VertxInternal vertx,
@@ -251,9 +267,9 @@ public class PgPoolRecorder {
             SyntheticCreationalContext<PgPool> context) {
         Instance<PgPoolCreator> instance;
         if (DataSourceUtil.isDefault(dataSourceName)) {
-            instance = context.getInjectedReference(TYPE_LITERAL);
+            instance = context.getInjectedReference(PG_POOL_CREATOR_TYPE_LITERAL);
         } else {
-            instance = context.getInjectedReference(TYPE_LITERAL,
+            instance = context.getInjectedReference(PG_POOL_CREATOR_TYPE_LITERAL,
                     new ReactiveDataSource.ReactiveDataSourceLiteral(dataSourceName));
         }
         if (instance.isResolvable()) {


### PR DESCRIPTION
Before this, the mutiny version would recreate the delegate instead of reusing the existing bean

- Fixes: #39047