### PR TITLE
Make it easy for custom OIDC filters to use programmaticatlly created OIDC Clients

### DIFF
--- a/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/OidcClientCreator.java
+++ b/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/OidcClientCreator.java
@@ -1,0 +1,53 @@
+package io.quarkus.it.keycloak;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.OidcClientConfig;
+import io.quarkus.oidc.client.OidcClientConfig.Grant.Type;
+import io.quarkus.oidc.client.OidcClients;
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class OidcClientCreator {
+
+    @Inject
+    OidcClients oidcClients;
+    @ConfigProperty(name = "quarkus.oidc.auth-server-url")
+    String oidcProviderAddress;
+    @ConfigProperty(name = "quarkus.oidc.client-id")
+    String oidcClientId;
+    @ConfigProperty(name = "quarkus.oidc.credentials.secret")
+    String oidcClientSecret;
+
+    private volatile OidcClient oidcClient;
+
+    public void init(@Observes StartupEvent event) {
+        createOidcClient().subscribe().with(client -> {
+            oidcClient = client;
+        });
+    }
+
+    public OidcClient getOidcClient() {
+        return oidcClient;
+    }
+
+    private Uni<OidcClient> createOidcClient() {
+        OidcClientConfig cfg = new OidcClientConfig();
+        cfg.setId("myclient");
+        cfg.setAuthServerUrl(oidcProviderAddress);
+        cfg.setClientId(oidcClientId);
+        cfg.getCredentials().setSecret(oidcClientSecret);
+        cfg.getGrant().setType(Type.PASSWORD);
+        cfg.setGrantOptions(Map.of("password",
+                Map.of("username", "jdoe", "password", "jdoe")));
+        return oidcClients.newClient(cfg);
+    }
+}

--- a/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/OidcClientRequestCustomFilter.java
+++ b/integration-tests/oidc-client-reactive/src/main/java/io/quarkus/it/keycloak/OidcClientRequestCustomFilter.java
@@ -1,54 +1,23 @@
 package io.quarkus.it.keycloak;
 
-import java.util.function.Consumer;
+import java.util.Optional;
 
 import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.Priorities;
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.Response;
 
-import org.jboss.logging.Logger;
-import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
-import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestFilter;
-
-import io.quarkus.oidc.client.Tokens;
-import io.quarkus.oidc.client.runtime.AbstractTokensProducer;
-import io.quarkus.oidc.client.runtime.DisabledOidcClientException;
-import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.reactive.filter.runtime.AbstractOidcClientRequestReactiveFilter;
 
 @Priority(Priorities.AUTHENTICATION)
-public class OidcClientRequestCustomFilter extends AbstractTokensProducer implements ResteasyReactiveClientRequestFilter {
-    private static final Logger LOG = Logger.getLogger(OidcClientRequestCustomFilter.class);
-    private static final String BEARER_SCHEME_WITH_SPACE = OidcConstants.BEARER_SCHEME + " ";
+public class OidcClientRequestCustomFilter extends AbstractOidcClientRequestReactiveFilter {
 
-    protected void initTokens() {
-        if (earlyTokenAcquisition) {
-            LOG.debug("Token acquisition will be delayed until this filter is executed to avoid blocking an IO thread");
-        }
-    }
+    @Inject
+    OidcClientCreator oidcClientCreator;
 
     @Override
-    public void filter(ResteasyReactiveClientRequestContext requestContext) {
-        requestContext.suspend();
-
-        super.getTokens().subscribe().with(new Consumer<Tokens>() {
-            @Override
-            public void accept(Tokens tokens) {
-                requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, BEARER_SCHEME_WITH_SPACE + tokens.getAccessToken());
-                requestContext.resume();
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable t) {
-                if (t instanceof DisabledOidcClientException) {
-                    LOG.debug("Client is disabled");
-                    requestContext.abortWith(Response.status(500).build());
-                } else {
-                    LOG.debugf("Access token is not available, aborting the request with HTTP 401 error: %s", t.getMessage());
-                    requestContext.abortWith(Response.status(401).build());
-                }
-                requestContext.resume();
-            }
-        });
+    protected Optional<OidcClient> client() {
+        return Optional.of(oidcClientCreator.getOidcClient());
     }
+
 }

--- a/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-reactive/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -28,12 +28,21 @@ import io.restassured.RestAssured;
 public class OidcClientTest {
 
     @Test
+    public void testGetUserNameReactive() {
+        RestAssured.given().header("Accept", "text/plain")
+                .when().get("/frontend/userNameReactive")
+                .then()
+                .statusCode(200)
+                .body(equalTo("alice"));
+    }
+
+    @Test
     public void testGetUserNameCustomFilter() {
         RestAssured.given().header("Accept", "text/plain")
                 .when().get("/frontend/userNameCustomFilter")
                 .then()
                 .statusCode(200)
-                .body(equalTo("alice"));
+                .body(equalTo("jdoe"));
     }
 
     @Test
@@ -52,15 +61,6 @@ public class OidcClientTest {
                 .then()
                 .statusCode(200)
                 .body(containsString("invalid_grant"));
-    }
-
-    @Test
-    public void testGetUserNameReactive() {
-        RestAssured.given().header("Accept", "text/plain")
-                .when().get("/frontend/userNameReactive")
-                .then()
-                .statusCode(200)
-                .body(equalTo("alice"));
     }
 
     @Test


### PR DESCRIPTION
This PR makes it possible for the custom filter to provide a programmatically created OIDC client, at the moment the filter can only use OIDC clients configured in `application.properties`.

I've updated the existing custom OidcClientReactiveFilter in 2 ways:
* First I removed the code which has been available in the abstract filter code for a while
* And updated it to use a different client configuration to create a new OidcClient programmatically, originally it was using the same, default OIDC Client configuration as the test using the filter shipped by Quarkus, so there was no way to assert if the custom filter really run.

- Closes: #39261 