### PR TITLE
Add handling of the annotation @PermissionsAllowed on methods or class for OpenAPI

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -89,6 +89,7 @@ import io.quarkus.resteasy.server.common.spi.AllowedJaxRsAnnotationPrefixBuildIt
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.util.ClassPathUtils;
 import io.quarkus.security.Authenticated;
+import io.quarkus.security.PermissionsAllowed;
 import io.quarkus.smallrye.openapi.OpenApiFilter;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.smallrye.openapi.deployment.filter.AutoRolesAllowedFilter;
@@ -565,6 +566,9 @@ public class SmallRyeOpenApiProcessor {
             Map<String, List<String>> rolesAllowedMethodReferences = getRolesAllowedMethodReferences(
                     apiFilteredIndexViewBuildItem);
 
+            getPermissionsAllowedMethodReferences(apiFilteredIndexViewBuildItem)
+                    .forEach(k -> rolesAllowedMethodReferences.putIfAbsent(k, List.of()));
+
             List<String> authenticatedMethodReferences = getAuthenticatedMethodReferences(
                     apiFilteredIndexViewBuildItem);
 
@@ -628,6 +632,17 @@ public class SmallRyeOpenApiProcessor {
                             }
                             return v1;
                         }));
+    }
+
+    private List<String> getPermissionsAllowedMethodReferences(
+            OpenApiFilteredIndexViewBuildItem indexViewBuildItem) {
+        return indexViewBuildItem.getIndex()
+                .getAnnotations(DotName.createSimple(PermissionsAllowed.class))
+                .stream()
+                .flatMap(SmallRyeOpenApiProcessor::getMethods)
+                .map(e -> JandexUtil.createUniqueMethodReference(e.getKey().declaringClass(), e.getKey()))
+                .distinct()
+                .toList();
     }
 
     private List<String> getAuthenticatedMethodReferences(OpenApiFilteredIndexViewBuildItem indexViewBuildItem) {

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedTestCase.java
@@ -26,7 +26,8 @@ class AutoSecurityRolesAllowedTestCase {
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(ResourceBean.class, OpenApiResourceSecuredAtClassLevel.class,
-                            OpenApiResourceSecuredAtMethodLevel.class, OpenApiResourceSecuredAtMethodLevel2.class)
+                            OpenApiResourceSecuredAtClassLevel2.class, OpenApiResourceSecuredAtMethodLevel.class,
+                            OpenApiResourceSecuredAtMethodLevel2.class)
                     .addAsResource(
                             new StringAsset("quarkus.smallrye-openapi.security-scheme=jwt\n"
                                     + "quarkus.smallrye-openapi.security-scheme-name=JWTCompanyAuthentication\n"
@@ -71,6 +72,7 @@ class AutoSecurityRolesAllowedTestCase {
                 .body("paths.'/resource2/test-security/methodLevel/public'.get.security", nullValue())
                 .body("paths.'/resource2/test-security/annotated/documented'.get.security", defaultSecurity)
                 .body("paths.'/resource2/test-security/methodLevel/3'.get.security", defaultSecurity)
+                .body("paths.'/resource2/test-security/methodLevel/4'.get.security", defaultSecurity)
                 .and()
                 // OpenApiResourceSecuredAtClassLevel
                 .body("paths.'/resource2/test-security/classLevel/1'.get.security", defaultSecurity)
@@ -79,7 +81,10 @@ class AutoSecurityRolesAllowedTestCase {
                 .body("paths.'/resource2/test-security/classLevel/4'.get.security", defaultSecurity)
                 .and()
                 // OpenApiResourceSecuredAtMethodLevel2
-                .body("paths.'/resource3/test-security/annotated'.get.security", schemeArray("AtClassLevel"));
+                .body("paths.'/resource3/test-security/annotated'.get.security", schemeArray("AtClassLevel"))
+                .and()
+                // OpenApiResourceSecuredAtClassLevel2
+                .body("paths.'/resource3/test-security/classLevel-2/1'.get.security", defaultSecurity);
     }
 
     @Test
@@ -153,7 +158,19 @@ class AutoSecurityRolesAllowedTestCase {
                         Matchers.equalTo("Who are you?"))
                 .and()
                 .body("paths.'/resource2/test-security/methodLevel/3'.get.responses.403.description",
-                        Matchers.equalTo("You cannot do that."));
+                        Matchers.equalTo("You cannot do that."))
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/4'.get.responses.401.description",
+                        Matchers.equalTo("Not Authorized"))
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/4'.get.responses.403.description",
+                        Matchers.equalTo("Not Allowed"))
+                .and()
+                .body("paths.'/resource3/test-security/classLevel-2/1'.get.responses.401.description",
+                        Matchers.equalTo("Not Authorized"))
+                .and()
+                .body("paths.'/resource3/test-security/classLevel-2/1'.get.responses.403.description",
+                        Matchers.equalTo("Not Allowed"));
     }
 
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtClassLevel2.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtClassLevel2.java
@@ -1,0 +1,26 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.openapi.annotations.servers.Server;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import io.quarkus.security.PermissionsAllowed;
+
+@Path("/resource3")
+@Tag(name = "test")
+@Server(url = "serverUrl")
+@PermissionsAllowed("secure:read")
+public class OpenApiResourceSecuredAtClassLevel2 {
+
+    @SuppressWarnings("unused")
+    private ResourceBean resourceBean;
+
+    @GET
+    @Path("/test-security/classLevel-2/1")
+    public String secureEndpoint1() {
+        return "secret";
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel.java
@@ -10,6 +10,8 @@ import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement
 import org.eclipse.microprofile.openapi.annotations.servers.Server;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
+import io.quarkus.security.PermissionsAllowed;
+
 @Path("/resource2")
 @Tag(name = "test")
 @Server(url = "serverUrl")
@@ -73,6 +75,13 @@ public class OpenApiResourceSecuredAtMethodLevel {
     @Path("/test-security/methodLevel/3")
     @RolesAllowed("admin")
     public String secureEndpoint3() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/methodLevel/4")
+    @PermissionsAllowed("secure:read")
+    public String secureEndpoint5() {
         return "secret";
     }
 


### PR DESCRIPTION
Closes #39227

Add support for annotation `@PermissionsAllowed` on the generated openapi file.

For a method declared as followed :
``` java
    @GET
    @Path("/test")
    @PermissionsAllowed("secure:read")
    public String endpoint() {
        return "secure";
    }
```
The result is
``` yaml
  /test:
    get:
      ...
      responses:
        "200":
          description: OK
          content:
            text/plain:
              schema:
                type: string
        "403":
          description: Not Allowed
        "401":
          description: Not Authorized
      security:
      - SecurityScheme: []
```

Please note that the content of SecurityScheme is empty. This is done on purpose to avoid mixing openapi scopes with the internal application permission.

If you desire the openapi file to reflect the proper scope, I would recommend doing the following.

``` java
@ApplicationScoped
@RolesAllowed("my-scope")
public class MyController {
    @GET
    @Path("/test")
    @PermissionsAllowed("secure:read")
    public String endpoint() {
        return "secure";
    }
}
```
Adding a `@RoleAllowed` on the class itself allows to set a scope in the openapi definition and the result is as follow
``` yaml
  /test:
    get:
      ...
      responses:
        "200":
          description: OK
          content:
            text/plain:
              schema:
                type: string
        "403":
          description: Not Allowed
        "401":
          description: Not Authorized
      security:
      - SecurityScheme:
        - my-scope
```