### PR TITLE
Explicitly set all HTTP methods for Azure Functions

### DIFF
--- a/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/Function.java
+++ b/extensions/azure-functions-http/runtime/src/main/java/io/quarkus/azure/functions/resteasy/runtime/Function.java
@@ -1,5 +1,7 @@
 package io.quarkus.azure.functions.resteasy.runtime;
 
+import static com.microsoft.azure.functions.HttpMethod.*;
+
 import java.util.Optional;
 
 import com.microsoft.azure.functions.ExecutionContext;
@@ -15,7 +17,9 @@ public class Function extends BaseFunction {
 
     @FunctionName(QUARKUS_HTTP)
     public HttpResponseMessage run(
-            @HttpTrigger(name = "req", dataType = "binary", route = "{*path}", authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
+            @HttpTrigger(name = "req", dataType = "binary", route = "{*path}", authLevel = AuthorizationLevel.ANONYMOUS, methods = {
+                    GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE,
+                    PATCH }) HttpRequestMessage<Optional<String>> request,
             ExecutionContext context) {
 
         return dispatch(request);


### PR DESCRIPTION
It appears that failure to do so results in the generated metadata not automatically including them (as opposed to what the javadoc of `@HttpTrigger` says)

- Fixes: #39242