### PR TITLE
Fix RESTEasy Reactive configuration mismatch for minChunkSize

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -1447,7 +1447,7 @@ public class ResteasyReactiveProcessor {
 
         return new org.jboss.resteasy.reactive.common.ResteasyReactiveConfig(
                 getEffectivePropertyValue("input-buffer-size", config.inputBufferSize().asLongValue(), Long.class, mpConfig),
-                getEffectivePropertyValue("min-chunk-size", config.outputBufferSize(), Integer.class, mpConfig),
+                getEffectivePropertyValue("min-chunk-size", config.minChunkSize(), Integer.class, mpConfig),
                 getEffectivePropertyValue("output-buffer-size", config.outputBufferSize(), Integer.class, mpConfig),
                 getEffectivePropertyValue("single-default-produces", config.singleDefaultProduces(), Boolean.class, mpConfig),
                 getEffectivePropertyValue("default-produces", config.defaultProduces(), Boolean.class, mpConfig));


### PR DESCRIPTION
Created as draft as I wasn't able to test it as I'm in the middle of renaming all the modules and I don't want to pollute my .m2 with the old artifacts.

Noticed while working on renaming the RESTEasy Reactive config root.