### PR TITLE
Bump GraalVM SDK version to 23.1.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -89,7 +89,8 @@
         <jboss-metadata-web.version>16.0.0.Final</jboss-metadata-web.version>
         <maven-toolchain.version>3.0-alpha-2</maven-toolchain.version>
         <plexus-component-annotations.version>2.1.0</plexus-component-annotations.version>
-        <graal-sdk.version>23.0.1</graal-sdk.version>
+        <!-- GraalVM sdk 23.1.2 has a minimum JDK requirement of 17+ at runtime -->
+        <graal-sdk.version>23.1.2</graal-sdk.version>
         <gizmo.version>1.8.0</gizmo.version>
         <jackson-bom.version>2.16.1</jackson-bom.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>


### PR DESCRIPTION
The minimum JDK version needed for runtime usage of the SDK is JDK 17.

- Closes #39257